### PR TITLE
feat: limit cpu num by memory limit when user only set memory limit

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2637,8 +2637,16 @@ pub fn init() -> Config {
 fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     // set real cpu num
     cfg.limit.real_cpu_num = max(1, sysinfo::get_cpu_limit());
+    // limit cpu num by memory, 1 core per 1GB, in case the user only set memory
+    // limit on k8s and we detect the whole node's cpu cores
+    let mem_total = sysinfo::get_memory_limit();
+    let cpu_num = if mem_total == 0 {
+        cfg.limit.real_cpu_num
+    } else {
+        cfg.limit.real_cpu_num.min(mem_total / (1024 * 1024 * 1024))
+    };
     // set at least 2 threads
-    let cpu_num = max(2, cfg.limit.real_cpu_num);
+    let cpu_num = max(2, cpu_num);
     cfg.limit.cpu_num = cpu_num;
     if cfg.limit.http_worker_num == 0 {
         cfg.limit.http_worker_num = cpu_num;

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2643,7 +2643,9 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     let cpu_num = if mem_total == 0 {
         cfg.limit.real_cpu_num
     } else {
-        cfg.limit.real_cpu_num.min(max(1, mem_total / (1024 * 1024 * 1024)))
+        cfg.limit
+            .real_cpu_num
+            .min(max(1, mem_total / (1024 * 1024 * 1024)))
     };
     // set at least 2 threads
     let cpu_num = max(2, cpu_num);

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2643,7 +2643,7 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     let cpu_num = if mem_total == 0 {
         cfg.limit.real_cpu_num
     } else {
-        cfg.limit.real_cpu_num.min(mem_total / (1024 * 1024 * 1024))
+        cfg.limit.real_cpu_num.min(max(1, mem_total / (1024 * 1024 * 1024)))
     };
     // set at least 2 threads
     let cpu_num = max(2, cpu_num);


### PR DESCRIPTION
Design at: #12995

## Summary

On k8s, when the user only sets a memory limit (no CPU limit), we detect the whole node's CPU cores via sysinfo — e.g. 64 cores on a node while the pod only has 8GB memory. All cpu-derived thread pools (`http_worker_num`, `query_thread_num = cpu * 4`, file download/move/merge threads, etc.) then get sized for 64 cores against an 8GB memory budget, causing memory pressure and OOM.

## Changes

- In `check_limit_config`, clamp `limit.cpu_num` by the memory limit: `cpu_num = real_cpu_num.min(mem_total / 1GB).max(2)`.
- If the memory limit is unknown (0), use the CPU limit directly.
- `real_cpu_num` keeps the true detected value; `get_cpu_limit()` / cgroup detection is untouched.

Example: 64-core node + 8GB memory limit → `cpu_num = 8`, so `query_thread_num` becomes 32 instead of 256.