### PR TITLE
ci: per-test flaky/failed → ci_test_results + per-shard API counts → ci_test_counts

### DIFF
--- a/.github/scripts/extract-flaky.js
+++ b/.github/scripts/extract-flaky.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Extract flaky + failed tests from a Playwright JSON report for OpenObserve.
+ *
+ * Usage:  node extract-flaky.js <path-to-report.json>
+ * Output: a JSON array on stdout, one object per flaky-or-failed test:
+ *           [{ module, title, file, status }]   status = "flaky" | "failed"
+ *
+ *   "flaky"  = Playwright status "flaky"      (failed, then passed on retry)
+ *   "failed" = Playwright status "unexpected" (failed even after retries)
+ *
+ * BOTH are captured on purpose. The consumer stream is `ci_test_results` (NOT
+ * `ci_test_flaky`) and every row carries a `status` field so dashboards can tell
+ * flaky from failed — a shard that failed then passed on rerun is flaky, not
+ * failed, and the per-test verdict here is what keeps that distinction honest.
+ *
+ * `title` comes from the SPEC (sp.title): in Playwright's JSON schema the spec is
+ * the test() call and holds the title; the per-project `test` objects nested under
+ * it have NO title field, so t.title would be undefined. Do not change to t.title.
+ *
+ * Never throws: a missing/malformed report is logged to stderr and prints `[]`
+ * with exit 0, so the calling workflow step stays non-fatal.
+ */
+const fs = require("fs");
+
+const reportPath = process.argv[2];
+if (!reportPath || !fs.existsSync(reportPath)) {
+  console.error(`extract-flaky: report not found at ${reportPath || "<no path>"}`);
+  process.stdout.write("[]");
+  process.exit(0);
+}
+
+let report;
+try {
+  report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+} catch (e) {
+  console.error("extract-flaky: report.json parse failed:", e && e.message);
+  process.stdout.write("[]");
+  process.exit(0);
+}
+
+const out = [];
+(function walk(suite) {
+  (suite.specs || []).forEach((sp) =>
+    (sp.tests || []).forEach((t) => {
+      if (t.status === "flaky" || t.status === "unexpected") {
+        const file = sp.file || suite.file || "";
+        out.push({
+          module: file.split("/")[0] || "unknown", // top-level test folder
+          title: sp.title,
+          file,
+          status: t.status === "flaky" ? "flaky" : "failed",
+        });
+      }
+    })
+  );
+  (suite.suites || []).forEach(walk);
+})({ suites: report.suites || [] });
+
+process.stdout.write(JSON.stringify(out));

--- a/.github/scripts/parse-api-junit.py
+++ b/.github/scripts/parse-api-junit.py
@@ -3,8 +3,9 @@
 
 The API suite is grouped into test CATEGORIES (set by the upload-artifact name
 `api-junit__<category>__<leg>` in api-testing.yml):
