### PR TITLE
test(autoe2e): generated E2E tests for #13025 (logs-stream-quick-pick)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -240,6 +240,7 @@ jobs:
                 "logsQueryBuilder-filters-advanced.spec.js",
                 "logsquickmode.spec.js",
                 "logshistogram.spec.js",
+                "logsQuickPick.spec.js",
               ]
           - testfolder: "Logs-Core"
             browser: "chrome"

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -11326,7 +11326,9 @@ export class LogsPage {
      * `[data-select-separator]` — lets Reka toggle it OFF. See OSelect.vue
      * handleItemClickCapture. The generic `deselectStream` clicks the option row
      * (label zone), so it cannot clear a single selected stream here — this helper
-     * clicks the far-left checkbox zone by position instead.
+     * clicks inside the checkbox zone instead, computing the x offset from the
+     * separator's position (falling back to a small fixed offset) so it stays
+     * correct if the checkbox/padding dimensions change.
      * @param {string} streamName
      */
     async deselectStreamViaCheckbox(streamName) {
@@ -11353,9 +11355,17 @@ export class LogsPage {
         ).first();
         await option.waitFor({ state: 'visible', timeout: 5000 });
         const box = await option.boundingBox();
-        // Click near the far-left checkbox zone (left of the separator) so Reka
-        // toggles the option off instead of re-selecting it.
-        await option.click({ position: { x: 6, y: box ? box.height / 2 : 12 } });
+        // The checkbox zone spans from the option's left edge to the separator.
+        // Click its midpoint so Reka toggles the option off (instead of the label
+        // zone, which would re-select it). Derive the x from the separator's
+        // position; fall back to a small fixed offset if it can't be measured.
+        const sepBox = await option
+            .locator('[data-select-separator]')
+            .first()
+            .boundingBox()
+            .catch(() => null);
+        const x = (sepBox && box) ? Math.max(4, (sepBox.x - box.x) / 2) : 6;
+        await option.click({ position: { x, y: box ? box.height / 2 : 12 } });
         await this.page.keyboard.press('Escape').catch(() => {});
         testLogger.info(`Deselected stream via checkbox zone: ${streamName}`);
     }
@@ -11469,16 +11479,33 @@ export class LogsPage {
     }
 
     /**
-     * Waits for the field list to appear after selecting a stream via quick pick.
-     * Accepts either the fields table or the "no field found" text as a valid post-selection state.
+     * Waits for the field list to settle after selecting a stream via quick pick.
+     * Resolves as soon as EITHER the fields table or the "no field found" text
+     * appears (both are valid post-selection states). THROWS if neither shows
+     * within the timeout — a stream whose field list silently never loads is a
+     * real failure, not a state to swallow.
      */
     async waitForFieldListAfterStreamSelection() {
-        const fieldTable = this.page.locator(this.timestampFieldTable);
+        // The logs field list renders one `logs-field-list-item-<name>` row per
+        // field (GroupedFieldList / FieldRow), or the "no field found" empty text
+        // when the stream has no fields. (The old `log-search-index-list-fields-table`
+        // data-test only exists in the traces IndexList, never the logs one.)
+        const fieldItem = this.page.locator('[data-test^="logs-field-list-item-"]').first();
         const noField = this.page.locator(this.noFieldFoundText);
-        await Promise.race([
-            fieldTable.waitFor({ state: 'visible', timeout: 20000 }),
-            noField.waitFor({ state: 'visible', timeout: 20000 }),
-        ]).catch(() => {});
+        // Promise.any resolves on the first success and only rejects if BOTH
+        // waits time out (unlike Promise.race, which would reject on the first
+        // timeout even when the other locator is about to appear).
+        try {
+            await Promise.any([
+                fieldItem.waitFor({ state: 'visible', timeout: 20000 }),
+                noField.waitFor({ state: 'visible', timeout: 20000 }),
+            ]);
+        } catch {
+            throw new Error(
+                'Field list did not load after stream selection: neither the fields '
+                + 'table nor the "no field found" text appeared within 20s',
+            );
+        }
         testLogger.info('Field list loaded after stream selection');
     }
 }

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -52,7 +52,9 @@ export class LogsPage {
         // Quick Pick (no-stream-selected sidebar state) locators
         this.quickPickContainer = '[data-test="logs-search-stream-quick-pick"]';
         this.quickPickButton = (streamName) => `[data-test="logs-search-stream-quick-pick-${streamName}"]`;
-        this.quickPickButtonWildcard = '[data-test^="logs-search-stream-quick-pick-"]';
+        // Match only the per-stream quick-pick buttons, NOT the "-more" footer
+        // span (which also starts with `logs-search-stream-quick-pick-`).
+        this.quickPickButtonWildcard = '[data-test^="logs-search-stream-quick-pick-"]:not([data-test="logs-search-stream-quick-pick-more"])';
         this.quickPickMoreFooter = '[data-test="logs-search-stream-quick-pick-more"]';
         // Hero state (main content no-stream-selected) locators
         this.noStreamHero = '[data-test="logs-search-no-stream-selected-text"]';
@@ -11254,6 +11256,65 @@ export class LogsPage {
         const btn = this.page.locator(this.quickPickButton(streamName));
         await btn.waitFor({ state: 'visible', timeout: 10000 });
         await btn.click();
+    }
+
+    /**
+     * Seeds `count` logs streams named `${prefix}${i}` (1-based) by ingesting a
+     * single record into each. First-time ingestion creates the stream, so this
+     * is how the footer test pushes the org above the quick-pick limit (8) to make
+     * the "more" footer render. Returns the created stream names.
+     *
+     * Freshly-ingested streams have no computed stats yet, so they sort to the
+     * bottom of the quick pick (ordered by stats.doc_time_max desc) and do NOT
+     * displace already-active streams like e2e_automate. These streams are swept
+     * by cleanup.spec.js via the matching `${prefix}` regex.
+     * @param {string} prefix — e.g. "e2e_qp_more_stream_"
+     * @param {number} count
+     * @returns {Promise<string[]>}
+     */
+    async seedLogStreams(prefix, count) {
+        const names = [];
+        for (let i = 1; i <= count; i++) {
+            const name = `${prefix}${i}`;
+            await this.ingestData(name, [{
+                level: 'info',
+                job: 'quickpick_more_footer_seed',
+                message: `quick-pick more-footer seed record ${i}`,
+            }]);
+            names.push(name);
+        }
+        testLogger.info(`Seeded ${names.length} quick-pick streams`, { prefix });
+        return names;
+    }
+
+    /**
+     * Polls the streams API until every name in `names` is listed (logs type),
+     * so a subsequent page load reflects the newly-seeded streams. Best-effort:
+     * returns true once all appear, false on timeout.
+     * @param {string[]} names
+     * @param {number} timeout
+     */
+    async waitForStreamsListed(names, timeout = 20000) {
+        const fetch = (await import('node-fetch')).default;
+        const orgId = getOrgIdentifier();
+        const url = `${process.env.INGESTION_URL}/api/${orgId}/streams?type=logs`;
+        const deadline = Date.now() + timeout;
+        while (Date.now() < deadline) {
+            try {
+                const res = await fetch(url, { headers: getAuthHeaders() });
+                const body = await res.json();
+                const existing = new Set((body.list || []).map((s) => s.name));
+                if (names.every((n) => existing.has(n))) {
+                    testLogger.info('All seeded streams are listed', { count: names.length });
+                    return true;
+                }
+            } catch (e) {
+                testLogger.debug(`waitForStreamsListed retry: ${e.message}`);
+            }
+            await this.page.waitForTimeout(1000);
+        }
+        testLogger.warn('Not all seeded streams listed before timeout', { names });
+        return false;
     }
 
     /**

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -49,6 +49,18 @@ export class LogsPage {
         this.indexDropDownTrigger = '[data-test="log-search-index-list-select-stream-trigger"]';
         this.indexDropDownPopover = '[data-test="log-search-index-list-select-stream-popover"]';
         this.indexDropDownSearch = '[data-test="log-search-index-list-select-stream-search"]';
+        // Quick Pick (no-stream-selected sidebar state) locators
+        this.quickPickContainer = '[data-test="logs-search-stream-quick-pick"]';
+        this.quickPickButton = (streamName) => `[data-test="logs-search-stream-quick-pick-${streamName}"]`;
+        this.quickPickButtonWildcard = '[data-test^="logs-search-stream-quick-pick-"]';
+        this.quickPickMoreFooter = '[data-test="logs-search-stream-quick-pick-more"]';
+        // Hero state (main content no-stream-selected) locators
+        this.noStreamHero = '[data-test="logs-search-no-stream-selected-text"]';
+        this.selectStreamCard = '[data-test="logs-no-stream-select-stream-card"]';
+        this.queryGuideCard = '[data-test="logs-no-stream-query-guide-card"]';
+        this.recentChip = (streamName) => `[data-test="logs-no-stream-recent-${streamName}"]`;
+        // Post stream-selection: empty schema indicator
+        this.noFieldFoundText = '[data-test="logs-search-no-field-found-text"]';
         this.streamToggle = '[data-test="log-search-index-list-stream-toggle-default"] [data-state]';
         this.searchPartitionButton = '[data-test="logs-search-partition-btn"]';
         this.histogramToggle = '[data-test="logs-search-bar-show-histogram-toggle-btn"]';
@@ -11209,5 +11221,204 @@ export class LogsPage {
         const option = this.page.locator(this.datetimeTimezoneOption(value));
         await option.waitFor({ state: 'visible', timeout: 10000 });
         await option.click();
+    }
+
+    // ──────────────────────────────────────────────
+    //  Quick Pick (No-Stream-Selected) helpers
+    // ──────────────────────────────────────────────
+
+    /**
+     * Waits for the sidebar quick pick container to become visible.
+     */
+    async expectQuickPickContainerVisible() {
+        const container = this.page.locator(this.quickPickContainer);
+        await container.waitFor({ state: 'visible', timeout: 15000 });
+        testLogger.info('Quick pick container is visible');
+    }
+
+    /**
+     * Asserts the sidebar quick pick container is NOT visible (hidden or detached).
+     * Uses toBeHidden() which covers both CSS hidden and DOM-detached states.
+     */
+    async expectQuickPickContainerNotVisible() {
+        const container = this.page.locator(this.quickPickContainer);
+        await expect(container, 'Quick pick container should not be visible after stream selection').toBeHidden({ timeout: 15000 });
+        testLogger.info('Quick pick container is not visible');
+    }
+
+    /**
+     * Clicks a quick pick stream button in the sidebar.
+     * @param {string} streamName — e.g. "e2e_automate"
+     */
+    async clickQuickPickButton(streamName) {
+        testLogger.info(`Clicking quick pick button for stream: ${streamName}`);
+        const btn = this.page.locator(this.quickPickButton(streamName));
+        await btn.waitFor({ state: 'visible', timeout: 10000 });
+        await btn.click();
+    }
+
+    /**
+     * Deselects a stream from the logs stream selector's checkbox zone.
+     *
+     * The logs stream OSelect runs in multi-mode with rowClickSingleSelect=true.
+     * In that mode clicking an option's LABEL zone re-selects it (single-select
+     * replace), while clicking its CHECKBOX zone — the area left of the option's
+     * `[data-select-separator]` — lets Reka toggle it OFF. See OSelect.vue
+     * handleItemClickCapture. The generic `deselectStream` clicks the option row
+     * (label zone), so it cannot clear a single selected stream here — this helper
+     * clicks the far-left checkbox zone by position instead.
+     * @param {string} streamName
+     */
+    async deselectStreamViaCheckbox(streamName) {
+        testLogger.info(`Deselecting stream via checkbox zone: ${streamName}`);
+        const trigger = this.page.locator(this.indexDropDownTrigger).first();
+        const popover = this.page.locator(this.indexDropDownPopover);
+        const search = this.page.locator(this.indexDropDownSearch);
+
+        if (await trigger.count() > 0) {
+            await trigger.click();
+        } else {
+            await this.page.locator(this.indexDropDown).click();
+        }
+        await popover.waitFor({ state: 'visible', timeout: 5000 });
+
+        // Narrow the list so the target option is rendered even with many streams.
+        if (await search.count() > 0) {
+            await search.fill(streamName).catch(() => {});
+            await this.page.waitForTimeout(300);
+        }
+
+        const option = this.page.locator(
+            `[data-test="log-search-index-list-select-stream-option"][data-test-value="${streamName}"]`,
+        ).first();
+        await option.waitFor({ state: 'visible', timeout: 5000 });
+        const box = await option.boundingBox();
+        // Click near the far-left checkbox zone (left of the separator) so Reka
+        // toggles the option off instead of re-selecting it.
+        await option.click({ position: { x: 6, y: box ? box.height / 2 : 12 } });
+        await this.page.keyboard.press('Escape').catch(() => {});
+        testLogger.info(`Deselected stream via checkbox zone: ${streamName}`);
+    }
+
+    /**
+     * Returns the count of visible quick pick stream buttons in the sidebar.
+     * @returns {Promise<number>}
+     */
+    async getQuickPickButtonCount() {
+        const buttons = this.page.locator(this.quickPickButtonWildcard);
+        await buttons.first().waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+        return await buttons.count();
+    }
+
+    /**
+     * Asserts the quick pick "more" footer is visible.
+     */
+    async expectQuickPickMoreFooterVisible() {
+        const footer = this.page.locator(this.quickPickMoreFooter);
+        await expect(footer, 'Quick pick more footer should be visible').toBeVisible({ timeout: 10000 });
+        testLogger.info('Quick pick more footer is visible');
+    }
+
+    /**
+     * Waits for the hero-state "no stream selected" container to be visible.
+     */
+    async expectNoStreamHeroVisible() {
+        const hero = this.page.locator(this.noStreamHero);
+        await hero.waitFor({ state: 'visible', timeout: 15000 });
+        testLogger.info('No-stream hero is visible');
+    }
+
+    /**
+     * Asserts the "Select a stream" hero card is visible.
+     */
+    async expectSelectStreamCardVisible() {
+        const card = this.page.locator(this.selectStreamCard);
+        await expect(card, 'Select stream card should be visible').toBeVisible({ timeout: 10000 });
+        testLogger.info('Select stream card is visible');
+    }
+
+    /**
+     * Asserts the "Read the query guide" hero card is visible.
+     */
+    async expectQueryGuideCardVisible() {
+        const card = this.page.locator(this.queryGuideCard);
+        await expect(card, 'Query guide card should be visible').toBeVisible({ timeout: 10000 });
+        testLogger.info('Query guide card is visible');
+    }
+
+    /**
+     * Clicks the "Select a stream" hero card.
+     */
+    async clickSelectStreamCard() {
+        testLogger.info('Clicking Select a stream card');
+        const card = this.page.locator(this.selectStreamCard);
+        await card.waitFor({ state: 'visible', timeout: 10000 });
+        await card.click();
+    }
+
+    /**
+     * Clicks the "Read the query guide" hero card.
+     */
+    async clickQueryGuideCard() {
+        testLogger.info('Clicking Query guide card');
+        const card = this.page.locator(this.queryGuideCard);
+        await card.waitFor({ state: 'visible', timeout: 10000 });
+        await card.click();
+    }
+
+    /**
+     * Asserts a recent-stream chip is visible in the hero state.
+     * @param {string} streamName
+     */
+    async expectRecentChipVisible(streamName) {
+        const chip = this.page.locator(this.recentChip(streamName));
+        await expect(chip, `Recent chip for ${streamName} should be visible`).toBeVisible({ timeout: 10000 });
+        testLogger.info(`Recent chip for ${streamName} is visible`);
+    }
+
+    /**
+     * Clicks a recent-stream chip in the hero state.
+     * @param {string} streamName
+     */
+    async clickRecentChip(streamName) {
+        testLogger.info(`Clicking recent chip for stream: ${streamName}`);
+        const chip = this.page.locator(this.recentChip(streamName));
+        await chip.waitFor({ state: 'visible', timeout: 10000 });
+        await chip.click();
+    }
+
+    /**
+     * Asserts the stream dropdown popover is visible.
+     */
+    async expectStreamDropdownPopoverVisible() {
+        const popover = this.page.locator(this.indexDropDownPopover);
+        await expect(popover, 'Stream dropdown popover should be visible').toBeVisible({ timeout: 10000 });
+        testLogger.info('Stream dropdown popover is visible');
+    }
+
+    /**
+     * Asserts the stream dropdown wrapper shows the selected stream name
+     * (i.e. the placeholder "Select Stream" has been replaced by a selected-item chip).
+     * Uses the wrapper div since OSelect renders selected items as tokens within it.
+     * @param {string} streamName
+     */
+    async expectStreamDropdownShowsStream(streamName) {
+        const wrapper = this.page.locator(this.indexDropDown);
+        await expect(wrapper, `Stream dropdown should show ${streamName}`).toContainText(streamName, { timeout: 10000 });
+        testLogger.info(`Stream dropdown shows stream: ${streamName}`);
+    }
+
+    /**
+     * Waits for the field list to appear after selecting a stream via quick pick.
+     * Accepts either the fields table or the "no field found" text as a valid post-selection state.
+     */
+    async waitForFieldListAfterStreamSelection() {
+        const fieldTable = this.page.locator(this.timestampFieldTable);
+        const noField = this.page.locator(this.noFieldFoundText);
+        await Promise.race([
+            fieldTable.waitFor({ state: 'visible', timeout: 20000 }),
+            noField.waitFor({ state: 'visible', timeout: 20000 }),
+        ]).catch(() => {});
+        testLogger.info('Field list loaded after stream selection');
     }
 }

