### PR TITLE
ci: capture build time + shard tallies (UI/API) + per-shard regression rows

### DIFF
--- a/.github/scripts/o2-run-report.sh
+++ b/.github/scripts/o2-run-report.sh
@@ -58,8 +58,11 @@ fi
 
 WORKFLOW_TAG="test"; [ "$STREAM" = "ci_regression" ] && WORKFLOW_TAG="regression"
 
-# Build-job duration + shard tallies from this attempt's jobs (shard jobs are named "e2e / ...";
-# the app build job is "build_binary"). Null/0 for suites without them (e.g. API) — harmless.
+# Build-job duration + shard tallies from this attempt's jobs, added to the run doc:
+#   build_duration_sec  — wall-clock of the "build_binary" job (null if absent)
+#   shards_total/passed/failed/skipped — counts of the "e2e / *" shard jobs by conclusion
+# Shard jobs are matched by the "e2e /" name prefix; the build job by exact name "build_binary".
+# Suites without these jobs (e.g. API) get null/0 — harmless, those panels just stay empty.
 JOBDUR='if (.completed_at and .started_at) then ((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601)) else null end'
 BUILD_DUR=$(printf '%s' "$THIS_JOBS" | jq "[.jobs[]|select(.name==\"build_binary\")]|.[0]|if . then ($JOBDUR) else null end" 2>/dev/null)
 [ -n "$BUILD_DUR" ] || BUILD_DUR=null

--- a/.github/scripts/o2-run-report.sh
+++ b/.github/scripts/o2-run-report.sh
@@ -58,11 +58,24 @@ fi
 
 WORKFLOW_TAG="test"; [ "$STREAM" = "ci_regression" ] && WORKFLOW_TAG="regression"
 
