### PR TITLE
ci: migrate release artifacts runner repo -> eks (branch-v0.91.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
   release:
     name: Release artifacts
     needs: [build]
-    runs-on: repo-openobserve-standard-4
+    runs-on: eks-openobserve-standard-4
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## What
Point the `Release artifacts` job in `release.yml` at `eks-openobserve-standard-4` on `branch-v0.91.0`.

## Why
`branch-v0.91.0` still targeted `repo-openobserve-standard-4`, a runner pool that has been decommissioned (migrated to `eks-*` on `main` via #12931 and on `branch-v0.92.0`). As a result the `Release artifacts` job on v0.91.x release runs stays `queued` with no runner ever assigned. This aligns the v0.91.0 release branch with `main` and `branch-v0.92.0`.

## Scope
One-line change; `main` and `branch-v0.92.0` already use `eks-*` and need no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)