### PR TITLE
ci: report regression run metrics to OpenObserve (ci_regression)

### DIFF
--- a/.github/scripts/O2-REPORTING.md
+++ b/.github/scripts/O2-REPORTING.md
@@ -19,28 +19,32 @@ passcode just shows up as an ingest `::warning::` with no metric for that run.
 Identical name + value in each repo (Settings → Secrets and variables → Actions). These can
 also be **org-level** secrets scoped to both repos instead of per-repo.
 
+> ⚠️ This file lives in a **public** repo — it deliberately contains **no** real host, org id,
+> IP, or credential. The concrete values live only in the GitHub Actions secrets below. Ask the
+> infra/QA owner for the actual ingest URL + passcode.
+
 **Secrets** (Settings → Secrets and variables → Actions → *Secrets*):
 
-| Secret | Value |
+| Secret | Value (format) |
 |---|---|
-| `O2_REPORTING_INGEST_BASE` | `https://o2latestmainapi.o2aks1.external.zinclabs.dev/api/3FhRJ0oGe6RhPZF4YJPndnRRtp0` (org `default` on o2latestmain, **external/public** endpoint) |
-| `O2_REPORTING_AUTH` | `base64("latestmain@openobserve.ai:<passcode>")` — e.g. `printf '%s' 'latestmain@openobserve.ai:<passcode>' \| base64` |
+| `O2_REPORTING_INGEST_BASE` | `https://<external-host>/api/<org-identifier>` — use the **externally-reachable** host (see note) |
+| `O2_REPORTING_AUTH` | `base64("<email>:<passcode>")` — e.g. `printf '%s' '<email>:<passcode>' \| base64` |
 
-> **Use the `external` host, not `internal`.** `o2latestmainapi.o2aks1.**internal**.zinclabs.dev`
-> resolves to a private VPC IP (`10.10.96.222`) that public GitHub/ubicloud runners cannot reach.
-> The `**external**` twin (`48.202.72.109`) is public and serves a **valid TLS cert** — verified by
-> a 200 test-ingest — so no `-k` and no `O2_REPORTING_INSECURE` variable are needed.
+> **Use an externally-reachable host.** An `*.internal.*` ingest host typically resolves to a
+> private VPC IP that public GitHub/ubicloud runners cannot reach (ingests then fail as harmless
+> `HTTP 000` warnings, no data lands). Use the public/`external` endpoint of the same instance,
+> which normally serves a valid TLS cert — then no `-k` / `O2_REPORTING_INSECURE` is needed.
 
-> Optional variable `O2_REPORTING_INSECURE=true` exists only as a fallback for a host with a
-> self-signed cert (it makes the poster use `curl -k`). Not needed for the external host above.
+> Optional variable `O2_REPORTING_INSECURE=true` (a GitHub Actions **variable**, not a secret) is
+> a fallback for a host with a self-signed cert — it makes the poster use `curl -k`. Leave it
+> unset for a host with a valid cert.
 
 > The passcode **rotates**. When it does, regenerate `O2_REPORTING_AUTH` in both repos.
 > Until the secrets exist the report job is a no-op (logs a skip warning) — safe to merge first,
 > add secrets after.
 
-> ℹ️ Final reachability (public IP + valid cert strongly indicate runners can reach it) is
-> confirmed on the first real CI run — a non-2xx/000 just warns and drops that run's metrics,
-> never failing the build.
+> ℹ️ Final reachability is confirmed on the first real CI run — a non-2xx/000 just warns and
+> drops that run's metrics, never failing the build.
 
 The PAT used by the engine report jobs for cross-repo PR-URL lookups is the existing
 `ORG_ADMIN_TOKEN` (no new token needed).

