### PR TITLE
fix: broken UI/API metrics ingest (bash brace-default mangled jq --argjson)

### DIFF
--- a/.github/scripts/o2-run-report.sh
+++ b/.github/scripts/o2-run-report.sh
@@ -78,7 +78,7 @@ printf '%s' "$RUN_JSON" | jq \
   --arg repo "$GITHUB_REPOSITORY" --arg run_id "$GITHUB_RUN_ID" --arg attempt "$ATT" \
   --arg run_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${ATT}" \
   --argjson final "${FINAL_DUR:-0}" --argjson total "${TOTAL_DUR:-0}" \
-  --argjson build "${BUILD_DUR:-null}" --argjson shards "${SHARDS:-{}}" \
+  --argjson build "$BUILD_DUR" --argjson shards "$SHARDS" \
   '($attempt|tonumber) as $a |
    {
      _timestamp: ((.run_started_at // .created_at | fromdateiso8601) * 1000000 | floor),


### PR DESCRIPTION
## Urgent — regression from #12917
`o2-run-report.sh` used `--argjson shards "${SHARDS:-{}}"`. In bash, `${SHARDS:-{}}` parses as **“SHARDS or `{`” plus a trailing literal `}`**, so when SHARDS was set jq received `{...}}` — invalid JSON → `payload build failed` → **no `ci_test_runs` doc ingested for any UI/API run since #12917 merged** (~1h of missing UI/API run metrics).

Regression + inventory are unaffected (they don't use this script).

## Fix
`SHARDS` and `BUILD_DUR` are already defaulted (`'{}'` / `null`) just above, so pass them directly:
```
--argjson build "$BUILD_DUR" --argjson shards "$SHARDS"
```

Verified locally: payload now builds (`build_duration_sec:360, shards_total:21, shards_failed:1`); `bash -n` clean. Please merge ASAP to restore UI/API reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)