### PR TITLE
ci(test-assist): batch dispatcher + qa-reports backlog sweep

### DIFF
--- a/qa-reports/test-assist-ci-backlog-sweep.md
+++ b/qa-reports/test-assist-ci-backlog-sweep.md
@@ -44,12 +44,65 @@ echo "12452
 11700
 12647" > /tmp/batch.txt
 
-# 2. Dispatch in parallel
+# 2. Dispatch (parallel with a bounded worker pool; use --dry-run first to preview)
+./scripts/test-assist-ci-batch.sh --dry-run < /tmp/batch.txt
 ./scripts/test-assist-ci-batch.sh < /tmp/batch.txt
 
 # 3. Watch progress at:
 #    https://github.com/openobserve/o2-enterprise/actions/workflows/test-assist.yml
 ```
+
+## How to update the sweep table after a batch completes
+
+Once all dispatched runs finish (check the Actions tab; each run is ~10-15 min):
+
+```bash
+# Get every recent test-assist run + its verdict from the artifact.
+gh run list --repo openobserve/o2-enterprise --workflow=test-assist.yml \
+  --limit 100 --json databaseId,conclusion,createdAt,displayTitle \
+  > /tmp/runs.json
+
+# For each run, pull the verdict-index.json from the artifact:
+for run_id in $(jq -r '.[] | .databaseId' /tmp/runs.json); do
+  mkdir -p "/tmp/artifacts/$run_id"
+  gh run download "$run_id" --repo openobserve/o2-enterprise \
+    -n "test-assist-ci-evidence-$run_id" \
+    -D "/tmp/artifacts/$run_id" 2>/dev/null || continue
+  # verdicts-index.json has [{issue_number, status, confidence}, ...]
+done
+
+# Append rows to the table between the BATCH_TABLE_START/END markers.
+# (A future scripts/collect-verdicts.py can automate this. For now, manual paste.)
+```
+
+Fields to populate per row: `#`, `Issue` (linked), `Verdict`, `Confidence`, `Elapsed`, `Run` (link), `Evidence` (screenshot link in the run's artifact).
+
+## Recovery — cancelling a batch mid-dispatch
+
+If you fired a batch by mistake (wrong issues, wrong mode, wrong repo target):
+
+1. **Stop dispatching more:** kill the local script with `Ctrl+C` — already-fired runs remain, but new ones stop.
+2. **Cancel running engine runs:**
+   ```bash
+   # List active test-assist runs
+   gh run list --repo openobserve/o2-enterprise --workflow=test-assist.yml \
+     --status in_progress --status queued --limit 100 \
+     --json databaseId,createdAt \
+     --jq '.[] | .databaseId'
+   # Pipe that list to gh run cancel
+   gh run list --repo openobserve/o2-enterprise --workflow=test-assist.yml \
+     --status in_progress --status queued --limit 100 --json databaseId \
+     --jq '.[] | .databaseId' \
+     | xargs -n1 -I{} gh run cancel {} --repo openobserve/o2-enterprise
+   ```
+3. **Un-apply the label** (if the run already reached the label step):
+   ```bash
+   # For each affected issue:
+   gh issue edit N --repo openobserve/openobserve --remove-label "Test-Assist-CI-Verified"
+   ```
+4. **Post-mortem:** note the batch cause in this file's "Historical sweeps" section so the mistake isn't repeated.
+
+Note: `write_mode=false` is the default — so a mis-dispatched batch produces artifacts + labels, but **no verdict comments on real issues**. That's the primary safety net.
 
 Tier queries used to build the 100-priority list:
 

