### PR TITLE
fix(test-assist-caller): use truthy negation to exclude PR comments

### DIFF
--- a/.github/workflows/test-assist-caller.yml
+++ b/.github/workflows/test-assist-caller.yml
@@ -60,10 +60,17 @@ jobs:
     #     verifies bug ISSUES, and a PR number would confuse the engine downstream. The
     #     org-member gate is the trust boundary for the PAT — a stranger's comment fails this
     #     `if:`, so the dispatch step (and therefore the PAT) never runs.
+    # The `!github.event.issue.pull_request` check excludes PR comments (the field is set on
+    # PRs, undefined on regular issues). We intentionally use the truthy-negation pattern —
+    # the earlier `== null` comparison silently evaluated to false for undefined fields in
+    # GHA expression context, causing every legitimate /verify-bug comment on an issue to be
+    # gated out (caller job showed `skipped` with an empty steps array; see the "why not the
+    # equals-null" note below). This mirrors the truthy pattern e2e-council-caller.yml uses
+    # in the opposite direction (that caller REQUIRES a PR).
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request == null &&
+       !github.event.issue.pull_request &&
        github.event.comment.body == '/verify-bug' &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest


### PR DESCRIPTION
Caller was silently gating out every `/verify-bug` comment on real issues. Five test comments today (#12452, #12647, #12603, #12820, #11700 — all by @neha00290, MEMBER association) all produced caller runs with:
```
{ conclusion: \"skipped\", steps: [] }
```

## Root cause

```yaml
# BEFORE — broken
github.event.issue.pull_request == null
```

For a regular issue (not a PR), the `pull_request` field is **undefined** in the GHA expression context — not literally `null`. GHA's null-comparison against an undefined field doesn't evaluate the way one would want, so the whole OR short-circuits to false → the caller's job is skipped without running any step.

## Fix

```yaml
# AFTER — works
!github.event.issue.pull_request
```

Truthy negation. Handles undefined / null / false uniformly → true for issues, false for PRs. Mirrors the pattern [`e2e-council-caller.yml`](.github/workflows/e2e-council-caller.yml) uses in the opposite direction (that caller REQUIRES a PR, so uses the truthy check directly).

## Impact

Without this fix, the `/verify-bug` comment path is completely dead:
- Caller never dispatches the engine
- No ack posts on the source issue
- Label/verdict flow never fires

Manual `workflow_dispatch` (from the GitHub UI or `gh workflow run`) still works.

## Test plan
- [x] YAML parses (verified locally)
- [ ] After merge: comment `/verify-bug` on any Needs-Testing issue → expect caller job to RUN (not skip) → engine dispatched via ORG_ADMIN_TOKEN → ack comment on the source issue

## Follow-up

The 5 comments already posted while this bug was live won't retroactively trigger. Options:
- Re-comment `/verify-bug` after merge, OR
- Manual dispatch via `gh workflow run test-assist.yml --repo openobserve/o2-enterprise ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)