### PR TITLE
fix: RED queries missing filter/date after brush selection in traces

### DIFF
--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -723,7 +723,6 @@ export default defineComponent({
 
     const setCustomDate = (dateType, dateobj) => {
       // Parent-invoked setter (e.g. metrics-brush time range) — programmatic.
-      markProgrammaticDateChange();
       var start_date = new Date(Math.floor(dateobj.start));
       const startObj = formatDate(start_date);
 
@@ -736,6 +735,7 @@ export default defineComponent({
       selectedTime.value.endTime = endObj.time;
 
       selectedType.value = dateType;
+      markProgrammaticDateChange();
     };
 
     const onBeforeShow = () => {

--- a/web/src/plugins/traces/metrics/TracesMetricsDashboard.spec.ts
+++ b/web/src/plugins/traces/metrics/TracesMetricsDashboard.spec.ts
@@ -45,6 +45,8 @@ vi.mock("./TracesAnalysisDashboard.vue", () => ({
 const mockMetricsRangeFilters = new Map();
 const mockSearchObj = reactive({
   data: {
+    editorValue: "",
+    datetime: { startTime: 1_000_000, endTime: 2_000_000 },
     stream: {
       selectedStream: { value: "default" },
       selectedStreamFields: [],
@@ -121,7 +123,6 @@ const mockStore = createStore({
 // ---------------------------------------------------------------------------
 const defaultProps = {
   streamName: "my_traces_stream",
-  timeRange: { startTime: 1_000_000, endTime: 2_000_000 },
   show: true,
 };
 
@@ -171,6 +172,7 @@ describe("TracesMetricsDashboard", () => {
   beforeEach(async () => {
     // Reset all shared state before every test
     mockMetricsRangeFilters.clear();
+    mockSearchObj.data.editorValue = "";
     mockSearchObj.meta.showHistogram = true;
     mockSearchObj.meta.searchMode = "traces";
     mockSearchObj.data.stream.selectedStream.value = "default";
@@ -309,7 +311,8 @@ describe("TracesMetricsDashboard", () => {
   describe("loadDashboard — WHERE clause from filter prop", () => {
     it("should include the filter prop in the Rate panel WHERE clause", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "service_name = 'api'" });
+      mockSearchObj.data.editorValue = "service_name = 'api'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -319,7 +322,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should include the filter prop in the Duration panel WHERE clause", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "service_name = 'api'" });
+      mockSearchObj.data.editorValue = "service_name = 'api'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -329,7 +333,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should include the filter prop in the Errors panel WHERE clause", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "service_name = 'api'" });
+      mockSearchObj.data.editorValue = "service_name = 'api'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -349,7 +354,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should convert span_kind='Server' label to '2' in the Rate panel WHERE clause", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "span_kind='Server'" });
+      mockSearchObj.data.editorValue = "span_kind='Server'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -360,7 +366,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should convert span_kind='Server' label to '2' in the Errors panel WHERE clause", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "span_kind='Server'" });
+      mockSearchObj.data.editorValue = "span_kind='Server'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -371,7 +378,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should convert span_kind='Client' label to '3' in both Rate and Errors panels", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "span_kind='Client'" });
+      mockSearchObj.data.editorValue = "span_kind='Client'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -385,7 +393,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should leave non-span_kind filter unchanged in the Errors panel WHERE clause", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "service_name = 'api'" });
+      mockSearchObj.data.editorValue = "service_name = 'api'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -395,7 +404,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should leave non-span_kind filter unchanged in the Duration panel WHERE clause", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "service_name = 'api'" });
+      mockSearchObj.data.editorValue = "service_name = 'api'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -405,7 +415,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should convert span_kind label case-insensitively in the Errors panel", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "span_kind='CONSUMER'" });
+      mockSearchObj.data.editorValue = "span_kind='CONSUMER'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -423,7 +434,8 @@ describe("TracesMetricsDashboard", () => {
         timeEnd: null,
       });
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "env = 'prod'" });
+      mockSearchObj.data.editorValue = "env = 'prod'";
+      wrapper = mountComponent();
       await flushPromises();
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -479,9 +491,8 @@ describe("TracesMetricsDashboard", () => {
   // Props reactivity — timeRange change triggers re-load
   // -------------------------------------------------------------------------
   describe("props reactivity", () => {
-    it("should update currentTimeObj when timeRange prop changes", async () => {
-      const newTimeRange = { startTime: 5_000_000, endTime: 6_000_000 };
-      await wrapper.setProps({ timeRange: newTimeRange });
+    it("should update currentTimeObj when timeRange changes", async () => {
+      mockSearchObj.data.datetime = { startTime: 5_000_000, endTime: 6_000_000 };
       // Directly calling loadDashboard (watch triggers it; call explicitly to avoid timing)
       await wrapper.vm.loadDashboard();
       await flushPromises();
@@ -491,8 +502,7 @@ describe("TracesMetricsDashboard", () => {
     });
 
     it("should set dashboardData after loadDashboard is called with new timeRange", async () => {
-      const newTimeRange = { startTime: 7_000_000, endTime: 8_000_000 };
-      await wrapper.setProps({ timeRange: newTimeRange });
+      mockSearchObj.data.datetime = { startTime: 7_000_000, endTime: 8_000_000 };
       await wrapper.vm.loadDashboard();
       await flushPromises();
       expect(wrapper.vm.dashboardData).not.toBeNull();
@@ -640,7 +650,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should include span_status = 'ERROR' when filter prop contains it", () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "span_status = 'ERROR'" });
+      mockSearchObj.data.editorValue = "span_status = 'ERROR'";
+      wrapper = mountComponent();
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toContain("span_status = 'ERROR'");
     });
@@ -652,28 +663,32 @@ describe("TracesMetricsDashboard", () => {
 
     it("should include the filter prop string when filter is a non-empty string", () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "http_method = 'GET'" });
+      mockSearchObj.data.editorValue = "http_method = 'GET'";
+      wrapper = mountComponent();
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toContain("http_method = 'GET'");
     });
 
     it("should not include a filter entry when filter prop is an empty string", () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "" });
+      mockSearchObj.data.editorValue = "";
+      wrapper = mountComponent();
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toEqual([]);
     });
 
     it("should not include a filter entry when filter prop is only whitespace", () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "   " });
+      mockSearchObj.data.editorValue = "   ";
+      wrapper = mountComponent();
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toEqual([]);
     });
 
     it("should convert span_kind='Server' label to numeric key '2' in the base filter", () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "span_kind='Server'" });
+      mockSearchObj.data.editorValue = "span_kind='Server'";
+      wrapper = mountComponent();
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toContain("span_kind='2'");
       expect(filters.join(" ")).not.toContain("span_kind='Server'");
@@ -681,7 +696,8 @@ describe("TracesMetricsDashboard", () => {
 
     it("should convert span_kind='Client' label to numeric key '3' in the base filter", () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "span_kind='Client'" });
+      mockSearchObj.data.editorValue = "span_kind='Client'";
+      wrapper = mountComponent();
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toContain("span_kind='3'");
       expect(filters.join(" ")).not.toContain("span_kind='Client'");
@@ -689,14 +705,16 @@ describe("TracesMetricsDashboard", () => {
 
     it("should convert span_kind label case-insensitively in the base filter", () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "span_kind='SERVER'" });
+      mockSearchObj.data.editorValue = "span_kind='SERVER'";
+      wrapper = mountComponent();
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toContain("span_kind='2'");
     });
 
     it("should leave non-span_kind filters unchanged in the base filter", () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "service_name = 'api'" });