--- a/qa-reports/test-assist-ci-backlog-sweep.md
+++ b/qa-reports/test-assist-ci-backlog-sweep.md
@@ -1,0 +1,72 @@
+# Test-Assist CI — Backlog Sweep
+
+> Automated bug-verification roll-up. One row per issue the [test-assist-ci pipeline](https://github.com/openobserve/o2-enterprise/actions/workflows/test-assist.yml) has processed. Verdicts come from CI; closures stay manual until pipeline accuracy is calibrated.
+
+**Pipeline:** [`test-assist.yml`](https://github.com/openobserve/o2-enterprise/actions/workflows/test-assist.yml) (o2-enterprise)
+**Batch dispatcher:** [`scripts/test-assist-ci-batch.sh`](../scripts/test-assist-ci-batch.sh)
+**Mode:** `write_mode=false` (no GitHub verdict writes; only the factual `Test-Assist-CI-Verified` label is applied per run)
+**Filter to find verified issues:** [`label:"Test-Assist-CI-Verified"`](https://github.com/openobserve/openobserve/issues?q=is%3Aissue+label%3A%22Test-Assist-CI-Verified%22)
+
+## How to read verdicts
+
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| `FIXED` (HIGH) | Pipeline asserts the reported behaviour is no longer present | Spot-check screenshot; if accurate, close + add `Testing-Completed` |
+| `STILL_PRESENT` (HIGH) | Pipeline asserts the bug is still reproducible | Confirm via screenshot; route to dev |
+| `INCONCLUSIVE` (LOW) | Pipeline could not produce a confident verdict (selectors stale, repro unclear, timeout, etc.) | Manual verification needed |
+| `SKIP` | Bug not testable by this pipeline (non-UI, no repro steps) | Route to backend QA or ask reporter for clarification |
+
+## Sweep — week of 2026-06-30
+
+_Populated as batches complete._
+
+| # | Issue | Verdict | Confidence | Elapsed | Run | Evidence |
+|---|-------|---------|------------|---------|-----|----------|
+<!-- BATCH_TABLE_START -->
+<!-- BATCH_TABLE_END -->
+
+## Tier breakdown for the 100-priority list
+
+| Tier | Source | Count | Priority |
+|------|--------|-------|----------|
+| 1 | Open `Needs-Testing` | ~9-10 | Highest — fresh verification queue |
+| 2 | Open `Retested-Failed` (newest first) | 30 | High — known-broken; chance of silent re-fix |
+| 3 | Open `Bug` from 2025+ (newest first) | ~60 | Medium — recent code → grounded selectors |
+| 4 | Open `Bug` from 2024 and older | (deferred) | Low — UI may have drifted from repro |
+
+## How to dispatch a batch
+
+```bash
+# From this OSS repo checkout, with `gh` authenticated:
+
+# 1. Stage the issue list (one number per line, or use the tier queries below)
+echo "12452
+11700
+12647" > /tmp/batch.txt
+
+# 2. Dispatch in parallel
+./scripts/test-assist-ci-batch.sh < /tmp/batch.txt
+
+# 3. Watch progress at:
+#    https://github.com/openobserve/o2-enterprise/actions/workflows/test-assist.yml
+```
+
+Tier queries used to build the 100-priority list:
+
+```bash
+# Tier 1
+gh issue list --repo openobserve/openobserve --label "☢️ Bug" --label "Needs-Testing" --state open \
+  --json number --jq '.[].number'
+
+# Tier 2 (sorted newest first)
+gh issue list --repo openobserve/openobserve --label "☢️ Bug" --label "Retested-Failed" --state open --limit 50 \
+  --json number,createdAt --jq 'sort_by(.createdAt)|reverse|.[].number'
+
+# Tier 3 (2025+, sorted newest first)
+gh issue list --repo openobserve/openobserve --label "☢️ Bug" --state open --limit 300 \
+  --json number,createdAt --jq 'sort_by(.createdAt)|reverse|.[]|select(.createdAt >= "2025-01-01")|.number'
+```
+
+## Historical sweeps
+
+_(none yet — this is the first)_

--- a/scripts/test-assist-ci-batch.sh
+++ b/scripts/test-assist-ci-batch.sh
@@ -6,19 +6,21 @@
 # runs them in parallel up to the runner cap.
 #
 # Usage:
-#   ./scripts/test-assist-ci-batch.sh < issue-numbers.txt          # one number per line
+#   ./scripts/test-assist-ci-batch.sh < issue-numbers.txt          # one number per line (stdin)
 #   ./scripts/test-assist-ci-batch.sh 12452 11700 12647            # positional args
-#   echo "12452 11700" | ./scripts/test-assist-ci-batch.sh --stdin
+#   echo "12452 11700 12647" | tr ' ' '\n' | ./scripts/test-assist-ci-batch.sh
 #
 # Requires: `gh` authenticated with a token that has Actions:write on openobserve/o2-enterprise
 # (typically the maintainer's PAT — `gh auth login` interactively works).
 #
 # Options:
-#   --repo-engine REPO    Override the engine repo (default: openobserve/o2-enterprise)
-#   --source-repo NAME    Override the source repo (default: openobserve)
-#   --write-mode          Set write_mode=true (default: false — no GitHub writes)
-#   --throttle SECS       Sleep between dispatches (default: 0.5)
-#   --dry-run             Print what would be dispatched; don't call gh
+#   --repo-engine REPO    Override the engine repo (default: openobserve/o2-enterprise).
+#                         Restricted to an allowlist to prevent redirecting dispatches.
+#   --source-repo NAME    Override the source repo short name (default: openobserve).
+#   --write-mode          Set write_mode=true (default: false — no GitHub verdict writes).
+#   --max-parallel N      Cap concurrent dispatches (default: 20). Waits when at cap.
+#   --throttle SECS       Sleep between dispatches (default: 2). Reduces API burst.
+#   --dry-run             Print what would be dispatched; don't call gh.
 #
 set -euo pipefail
 
@@ -26,23 +28,43 @@ REPO_ENGINE="openobserve/o2-enterprise"
 SOURCE_REPO="openobserve"
 WORKFLOW="test-assist.yml"
 WRITE_MODE="false"
-THROTTLE="0.5"
+THROTTLE="2"
+MAX_PARALLEL="20"
 DRY_RUN=""
+
+# Allowlist of accepted engine-repos. Prevents an accidental (or malicious) override from
+# redirecting maintainer-PAT dispatches to an unrelated repo.
+ALLOWED_ENGINES=("openobserve/o2-enterprise")
+
+is_allowed_engine() {
+  local candidate="$1"
+  for e in "${ALLOWED_ENGINES[@]}"; do
+    [ "$candidate" = "$e" ] && return 0
+  done
+  return 1
+}
 
 # Parse flags.
 args=()
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo-engine) REPO_ENGINE="$2"; shift 2;;
-    --source-repo) SOURCE_REPO="$2"; shift 2;;
-    --write-mode)  WRITE_MODE="true"; shift;;
-    --throttle)    THROTTLE="$2"; shift 2;;
-    --dry-run)     DRY_RUN="1"; shift;;
-    --stdin)       args=(); shift;;
-    -h|--help)     grep -E '^# ' "$0" | sed 's/^# //'; exit 0;;
-    *)             args+=("$1"); shift;;
+    --repo-engine)   REPO_ENGINE="$2"; shift 2;;
+    --source-repo)   SOURCE_REPO="$2"; shift 2;;
+    --write-mode)    WRITE_MODE="true"; shift;;
+    --max-parallel)  MAX_PARALLEL="$2"; shift 2;;
+    --throttle)      THROTTLE="$2"; shift 2;;
+    --dry-run)       DRY_RUN="1"; shift;;
+    -h|--help)       grep -E '^# ' "$0" | sed 's/^# //'; exit 0;;
+    *)               args+=("$1"); shift;;
   esac
 done
