### PR TITLE
test: common data seed for real-issue verification

### DIFF
--- a/tests/test-data/test-assist-ci/README.md
+++ b/tests/test-data/test-assist-ci/README.md
@@ -7,8 +7,13 @@ Throwaway scaffolding for bringing up the test-assist CI agent. Will be replaced
 
 | Path | Purpose |
 |------|---------|
-| `seed/logs_seed.json` | Tiny log batch ingested before the agent runs, so Logs/Streams pages are non-empty. |
-| `seed/seed.sh` | Idempotent script the engine calls in fixture mode. POSTs `logs_seed.json` to `ZO_BASE_URL`. Uses `set -euo pipefail` + header-based auth (no creds in `ps`). |
+| `seed/seed-common.sh` | **Main seed** — runs for BOTH fixture AND real-issue dispatches. Ingests logs (4 streams), OTLP traces, OTLP metrics, 3 alerts, 1 pipeline. This is what unblocks real-bug verification: without seed, Tester finds an empty app and can't observe reported behaviours. |
+| `seed/logs_seed.json` | Tiny 5-entry log batch → `ci_seed_stream` (kept for fixture #90001 backward compat). Read by `seed-common.sh`. |
+| `seed/traces_seed.json` | Small OTLP resource-spans payload (5 spans across a checkout flow). |
+| `seed/metrics_seed.json` | Small OTLP resource-metrics payload (HTTP counters + latency gauge + memory gauge). |
+| `seed/alerts_seed.json` | 3 sample alerts (scheduled + real-time + disabled) — populates the Alerts page. |
+| `seed/pipeline_seed.json` | 1 basic pipeline (default → ci_pipeline_out) — populates the Pipelines page. |
+| `seed/seed.sh` | ⚠️ Deprecated — the fixture-only seed. Superseded by `seed-common.sh`; delete after two clean batches confirm the common seed works. |
 | `fixture-issues/` | Synthetic GitHub issue payloads — same JSON shape as `gh issue view`. Lets Scout run without real issues. |
 | `expected-verdicts.json` | Verdict each fixture issue should produce. Pipeline regression contract. |
 

--- a/tests/test-data/test-assist-ci/seed/alerts_seed.json
+++ b/tests/test-data/test-assist-ci/seed/alerts_seed.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "ci_seed_high_error_rate",
+    "stream_type": "logs",
+    "stream_name": "default",
+    "is_real_time": false,
+    "query_condition": {
+      "type": "sql",
+      "sql": "SELECT COUNT(*) as error_count FROM \"default\" WHERE level = 'error'",
+      "aggregation": null
+    },
+    "trigger_condition": {
+      "period": 15,
+      "threshold": 5,
+      "operator": ">",
+      "silence": 10,
+      "frequency": 5
+    },
+    "enabled": true,
+    "description": "CI-seed alert: fires when there are more than 5 error-level logs in a 15-minute window."
+  },
+  {
+    "name": "ci_seed_slow_query_detected",
+    "stream_type": "logs",
+    "stream_name": "default",
+    "is_real_time": true,
+    "query_condition": {
+      "type": "sql",
+      "sql": "SELECT * FROM \"default\" WHERE message LIKE '%slow query%'"
+    },
+    "trigger_condition": {
+      "threshold": 1,
+      "operator": ">=",
+      "silence": 5
+    },
+    "enabled": true,
+    "description": "CI-seed alert: real-time alert on any slow-query log line."
+  },
+  {
+    "name": "ci_seed_auth_failures",
+    "stream_type": "logs",
+    "stream_name": "default",
+    "is_real_time": false,
+    "query_condition": {
+      "type": "sql",
+      "sql": "SELECT COUNT(*) as auth_fails FROM \"default\" WHERE code = 401"
+    },
+    "trigger_condition": {
+      "period": 30,
+      "threshold": 3,
+      "operator": ">=",
+      "silence": 15,
+      "frequency": 10
+    },
+    "enabled": false,
+    "description": "CI-seed alert: disabled sample alert on repeated auth failures."
+  }
+]

