### PR TITLE
fix: pagerduty integration bugs (#12975)

### DIFF
--- a/config/prebuilt-destinations.json
+++ b/config/prebuilt-destinations.json
@@ -93,7 +93,7 @@
       },
       "template": {
         "name": "prebuilt_pagerduty",
-        "body": "{\n  \"routing_key\": \"{integration_key}\",\n  \"event_action\": \"trigger\",\n  \"payload\": {\n    \"summary\": \"OpenObserve Alert: {alert_name}\",\n    \"severity\": \"error\",\n    \"source\": \"openobserve\",\n    \"component\": \"{stream_name}\",\n    \"group\": \"{stream_type}\",\n    \"class\": \"alert\",\n    \"custom_details\": {\n      \"alert_name\": \"{alert_name}\",\n      \"stream_name\": \"{stream_name}\",\n      \"stream_type\": \"{stream_type}\",\n      \"alert_count\": \"{alert_count}\",\n      \"alert_threshold\": \"{alert_operator} {alert_threshold}\",\n      \"alert_time\": \"{alert_time}\",\n      \"alert_url\": \"{alert_url}\"\n    }\n  }\n}"
+        "body": "{\n  \"payload\": {\n    \"summary\": \"OpenObserve Alert: {alert_name}\",\n    \"severity\": \"{severity}\",\n    \"source\": \"{source}\",\n    \"component\": \"{stream_name}\",\n    \"group\": \"{stream_type}\",\n    \"class\": \"alert\",\n    \"custom_details\": {\n      \"alert_name\": \"{alert_name}\",\n      \"stream_name\": \"{stream_name}\",\n      \"stream_type\": \"{stream_type}\",\n      \"alert_count\": \"{alert_count}\",\n      \"alert_threshold\": \"{alert_operator} {alert_threshold}\",\n      \"alert_time\": \"{alert_trigger_time_str}\",\n      \"alert_url\": \"{alert_url}\"\n    }\n  },\n  \"routing_key\": \"{routing_key}\",\n  \"event_action\": \"trigger\",\n  \"links\": [\n    {\n      \"href\": \"{alert_url}\",\n      \"text\": \"View in OpenObserve\"\n    }\n  ]\n}"
       },
       "credential_fields": [
         {

--- a/src/config/src/meta/destinations.rs
+++ b/src/config/src/meta/destinations.rs
@@ -254,7 +254,7 @@ impl MemorySize for Template {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, ToSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum TemplateType {
     #[default]

--- a/src/config/src/prebuilt_loader.rs
+++ b/src/config/src/prebuilt_loader.rs
@@ -266,7 +266,7 @@ fn load_builtin_config() -> PrebuiltDestinationsConfig {
                 }),
                 template: TemplateConfig {
                     name: "prebuilt_pagerduty".to_string(),
-                    body: r#"{"event_action": "trigger", "payload": {"summary": "Alert: {alert_name}"}}"#.to_string(),
+                    body: r#"{"payload": {"summary": "OpenObserve Alert: {alert_name}", "severity": "{severity}", "source": "{source}"}, "routing_key": "{routing_key}", "event_action": "trigger"}"#.to_string(),
                     title: None,
                 },
                 credential_fields: vec![],

--- a/src/service/alerts/templates.rs
+++ b/src/service/alerts/templates.rs
@@ -149,6 +149,7 @@ pub async fn ensure_system_templates() -> Result<(), anyhow::Error> {
     ];
 
     let mut created_count = 0;
+    let mut updated_count = 0;
     let mut skipped_count = 0;
 
     for prebuilt_type in prebuilt_types {
@@ -158,14 +159,41 @@ pub async fn ensure_system_templates() -> Result<(), anyhow::Error> {
 
             // Check if template already exists
             match db::alerts::templates::get(DEFAULT_ORG, &template.name).await {
-                Ok(_) => {
-                    // Template already exists, skip
-                    skipped_count += 1;
-                    log::debug!(
-                        "[TEMPLATES] System template '{}' already exists in {}",
-                        template.name,
-                        DEFAULT_ORG
-                    );
+                Ok(existing) => {
+                    // System templates are protected from user edits, so the
+                    // prebuilt definition is the source of truth. Refresh the
+                    // stored copy when it has drifted (e.g. a shipped fix to the
+                    // body/title) so existing installs pick up the correction.
+                    if existing.body != template.body
+                        || existing.template_type != template.template_type
+                    {
+                        // Preserve the stored id so this is an update, not an insert.
+                        template.id = existing.id;
+                        match db::alerts::templates::set(template.clone()).await {
+                            Ok(_) => {
+                                updated_count += 1;
+                                log::info!(
+                                    "[TEMPLATES] Updated system template '{}' in {}",
+                                    template.name,
+                                    DEFAULT_ORG
+                                );
+                            }
+                            Err(e) => {
+                                log::error!(
+                                    "[TEMPLATES] Failed to update system template '{}': {}",
+                                    template.name,
+                                    e
+                                );
+                            }
+                        }
+                    } else {
+                        skipped_count += 1;
+                        log::debug!(
+                            "[TEMPLATES] System template '{}' already up to date in {}",
+                            template.name,
+                            DEFAULT_ORG
+                        );
+                    }
                 }
                 Err(TemplateError::NotFound) => {
                     // Template doesn't exist, create it
@@ -203,8 +231,9 @@ pub async fn ensure_system_templates() -> Result<(), anyhow::Error> {
     drop(locker);
 
     log::info!(
-        "[TEMPLATES] System templates initialization complete: {} created, {} already existed",
+        "[TEMPLATES] System templates initialization complete: {} created, {} updated, {} already existed",
         created_count,
+        updated_count,
         skipped_count
     );
 

--- a/web/src/components/alerts/AddDestination.vue
+++ b/web/src/components/alerts/AddDestination.vue
@@ -892,6 +892,10 @@ const setupDestinationData = () => {
             if (key.startsWith("credential_")) {
               const credentialKey = key.replace("credential_", "");
               credentials[credentialKey] = value;
+            } else if (key === "routing_key") {
+              // PagerDuty stores the integration key as the bare `routing_key`
+              // metadata variable (substituted into the request body).
+              credentials.integrationKey = value;
             }
           });
         } catch (e) {
@@ -917,9 +921,12 @@ const setupDestinationData = () => {
           : props.destination.emails;
       }
 
-      // For PagerDuty, integrationKey is in headers (if present)
+      // For PagerDuty, integrationKey is restored from the routing_key metadata
+      // above. Fall back to the legacy X-Routing-Key header for destinations
+      // saved before the key was moved into the request body.
       if (
         typeId === "pagerduty" &&
+        !credentials.integrationKey &&
         props.destination.headers?.["X-Routing-Key"]
       ) {
         credentials.integrationKey = props.destination.headers["X-Routing-Key"];

--- a/web/src/composables/usePrebuiltDestinations.ts
+++ b/web/src/composables/usePrebuiltDestinations.ts
@@ -28,6 +28,7 @@ import {
   detectPrebuiltTypeFromUrl,
   generateDestinationUrl,
   generateDestinationHeaders,
+  generatePrebuiltMetadata,
   getPopularPrebuiltTypes,
   getPrebuiltTypesByCategory
 } from '@/utils/prebuilt-templates';
@@ -242,10 +243,13 @@ export function usePrebuiltDestinations() {
       alert_operator: 'greater than',
       alert_threshold: '80%',
       alert_time: new Date().toLocaleString(),
+      alert_trigger_time_str: new Date().toLocaleString(),
       // Use actual OpenObserve instance URL instead of fake example
       alert_url: `${baseUrl}/web/logs?org_identifier=${orgId}&stream_type=logs&stream=system-metrics&from=${oneHourAgo}&to=${now}&type=alert_destination_test`,
       // Default values for credential-based fields
       integration_key: 'sample-integration-key',
+      routing_key: 'sample-integration-key',
+      source: 'openobserve',
       severity: 'error',
       assignment_group: 'IT Operations',
       api_key: 'sample-api-key'
@@ -256,6 +260,7 @@ export function usePrebuiltDestinations() {
       // Map credential keys to template placeholder names
       if (credentials.integrationKey) {
         sampleData.integration_key = credentials.integrationKey;
+        sampleData.routing_key = credentials.integrationKey;
       }
       if (credentials.severity) {
         sampleData.severity = credentials.severity;
@@ -352,8 +357,11 @@ export function usePrebuiltDestinations() {
         alert_operator: 'greater than',
         alert_threshold: '80%',
         alert_time: new Date().toLocaleString(),
+        alert_trigger_time_str: new Date().toLocaleString(),
         alert_url: `${baseUrl}/web/logs?org_identifier=${orgId}&stream_type=logs&stream=system-metrics&from=${oneHourAgo}&to=${now}&type=alert_destination_test`,
         integration_key: 'sample-integration-key',
+        routing_key: 'sample-integration-key',
+        source: 'openobserve',
         severity: 'error',
         assignment_group: 'IT Operations',
         api_key: 'sample-api-key'
@@ -361,7 +369,10 @@ export function usePrebuiltDestinations() {
 
       // Override with actual credentials
       if (credentials) {
-        if (credentials.integrationKey) sampleData.integration_key = credentials.integrationKey;
+        if (credentials.integrationKey) {
+          sampleData.integration_key = credentials.integrationKey;
+          sampleData.routing_key = credentials.integrationKey;
+        }
         if (credentials.severity) sampleData.severity = credentials.severity;
         if (credentials.apiKey) sampleData.api_key = credentials.apiKey;
         if (credentials.assignmentGroup) sampleData.assignment_group = credentials.assignmentGroup;
@@ -492,7 +503,10 @@ export function usePrebuiltDestinations() {
                 !key.toLowerCase().includes('key') &&
                 !key.toLowerCase().includes('token')
               ).map(([k, v]) => [`credential_${k}`, String(v)])
-            )
+            ),
+            // Bare template-body variables the alert engine substitutes
+            // server-side (e.g. PagerDuty routing_key/severity/source).
+            ...generatePrebuiltMetadata(type, credentials)
           }
         };
       } else {
@@ -516,7 +530,10 @@ export function usePrebuiltDestinations() {
                 !key.toLowerCase().includes('key') &&
                 !key.toLowerCase().includes('token')
               ).map(([k, v]) => [`credential_${k}`, String(v)])
-            )
+            ),
+            // Bare template-body variables the alert engine substitutes
+            // server-side (e.g. PagerDuty routing_key/severity/source).
+            ...generatePrebuiltMetadata(type, credentials)
           }
         };
 
@@ -610,7 +627,10 @@ export function usePrebuiltDestinations() {
                 !key.toLowerCase().includes('key') &&
                 !key.toLowerCase().includes('token')
               ).map(([k, v]) => [`credential_${k}`, String(v)])
-            )
+            ),
+            // Bare template-body variables the alert engine substitutes
+            // server-side (e.g. PagerDuty routing_key/severity/source).
+            ...generatePrebuiltMetadata(type, credentials)
           }
         };
       } else {
@@ -632,7 +652,10 @@ export function usePrebuiltDestinations() {
                 !key.toLowerCase().includes('key') &&
                 !key.toLowerCase().includes('token')
               ).map(([k, v]) => [`credential_${k}`, String(v)])
-            )
+            ),
+            // Bare template-body variables the alert engine substitutes
+            // server-side (e.g. PagerDuty routing_key/severity/source).
+            ...generatePrebuiltMetadata(type, credentials)
           }
         };
 