--- a/.github/scripts/O2-REPORTING.md
+++ b/.github/scripts/O2-REPORTING.md
@@ -1,0 +1,132 @@
+# CI → OpenObserve reporting
+
+Each of three CI workflows emits **one summary JSON document per run** into a dedicated
+OpenObserve stream, so we can build performance/reliability dashboards on top of them.
+
+| Workflow | Repo | Stream | Emitting job |
+|---|---|---|---|
+| Playwright Regression (`playwright_regression.yml`) | openobserve (OSS) | `ci_regression` | `report_to_openobserve` |
+| DocGen engine (`docgen.yml`) | o2-enterprise | `ci_docgen` | `report_metrics` |
+| E2E Council engine (`e2e-council.yml`) | o2-enterprise | `ci_council` | `report_metrics` |
+
+All three post via the shared, never-fail poster `.github/scripts/o2-report.sh`
+(`POST {base}/{stream}/_json`, Basic auth). The report job is `continue-on-error` and the
+poster always `exit 0`s — **reporting can never fail or slow the real CI run.** A rotated
+passcode just shows up as an ingest `::warning::` with no metric for that run.
+
+## Secrets to create (BOTH repos: openobserve + o2-enterprise)
+
+Identical name + value in each repo (Settings → Secrets and variables → Actions). These can
+also be **org-level** secrets scoped to both repos instead of per-repo.
+
+**Secrets** (Settings → Secrets and variables → Actions → *Secrets*):
+
+| Secret | Value |
+|---|---|
+| `O2_REPORTING_INGEST_BASE` | `https://o2latestmainapi.o2aks1.external.zinclabs.dev/api/3FhRJ0oGe6RhPZF4YJPndnRRtp0` (org `default` on o2latestmain, **external/public** endpoint) |
+| `O2_REPORTING_AUTH` | `base64("latestmain@openobserve.ai:<passcode>")` — e.g. `printf '%s' 'latestmain@openobserve.ai:<passcode>' \| base64` |
+
+> **Use the `external` host, not `internal`.** `o2latestmainapi.o2aks1.**internal**.zinclabs.dev`
+> resolves to a private VPC IP (`10.10.96.222`) that public GitHub/ubicloud runners cannot reach.
+> The `**external**` twin (`48.202.72.109`) is public and serves a **valid TLS cert** — verified by
+> a 200 test-ingest — so no `-k` and no `O2_REPORTING_INSECURE` variable are needed.
+
+> Optional variable `O2_REPORTING_INSECURE=true` exists only as a fallback for a host with a
+> self-signed cert (it makes the poster use `curl -k`). Not needed for the external host above.
+
+> The passcode **rotates**. When it does, regenerate `O2_REPORTING_AUTH` in both repos.
+> Until the secrets exist the report job is a no-op (logs a skip warning) — safe to merge first,
+> add secrets after.
+
+> ℹ️ Final reachability (public IP + valid cert strongly indicate runners can reach it) is
+> confirmed on the first real CI run — a non-2xx/000 just warns and drops that run's metrics,
+> never failing the build.
+
+The PAT used by the engine report jobs for cross-repo PR-URL lookups is the existing
+`ORG_ADMIN_TOKEN` (no new token needed).
+
+## Event schemas
+
+### Shared core (all three streams)
+`_timestamp` (auto), `workflow` (`regression`|`docgen`|`council`), `repo`, `run_id`,
+`run_attempt`, `run_url`, `trigger` (`schedule`|`workflow_dispatch`|`issue_comment`|`pull_request`),
+`actor`, `started_at`, `finished_at`, `duration_sec` (wall-clock), `runner_seconds`
+(Σ job durations — cost proxy).
+
+### `ci_regression`
+`branch`, `conclusion` (success/failure), `build_result`, `ui_result`, `merge_result`,
+`build_duration_sec`, `shards_total`, `shards_passed`, `shards_failed`,
+`shards[]` (`{name, conclusion, duration_sec}` per matrix shard),
+`tests_total`, `tests_passed`, `tests_failed`, `tests_flaky`, `tests_skipped`.
+
+### `ci_docgen`
+`source_repo`, `pr_number`, `dry_run`, `mode` (dryrun/full),
+`outcome` (`gated_out`|`triaged`|`no_docs_needed`|`docs_pr_opened`|`failed`),
+`gate_allowed`, `needs_docs`, `feature_slug`, `doc_mode` (new/augment/update),
+`triage_result`, `generate_result`, `screenshots_result`, `open_prs_result`,
+`has_placeholders`, `screenshots_applied`, `screenshots_total`, `screenshots_complete`,
+`docs_pr_dev_url`, `docs_pr_main_url`,
+`stage_triage_sec`, `stage_generate_sec`, `stage_screenshots_sec`, `stage_open_prs_sec`.
+
+### `ci_council`
+`source_repo`, `pr_number`, `dry_run`, `mode`,
+`outcome` (`gated_out`|`skipped`|`triaged`|`no_e2e_needed`|`test_pr_opened`|`heal_passed_no_pr`|`heal_failed`),
+`author_allowed`, `skip`, `needs_e2e`, `reuse`, `feature_mode` (open/merged), `work_branch`,
+`triage_result`, `generate_result`, `generate_has_changes`, `verify_heal_result`,
+`heal_status` (passing/failing/…), `quality_status` (pass/fail), `heal_passed`,
+`pr_back_result`, `ent_register_result`, `test_pr_url`,
+`stage_triage_sec`, `stage_generate_sec`, `stage_verify_heal_sec`, `stage_pr_back_sec`, `stage_ent_register_sec`.
+
+## Starter dashboard queries (OpenObserve SQL)
+
+**Regression — pass rate over time**
+```sql
+SELECT histogram(_timestamp, '1 day') AS day,
+       count(*) AS runs,
+       sum(CASE WHEN conclusion = 'success' THEN 1 ELSE 0 END) AS passed,
+       round(100.0 * sum(CASE WHEN conclusion='success' THEN 1 ELSE 0 END)/count(*), 1) AS pass_pct
+FROM ci_regression GROUP BY day ORDER BY day;
+```
+
+**Regression — flaky/failed test counts trend**
+```sql
+SELECT histogram(_timestamp,'1 day') AS day,
+       sum(tests_failed) AS failed, sum(tests_flaky) AS flaky
+FROM ci_regression GROUP BY day ORDER BY day;
+```
+
+**Regression — slowest shards (avg duration)** — unnest `shards` or query the flattened field.
+```sql
+SELECT avg(build_duration_sec) AS avg_build_sec, avg(duration_sec) AS avg_wallclock_sec,
+       avg(runner_seconds) AS avg_runner_sec
+FROM ci_regression;
+```
+
+**DocGen — outcome breakdown**
+```sql
+SELECT outcome, count(*) FROM ci_docgen GROUP BY outcome ORDER BY count(*) DESC;
+```
+
+**DocGen — stage time profile (where time goes)**
+```sql
+SELECT avg(stage_triage_sec) AS triage, avg(stage_generate_sec) AS generate,
+       avg(stage_screenshots_sec) AS screenshots, avg(stage_open_prs_sec) AS open_prs
+FROM ci_docgen WHERE dry_run = false;
+```
+
+**Council — heal success rate + outcome funnel**
+```sql
+SELECT outcome, count(*) AS runs,
+       sum(CASE WHEN heal_passed THEN 1 ELSE 0 END) AS healed_pass
+FROM ci_council GROUP BY outcome ORDER BY runs DESC;
+```
+
+**All workflows — throughput by trigger (volume)**
+```sql
+SELECT trigger, count(*) FROM ci_council GROUP BY trigger;   -- repeat per stream
+```
+
+## Building the dashboards
+After the **first real run lands in each stream** (so field types are inferred), import a
+dashboard JSON or build panels in the UI using the queries above. Field names here are the
+contract the report jobs emit — verify the first ingest matches, then wire panels.