+      mockSearchObj.data.editorValue = "service_name = 'api'";
+      wrapper = mountComponent();
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toContain("service_name = 'api'");
     });
@@ -710,7 +728,8 @@ describe("TracesMetricsDashboard", () => {
         timeEnd: null,
       });
       wrapper.unmount();
-      wrapper = mountComponent({ filter: "span_kind='Internal'" });
+      mockSearchObj.data.editorValue = "span_kind='Internal'";
+      wrapper = mountComponent();
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toContain("duration >= 100 and duration <= 500");
       expect(filters).toContain("span_kind='1'");
@@ -826,7 +845,7 @@ describe("TracesMetricsDashboard", () => {
 
     it("should mount without error when filter prop is undefined", async () => {
       wrapper.unmount();
-      wrapper = mountComponent({ filter: undefined });
+      wrapper = mountComponent();
       await flushPromises();
       expect(wrapper.exists()).toBe(true);
     });

--- a/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
+++ b/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
@@ -55,11 +55,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       v-if="showAnalysisDashboard"
       :streamName="streamName"
       streamType="traces"
-      :timeRange="originalTimeRangeBeforeSelection || timeRange"
+      :timeRange="originalTimeRangeBeforeSelection || effectiveTimeRange"
       :rateFilter="analysisRateFilter"
       :durationFilter="analysisDurationFilter"
       :errorFilter="analysisErrorFilter"
-      :baseFilter="filter"
+      :baseFilter="effectiveFilter"
       :streamFields="streamFields"
       :analysisType="defaultAnalysisTab"
       :availableAnalysisTypes="['volume', 'error', 'duration']"
@@ -76,6 +76,7 @@ import {
   onBeforeUnmount,
   computed,
   defineAsyncComponent,
+  nextTick,
 } from "vue";
 import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
@@ -107,8 +108,6 @@ export interface TimeRange {
 
 const props = defineProps<{
   streamName: string;
-  timeRange: TimeRange;
-  filter?: string;
   show?: boolean;
   streamFields?: any[];
 }>();
@@ -123,14 +122,26 @@ const store = useStore();
 const { searchObj } = useTraces();
 const { t } = useI18n();
 
+
+// Read filter and timeRange directly from the shared composable rather than via props.
+// The props go stale during synchronous call chains (e.g., auto_query_enabled
+// triggers searchData → getQueryData → getDashboardData → loadDashboard before
+// Vue has re-rendered SearchResult and propagated the new prop). Reading from the
+// composable — the same object buildSearch() reads — guarantees the latest value.
+const effectiveFilter = computed(() => searchObj.data.editorValue);
+const effectiveTimeRange = computed<TimeRange>(() => ({
+  startTime: searchObj.data.datetime.startTime,
+  endTime: searchObj.data.datetime.endTime,
+}));
+
 const autoRefreshEnabled = ref(false);
 const autoRefreshIntervalId = ref<number | null>(null);
 const error = ref<string | null>(null);
 const dashboardChartsRef = ref<any>(null);
 const currentTimeObj = ref({
   __global: {
-    start_time: new Date(props.timeRange.startTime),
-    end_time: new Date(props.timeRange.endTime),
+    start_time: new Date(effectiveTimeRange.value.startTime),
+    end_time: new Date(effectiveTimeRange.value.endTime),
   },
 });
 
@@ -218,15 +229,15 @@ const getBaseFilters = () => {
   // Add user-provided filters from query editor, parsing any human-readable
   // duration values (e.g. '1.50ms') back to raw microseconds for SQL,
   // and span_kind labels (e.g. 'Server') back to numeric OTEL keys (e.g. '2').
-  if (props.filter?.trim().length) {
+  if (effectiveFilter.value?.trim().length) {
     const parsed = parseDurationWhereClause(
-      props.filter.trim(),
+      effectiveFilter.value.trim(),
       sqlParser.value,
       searchObj.data.stream.selectedStream.value,
     );
     baseFilters.push(
       parseSpanKindWhereClause(
-        typeof parsed === "string" ? parsed : props.filter.trim(),
+        typeof parsed === "string" ? parsed : effectiveFilter.value.trim(),
         sqlParser.value,
         searchObj.data.stream.selectedStream.value,
       ),
@@ -242,8 +253,8 @@ const loadDashboard = async () => {
 
     currentTimeObj.value = {
       __global: {
-        start_time: new Date(props.timeRange.startTime),
-        end_time: new Date(props.timeRange.endTime),
+        start_time: new Date(effectiveTimeRange.value.startTime),
+        end_time: new Date(effectiveTimeRange.value.endTime),
       },
     };
 
@@ -259,11 +270,11 @@ const loadDashboard = async () => {
       // Special handling for "Errors" panel - always filter by error status
       if (panel.title === "Errors") {
         const errorFilters = ["span_status = 'ERROR'"];
-        if (props.filter?.trim().length) {
+        if (effectiveFilter.value?.trim().length) {
           // Parse human-readable duration values back to raw µs for SQL,
           // and span_kind labels back to numeric OTEL keys.
           const parsedFilter = parseDurationWhereClause(
-            props.filter.trim(),
+            effectiveFilter.value.trim(),
             sqlParser.value,
             searchObj.data.stream.selectedStream.value,
           );
@@ -271,7 +282,7 @@ const loadDashboard = async () => {
             parseSpanKindWhereClause(
               typeof parsedFilter === "string"
                 ? parsedFilter
-                : props.filter.trim(),
+                : effectiveFilter.value.trim(),
               sqlParser.value,
               searchObj.data.stream.selectedStream.value,
             ),
@@ -401,7 +412,7 @@ const emitFiltersToQueryEditor = () => {
   emit("filters-updated", filters);
 };
 
-const onDataZoom = ({
+const onDataZoom = async ({
   start,
   end,
   start1,
@@ -420,11 +431,16 @@ const onDataZoom = ({
     // Store the original time range BEFORE selection for volume analysis baseline
     // This must be done before emit() which triggers the parent to update the datetime control
     originalTimeRangeBeforeSelection.value = {
-      startTime: props.timeRange.startTime,
-      endTime: props.timeRange.endTime,
+      startTime: effectiveTimeRange.value.startTime,
+      endTime: effectiveTimeRange.value.endTime,
     };
 
     searchObj.meta.metricsRangeFilters.clear();
+
+    // All panels emit time-range-selected to update global datetime control
+    emit("time-range-selected", { start, end });
+
+    await nextTick();
 
     // For Rate and Errors panels: use placeholder values to indicate time-based selection
     // Volume/Error analysis will use the time range, not Y-axis values
@@ -444,9 +460,6 @@ const onDataZoom = ({
 
       createRangeFilter(data, start1, end1, timeStartMicros, timeEndMicros);
     }
-
-    // All panels emit time-range-selected to update global datetime control
-    emit("time-range-selected", { start, end });
   }
 };
 


### PR DESCRIPTION
#12854 

## What changed

Fixes a race condition where RED (metrics) queries were missing the error filter on first click when `auto_query_enabled` is true. The root cause was that `onDataZoom` in `TracesMetricsDashboard.vue` emitted `"time-range-selected"` *after* `"filters-updated"`, so queries triggered by the filter change ran with stale time range data. The fix reorders these two events and adds `await nextTick()` between them. Additionally, the `filter` and `timeRange` props were removed from `TracesMetricsDashboard.vue` — the component now reads `editorValue` and `datetime` directly from `searchObj.data`, and the `setCustomDate.vue` component moves `markProgrammaticDateChange` to the end of the save flow.

## Why

The bug (RED queries not receiving the latest error filter on first auto-query) was caused by event ordering: `"time-range-selected"` fired after `"filters-updated"`, meaning the query triggered by the filter change used the previous time range. The second click worked because by then the cached time range had caught up. The decision to remove `filter`/`timeRange` props was driven by a dependency on `searchObj` data that is always available; passing them as separate props introduced an unnecessary synchronization risk.