--- a/web/src/utils/prebuilt-templates/index.spec.ts
+++ b/web/src/utils/prebuilt-templates/index.spec.ts
@@ -21,6 +21,7 @@ import {
   detectPrebuiltTypeFromUrl,
   generateDestinationUrl,
   generateDestinationHeaders,
+  generatePrebuiltMetadata,
   getPopularPrebuiltTypes,
   getPrebuiltTypesByCategory
 } from '@/utils/prebuilt-templates';
@@ -224,8 +225,9 @@ describe('Prebuilt Templates Index', () => {
       const credentials = { integrationKey: 'test-integration-key-12345678' };
       const headers = generateDestinationHeaders('pagerduty', credentials);
 
-      expect(headers).toHaveProperty('X-Routing-Key');
-      expect(headers['X-Routing-Key']).toBe('test-integration-key-12345678');
+      // PagerDuty Events API v2 reads the integration key from the request body
+      // (routing_key), not from a header — so no routing header is emitted.
+      expect(headers).not.toHaveProperty('X-Routing-Key');
       expect(headers['Content-Type']).toBe('application/json');
     });
 
@@ -247,6 +249,29 @@ describe('Prebuilt Templates Index', () => {
       const headers2 = generateDestinationHeaders('opsgenie', { apiKey: 'different-key' });
 
       expect(headers1.Authorization).not.toBe(headers2.Authorization);
+    });
+  });
+
+  describe('generatePrebuiltMetadata', () => {
+    it('should map PagerDuty credentials to body template variables', () => {
+      const credentials = { integrationKey: 'test-integration-key-12345678', severity: 'critical' };
+      const metadata = generatePrebuiltMetadata('pagerduty', credentials);
+
+      // routing_key carries the integration key into the request body.
+      expect(metadata.routing_key).toBe('test-integration-key-12345678');
+      expect(metadata.severity).toBe('critical');
+      expect(metadata.source).toBe('openobserve');
+    });
+
+    it('should still set a source for PagerDuty without credentials', () => {
+      const metadata = generatePrebuiltMetadata('pagerduty', {});
+      expect(metadata.source).toBe('openobserve');
+      expect(metadata).not.toHaveProperty('routing_key');
+    });
+
+    it('should return empty metadata for types without body variables', () => {
+      expect(generatePrebuiltMetadata('slack', { webhookUrl: 'https://x' })).toEqual({});
+      expect(generatePrebuiltMetadata('unknown', {})).toEqual({});
     });
   });
 