--- a/tests/ui-testing/playwright-tests/Logs/logsQuickPick.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/logsQuickPick.spec.js
@@ -127,33 +127,47 @@ test.describe("Logs No-Stream Quick Pick testcases", () => {
     testLogger.info('Deselect and re-pick workflow completed');
   });
 
-  // ── P2: Quick pick "X more" footer (conditional on > 8 streams) ────
-  test("should show more footer when org has more than 8 streams", {
+  // ── P2: Quick pick "X more" footer (seeds > 8 streams, then verifies) ─
+  // QUICK_PICK_LIMIT is 8 (IndexList.vue). The quick pick caps at 8 buttons and
+  // shows a "Search above for N more" footer whenever the org has more than 8
+  // logs streams. This test CREATES 9 streams so the condition always holds, then
+  // asserts the cap + footer.
+  //
+  // Stream names carry a per-run unique token (e2e_qp_more_stream_<token>_N) so
+  // repeat/parallel runs never collide with a still-deleting same-named stream
+  // (stream deletion in OpenObserve is async). Freshly-ingested streams have no
+  // stats yet, so they sort to the bottom of the quick pick and never displace
+  // already-active streams (e.g. e2e_automate) that sibling tests rely on. The
+  // seeds are swept by cleanup.spec.js via the `e2e_qp_more_stream_` prefix.
+  test("should create more than 8 streams and show the quick pick more footer", {
     tag: ['@logs-stream-quick-pick', '@all', '@logs']
   }, async ({ page }) => {
-    testLogger.info('Testing quick pick more footer');
+    testLogger.info('Testing quick pick more footer with seeded streams');
+
+    const QUICK_PICK_LIMIT = 8;
+    const runToken = `${Date.now()}${Math.floor(Math.random() * 1000)}`;
+    const seedPrefix = `e2e_qp_more_stream_${runToken}_`;
+
+    // Create one more than the limit so streamList always exceeds it.
+    const seededStreams = await pm.logsPage.seedLogStreams(seedPrefix, QUICK_PICK_LIMIT + 1);
+    await pm.logsPage.waitForStreamsListed(seededStreams);
+
+    // Reload the no-stream logs page so the stream list picks up the new streams.
+    await page.goto(`${logData.logsUrl}?org_identifier=${getOrgIdentifier()}`);
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
 
     await pm.logsPage.expectQuickPickContainerVisible();
 
-    // Count how many quick pick stream buttons are visible
+    // The quick pick must cap visible stream buttons at the limit.
     const count = await pm.logsPage.getQuickPickButtonCount();
+    expect(count, 'Quick pick should cap visible buttons at the limit (8)').toBe(QUICK_PICK_LIMIT);
 
-    // This test is conditional: it only asserts the footer when the org has > 8 streams.
-    // QUICK_PICK_LIMIT is 8 (IndexList.vue:549), so ≤ 8 buttons means the footer
-    // won't appear. Skip gracefully with a clear message.
-    if (count < 8) {
-      testLogger.info(`Quick pick shows ${count} buttons (≤ 8), skipping more-footer test`);
-      test.skip(true, `Org has fewer than 8 streams (${count} visible), more-footer not applicable`);
-      return;
-    }
-
-    // Footer should be visible when streamList > quickPickStreams
+    // The "more" footer must be visible and report a positive remaining count.
     await pm.logsPage.expectQuickPickMoreFooterVisible();
+    const footerText = await page.locator(pm.logsPage.quickPickMoreFooter).innerText();
+    expect(footerText, 'More footer should report a remaining count').toMatch(/\d+/);
 
-    // The number of visible quick pick buttons must not exceed the limit
-    expect(count, 'Quick pick button count should not exceed 8').toBeLessThanOrEqual(8);
-
-    testLogger.info('Quick pick more footer verified');
+    testLogger.info(`Quick pick more footer verified (${footerText.trim()})`);
   });
 
   // ── P2: Hero "Recent:" chip selects stream and triggers search ─────

--- a/tests/ui-testing/playwright-tests/Logs/logsQuickPick.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/logsQuickPick.spec.js
@@ -1,0 +1,233 @@
+/**
+ * Logs No-Stream Quick Pick — E2E suite
+ *
+ * Verifies that when a user navigates to the Logs page without a pre-selected stream,
+ * the UI surfaces two complementary quick-pick surfaces:
+ *   1. Sidebar quick pick — up to 8 one-click stream buttons (IndexList)
+ *   2. Hero-state quick pick — action cards + recent-stream chips (LogsNoStreamState)
+ *
+ * Test coverage:
+ *   - TC-QP-001: Quick pick a stream from the sidebar
+ *   - TC-QP-002: Hero state appears on fresh arrival
+ *   - TC-QP-003: Hero "Select a stream" card opens the stream dropdown
+ *   - TC-QP-004: Deselect a stream, quick pick reappears, re-select works
+ *   - TC-QP-005: Quick pick "X more" footer (conditional, org must have > 8 streams)
+ *   - TC-QP-006: Hero "Recent:" chip selects stream (gated on localStorage seeding)
+ *   - TC-QP-007: "Read the query guide" card opens documentation in new tab
+ */
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+const logData = require("../../fixtures/log.json");
+const { getOrgIdentifier } = require('../utils/cloud-auth.js');
+
+test.describe("Logs No-Stream Quick Pick testcases", () => {
+  test.describe.configure({ mode: 'parallel' });
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    // Navigate to logs page WITHOUT a stream query param — triggers the
+    // no-stream-selected state which renders both the sidebar quick pick
+    // and the main-content hero cards.
+    await page.goto(`${logData.logsUrl}?org_identifier=${getOrgIdentifier()}`);
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    testLogger.info('Test setup completed');
+  });
+
+  // ── P0: Quick Pick a stream from the sidebar ────────────────────────
+  test("should quick pick a stream from the sidebar", {
+    tag: ['@logs-stream-quick-pick', '@all', '@logs']
+  }, async ({ page }) => {
+    testLogger.info('Testing quick pick stream selection from the sidebar');
+
+    // Wait for the sidebar quick pick container to become visible
+    await pm.logsPage.expectQuickPickContainerVisible();
+
+    // Click the quick pick button for e2e_automate
+    await pm.logsPage.clickQuickPickButton('e2e_automate');
+
+    // After selection the quick pick container should disappear
+    await pm.logsPage.expectQuickPickContainerNotVisible();
+
+    // Verify the stream dropdown now shows the selected stream name
+    await pm.logsPage.expectStreamDropdownShowsStream('e2e_automate');
+
+    // Wait for field list to load (or "no field found" to appear)
+    await pm.logsPage.waitForFieldListAfterStreamSelection();
+
+    testLogger.info('Quick pick stream selection completed');
+  });
+
+  // ── P0: Hero state appears on fresh arrival ────────────────────────
+  test("should show hero state on fresh arrival with no stream selected", {
+    tag: ['@logs-stream-quick-pick', '@all', '@logs']
+  }, async ({ page }) => {
+    testLogger.info('Testing hero state visibility on fresh arrival');
+
+    // Wait for the hero container to be visible in the main content area
+    await pm.logsPage.expectNoStreamHeroVisible();
+
+    // Assert both action cards are present
+    await pm.logsPage.expectSelectStreamCardVisible();
+    await pm.logsPage.expectQueryGuideCardVisible();
+
+    testLogger.info('Hero state verified');
+  });
+
+  // ── P1: Hero "Select a stream" card opens the stream dropdown ──────
+  test("should open stream dropdown when clicking select stream card", {
+    tag: ['@logs-stream-quick-pick', '@all', '@logs']
+  }, async ({ page }) => {
+    testLogger.info('Testing select stream card opens the stream dropdown');
+
+    // Hero card must be visible first
+    await pm.logsPage.expectNoStreamHeroVisible();
+    await pm.logsPage.expectSelectStreamCardVisible();
+
+    // Click the card — should trigger onSelectStream() which opens the dropdown
+    await pm.logsPage.clickSelectStreamCard();
+
+    // Verify the stream dropdown popover opened
+    await pm.logsPage.expectStreamDropdownPopoverVisible();
+
+    testLogger.info('Dropdown opened via select stream card');
+  });
+
+  // ── P1: Deselect, quick pick reappears, re-select works ────────────
+  test("should reappear quick pick after deselecting and re-select works", {
+    tag: ['@logs-stream-quick-pick', '@all', '@logs']
+  }, async ({ page }) => {
+    testLogger.info('Testing deselect and re-pick workflow');
+
+    // Step 1: Select a stream via quick pick
+    await pm.logsPage.expectQuickPickContainerVisible();
+    await pm.logsPage.clickQuickPickButton('e2e_automate');
+    await pm.logsPage.expectQuickPickContainerNotVisible();
+    await pm.logsPage.expectStreamDropdownShowsStream('e2e_automate');
+
+    // Step 2: Deselect the stream. The logs stream OSelect is multi-mode with
+    // rowClickSingleSelect, so clearing the single selection requires clicking the
+    // option's checkbox zone (see deselectStreamViaCheckbox), not the option row.
+    await pm.logsPage.deselectStreamViaCheckbox('e2e_automate');
+
+    // Step 3: Quick pick should reappear in the sidebar
+    await pm.logsPage.expectQuickPickContainerVisible();
+
+    // Step 4: Re-select the same stream via quick pick
+    await pm.logsPage.clickQuickPickButton('e2e_automate');
+    await pm.logsPage.expectQuickPickContainerNotVisible();
+    await pm.logsPage.expectStreamDropdownShowsStream('e2e_automate');
+
+    // Verify field list loads after re-selection
+    await pm.logsPage.waitForFieldListAfterStreamSelection();
+
+    testLogger.info('Deselect and re-pick workflow completed');
+  });
+
+  // ── P2: Quick pick "X more" footer (conditional on > 8 streams) ────
+  test("should show more footer when org has more than 8 streams", {
+    tag: ['@logs-stream-quick-pick', '@all', '@logs']
+  }, async ({ page }) => {
+    testLogger.info('Testing quick pick more footer');
+
+    await pm.logsPage.expectQuickPickContainerVisible();
+
+    // Count how many quick pick stream buttons are visible
+    const count = await pm.logsPage.getQuickPickButtonCount();
+
+    // This test is conditional: it only asserts the footer when the org has > 8 streams.
+    // QUICK_PICK_LIMIT is 8 (IndexList.vue:549), so ≤ 8 buttons means the footer
+    // won't appear. Skip gracefully with a clear message.
+    if (count < 8) {
+      testLogger.info(`Quick pick shows ${count} buttons (≤ 8), skipping more-footer test`);
+      test.skip(true, `Org has fewer than 8 streams (${count} visible), more-footer not applicable`);
+      return;
+    }
+
+    // Footer should be visible when streamList > quickPickStreams
+    await pm.logsPage.expectQuickPickMoreFooterVisible();
+
+    // The number of visible quick pick buttons must not exceed the limit
+    expect(count, 'Quick pick button count should not exceed 8').toBeLessThanOrEqual(8);
+
+    testLogger.info('Quick pick more footer verified');
+  });
+
+  // ── P2: Hero "Recent:" chip selects stream and triggers search ─────
+  test("should select stream via hero recent chip", {
+    tag: ['@logs-stream-quick-pick', '@all', '@logs']
+  }, async ({ page }) => {
+    testLogger.info('Testing hero recent chip stream selection');
+
+    const orgId = getOrgIdentifier();
+
+    // Seed localStorage with a recent stream entry BEFORE navigation so that
+    // restoreLogsStream() picks it up when the page mounts. The key is
+    // `oo_selected_stream_logs_<orgId>` and the value is a string[] (see streamPersist.ts:3-4,10-13).
+    await page.evaluate((oid) => {
+      localStorage.setItem(
+        `oo_selected_stream_logs_${oid}`,
+        JSON.stringify(["e2e_automate"])
+      );
+    }, orgId);
+
+    // Re-navigate to pick up the localStorage-seeded recent streams.
+    // The beforeEach already navigated, but the localStorage was not set yet
+    // at that point, so we must go again.
+    await page.goto(`${logData.logsUrl}?org_identifier=${orgId}`);
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+
+    // Hero state must be visible with the recent chip
+    await pm.logsPage.expectNoStreamHeroVisible();
+    await pm.logsPage.expectRecentChipVisible('e2e_automate');
+
+    // Click the recent chip — should select the stream and trigger a search
+    await pm.logsPage.clickRecentChip('e2e_automate');
+
+    // Verify the stream was selected: the quick pick disappears and the
+    // dropdown shows the stream name
+    await pm.logsPage.expectQuickPickContainerNotVisible();
+    await pm.logsPage.expectStreamDropdownShowsStream('e2e_automate');
+
+    // Wait for the field list to load (confirms the stream selection completed)
+    await pm.logsPage.waitForFieldListAfterStreamSelection();
+
+    testLogger.info('Hero recent chip selection completed');
+  });
+
+  // ── P2: "Read the query guide" card opens documentation ────────────
+  test("should open query guide documentation in new tab", {
+    tag: ['@logs-stream-quick-pick', '@all', '@logs']
+  }, async ({ page }) => {
+    testLogger.info('Testing query guide card opens documentation');
+
+    await pm.logsPage.expectNoStreamHeroVisible();
+    await pm.logsPage.expectQueryGuideCardVisible();
+
+    // Set up a popup listener BEFORE clicking, so we capture the new tab
+    // that window.open() creates (LogsNoStreamState.vue:55)
+    const pagePromise = page.context().waitForEvent('page');
+
+    await pm.logsPage.clickQueryGuideCard();
+
+    // Wait for the new page to be created and load
+    const newPage = await pagePromise;
+    await newPage.waitForLoadState('domcontentloaded', { timeout: 15000 }).catch(() => {});
+
+    // The card opens https://openobserve.ai/docs/example-queries/ which
+    // redirects to /docs/user-guide/data-exploration/example-queries/.
+    // Accept any URL under openobserve.ai that contains "example-queries".
+    expect(
+      newPage.url(),
+      'New tab URL should point to openobserve query guide docs'
+    ).toMatch(/openobserve\.ai\/.*example-queries/);
+
+    // Clean up the new tab
+    await newPage.close().catch(() => {});
+
+    testLogger.info('Query guide card verified — docs opened in new tab');
+  });
+});