+
+# Validate the engine target BEFORE reading any input.
+if ! is_allowed_engine "$REPO_ENGINE"; then
+  echo "::error::--repo-engine \"$REPO_ENGINE\" is not in the allowlist (${ALLOWED_ENGINES[*]})" >&2
+  echo "::error::Extend ALLOWED_ENGINES in this script if you need a new target." >&2
+  exit 1
+fi
 
 # Read issue list from positional args, or stdin if no args.
 if [ "${#args[@]}" -eq 0 ]; then
@@ -55,10 +77,12 @@ fi
 
 echo "==========================================="
 echo "Test-Assist CI — batch dispatch"
-echo "  engine: $REPO_ENGINE (workflow: $WORKFLOW)"
-echo "  source: $SOURCE_REPO"
-echo "  count:  ${#NUMS[@]}"
-echo "  write_mode: $WRITE_MODE"
+echo "  engine:       $REPO_ENGINE (workflow: $WORKFLOW)"
+echo "  source:       $SOURCE_REPO"
+echo "  count:        ${#NUMS[@]}"
+echo "  max_parallel: $MAX_PARALLEL"
+echo "  throttle:     ${THROTTLE}s"
+echo "  write_mode:   $WRITE_MODE"
 [ -n "$DRY_RUN" ] && echo "  (DRY RUN — no dispatches)"
 echo "==========================================="
 