--- a/tests/test-data/test-assist-ci/seed/metrics_seed.json
+++ b/tests/test-data/test-assist-ci/seed/metrics_seed.json
@@ -1,0 +1,95 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "test-assist-ci-seed" } }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": { "name": "test-assist-ci-seed" },
+          "metrics": [
+            {
+              "name": "http_requests_total",
+              "description": "Total HTTP requests",
+              "unit": "1",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      { "key": "method", "value": { "stringValue": "GET" } },
+                      { "key": "status", "value": { "stringValue": "200" } }
+                    ],
+                    "startTimeUnixNano": "1720000000000000000",
+                    "timeUnixNano": "1720000060000000000",
+                    "asInt": "12480"
+                  },
+                  {
+                    "attributes": [
+                      { "key": "method", "value": { "stringValue": "POST" } },
+                      { "key": "status", "value": { "stringValue": "200" } }
+                    ],
+                    "startTimeUnixNano": "1720000000000000000",
+                    "timeUnixNano": "1720000060000000000",
+                    "asInt": "3210"
+                  },
+                  {
+                    "attributes": [
+                      { "key": "method", "value": { "stringValue": "GET" } },
+                      { "key": "status", "value": { "stringValue": "500" } }
+                    ],
+                    "startTimeUnixNano": "1720000000000000000",
+                    "timeUnixNano": "1720000060000000000",
+                    "asInt": "42"
+                  }
+                ],
+                "aggregationTemporality": 2,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "http_request_duration_seconds",
+              "description": "HTTP request latency",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      { "key": "endpoint", "value": { "stringValue": "/api/orders" } }
+                    ],
+                    "timeUnixNano": "1720000060000000000",
+                    "asDouble": 0.128
+                  },
+                  {
+                    "attributes": [
+                      { "key": "endpoint", "value": { "stringValue": "/api/checkout" } }
+                    ],
+                    "timeUnixNano": "1720000060000000000",
+                    "asDouble": 0.412
+                  }
+                ]
+              }
+            },
+            {
+              "name": "memory_usage_bytes",
+              "description": "Memory used by process",
+              "unit": "By",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      { "key": "pod", "value": { "stringValue": "frontend-0" } }
+                    ],
+                    "timeUnixNano": "1720000060000000000",
+                    "asDouble": 314572800
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test-data/test-assist-ci/seed/pipeline_seed.json
+++ b/tests/test-data/test-assist-ci/seed/pipeline_seed.json
@@ -1,0 +1,38 @@
+{
+  "name": "ci_seed_pipeline",
+  "description": "CI-seed pipeline: routes 'default' logs through a passthrough transform to 'ci_pipeline_out'. Gives the Pipelines page something to display for test-assist runs.",
+  "source": {
+    "source_type": "realtime",
+    "stream_name": "default",
+    "stream_type": "logs",
+    "org_id": "default"
+  },
+  "nodes": [
+    {
+      "id": "src-1",
+      "type": "input",
+      "data": {
+        "node_type": "stream",
+        "stream_name": "default",
+        "stream_type": "logs",
+        "org_id": "default"
+      },
+      "position": { "x": 100, "y": 100 }
+    },
+    {
+      "id": "dst-1",
+      "type": "output",
+      "data": {
+        "node_type": "stream",
+        "stream_name": "ci_pipeline_out",
+        "stream_type": "logs",
+        "org_id": "default"
+      },
+      "position": { "x": 400, "y": 100 }
+    }
+  ],
+  "edges": [
+    { "id": "e-1", "source": "src-1", "target": "dst-1" }
+  ],
+  "enabled": true
+}

