### PR TITLE
test(test-assist-ci): vision-preprocessor fixture + caller filter fix

### DIFF
--- a/.github/workflows/test-assist-caller.yml
+++ b/.github/workflows/test-assist-caller.yml
@@ -60,10 +60,17 @@ jobs:
     #     verifies bug ISSUES, and a PR number would confuse the engine downstream. The
     #     org-member gate is the trust boundary for the PAT — a stranger's comment fails this
     #     `if:`, so the dispatch step (and therefore the PAT) never runs.
+    # The `!github.event.issue.pull_request` check excludes PR comments (the field is set on
+    # PRs, undefined on regular issues). We intentionally use the truthy-negation pattern —
+    # the earlier `== null` comparison silently evaluated to false for undefined fields in
+    # GHA expression context, causing every legitimate /verify-bug comment on an issue to be
+    # gated out (caller job showed `skipped` with an empty steps array; see the "why not the
+    # equals-null" note below). This mirrors the truthy pattern e2e-council-caller.yml uses
+    # in the opposite direction (that caller REQUIRES a PR).
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request == null &&
+       !github.event.issue.pull_request &&
        github.event.comment.body == '/verify-bug' &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/tests/test-data/test-assist-ci/expected-verdicts.json
+++ b/tests/test-data/test-assist-ci/expected-verdicts.json
@@ -3,5 +3,16 @@
     "fixture": "bug-001-fixed.json",
     "expected_status": "FIXED",
     "expected_confidence": "HIGH"
+  },
+  "90002": {
+    "fixture": "bug-002-image-attachment.json",
+    "expected_pipeline_signals": {
+      "attachments_summary_exists": true,
+      "attachments_summary_non_empty": true,
+      "analyst_area": "Streams",
+      "analyst_testability_at_least": "MEDIUM"
+    },
+    "notes": "Fixture exercises the vision preprocessor. Success = vision preprocessor produced a non-empty attachments.md AND the Analyst used it to classify area=Streams AND didn't SKIP for 'no repro steps'. Verdict itself may vary (visual layout bugs are hard to auto-verify) but the pipeline should NOT skip due to text-only 'no repro'."
   }
 }
+

--- a/tests/test-data/test-assist-ci/expected-verdicts.json
+++ b/tests/test-data/test-assist-ci/expected-verdicts.json
@@ -6,13 +6,15 @@
   },
   "90002": {
     "fixture": "bug-002-image-attachment.json",
+    "expected_status": null,
+    "expected_confidence": null,
     "expected_pipeline_signals": {
       "attachments_summary_exists": true,
       "attachments_summary_non_empty": true,
       "analyst_area": "Streams",
       "analyst_testability_at_least": "MEDIUM"
     },
-    "notes": "Fixture exercises the vision preprocessor. Success = vision preprocessor produced a non-empty attachments.md AND the Analyst used it to classify area=Streams AND didn't SKIP for 'no repro steps'. Verdict itself may vary (visual layout bugs are hard to auto-verify) but the pipeline should NOT skip due to text-only 'no repro'."
+    "notes": "Fixture exercises the vision preprocessor. Success is measured via expected_pipeline_signals — not the final verdict — because visual layout bugs are hard to auto-verify. expected_status/confidence are null to explicitly signal that the harness must NOT assert on the Validator verdict for this fixture. Success = vision preprocessor produced a non-empty attachments.md AND the Analyst used it to classify area=Streams AND didn't SKIP for 'no repro steps'."
   }
 }
 

--- a/tests/test-data/test-assist-ci/fixture-issues/bug-002-image-attachment.json
+++ b/tests/test-data/test-assist-ci/fixture-issues/bug-002-image-attachment.json
@@ -1,0 +1,10 @@
+{
+  "number": 90002,
+  "title": "[fixture] Streams page — spacing between stream count and Bulk Delete button is too tight",
+  "body": "### Bug Description\n\nOn the Streams page, the horizontal spacing between the stream-count text (e.g. `50 streams`) and the **Bulk Delete** button is visibly too small. The two elements appear to touch or nearly touch, giving a cramped look.\n\n<img width=\"2316\" height=\"1239\" alt=\"streams-spacing\" src=\"https://github.com/user-attachments/assets/c8f7d889-ccca-449f-9aec-a293b9e63673\" />\n\n### Priority\n\nP3 - Low\n\n### Severity\n\nMinor\n\n### Steps to Reproduce (Optional)\n\n_No response_\n\n### Which OpenObserve Functionalities Are Affected?\n\n- [x] Streams\n- [x] Cosmetic\n\n(Synthetic fixture — the repro is ENTIRELY in the attached screenshot. This exercises the vision preprocessor + Analyst reading `bug-<N>-attachments.md`. Expected outcome: vision preprocessor produces a non-empty description of the streams-page screenshot; Analyst extracts `area: Streams`, uses the image description to populate reproduction_steps or note `has_visual_repro: true`; testability >= MEDIUM instead of SKIP.)",
+  "labels": [
+    {"name": "Needs-Testing"},
+    {"name": "fixture"}
+  ],
+  "comments": []
+}


### PR DESCRIPTION
Consolidated OSS-side changes for the vision preprocessor rollout. Two things bundled here — both small, both OSS-only, related by "unblocks test-assist real-issue verification."

## Change 1 — Caller filter fix (originally in #12972, now closed)

**One-line fix** for `.github/workflows/test-assist-caller.yml`:

```yaml
# BEFORE — broken (silently skipped every /verify-bug comment on real issues)
github.event.issue.pull_request == null

# AFTER — truthy negation, evaluates correctly for undefined fields
!github.event.issue.pull_request
```

Yesterday: 5 `/verify-bug` comments on real issues (#12452, #12647, #12603, #12820, #11700 — all by @neha00290, MEMBER association) produced 5 caller runs with `conclusion: skipped` and empty steps arrays. Root cause: `== null` compared against an *undefined* field in GHA expression context returns unexpected results → the entire OR short-circuited to false.

The council caller uses the truthy check in the opposite direction (`github.event.issue.pull_request` alone → *requires* a PR). We use the negation of the same pattern — proven, works.

## Change 2 — Vision preprocessor fixture (`bug-002-image-attachment.json`)

Adds fixture #90002 whose repro info lives **entirely in an image attachment**:
- body has `Steps to Reproduce: _No response_`
- body embeds a stable github.com/user-attachments/... permalink (streams-page screenshot from real bug #11700)

Pairs with the ENT-side vision preprocessor PR (adds extract-attachments + describe-via-GLM-4.6V-Flash steps before Analyst). Success = pipeline extracts the image, GLM describes it, Analyst uses the description → produces `area: Streams` + `testability >= MEDIUM` instead of skipping for "no repro steps."

`expected-verdicts.json` updated with the pipeline-signal expectations for #90002.

## Why bundled

Both changes unblock real-bug verification. The caller fix means `/verify-bug` starts dispatching; the fixture proves the vision preprocessor works on visual-only bugs. Reviewing them together is faster than in isolation.

## Test plan

- [x] YAML parses; fixture JSON valid; expected-verdicts JSON valid
- [ ] After merge (this + ENT PR): comment `/verify-bug` on any Needs-Testing issue → expect caller job to RUN (not skip) → engine dispatched
- [ ] After merge: dispatch fixture 90002 via workflow_dispatch → confirm vision preprocessor produces non-empty `bug-90002-attachments.md` → confirm Analyst produces `area: Streams` + non-SKIP testability

Closes #12972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)