### PR TITLE
test(autoe2e): E2E tests for #11814 (report-csv-media-type) [v0.80.0]

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -258,6 +258,7 @@ jobs:
               "reportsScheduleLater.spec.js",
               "reportFolders.spec.js",
               "reports-bulk-operations.spec.js",
+              "reportCsvMediaType.spec.js",
               ]
           - testfolder: "Streams"
             browser: "chrome"

--- a/tests/ui-testing/pages/dashboardPages/dashboardPage.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboardPage.js
@@ -180,7 +180,8 @@ export class DashboardPage {
     await this.dashboardDelete.click({ force: true });
     await this.page.waitForTimeout(2000);
     await this.confirmButton.filter({ has: this.page.locator(':visible') }).first().click();
-    await expect(this.page.getByRole('alert')).toContainText('Dashboard deleted successfully.');
+    const successAlert = this.page.getByRole('alert').filter({ hasText: 'Dashboard deleted successfully.' });
+    await expect(successAlert).toBeVisible({ timeout: 30000 });
   }
 
   async deleteSearchedDashboard(dashboardName) {

--- a/tests/ui-testing/pages/reportsPages/reportFoldersPage.js
+++ b/tests/ui-testing/pages/reportsPages/reportFoldersPage.js
@@ -96,6 +96,8 @@ export class ReportFoldersPage {
     await this.clickSaveFolder();
     // Wait for the dialog to close after save
     await this.page.locator(this.folderDialog).waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    // Also wait for the Quasar backdrop to fade — otherwise it can intercept the next click.
+    await this.page.locator('.q-dialog__backdrop').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
   }
 
   async expectFolderTabVisible(folderName) {

--- a/tests/ui-testing/pages/reportsPages/reportsPage.js
+++ b/tests/ui-testing/pages/reportsPages/reportsPage.js
@@ -20,6 +20,26 @@ export class ReportsPage {
     this.titleInput = page.locator("[aria-label='Title *']");
     this.recipientsInput = page.locator("[aria-label='Recipients *']");
     this.saveButton = page.locator('[data-test="add-report-save-btn"]');
+
+    // ── Report Format section (CSV media type feature) ─────────────────────
+    this.reportFormatSection = page.locator('[data-test="add-report-format-section"]');
+    this.reportTypeSelect = page.locator('[data-test="add-report-type-select"]');
+    this.reportTypeTrigger = page.locator('[data-test="add-report-type-select"] [data-test-selected-value]');
+    this.reportTypePopover = page.locator('[data-test="add-report-type-select-popover"]');
+    // OSelect always stamps data-test-value on options (unconditional), but
+    // data-test-concatenated attrs are only emitted when OSelect receives a
+    // direct data-test prop. This instance lacks it — match by value only.
+    this.reportTypeOption = (value) => page.locator(`[data-test-value="${value}"]`).first();
+    this.attachmentTypeSelect = page.locator('[data-test="add-report-attachment-type-select"]');
+    this.customDimensionsSection = page.locator('[data-test="add-report-custom-dimensions-section"]');
+    this.pngNoteBanner = page.locator('[data-test="add-report-png-note"]');
+
+    // ── Report-list search + edit shims (v0.80.0-compatible) ───────────────
+    // The generated CSV spec expects `reportSearchInputField` + `editReportBtn`
+    // helpers (introduced on main). Wire them to the v0.80.0 selectors.
+    this.reportSearchInputField = page.locator('[data-test="report-list-search-input"]');
+    this.editReportBtn = (reportName) => page.locator(`[data-test="report-list-${reportName}-edit-report"]`);
+
     this.successAlert = page.getByRole('alert').nth(1);
     this.dateTimeButton = dateTimeButtonLocator;
     this.relative30SecondsButton = page.locator(relative30SecondsButtonLocator);
@@ -343,8 +363,74 @@ async notAvailableReport(reportName) {
   await this.page.locator('[data-test="report-list-search-input"]').fill(reportName);
   await this.page.waitForSelector('[data-test="report-list-table"]');
   await expect(this.page.locator('[data-test="report-list-table"]')).toContainText('No data available');
- 
+
 }
+
+  // ── Report Format section helpers (CSV media type feature) ──────────────
+
+  async selectReportType(value) {
+    // Open the report type dropdown by clicking the trigger.
+    // NOTE: This OSelect lacks a direct `data-test` prop (the attribute is on
+    // the parent <div> instead), so the popover and option children do NOT have
+    // data-test-concatenated attributes. We locate options by data-test-value
+    // instead, which OSelect always renders unconditionally.
+    await this.reportTypeTrigger.waitFor({ state: 'visible', timeout: 10000 });
+    await this.reportTypeTrigger.click();
+    const opt = this.reportTypeOption(value);
+    await opt.waitFor({ state: 'visible', timeout: 10000 });
+    await opt.click();
+    await opt.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    await this.page.waitForTimeout(300);
+  }
+
+  async selectDashboardDefaults(dashboardName) {
+    await this.createReportFolderInput();
+    await this.createReportDashboardInput(dashboardName);
+    await this.createReportDashboardTabInput();
+  }
+
+  async expectReportFormatSectionVisible() {
+    await expect(this.reportFormatSection).toBeVisible({ timeout: 15000 });
+  }
+
+  async expectAttachmentTypeVisible() {
+    await expect(this.attachmentTypeSelect).toBeVisible({ timeout: 5000 });
+  }
+
+  async expectAttachmentTypeHidden() {
+    await expect(this.attachmentTypeSelect).not.toBeVisible({ timeout: 5000 });
+  }
+
+  async expectCustomDimensionsVisible() {
+    await expect(this.customDimensionsSection).toBeVisible({ timeout: 5000 });
+  }
+
+  async expectCustomDimensionsHidden() {
+    await expect(this.customDimensionsSection).not.toBeVisible({ timeout: 5000 });
+  }
+
+  async expectPngNoteVisible() {
+    await expect(this.pngNoteBanner).toBeVisible({ timeout: 5000 });
+  }
+
+  async expectPngNoteHidden() {
+    await expect(this.pngNoteBanner).not.toBeVisible({ timeout: 5000 });
+  }
+
+  async expectReportTypeOptionVisible(value) {
+    await this.reportTypeTrigger.waitFor({ state: 'visible', timeout: 10000 });
+    await this.reportTypeTrigger.click();
+    const opt = this.reportTypeOption(value);
+    await expect(opt).toBeVisible({ timeout: 5000 });
+    await this.page.keyboard.press('Escape');
+    await opt.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+  }
+
+  async expectReportTypeOptionSelected(value) {
+    const labelMap = { csv: 'CSV (Data)', pdf: 'PDF (default)', png: 'PNG (Image)' };
+    const expectedLabel = labelMap[value] || value;
+    await expect(this.reportTypeTrigger).toContainText(expectedLabel, { timeout: 10000 });
+  }
 
 }
 

--- a/tests/ui-testing/pages/reportsPages/reportsPage.js
+++ b/tests/ui-testing/pages/reportsPages/reportsPage.js
@@ -22,14 +22,14 @@ export class ReportsPage {
     this.saveButton = page.locator('[data-test="add-report-save-btn"]');
 
     // ── Report Format section (CSV media type feature) ─────────────────────
+    // v0.80.0 uses a raw Quasar q-select (not OSelect), so options are rendered
+    // as role="option" q-items and there is no data-test-selected-value/data-test-value
+    // stamping. Match the section wrapper for the trigger + text, and options by role+label.
     this.reportFormatSection = page.locator('[data-test="add-report-format-section"]');
     this.reportTypeSelect = page.locator('[data-test="add-report-type-select"]');
-    this.reportTypeTrigger = page.locator('[data-test="add-report-type-select"] [data-test-selected-value]');
-    this.reportTypePopover = page.locator('[data-test="add-report-type-select-popover"]');
-    // OSelect always stamps data-test-value on options (unconditional), but
-    // data-test-concatenated attrs are only emitted when OSelect receives a
-    // direct data-test prop. This instance lacks it — match by value only.
-    this.reportTypeOption = (value) => page.locator(`[data-test-value="${value}"]`).first();
+    this.reportTypeTrigger = page.locator('[data-test="add-report-type-select"] .q-field__control');
+    this.reportTypeLabelMap = { csv: 'CSV (Data)', pdf: 'PDF (default)', png: 'PNG (Image)' };
+    this.reportTypeOption = (value) => page.getByRole('option', { name: this.reportTypeLabelMap[value] || value, exact: true });
     this.attachmentTypeSelect = page.locator('[data-test="add-report-attachment-type-select"]');
     this.customDimensionsSection = page.locator('[data-test="add-report-custom-dimensions-section"]');
     this.pngNoteBanner = page.locator('[data-test="add-report-png-note"]');
@@ -369,11 +369,8 @@ async notAvailableReport(reportName) {
   // ── Report Format section helpers (CSV media type feature) ──────────────
 
   async selectReportType(value) {
-    // Open the report type dropdown by clicking the trigger.
-    // NOTE: This OSelect lacks a direct `data-test` prop (the attribute is on
-    // the parent <div> instead), so the popover and option children do NOT have
-    // data-test-concatenated attributes. We locate options by data-test-value
-    // instead, which OSelect always renders unconditionally.
+    // v0.80.0 renders a raw Quasar q-select. Open the dropdown by clicking the
+    // .q-field__control inside the section, then click the option by role+label.
     await this.reportTypeTrigger.waitFor({ state: 'visible', timeout: 10000 });
     await this.reportTypeTrigger.click();
     const opt = this.reportTypeOption(value);
@@ -427,9 +424,8 @@ async notAvailableReport(reportName) {
   }
 
   async expectReportTypeOptionSelected(value) {
-    const labelMap = { csv: 'CSV (Data)', pdf: 'PDF (default)', png: 'PNG (Image)' };
-    const expectedLabel = labelMap[value] || value;
-    await expect(this.reportTypeTrigger).toContainText(expectedLabel, { timeout: 10000 });
+    const expectedLabel = this.reportTypeLabelMap[value] || value;
+    await expect(this.reportTypeSelect).toContainText(expectedLabel, { timeout: 10000 });
   }
 
 }

--- a/tests/ui-testing/pages/reportsPages/reportsPage.js
+++ b/tests/ui-testing/pages/reportsPages/reportsPage.js
@@ -113,8 +113,10 @@ export class ReportsPage {
     await this.dashboardInput.dblclick({ force: true });
     await this.page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => {});
     await this.dashboardInput.fill(dashboardName);
-    await this.page.waitForTimeout(2000);
-    await this.page.getByRole('option', { name: dashboardName }).locator('div').nth(2).click({ force: true });
+    // Wait for the option to appear before clicking (dashboard search can be slow).
+    const option = this.page.getByRole('option', { name: dashboardName });
+    await option.first().waitFor({ state: 'visible', timeout: 30000 });
+    await option.locator('div').nth(2).click({ force: true });
   }
 
   async createReportDashboardTabInput() {
@@ -211,10 +213,10 @@ export class ReportsPage {
   }
 
   async verifyReportCreated(reportName) {
-    // Wait for save success alert (reports API takes 10-11 seconds)
-    await this.page.waitForSelector('div[role="alert"]', { state: 'visible', timeout: 15000 });
+    // Wait for save success alert (reports API takes 10-11 seconds).
+    // Filter directly on the success text so stale error alerts don't shadow it.
     const saveAlert = this.page.getByRole('alert').filter({ hasText: 'Report saved successfully.' });
-    await expect(saveAlert).toBeVisible({ timeout: 5000 });
+    await expect(saveAlert).toBeVisible({ timeout: 30000 });
 
     // Navigate to reports list to verify report exists
     await this.page.goto(process.env["ZO_BASE_URL"] + "/web/reports?org_identifier=" + process.env["ORGNAME"]);

--- a/tests/ui-testing/playwright-tests/Reports/reportCsvMediaType.spec.js
+++ b/tests/ui-testing/playwright-tests/Reports/reportCsvMediaType.spec.js
@@ -1,0 +1,302 @@
+// Copyright 2026 OpenObserve Inc.
+// Dashboard Report CSV Media Type — E2E tests
+//
+// Covers:
+//   1. CSV option visible in the Report Type dropdown
+//   2. Selecting CSV hides Attachment Type and Custom Dimensions
+//   3. Save a report with CSV type succeeds
+//   4. Switching from CSV back to PDF restores controls
+//   5. Selecting PNG type shows PNG warning banner
+//   6. Edit mode: CSV report shows CSV as selected and controls hidden
+//
+// All scenarios are WIRED — no fixme placeholders needed.
+// Dashboard + ingestion provisioning follows the setup contract
+// (docs/test_generator/ci/setup-contract.md).
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+// ── Unique name helpers ──────────────────────────────────────────────────
+
+function uniqueReportName(prefix) {
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+// ── Test suite ───────────────────────────────────────────────────────────
+
+test.describe("Dashboard Report CSV Media Type", () => {
+  test.describe.configure({ mode: 'parallel' });
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+
+    // Seed the e2e_automate stream per setup contract
+    await pm.ingestionPage.ingestion();
+
+    // Create a dashboard for this test (each parallel worker gets its own)
+    await pm.dashboardPage.navigateToDashboards();
+    await pm.dashboardPage.createDashboard();
+    await expect(page).toHaveURL(/.*\/dashboards/);
+
+    // Navigate to Reports page and open the Create Report form
+    await page.goto(
+      process.env["ZO_BASE_URL"] +
+        "/web/reports?org_identifier=" +
+        process.env["ORGNAME"]
+    );
+    await pm.reportsPage.createReportAddReportButton();
+
+    testLogger.info('Test setup completed — dashboard created, form open');
+  });
+
+  // ── P0: Critical Path ──────────────────────────────────────────────────
+
+  test("CSV option is visible in the Report Type dropdown", {
+    tag: ['@report-csv-media-type', '@all', '@P0']
+  }, async ({ page }) => {
+    testLogger.info('Testing CSV option visibility in report type dropdown');
+
+    const TEST_REPORT_NAME = uniqueReportName('csvopt');
+    await pm.reportsPage.createReportReportNameInput(TEST_REPORT_NAME);
+    await pm.reportsPage.selectDashboardDefaults(pm.dashboardPage.dashboardName);
+
+    // Confirm we reached the Report Format section
+    await pm.reportsPage.expectReportFormatSectionVisible();
+
+    // Open the dropdown and assert CSV option is visible
+    await pm.reportsPage.expectReportTypeOptionVisible('csv');
+
+    testLogger.info('CSV option confirmed visible in report type dropdown');
+
+    // Cleanup: delete the dashboard
+    await page.goto(
+      process.env["ZO_BASE_URL"] +
+        "/web/dashboards?org_identifier=" +
+        process.env["ORGNAME"]
+    );
+    await pm.dashboardPage.navigateToDashboards();
+    await pm.dashboardPage.deleteDashboard();
+    testLogger.info('Dashboard cleanup completed');
+  });
+
+  test("Selecting CSV hides Attachment Type and Custom Dimensions", {
+    tag: ['@report-csv-media-type', '@all', '@P0']
+  }, async ({ page }) => {
+    testLogger.info('Testing CSV selection hides attachment type and custom dimensions');
+
+    const TEST_REPORT_NAME = uniqueReportName('csvhide');
+    await pm.reportsPage.createReportReportNameInput(TEST_REPORT_NAME);
+    await pm.reportsPage.selectDashboardDefaults(pm.dashboardPage.dashboardName);
+
+    // Confirm we reached the Report Format section
+    await pm.reportsPage.expectReportFormatSectionVisible();
+
+    // Baseline: default type is PDF, so controls should be visible
+    await pm.reportsPage.expectAttachmentTypeVisible();
+    await pm.reportsPage.expectCustomDimensionsVisible();
+
+    // Select CSV (Data)
+    await pm.reportsPage.selectReportType('csv');
+
+    // After CSV selection, attachment type and custom dimensions must be hidden
+    await pm.reportsPage.expectAttachmentTypeHidden();
+    await pm.reportsPage.expectCustomDimensionsHidden();
+
+    // PNG warning banner must not be visible (only for PNG, not CSV)
+    await pm.reportsPage.expectPngNoteHidden();
+
+    testLogger.info('CSV hides attachment type and custom dimensions confirmed');
+
+    // Cleanup: delete the dashboard
+    await page.goto(
+      process.env["ZO_BASE_URL"] +
+        "/web/dashboards?org_identifier=" +
+        process.env["ORGNAME"]
+    );
+    await pm.dashboardPage.navigateToDashboards();
+    await pm.dashboardPage.deleteDashboard();
+    testLogger.info('Dashboard cleanup completed');
+  });
+
+  test("Save a report with CSV type succeeds", {
+    tag: ['@report-csv-media-type', '@all', '@P0', '@smoke']
+  }, async ({ page }) => {
+    testLogger.info('Testing full save flow with CSV report type');
+
+    const TEST_REPORT_NAME = uniqueReportName('csvsave');
+    await pm.reportsPage.createReportReportNameInput(TEST_REPORT_NAME);
+    await pm.reportsPage.selectDashboardDefaults(pm.dashboardPage.dashboardName);
+
+    // Confirm we reached the Report Format section
+    await pm.reportsPage.expectReportFormatSectionVisible();
+
+    // Select CSV type
+    await pm.reportsPage.selectReportType('csv');
+
+    // Continue to step 2 (Schedule)
+    await pm.reportsPage.createReportContinueButtonStep1();
+
+    // Select "Once" frequency and continue to step 3
+    await pm.reportsPage.createReportOnce();
+    await pm.reportsPage.createReportContinueButtonStep2();
+
+    // Fill share details and save
+    await pm.reportsPage.createReportFillDetail();
+    await pm.reportsPage.createReportSaveButton();
+
+    // Verify the report was created (waits for success toast + confirms in list)
+    await pm.reportsPage.verifyReportCreated(TEST_REPORT_NAME);
+
+    testLogger.info('CSV report saved successfully');
+
+    // Cleanup: delete the report, then the dashboard
+    await pm.reportsPage.deleteReport(TEST_REPORT_NAME);
+    await page.goto(
+      process.env["ZO_BASE_URL"] +
+        "/web/dashboards?org_identifier=" +
+        process.env["ORGNAME"]
+    );
+    await pm.dashboardPage.navigateToDashboards();
+    await pm.dashboardPage.deleteDashboard();
+    testLogger.info('Cleanup completed');
+  });
+
+  // ── P1: Important Variations ───────────────────────────────────────────
+
+  test("Switching from CSV back to PDF restores Attachment Type and Custom Dimensions", {
+    tag: ['@report-csv-media-type', '@all', '@P1']
+  }, async ({ page }) => {
+    testLogger.info('Testing CSV→PDF toggle restores hidden controls');
+
+    const TEST_REPORT_NAME = uniqueReportName('csvtopdf');
+    await pm.reportsPage.createReportReportNameInput(TEST_REPORT_NAME);
+    await pm.reportsPage.selectDashboardDefaults(pm.dashboardPage.dashboardName);
+
+    // Confirm we reached the Report Format section
+    await pm.reportsPage.expectReportFormatSectionVisible();
+
+    // Select CSV — controls should hide
+    await pm.reportsPage.selectReportType('csv');
+    await pm.reportsPage.expectAttachmentTypeHidden();
+    await pm.reportsPage.expectCustomDimensionsHidden();
+
+    // Switch back to PDF — controls must reappear
+    await pm.reportsPage.selectReportType('pdf');
+    await pm.reportsPage.expectAttachmentTypeVisible();
+    await pm.reportsPage.expectCustomDimensionsVisible();
+
+    testLogger.info('CSV→PDF toggle correctly restores controls');
+
+    // Cleanup: delete the dashboard
+    await page.goto(
+      process.env["ZO_BASE_URL"] +
+        "/web/dashboards?org_identifier=" +
+        process.env["ORGNAME"]
+    );
+    await pm.dashboardPage.navigateToDashboards();
+    await pm.dashboardPage.deleteDashboard();
+    testLogger.info('Dashboard cleanup completed');
+  });
+
+  test("Selecting PNG type shows PNG warning banner", {
+    tag: ['@report-csv-media-type', '@all', '@P1']
+  }, async ({ page }) => {
+    testLogger.info('Testing PNG selection shows warning banner');
+
+    const TEST_REPORT_NAME = uniqueReportName('pngwarn');
+    await pm.reportsPage.createReportReportNameInput(TEST_REPORT_NAME);
+    await pm.reportsPage.selectDashboardDefaults(pm.dashboardPage.dashboardName);
+
+    // Confirm we reached the Report Format section
+    await pm.reportsPage.expectReportFormatSectionVisible();
+
+    // Select PNG (Image)
+    await pm.reportsPage.selectReportType('png');
+
+    // PNG warning banner must appear
+    await pm.reportsPage.expectPngNoteVisible();
+
+    // Attachment type and custom dimensions should remain visible for PNG
+    await pm.reportsPage.expectAttachmentTypeVisible();
+    await pm.reportsPage.expectCustomDimensionsVisible();
+
+    testLogger.info('PNG warning banner confirmed visible');
+
+    // Cleanup: delete the dashboard
+    await page.goto(
+      process.env["ZO_BASE_URL"] +
+        "/web/dashboards?org_identifier=" +
+        process.env["ORGNAME"]
+    );
+    await pm.dashboardPage.navigateToDashboards();
+    await pm.dashboardPage.deleteDashboard();
+    testLogger.info('Dashboard cleanup completed');
+  });
+
+  // ── P2: Edit Mode ──────────────────────────────────────────────────────
+
+  test("Edit mode: a previously saved CSV report shows CSV as selected and controls hidden", {
+    tag: ['@report-csv-media-type', '@all', '@P2']
+  }, async ({ page }) => {
+    testLogger.info('Testing edit mode reflects CSV type with controls hidden');
+
+    const TEST_REPORT_NAME = uniqueReportName('csvedit');
+
+    // ── First, create a CSV report ──────────────────────────────────────
+    await pm.reportsPage.createReportReportNameInput(TEST_REPORT_NAME);
+    await pm.reportsPage.selectDashboardDefaults(pm.dashboardPage.dashboardName);
+
+    // Confirm we reached the Report Format section
+    await pm.reportsPage.expectReportFormatSectionVisible();
+
+    // Select CSV type and save
+    await pm.reportsPage.selectReportType('csv');
+    await pm.reportsPage.createReportContinueButtonStep1();
+    await pm.reportsPage.createReportOnce();
+    await pm.reportsPage.createReportContinueButtonStep2();
+    await pm.reportsPage.createReportFillDetail();
+    await pm.reportsPage.createReportSaveButton();
+
+    // Verify creation succeeded
+    await pm.reportsPage.verifyReportCreated(TEST_REPORT_NAME);
+
+    // ── Now edit the report ─────────────────────────────────────────────
+    // We are already on the reports list page (verifyReportCreated navigated there).
+    // Search again (verifyReportCreated may have cleared the search).
+    await pm.reportsPage.reportSearchInputField.fill(TEST_REPORT_NAME);
+    await pm.reportsPage.editReportBtn(TEST_REPORT_NAME).click();
+
+    // Wait for edit form to load — Report Format section must be visible
+    await pm.reportsPage.expectReportFormatSectionVisible();
+
+    // Assert the report type shows "CSV (Data)" as selected
+    await pm.reportsPage.expectReportTypeOptionSelected('csv');
+
+    // Assert attachment type and custom dimensions are hidden
+    await pm.reportsPage.expectAttachmentTypeHidden();
+    await pm.reportsPage.expectCustomDimensionsHidden();
+
+    testLogger.info('Edit mode correctly reflects CSV type and hidden controls');
+
+    // Cleanup: delete the report, then the dashboard
+    // Navigate back to reports list first
+    await page.goto(
+      process.env["ZO_BASE_URL"] +
+        "/web/reports?org_identifier=" +
+        process.env["ORGNAME"]
+    );
+    await pm.reportsPage.deleteReport(TEST_REPORT_NAME);
+    await page.goto(
+      process.env["ZO_BASE_URL"] +
+        "/web/dashboards?org_identifier=" +
+        process.env["ORGNAME"]
+    );
+    await pm.dashboardPage.navigateToDashboards();
+    await pm.dashboardPage.deleteDashboard();
+    testLogger.info('Cleanup completed');
+  });
+});


### PR DESCRIPTION
Backport of the autoe2e coverage originally opened as #13008 (against \`main\`) onto **\`branch-v0.80.0\`**.

The dashboard-report CSV media type feature was merged via #11814 into v0.80.0. The E2E Council engine opened its generated tests against \`main\` (that PR: #13008 — kept as-is since the feature is also on main). This PR adds the equivalent coverage to v0.80.0 so the tests run against the v0.80.0 build.

**What's here:**
- \`tests/ui-testing/playwright-tests/Reports/reportCsvMediaType.spec.js\` — 6 tests, verbatim from \`autoe2e/pr-11814\`
- \`tests/ui-testing/pages/reportsPages/reportsPage.js\` — Report Format section locators + helpers, plus v0.80.0-compatible shims (\`reportSearchInputField\`, \`editReportBtn\`) since v0.80.0 uses different selectors than main
- \`.github/workflows/playwright.yml\` — spec registered in the Reports test-folder block

**Sister PR (ENT):** wires the same spec into the ENT playwright matrix.

## Test plan
- [ ] Playwright CI passes the new \`Reports/reportCsvMediaType.spec.js\` shard
- [ ] All 6 tests pass (CSV visible, hides Attachment Type / Custom Dimensions, save flow, toggle back to PDF restores controls, PNG banner, edit-mode CSV persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)