--- a/web/src/utils/prebuilt-templates/index.ts
+++ b/web/src/utils/prebuilt-templates/index.ts
@@ -151,10 +151,10 @@ export function generateDestinationHeaders(type: string, credentials: Record<str
   // Add dynamic headers based on credentials
   switch (type) {
     case 'pagerduty':
-      // PagerDuty uses X-Routing-Key header for integration key
-      if (credentials.integrationKey) {
-        headers['X-Routing-Key'] = credentials.integrationKey;
-      }
+      // PagerDuty Events API v2 reads the integration key from the request body
+      // (`routing_key`), NOT from any header. The key is carried in destination
+      // metadata (see generatePrebuiltMetadata) so the server can substitute it
+      // into the template body at send time.
       break;
     case 'opsgenie':
       if (credentials.apiKey) {
@@ -169,4 +169,33 @@ export function generateDestinationHeaders(type: string, credentials: Record<str
   }
 
   return headers;
+}
+
+/**
+ * Generate destination metadata (bare template variables) for a prebuilt type.
+ *
+ * These keys are substituted into the template body server-side by the alert
+ * engine's endpoint-metadata substitution (each `{key}` in the template body is
+ * replaced by the matching metadata value at send time). Use this for values
+ * that must appear inside the request body — e.g. PagerDuty's `routing_key`,
+ * which the Events API v2 requires in the payload rather than a header.
+ */
+export function generatePrebuiltMetadata(type: string, credentials: Record<string, any>): Record<string, string> {
+  const metadata: Record<string, string> = {};
+
+  switch (type) {
+    case 'pagerduty':
+      // routing_key = PagerDuty integration key (required in the body).
+      if (credentials.integrationKey) {
+        metadata['routing_key'] = credentials.integrationKey;
+      }
+      if (credentials.severity) {
+        metadata['severity'] = credentials.severity;
+      }
+      // PagerDuty requires a non-empty `source` in the payload.
+      metadata['source'] = 'openobserve';
+      break;
+  }
+
+  return metadata;
 }

--- a/web/src/utils/prebuilt-templates/pagerduty.ts
+++ b/web/src/utils/prebuilt-templates/pagerduty.ts
@@ -21,12 +21,10 @@ import { PrebuiltConfig } from './types';
 export const pagerdutyTemplate = {
   name: 'prebuilt_pagerduty',
   body: JSON.stringify({
-    "routing_key": "{integration_key}",
-    "event_action": "trigger",
     "payload": {
       "summary": "OpenObserve Alert: {alert_name}",
-      "source": "openobserve",
       "severity": "{severity}",
+      "source": "{source}",
       "component": "{stream_name}",
       "group": "{stream_type}",
       "class": "alert",
@@ -37,10 +35,12 @@ export const pagerdutyTemplate = {
         "alert_count": "{alert_count}",
         "alert_operator": "{alert_operator}",
         "alert_threshold": "{alert_threshold}",
-        "alert_time": "{alert_time}",
+        "alert_time": "{alert_trigger_time_str}",
         "alert_url": "{alert_url}"
       }
     },
+    "routing_key": "{routing_key}",
+    "event_action": "trigger",
     "links": [
       {
         "href": "{alert_url}",


### PR DESCRIPTION
## Fix PagerDuty prebuilt destination

### Problem
PagerDuty Events API v2 requires the integration key as `routing_key` **in the JSON body**, but it never got there:

- Template used `{integration_key}` — not a real server variable → sent literally → PagerDuty rejects payload. `severity`/`source` hardcoded.
- UI stored integration key only in an `X-Routing-Key` header, which PagerDuty ignores.
- Severity stored as `credential_severity`, never referenced by the template.
- "Test" passed only via client-side substitution, diverging from the real server send path → Test could pass while real alerts failed.

### Fix
Route everything through the alert engine's existing endpoint-metadata substitution so real sends and Test/Preview render identical, valid payloads.

- **Template body**: corrected to PagerDuty v2 shape with substitutable `{routing_key}`, `{severity}`, `{source}` (`prebuilt-destinations.json`, Rust fallback, web `pagerduty.ts`).
- **Fields now used**: new `generatePrebuiltMetadata()` writes `routing_key` (=integration key), `severity`, `source` into destination metadata on save → server fills them at send time. Dropped useless `X-Routing-Key` header; edit-restore reads key from metadata (legacy header kept as fallback).
- **Test uses real template**: Test/Preview sample data now supplies `routing_key`/`source` → client renders the same body the server sends.
- **Stale templates**: `ensure_system_templates()` previously skipped already-existing prebuilt templates → existing installs kept the broken body. Now refreshes system-managed templates whose stored body has drifted from shipped source.

### Verification
- Rust: `config` + `openobserve` binary compile; prebuilt loader tests pass (10/10). Added `PartialEq`/`Eq` to `TemplateType` for drift check.
- Updated header unit test + added `generatePrebuiltMetadata` tests. JS suite not runnable locally (pre-existing `ERR_REQUIRE_ESM` in vitest setup, unrelated) — run in CI.

### Note
Out of scope: Test always uses `prebuilt_pagerduty` template name, not a per-destination custom template override.