@@ -68,40 +92,75 @@ if [ -z "$DRY_RUN" ]; then
     || { echo "::error::cannot access workflow $WORKFLOW on $REPO_ENGINE — check gh auth + PAT scopes"; exit 1; }
 fi
 
+# Track results properly (previous version silently swallowed backgrounded failures).
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PID_TO_ISSUE="$TMPDIR/pid-to-issue"
+: > "$PID_TO_ISSUE"
 DISPATCHED=0
+FAILED=0
 SKIPPED=0
+ACTIVE=0
+
 for N in "${NUMS[@]}"; do
   if ! [[ "$N" =~ ^[0-9]+$ ]]; then
     echo "  skip non-numeric: $N" >&2
     SKIPPED=$(( SKIPPED + 1 ))
     continue
   fi
+
+  # Bounded parallelism: wait for a slot before firing the next dispatch.
+  while [ "$ACTIVE" -ge "$MAX_PARALLEL" ]; do
+    wait -n
+    ACTIVE=$(( ACTIVE - 1 ))
+  done
+
   if [ -n "$DRY_RUN" ]; then
     echo "  DRY: would dispatch #$N"
-  else
-    echo "  dispatch #$N"
-    gh workflow run "$WORKFLOW" \
-      --repo "$REPO_ENGINE" \
-      --ref main \
-      -f source_repo="$SOURCE_REPO" \
-      -f issue_number="$N" \
-      -f fixture_mode=false \
-      -f write_mode="$WRITE_MODE" &
+    DISPATCHED=$(( DISPATCHED + 1 ))
+    continue
   fi
-  DISPATCHED=$(( DISPATCHED + 1 ))
+
+  echo "  dispatch #$N"
+  gh workflow run "$WORKFLOW" \
+    --repo "$REPO_ENGINE" \
+    --ref main \
+    -f source_repo="$SOURCE_REPO" \
+    -f issue_number="$N" \
+    -f fixture_mode=false \
+    -f write_mode="$WRITE_MODE" \
+    >/dev/null 2>>"$TMPDIR/errors.log" &
+  echo "$! $N" >> "$PID_TO_ISSUE"
+  ACTIVE=$(( ACTIVE + 1 ))
   sleep "$THROTTLE"
 done
-wait
+
+# Wait for the remaining background jobs, tallying failures.
+while read -r pid issue; do
+  if ! wait "$pid" 2>/dev/null; then
+    echo "  FAILED: dispatch for #$issue" >&2
+    FAILED=$(( FAILED + 1 ))
+  else
+    DISPATCHED=$(( DISPATCHED + 1 ))
+  fi
+done < "$PID_TO_ISSUE"
 
 echo ""
 echo "==========================================="
-echo "Done. Dispatched: $DISPATCHED  Skipped: $SKIPPED"
+echo "Done."
+echo "  Dispatched: $DISPATCHED"
+echo "  Failed:     $FAILED"
+echo "  Skipped:    $SKIPPED  (non-numeric input)"
+if [ "$FAILED" -gt 0 ]; then
+  echo ""
+  echo "See errors:"
+  head -30 "$TMPDIR/errors.log" 2>/dev/null || true
+fi
 echo ""
 echo "Track progress:"
 echo "  https://github.com/${REPO_ENGINE}/actions/workflows/${WORKFLOW}"
-echo ""
-echo "After runs complete, populate qa-reports/test-assist-ci-backlog-sweep.md by:"
-echo "  - reading each run's artifact (test-assist-ci-evidence-<run_id>)"
-echo "  - extracting bug-<N>-verdict.json"
-echo "  - appending a row to the sweep table"
 echo "==========================================="
