### PR TITLE
fix(test): SDR combined-field verification via search API (definitive fix for e2e/SDR flakes)

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -2706,15 +2706,23 @@ export class LogsPage {
             ? process.env.INGESTION_URL.slice(0, -1)
             : process.env.INGESTION_URL;
 
+        // Unique per-batch marker. Verification queries the search API by this exact
+        // value (WHERE sdr_test_id = '<marker>'), so it inspects ONLY the records this
+        // call ingested — never stale data from an earlier batch on the same stream.
+        // This is what makes SDR verification deterministic instead of relying on the
+        // virtualized results table rendering the right rows at the right time.
+        const marker = `sdr-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
         const baseTimestamp = Date.now() * 1000;
         const logData = dataObjects.map(({ fieldName, fieldValue }, index) => ({
             level: "info",
             [fieldName]: fieldValue,
             log: `Test log with ${fieldName} field - entry ${index}`,
+            sdr_test_id: marker,
             _timestamp: baseTimestamp + (index * 1000000)
         }));
 
-        testLogger.info(`Preparing to ingest ${logData.length} separate log entries`);
+        testLogger.info(`Preparing to ingest ${logData.length} separate log entries (marker: ${marker})`);
 
         for (let attempt = 1; attempt <= maxRetries; attempt++) {
             try {
@@ -2732,9 +2740,10 @@ export class LogsPage {
                     testLogger.info('Ingestion successful, waiting for stream to be indexed...');
                     // NOTE: This is a backend async indexing wait, not a UI wait.
                     // waitForLoadState won't help as no page navigation occurs.
-                    // Consider using waitForStreamData() polling for production tests.
+                    // Verification polls the search API for this marker, so this is just
+                    // a small head start to reduce poll iterations — not the readiness gate.
                     await this.page.waitForTimeout(5000);
-                    return;
+                    return marker;
                 }
 
                 const errorMessage = responseBody?.message || JSON.stringify(responseBody);

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -2711,7 +2711,7 @@ export class LogsPage {
         // call ingested — never stale data from an earlier batch on the same stream.
         // This is what makes SDR verification deterministic instead of relying on the
         // virtualized results table rendering the right rows at the right time.
-        const marker = `sdr-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+        const marker = `sdr-${require('crypto').randomUUID()}`;
 
         const baseTimestamp = Date.now() * 1000;
         const logData = dataObjects.map(({ fieldName, fieldValue }, index) => ({

--- a/tests/ui-testing/pages/sdrPages/sdrVerificationPage.js
+++ b/tests/ui-testing/pages/sdrPages/sdrVerificationPage.js
@@ -1,307 +1,199 @@
 const { expect } = require('@playwright/test');
 const testLogger = require('../../playwright-tests/utils/test-logger.js');
+const { getAuthHeaders, getOrgIdentifier } = require('../../playwright-tests/utils/cloud-auth.js');
 
+/**
+ * SDR (Sensitive Data Redaction) verification.
+ *
+ * Verification reads the Search API (`/_search`) directly instead of scraping the
+ * logs results table. The search response IS the source of truth for SDR:
+ *   - query-time redaction/hashing/drop is applied server-side in the search
+ *     pipeline, so the API hits already contain `[REDACTED]` / `[REDACTED:hash]`
+ *     or omit dropped fields — exactly what the UI would render;
+ *   - ingestion-time transforms are baked into the stored record, so they show up
+ *     in the hits too.
+ *
+ * Every ingest tags its records with a unique `sdr_test_id` marker (see
+ * `logsPage.ingestMultipleFields` / the specs' `ingestSingleLog`). Verification
+ * queries by that marker, so it inspects ONLY the batch under test and never races
+ * against stale rows, virtualization, or highlight-HTML in the DOM table. Readiness
+ * is a precise count gate (we know exactly how many records we ingested), not a
+ * best-effort retry against the rendered table.
+ */
 export class SDRVerificationPage {
   constructor(page) {
     this.page = page;
-
-    // Locators
-    this.cancelButton = { role: 'button', name: 'Cancel' };
-    this.logsMenuItem = '[data-test="menu-link-\\/logs-item"]';
-    this.logTableColumnSource = '[data-test="log-table-column-0-source"]';
-    this.logTableBodyRowsAlt = '.logs-result-table tbody tr[role="row"]';
-    this.logTableBodyRows = 'tbody tr';
-  }
-
-  async closeStreamDetailSidebarIfOpen() {
-    const cancelButton = this.page.getByRole(this.cancelButton.role, { name: this.cancelButton.name });
-    const cancelVisible = await cancelButton.isVisible({ timeout: 1000 }).catch(() => false);
-    if (cancelVisible) {
-      await cancelButton.click();
-      testLogger.info('Closed stream detail sidebar');
-    }
-  }
-
-  async navigateToLogsQuick() {
-    await this.page.locator(this.logsMenuItem).click();
-    await this.page.waitForLoadState('domcontentloaded');
-    // Use short networkidle with catch — Logs page may have persistent connections
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
-    testLogger.info('Navigated to Logs (fast - no VRL wait)');
   }
 
   /**
-   * Wait for the loading indicator to disappear.
-   * @param {number} timeout - Max milliseconds to wait (default 15000)
+   * Field-state predicates over a single search hit (a record object).
+   * `[REDACTED:<32 hex>]` is the hash marker; a bare `[REDACTED]` is a redaction.
+   * Note `'[REDACTED:abc]'.includes('[REDACTED]')` is false, so redact and hash
+   * never alias each other.
    */
-  async waitForLoadingToDisappear(timeout = 15000) {
-    const loadingIndicator = this.page.getByText('Loading...').first();
-    await loadingIndicator.waitFor({ state: 'hidden', timeout }).catch(() => {
-      testLogger.info(`Loading indicator still visible after ${timeout}ms`);
-    });
+  static _fieldValue(hit, fieldName) {
+    const value = hit?.[fieldName];
+    return value === undefined || value === null ? null : String(value);
+  }
+  static _isPresent(hit, fieldName) {
+    return SDRVerificationPage._fieldValue(hit, fieldName) !== null;
+  }
+  static _isRedacted(value) {
+    return typeof value === 'string' && value.includes('[REDACTED]');
+  }
+  static _isHashed(value) {
+    return typeof value === 'string' && /\[REDACTED:[0-9a-f]{32}\]/i.test(value);
+  }
+  static _looksRedactedOrHashed(value) {
+    return typeof value === 'string' && /\[REDACTED/.test(value);
   }
 
   /**
-   * Get log entry count and the matching locator.
-   * Tries the source column first, falls back to tbody rows.
-   * @returns {{ locator: import('@playwright/test').Locator, count: number }}
+   * Poll the Search API for records tagged with `marker` until at least `minCount`
+   * are searchable. Records are returned newest-first. The poll only waits out async
+   * ingestion indexing for THIS batch — once `minCount` records appear, any SDR
+   * transform on them is already final, so the result is deterministic.
+   *
+   * @returns {Promise<Object[]>} hit objects (may be fewer than minCount on timeout)
    */
-  async getLogEntries() {
-    let locator = this.page.locator(this.logTableColumnSource);
-    let count = await locator.count();
+  async fetchRecordsByMarker(streamName, marker, minCount = 1) {
+    expect(marker, 'SDR verification requires an ingest marker — pass the value returned by ingestMultipleFields/ingestSingleLog').toBeTruthy();
 
-    if (count === 0) {
-      locator = this.page.locator(this.logTableBodyRows);
-      count = await locator.count();
-    }
+    const headers = getAuthHeaders();
+    const baseUrl = process.env['ZO_BASE_URL'];
+    const orgName = getOrgIdentifier();
+    const sql = `SELECT * FROM "${streamName}" WHERE sdr_test_id = '${marker}' ORDER BY _timestamp DESC`;
 
-    return { locator, count };
-  }
+    const maxAttempts = 20; // ~60s ceiling at 3s/attempt — generous for CI index lag
+    let hits = [];
 
-  async getLatestLogText() {
-    const { locator, count } = await this.getLogEntries();
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const endTime = (Date.now() + 60000) * 1000; // +1m future buffer (microseconds)
+      const startTime = endTime - 60 * 60 * 1000 * 1000; // 60-minute lookback window
 
-    testLogger.info(`Found ${count} log entries in the UI`);
+      const searchPayload = {
+        query: { sql, start_time: startTime, end_time: endTime, from: 0, size: 1000 },
+      };
 
-    if (count === 0) {
-      return null;
-    }
-
-    // Get the first log entry (most recent)
-    const logText = await locator.nth(0).textContent();
-    return logText;
-  }
-
-  /**
-   * Verify a single field in the latest log entry with retry logic for CI.
-   * @param {Object} logsPage - The logsPage instance from PageManager
-   * @param {string} streamName - Name of the stream
-   * @param {string} fieldName - Name of the field to verify
-   * @param {boolean} shouldBeDropped - Whether field should be dropped
-   * @param {boolean} shouldBeRedacted - Whether field should be redacted
-   */
-  async verifySingleFieldInLatestLog(logsPage, streamName, fieldName, shouldBeDropped, shouldBeRedacted) {
-    testLogger.info(`Verifying field: ${fieldName}, shouldBeDropped: ${shouldBeDropped}, shouldBeRedacted: ${shouldBeRedacted}`);
-
-    // Use page object functions to navigate and get log
-    await this.closeStreamDetailSidebarIfOpen();
-    await this.navigateToLogsQuick();
-    await logsPage.selectStream(streamName);
-
-    // The field key is expected to be present unless it is being dropped (redacted/visible
-    // both keep the key). Use that to gate the retry on content rather than mere presence
-    // of a row — under CI load the latest row can render before the freshly-ingested field
-    // is searchable, so breaking on the first non-null row asserts against stale data.
-    const fieldAsJsonKey = `"${fieldName}":`;
-    const fieldAsKey = `${fieldName}:`;
-    const expectFieldPresent = !shouldBeDropped;
-    const hasField = (text) => text.includes(fieldAsJsonKey) || text.includes(fieldAsKey);
-
-    // Retry loop: wait for logs to appear after ingestion (CI can be slow to index)
-    const maxRetries = 5;
-    let logText = null;
-
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      await this.page.waitForTimeout(1000);
-      await logsPage.clickRefreshButton();
-      await this.waitForLoadingToDisappear(15000);
-      await this.page.waitForTimeout(2000);
-
-      logText = await this.getLatestLogText();
-
-      const fieldReady = logText !== null && (!expectFieldPresent || hasField(logText));
-      testLogger.info(`Attempt ${attempt}/${maxRetries}: ${logText ? (fieldReady ? 'Log entry ready' : 'Log entry found but field not yet indexed') : 'No logs found'}`);
-
-      if (fieldReady) {
-        break;
+      try {
+        const response = await this.page.request.post(
+          `${baseUrl}/api/${orgName}/_search?type=logs`,
+          { headers, data: searchPayload }
+        );
+        const data = await response.json().catch(() => null);
+        hits = data?.hits || [];
+      } catch (error) {
+        testLogger.warn(`fetchRecordsByMarker attempt ${attempt}: search request failed: ${error.message}`);
+        hits = [];
       }
 
-      if (attempt < maxRetries) {
-        const waitTime = attempt * 3000;
-        testLogger.info(`Log not ready yet, waiting ${waitTime / 1000}s before retry...`);
-        await this.page.waitForTimeout(waitTime);
+      if (hits.length >= minCount) {
+        testLogger.info(`fetchRecordsByMarker: ${hits.length} record(s) for marker ${marker} (need ${minCount})`);
+        return hits;
+      }
+
+      testLogger.info(`fetchRecordsByMarker attempt ${attempt}/${maxAttempts}: ${hits.length}/${minCount} records for marker ${marker}, waiting for indexing...`);
+      if (attempt < maxAttempts) {
+        await this.page.waitForTimeout(3000);
       }
     }
 
-    expect(logText, 'No logs found in the stream after multiple retries').not.toBeNull();
+    testLogger.warn(`fetchRecordsByMarker: returning ${hits.length} record(s) for marker ${marker} after ${maxAttempts} attempts (needed ${minCount})`);
+    return hits;
+  }
 
-    testLogger.info(`Latest log text (first 300 chars): ${logText?.substring(0, 300)}...`);
+  /**
+   * Verify a single field on the record just ingested with `marker`.
+   * Used by sequential flows that re-ingest to the same stream and assert on the
+   * latest write (and on query-time transforms applied to an existing record by
+   * reusing that record's marker).
+   *
+   * @param {Object} logsPage - kept for call-site compatibility (unused; API-based)
+   * @param {string} marker   - marker returned by the ingest that wrote this record
+   */
+  async verifySingleFieldInLatestLog(logsPage, streamName, fieldName, shouldBeDropped, shouldBeRedacted, marker) {
+    testLogger.info(`Verifying field: ${fieldName}, shouldBeDropped: ${shouldBeDropped}, shouldBeRedacted: ${shouldBeRedacted}, marker: ${marker}`);
 
-    // Check if field exists in the log
-    const fieldFound = hasField(logText);
+    const hits = await this.fetchRecordsByMarker(streamName, marker, 1);
+    expect(hits.length, `No record found for marker ${marker} in stream ${streamName}`).toBeGreaterThan(0);
+
+    const hit = hits[0];
+    const value = SDRVerificationPage._fieldValue(hit, fieldName);
 
     if (shouldBeDropped) {
-      // Field should NOT be present at all
-      expect(fieldFound, `Field ${fieldName} should have been DROPPED but was found in log`).toBe(false);
-      testLogger.info(`✓ Field ${fieldName} is correctly DROPPED (not present)`);
+      expect(value, `Field ${fieldName} should have been DROPPED but was found: ${value}`).toBeNull();
+      testLogger.info(`✓ Field ${fieldName} is correctly DROPPED (absent from record)`);
     } else if (shouldBeRedacted) {
-      // Field should be present with [REDACTED]
-      expect(fieldFound, `Field ${fieldName} should be present but was not found in log`).toBe(true);
-      expect(logText, `Field ${fieldName} should be REDACTED but [REDACTED] marker not found`).toContain('[REDACTED]');
+      expect(value, `Field ${fieldName} should be present but was not found in record`).not.toBeNull();
+      expect(SDRVerificationPage._isRedacted(value), `Field ${fieldName} should be REDACTED but value was: ${value}`).toBe(true);
       testLogger.info(`✓ Field ${fieldName} is correctly REDACTED`);
     } else {
-      // Field should be visible with actual value
-      expect(fieldFound, `Field ${fieldName} should be visible but was not found in log`).toBe(true);
-      expect(logText, `Field ${fieldName} should be visible but is REDACTED`).not.toContain('[REDACTED]');
-      testLogger.info(`✓ Field ${fieldName} is visible with actual value (as expected)`);
+      expect(value, `Field ${fieldName} should be visible but was not found in record`).not.toBeNull();
+      expect(SDRVerificationPage._looksRedactedOrHashed(value), `Field ${fieldName} should be visible but appears redacted/hashed: ${value}`).toBe(false);
+      testLogger.info(`✓ Field ${fieldName} is visible with actual value`);
     }
   }
 
   /**
-   * Fetch all log entry texts with full retry and 3-tier locator fallback.
-   * Navigates to Logs, selects stream, waits until at least minCount entries appear.
+   * Verify multiple fields written by one ingest batch (each field lives in its own
+   * record). Each descriptor: { fieldName, shouldBeDropped?, shouldBeRedacted?, shouldBeHashed? }.
+   * Default (all flags false/absent): field must be present and not redacted/hashed.
    *
-   * Row count alone is an unreliable readiness signal: under CI load the search can
-   * return a partial/stale result set (or the loose `tbody tr` fallback can count
-   * non-data rows) where the row count is satisfied but freshly-ingested fields are
-   * not yet searchable. When `requiredFields` is supplied, the fetch additionally
-   * waits until every one of those field names actually appears in the fetched logs,
-   * making readiness content-aware rather than purely count-based.
-   *
-   * @param {string[]} requiredFields - Field names that must appear before returning.
-   * @returns {string[]} Array of log text strings (may be fewer than minCount on timeout).
+   * @param {Object} logsPage - kept for call-site compatibility (unused; API-based)
+   * @param {string} marker   - marker returned by the ingest under test
    */
-  async fetchAllLogTexts(logsPage, streamName, minCount = 1, requiredFields = []) {
-    await this.closeStreamDetailSidebarIfOpen();
-    await this.navigateToLogsQuick();
-    await logsPage.selectStream(streamName);
+  async verifyMultipleFields(logsPage, streamName, fieldsToVerify, marker) {
+    testLogger.info(`Verifying ${fieldsToVerify.length} fields in stream: ${streamName} (marker: ${marker})`);
 
-    const hasField = (text, field) =>
-      text.includes(`"${field}":`) || text.includes(`${field}:`);
-
-    const maxRetries = 5;
-    let logTexts = [];
-
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      await this.page.waitForTimeout(1000);
-      await logsPage.clickRefreshButton();
-      await this.page.waitForTimeout(2000);
-
-      let locator = this.page.locator(this.logTableColumnSource);
-      let count = await locator.count();
-
-      if (count < minCount) {
-        locator = this.page.locator(this.logTableBodyRowsAlt);
-        count = await locator.count();
-      }
-
-      if (count < minCount) {
-        locator = this.page.locator(this.logTableBodyRows);
-        count = await locator.count();
-      }
-
-      if (count > 0) {
-        logTexts = [];
-        for (let i = 0; i < count; i++) {
-          const text = await locator.nth(i).textContent();
-          logTexts.push(text);
-        }
-
-        // Content gate: only treat the result set as "ready" once every required
-        // field is actually present. Otherwise the freshly-ingested data is still
-        // indexing — keep retrying so we don't assert against a partial result set.
-        const missingFields = requiredFields.filter(
-          (field) => !logTexts.some((text) => hasField(text, field))
-        );
-
-        if (logTexts.length >= minCount && missingFields.length === 0) break;
-
-        if (missingFields.length > 0) {
-          testLogger.info(`fetchAllLogTexts attempt ${attempt}/${maxRetries}: ${logTexts.length} entries found but fields not yet indexed: ${missingFields.join(', ')}`);
-        }
-      }
-
-      testLogger.info(`fetchAllLogTexts attempt ${attempt}/${maxRetries}: found ${logTexts.length} entries (need ${minCount})`);
-
-      if (attempt < maxRetries) {
-        await this.page.waitForTimeout(attempt * 3000);
-      }
-    }
-
-    testLogger.info(`fetchAllLogTexts: returning ${logTexts.length} log entries`);
-    return logTexts;
-  }
-
-  /**
-   * Verify multiple fields across log entries with a single navigation + retry.
-   * Each field descriptor: { fieldName, shouldBeDropped?, shouldBeRedacted?, shouldBeHashed? }
-   * Default (no flag / all false): field must be present and not redacted.
-   */
-  async verifyMultipleFields(logsPage, streamName, fieldsToVerify) {
-    testLogger.info(`Verifying ${fieldsToVerify.length} fields in stream: ${streamName}`);
-
-    // Fields that must be present (everything except dropped fields) gate the fetch so we
-    // wait for them to be searchable instead of asserting against a partially-indexed result.
-    const requiredFields = fieldsToVerify
-      .filter(({ shouldBeDropped }) => !shouldBeDropped)
-      .map(({ fieldName }) => fieldName);
-
-    const logTexts = await this.fetchAllLogTexts(logsPage, streamName, fieldsToVerify.length, requiredFields);
-    expect(logTexts.length, 'No logs found in the stream after multiple retries').toBeGreaterThan(0);
+    const hits = await this.fetchRecordsByMarker(streamName, marker, fieldsToVerify.length);
+    expect(hits.length, `Expected ${fieldsToVerify.length} records for marker ${marker} but found ${hits.length}`).toBeGreaterThanOrEqual(fieldsToVerify.length);
 
     for (const { fieldName, shouldBeDropped, shouldBeRedacted, shouldBeHashed } of fieldsToVerify) {
       testLogger.info(`Verifying field: ${fieldName}`);
 
-      let foundLog = null;
-      for (const logText of logTexts) {
-        if (logText.includes(`"${fieldName}":`) || logText.includes(`${fieldName}:`)) {
-          foundLog = logText;
-          break;
-        }
-      }
+      // The record carrying this field (present-and-non-null). For a dropped field
+      // no record will carry it, which is exactly what we assert below.
+      const carrier = hits.find((hit) => SDRVerificationPage._isPresent(hit, fieldName));
+      const value = carrier ? SDRVerificationPage._fieldValue(carrier, fieldName) : null;
 
       if (shouldBeDropped) {
-        expect(foundLog, `Field ${fieldName} should be DROPPED but was found in logs`).toBeNull();
+        expect(carrier, `Field ${fieldName} should be DROPPED but was found in a record: ${value}`).toBeFalsy();
         testLogger.info(`✓ Field ${fieldName} is correctly DROPPED`);
       } else if (shouldBeRedacted) {
-        expect(foundLog, `Field ${fieldName} should be present but was not found`).not.toBeNull();
-        expect(foundLog, `Field ${fieldName} should contain [REDACTED] marker`).toContain('[REDACTED]');
+        expect(carrier, `Field ${fieldName} should be present but was not found`).toBeTruthy();
+        expect(SDRVerificationPage._isRedacted(value), `Field ${fieldName} should contain [REDACTED] marker but was: ${value}`).toBe(true);
         testLogger.info(`✓ Field ${fieldName} is correctly REDACTED`);
       } else if (shouldBeHashed) {
-        expect(foundLog, `Field ${fieldName} should be present but was not found`).not.toBeNull();
-        const hashPattern = /\[REDACTED:[0-9a-f]{32}\]/i;
-        expect(hashPattern.test(foundLog), `Field ${fieldName} should be in [REDACTED:hash] format`).toBe(true);
-        const hashMatch = foundLog.match(/\[REDACTED:([0-9a-f]{32})\]/i);
-        testLogger.info(`✓ Field ${fieldName} is correctly HASHED: [REDACTED:${hashMatch?.[1]}]`);
+        expect(carrier, `Field ${fieldName} should be present but was not found`).toBeTruthy();
+        expect(SDRVerificationPage._isHashed(value), `Field ${fieldName} should be in [REDACTED:hash] format but was: ${value}`).toBe(true);
+        testLogger.info(`✓ Field ${fieldName} is correctly HASHED: ${value}`);
       } else {
-        // shouldBeDropped/Redacted/Hashed all false or absent — field must be visible
-        expect(foundLog, `Field ${fieldName} should be visible but was not found`).not.toBeNull();
-        const redactedPresent = /\[REDACTED/.test(foundLog);
-        expect(redactedPresent, `Field ${fieldName} should be visible but appears redacted/hashed`).toBe(false);
+        expect(carrier, `Field ${fieldName} should be visible but was not found`).toBeTruthy();
+        expect(SDRVerificationPage._looksRedactedOrHashed(value), `Field ${fieldName} should be visible but appears redacted/hashed: ${value}`).toBe(false);
         testLogger.info(`✓ Field ${fieldName} is visible with actual value`);
       }
     }
   }
 
   /**
-   * Verify that fields are completely absent from the most recent N log entries.
-   * Use this for ingestion-time DROP where older logs still contain the fields.
-   * @param {string[]} fieldNames - Plain array of field name strings
+   * Verify that every field in `fieldNames` is absent from the batch tagged with
+   * `marker`. Used for ingestion-time DROP, where the dropped fields never reach
+   * storage for the post-pattern batch.
+   *
+   * @param {Object} logsPage - kept for call-site compatibility (unused; API-based)
+   * @param {string} marker   - marker of the post-drop ingest batch
    */
-  async verifyFieldsAreAbsent(logsPage, streamName, fieldNames) {
-    testLogger.info(`Verifying ${fieldNames.length} fields are ABSENT in recent logs`);
+  async verifyFieldsAreAbsent(logsPage, streamName, fieldNames, marker) {
+    testLogger.info(`Verifying ${fieldNames.length} fields are ABSENT in stream ${streamName} (marker: ${marker})`);
 
-    const logTexts = await this.fetchAllLogTexts(logsPage, streamName, fieldNames.length);
-    expect(logTexts.length, 'No logs found in the stream after multiple retries').toBeGreaterThan(0);
-
-    // Only inspect the most recent N entries — older logs pre-date the drop pattern
-    const recentTexts = logTexts.slice(0, fieldNames.length);
-    testLogger.info(`Checking ${recentTexts.length} most recent log entries for absence of fields`);
+    const hits = await this.fetchRecordsByMarker(streamName, marker, fieldNames.length);
+    expect(hits.length, `Expected ${fieldNames.length} records for marker ${marker} but found ${hits.length}`).toBeGreaterThanOrEqual(fieldNames.length);
 
     for (const fieldName of fieldNames) {
-      testLogger.info(`Verifying field ${fieldName} is ABSENT in recent logs`);
-
-      let foundInRecent = false;
-      for (const logText of recentTexts) {
-        if (logText.includes(`"${fieldName}":`) || logText.includes(`${fieldName}:`)) {
-          foundInRecent = true;
-          testLogger.error(`Field ${fieldName} unexpectedly found: ${logText.substring(0, 200)}`);
-          break;
-        }
-      }
-
-      expect(foundInRecent, `Field ${fieldName} should be DROPPED but was found in recent logs`).toBe(false);
-      testLogger.info(`✓ Field ${fieldName} is correctly absent from recent logs`);
+      const carrier = hits.find((hit) => SDRVerificationPage._isPresent(hit, fieldName));
+      const value = carrier ? SDRVerificationPage._fieldValue(carrier, fieldName) : null;
+      expect(carrier, `Field ${fieldName} should be DROPPED but was found in a record: ${value}`).toBeFalsy();
+      testLogger.info(`✓ Field ${fieldName} is correctly absent`);
     }
   }
 }

--- a/tests/ui-testing/pages/sdrPages/sdrVerificationPage.js
+++ b/tests/ui-testing/pages/sdrPages/sdrVerificationPage.js
@@ -78,10 +78,18 @@ export class SDRVerificationPage {
       try {
         const response = await this.page.request.post(
           `${baseUrl}/api/${orgName}/_search?type=logs`,
-          { headers, data: searchPayload }
+          { headers, data: searchPayload, timeout: 15000 }
         );
-        const data = await response.json().catch(() => null);
-        hits = data?.hits || [];
+        if (!response.ok()) {
+          // A non-2xx is a real failure (auth/server error), not indexing lag —
+          // surface it distinctly instead of silently treating it as "no records yet".
+          const body = await response.text().catch(() => '');
+          testLogger.warn(`fetchRecordsByMarker attempt ${attempt}: search returned HTTP ${response.status()} — ${body.slice(0, 200)}`);
+          hits = [];
+        } else {
+          const data = await response.json().catch(() => null);
+          hits = data?.hits || [];
+        }
       } catch (error) {
         testLogger.warn(`fetchRecordsByMarker attempt ${attempt}: search request failed: ${error.message}`);
         hits = [];

--- a/tests/ui-testing/playwright-tests/SDR/ingestionTimeDrop.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/ingestionTimeDrop.spec.js
@@ -100,10 +100,10 @@ test.describe("Ingestion Time Drop - Combined Test", { tag: '@enterprise' }, () 
     // STEP 1: Ingest data WITHOUT any SDR patterns - all fields should be visible
     testLogger.info('STEP 1: Ingest 4 lines of data WITHOUT any SDR patterns linked');
     const dataToIngest = patternsToTest.map(p => ({ fieldName: p.field, fieldValue: p.value }));
-    await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
+    const markerStep1 = await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
 
     const fieldsToVerifyStep1 = patternsToTest.map(p => ({ fieldName: p.field, shouldBeDropped: false }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep1);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep1, markerStep1);
     testLogger.info('✓ STEP 1 PASSED: All fields visible without SDR');
 
     // STEP 2: Create all 4 SDR patterns
@@ -139,11 +139,13 @@ test.describe("Ingestion Time Drop - Combined Test", { tag: '@enterprise' }, () 
     testLogger.info('✓ STEP 3 PASSED: All 4 patterns linked to fields with DROP action');
 
     // STEP 4: Ingest data WITH SDR patterns linked - all fields should be DROPPED
+    // Ingestion-time drop removes the fields at write time, so this is a NEW batch
+    // (new marker) — distinct from the still-visible STEP 1 batch on the same stream.
     testLogger.info('STEP 4: Ingest 4 lines of data WITH SDR patterns linked');
-    await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
+    const markerStep4 = await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
 
     const fieldsToCheck = patternsToTest.map(p => p.field);
-    await pm.sdrVerificationPage.verifyFieldsAreAbsent(pm.logsPage, testStreamName, fieldsToCheck);
+    await pm.sdrVerificationPage.verifyFieldsAreAbsent(pm.logsPage, testStreamName, fieldsToCheck, markerStep4);
     testLogger.info('✓ STEP 4 PASSED: All fields are DROPPED (not present)');
 
     testLogger.info('=== ✓ COMBINED DROP TEST COMPLETED SUCCESSFULLY ===');

--- a/tests/ui-testing/playwright-tests/SDR/ingestionTimeHash.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/ingestionTimeHash.spec.js
@@ -99,10 +99,10 @@ test.describe("Ingestion Time Hash - Combined Test", { tag: '@enterprise' }, () 
     // STEP 1: Ingest data WITHOUT any SDR patterns - all fields should be visible
     testLogger.info('STEP 1: Ingest 4 lines of data WITHOUT any SDR patterns linked');
     const dataToIngest = patternsToTest.map(p => ({ fieldName: p.field, fieldValue: p.value }));
-    await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
+    const markerStep1 = await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
 
     const fieldsToVerifyStep1 = patternsToTest.map(p => ({ fieldName: p.field, shouldBeHashed: false }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep1);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep1, markerStep1);
     testLogger.info('✓ STEP 1 PASSED: All fields visible without SDR');
 
     // STEP 2: Create all 4 SDR patterns
@@ -137,11 +137,13 @@ test.describe("Ingestion Time Hash - Combined Test", { tag: '@enterprise' }, () 
     testLogger.info('✓ STEP 3 PASSED: All 4 patterns linked to fields with HASH action');
 
     // STEP 4: Ingest data WITH SDR patterns linked - all fields should be HASHED
+    // Ingestion-time hashing is baked in at write time, so this is a NEW batch
+    // (new marker) — distinct from the still-visible STEP 1 batch on the same stream.
     testLogger.info('STEP 4: Ingest 4 lines of data WITH SDR patterns linked');
-    await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
+    const markerStep4 = await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
 
     const fieldsToVerifyStep4 = patternsToTest.map(p => ({ fieldName: p.field, shouldBeHashed: true }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep4);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep4, markerStep4);
     testLogger.info('✓ STEP 4 PASSED: All fields are HASHED (present with hashed values)');
 
     testLogger.info('=== ✓ COMBINED HASH TEST COMPLETED SUCCESSFULLY ===');

--- a/tests/ui-testing/playwright-tests/SDR/ingestionTimeRedaction.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/ingestionTimeRedaction.spec.js
@@ -100,10 +100,10 @@ test.describe("Ingestion Time Redaction - Combined Test", { tag: '@enterprise' }
     // STEP 1: Ingest data WITHOUT any SDR patterns - all fields should be visible
     testLogger.info('STEP 1: Ingest 4 lines of data WITHOUT any SDR patterns linked');
     const dataToIngest = patternsToTest.map(p => ({ fieldName: p.field, fieldValue: p.value }));
-    await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
+    const markerStep1 = await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
 
     const fieldsToVerifyStep1 = patternsToTest.map(p => ({ fieldName: p.field, shouldBeRedacted: false }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep1);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep1, markerStep1);
     testLogger.info('✓ STEP 1 PASSED: All fields visible without SDR');
 
     // STEP 2: Create all 4 SDR patterns
@@ -139,11 +139,13 @@ test.describe("Ingestion Time Redaction - Combined Test", { tag: '@enterprise' }
     testLogger.info('✓ STEP 3 PASSED: All 4 patterns linked to fields');
 
     // STEP 4: Ingest data WITH SDR patterns linked - all fields should be REDACTED
+    // Ingestion-time redaction is baked in at write time, so this is a NEW batch
+    // (new marker) — distinct from the still-visible STEP 1 batch on the same stream.
     testLogger.info('STEP 4: Ingest 4 lines of data WITH SDR patterns linked');
-    await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
+    const markerStep4 = await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
 
     const fieldsToVerifyStep4 = patternsToTest.map(p => ({ fieldName: p.field, shouldBeRedacted: true }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep4);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsToVerifyStep4, markerStep4);
     testLogger.info('✓ STEP 4 PASSED: All fields are REDACTED');
 
     testLogger.info('=== ✓ COMBINED REDACTION TEST COMPLETED SUCCESSFULLY ===');

--- a/tests/ui-testing/playwright-tests/SDR/multipleSDRPatterns.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/multipleSDRPatterns.spec.js
@@ -8,10 +8,15 @@ async function ingestSingleLog(page, streamName, fieldName, fieldValue, maxRetri
   const orgId = getOrgIdentifier();
   const headers = getAuthHeaders();
 
+  // Unique marker so verification can query the search API for THIS exact record
+  // (WHERE sdr_test_id = '<marker>') instead of guessing which rendered row is latest.
+  const marker = `sdr-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
   const logEntry = {
     level: "info",
     [fieldName]: fieldValue,
     log: `Test log with ${fieldName} = ${fieldValue}`,
+    sdr_test_id: marker,
     _timestamp: Date.now() * 1000
   };
 
@@ -44,7 +49,7 @@ async function ingestSingleLog(page, streamName, fieldName, fieldValue, maxRetri
     if (response.status === 200) {
       testLogger.info('Ingestion successful, waiting for stream to be indexed...');
       await page.waitForTimeout(5000);
-      return;
+      return marker;
     }
 
     // Check for "stream being deleted" error - retry with backoff
@@ -140,8 +145,8 @@ test.describe("Multiple Patterns on One Field", { tag: '@enterprise' }, () => {
 
     // ==================== STEP 1: Ingest log #1 for query-time drop pattern ====================
     testLogger.info('========== STEP 1: Ingest log with value "application.log" ==========');
-    await ingestSingleLog(page, testStreamName, fieldName, queryTimePatterns[0].value); // "application.log"
-    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, false, false);
+    const markerLog1 = await ingestSingleLog(page, testStreamName, fieldName, queryTimePatterns[0].value); // "application.log"
+    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, false, false, markerLog1);
     testLogger.info('STEP 1 PASSED: Log #1 ingested, field visible (no patterns yet)');
 
     // ==================== STEP 2: Link query-time DROP pattern ====================
@@ -156,14 +161,15 @@ test.describe("Multiple Patterns on One Field", { tag: '@enterprise' }, () => {
     testLogger.info('STEP 2 PASSED: Query-time DROP pattern linked');
 
     // ==================== STEP 3: Verify query-time DROP on existing log ====================
+    // No re-ingestion: query-time drop transforms log #1 at search time. Reuse its marker.
     testLogger.info('========== STEP 3: Verify query-time DROP works on EXISTING log ==========');
-    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, true, false);
+    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, true, false, markerLog1);
     testLogger.info('STEP 3 PASSED: Field DROPPED at query time (no re-ingestion needed)');
 
     // ==================== STEP 4: Ingest log #2 for query-time redact pattern ====================
     testLogger.info('========== STEP 4: Ingest log with value "14:30:45" ==========');
-    await ingestSingleLog(page, testStreamName, fieldName, queryTimePatterns[1].value); // "14:30:45"
-    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, false, false);
+    const markerLog2 = await ingestSingleLog(page, testStreamName, fieldName, queryTimePatterns[1].value); // "14:30:45"
+    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, false, false, markerLog2);
     testLogger.info('STEP 4 PASSED: Log #2 ingested, field visible (pattern not yet linked)');
 
     // ==================== STEP 5: Link query-time REDACT pattern ====================
@@ -178,8 +184,9 @@ test.describe("Multiple Patterns on One Field", { tag: '@enterprise' }, () => {
     testLogger.info('STEP 5 PASSED: Query-time REDACT pattern linked (now 2 patterns total)');
 
     // ==================== STEP 6: Verify query-time REDACT on existing log ====================
+    // No re-ingestion: query-time redact transforms log #2 at search time. Reuse its marker.
     testLogger.info('========== STEP 6: Verify query-time REDACT works on EXISTING log ==========');
-    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, false, true);
+    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, false, true, markerLog2);
     testLogger.info('STEP 6 PASSED: Field REDACTED at query time (no re-ingestion needed)');
 
     // ==================== STEP 7: Link ingestion-time DROP pattern ====================
@@ -195,8 +202,8 @@ test.describe("Multiple Patterns on One Field", { tag: '@enterprise' }, () => {
 
     // ==================== STEP 8: Ingest log #3 and verify ingestion-time DROP ====================
     testLogger.info('========== STEP 8: Ingest log with value "AB12CDEF1234567890" ==========');
-    await ingestSingleLog(page, testStreamName, fieldName, ingestionTimePatterns[0].value); // IFSC code
-    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, true, false);
+    const markerLog3 = await ingestSingleLog(page, testStreamName, fieldName, ingestionTimePatterns[0].value); // IFSC code
+    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, true, false, markerLog3);
     testLogger.info('STEP 8 PASSED: Field DROPPED at ingestion time');
 
     // ==================== STEP 9: Link ingestion-time REDACT pattern ====================
@@ -212,8 +219,8 @@ test.describe("Multiple Patterns on One Field", { tag: '@enterprise' }, () => {
 
     // ==================== STEP 10: Ingest log #4 and verify ingestion-time REDACT ====================
     testLogger.info('========== STEP 10: Ingest log with value "25/12/2024" ==========');
-    await ingestSingleLog(page, testStreamName, fieldName, ingestionTimePatterns[1].value); // Date
-    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, false, true);
+    const markerLog4 = await ingestSingleLog(page, testStreamName, fieldName, ingestionTimePatterns[1].value); // Date
+    await pm.sdrVerificationPage.verifySingleFieldInLatestLog(pm.logsPage, testStreamName, fieldName, false, true, markerLog4);
     testLogger.info('STEP 10 PASSED: Field REDACTED at ingestion time');
 
     testLogger.info('=== ALL 4 PATTERNS ON ONE FIELD TEST COMPLETED SUCCESSFULLY ===');

--- a/tests/ui-testing/playwright-tests/SDR/multipleSDRPatterns.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/multipleSDRPatterns.spec.js
@@ -10,7 +10,7 @@ async function ingestSingleLog(page, streamName, fieldName, fieldValue, maxRetri
 
   // Unique marker so verification can query the search API for THIS exact record
   // (WHERE sdr_test_id = '<marker>') instead of guessing which rendered row is latest.
-  const marker = `sdr-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  const marker = `sdr-${require('crypto').randomUUID()}`;
 
   const logEntry = {
     level: "info",

--- a/tests/ui-testing/playwright-tests/SDR/queryTimeDrop.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/queryTimeDrop.spec.js
@@ -104,14 +104,16 @@ test.describe("Query Time Drop - Combined Test", { tag: '@enterprise' }, () => {
       fieldValue: p.value
     }));
 
-    await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
+    // Query-time SDR transforms data at search time, so STEP 1 (visible) and STEP 4
+    // (dropped) inspect the SAME ingested batch — reuse one marker for both.
+    const ingestMarker = await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
 
     // Verify all fields are visible before drop
     const fieldsBeforeDrop = patternsToTest.map(p => ({
       fieldName: p.field,
       shouldBeDropped: false
     }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsBeforeDrop);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsBeforeDrop, ingestMarker);
     testLogger.info('✓ STEP 1 PASSED: All fields visible without SDR');
 
     // STEP 2: Create all 4 SDR patterns
@@ -154,7 +156,7 @@ test.describe("Query Time Drop - Combined Test", { tag: '@enterprise' }, () => {
       fieldName: p.field,
       shouldBeDropped: true
     }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsAfterDrop);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsAfterDrop, ingestMarker);
     testLogger.info('✓ STEP 4 PASSED: All fields are DROPPED at query time');
 
     testLogger.info('=== ✓ COMBINED QUERY TIME DROP TEST COMPLETED SUCCESSFULLY ===');

--- a/tests/ui-testing/playwright-tests/SDR/queryTimeHash.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/queryTimeHash.spec.js
@@ -104,14 +104,16 @@ test.describe("Query Time Hash - Combined Test", { tag: '@enterprise' }, () => {
       fieldValue: p.value
     }));
 
-    await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
+    // Query-time SDR transforms data at search time, so STEP 1 (visible) and STEP 4
+    // (hashed) inspect the SAME ingested batch — reuse one marker for both.
+    const ingestMarker = await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
 
     // Verify all fields are visible without hashing
     const fieldsBeforeHashing = patternsToTest.map(p => ({
       fieldName: p.field,
       shouldBeHashed: false
     }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsBeforeHashing);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsBeforeHashing, ingestMarker);
     testLogger.info('✓ STEP 1 PASSED: All fields visible without SDR');
 
     // STEP 2: Create all 4 SDR patterns
@@ -154,7 +156,7 @@ test.describe("Query Time Hash - Combined Test", { tag: '@enterprise' }, () => {
       fieldName: p.field,
       shouldBeHashed: true
     }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsAfterHashing);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsAfterHashing, ingestMarker);
     testLogger.info('✓ STEP 4 PASSED: All fields are HASHED at query time');
 
     testLogger.info('=== ✓ COMBINED QUERY TIME HASH TEST COMPLETED SUCCESSFULLY ===');

--- a/tests/ui-testing/playwright-tests/SDR/queryTimeRedaction.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/queryTimeRedaction.spec.js
@@ -103,14 +103,16 @@ test.describe("Query Time Redaction - Combined Test", { tag: '@enterprise' }, ()
       fieldValue: p.value
     }));
 
-    await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
+    // Query-time SDR transforms data at search time, so STEP 1 (visible) and STEP 4
+    // (redacted) inspect the SAME ingested batch — reuse one marker for both.
+    const ingestMarker = await pm.logsPage.ingestMultipleFields(testStreamName, dataToIngest);
 
     // Verify all fields are visible without redaction
     const fieldsBeforeRedaction = patternsToTest.map(p => ({
       fieldName: p.field,
       shouldBeRedacted: false
     }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsBeforeRedaction);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsBeforeRedaction, ingestMarker);
     testLogger.info('✓ STEP 1 PASSED: All fields visible without SDR');
 
     // STEP 2: Create all 4 SDR patterns
@@ -153,7 +155,7 @@ test.describe("Query Time Redaction - Combined Test", { tag: '@enterprise' }, ()
       fieldName: p.field,
       shouldBeRedacted: true
     }));
-    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsAfterRedaction);
+    await pm.sdrVerificationPage.verifyMultipleFields(pm.logsPage, testStreamName, fieldsAfterRedaction, ingestMarker);
     testLogger.info('✓ STEP 4 PASSED: All fields are REDACTED at query time');
 
     testLogger.info('=== ✓ COMBINED QUERY TIME REDACTION TEST COMPLETED SUCCESSFULLY ===');


### PR DESCRIPTION
## Problem

The 7 `@combined` SDR specs (`queryTime{Redaction,Drop,Hash}`, `ingestionTime{Redaction,Hash,Drop}`, `multipleSDRPatterns`) fail deterministically on `e2e / SDR` (ENT [run 28216495512](https://github.com/openobserve/o2-enterprise/actions/runs/28216495512)) with `Field <name> should be visible but was not found`, even after the content-gate retry in #12893.

## Root cause (a logic bug, not timing)

Verification scraped the virtualized logs results table. Two structural defects:

1. **Row-indexed selector misused as a count.** `[data-test="log-table-column-0-source"]` — `TenstackTable.vue` renders `log-table-column-{rowIndex}-source`, so it only ever matches **row 0** (1 element). The combined path's `count >= 4` gate can never be met by the reliable source locator.
2. **Dead fallback selector.** `.logs-result-table tbody tr[role="row"]` references a class that **does not exist** in `web/src` → always 0.

So the fetch collapsed to whole-page `tbody tr` scraping whose text never matched the field keys → the flat *"4 entries found but fields not yet indexed"* across every retry. #12893's retry couldn't help because the scraped data was structurally wrong, not late. Single-field tests passed only because they read row 0 directly.

## Fix

Verify against the **Search API** — the actual source of truth for SDR. Query-time redaction is applied server-side in `apply_regex_to_response` (`ApplyPolicy::AtSearch`); the web only displays API output, so `[REDACTED]` / `[REDACTED:<hash>]` / dropped-field semantics are all present in the API hits.

- Each ingest tags records with a unique `sdr_test_id` marker and returns it.
- Verification queries `_search` with `WHERE sdr_test_id = '<marker>'`, polls only until the **known** record count is searchable, then asserts on the JSON hits.
- Markers threaded through all 7 specs: query-time reuses one marker (visible → transformed); ingestion-time uses distinct per-batch markers; `multipleSDRPatterns` threads one per sequential ingest.

Net **−80 lines** — removes all brittle DOM scraping from SDR verification.

## Validation

`node --check` passes on all changed files; every verify call confirmed to thread a marker; root-cause selectors + server-side redaction path confirmed against source. Live `e2e / SDR` run validated via a matching-name ENT branch (CI tree-merge picks up this OSS branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)