--- a/tests/test-data/test-assist-ci/seed/seed-common.sh
+++ b/tests/test-data/test-assist-ci/seed/seed-common.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# tests/test-data/test-assist-ci/seed/seed-common.sh
+#
+# Common data seed for the Test-Assist CI engine. Runs for BOTH fixture and real-issue
+# dispatches. Populates the ephemeral OpenObserve Docker instance so verification agents
+# (Tester + Playwright MCP) find non-empty pages.
+#
+# Seeds (in order):
+#   1. Fixture logs → ci_seed_stream  (kept for fixture #90001 backward compat)
+#   2. Bulk logs → default, e2e_automate, web_logs, k8s_logs streams
+#      (~3.8k entries × 4 streams = general log coverage for Logs / Streams / SQL editor bugs)
+#   3. OTLP traces → default trace stream  (unblocks Traces-page bugs)
+#   4. OTLP metrics → default metrics stream (Metrics-page bugs)
+#   5. Alert definitions  (Alerts-page bugs)
+#   6. A basic pipeline   (Pipelines-page bugs)
+#
+# All ingestion via HTTP Basic auth (matches OSS Playwright's ingestion utilities).
+# The password is base64-encoded into an Authorization header — never on the command line.
+#
+# Idempotent: re-running is safe. Data-ingestion endpoints tolerate duplicates; config
+# endpoints (alert / pipeline) silently no-op on 409 "already exists".
+#
+set -euo pipefail
+
+: "${ZO_BASE_URL:?ZO_BASE_URL not set}"
+: "${ZO_ROOT_USER_EMAIL:?ZO_ROOT_USER_EMAIL not set}"
+: "${ZO_ROOT_USER_PASSWORD:?ZO_ROOT_USER_PASSWORD not set}"
+ORG="${ORGNAME:-default}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE="${ZO_BASE_URL%/}"
+AUTH_B64="$(printf '%s' "${ZO_ROOT_USER_EMAIL}:${ZO_ROOT_USER_PASSWORD}" | base64)"
+
+# Compact curl wrapper. All calls best-effort — we log per-step but don't abort the whole
+# seed on any single failure (the pipeline should still start up; unpopulated areas just
+# get INCONCLUSIVE later, which is a better outcome than the whole engine failing at seed).
+_curl() {
+  local method="$1"; local url="$2"; local data_arg="$3"
+  local resp code
+  # -w writes status code to stdout after the body; -o /dev/null suppresses body.
+  if [ -n "$data_arg" ]; then
+    code=$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X "$method" \
+      -H "Authorization: Basic ${AUTH_B64}" \
+      -H 'Content-Type: application/json' \
+      --data-binary "$data_arg" \
+      --max-time 30 \
+      "$url" || echo "ERR")
+  else
+    code=$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X "$method" \
+      -H "Authorization: Basic ${AUTH_B64}" \
+      --max-time 30 \
+      "$url" || echo "ERR")
+  fi
+  echo "$code"
+}
+
+echo "==============================================="
+echo "Test-Assist CI — common data seed"
+echo "  target: $BASE (org=$ORG)"
+echo "==============================================="
+
+# ------------------------------------------------------------------------
+# 1. Fixture logs → ci_seed_stream (kept for fixture #90001)
+# ------------------------------------------------------------------------
+if [ -f "${HERE}/logs_seed.json" ]; then
+  echo "[1/6] Fixture logs → ci_seed_stream"
+  code=$(_curl POST "${BASE}/api/${ORG}/ci_seed_stream/_json" "@${HERE}/logs_seed.json")
+  echo "     status: $code"
+else
+  echo "[1/6] Skipping fixture logs (logs_seed.json missing)"
+fi
+
+# ------------------------------------------------------------------------
+# 2. Bulk logs → 4 streams (default, e2e_automate, web_logs, k8s_logs)
+#    Reuses the existing test-data/logs_data.json used by OSS Playwright's globalSetup.
+# ------------------------------------------------------------------------
+BULK_LOGS="${HERE}/../../logs_data.json"
+if [ -f "$BULK_LOGS" ]; then
+  echo "[2/6] Bulk logs → default, e2e_automate, web_logs, k8s_logs"
+  for STREAM in default e2e_automate web_logs k8s_logs; do
+    code=$(_curl POST "${BASE}/api/${ORG}/${STREAM}/_json" "@${BULK_LOGS}")
+    echo "     $STREAM: $code"
+  done
+else
+  echo "[2/6] Skipping bulk logs (tests/test-data/logs_data.json not found)"
+fi
+
+# ------------------------------------------------------------------------
+# 3. OTLP traces → default trace stream
+# ------------------------------------------------------------------------
+if [ -f "${HERE}/traces_seed.json" ]; then
+  echo "[3/6] OTLP traces"
+  # OpenObserve trace endpoint: /api/{org}/v1/traces  (OTLP HTTP)
+  code=$(_curl POST "${BASE}/api/${ORG}/v1/traces" "@${HERE}/traces_seed.json")
+  echo "     status: $code"
+else
+  echo "[3/6] Skipping traces (traces_seed.json missing)"
+fi
+
+# ------------------------------------------------------------------------
+# 4. OTLP metrics → default metrics stream
+# ------------------------------------------------------------------------
+if [ -f "${HERE}/metrics_seed.json" ]; then
+  echo "[4/6] OTLP metrics"
+  # OpenObserve OTLP metrics HTTP endpoint: /api/{org}/v1/metrics
+  code=$(_curl POST "${BASE}/api/${ORG}/v1/metrics" "@${HERE}/metrics_seed.json")
+  echo "     status: $code"
+else
+  echo "[4/6] Skipping metrics (metrics_seed.json missing)"
+fi
+
+# ------------------------------------------------------------------------
+# 5. Alert definitions
+#    Endpoint: POST /api/{org}/{stream}/alerts (JSON body per alert)
+#    The alerts_seed.json is an ARRAY — we split into one POST per alert so a single
+#    conflict doesn't nuke the whole batch.
+# ------------------------------------------------------------------------
+if [ -f "${HERE}/alerts_seed.json" ]; then
+  echo "[5/6] Alerts"
+  ALERT_COUNT=$(jq 'length' "${HERE}/alerts_seed.json")
+  for i in $(seq 0 $((ALERT_COUNT - 1))); do
+    ALERT=$(jq -c ".[$i]" "${HERE}/alerts_seed.json")
+    STREAM=$(echo "$ALERT" | jq -r '.stream_name')
+    NAME=$(echo "$ALERT" | jq -r '.name')
+    code=$(_curl POST "${BASE}/api/${ORG}/${STREAM}/alerts" "$ALERT")
+    echo "     $NAME → $STREAM: $code"
+  done
+else
+  echo "[5/6] Skipping alerts (alerts_seed.json missing)"
+fi
+
+# ------------------------------------------------------------------------
+# 6. Pipeline
+#    Endpoint: POST /api/{org}/pipelines
+# ------------------------------------------------------------------------
+if [ -f "${HERE}/pipeline_seed.json" ]; then
+  echo "[6/6] Pipeline"
+  code=$(_curl POST "${BASE}/api/${ORG}/pipelines" "@${HERE}/pipeline_seed.json")
+  echo "     status: $code"
+else
+  echo "[6/6] Skipping pipeline (pipeline_seed.json missing)"
+fi
+
+echo ""
+echo "==============================================="
+echo "Seed complete."
+echo "==============================================="