+
+# Non-zero exit if any dispatches failed — lets CI-invoked callers detect.
+[ "$FAILED" -eq 0 ]

--- a/scripts/test-assist-ci-batch.sh
+++ b/scripts/test-assist-ci-batch.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scripts/test-assist-ci-batch.sh — batch dispatcher for the Test-Assist CI engine.
+#
+# Fires the `test-assist.yml` engine (in o2-enterprise) in parallel for a list of OSS issues.
+# Each engine run is its own concurrency group (keyed on source_repo+issue), so GitHub Actions
+# runs them in parallel up to the runner cap.
+#
+# Usage:
+#   ./scripts/test-assist-ci-batch.sh < issue-numbers.txt          # one number per line
+#   ./scripts/test-assist-ci-batch.sh 12452 11700 12647            # positional args
+#   echo "12452 11700" | ./scripts/test-assist-ci-batch.sh --stdin
+#
+# Requires: `gh` authenticated with a token that has Actions:write on openobserve/o2-enterprise
+# (typically the maintainer's PAT — `gh auth login` interactively works).
+#
+# Options:
+#   --repo-engine REPO    Override the engine repo (default: openobserve/o2-enterprise)
+#   --source-repo NAME    Override the source repo (default: openobserve)
+#   --write-mode          Set write_mode=true (default: false — no GitHub writes)
+#   --throttle SECS       Sleep between dispatches (default: 0.5)
+#   --dry-run             Print what would be dispatched; don't call gh
+#
+set -euo pipefail
+
+REPO_ENGINE="openobserve/o2-enterprise"
+SOURCE_REPO="openobserve"
+WORKFLOW="test-assist.yml"
+WRITE_MODE="false"
+THROTTLE="0.5"
+DRY_RUN=""
+
+# Parse flags.
+args=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-engine) REPO_ENGINE="$2"; shift 2;;
+    --source-repo) SOURCE_REPO="$2"; shift 2;;
+    --write-mode)  WRITE_MODE="true"; shift;;
+    --throttle)    THROTTLE="$2"; shift 2;;
+    --dry-run)     DRY_RUN="1"; shift;;
+    --stdin)       args=(); shift;;
+    -h|--help)     grep -E '^# ' "$0" | sed 's/^# //'; exit 0;;
+    *)             args+=("$1"); shift;;
+  esac
+done
+
+# Read issue list from positional args, or stdin if no args.
+if [ "${#args[@]}" -eq 0 ]; then
+  mapfile -t NUMS < <(grep -E '^[0-9]+$')
+else
+  NUMS=("${args[@]}")
+fi
+
+[ "${#NUMS[@]}" -gt 0 ] || { echo "::error::no issue numbers provided" >&2; exit 1; }
+
+echo "==========================================="
+echo "Test-Assist CI — batch dispatch"
+echo "  engine: $REPO_ENGINE (workflow: $WORKFLOW)"
+echo "  source: $SOURCE_REPO"
+echo "  count:  ${#NUMS[@]}"
+echo "  write_mode: $WRITE_MODE"
+[ -n "$DRY_RUN" ] && echo "  (DRY RUN — no dispatches)"
+echo "==========================================="
+
+# Pre-flight: verify gh auth works and can hit the workflow.
+if [ -z "$DRY_RUN" ]; then
+  gh workflow view "$WORKFLOW" --repo "$REPO_ENGINE" >/dev/null 2>&1 \
+    || { echo "::error::cannot access workflow $WORKFLOW on $REPO_ENGINE — check gh auth + PAT scopes"; exit 1; }
+fi
+
+DISPATCHED=0
+SKIPPED=0
+for N in "${NUMS[@]}"; do
+  if ! [[ "$N" =~ ^[0-9]+$ ]]; then
+    echo "  skip non-numeric: $N" >&2
+    SKIPPED=$(( SKIPPED + 1 ))
+    continue
+  fi
+  if [ -n "$DRY_RUN" ]; then
+    echo "  DRY: would dispatch #$N"
+  else
+    echo "  dispatch #$N"
+    gh workflow run "$WORKFLOW" \
+      --repo "$REPO_ENGINE" \
+      --ref main \
+      -f source_repo="$SOURCE_REPO" \
+      -f issue_number="$N" \
+      -f fixture_mode=false \
+      -f write_mode="$WRITE_MODE" &
+  fi
+  DISPATCHED=$(( DISPATCHED + 1 ))
+  sleep "$THROTTLE"
+done
+wait
+
+echo ""
+echo "==========================================="
+echo "Done. Dispatched: $DISPATCHED  Skipped: $SKIPPED"
+echo ""
+echo "Track progress:"
+echo "  https://github.com/${REPO_ENGINE}/actions/workflows/${WORKFLOW}"
+echo ""
+echo "After runs complete, populate qa-reports/test-assist-ci-backlog-sweep.md by:"
+echo "  - reading each run's artifact (test-assist-ci-evidence-<run_id>)"
+echo "  - extracting bug-<N>-verdict.json"
+echo "  - appending a row to the sweep table"
+echo "==========================================="