-  OSS = api_integration_tests, query_agent_tests
-  ENT = api_integration_tests, query_agent_tests, cli, vortex
+  OSS = api_integration_tests, query_agent_memtable, query_agent_parquet
+  ENT = api_integration_tests, query_agent_memtable, query_agent_parquet, cli, vortex
+(query_agent is split by phase — see PHASE_RE below.)
 Several jobs/shards fold into one category (their test sets are DISJOINT, so the
 dedup below makes "within-category dedup" == sum):
   api_integration_tests = the integration default-set + regression (+ ENT's
@@ -35,10 +36,21 @@ Best-effort: unreadable files are skipped; on no input it still prints zeroes.
 import glob
 import json
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 
 RANK = {"skipped": 0, "passed": 1, "failed": 2}
+
+# The query_agent SQL suite runs every query in two phases — memtable and parquet
+# (pytest classes test_1_memtable / test_2_parquet) — and a vortex phase
+# (test_3_vortex). They're genuinely separate tests (different code paths), so
+# rather than one big query_agent bucket we split it BY PHASE from the classname:
+# query_agent_memtable / query_agent_parquet, and route the vortex phase into the
+# `vortex` category (so ENT's main query_agent run, which also executes
+# test_3_vortex, merges with the dedicated vortex job). Tests whose classname
+# doesn't match keep their artifact-derived category untouched.
+PHASE_RE = re.compile(r"test_\d+_(memtable|parquet|vortex)")
 
 
 def category_of(path: str, root: str) -> str:
@@ -46,6 +58,14 @@ def category_of(path: str, root: str) -> str:
     top = rel.split(os.sep)[0]  # per-artifact subdir name
     parts = top.split("__")
     return parts[1] if len(parts) >= 2 else top
+
+
+def refine_category(base: str, classname: str) -> str:
+    m = PHASE_RE.search(classname or "")
+    if not m:
+        return base
+    phase = m.group(1)
+    return "vortex" if phase == "vortex" else f"query_agent_{phase}"
 
 
 def summarize(status_map: dict) -> dict:
@@ -63,15 +83,17 @@ def main() -> int:
     root = sys.argv[1] if len(sys.argv) > 1 else "junit-xml"
     cats: dict[str, dict] = {}
     for path in glob.glob(f"{root}/**/*.xml", recursive=True):
-        cat = category_of(path, root)
-        seen = cats.setdefault(cat, {})
+        base = category_of(path, root)
         try:
             tree = ET.parse(path)
         except Exception as e:  # noqa: BLE001 - skip unreadable/partial files
             print(f"parse-api-junit: skipping {path}: {e}", file=sys.stderr)
             continue
         for tc in tree.getroot().iter("testcase"):
-            key = (tc.get("classname", ""), tc.get("name", ""))
+            classname = tc.get("classname", "")
+            cat = refine_category(base, classname)  # phase-split query_agent
+            seen = cats.setdefault(cat, {})
+            key = (classname, tc.get("name", ""))
             status = "passed"
             for child in tc:
                 tag = child.tag.lower()

--- a/.github/scripts/parse-api-junit.py
+++ b/.github/scripts/parse-api-junit.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Aggregate API pytest junit XML into PER-CATEGORY + total test-count summaries.
+
+The API suite is sharded into test CATEGORIES (the api-testing.yml matrix
+"shards"): e.g. OSS = integration / query_agent / regression; ENT additionally
+splits integration into oss_in_ent / ent_top / ent_rbac and adds cli / vortex_*.
+Some categories run the SAME tests under several env-flag matrix legs
+(query_agent opt true|false; regression utf8/join combos) — those legs must
+collapse, not multiply, the count. So within each category we DEDUP by test
+identity (classname::name) and pick the worst status across legs:
+
+    failed  if it failed/errored in ANY leg   (precedence 2)
+    passed  if it passed in any leg (never failed)  (precedence 1)
+    skipped only if skipped in EVERY leg           (precedence 0)
+
+Category is read from the per-artifact download subdir name, which the workflow
+names `api-junit__<category>__<leg>` (download-artifact WITHOUT merge-multiple,
+so each artifact is its own subdir). category = the part between the `__`s.
+
+Emits one JSON object on stdout:
+  {"total": {tests_total,tests_passed,tests_failed,tests_flaky,tests_skipped},
+   "by_category": [{module, tests_total, ...}, ...]}
+`total` dedups across every category (categories are disjoint test dirs, so this
+also equals the sum, but global dedup guards against accidental overlap).
+flaky is always 0 (pytest doesn't flag reruns without pytest-rerunfailures).
+
+Best-effort: unreadable files are skipped; on no input it still prints zeroes.
+"""
+import glob
+import json
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+RANK = {"skipped": 0, "passed": 1, "failed": 2}
+
+
+def category_of(path: str, root: str) -> str:
+    rel = os.path.relpath(path, root)
+    top = rel.split(os.sep)[0]  # per-artifact subdir name
+    parts = top.split("__")
+    return parts[1] if len(parts) >= 2 else top
+
+
+def summarize(status_map: dict) -> dict:
+    vals = list(status_map.values())
+    return {
+        "tests_total": len(vals),
+        "tests_passed": vals.count("passed"),
+        "tests_failed": vals.count("failed"),
+        "tests_flaky": 0,
+        "tests_skipped": vals.count("skipped"),
+    }
+
+
+def main() -> int:
+    root = sys.argv[1] if len(sys.argv) > 1 else "junit-xml"
+    cats: dict[str, dict] = {}
+    for path in glob.glob(f"{root}/**/*.xml", recursive=True):
+        cat = category_of(path, root)
+        seen = cats.setdefault(cat, {})
+        try:
+            tree = ET.parse(path)
+        except Exception as e:  # noqa: BLE001 - skip unreadable/partial files
+            print(f"parse-api-junit: skipping {path}: {e}", file=sys.stderr)
+            continue
+        for tc in tree.getroot().iter("testcase"):
+            key = (tc.get("classname", ""), tc.get("name", ""))
+            status = "passed"
+            for child in tc:
+                tag = child.tag.lower()
+                if tag == "skipped":
+                    status = "skipped"
+                elif tag in ("failure", "error"):
+                    status = "failed"
+            prev = seen.get(key)
+            if prev is None or RANK[status] > RANK[prev]:
+                seen[key] = status
+
+    by_category = [
+        {"module": cat, **summarize(m)} for cat, m in sorted(cats.items())
+    ]
+    global_map: dict = {}
+    for m in cats.values():
+        for key, status in m.items():
+            prev = global_map.get(key)
+            if prev is None or RANK[status] > RANK[prev]:
+                global_map[key] = status
+
+    print(json.dumps({"total": summarize(global_map), "by_category": by_category}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/parse-api-junit.py
+++ b/.github/scripts/parse-api-junit.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 """Aggregate API pytest junit XML into PER-CATEGORY + total test-count summaries.
 
-The API suite is sharded into test CATEGORIES (the api-testing.yml matrix
-"shards"): e.g. OSS = integration / query_agent / regression; ENT additionally
-splits integration into oss_in_ent / ent_top / ent_rbac and adds cli / vortex_*.
-Some categories run the SAME tests under several env-flag matrix legs
-(query_agent opt true|false; regression utf8/join combos) — those legs must
-collapse, not multiply, the count. So within each category we DEDUP by test
-identity (classname::name) and pick the worst status across legs:
+The API suite is grouped into test CATEGORIES (set by the upload-artifact name
+`api-junit__<category>__<leg>` in api-testing.yml):
+  OSS = api_integration_tests, query_agent_tests
+  ENT = api_integration_tests, query_agent_tests, cli, vortex
+Several jobs/shards fold into one category (their test sets are DISJOINT, so the
+dedup below makes "within-category dedup" == sum):
+  api_integration_tests = the integration default-set + regression (+ ENT's
+                          oss_in_ent / ent_top / ent_rbac shards)
+  vortex                = tests/vortex/* + test_3_vortex.py
+Other jobs re-run the SAME tests under several env-flag matrix legs (query_agent
+opt true|false; regression utf8/join combos) — those legs must collapse, not
+multiply, the count. So within each category we DEDUP by test identity
+(classname::name) and pick the worst status across legs:
 
     failed  if it failed/errored in ANY leg   (precedence 2)
     passed  if it passed in any leg (never failed)  (precedence 1)

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -142,7 +142,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: api-junit__integration__main
+          name: api-junit__api_integration_tests__main
           path: tests/api-testing/junit-integration.xml
           if-no-files-found: warn
           retention-days: 7
@@ -258,7 +258,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: api-junit__query_agent__${{ matrix.config.label }}
+          name: api-junit__query_agent_tests__${{ matrix.config.label }}
           path: tests/api-testing/junit-queryagent-${{ matrix.config.label }}.xml
           if-no-files-found: warn
           retention-days: 7
@@ -372,7 +372,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: api-junit__regression__${{ matrix.config.label }}
+          name: api-junit__api_integration_tests__regression_${{ matrix.config.label }}
           path: tests/api-testing/junit-regression-${{ matrix.config.label }}.xml
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -131,9 +131,21 @@ jobs:
             fi
             sleep 1
           done
-          rye run pytest --ignore=tests/regression --ignore=tests/query_agent --ignore=tests/vortex
+          rye run pytest --ignore=tests/regression --ignore=tests/query_agent --ignore=tests/vortex --junitxml=junit-integration.xml
           kill $SERVER_PID_DEFAULT || true
         working-directory: tests/api-testing/
+
+      # Test-count metrics sidecar: ship the junit so report_to_openobserve can
+      # tally API active/skipped counts (suite=api). always() so counts emit even
+      # when pytest fails (junit is written before pytest's non-zero exit).
+      - name: Upload API junit (integration)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-junit__integration__main
+          path: tests/api-testing/junit-integration.xml
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Upload OpenObserve server logs on failure
         if: failure()
@@ -236,9 +248,20 @@ jobs:
             sleep 1
           done
           # SINGLE_NODE_OPT_MODE controls which queries load_all_queries() includes
-          SINGLE_NODE_OPT_MODE=${{ matrix.config.mode }} rye run pytest tests/query_agent/ --ignore=tests/query_agent/test_3_vortex.py -v
+          SINGLE_NODE_OPT_MODE=${{ matrix.config.mode }} rye run pytest tests/query_agent/ --ignore=tests/query_agent/test_3_vortex.py -v --junitxml=junit-queryagent-${{ matrix.config.label }}.xml
           kill $SERVER_PID || true
         working-directory: tests/api-testing/
+
+      # Test-count metrics sidecar (see integration job). Parser dedups the two
+      # opt-mode legs by test identity so the same suite isn't counted twice.
+      - name: Upload API junit (query_agent)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-junit__query_agent__${{ matrix.config.label }}
+          path: tests/api-testing/junit-queryagent-${{ matrix.config.label }}.xml
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Upload server log on failure
         if: failure()
@@ -339,9 +362,20 @@ jobs:
             fi
             sleep 1
           done
-          rye run pytest ${{ matrix.config.target }} -v
+          rye run pytest ${{ matrix.config.target }} -v --junitxml=junit-regression-${{ matrix.config.label }}.xml
           kill $SERVER_PID || true
         working-directory: tests/api-testing/
+
+      # Test-count metrics sidecar (see integration job). Parser dedups the
+      # flag-combo legs that re-run the same target files.
+      - name: Upload API junit (regression)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-junit__regression__${{ matrix.config.label }}
+          path: tests/api-testing/junit-regression-${{ matrix.config.label }}.xml
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Upload server log on failure
         if: failure()
@@ -505,6 +539,16 @@ jobs:
     steps:
       - name: Clone the current repo
         uses: actions/checkout@v5
+      # Pull every per-shard junit. NO merge-multiple: each artifact lands in its
+      # own subdir (api-junit__<category>__<leg>) so the parser can read the test
+      # CATEGORY from the dir name. Missing artifacts are non-fatal.
+      - name: Download API junit reports
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: api-junit__*
+          path: junit-xml
       - name: Report run metrics
         continue-on-error: true
         env:
@@ -523,4 +567,21 @@ jobs:
           elif [ "$INTEG" = "cancelled" ] || [ "$AGENT" = "cancelled" ] || [ "$REG" = "cancelled" ]; then CONCLUSION=cancelled
           else CONCLUSION=success; fi
           export CONCLUSION STREAM=ci_test_runs SUITE=api
+          # Parse junit into per-category + total counts. The TOTAL folds into the
+          # run doc (EXTRA_JSON) so suite=api shows up in the same KPI/pie panels
+          # as UI; the per-category rows go to ci_test_counts for the per-shard
+          # breakdown (the API analog of UI's ci_test_modules). All best-effort.
+          if [ -d junit-xml ]; then
+            COUNTS=$(python3 .github/scripts/parse-api-junit.py junit-xml 2>/dev/null || echo "")
+            if [ -n "$COUNTS" ] && printf '%s' "$COUNTS" | jq -e . >/dev/null 2>&1; then
+              echo "API counts: $COUNTS"
+              EXTRA_JSON=$(printf '%s' "$COUNTS" | jq -c .total); export EXTRA_JSON
+              printf '%s' "$COUNTS" | jq -c --arg run_id "$GITHUB_RUN_ID" --arg repo "$GITHUB_REPOSITORY" \
+                '[.by_category[] | {run_id:$run_id, repo:$repo, suite:"api", workflow:"test", ingest_source:"live",
+                  module:.module, tests_total, tests_passed, tests_failed, tests_flaky, tests_skipped}]' > api_counts_rows.json
+              if [ "$(jq 'length' api_counts_rows.json 2>/dev/null || echo 0)" -gt 0 ]; then
+                bash .github/scripts/o2-report.sh ci_test_counts api_counts_rows.json
+              fi
+            fi
+          fi
           bash .github/scripts/o2-run-report.sh

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -890,6 +890,8 @@ jobs:
       # Compact Playwright stats (expected/unexpected/flaky/skipped) from the merged report.json,
       # consumed by report_to_openobserve to record per-test counts in ci_test_runs.
       stats: ${{ steps.report_stats.outputs.stats }}
+      # Flaky test names + their module (top-level test folder), JSON array, for ci_test_flaky.
+      flaky: ${{ steps.report_flaky.outputs.flaky }}
 
     steps:
       - name: Clone the current repo
@@ -991,6 +993,25 @@ jobs:
           fi
           echo "stats=$STATS" >> "$GITHUB_OUTPUT"
           echo "report stats: $STATS"
+
+      - name: Extract flaky tests for OpenObserve
+        id: report_flaky
+        if: always()
+        run: |
+          cd tests/ui-testing
+          if [ -f playwright-results/report.json ]; then
+            # Pull each flaky test (status==="flaky": failed then passed on retry) + its module
+            # (top-level test folder from the spec file path). Single-line JSON for GITHUB_OUTPUT.
+            FLAKY=$(node -e '
+              const fs=require("fs"); let r; try{r=JSON.parse(fs.readFileSync("playwright-results/report.json","utf8"))}catch(e){process.stdout.write("[]");process.exit(0)}
+              const out=[]; (function w(s){(s.specs||[]).forEach(sp=>(sp.tests||[]).forEach(t=>{if(t.status==="flaky"){const f=(sp.file||s.file||"");out.push({module:(f.split("/")[0]||"unknown"),title:sp.title,file:f})}}));(s.suites||[]).forEach(w)})({suites:r.suites||[]});
+              process.stdout.write(JSON.stringify(out));
+            ' 2>/dev/null || echo "[]")
+          else
+            FLAKY="[]"
+          fi
+          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
+          echo "flaky tests: $FLAKY"
 
       - name: Cache test failures to TestDino
         if: ${{ needs.ui_integration_tests.result == 'failure' }}
@@ -1177,6 +1198,7 @@ jobs:
           BUILD: ${{ needs.build_binary.result }}
           TESTS: ${{ needs.ui_integration_tests.result }}
           MERGE_STATS: ${{ needs.merge_and_upload_reports.outputs.stats }}
+          MERGE_FLAKY: ${{ needs.merge_and_upload_reports.outputs.flaky }}
         run: |
           # No relevant changes → tests were skipped → no run to record.
           if [ "$TESTS" = "skipped" ] && [ "$BUILD" = "skipped" ]; then
@@ -1193,3 +1215,15 @@ jobs:
           fi
           export CONCLUSION STREAM=ci_test_runs SUITE=ui
           bash .github/scripts/o2-run-report.sh
+
+          # Emit one row per flaky test (with its module) to ci_test_flaky, for the per-module
+          # flaky dashboard. Non-fatal: empty/parse issues just skip. _timestamp left unset -> ingest time.
+          FLAKY="${MERGE_FLAKY:-[]}"
+          if printf '%s' "$FLAKY" | jq -e 'type=="array" and length>0' >/dev/null 2>&1; then
+            printf '%s' "$FLAKY" | jq -c --arg run_id "$GITHUB_RUN_ID" --arg repo "$GITHUB_REPOSITORY" \
+              '[.[] | {run_id:$run_id, repo:$repo, suite:"ui", workflow:"test", ingest_source:"live", module:.module, test_title:.title, test_file:.file}]' \
+              > flaky.json 2>/dev/null || echo '[]' > flaky.json
+            if [ "$(jq 'length' flaky.json 2>/dev/null || echo 0)" -gt 0 ]; then
+              bash .github/scripts/o2-report.sh ci_test_flaky flaky.json
+            fi
+          fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1004,7 +1004,7 @@ jobs:
             # (top-level test folder from the spec file path). Single-line JSON for GITHUB_OUTPUT.
             FLAKY=$(node -e '
               const fs=require("fs"); let r; try{r=JSON.parse(fs.readFileSync("playwright-results/report.json","utf8"))}catch(e){process.stdout.write("[]");process.exit(0)}
-              const out=[]; (function w(s){(s.specs||[]).forEach(sp=>(sp.tests||[]).forEach(t=>{if(t.status==="flaky"){const f=(sp.file||s.file||"");out.push({module:(f.split("/")[0]||"unknown"),title:sp.title,file:f})}}));(s.suites||[]).forEach(w)})({suites:r.suites||[]});
+              const out=[]; (function w(s){(s.specs||[]).forEach(sp=>(sp.tests||[]).forEach(t=>{if(t.status==="flaky"||t.status==="unexpected"){const f=(sp.file||s.file||"");out.push({module:(f.split("/")[0]||"unknown"),title:sp.title,file:f,status:(t.status==="flaky"?"flaky":"failed")})}}));(s.suites||[]).forEach(w)})({suites:r.suites||[]});
               process.stdout.write(JSON.stringify(out));
             ' 2>/dev/null || echo "[]")
           else
@@ -1216,12 +1216,14 @@ jobs:
           export CONCLUSION STREAM=ci_test_runs SUITE=ui
           bash .github/scripts/o2-run-report.sh
 
-          # Emit one row per flaky test (with its module) to ci_test_flaky, for the per-module
-          # flaky dashboard. Non-fatal: empty/parse issues just skip. _timestamp left unset -> ingest time.
+          # Emit one row per flaky-or-failed test (with its module + status) to ci_test_flaky, for
+          # the per-module flaky/failed dashboards. status: "flaky" (failed then passed on retry) or
+          # "failed" (failed even after retries) — from report.json's final per-test verdict, so flaky
+          # is never mislabeled as failed. Non-fatal; _timestamp left unset -> ingest time.
           FLAKY="${MERGE_FLAKY:-[]}"
           if printf '%s' "$FLAKY" | jq -e 'type=="array" and length>0' >/dev/null 2>&1; then
             printf '%s' "$FLAKY" | jq -c --arg run_id "$GITHUB_RUN_ID" --arg repo "$GITHUB_REPOSITORY" \
-              '[.[] | {run_id:$run_id, repo:$repo, suite:"ui", workflow:"test", ingest_source:"live", module:.module, test_title:.title, test_file:.file}]' \
+              '[.[] | {run_id:$run_id, repo:$repo, suite:"ui", workflow:"test", ingest_source:"live", status:.status, module:.module, test_title:.title, test_file:.file}]' \
               > flaky.json 2>/dev/null || echo '[]' > flaky.json
             if [ "$(jq 'length' flaky.json 2>/dev/null || echo 0)" -gt 0 ]; then
               bash .github/scripts/o2-report.sh ci_test_flaky flaky.json

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1003,10 +1003,10 @@ jobs:
             # Pull each flaky test (status==="flaky": failed then passed on retry) + its module
             # (top-level test folder from the spec file path). Single-line JSON for GITHUB_OUTPUT.
             FLAKY=$(node -e '
-              const fs=require("fs"); let r; try{r=JSON.parse(fs.readFileSync("playwright-results/report.json","utf8"))}catch(e){process.stdout.write("[]");process.exit(0)}
+              const fs=require("fs"); let r; try{r=JSON.parse(fs.readFileSync("playwright-results/report.json","utf8"))}catch(e){console.error("flaky-extract: report.json parse failed:",e&&e.message);process.stdout.write("[]");process.exit(0)}
               const out=[]; (function w(s){(s.specs||[]).forEach(sp=>(sp.tests||[]).forEach(t=>{if(t.status==="flaky"||t.status==="unexpected"){const f=(sp.file||s.file||"");out.push({module:(f.split("/")[0]||"unknown"),title:sp.title,file:f,status:(t.status==="flaky"?"flaky":"failed")})}}));(s.suites||[]).forEach(w)})({suites:r.suites||[]});
               process.stdout.write(JSON.stringify(out));
-            ' 2>/dev/null || echo "[]")
+            ' || echo "[]")
           else
             FLAKY="[]"
           fi
@@ -1226,6 +1226,6 @@ jobs:
               '[.[] | {run_id:$run_id, repo:$repo, suite:"ui", workflow:"test", ingest_source:"live", status:.status, module:.module, test_title:.title, test_file:.file}]' \
               > flaky.json 2>/dev/null || echo '[]' > flaky.json
             if [ "$(jq 'length' flaky.json 2>/dev/null || echo 0)" -gt 0 ]; then
-              bash .github/scripts/o2-report.sh ci_test_flaky flaky.json
+              bash .github/scripts/o2-report.sh ci_test_results flaky.json
             fi
           fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1009,6 +1009,45 @@ jobs:
           # Log a count only — avoid dumping test file paths/titles into public CI logs.
           echo "flaky/failed test count: $(printf '%s' "$FLAKY" | jq 'length' 2>/dev/null || echo '?')"
 
+      # Non-fatal metrics sidecar — runs HERE inside the report flow (like the TestDino
+      # step below) so it never trails / gates playwright_summary (which doesn't need this
+      # job). One retry-aware run-summary doc to OpenObserve (ci_test_runs, suite=ui) plus
+      # per-test flaky/failed rows to ci_test_results. continue-on-error: never fails the run.
+      - name: Report run metrics to OpenObserve
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          O2_REPORTING_INGEST_BASE: ${{ secrets.O2_REPORTING_INGEST_BASE }}
+          O2_REPORTING_AUTH: ${{ secrets.O2_REPORTING_AUTH }}
+          O2_REPORTING_INSECURE: ${{ vars.O2_REPORTING_INSECURE }}
+          TESTS: ${{ needs.ui_integration_tests.result }}
+          MERGE_STATS: ${{ steps.report_stats.outputs.stats }}
+          MERGE_FLAKY: ${{ steps.report_flaky.outputs.flaky }}
+        run: |
+          # This job runs only when tests actually ran (merge `if:` gates on !cancelled &&
+          # ui != skipped), so TESTS is success|failure here.
+          if [ "$TESTS" = "failure" ]; then CONCLUSION=failure; else CONCLUSION=success; fi
+          # Per-test counts from the merged report.json (tests_total includes skipped).
+          if [ -n "${MERGE_STATS:-}" ] && [ "$MERGE_STATS" != "null" ] && [ "$MERGE_STATS" != "{}" ]; then
+            EXTRA_JSON=$(printf '%s' "$MERGE_STATS" | jq -c '{tests_total:((.expected//0)+(.unexpected//0)+(.flaky//0)+(.skipped//0)), tests_passed:(.expected//0), tests_failed:(.unexpected//0), tests_flaky:(.flaky//0), tests_skipped:(.skipped//0)}' 2>/dev/null || echo "")
+            [ -n "$EXTRA_JSON" ] && export EXTRA_JSON
+          fi
+          export CONCLUSION STREAM=ci_test_runs SUITE=ui
+          bash .github/scripts/o2-run-report.sh
+          # One row per flaky-or-failed test -> ci_test_results (status flaky|failed; suite/
+          # workflow hardcoded UI-only). o2-report.sh takes the stream as arg 1. Non-fatal.
+          FLAKY="${MERGE_FLAKY:-[]}"
+          if printf '%s' "$FLAKY" | jq -e 'type=="array" and length>0' >/dev/null 2>&1; then
+            FLAKY_FILE=$(mktemp "${TMPDIR:-/tmp}/flaky.XXXXXX")
+            trap 'rm -f "$FLAKY_FILE"' EXIT
+            printf '%s' "$FLAKY" | jq -c --arg run_id "$GITHUB_RUN_ID" --arg repo "$GITHUB_REPOSITORY" \
+              '[.[] | {run_id:$run_id, repo:$repo, suite:"ui", workflow:"test", ingest_source:"live", status:.status, module:.module, test_title:.title, test_file:.file}]' \
+              > "$FLAKY_FILE" 2>/dev/null || echo '[]' > "$FLAKY_FILE"
+            if [ "$(jq 'length' "$FLAKY_FILE" 2>/dev/null || echo 0)" -gt 0 ]; then
+              bash .github/scripts/o2-report.sh ci_test_results "$FLAKY_FILE"
+            fi
+          fi
+
       - name: Cache test failures to TestDino
         if: ${{ needs.ui_integration_tests.result == 'failure' }}
         env:
@@ -1169,67 +1208,4 @@ jobs:
             echo "  build_binary: ${{ needs.build_binary.result }}"
             echo "  ui_integration_tests: ${{ needs.ui_integration_tests.result }}"
             exit 1
-          fi
-
-  # Non-fatal metrics sidecar: one retry-aware run-summary doc to OpenObserve (stream ci_test_runs,
-  # suite=ui). Re-runs append one doc per attempt; the dashboard keeps the latest attempt per run_id.
-  report_to_openobserve:
-    name: Report run metrics to OpenObserve
-    needs: [check_changes, build_binary, ui_integration_tests, merge_and_upload_reports]
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-    steps:
-      - name: Clone the current repo
-        uses: actions/checkout@v5
-      - name: Report run metrics
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          O2_REPORTING_INGEST_BASE: ${{ secrets.O2_REPORTING_INGEST_BASE }}
-          O2_REPORTING_AUTH: ${{ secrets.O2_REPORTING_AUTH }}
-          O2_REPORTING_INSECURE: ${{ vars.O2_REPORTING_INSECURE }}
-          BUILD: ${{ needs.build_binary.result }}
-          TESTS: ${{ needs.ui_integration_tests.result }}
-          MERGE_STATS: ${{ needs.merge_and_upload_reports.outputs.stats }}
-          # Flaky/failed test rows (JSON array, "[]" if none) → ci_test_results below.
-          MERGE_FLAKY: ${{ needs.merge_and_upload_reports.outputs.flaky }}
-        run: |
-          # No relevant changes → tests were skipped → no run to record.
-          if [ "$TESTS" = "skipped" ] && [ "$BUILD" = "skipped" ]; then
-            echo "::notice::no tests ran (no relevant changes) — skipping metrics"; exit 0
-          fi
-          if [ "$TESTS" = "failure" ] || [ "$BUILD" = "failure" ]; then CONCLUSION=failure
-          elif [ "$TESTS" = "cancelled" ] || [ "$BUILD" = "cancelled" ]; then CONCLUSION=cancelled
-          else CONCLUSION=success; fi
-          # Per-test counts from the merged report.json. tests_total is the FULL total (includes
-          # skipped, matching regression); the dashboard derives executed = passed+failed+flaky.
-          if [ -n "${MERGE_STATS:-}" ] && [ "$MERGE_STATS" != "null" ] && [ "$MERGE_STATS" != "{}" ]; then
-            EXTRA_JSON=$(printf '%s' "$MERGE_STATS" | jq -c '{tests_total:((.expected//0)+(.unexpected//0)+(.flaky//0)+(.skipped//0)), tests_passed:(.expected//0), tests_failed:(.unexpected//0), tests_flaky:(.flaky//0), tests_skipped:(.skipped//0)}' 2>/dev/null || echo "")
-            [ -n "$EXTRA_JSON" ] && export EXTRA_JSON
-          fi
-          export CONCLUSION STREAM=ci_test_runs SUITE=ui
-          bash .github/scripts/o2-run-report.sh
-
-          # Emit one row per flaky-or-failed test (module + status) to ci_test_results, for the
-          # per-module flaky/failed dashboards. Row schema:
-          #   {run_id, repo, suite:"ui", workflow:"test", ingest_source:"live",
-          #    status:"flaky"|"failed", module, test_title, test_file}
-          # suite/workflow are hardcoded — this step is UI-only. status comes from report.json's
-          # final per-test verdict, so a flaky test (failed then passed on retry) is never
-          # mislabeled as failed. MERGE_FLAKY is the merge job's `flaky` output (JSON array, "[]"
-          # if none). Non-fatal throughout; _timestamp left unset -> ingest time. o2-report.sh
-          # takes the stream as arg 1 (no STREAM env needed, unlike o2-run-report.sh).
-          FLAKY="${MERGE_FLAKY:-[]}"
-          if printf '%s' "$FLAKY" | jq -e 'type=="array" and length>0' >/dev/null 2>&1; then
-            FLAKY_FILE=$(mktemp "${TMPDIR:-/tmp}/flaky.XXXXXX")
-            trap 'rm -f "$FLAKY_FILE"' EXIT
-            printf '%s' "$FLAKY" | jq -c --arg run_id "$GITHUB_RUN_ID" --arg repo "$GITHUB_REPOSITORY" \
-              '[.[] | {run_id:$run_id, repo:$repo, suite:"ui", workflow:"test", ingest_source:"live", status:.status, module:.module, test_title:.title, test_file:.file}]' \
-              > "$FLAKY_FILE" 2>/dev/null || echo '[]' > "$FLAKY_FILE"
-            if [ "$(jq 'length' "$FLAKY_FILE" 2>/dev/null || echo 0)" -gt 0 ]; then
-              bash .github/scripts/o2-report.sh ci_test_results "$FLAKY_FILE"
-            fi
           fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -890,7 +890,9 @@ jobs:
       # Compact Playwright stats (expected/unexpected/flaky/skipped) from the merged report.json,
       # consumed by report_to_openobserve to record per-test counts in ci_test_runs.
       stats: ${{ steps.report_stats.outputs.stats }}
-      # Flaky test names + their module (top-level test folder), JSON array, for ci_test_flaky.
+      # Flaky + failed tests for the ci_test_results stream, consumed by
+      # report_to_openobserve. JSON array: [{module,title,file,status}] where
+      # status is "flaky"|"failed" (see .github/scripts/extract-flaky.js). "[]" if none.
       flaky: ${{ steps.report_flaky.outputs.flaky }}
 
     steps:
@@ -998,20 +1000,14 @@ jobs:
         id: report_flaky
         if: always()
         run: |
-          cd tests/ui-testing
-          if [ -f playwright-results/report.json ]; then
-            # Pull each flaky test (status==="flaky": failed then passed on retry) + its module
-            # (top-level test folder from the spec file path). Single-line JSON for GITHUB_OUTPUT.
-            FLAKY=$(node -e '
-              const fs=require("fs"); let r; try{r=JSON.parse(fs.readFileSync("playwright-results/report.json","utf8"))}catch(e){console.error("flaky-extract: report.json parse failed:",e&&e.message);process.stdout.write("[]");process.exit(0)}
-              const out=[]; (function w(s){(s.specs||[]).forEach(sp=>(sp.tests||[]).forEach(t=>{if(t.status==="flaky"||t.status==="unexpected"){const f=(sp.file||s.file||"");out.push({module:(f.split("/")[0]||"unknown"),title:sp.title,file:f,status:(t.status==="flaky"?"flaky":"failed")})}}));(s.suites||[]).forEach(w)})({suites:r.suites||[]});
-              process.stdout.write(JSON.stringify(out));
-            ' || echo "[]")
-          else
-            FLAKY="[]"
-          fi
+          # Flaky + failed tests from the merged report, as one JSON array, for the
+          # ci_test_results stream. Logic + schema live in extract-flaky.js (it
+          # handles a missing/malformed report by printing [] non-fatally, and is
+          # commented to explain status="flaky" vs "failed" and the sp.title choice).
+          FLAKY=$(node .github/scripts/extract-flaky.js tests/ui-testing/playwright-results/report.json)
           echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
-          echo "flaky tests: $FLAKY"
+          # Log a count only — avoid dumping test file paths/titles into public CI logs.
+          echo "flaky/failed test count: $(printf '%s' "$FLAKY" | jq 'length' 2>/dev/null || echo '?')"
 
       - name: Cache test failures to TestDino
         if: ${{ needs.ui_integration_tests.result == 'failure' }}
@@ -1198,6 +1194,7 @@ jobs:
           BUILD: ${{ needs.build_binary.result }}
           TESTS: ${{ needs.ui_integration_tests.result }}
           MERGE_STATS: ${{ needs.merge_and_upload_reports.outputs.stats }}
+          # Flaky/failed test rows (JSON array, "[]" if none) → ci_test_results below.
           MERGE_FLAKY: ${{ needs.merge_and_upload_reports.outputs.flaky }}
         run: |
           # No relevant changes → tests were skipped → no run to record.
@@ -1216,16 +1213,23 @@ jobs:
           export CONCLUSION STREAM=ci_test_runs SUITE=ui
           bash .github/scripts/o2-run-report.sh
 
-          # Emit one row per flaky-or-failed test (with its module + status) to ci_test_flaky, for
-          # the per-module flaky/failed dashboards. status: "flaky" (failed then passed on retry) or
-          # "failed" (failed even after retries) — from report.json's final per-test verdict, so flaky
-          # is never mislabeled as failed. Non-fatal; _timestamp left unset -> ingest time.
+          # Emit one row per flaky-or-failed test (module + status) to ci_test_results, for the
+          # per-module flaky/failed dashboards. Row schema:
+          #   {run_id, repo, suite:"ui", workflow:"test", ingest_source:"live",
+          #    status:"flaky"|"failed", module, test_title, test_file}
+          # suite/workflow are hardcoded — this step is UI-only. status comes from report.json's
+          # final per-test verdict, so a flaky test (failed then passed on retry) is never
+          # mislabeled as failed. MERGE_FLAKY is the merge job's `flaky` output (JSON array, "[]"
+          # if none). Non-fatal throughout; _timestamp left unset -> ingest time. o2-report.sh
+          # takes the stream as arg 1 (no STREAM env needed, unlike o2-run-report.sh).
           FLAKY="${MERGE_FLAKY:-[]}"
           if printf '%s' "$FLAKY" | jq -e 'type=="array" and length>0' >/dev/null 2>&1; then
+            FLAKY_FILE=$(mktemp "${TMPDIR:-/tmp}/flaky.XXXXXX")
+            trap 'rm -f "$FLAKY_FILE"' EXIT
             printf '%s' "$FLAKY" | jq -c --arg run_id "$GITHUB_RUN_ID" --arg repo "$GITHUB_REPOSITORY" \
               '[.[] | {run_id:$run_id, repo:$repo, suite:"ui", workflow:"test", ingest_source:"live", status:.status, module:.module, test_title:.title, test_file:.file}]' \
-              > flaky.json 2>/dev/null || echo '[]' > flaky.json
-            if [ "$(jq 'length' flaky.json 2>/dev/null || echo 0)" -gt 0 ]; then
-              bash .github/scripts/o2-report.sh ci_test_results flaky.json
+              > "$FLAKY_FILE" 2>/dev/null || echo '[]' > "$FLAKY_FILE"
+            if [ "$(jq 'length' "$FLAKY_FILE" 2>/dev/null || echo 0)" -gt 0 ]; then
+              bash .github/scripts/o2-report.sh ci_test_results "$FLAKY_FILE"
             fi
           fi

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -547,6 +547,7 @@ jobs:
       labels: ubicloud-standard-4
     permissions:
       contents: read
+      actions: read  # report step reads run/job timings from the Actions API
     outputs:
       # Compact Playwright stats (expected/unexpected/flaky/skipped/duration) from the merged
       # report.json — consumed by report_to_openobserve to record reliability metrics.
@@ -714,62 +715,14 @@ jobs:
             --verbose \
             --token="${{ secrets.TESTDINO_API_TOKEN }}"
 
-  playwright_summary:
-    timeout-minutes: 5
-    runs-on:
-      labels: ubicloud-standard-4
-    permissions: {}
-    needs: [build_binary, ui_integration_tests, merge_and_upload_reports]
-    if: always()
-    steps:
-      - name: Check test results
-        run: |
-          BUILD_OK=false
-          UI_OK=false
-          MERGE_OK=false
-
-          if [ "${{ needs.build_binary.result }}" == "success" ] || [ "${{ needs.build_binary.result }}" == "skipped" ]; then
-            BUILD_OK=true
-          fi
-
-          if [ "${{ needs.ui_integration_tests.result }}" == "success" ] || [ "${{ needs.ui_integration_tests.result }}" == "skipped" ]; then
-            UI_OK=true
-          fi
-
-          if [ "${{ needs.merge_and_upload_reports.result }}" == "success" ] || [ "${{ needs.merge_and_upload_reports.result }}" == "skipped" ] || [ "${{ needs.merge_and_upload_reports.result }}" == "failure" ]; then
-            MERGE_OK=true
-          fi
-
-          if [ "$BUILD_OK" == "true" ] && [ "$UI_OK" == "true" ] && [ "$MERGE_OK" == "true" ]; then
-            echo "All regression tests completed successfully"
-            exit 0
-          else
-            echo "Regression tests failed:"
-            echo "  build_binary: ${{ needs.build_binary.result }}"
-            echo "  ui_integration_tests: ${{ needs.ui_integration_tests.result }}"
-            echo "  merge_and_upload_reports: ${{ needs.merge_and_upload_reports.result }}"
-            exit 1
-          fi
-
-  # ---------------------------------------------------------------------------
-  # Report one run-summary document to OpenObserve (stream: ci_regression).
-  # Pure metrics sidecar: derives per-job timings + per-shard pass/fail from the
-  # GitHub jobs API and the merged Playwright stats. continue-on-error + a
-  # never-fail poster script mean this can NEVER break the regression run.
-  # ---------------------------------------------------------------------------
-  report_to_openobserve:
-    name: Report metrics to OpenObserve
-    needs: [build_binary, ui_integration_tests, merge_and_upload_reports]
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-    steps:
-      - name: Clone the current repo
-        uses: actions/checkout@v5
-
-      - name: Build payload and ingest
+      # ---------------------------------------------------------------------------
+      # Non-fatal metrics sidecar — runs HERE inside the report flow (like the TestDino
+      # step above) so it never trails / gates playwright_summary. One run-summary
+      # document to OpenObserve (stream: ci_regression) + per-shard rows
+      # (ci_regression_shards). continue-on-error + a never-fail poster script mean
+      # this can NEVER break the regression run.
+      # ---------------------------------------------------------------------------
+      - name: Report run metrics to OpenObserve
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -777,10 +730,13 @@ jobs:
           O2_REPORTING_AUTH: ${{ secrets.O2_REPORTING_AUTH }}
           O2_REPORTING_INSECURE: ${{ vars.O2_REPORTING_INSECURE }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
-          BUILD_RESULT: ${{ needs.build_binary.result }}
+          # We are now inside merge_and_upload_reports (needs: [ui_integration_tests]), which
+          # runs only when tests actually ran. build_binary precedes ui_integration_tests, so
+          # build is effectively success here; merge is in-progress (treated success).
+          BUILD_RESULT: success
           UI_RESULT: ${{ needs.ui_integration_tests.result }}
-          MERGE_RESULT: ${{ needs.merge_and_upload_reports.result }}
-          MERGE_STATS: ${{ needs.merge_and_upload_reports.outputs.stats }}
+          MERGE_RESULT: success
+          MERGE_STATS: ${{ steps.report_stats.outputs.stats }}
         run: |
           set -uo pipefail
           # Forks / unconfigured repos: skip entirely (no API call, no rate-limit spend).
@@ -898,4 +854,41 @@ jobs:
             bash .github/scripts/o2-report.sh ci_regression_shards shards.json
           else
             echo "::notice::no shard rows to emit"
+          fi
+
+  playwright_summary:
+    timeout-minutes: 5
+    runs-on:
+      labels: ubicloud-standard-4
+    permissions: {}
+    needs: [build_binary, ui_integration_tests, merge_and_upload_reports]
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          BUILD_OK=false
+          UI_OK=false
+          MERGE_OK=false
+
+          if [ "${{ needs.build_binary.result }}" == "success" ] || [ "${{ needs.build_binary.result }}" == "skipped" ]; then
+            BUILD_OK=true
+          fi
+
+          if [ "${{ needs.ui_integration_tests.result }}" == "success" ] || [ "${{ needs.ui_integration_tests.result }}" == "skipped" ]; then
+            UI_OK=true
+          fi
+
+          if [ "${{ needs.merge_and_upload_reports.result }}" == "success" ] || [ "${{ needs.merge_and_upload_reports.result }}" == "skipped" ] || [ "${{ needs.merge_and_upload_reports.result }}" == "failure" ]; then
+            MERGE_OK=true
+          fi
+
+          if [ "$BUILD_OK" == "true" ] && [ "$UI_OK" == "true" ] && [ "$MERGE_OK" == "true" ]; then
+            echo "All regression tests completed successfully"
+            exit 0
+          else
+            echo "Regression tests failed:"
+            echo "  build_binary: ${{ needs.build_binary.result }}"
+            echo "  ui_integration_tests: ${{ needs.ui_integration_tests.result }}"
+            echo "  merge_and_upload_reports: ${{ needs.merge_and_upload_reports.result }}"
+            exit 1
           fi


### PR DESCRIPTION
## Why
Two CI-observability gaps, both about **per-test/per-shard counts** that the run-level metrics couldn't show:

1. **Flaky vs failed was conflated.** "Failed Shards by Module" counted shard-*job* failures — but a shard that **failed then passed on rerun is flaky, not failed**. A bare count told you nothing and misclassified recovered flakes as failures.
2. **API had no test counts at all.** API `ci_test_runs` rows carried only run health (conclusion/duration) — `tests_total` was NULL — so the Test Counts dashboard had nothing for API.

## What

### Per-test flaky **and** failed → `ci_test_results`
- The **merge job** parses the merged `report.json` for tests with `status="flaky"` (failed→passed on retry) or `status="unexpected"` (failed after retries) via the new commented **`.github/scripts/extract-flaky.js`**, emitting **title + module + status**.
- **report_to_openobserve** posts **one row per such test** to **`ci_test_results`**.
- Row schema: `{run_id, repo, suite, workflow, ingest_source, status ("flaky"|"failed"), module, test_title, test_file}` — powers accurate per-module **flaky** *and* **failed** dashboards, no misclassification.

### Per-shard API test counts → `ci_test_counts` (+ run-doc total)
- Each API pytest job emits `--junitxml` and uploads an **`api-junit__<category>__<leg>`** artifact (category = the test shard: integration / query_agent / regression / … ENT also cli / vortex_* / oss_in_ent / ent_top / ent_rbac).
- **report_to_openobserve** runs **`.github/scripts/parse-api-junit.py`**, which reads the category per artifact and **dedups config-leg reruns by test identity** (query_agent opt true|false, regression flag combos) so the same suite isn't counted twice.
- The deduped **total** folds into the run doc (`ci_test_runs`, suite=api) so API shows in the same KPI/pie panels as UI; **per-category rows** go to the new **`ci_test_counts`** stream for the per-shard breakdown (the API analog of UI's `ci_test_modules`).

## Notes
- **Forward-only** — historical runs never stored junit / per-test names (only counts), so no backfill; both streams accumulate from merge.
- All **non-fatal**: any parse/ingest error only warns, never fails the workflow. `_timestamp` unset → ingest time.
- Pairs with the same-named branch on the other repo (OSS ⇄ ENT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
