### PR TITLE
fix: remove trailing slash from the end in auth extractor

### DIFF
--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -339,7 +339,18 @@ where
             None => local_path.strip_prefix("/").unwrap_or(&local_path),
         };
 
-        let path_columns = path.split('/').collect::<Vec<&str>>();
+        let mut path_columns = path.split('/').collect::<Vec<&str>>();
+        // Drop a trailing empty segment produced by a trailing slash (e.g.
+        // "default/" -> ["default", ""]). Without this, the segment count is off
+        // by one and exact-length route matching in `resolve_permission` fails —
+        // e.g. the ES-compat org-root route `["{org}"]` never matches the
+        // slash-mandatory `/{org_id}/` handler. Mirrors `validate_credentials`.
+        if path_columns.len() > 1
+            && let Some(v) = path_columns.last()
+            && v.is_empty()
+        {
+            path_columns.pop();
+        }
         let url_len = path_columns.len();
         let org_id = if url_len > 1 && path_columns[0].eq(V2_API_PREFIX) {
             path_columns[1].to_string()


### PR DESCRIPTION
## Problem

Filebeat (and other Elasticsearch clients) can't ingest using an org ingestion token (`o2oi_…`). On startup Filebeat's `eslegclient` pings the root URL `GET /api/{org_id}/` to detect the ES version. That request **403s** (`Unauthorized Access`), so Filebeat never gets past the handshake and loops in backoff-retry, shipping nothing — even though `POST /api/{org_id}/_bulk` works fine.

## Root cause

The org-root handler is registered as the slash-mandatory route `/{org_id}/`, so every request to it carries a trailing slash. In `AuthExtractor::from_request_parts`, `"default/".split('/')` yields `["default", ""]` (len 2).

The ES-compat bypass entry in `ROUTE_PERMISSIONS` is `path: &["{org}"]` (len 1, `bypass: true`), and `path_matches` requires an exact length match (`si == path.len()`). The trailing empty segment makes the length 2 ≠ 1 → no match → the "route missing" fallback sets `bypass_check = false` with an empty `o2_type` → a roleless ingestion token hits OpenFGA → **403**.

Because the route *requires* the trailing slash, this bypass entry was effectively **dead code** — no request could ever satisfy both the route and the matcher. Notably `validate_credentials` already strips the trailing empty segment; `AuthExtractor` did not. That inconsistency was the bug.

## Fix

Strip a trailing empty path segment in `AuthExtractor::from_request_parts` before route resolution, mirroring `validate_credentials`:

```rust
let mut path_columns = path.split('/').collect::<Vec<&str>>();
if path_columns.len() > 1
    && let Some(v) = path_columns.last()
    && v.is_empty()
{
    path_columns.pop();
}
```

## Blast radius

- Only affects requests that arrive **with a trailing slash**; no-slash paths split identically → no behavior change.
- `/{org_id}/` is the **only** org-scoped handler in the codebase registered with a trailing slash; every other endpoint 404s at routing for trailing-slash requests regardless of auth, so no working (200) request can break.
- Trailing slash never grants more access than no-slash (verified for both token and root).
- Guarded `len > 1` → no empty-vec / out-of-bounds risk.

## Verification

Local: enterprise build, OpenFGA enabled, org ingestion token on `default`.

| Request | Before | After |
|---|---|---|
| token `GET /api/default/` (handshake) | 403 | **200** |
| token `POST /api/default/_bulk` | 200 | 200 |
| token `GET /api/default/streams` (real read API) | 401 | 401 (still blocked) |
| **Filebeat** (token) | `403 Forbidden` → infinite backoff | **"Connection established"**, logs ingested |