### PR DESCRIPTION
Follow-up tooling to [#12946](https://github.com/openobserve/openobserve/pull/12946). Pairs with the [ENT MCP-fixes PR](https://github.com/openobserve/o2-enterprise/pull/2072) to complete the loop from "engine works on one issue" → "batch of 100 fires in parallel and lands verdicts in a reviewable table."

## Summary

- **`scripts/test-assist-ci-batch.sh`** — POSIX bash script that dispatches the test-assist engine (in o2-enterprise) for a list of OSS issues. Reads issue numbers from stdin or positional args. Supports `--dry-run`, `--write-mode`, `--throttle`. Uses `gh workflow run` under the maintainer's local `gh auth`. Each dispatch is fire-and-forget; the engine's own concurrency group (`source_repo+issue`) enforces one-run-per-issue-at-a-time.
- **`qa-reports/test-assist-ci-backlog-sweep.md`** — Roll-up table where verdicts land after each batch. Documents the tier structure of the priority-100 list, the verdict-to-action map (FIXED / STILL_PRESENT / INCONCLUSIVE / SKIP), and the tier queries used to build the list. Table starts empty; batches append rows.

## Usage

```bash
# One-shot: dispatch for a single issue
./scripts/test-assist-ci-batch.sh 12452

# Batch: dispatch for many issues in parallel (from stdin)
gh issue list --repo openobserve/openobserve --label "☢️ Bug" --label "Retested-Failed" --state open --limit 30 \
  --json number --jq '.[].number' \
  | ./scripts/test-assist-ci-batch.sh

# Dry-run to see what would fire (no dispatches)
./scripts/test-assist-ci-batch.sh --dry-run 12452 11700 12647

# Explicitly enable label+comment writes (only after soak calibration)
./scripts/test-assist-ci-batch.sh --write-mode < /tmp/batch.txt
```

## Interaction with the `Test-Assist-CI-Verified` label

The ENT engine ([PR #2072](https://github.com/openobserve/o2-enterprise/pull/2072)) applies the `Test-Assist-CI-Verified` label to each processed issue as factual metadata (independent of `write_mode`). After a batch:

- [Filter checked issues](https://github.com/openobserve/openobserve/issues?q=is%3Aissue+label%3A%22Test-Assist-CI-Verified%22) → the ones we've processed
- [Filter unchecked issues](https://github.com/openobserve/openobserve/issues?q=is%3Aissue+is%3Aopen+label%3A%22%E2%98%A2%EF%B8%8F+Bug%22+-label%3A%22Test-Assist-CI-Verified%22) → the untouched backlog

## Test plan
- [ ] `bash -n scripts/test-assist-ci-batch.sh` — script parses (verified locally)
- [ ] `./scripts/test-assist-ci-batch.sh --dry-run 12452` — prints "DRY: would dispatch #12452"
- [ ] After ENT PR #2072 merges: fire a single-issue dispatch via the script → confirm run appears in o2-enterprise Actions
- [ ] Fire the 100-issue batch → confirm verdicts populate the sweep markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)