### PR TITLE
perf: improve partial reduce logical for more parallel

### DIFF
--- a/src/service/search/datafusion/optimizer/physical_optimizer/remote_scan.rs
+++ b/src/service/search/datafusion/optimizer/physical_optimizer/remote_scan.rs
@@ -361,19 +361,32 @@ fn wrap_partial_reduce(
         .collect::<Result<_>>()?;
     // null_expr entries are schema-independent NULL literals used by GROUPING SETS
     let null_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = agg.group_expr().null_expr().to_vec();
+    // Reuse the group-key Column refs as the hash-partition keys.
+    let hash_exprs: Vec<Arc<dyn PhysicalExpr>> = group_exprs
+        .iter()
+        .map(|(expr, _)| Arc::clone(expr))
+        .collect();
     let new_group_by = PhysicalGroupBy::new(
         group_exprs,
         null_exprs,
         agg.group_expr().groups().to_vec(),
         !agg.group_expr().is_single(),
     );
-    let coalesce_partition_exec = Arc::new(CoalescePartitionsExec::new(input.clone()));
+    let reduce_input: Arc<dyn ExecutionPlan> = if !hash_exprs.is_empty() {
+        let num_partitions = input.output_partitioning().partition_count();
+        Arc::new(RepartitionExec::try_new(
+            input.clone(),
+            Partitioning::Hash(hash_exprs, num_partitions),
+        )?)
+    } else {
+        Arc::new(CoalescePartitionsExec::new(input.clone()))
+    };
     Ok(Arc::new(AggregateExec::try_new(
         AggregateMode::PartialReduce,
         new_group_by,
         agg.aggr_expr().to_vec(),
         vec![None; agg.aggr_expr().len()],
-        coalesce_partition_exec,
+        reduce_input,
         agg.input_schema(),
     )?) as Arc<dyn ExecutionPlan>)
 }
@@ -602,6 +615,69 @@ mod tests {
             .expect("group expr should be a Column reference into partial output schema");
         assert_eq!(col_expr.name(), "a");
         assert_eq!(col_expr.index(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_wrap_partial_reduce_multi_partition_group_by_hash_repartitions()
+    -> datafusion::common::Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let group_by = PhysicalGroupBy::new(
+            vec![(col("a", &schema)?, "a".to_string())],
+            vec![],
+            vec![vec![false]],
+            false,
+        );
+        // Partial agg over a 4-partition input -> 4 output partitions.
+        let agg = AggregateExec::try_new(
+            AggregateMode::Partial,
+            group_by,
+            vec![],
+            vec![],
+            Arc::new(EmptyExec::new(Arc::clone(&schema)).with_partitions(4)),
+            Arc::clone(&schema),
+        )?;
+        let input: Arc<dyn ExecutionPlan> = Arc::new(agg);
+        let result = wrap_partial_reduce(true, input)?;
+        let result_agg = result.downcast_ref::<AggregateExec>().unwrap();
+        assert_eq!(*result_agg.mode(), AggregateMode::PartialReduce);
+        // PartialReduce preserves the partial agg's partition count (partition-local reduce).
+        assert_eq!(result.output_partitioning().partition_count(), 4);
+        // Its child must be a Hash RepartitionExec on the group key into 4 partitions,
+        // so each group key lands in exactly one bucket (no duplication across buckets).
+        let child = result.children()[0].clone();
+        let repartition = child
+            .downcast_ref::<RepartitionExec>()
+            .expect("a multi-partition GROUP BY should hash-partition the partial output");
+        match repartition.partitioning() {
+            Partitioning::Hash(exprs, n) => {
+                assert_eq!(*n, 4);
+                assert_eq!(exprs.len(), 1, "should hash on the single group key");
+            }
+            other => panic!("expected Hash partitioning, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_wrap_partial_reduce_multi_partition_no_group_by_falls_back_to_coalesce()
+    -> datafusion::common::Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let group_by = PhysicalGroupBy::new(vec![], vec![], vec![vec![]], false);
+        // Partial agg over a 4-partition input but with no GROUP BY.
+        let agg = AggregateExec::try_new(
+            AggregateMode::Partial,
+            group_by,
+            vec![],
+            vec![],
+            Arc::new(EmptyExec::new(Arc::clone(&schema)).with_partitions(4)),
+            Arc::clone(&schema),
+        )?;
+        let input: Arc<dyn ExecutionPlan> = Arc::new(agg);
+        // No GROUP BY: can't hash-partition even with multiple input partitions -> coalesce to one.
+        let result = wrap_partial_reduce(true, input)?;
+        assert_eq!(result.children()[0].name(), "CoalescePartitionsExec");
+        assert_eq!(result.output_partitioning().partition_count(), 1);
         Ok(())
     }
 


### PR DESCRIPTION
related to: https://github.com/openobserve/o2-enterprise/issues/1860
related to: https://github.com/openobserve/openobserve/pull/12418

## Performance

100M records
single node optimzier disable(to simulate the distribute query)


### Q1
```sql
SELECT
  trace_id,
  count(*) AS cnt,
  max(_timestamp) AS ts
FROM
  "k8s_logs"
GROUP BY
  trace_id ORDER BY cnt DESC LIMIT 100
```
12M trace_id unique value
12M records send from follower to leader
main branch: 20s 
this branch: 12s 


### Q2
```sql
SELECT count(distinct request_id) FROM "k8s_logs"
```
100M request_id unique value
100M records send from follower to leader
main branch: 77s 
this branch: 74s 


### Q3
```sql
SELECT
  kubernetes_namespace_name,
  COUNT(DISTINCT trace_id) AS cnt
FROM
  k8s_logs
GROUP BY
  kubernetes_namespace_name ORDER BY cnt DESC
```
10 kubernetes_namespace_name unique value, 12M trace_id unique value
63M records send from follower to leader
main branch: 54s
this branch: 48s

### Q4
```sql
SELECT
  host,
  COUNT(DISTINCT trace_id) AS cnt
FROM
  k8s_logs
GROUP BY
  host ORDER BY cnt DESC
```
2160 host unique value, 12M trace_id unique value
99.57M records send from follower to leader
main branch: 112s
this branch: 104s
disable partial reduce: 88s

## Summary

Improve `PartialReduce` execution parallelism in remote scan aggregation plans.

For grouped aggregations, `PartialReduce` now hash repartitions partial aggregate output by the group keys instead of always coalescing all partitions into one. This keeps the reduce stage parallel while ensuring rows with the same group key are routed to the same partition.

## ExecutionPlan change

Before:

```text
AggregateExec: mode=PartialReduce
  CoalescePartitionsExec
    AggregateExec: mode=Partial
      ...
```

After, for `GROUP BY`:

```text
AggregateExec: mode=PartialReduce
  RepartitionExec: partitioning=Hash([group_keys...], N)
    AggregateExec: mode=Partial
      ...
```

For no `GROUP BY`, the plan still falls back to:

```text
AggregateExec: mode=PartialReduce
  CoalescePartitionsExec
    AggregateExec: mode=Partial
      ...
```

## Changes

- Reuse `GROUP BY` column expressions as hash repartition keys before `PartialReduce`.
- Preserve the partial aggregate output partition count for grouped partial reduce.
- Keep `CoalescePartitionsExec` behavior for global aggregations without group keys.
- Add unit tests for grouped hash repartition and no-group-by coalesce fallback.

## Testing

Added tests in `remote_scan.rs` covering the new `PartialReduce` planning behavior.