--- a/.github/scripts/o2-report.sh
+++ b/.github/scripts/o2-report.sh
@@ -16,6 +16,13 @@ set -uo pipefail
 STREAM="${1:?stream name required}"
 PAYLOAD="${2:?payload file required}"
 
+# Stream names are workflow-controlled, but validate defensively so this is safe to reuse:
+# only [a-z0-9_], which can't break out of the URL path.
+if ! printf '%s' "$STREAM" | grep -qE '^[a-z0-9_]+$'; then
+  echo "::warning::invalid stream name '$STREAM' (expected [a-z0-9_]) — skipping OpenObserve ingest"
+  exit 0
+fi
+
 if [ -z "${O2_REPORTING_INGEST_BASE:-}" ] || [ -z "${O2_REPORTING_AUTH:-}" ]; then
   echo "::warning::O2_REPORTING_INGEST_BASE / O2_REPORTING_AUTH not set — skipping OpenObserve ingest"
   exit 0
@@ -27,25 +34,30 @@ if [ ! -s "$PAYLOAD" ]; then
 fi
 
 # OpenObserve's _json endpoint accepts a single object or an array; wrap to an array.
+# Stream the body from a temp file (mktemp → unique per invocation, no shared-/tmp races,
+# no whole-payload-in-a-shell-var).
 URL="${O2_REPORTING_INGEST_BASE%/}/${STREAM}/_json"