--- a/tests/ui-testing/playwright-tests/cleanup.spec.js
+++ b/tests/ui-testing/playwright-tests/cleanup.spec.js
@@ -291,6 +291,7 @@ test.describe("Pre-Test Cleanup", () => {
         /^e2e_apostrophe_/,            // e2e_apostrophe_* (Bug #9475 apostrophe test streams from logs-regression.spec.js)
         /^e2e_highlighting_test$/,     // e2e_highlighting_test (Bug #9754 logs highlighting test stream from logs-9754.spec.js)
         /^e2e_streamcreation_/,        // e2e_streamcreation_* (Stream creation UI test streams)
+        /^e2e_qp_more_stream_/,        // e2e_qp_more_stream_* (logsQuickPick.spec.js more-footer seed streams)
         /^e2e_MyUpperStream/i,         // e2e_MyUpperStream* (Stream name casing test streams)
         /^e2e_mylowerstream/i,         // e2e_mylowerstream* (Stream name casing test streams)
         /^[a-z]{8,9}$/,                // Random 8-9 char lowercase strings


### PR DESCRIPTION
🤖 Auto-generated E2E tests for #13025 — **healed to passing** against a live OpenObserve before this PR was opened.

- Branch `autoe2e/pr-13025` (stacked on `issue-ent-2038`), so the tests run against the feature code and pass before it merges.
- Spec: `tests/ui-testing/playwright-tests/Logs/logsQuickPick.spec.js`

The repo Playwright CI re-validates here. Review is for **quality + coverage** — the tests already pass.

_Generated by the E2E Council pipeline._


**Test cases added / changed:**

| Test case | Type | What it verifies |
|---|---|---|
| `should quick pick a stream from the sidebar` | new | clicking a sidebar quick pick button selects the stream and loads the field list |
| `should show hero state on fresh arrival with no stream selected` | new | the main content area shows both hero action cards when no stream is selected |
| `should open stream dropdown when clicking select stream card` | new | clicking the "Select a stream" hero card opens the stream dropdown popover |
| `should reappear quick pick after deselecting and re-select works` | new | after deselecting a stream the quick pick reappears and re-selection works correctly |
| `should show more footer when org has more than 8 streams` | new | the quick pick more footer is visible with the correct remaining count when org has > 8 streams (skips otherwise) |
| `should select stream via hero recent chip` | new | clicking a recent-stream chip in the hero state selects the stream and triggers field list loading |
| `should open query guide documentation in new tab` | new | clicking the "Read the query guide" card opens the OpenObserve docs in a new browser tab |
