### PR TITLE
test: heal enterprise-only GeneralTests specs surfaced by ENT matrix sync (2047)

### DIFF
--- a/tests/ui-testing/playwright-tests/GeneralTests/ai-toolsets-form-validation.spec.js
+++ b/tests/ui-testing/playwright-tests/GeneralTests/ai-toolsets-form-validation.spec.js
@@ -159,9 +159,13 @@ test.describe('AI Toolsets form validation', { tag: '@enterprise' }, () => {
 test.describe('CrossLink dialog form validation', () => {
     test.describe.configure({ mode: 'serial' });
     let pm;
-    // Name of a stream to use for the cross-link tests. Can be any existing
-    // stream in the environment; falls back to 'default' if not set.
-    const testStream = process.env['TEST_STREAM_NAME'] || 'default';
+    // Name of a stream to use for the cross-link tests. Must be a *logs* stream:
+    // the streams page defaults to the "logs" type filter (LogStream.vue
+    // selectedStreamType=ref("logs")), so a non-logs stream (e.g. the traces
+    // stream named "default") never renders a row and the schema button is
+    // unreachable. e2e_automate is the logs stream the global ingestion always
+    // creates in CI; override via TEST_STREAM_NAME for other environments.
+    const testStream = process.env['TEST_STREAM_NAME'] || 'e2e_automate';
 
     test.beforeEach(async ({ page }, testInfo) => {
         testLogger.testStart(testInfo.title, testInfo.file);

--- a/tests/ui-testing/playwright-tests/GeneralTests/regex-patterns-form-validation.spec.js
+++ b/tests/ui-testing/playwright-tests/GeneralTests/regex-patterns-form-validation.spec.js
@@ -62,6 +62,11 @@ test.describe("Regex Patterns form validation", () => {
         // (vee-validate blocks the @submit handler while the form is invalid).
         await pm.regexPatternsFormValidation.clickSave();
 
+        // vee-validate blocks the @submit handler while the form is invalid, so
+        // no save fires and the drawer must stay open — guards against an
+        // accidental side-effect submit on the empty form.
+        await expect(pm.regexPatternsFormValidation.getDrawerLocator()).toBeVisible();
+
         // OFormInput validator: '* Name is required'
         await expect(pm.regexPatternsFormValidation.getNameErrorLocator()).toBeVisible();
         await expect(pm.regexPatternsFormValidation.getNameErrorLocator()).toContainText('* Name is required');

--- a/tests/ui-testing/playwright-tests/GeneralTests/regex-patterns-form-validation.spec.js
+++ b/tests/ui-testing/playwright-tests/GeneralTests/regex-patterns-form-validation.spec.js
@@ -49,17 +49,18 @@ test.describe("Regex Patterns form validation", () => {
         await pm.regexPatternsFormValidation.openAddPatternDrawer();
         await expect(pm.regexPatternsFormValidation.getDrawerLocator()).toBeVisible();
 
-        // Save button should be disabled because both fields are empty
-        // (isFormEmpty is true when name or pattern is empty)
-        await expect(pm.regexPatternsFormValidation.getSaveButtonLocator()).toBeDisabled();
+        // The Create button is NOT gated on form contents — AddRegexPattern.vue's
+        // ODrawer has no :primary-button-disabled binding, so the primary button
+        // stays enabled and validation is enforced on submit via the OForm schema.
+        // (Verified against the enterprise build; OSS skips this suite entirely.)
+        await expect(pm.regexPatternsFormValidation.getSaveButtonLocator()).toBeEnabled();
 
-        testLogger.info('Save button correctly disabled for empty form');
+        testLogger.info('Save button enabled for empty form — validation enforced on submit');
 
-        // OFormInput shows errors only when isTouched=true AND value is invalid.
-        // isTouched is set via field.handleBlur(), which OFormInput calls on every
-        // update:model-value event (fill → clear sequence triggers it reliably).
-        await pm.regexPatternsFormValidation.touchNameField();
-        await pm.regexPatternsFormValidation.touchPatternField();
+        // Submitting the empty form runs the OForm schema validators, which mark
+        // every field touched and surface the required errors without submitting
+        // (vee-validate blocks the @submit handler while the form is invalid).
+        await pm.regexPatternsFormValidation.clickSave();
 
         // OFormInput validator: '* Name is required'
         await expect(pm.regexPatternsFormValidation.getNameErrorLocator()).toBeVisible();


### PR DESCRIPTION
## What

Heals the two GeneralTests specs that fail in the ENT playwright matrix (ENT PR #2047, `test/ent-matrix-sync-missing-specs`) but are **skipped on OSS**.

Both cover **enterprise-only** features (Regex Patterns, AI Toolsets / CrossLink). Their `beforeEach` probes for the feature route and `test.skip()`s when absent — so on the OSS binary they never run. ENT PR #2047 adds them to the ENT matrix, running them against the enterprise build for the first time and exposing two assertions that were never actually exercised. Not regressions — untested assertions finally hitting a real enterprise build.

## Fixes

1. **regex-patterns-form-validation** — `AddRegexPattern.vue`'s ODrawer has no `:primary-button-disabled` binding, so the Create button stays enabled on an empty form (validation runs on submit via the OForm schema). Assert `toBeEnabled()` and trigger the required-field errors by submitting.
2. **ai-toolsets-form-validation (CrossLink)** — the streams page defaults to the "logs" type filter (`LogStream.vue selectedStreamType=ref("logs")`), so the traces stream named `default` never renders a row and `log-stream-schema-btn` is unreachable. Point the suite at `e2e_automate` (the logs stream global ingestion always creates; cross-linking is logs-only and gated by `ZO_ENABLE_CROSS_LINKING=true`, which CI sets).

## Verification

Reproduced both failures and verified the fixes on a local **enterprise** build (`build_type=enterprise`, v0.91.0-rc2):
- regex-patterns: all 4 tests pass.
- CrossLink: stream-detail step (original failure point) now passes; the tab additionally needs `ZO_ENABLE_CROSS_LINKING=true` (off on local dev binary, on in CI).

## Note

Branch name matches the ENT branch `test/ent-matrix-sync-missing-specs` so the ENT CI tree-merge picks up these fixes for PR #2047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)