### PR TITLE
ci: live retry-aware metrics for playwright, api-testing + regression

### DIFF
--- a/.github/scripts/o2-run-report.sh
+++ b/.github/scripts/o2-run-report.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Emit ONE retry-aware run-summary document per workflow run to an OpenObserve stream.
+#
+# Generic across test workflows: the CALLER passes CONCLUSION (derived from needs.*.result),
+# STREAM, and SUITE; this script derives wall-clock timing from the GitHub jobs API, sums the
+# cost across ALL attempts (so a re-run's doc carries the cumulative compute), and pulls
+# attribution (branch/author/commit/PR/trigger) from the run object. It then POSTs via the
+# shared o2-report.sh. Live re-runs append one doc per attempt; dashboards keep the latest
+# attempt per run_id (row_number() dedup), so retries become an attribute, not duplicate rows.
+#
+# Never fails the workflow: missing secrets or any API/ingest error only warns.
+set -uo pipefail
+: "${STREAM:?STREAM required}"
+SUITE="${SUITE:-}"
+CONCLUSION="${CONCLUSION:-}"
+
+if [ -z "${O2_REPORTING_INGEST_BASE:-}" ] || [ -z "${O2_REPORTING_AUTH:-}" ]; then
+  echo "::notice::O2_REPORTING_* secrets not set — skipping metrics ingest"; exit 0
+fi
+
+API="${GITHUB_API_URL:-https://api.github.com}"
+gh_get(){ curl -s -H "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$API/$1"; }
+
+# wall-clock of one attempt = max(completed) - min(started) across its jobs.
+attempt_wall(){ jq '[.jobs[]|select(.completed_at!=null and .started_at!=null)] as $j
+  | if ($j|length)>0 then (($j|map(.completed_at|fromdateiso8601)|max)-($j|map(.started_at|fromdateiso8601)|min)) else 0 end'; }
+
+RUN_JSON=$(gh_get "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" 2>/dev/null)
+[ -n "$RUN_JSON" ] || { echo "::warning::could not fetch run object — skipping"; exit 0; }
+ATT="${GITHUB_RUN_ATTEMPT:-1}"
+
+THIS_JOBS=$(gh_get "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${ATT}/jobs?per_page=100" 2>/dev/null)
+FINAL_DUR=$(printf '%s' "$THIS_JOBS" | attempt_wall 2>/dev/null || echo 0)
+
+# total across attempts: add each prior attempt's wall-clock.
+TOTAL_DUR="$FINAL_DUR"
+if [ "$ATT" -gt 1 ] 2>/dev/null; then
+  SUM="$FINAL_DUR"
+  for n in $(seq 1 $((ATT-1))); do
+    W=$(gh_get "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${n}/jobs?per_page=100" 2>/dev/null | attempt_wall 2>/dev/null || echo 0)
+    SUM=$(awk -v a="$SUM" -v b="$W" 'BEGIN{print a+b}')
+  done
+  TOTAL_DUR="$SUM"
+fi
+
+WORKFLOW_TAG="test"; [ "$STREAM" = "ci_regression" ] && WORKFLOW_TAG="regression"
+
+printf '%s' "$RUN_JSON" | jq \
+  --arg suite "$SUITE" --arg conclusion "$CONCLUSION" --arg wf "$WORKFLOW_TAG" \
+  --arg repo "$GITHUB_REPOSITORY" --arg run_id "$GITHUB_RUN_ID" --arg attempt "$ATT" \
+  --arg run_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${ATT}" \
+  --argjson final "${FINAL_DUR:-0}" --argjson total "${TOTAL_DUR:-0}" \
+  '($attempt|tonumber) as $a |
+   {
+     _timestamp: ((.run_started_at // .created_at | fromdateiso8601) * 1000000 | floor),
+     workflow: $wf, suite: $suite, repo: $repo,
+     run_id: $run_id, run_attempt: $a, retries: ($a-1), was_retried: ($a>1),
+     conclusion: (if $conclusion=="" then .conclusion else $conclusion end),
+     trigger: .event, author: (.actor.login // null), branch: .head_branch,
+     commit_sha: ((.head_sha // "")[0:12]),
+     pr_number: (.pull_requests[0].number // null),
+     run_url: $run_url,
+     final_duration_sec: ($final|round), total_duration_sec: ($total|round),
+     retry_wasted_sec: (($total-$final)|round)
+   }' > /tmp/o2_run_payload.json 2>/dev/null || { echo "::warning::payload build failed"; exit 0; }
+
+bash "$(dirname "$0")/o2-report.sh" "$STREAM" /tmp/o2_run_payload.json

--- a/.github/scripts/o2-run-report.sh
+++ b/.github/scripts/o2-run-report.sh
@@ -17,13 +17,22 @@ CONCLUSION="${CONCLUSION:-}"
 if [ -z "${O2_REPORTING_INGEST_BASE:-}" ] || [ -z "${O2_REPORTING_AUTH:-}" ]; then
   echo "::notice::O2_REPORTING_* secrets not set — skipping metrics ingest"; exit 0
 fi
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "::warning::GH_TOKEN not set — skipping metrics ingest"; exit 0
+fi
+
+# Unique payload file (no fixed /tmp path), cleaned up on exit.
+PAYLOAD_FILE=$(mktemp "${TMPDIR:-/tmp}/o2_run_payload.XXXXXX")
+trap 'rm -f "$PAYLOAD_FILE"' EXIT
 
 API="${GITHUB_API_URL:-https://api.github.com}"
 gh_get(){ curl -s -H "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$API/$1"; }
 
-# wall-clock of one attempt = max(completed) - min(started) across its jobs.
+# wall-clock of one attempt = max(completed) - min(started) across its jobs (clamped non-negative
+# to guard against clock-skew where a completed_at precedes a started_at).
 attempt_wall(){ jq '[.jobs[]|select(.completed_at!=null and .started_at!=null)] as $j
-  | if ($j|length)>0 then (($j|map(.completed_at|fromdateiso8601)|max)-($j|map(.started_at|fromdateiso8601)|min)) else 0 end'; }
+  | (if ($j|length)>0 then (($j|map(.completed_at|fromdateiso8601)|max)-($j|map(.started_at|fromdateiso8601)|min)) else 0 end)
+  | if . < 0 then 0 else . end'; }
 
 RUN_JSON=$(gh_get "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" 2>/dev/null)
 [ -n "$RUN_JSON" ] || { echo "::warning::could not fetch run object — skipping"; exit 0; }
@@ -62,6 +71,6 @@ printf '%s' "$RUN_JSON" | jq \
      run_url: $run_url,
      final_duration_sec: ($final|round), total_duration_sec: ($total|round),
      retry_wasted_sec: (($total-$final)|round)
-   }' > /tmp/o2_run_payload.json 2>/dev/null || { echo "::warning::payload build failed"; exit 0; }
+   }' > "$PAYLOAD_FILE" 2>/dev/null || { echo "::warning::payload build failed"; exit 0; }
 
-bash "$(dirname "$0")/o2-report.sh" "$STREAM" /tmp/o2_run_payload.json
+bash "$(dirname "$0")/o2-report.sh" "$STREAM" "$PAYLOAD_FILE"

--- a/.github/scripts/o2-run-report.sh
+++ b/.github/scripts/o2-run-report.sh
@@ -62,7 +62,7 @@ printf '%s' "$RUN_JSON" | jq \
   '($attempt|tonumber) as $a |
    {
      _timestamp: ((.run_started_at // .created_at | fromdateiso8601) * 1000000 | floor),
-     workflow: $wf, suite: $suite, repo: $repo,
+     workflow: $wf, suite: $suite, repo: $repo, ingest_source: "live",
      run_id: $run_id, run_attempt: $a, retries: ($a-1), was_retried: ($a>1),
      conclusion: (if $conclusion=="" then .conclusion else $conclusion end),
      trigger: .event, author: (.actor.login // null), branch: .head_branch,

--- a/.github/scripts/o2_metrics_resync.py
+++ b/.github/scripts/o2_metrics_resync.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Fallback re-sync for OpenObserve CI metrics. Runs on a schedule and re-posts the last
+LOOKBACK_DAYS of runs for THIS repo's test workflows, tagged ingest_source="backfill".
+
+The live report jobs are the happy path (ingest_source="live"); this catches any run whose
+live emit was missed (skipped job, ingest blip, etc.). Dashboards dedup by run_id keeping the
+latest attempt and PREFER the live doc, so a backfill row only "wins" when live truly missed —
+which makes the live-vs-fallback split visible.
+
+Env: GITHUB_REPOSITORY, GH_TOKEN, O2_REPORTING_INGEST_BASE, O2_REPORTING_AUTH,
+     O2_REPORTING_INSECURE (opt), LOOKBACK_DAYS (default 2), GITHUB_API_URL (opt).
+Never raises fatally — best-effort.
+"""
+import os, json, ssl, base64, urllib.request, urllib.error, time
+from datetime import datetime, timezone, timedelta
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "")
+GH_TOKEN = os.environ.get("GH_TOKEN", "")
+BASE = os.environ.get("O2_REPORTING_INGEST_BASE", "")
+AUTH = os.environ.get("O2_REPORTING_AUTH", "")
+API = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+DAYS = int(os.environ.get("LOOKBACK_DAYS", "2"))
+CTX = ssl.create_default_context()
+if os.environ.get("O2_REPORTING_INSECURE", "") == "true":
+    CTX.check_hostname = False; CTX.verify_mode = ssl.CERT_NONE
+
+# (workflow file, stream, suite, is_regression)
+TARGETS = [
+    ("playwright.yml", "ci_test_runs", "ui", False),
+    ("api-testing.yml", "ci_test_runs", "api", False),
+    ("playwright_regression.yml", "ci_regression", "regression", True),
+]
+
+def gh(path):
+    req = urllib.request.Request(f"{API}/{path}", headers={
+        "Authorization": f"token {GH_TOKEN}", "Accept": "application/vnd.github+json"})
+    try:
+        with urllib.request.urlopen(req, context=CTX, timeout=30) as r:
+            return json.loads(r.read().decode())
+    except Exception as e:
+        print(f"  gh error {path}: {str(e)[:80]}"); return {}
+
+def ep(ts):
+    return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp() if ts else None
+
+def wall(jobs):
+    pts = [(ep(j.get("started_at")), ep(j.get("completed_at"))) for j in jobs
+           if j.get("started_at") and j.get("completed_at")]
+    if not pts: return 0
+    d = round(max(b for _, b in pts) - min(a for a, _ in pts))
+    return d if d >= 0 else 0
+
+def jdur(j):
+    if j.get("conclusion") in ("skipped", "cancelled", None): return None
+    a, b = ep(j.get("started_at")), ep(j.get("completed_at"))
+    if a is None or b is None: return None
+    d = round(b - a); return d if d >= 0 else None
+
+def reconstruct(run, suite, is_reg):
+    rid, att = run["id"], run.get("run_attempt", 1)
+    jobs = gh(f"repos/{REPO}/actions/runs/{rid}/attempts/{att}/jobs?per_page=100").get("jobs", [])
+    final = wall(jobs)
+    total = final
+    for n in range(1, att):
+        total += wall(gh(f"repos/{REPO}/actions/runs/{rid}/attempts/{n}/jobs?per_page=100").get("jobs", []))
+    started = ep(run.get("run_started_at") or run.get("created_at"))
+    prs = run.get("pull_requests") or []
+    doc = {
+        "_timestamp": int((started or time.time()) * 1_000_000),
+        "ingest_source": "backfill",
+        "workflow": "regression" if is_reg else "test",
+        "suite": suite, "repo": REPO,
+        "run_id": str(rid), "run_attempt": att,
+        "retries": att - 1, "was_retried": att > 1,
+        "conclusion": run.get("conclusion"),
+        "trigger": run.get("event"),
+        "author": (run.get("actor") or {}).get("login"),
+        "branch": run.get("head_branch"),
+        "commit_sha": (run.get("head_sha") or "")[:12],
+        "pr_number": (prs[0]["number"] if prs else None),
+        "run_url": run.get("html_url"),
+        "final_duration_sec": final, "total_duration_sec": total,
+        "retry_wasted_sec": total - final,
+    }
+    if is_reg:
+        sh = [j for j in jobs if j.get("name", "").startswith("e2e /")]
+        bj = [j for j in jobs if j.get("name") == "build_binary"]
+        doc.update({
+            "build_duration_sec": (jdur(bj[0]) if bj else None),
+            "shards_total": len(sh),
+            "shards_passed": sum(1 for j in sh if j.get("conclusion") == "success"),
+            "shards_failed": sum(1 for j in sh if j.get("conclusion") == "failure"),
+            "shards_skipped": sum(1 for j in sh if j.get("conclusion") in ("skipped", "cancelled")),
+            "shards": [{"name": j["name"], "conclusion": j.get("conclusion"), "duration_sec": jdur(j)} for j in sh],
+            "tests_total": None, "tests_passed": None, "tests_failed": None, "tests_flaky": None, "tests_skipped": None,
+        })
+    return doc
+
+def post(stream, docs):
+    if not docs: return 0
+    url = f"{BASE.rstrip('/')}/{stream}/_json"
+    hdr = {"Authorization": "Basic " + base64.b64encode(AUTH.encode()).decode(), "Content-Type": "application/json"}
+    ok = 0
+    for k in range(0, len(docs), 200):
+        chunk = docs[k:k+200]
+        for a in range(4):
+            try:
+                req = urllib.request.Request(url, data=json.dumps(chunk).encode(), headers=hdr, method="POST")
+                with urllib.request.urlopen(req, context=CTX, timeout=60) as r:
+                    ok += json.loads(r.read().decode()).get("status", [{}])[0].get("successful", 0)
+                break
+            except Exception as e:
+                if a == 3: print(f"  ingest error: {str(e)[:80]}")
+                else: time.sleep(2 * (a + 1))
+    return ok
+
+def main():
+    if not (REPO and GH_TOKEN and BASE and AUTH):
+        print("::notice::missing env (repo/token/O2_REPORTING_*) — skipping re-sync"); return
+    since = (datetime.now(timezone.utc) - timedelta(days=DAYS)).strftime("%Y-%m-%d")
+    grand = 0
+    for wf, stream, suite, is_reg in TARGETS:
+        runs = gh(f"repos/{REPO}/actions/workflows/{wf}/runs?created=%3E%3D{since}&per_page=100").get("workflow_runs", [])
+        runs = [r for r in runs if r.get("status") == "completed"]
+        docs = [reconstruct(r, suite, is_reg) for r in runs]
+        n = post(stream, docs); grand += n
+        print(f"{wf:<26} -> {stream} ({suite}): {len(docs)} runs, ingested {n}")
+    print(f"TOTAL re-synced: {grand}")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -491,3 +491,36 @@ jobs:
             echo "API tests failed: integration=${{ needs.api_integration_tests.result }}, query_agent=${{ needs.api_query_agent_tests.result }}, regression=${{ needs.api_regression_tests.result }}"
             exit 1
           fi
+
+  # Non-fatal metrics sidecar: one retry-aware run-summary doc to OpenObserve (stream ci_test_runs,
+  # suite=api). Re-runs append one doc per attempt; the dashboard keeps the latest attempt per run_id.
+  report_to_openobserve:
+    name: Report run metrics to OpenObserve
+    needs: [check_changes, api_integration_tests, api_query_agent_tests, api_regression_tests]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Clone the current repo
+        uses: actions/checkout@v5
+      - name: Report run metrics
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          O2_REPORTING_INGEST_BASE: ${{ secrets.O2_REPORTING_INGEST_BASE }}
+          O2_REPORTING_AUTH: ${{ secrets.O2_REPORTING_AUTH }}
+          O2_REPORTING_INSECURE: ${{ vars.O2_REPORTING_INSECURE }}
+          INTEG: ${{ needs.api_integration_tests.result }}
+          AGENT: ${{ needs.api_query_agent_tests.result }}
+          REG: ${{ needs.api_regression_tests.result }}
+        run: |
+          if [ "$INTEG" = "skipped" ] && [ "$AGENT" = "skipped" ] && [ "$REG" = "skipped" ]; then
+            echo "::notice::no API tests ran (no relevant changes) — skipping metrics"; exit 0
+          fi
+          if [ "$INTEG" = "failure" ] || [ "$AGENT" = "failure" ] || [ "$REG" = "failure" ]; then CONCLUSION=failure
+          elif [ "$INTEG" = "cancelled" ] || [ "$AGENT" = "cancelled" ] || [ "$REG" = "cancelled" ]; then CONCLUSION=cancelled
+          else CONCLUSION=success; fi
+          export CONCLUSION STREAM=ci_test_runs SUITE=api
+          bash .github/scripts/o2-run-report.sh

--- a/.github/workflows/o2-metrics-resync.yml
+++ b/.github/workflows/o2-metrics-resync.yml
@@ -1,0 +1,43 @@
+name: OpenObserve Metrics Re-sync (fallback)
+
+# Fallback for the LIVE per-run metrics (report_to_openobserve jobs in playwright.yml,
+# api-testing.yml, playwright_regression.yml). Those are the happy path (ingest_source="live").
+# This cron re-posts the last LOOKBACK_DAYS of runs tagged ingest_source="backfill" so any run
+# whose live emit was missed still lands. Dashboards dedup by run_id (latest attempt) and PREFER
+# the live doc, so a backfill row only surfaces when live genuinely missed — making the
+# live-vs-fallback split visible. No-ops until the O2_REPORTING_* secrets are set.
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # daily, 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      lookback_days:
+        description: "How many days back to re-sync"
+        required: false
+        default: "2"
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: o2-metrics-resync
+  cancel-in-progress: false
+
+jobs:
+  resync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Clone the current repo
+        uses: actions/checkout@v5
+      - name: Re-sync recent runs to OpenObserve
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          O2_REPORTING_INGEST_BASE: ${{ secrets.O2_REPORTING_INGEST_BASE }}
+          O2_REPORTING_AUTH: ${{ secrets.O2_REPORTING_AUTH }}
+          O2_REPORTING_INSECURE: ${{ vars.O2_REPORTING_INSECURE }}
+          LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '2' }}
+        run: python3 .github/scripts/o2_metrics_resync.py

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1138,3 +1138,36 @@ jobs:
             echo "  ui_integration_tests: ${{ needs.ui_integration_tests.result }}"
             exit 1
           fi
+
+  # Non-fatal metrics sidecar: one retry-aware run-summary doc to OpenObserve (stream ci_test_runs,
+  # suite=ui). Re-runs append one doc per attempt; the dashboard keeps the latest attempt per run_id.
+  report_to_openobserve:
+    name: Report run metrics to OpenObserve
+    needs: [check_changes, build_binary, ui_integration_tests]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Clone the current repo
+        uses: actions/checkout@v5
+      - name: Report run metrics
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          O2_REPORTING_INGEST_BASE: ${{ secrets.O2_REPORTING_INGEST_BASE }}
+          O2_REPORTING_AUTH: ${{ secrets.O2_REPORTING_AUTH }}
+          O2_REPORTING_INSECURE: ${{ vars.O2_REPORTING_INSECURE }}
+          BUILD: ${{ needs.build_binary.result }}
+          TESTS: ${{ needs.ui_integration_tests.result }}
+        run: |
+          # No relevant changes → tests were skipped → no run to record.
+          if [ "$TESTS" = "skipped" ] && [ "$BUILD" = "skipped" ]; then
+            echo "::notice::no tests ran (no relevant changes) — skipping metrics"; exit 0
+          fi
+          if [ "$TESTS" = "failure" ] || [ "$BUILD" = "failure" ]; then CONCLUSION=failure
+          elif [ "$TESTS" = "cancelled" ] || [ "$BUILD" = "cancelled" ]; then CONCLUSION=cancelled
+          else CONCLUSION=success; fi
+          export CONCLUSION STREAM=ci_test_runs SUITE=ui
+          bash .github/scripts/o2-run-report.sh

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -843,6 +843,7 @@ jobs:
                 author: \$actor,
                 branch: \$branch,
                 suite: \"regression\",
+                ingest_source: \"live\",
                 commit_sha: \$commit,
                 retries: ((\$run_attempt|tonumber)-1),
                 was_retried: ((\$run_attempt|tonumber)>1),

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -794,6 +794,23 @@ jobs:
 
           STATS="${MERGE_STATS:-}"; [ -z "$STATS" ] && STATS=null
 
+          # Retry-aware: this attempt's wall-clock + total summed across all attempts (so the
+          # latest-attempt doc carries the cumulative compute; dashboards keep latest per run_id).
+          ATT="${GITHUB_RUN_ATTEMPT:-1}"
+          awall(){ jq '[.jobs[]|select(.completed_at!=null and .started_at!=null)] as $j | (if ($j|length)>0 then (($j|map(.completed_at|fromdateiso8601)|max)-($j|map(.started_at|fromdateiso8601)|min)) else 0 end) | if . < 0 then 0 else . end'; }
+          FINAL_DUR=$(awall < jobs.json 2>/dev/null || echo 0)
+          TOTAL_DUR="$FINAL_DUR"
+          if [ "$ATT" -gt 1 ] 2>/dev/null; then
+            SUM="$FINAL_DUR"
+            for n in $(seq 1 $((ATT-1))); do
+              W=$(curl -s -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${n}/jobs?per_page=100" | awall 2>/dev/null || echo 0)
+              SUM=$(awk -v a="$SUM" -v b="$W" 'BEGIN{print a+b}')
+            done
+            TOTAL_DUR="$SUM"
+          fi
+          COMMIT="${GITHUB_SHA:0:12}"
+
           dur='if (.completed_at and .started_at) then ((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601)) else null end'
           jq -n \
             --slurpfile jb jobs.json \
@@ -809,6 +826,9 @@ jobs:
             --arg ui_result "$UI_RESULT" \
             --arg merge_result "$MERGE_RESULT" \
             --argjson stats "$STATS" \
+            --argjson final "${FINAL_DUR:-0}" \
+            --argjson total "${TOTAL_DUR:-0}" \
+            --arg commit "$COMMIT" \
             "
             (\$jb[0].jobs // []) as \$j
             | [ \$j[] | select(.conclusion != null) ] as \$done
@@ -820,7 +840,15 @@ jobs:
                 run_url: \$run_url,
                 trigger: \$trigger,
                 actor: \$actor,
+                author: \$actor,
                 branch: \$branch,
+                suite: \"regression\",
+                commit_sha: \$commit,
+                retries: ((\$run_attempt|tonumber)-1),
+                was_retried: ((\$run_attempt|tonumber)>1),
+                final_duration_sec: \$final,
+                total_duration_sec: \$total,
+                retry_wasted_sec: (\$total-\$final),
                 conclusion: (
                   if (\$build_result==\"cancelled\" or \$ui_result==\"cancelled\" or \$merge_result==\"cancelled\") then \"cancelled\"
                   elif (\$build_result==\"success\" and \$ui_result==\"success\") then \"success\"


### PR DESCRIPTION
## What

Makes the per-run test dashboards **live**. Adds non-fatal `report_to_openobserve` jobs that emit **one retry-aware run-summary doc per run** to OpenObserve, following the metrics work merged earlier (regression/docgen/council). Companion PR in the other repo mirrors this.

**Scope (this PR):**
1. **`playwright.yml` + `api-testing.yml`** → new report jobs → `ci_test_runs` (`suite=ui` / `suite=api`).
2. **`playwright_regression.yml`** → retry-aware reporting → `ci_regression` (OSS: augments the existing job; ENT: adds the job — was uninstrumented).

## How it works

- **Shared `.github/scripts/o2-run-report.sh`** (used by playwright/api) derives the run's `conclusion` from job results, wall-clock from the jobs API, and **sums cost across all attempts**. Regression jobs do the same inline (they also emit shard/build/test fields).
- Emits: `run_id`, `run_attempt`, `retries`, `was_retried`, `conclusion`, `suite`, `repo`, `branch`, `author`, `commit_sha`, `pr_number`, `trigger`, `final_duration_sec`, `total_duration_sec`, `retry_wasted_sec`.
- **Dedup model:** re-runs append one doc per attempt; dashboards keep the **latest attempt per `run_id`** via `row_number() OVER (PARTITION BY run_id ORDER BY run_attempt DESC)`. Retries become an *attribute*, never duplicate rows; `total_duration_sec` on the kept row carries cumulative compute.
- **Safe by construction:** `continue-on-error` + the never-fail poster — can't fail/slow a test run; skips when no tests ran; **no-ops until `O2_REPORTING_*` secrets are set**.

## Review
AI review addressed (mktemp payload, `GH_TOKEN` guard, non-negative duration clamp). YAML + jq unit-tested + `actionlint` clean on the added jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
