### PR TITLE
test: heal flaky logs field-values-cache regression test (readiness gate)

### DIFF
--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-bugs.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-bugs.spec.js
@@ -34,7 +34,7 @@ const { test, expect, navigateToBase } = require('../../utils/enhanced-baseFixtu
 const testLogger = require('../../utils/test-logger.js');
 const PageManager = require('../../../pages/page-manager.js');
 const logData = require("../../../fixtures/log.json");
-const { ingestTestData, sendRequest, getHeaders, getIngestionUrl } = require('../../utils/data-ingestion.js');
+const { ingestTestData, sendRequest, getHeaders, getIngestionUrl, waitForFieldValueSearchable } = require('../../utils/data-ingestion.js');
 const { getOrgIdentifier, isCloudEnvironment } = require('../../utils/cloud-auth.js');
 
 test.describe("Logs Regression Bug Fixes", () => {
@@ -578,6 +578,14 @@ test.describe("Logs Regression Bug Fixes", () => {
     ], headers);
     testLogger.info(`Stream1 ingestion response: ${JSON.stringify(stream1Response)}`);
 
+    // Readiness gate: e2e_automate is a SHARED stream and freshly-ingested data is not
+    // queryable immediately (WAL -> index lag). Without waiting on the actual value, the
+    // field-values panel returns svc-automate-* values from earlier runs/retries but misses
+    // the one we just ingested, making the stream1 assertion flaky. Wait until it's searchable.
+    const stream1Searchable = await waitForFieldValueSearchable(page, stream1Name, testFieldName, stream1Value, streamWaitMs, 3000);
+    expect(stream1Searchable, `Value ${stream1Value} should be searchable in ${stream1Name} via API`).toBeTruthy();
+    testLogger.info(`Value ${stream1Value} confirmed searchable in ${stream1Name}`);
+
     // Step 2: Create new stream by ingesting standard test data first (ensures proper stream registration),
     // then ingest custom records with distinct service_name for the field values cache test.
     testLogger.info(`Creating stream ${stream2Name} with standard test data`);
@@ -596,6 +604,12 @@ test.describe("Logs Regression Bug Fixes", () => {
     const stream2Available = await pm.logsPage.waitForStreamAvailable(stream2Name, streamWaitMs, 3000);
     expect(stream2Available, `Stream ${stream2Name} should be available via API`).toBeTruthy();
     testLogger.info(`Stream ${stream2Name} confirmed available via API`);
+
+    // Readiness gate for the custom value too: waitForStreamAvailable only confirms the
+    // stream's metadata exists, not that our distinct svc-newstream value is searchable yet.
+    const stream2Searchable = await waitForFieldValueSearchable(page, stream2Name, testFieldName, stream2Value, streamWaitMs, 3000);
+    expect(stream2Searchable, `Value ${stream2Value} should be searchable in ${stream2Name} via API`).toBeTruthy();
+    testLogger.info(`Value ${stream2Value} confirmed searchable in ${stream2Name}`);
 
     // Step 3: Navigate to logs and select stream1 (e2e_automate — always available)
     await pm.logsPage.clickMenuLinkLogsItem();

--- a/tests/ui-testing/playwright-tests/utils/data-ingestion.js
+++ b/tests/ui-testing/playwright-tests/utils/data-ingestion.js
@@ -241,6 +241,11 @@ async function waitForStreamData(page, streamName, expectedMinCount = 1, maxWait
  * @returns {Promise<boolean>} - True if the value became searchable, false if timed out
  */
 async function waitForFieldValueSearchable(page, streamName, fieldName, fieldValue, maxWaitMs = 30000, pollIntervalMs = 2000) {
+  // fieldName is interpolated unescaped into the SQL identifier position, so restrict it
+  // to a plain column identifier (callers pass hardcoded names like "service_name").
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(fieldName)) {
+    throw new Error(`waitForFieldValueSearchable: invalid fieldName "${fieldName}" (expected a column identifier)`);
+  }
   const orgId = getOrgIdentifier();
   const headers = getHeaders();
   const baseUrl = process.env.INGESTION_URL.endsWith('/')
@@ -277,9 +282,13 @@ async function waitForFieldValueSearchable(page, streamName, fieldName, fieldVal
           return true;
         }
         testLogger.debug('Polling for field value', { streamName, fieldName, fieldValue });
+      } else {
+        // Surface non-200s (400/401/403/5xx) so a persistent failure is visible in logs
+        // rather than silently burning the full timeout as "not found yet".
+        testLogger.warn('Field value poll got non-200', { status: response.status(), streamName, fieldName });
       }
     } catch (e) {
-      testLogger.debug('Field value poll error', { error: e.message, streamName, fieldName });
+      testLogger.warn('Field value poll error', { error: e.message, streamName, fieldName });
     }
 
     await new Promise(resolve => setTimeout(resolve, pollIntervalMs));

--- a/tests/ui-testing/playwright-tests/utils/data-ingestion.js
+++ b/tests/ui-testing/playwright-tests/utils/data-ingestion.js
@@ -225,6 +225,70 @@ async function waitForStreamData(page, streamName, expectedMinCount = 1, maxWait
   return false;
 }
 
+/**
+ * Polls the search API until a specific field value is searchable in a stream.
+ * Use this as a readiness gate after ingesting a unique value into a SHARED stream
+ * (e.g. e2e_automate) before driving the UI: freshly-ingested data is not queryable
+ * immediately (WAL -> index lag), so the field-values panel can return stale/other
+ * values and miss the just-ingested one. Waiting on the actual value (not just a row
+ * count) guarantees the value is present before the UI assertion runs.
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string} streamName - Name of the stream to check
+ * @param {string} fieldName - Field to filter on (e.g. "service_name")
+ * @param {string} fieldValue - Exact value that must be searchable
+ * @param {number} maxWaitMs - Maximum wait time in ms (default: 30000)
+ * @param {number} pollIntervalMs - Polling interval in ms (default: 2000)
+ * @returns {Promise<boolean>} - True if the value became searchable, false if timed out
+ */
+async function waitForFieldValueSearchable(page, streamName, fieldName, fieldValue, maxWaitMs = 30000, pollIntervalMs = 2000) {
+  const orgId = getOrgIdentifier();
+  const headers = getHeaders();
+  const baseUrl = process.env.INGESTION_URL.endsWith('/')
+    ? process.env.INGESTION_URL.slice(0, -1)
+    : process.env.INGESTION_URL;
+
+  const startTime = Date.now();
+  // Escape single quotes to keep the SQL literal well-formed.
+  const safeValue = String(fieldValue).replace(/'/g, "''");
+  const searchPayload = {
+    query: {
+      sql: `SELECT COUNT(*) as count FROM "${streamName}" WHERE ${fieldName} = '${safeValue}'`,
+      start_time: (Date.now() - 3600000) * 1000, // 1 hour ago in microseconds
+      end_time: Date.now() * 1000,
+      from: 0,
+      size: 1
+    }
+  };
+
+  while (Date.now() - startTime < maxWaitMs) {
+    try {
+      // end_time must advance each poll so newly-ingested records fall inside the window.
+      searchPayload.query.end_time = Date.now() * 1000;
+      const response = await page.request.post(`${baseUrl}/api/${orgId}/_search?type=logs`, {
+        headers: headers,
+        data: searchPayload
+      });
+
+      if (response.status() === 200) {
+        const data = await response.json().catch(() => null);
+        const count = data?.hits?.[0]?.count || 0;
+        if (count >= 1) {
+          testLogger.debug('Field value searchable', { streamName, fieldName, fieldValue, count, waitedMs: Date.now() - startTime });
+          return true;
+        }
+        testLogger.debug('Polling for field value', { streamName, fieldName, fieldValue });
+      }
+    } catch (e) {
+      testLogger.debug('Field value poll error', { error: e.message, streamName, fieldName });
+    }
+
+    await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+  }
+
+  testLogger.warn('Field value poll timed out', { streamName, fieldName, fieldValue, maxWaitMs });
+  return false;
+}
+
 module.exports = {
   ingestTestData,
   getHeaders,
@@ -232,5 +296,6 @@ module.exports = {
   sendRequest,
   ingestCustomData,
   enableLogPatternsExtraction,
-  waitForStreamData
+  waitForStreamData,
+  waitForFieldValueSearchable
 };


### PR DESCRIPTION
## What

Heals the flaky **\`should fetch fresh field values when switching streams\`** (`@fieldValuesCache @P1 @regression`) test in `RegressionSet/Logs/logs-bugs.spec.js`, which failed the `Logs-Regression` job in [o2-enterprise run 28454057830](https://github.com/openobserve/o2-enterprise/actions/runs/28454057830/job/84328391696).

## Root cause

The test ingests a unique `service_name=svc-automate-<runId>` into the **shared** `e2e_automate` stream, then immediately drives the UI field-values panel — with **no readiness gate** confirming that value is searchable yet. Freshly-ingested data isn't queryable instantly (WAL → index lag), so the `_values` call returns `svc-automate-*` values from earlier runs/retries but misses the just-ingested one:

```
Error: Expected stream1 values to contain svc-automate-1782832273253, got: svc-automate-17828322504262
```

Playwright retries amplify it — each retry adds another `svc-automate` value to the shared stream while still missing the current run's value, so all retries fail.

> Note: the CI job's attempt-2 then crashed on a `jq: Cannot iterate over null` error in the rerun-detection step. That is a **separate, already-fixed** issue — current `main` already has `actions: read` on the job + jq guards; the failing run executed a stale pre-fix workflow snapshot (GitHub re-runs reuse the original attempt's YAML). No workflow change is needed here.

## Fix

- Add `waitForFieldValueSearchable()` to `utils/data-ingestion.js` — polls `_search` until the exact field value is returned (the proven readiness-gate pattern, value-level rather than row-count level).
- Gate both the stream1 and stream2 ingested values before the UI assertions.

## Verification

Run locally against a local OpenObserve with `--repeat-each=3`:

```
Stream1 field values: ["svc-automate-...0702","svc-automate-...4762"]              # accumulates (reproduces CI pollution)
✓ Stream1 shows correct value: svc-automate-1782833946762                          # current value always present now
...
3 passed (1.0m)
```

The accumulating `svc-automate-*` values across repeats reproduce exactly the shared-stream pollution seen in CI, and the gate ensures the current run's value is always present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)