+# Build-job duration + shard tallies from this attempt's jobs (shard jobs are named "e2e / ...";
+# the app build job is "build_binary"). Null/0 for suites without them (e.g. API) — harmless.
+JOBDUR='if (.completed_at and .started_at) then ((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601)) else null end'
+BUILD_DUR=$(printf '%s' "$THIS_JOBS" | jq "[.jobs[]|select(.name==\"build_binary\")]|.[0]|if . then ($JOBDUR) else null end" 2>/dev/null)
+[ -n "$BUILD_DUR" ] || BUILD_DUR=null
+SHARDS=$(printf '%s' "$THIS_JOBS" | jq -c '[.jobs[]|select(.name|startswith("e2e /"))] as $s
+  | {shards_total:($s|length),
+     shards_passed:([$s[]|select(.conclusion=="success")]|length),
+     shards_failed:([$s[]|select(.conclusion=="failure")]|length),
+     shards_skipped:([$s[]|select(.conclusion=="skipped" or .conclusion=="cancelled")]|length)}' 2>/dev/null)
+[ -n "$SHARDS" ] || SHARDS='{}'
+
 printf '%s' "$RUN_JSON" | jq \
   --arg suite "$SUITE" --arg conclusion "$CONCLUSION" --arg wf "$WORKFLOW_TAG" \
   --arg repo "$GITHUB_REPOSITORY" --arg run_id "$GITHUB_RUN_ID" --arg attempt "$ATT" \
   --arg run_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${ATT}" \
   --argjson final "${FINAL_DUR:-0}" --argjson total "${TOTAL_DUR:-0}" \
+  --argjson build "${BUILD_DUR:-null}" --argjson shards "${SHARDS:-{}}" \
   '($attempt|tonumber) as $a |
    {
      _timestamp: ((.run_started_at // .created_at | fromdateiso8601) * 1000000 | floor),
@@ -74,7 +87,10 @@ printf '%s' "$RUN_JSON" | jq \
      pr_number: (.pull_requests[0].number // null),
      run_url: $run_url,
      final_duration_sec: ($final|round), total_duration_sec: ($total|round),
-     retry_wasted_sec: (($total-$final)|round)
+     retry_wasted_sec: (($total-$final)|round),
+     build_duration_sec: ($build | if .==null then null else round end),
+     shards_total: ($shards.shards_total // null), shards_passed: ($shards.shards_passed // null),
+     shards_failed: ($shards.shards_failed // null), shards_skipped: ($shards.shards_skipped // null)
    }' > "$PAYLOAD_FILE" 2>/dev/null || { echo "::warning::payload build failed"; exit 0; }
 
 # Optional EXTRA_JSON: shallow-merge caller-supplied fields into the doc (e.g. test counts).

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -879,17 +879,21 @@ jobs:
 
           bash .github/scripts/o2-report.sh ci_regression payload.json
 
-          # Also emit one row per shard to ci_regression_shards (flattened from payload.shards)
-          # so the dashboard can chart per-shard durations / slowest shards / per-module health.
-          TS_US="$(date +%s)000000"
-          jq -c --arg ts "$TS_US" --arg repo "$GITHUB_REPOSITORY" --arg run_id "$GITHUB_RUN_ID" \
+          # Also emit one row per shard to the ci_regression_shards stream, flattened from
+          # payload.shards (each = {name, conclusion, duration_sec}). Powers per-shard duration /
+          # slowest-shard / per-module panels. Row schema:
+          #   run_id, repo, workflow="regression", ingest_source="live",
+          #   shard_name (raw job name), module (shard_name minus "e2e / " prefix and "-Regression"
+          #   suffix; "unknown" if empty), conclusion, duration_sec.
+          # _timestamp is intentionally NOT set, so OpenObserve stamps ingest time — same as the run
+          # doc above (which also leaves it unset), keeping the two streams time-aligned.
+          shards_json=$(jq -c --arg repo "$GITHUB_REPOSITORY" --arg run_id "$GITHUB_RUN_ID" \
             '[.shards[]? | {
-              _timestamp: ($ts|tonumber), run_id: $run_id, repo: $repo,
-              workflow: "regression", ingest_source: "live",
+              run_id: $run_id, repo: $repo, workflow: "regression", ingest_source: "live",
               shard_name: .name,
-              module: (.name | sub("^e2e / ";"") | sub("-Regression$";"")),
+              module: (.name | sub("^e2e / ";"") | sub("-Regression$";"") | if . == "" then "unknown" else . end),
               conclusion: .conclusion, duration_sec: .duration_sec
-            }]' payload.json > shards.json 2>/dev/null || echo '[]' > shards.json
+            }]' payload.json 2>/dev/null) && printf '%s' "$shards_json" > shards.json || echo '[]' > shards.json
           if [ "$(jq 'length' shards.json 2>/dev/null || echo 0)" -gt 0 ]; then
             bash .github/scripts/o2-report.sh ci_regression_shards shards.json
           else

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -878,3 +878,20 @@ jobs:
             " > payload.json || { echo "::warning::payload build failed"; echo '{}' > payload.json; }
 
           bash .github/scripts/o2-report.sh ci_regression payload.json
+
+          # Also emit one row per shard to ci_regression_shards (flattened from payload.shards)
+          # so the dashboard can chart per-shard durations / slowest shards / per-module health.
+          TS_US="$(date +%s)000000"
+          jq -c --arg ts "$TS_US" --arg repo "$GITHUB_REPOSITORY" --arg run_id "$GITHUB_RUN_ID" \
+            '[.shards[]? | {
+              _timestamp: ($ts|tonumber), run_id: $run_id, repo: $repo,
+              workflow: "regression", ingest_source: "live",
+              shard_name: .name,
+              module: (.name | sub("^e2e / ";"") | sub("-Regression$";"")),
+              conclusion: .conclusion, duration_sec: .duration_sec
+            }]' payload.json > shards.json 2>/dev/null || echo '[]' > shards.json
+          if [ "$(jq 'length' shards.json 2>/dev/null || echo 0)" -gt 0 ]; then
+            bash .github/scripts/o2-report.sh ci_regression_shards shards.json
+          else
+            echo "::notice::no shard rows to emit"
+          fi


### PR DESCRIPTION
Closes the **UI ↔ Regression dashboard parity** gaps by capturing the few fields the dashboards were missing. One PR (pairs with the same-branch ENT PR).

## Changes
- **`o2-run-report.sh`** (UI + API runs → `ci_test_runs`): adds
  - `build_duration_sec` (from the `build_binary` job)
  - `shards_total / shards_passed / shards_failed / shards_skipped` (from the `e2e /` shard jobs)
  - Null/0 for suites without them (API) — harmless.
- **`playwright_regression.yml`**: after the run doc, emits **one row per shard** to a new **`ci_regression_shards`** stream (flattened from `payload.shards`) → enables per-shard duration / slowest-shard / per-module panels.

## Why
The Regression tab had per-shard + build-time panels that UI/Combined couldn't match because the data wasn't captured. Now it is.

## Safety
All additions are non-fatal (the report job is `continue-on-error`; shard emit is guarded). Verified locally: build/shard jq (build=360, shards total/passed/failed correct), per-shard row shape (module extracted), and YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)