-BODY="[$(cat "$PAYLOAD")]"
+BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/o2_report_body.XXXXXX")
+RESP_FILE=$(mktemp "${TMPDIR:-/tmp}/o2_report_resp.XXXXXX")
+trap 'rm -f "$BODY_FILE" "$RESP_FILE"' EXIT
+{ printf '['; cat "$PAYLOAD"; printf ']'; } > "$BODY_FILE"
 
 INSECURE=""
 [ "${O2_REPORTING_INSECURE:-}" = "true" ] && INSECURE="-k"
 
 echo "::group::OpenObserve ingest → ${STREAM}"
 echo "payload:"; cat "$PAYLOAD"
-HTTP_CODE=$(curl -s $INSECURE --max-time 20 -o /tmp/o2_report_resp.txt -w '%{http_code}' -X POST "$URL" \
+HTTP_CODE=$(curl -s $INSECURE --max-time 20 -o "$RESP_FILE" -w '%{http_code}' -X POST "$URL" \
   -H "Authorization: Basic ${O2_REPORTING_AUTH}" \
   -H "Content-Type: application/json" \
-  --data "$BODY" 2>/dev/null || echo "000")
+  --data-binary @"$BODY_FILE" 2>/dev/null || echo "000")
 
-if [ "$HTTP_CODE" -ge 200 ] 2>/dev/null && [ "$HTTP_CODE" -lt 300 ] 2>/dev/null; then
+if printf '%s' "$HTTP_CODE" | grep -qE '^[0-9]+$' && [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
   echo "::notice::Ingested CI metrics to OpenObserve stream '${STREAM}' (HTTP ${HTTP_CODE})"
-  cat /tmp/o2_report_resp.txt 2>/dev/null || true
+  cat "$RESP_FILE" 2>/dev/null || true
 else
   echo "::warning::OpenObserve ingest to '${STREAM}' returned HTTP ${HTTP_CODE} — passcode may have rotated, or the host is unreachable. Metrics for this run were not recorded."
-  cat /tmp/o2_report_resp.txt 2>/dev/null || true
+  cat "$RESP_FILE" 2>/dev/null || true
 fi
 echo "::endgroup::"
 exit 0

--- a/.github/scripts/o2-report.sh
+++ b/.github/scripts/o2-report.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Post a single CI run-summary JSON document to an OpenObserve stream.
+#
+#   Usage: o2-report.sh <stream> <payload-file>
+#
+# Reads the destination from the environment (set these as repo/org secrets):
+#   O2_REPORTING_INGEST_BASE  e.g. https://<host>/api/<org-identifier>
+#   O2_REPORTING_AUTH         base64("<email>:<passcode>")  — the Basic-auth credential
+#   O2_REPORTING_INSECURE     optional; "true" skips TLS verification (curl -k) for hosts
+#                             with a self-signed cert (e.g. *.internal.zinclabs.dev).
+#
+# This NEVER fails the caller: a missing secret, a rotated passcode (401), or any
+# non-2xx response only warns. The reporting layer must not break the real CI run.
+set -uo pipefail
+
+STREAM="${1:?stream name required}"
+PAYLOAD="${2:?payload file required}"
+
+if [ -z "${O2_REPORTING_INGEST_BASE:-}" ] || [ -z "${O2_REPORTING_AUTH:-}" ]; then
+  echo "::warning::O2_REPORTING_INGEST_BASE / O2_REPORTING_AUTH not set — skipping OpenObserve ingest"
+  exit 0
+fi
+
+if [ ! -s "$PAYLOAD" ]; then
+  echo "::warning::payload file '$PAYLOAD' missing or empty — skipping OpenObserve ingest"
+  exit 0
+fi
+
+# OpenObserve's _json endpoint accepts a single object or an array; wrap to an array.
+URL="${O2_REPORTING_INGEST_BASE%/}/${STREAM}/_json"
+BODY="[$(cat "$PAYLOAD")]"
+
+INSECURE=""
+[ "${O2_REPORTING_INSECURE:-}" = "true" ] && INSECURE="-k"
+
+echo "::group::OpenObserve ingest → ${STREAM}"
+echo "payload:"; cat "$PAYLOAD"
+HTTP_CODE=$(curl -s $INSECURE --max-time 20 -o /tmp/o2_report_resp.txt -w '%{http_code}' -X POST "$URL" \
+  -H "Authorization: Basic ${O2_REPORTING_AUTH}" \
+  -H "Content-Type: application/json" \
+  --data "$BODY" 2>/dev/null || echo "000")
+
+if [ "$HTTP_CODE" -ge 200 ] 2>/dev/null && [ "$HTTP_CODE" -lt 300 ] 2>/dev/null; then
+  echo "::notice::Ingested CI metrics to OpenObserve stream '${STREAM}' (HTTP ${HTTP_CODE})"
+  cat /tmp/o2_report_resp.txt 2>/dev/null || true
+else
+  echo "::warning::OpenObserve ingest to '${STREAM}' returned HTTP ${HTTP_CODE} — passcode may have rotated, or the host is unreachable. Metrics for this run were not recorded."
+  cat /tmp/o2_report_resp.txt 2>/dev/null || true
+fi
+echo "::endgroup::"
+exit 0

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -783,6 +783,10 @@ jobs:
           MERGE_STATS: ${{ needs.merge_and_upload_reports.outputs.stats }}
         run: |
           set -uo pipefail
+          # Forks / unconfigured repos: skip entirely (no API call, no rate-limit spend).
+          if [ -z "${O2_REPORTING_INGEST_BASE:-}" ] || [ -z "${O2_REPORTING_AUTH:-}" ]; then
+            echo "::notice::O2_REPORTING_* secrets not set — skipping metrics ingest"; exit 0
+          fi
           # Per-job metadata (durations + conclusions) for THIS run attempt.
           curl -s -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" \
@@ -817,7 +821,12 @@ jobs:
                 trigger: \$trigger,
                 actor: \$actor,
                 branch: \$branch,
-                conclusion: (if (\$build_result==\"success\" and \$ui_result==\"success\") then \"success\" else \"failure\" end),
+                conclusion: (
+                  if (\$build_result==\"cancelled\" or \$ui_result==\"cancelled\" or \$merge_result==\"cancelled\") then \"cancelled\"
+                  elif (\$build_result==\"success\" and \$ui_result==\"success\") then \"success\"
+                  elif (\$ui_result==\"skipped\" and \$build_result!=\"failure\") then \"skipped\"
+                  else \"failure\" end
+                ),
                 build_result: \$build_result,
                 ui_result: \$ui_result,
                 merge_result: \$merge_result,
@@ -829,6 +838,7 @@ jobs:
                 shards_total: ([ \$j[] | select(.name|startswith(\"e2e /\")) ] | length),
                 shards_passed: ([ \$j[] | select((.name|startswith(\"e2e /\")) and .conclusion==\"success\") ] | length),
                 shards_failed: ([ \$j[] | select((.name|startswith(\"e2e /\")) and .conclusion==\"failure\") ] | length),
+                shards_skipped: ([ \$j[] | select((.name|startswith(\"e2e /\")) and (.conclusion==\"skipped\" or .conclusion==\"cancelled\")) ] | length),
                 shards: [ \$j[] | select(.name|startswith(\"e2e /\")) | {name: .name, conclusion: .conclusion, duration_sec: ($dur)} ],
                 tests_total: (if \$stats then ((\$stats.expected//0)+(\$stats.unexpected//0)+(\$stats.flaky//0)+(\$stats.skipped//0)) else null end),
                 tests_passed: (if \$stats then (\$stats.expected//0) else null end),

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -547,6 +547,10 @@ jobs:
       labels: ubicloud-standard-4
     permissions:
       contents: read
+    outputs:
+      # Compact Playwright stats (expected/unexpected/flaky/skipped/duration) from the merged
+      # report.json — consumed by report_to_openobserve to record reliability metrics.
+      stats: ${{ steps.report_stats.outputs.stats }}
 
     steps:
       - name: Clone the current repo
@@ -616,6 +620,19 @@ jobs:
           ls -la playwright-results/html-report/
           echo "Checking report.json:"
           ls -lh playwright-results/report.json
+
+      - name: Extract report stats for OpenObserve
+        id: report_stats
+        if: always()
+        run: |
+          cd tests/ui-testing
+          if [ -f playwright-results/report.json ]; then
+            STATS=$(jq -c '.stats // {}' playwright-results/report.json 2>/dev/null || echo '{}')
+          else
+            STATS='{}'
+          fi
+          echo "stats=$STATS" >> "$GITHUB_OUTPUT"
+          echo "report stats: $STATS"
 
       - name: Cache test failures to TestDino
         if: ${{ needs.ui_integration_tests.result == 'failure' }}
@@ -733,3 +750,92 @@ jobs:
             echo "  merge_and_upload_reports: ${{ needs.merge_and_upload_reports.result }}"
             exit 1
           fi
+
+  # ---------------------------------------------------------------------------
+  # Report one run-summary document to OpenObserve (stream: ci_regression).
+  # Pure metrics sidecar: derives per-job timings + per-shard pass/fail from the
+  # GitHub jobs API and the merged Playwright stats. continue-on-error + a
+  # never-fail poster script mean this can NEVER break the regression run.
+  # ---------------------------------------------------------------------------
+  report_to_openobserve:
+    name: Report metrics to OpenObserve
+    needs: [build_binary, ui_integration_tests, merge_and_upload_reports]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Clone the current repo
+        uses: actions/checkout@v5
+
+      - name: Build payload and ingest
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          O2_REPORTING_INGEST_BASE: ${{ secrets.O2_REPORTING_INGEST_BASE }}
+          O2_REPORTING_AUTH: ${{ secrets.O2_REPORTING_AUTH }}
+          O2_REPORTING_INSECURE: ${{ vars.O2_REPORTING_INSECURE }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BUILD_RESULT: ${{ needs.build_binary.result }}
+          UI_RESULT: ${{ needs.ui_integration_tests.result }}
+          MERGE_RESULT: ${{ needs.merge_and_upload_reports.result }}
+          MERGE_STATS: ${{ needs.merge_and_upload_reports.outputs.stats }}
+        run: |
+          set -uo pipefail
+          # Per-job metadata (durations + conclusions) for THIS run attempt.
+          curl -s -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" \
+            > jobs.json || echo '{"jobs":[]}' > jobs.json
+
+          STATS="${MERGE_STATS:-}"; [ -z "$STATS" ] && STATS=null
+
+          dur='if (.completed_at and .started_at) then ((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601)) else null end'
+          jq -n \
+            --slurpfile jb jobs.json \
+            --arg workflow "regression" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg run_url "$RUN_URL" \
+            --arg trigger "$GITHUB_EVENT_NAME" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg branch "$GITHUB_REF_NAME" \
+            --arg build_result "$BUILD_RESULT" \
+            --arg ui_result "$UI_RESULT" \
+            --arg merge_result "$MERGE_RESULT" \
+            --argjson stats "$STATS" \
+            "
+            (\$jb[0].jobs // []) as \$j
+            | [ \$j[] | select(.conclusion != null) ] as \$done
+            | {
+                workflow: \$workflow,
+                repo: \$repo,
+                run_id: \$run_id,
+                run_attempt: (\$run_attempt|tonumber),
+                run_url: \$run_url,
+                trigger: \$trigger,
+                actor: \$actor,
+                branch: \$branch,
+                conclusion: (if (\$build_result==\"success\" and \$ui_result==\"success\") then \"success\" else \"failure\" end),
+                build_result: \$build_result,
+                ui_result: \$ui_result,
+                merge_result: \$merge_result,
+                started_at: (\$done | map(.started_at) | min),
+                finished_at: (\$done | map(.completed_at) | max),
+                duration_sec: ((\$done | map(.completed_at|fromdateiso8601) | max) - (\$done | map(.started_at|fromdateiso8601) | min)),
+                runner_seconds: ([ \$done[] | ($dur) ] | add),
+                build_duration_sec: ( [ \$j[] | select(.name==\"build_binary\") ] | .[0] | if . then ($dur) else null end ),
+                shards_total: ([ \$j[] | select(.name|startswith(\"e2e /\")) ] | length),
+                shards_passed: ([ \$j[] | select((.name|startswith(\"e2e /\")) and .conclusion==\"success\") ] | length),
+                shards_failed: ([ \$j[] | select((.name|startswith(\"e2e /\")) and .conclusion==\"failure\") ] | length),
+                shards: [ \$j[] | select(.name|startswith(\"e2e /\")) | {name: .name, conclusion: .conclusion, duration_sec: ($dur)} ],
+                tests_total: (if \$stats then ((\$stats.expected//0)+(\$stats.unexpected//0)+(\$stats.flaky//0)+(\$stats.skipped//0)) else null end),
+                tests_passed: (if \$stats then (\$stats.expected//0) else null end),
+                tests_failed: (if \$stats then (\$stats.unexpected//0) else null end),
+                tests_flaky: (if \$stats then (\$stats.flaky//0) else null end),
+                tests_skipped: (if \$stats then (\$stats.skipped//0) else null end)
+              }
+            " > payload.json || { echo "::warning::payload build failed"; echo '{}' > payload.json; }
+
+          bash .github/scripts/o2-report.sh ci_regression payload.json


### PR DESCRIPTION
## What

Adds a CI→OpenObserve metrics sidecar to the Playwright Regression workflow. A new terminal job `report_to_openobserve` emits **one summary JSON document per run** into the `ci_regression` OpenObserve stream, so we can build reliability/performance dashboards.

This is the OSS half of a cross-repo change — the companion o2-enterprise PR (`ci/o2-reporting`) instruments the DocGen and E2E Council engines into `ci_docgen` / `ci_council`.

## How it works (safe by construction)

- **Non-invasive:** derives per-job timings + per-shard pass/fail from the GitHub jobs API and the merged Playwright stats. The only edit to an existing job is one additive `stats` output on `merge_and_upload_reports`.
- **Cannot break CI:** the job is `continue-on-error` and posts through `.github/scripts/o2-report.sh`, which always `exit 0`s (a missing secret / rotated passcode / unreachable host only warns).
- **No-ops until secrets exist** — safe to merge first.

## Metrics captured
Reliability (conclusion, shard pass/fail, test pass/fail/flaky/skipped), duration & cost (wall-clock, `runner_seconds`, build time, per-shard durations), throughput (trigger/actor/branch).

## Required secrets (this repo + o2-enterprise)
- `O2_REPORTING_INGEST_BASE` — `https://<host>/api/<org>`
- `O2_REPORTING_AUTH` — `base64("email:passcode")`

Full schema, dashboard SQL, and setup notes: `.github/scripts/O2-REPORTING.md`.

## Validation
- YAML parse + jq unit tests + `actionlint` clean on the added code.
- Live **HTTP 200** test-ingest into the target instance, both via raw curl and through the poster script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