--- a/tests/test-data/test-assist-ci/seed/traces_seed.json
+++ b/tests/test-data/test-assist-ci/seed/traces_seed.json
@@ -1,0 +1,89 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "frontend" } },
+          { "key": "service.version", "value": { "stringValue": "1.0.0" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": { "name": "test-assist-ci-seed" },
+          "spans": [
+            {
+              "traceId": "5b8aa5a2d2c872e8321cf37308d69df2",
+              "spanId": "051581bf3cb55c13",
+              "name": "GET /api/orders",
+              "kind": 2,
+              "startTimeUnixNano": "1720000000000000000",
+              "endTimeUnixNano": "1720000000150000000",
+              "attributes": [
+                { "key": "http.method", "value": { "stringValue": "GET" } },
+                { "key": "http.route", "value": { "stringValue": "/api/orders" } },
+                { "key": "http.status_code", "value": { "intValue": 200 } }
+              ],
+              "status": { "code": 1 }
+            },
+            {
+              "traceId": "5b8aa5a2d2c872e8321cf37308d69df3",
+              "spanId": "051581bf3cb55c14",
+              "name": "POST /api/checkout",
+              "kind": 2,
+              "startTimeUnixNano": "1720000005000000000",
+              "endTimeUnixNano": "1720000005420000000",
+              "attributes": [
+                { "key": "http.method", "value": { "stringValue": "POST" } },
+                { "key": "http.route", "value": { "stringValue": "/api/checkout" } },
+                { "key": "http.status_code", "value": { "intValue": 200 } }
+              ],
+              "status": { "code": 1 }
+            },
+            {
+              "traceId": "5b8aa5a2d2c872e8321cf37308d69df4",
+              "spanId": "051581bf3cb55c15",
+              "name": "GET /api/products",
+              "kind": 2,
+              "startTimeUnixNano": "1720000010000000000",
+              "endTimeUnixNano": "1720000010080000000",
+              "attributes": [
+                { "key": "http.method", "value": { "stringValue": "GET" } },
+                { "key": "http.route", "value": { "stringValue": "/api/products" } },
+                { "key": "http.status_code", "value": { "intValue": 200 } }
+              ],
+              "status": { "code": 1 }
+            },
+            {
+              "traceId": "5b8aa5a2d2c872e8321cf37308d69df5",
+              "spanId": "051581bf3cb55c16",
+              "name": "DELETE /api/session",
+              "kind": 2,
+              "startTimeUnixNano": "1720000015000000000",
+              "endTimeUnixNano": "1720000015020000000",
+              "attributes": [
+                { "key": "http.method", "value": { "stringValue": "DELETE" } },
+                { "key": "http.route", "value": { "stringValue": "/api/session" } },
+                { "key": "http.status_code", "value": { "intValue": 204 } }
+              ],
+              "status": { "code": 1 }
+            },
+            {
+              "traceId": "5b8aa5a2d2c872e8321cf37308d69df6",
+              "spanId": "051581bf3cb55c17",
+              "name": "GET /api/health",
+              "kind": 2,
+              "startTimeUnixNano": "1720000020000000000",
+              "endTimeUnixNano": "1720000020005000000",
+              "attributes": [
+                { "key": "http.method", "value": { "stringValue": "GET" } },
+                { "key": "http.route", "value": { "stringValue": "/api/health" } },
+                { "key": "http.status_code", "value": { "intValue": 200 } }
+              ],
+              "status": { "code": 2, "message": "upstream slow" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Yesterday's real-bug proof-of-concept showed the pipeline plumbing works, but every real bug came back INCONCLUSIVE because the Tester (via Playwright MCP) opened pages on an **empty OpenObserve instance**. There was nothing to observe — no streams, no alerts, no pipelines, no traces.

This PR adds a common data seed the engine runs before every dispatch. **Pairs with [o2-enterprise#XXXX](https://github.com/openobserve/o2-enterprise/pull/XXXX) — both must merge together.**

## Files added

| File | Contents |
|------|----------|
| `seed/seed-common.sh` | Main orchestrator. POSTs everything via HTTP Basic auth (matches OSS Playwright's `data-ingestion.js` — header-based, no creds on CLI args). |
| `seed/traces_seed.json` | 5-span OTLP payload (synthetic — OSS doesn't ship a static traces JSON; `trace-ingestion.js` generates programmatically) |
| `seed/metrics_seed.json` | 3-metric OTLP payload (HTTP counter + latency gauge + memory gauge; synthetic for the same reason) |
| `seed/alerts_seed.json` | 3 alerts (one scheduled, one real-time, one disabled) |
| `seed/pipeline_seed.json` | 1 pipeline (default → ci_pipeline_out) |

## What runs (in order)

1. **Fixture logs** → `ci_seed_stream` (kept for fixture #90001 backward compat via existing `logs_seed.json`)
2. **Bulk logs** (~3.8k entries from existing `tests/test-data/logs_data.json`) → 4 streams: `default`, `e2e_automate`, `web_logs`, `k8s_logs`. **Same file** OSS Playwright's `globalSetup` uses.
3. **OTLP traces** → `default` trace stream
4. **OTLP metrics** → `default` metrics stream
5. **3 alert definitions** (POST /api/{org}/{stream}/alerts)
6. **1 pipeline** (POST /api/{org}/pipelines)

Idempotent — all ingestion is best-effort; single-endpoint failures log the HTTP status code but don't abort the seed. Unpopulated areas still yield INCONCLUSIVE downstream (better than the whole engine failing at seed).

## Coverage for the 10 Needs-Testing bugs we're firing next

| Bug | Data type needed | Seed step |
|-----|------------------|-----------|
| #12452 SQL editor overflow | logs | 2 |
| #11700 Streams spacing | streams (auto-created via ingest) | 2 |
| #5042 Include search cmd+enter | logs | 2 |
| #12603 Traces page issues | traces | 3 |
| #12820 Alerts UX | alerts | 5 |
| #6750 Multi-window custom time | alerts | 5 |
| #10530 Pipeline cron alignment | pipeline | 6 |
| #12647 Pipelines popup overflow | pipeline | 6 |
| #9252 Pipeline destination verbiage | pipeline | 6 |
| #12803 Language translation | any page (no seed needed) | — |

## Validated end-to-end

Fixture #90002 dispatched on the paired branches ([run 28657529004](https://github.com/openobserve/o2-enterprise/actions/runs/28657529004)) — all 26 pipeline steps completed successfully, including the new Seed step showing 6 sub-seeds with their HTTP status codes.

## What's NOT in this PR

- The old `seed/seed.sh` stays for one merge cycle (deprecated in the README) — will delete once two clean real-bug batches confirm seed-common works
- No `Test-Assist-CI-Verified` label changes
- No qa-reports table updates

## Test plan

- [x] Fixture #90002 with `source_ref=feat/test-assist-common-seed` — all 26 steps green
- [ ] After merge (this + ENT PR): dispatch on any real bug — expect seed step to run before Scout, and Tester to find non-empty pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)