### PR TITLE
[Security] Reject pipelines whose nodes reference a foreign tenant

### DIFF
--- a/src/config/src/meta/pipeline/mod.rs
+++ b/src/config/src/meta/pipeline/mod.rs
@@ -135,6 +135,8 @@ impl Pipeline {
     /// 7. In the same branch, unchecked `after_flattened` FunctionNode can't follow checked
     ///    `after_flattened` checked FunctionNode
     /// 8. EnrichmentTables can only be used in Scheduled pipelines
+    /// 9. every Stream/RemoteStream/Query node's `org_id` matches the pipeline's `org` — a
+    ///    pipeline must not read from or write to another tenant's streams.
     ///
     /// If all satisfies, populates the [Pipeline::source] with the first node in nodes list
     pub fn validate(&mut self) -> Result<()> {
@@ -172,6 +174,20 @@ impl Pipeline {
             }
             _ => return Err(anyhow!("Source must be either a StreamNode or QueryNode")),
         };
+
+        // ck 9: cross-tenant node authorization. Every node that names an org_id
+        // (Stream, RemoteStream, Query source) must belong to the same org as
+        // the pipeline itself — otherwise an admin of org A could route data
+        // into (or read from) org B's streams. The check runs before the
+        // reachability / DFS checks so a malicious payload can't shortcut it by
+        // being structurally broken. `pipeline.org` is set by the API handler
+        // from the URL path, so it is the authoritative tenant identifier.
+        if self.org.is_empty() {
+            return Err(anyhow!(
+                "Pipeline org is empty; cannot enforce cross-tenant authorization"
+            ));
+        }
+        self.check_nodes_belong_to_org()?;
 
         for node in self.nodes.iter_mut() {
             // ck 4
@@ -221,6 +237,83 @@ impl Pipeline {
             false,
             &mut visited,
         )?;
+
+        Ok(())
+    }
+
+    /// Enforces that every node touching a tenant identifier — stream nodes,
+    /// remote-stream nodes, and the derived-stream source — carries an
+    /// `org_id` equal to `self.org`. This is the cross-tenant authorization
+    /// invariant: without it, an admin of tenant A could persist a pipeline
+    /// that reads from or writes to tenant B's streams. Returns an error
+    /// naming the offending node so the client can pinpoint the mismatch.
+    ///
+    /// Callers that only want the check (e.g. before enabling a pre-existing
+    /// pipeline that was stored before this defense landed) can invoke this
+    /// directly without running the full [`Pipeline::validate`] pipeline.
+    pub fn check_nodes_belong_to_org(&self) -> Result<()> {
+        let expected_org = self.org.as_str();
+        // Guard against silently passing when the pipeline org is missing —
+        // that would defeat the invariant. Callers of this helper on the
+        // enable path guarantee a non-empty org via the URL, and `validate`
+        // pre-checks it above.
+        if expected_org.is_empty() {
+            return Err(anyhow!(
+                "Pipeline org is empty; cannot enforce cross-tenant authorization"
+            ));
+        }
+
+        // Derived-stream source (Scheduled pipelines): the source's org_id is
+        // the tenant whose stream the query runs against.
+        if let PipelineSource::Scheduled(derived_stream) = &self.source
+            && derived_stream.org_id != expected_org
+        {
+            return Err(anyhow!(
+                "Pipeline source's org_id '{}' does not belong to organization '{}'",
+                derived_stream.org_id,
+                expected_org,
+            ));
+        }
+
+        for node in &self.nodes {
+            match &node.data {
+                NodeData::Stream(stream_params) => {
+                    if stream_params.org_id.as_str() != expected_org {
+                        return Err(anyhow!(
+                            "Stream node '{}' references org_id '{}' which does not belong to organization '{}'",
+                            node.id,
+                            stream_params.org_id,
+                            expected_org,
+                        ));
+                    }
+                }
+                NodeData::RemoteStream(remote_stream_params) => {
+                    if remote_stream_params.org_id.as_str() != expected_org {
+                        return Err(anyhow!(
+                            "RemoteStream node '{}' references org_id '{}' which does not belong to organization '{}'",
+                            node.id,
+                            remote_stream_params.org_id,
+                            expected_org,
+                        ));
+                    }
+                }
+                NodeData::Query(derived_stream) => {
+                    if derived_stream.org_id != expected_org {
+                        return Err(anyhow!(
+                            "Query node '{}' references org_id '{}' which does not belong to organization '{}'",
+                            node.id,
+                            derived_stream.org_id,
+                            expected_org,
+                        ));
+                    }
+                }
+                // Function, Condition, LlmEvaluation nodes do not name an
+                // org_id — they run in-process on the pipeline's own tenant.
+                NodeData::Function(_)
+                | NodeData::Condition(_)
+                | NodeData::LlmEvaluation(_) => {}
+            }
+        }
 
         Ok(())
     }
@@ -1403,5 +1496,280 @@ mod tests {
 
         let destinations = pipeline.get_all_destination_streams(&node_map, &graph);
         assert!(destinations.is_empty());
+    }
+
+    // ---------------------------------------------------------------------
+    // Cross-tenant node authorization: every stream / remote-stream node
+    // (input, output, and inner) must belong to the pipeline's own org.
+    //
+    // Regression coverage for the pipeline-node cross-tenant gap: without
+    // these checks an org admin could create (or update, or enable) a
+    // pipeline whose output node's org_id points at a different tenant's
+    // stream, silently routing data cross-tenant at processing time.
+    // ---------------------------------------------------------------------
+
+    /// Baseline: a same-org realtime pipeline validates cleanly. Paired with
+    /// the cross-tenant cases below so a failing red is provably the tenant
+    /// invariant, not a structural mistake in the fixture.
+    #[test]
+    fn test_pipeline_validation_same_org_nodes_accepted() {
+        let mut pipeline = Pipeline {
+            id: "test_pipeline".to_string(),
+            version: 1,
+            enabled: true,
+            org: "org_a".to_string(),
+            name: "test_pipeline".to_string(),
+            description: "test description".to_string(),
+            source: PipelineSource::Realtime(StreamParams::new(
+                "org_a",
+                "src",
+                StreamType::Logs,
+            )),
+            kind: PipelineKind::User,
+            nodes: vec![
+                Node::new(
+                    "1".to_string(),
+                    NodeData::Stream(StreamParams::new("org_a", "src", StreamType::Logs)),
+                    100.0,
+                    100.0,
+                    "input".to_string(),
+                ),
+                Node::new(
+                    "2".to_string(),
+                    NodeData::Stream(StreamParams::new("org_a", "dst", StreamType::Logs)),
+                    300.0,
+                    100.0,
+                    "output".to_string(),
+                ),
+            ],
+            edges: vec![Edge {
+                id: "e1-2".to_string(),
+                source: "1".to_string(),
+                target: "2".to_string(),
+            }],
+        };
+
+        assert!(
+            pipeline.validate().is_ok(),
+            "same-org pipeline must validate cleanly (baseline control)"
+        );
+    }
+
+    /// The vulnerability: a realtime pipeline in org_a whose OUTPUT stream
+    /// node carries org_b's org_id must be rejected. On unfixed code the
+    /// validation passes and the persisted pipeline routes org_a data to
+    /// org_b at ingest time.
+    #[test]
+    fn test_pipeline_validation_rejects_cross_tenant_output_node() {
+        let mut pipeline = Pipeline {
+            id: "test_pipeline".to_string(),
+            version: 1,
+            enabled: true,
+            org: "org_a".to_string(),
+            name: "test_pipeline".to_string(),
+            description: "test description".to_string(),
+            source: PipelineSource::Realtime(StreamParams::new(
+                "org_a",
+                "src",
+                StreamType::Logs,
+            )),
+            kind: PipelineKind::User,
+            nodes: vec![
+                Node::new(
+                    "1".to_string(),
+                    NodeData::Stream(StreamParams::new("org_a", "src", StreamType::Logs)),
+                    100.0,
+                    100.0,
+                    "input".to_string(),
+                ),
+                Node::new(
+                    "2".to_string(),
+                    // Cross-tenant: output points at org_b.
+                    NodeData::Stream(StreamParams::new(
+                        "org_b",
+                        "victim_stream",
+                        StreamType::Logs,
+                    )),
+                    300.0,
+                    100.0,
+                    "output".to_string(),
+                ),
+            ],
+            edges: vec![Edge {
+                id: "e1-2".to_string(),
+                source: "1".to_string(),
+                target: "2".to_string(),
+            }],
+        };
+
+        let result = pipeline.validate();
+        assert!(
+            result.is_err(),
+            "pipeline with a cross-tenant output node must be rejected"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("does not belong to organization") || msg.contains("cross-tenant"),
+            "error must identify the cross-tenant node, got: {msg}",
+        );
+    }
+
+    /// Input-node authorization: a stream node marked as input whose
+    /// org_id references a foreign tenant must also be rejected — otherwise
+    /// an admin could read another tenant's stream into their own pipeline.
+    #[test]
+    fn test_pipeline_validation_rejects_cross_tenant_input_node() {
+        let mut pipeline = Pipeline {
+            id: "test_pipeline".to_string(),
+            version: 1,
+            enabled: true,
+            org: "org_a".to_string(),
+            name: "test_pipeline".to_string(),
+            description: "test description".to_string(),
+            source: PipelineSource::Realtime(StreamParams::new(
+                "org_b",
+                "src",
+                StreamType::Logs,
+            )),
+            kind: PipelineKind::User,
+            nodes: vec![
+                Node::new(
+                    "1".to_string(),
+                    // Cross-tenant input: source stream is in org_b.
+                    NodeData::Stream(StreamParams::new("org_b", "src", StreamType::Logs)),
+                    100.0,
+                    100.0,
+                    "input".to_string(),
+                ),
+                Node::new(
+                    "2".to_string(),
+                    NodeData::Stream(StreamParams::new("org_a", "dst", StreamType::Logs)),
+                    300.0,
+                    100.0,
+                    "output".to_string(),
+                ),
+            ],
+            edges: vec![Edge {
+                id: "e1-2".to_string(),
+                source: "1".to_string(),
+                target: "2".to_string(),
+            }],
+        };
+
+        let result = pipeline.validate();
+        assert!(
+            result.is_err(),
+            "pipeline with a cross-tenant input node must be rejected"
+        );
+    }
+
+    /// Remote-stream (destination) node authorization: same rule applies
+    /// to `remote_stream` output nodes.
+    #[test]
+    fn test_pipeline_validation_rejects_cross_tenant_remote_stream_node() {
+        let mut pipeline = Pipeline {
+            id: "test_pipeline".to_string(),
+            version: 1,
+            enabled: true,
+            org: "org_a".to_string(),
+            name: "test_pipeline".to_string(),
+            description: "test description".to_string(),
+            source: PipelineSource::Realtime(StreamParams::new(
+                "org_a",
+                "src",
+                StreamType::Logs,
+            )),
+            kind: PipelineKind::User,
+            nodes: vec![
+                Node::new(
+                    "1".to_string(),
+                    NodeData::Stream(StreamParams::new("org_a", "src", StreamType::Logs)),
+                    100.0,
+                    100.0,
+                    "input".to_string(),
+                ),
+                Node::new(
+                    "2".to_string(),
+                    NodeData::RemoteStream(crate::meta::stream::RemoteStreamParams {
+                        // Cross-tenant remote destination.
+                        org_id: "org_b".to_string().into(),
+                        destination_name: "victim_destination".to_string().into(),
+                    }),
+                    300.0,
+                    100.0,
+                    "output".to_string(),
+                ),
+            ],
+            edges: vec![Edge {
+                id: "e1-2".to_string(),
+                source: "1".to_string(),
+                target: "2".to_string(),
+            }],
+        };
+
+        let result = pipeline.validate();
+        assert!(
+            result.is_err(),
+            "pipeline with a cross-tenant remote-stream node must be rejected"
+        );
+    }
+
+    /// Scheduled (DerivedStream) source authorization: the query source's
+    /// org_id must also match the pipeline's org.
+    #[test]
+    fn test_pipeline_validation_rejects_cross_tenant_derived_stream_source() {
+        let derived_stream = DerivedStream {
+            // Cross-tenant: derived-stream source targets org_b.
+            org_id: "org_b".to_string(),
+            stream_type: StreamType::Logs,
+            query_condition: QueryCondition {
+                sql: Some("SELECT * FROM src".to_string()),
+                ..Default::default()
+            },
+            trigger_condition: TriggerCondition {
+                period: 5,
+                ..Default::default()
+            },
+            tz_offset: 0,
+            delay: None,
+            start_at: None,
+        };
+        let mut pipeline = Pipeline {
+            id: "test_pipeline".to_string(),
+            version: 1,
+            enabled: true,
+            org: "org_a".to_string(),
+            name: "test_pipeline".to_string(),
+            description: "test description".to_string(),
+            source: PipelineSource::Scheduled(derived_stream.clone()),
+            kind: PipelineKind::User,
+            nodes: vec![
+                Node::new(
+                    "1".to_string(),
+                    NodeData::Query(derived_stream),
+                    100.0,
+                    100.0,
+                    "input".to_string(),
+                ),
+                Node::new(
+                    "2".to_string(),
+                    NodeData::Stream(StreamParams::new("org_a", "dst", StreamType::Logs)),
+                    300.0,
+                    100.0,
+                    "output".to_string(),
+                ),
+            ],
+            edges: vec![Edge {
+                id: "e1-2".to_string(),
+                source: "1".to_string(),
+                target: "2".to_string(),
+            }],
+        };
+
+        let result = pipeline.validate();
+        assert!(
+            result.is_err(),
+            "pipeline with a cross-tenant DerivedStream source must be rejected"
+        );
     }
 }

--- a/src/service/pipeline/mod.rs
+++ b/src/service/pipeline/mod.rs
@@ -321,6 +321,15 @@ pub async fn enable_pipeline(
         return Err(PipelineError::NotFound(pipeline_id.to_string()));
     };
 
+    // Cross-tenant guard: re-validate the stored pipeline's node org_ids
+    // before enabling. Any pipeline that was persisted *before* the create /
+    // update path started enforcing this — e.g. an admin's pre-existing
+    // cross-tenant pipeline — must be blocked from activation so the fix
+    // covers historical rows, not just newly-written ones.
+    if enable && let Err(e) = pipeline.check_nodes_belong_to_org() {
+        return Err(PipelineError::InvalidPipeline(e.to_string()));
+    }
+
     pipeline.enabled = enable;
     // add or remove trigger if it's a scheduled pipeline
     if let PipelineSource::Scheduled(derived_stream) = &mut pipeline.source {


### PR DESCRIPTION
## Summary

Pipeline create / update / enable did not verify that each stream, remote-stream, or query node's `org_id` matched the pipeline's own org. An org admin could persist and activate a pipeline whose output routed data into (or read data from) another tenant's stream. This PR enforces a same-org invariant on every node at validation time and re-runs it on the enable path so pipelines persisted before the fix landed cannot be activated cross-tenant.

## Consequence

An admin of any tenant can configure a pipeline that routes their org's log data into another tenant's stream, or injects arbitrary data into that tenant's stream — either direction executes silently without the victim tenant's knowledge or consent, enabling persistent cross-tenant data exfiltration and data injection at processing time.

## Reproduction

Actor: an org admin of `orgA` who can authenticate to `POST /api/orgA/pipelines` (substitute your own equivalent credentials — represented below as `<org-admin-a-user>` / `<org-admin-a-password>`).  Victim: any other tenant `orgB` with an existing stream (`pentest_logs_b` below).

1. Seed a source stream in `orgA` (a source stream is required because only one realtime pipeline can bind a source at a time):
   ```
   curl -u '<org-admin-a-user>:<org-admin-a-password>' \
        -H 'Content-Type: application/json' \
        -X POST "$TARGET/api/orgA/tc91_source_a/_json" \
        -d '[{"timestamp":"2026-07-04T00:00:00Z","level":"info","msg":"seed"}]'
   ```
   -> HTTP 200, 1 record ingested.
2. Create a cross-tenant pipeline — the output node's `org_id` names `orgB`:
   ```
   curl -u '<org-admin-a-user>:<org-admin-a-password>' \
        -H 'Content-Type: application/json' \
        -X POST "$TARGET/api/orgA/pipelines" \
        -d '{
              "name": "xtenant",
              "source": {"source_type":"realtime","org_id":"orgA","stream_name":"tc91_source_a","stream_type":"logs"},
              "nodes": [
                {"id":"n1","io_type":"input","position":{"x":0,"y":0},"data":{"node_type":"stream","org_id":"orgA","stream_name":"tc91_source_a","stream_type":"logs"}},
                {"id":"n2","io_type":"output","position":{"x":200,"y":0},"data":{"node_type":"stream","org_id":"orgB","stream_name":"pentest_logs_b","stream_type":"logs"}}
              ],
              "edges": [{"id":"e1","source":"n1","target":"n2"}]
            }'
   ```
   -> HTTP 200 `{"code":200,"message":"Pipeline created successfully","id":"<pipeline-id>"}` — smoking-gun: the pipeline is persisted with the foreign `org_id` unchanged.
3. Enable the pipeline:
   ```
   curl -u '<org-admin-a-user>:<org-admin-a-password>' \
        -X PUT "$TARGET/api/orgA/pipelines/<pipeline-id>/enable?value=true"
   ```
   -> HTTP 200 `{"code":200,"message":"Pipeline successfully enabled"}` — from this point onward, ingest against `tc91_source_a` in `orgA` is routed to `pentest_logs_b` in `orgB`.
4. Control — same request with the output node's `org_id` set to `orgA` (a legitimate same-org pipeline):
   -> HTTP 200 `Pipeline created successfully`, and the persisted output node's `org_id` stays `orgA`. This proves the vulnerability is specific to the cross-tenant case, not a broken setup.

Expected secure: create must return `HTTP 400` (invalid pipeline — cross-tenant node); enable must return the same on any pre-existing pipeline whose stored nodes reference a foreign tenant.

## What changed

- `src/config/src/meta/pipeline/mod.rs` — added `Pipeline::check_nodes_belong_to_org()` and wired it into `Pipeline::validate()` as check 9. Every `Stream` / `RemoteStream` / `Query` node's `org_id`, and (for scheduled pipelines) the source `DerivedStream`'s `org_id`, must equal `pipeline.org` (the tenant taken from the URL path in the handler). A mismatch returns a descriptive `anyhow!` error naming the offending node, which the HTTP layer maps to 400. `Function`, `Condition`, and `LlmEvaluation` nodes carry no tenant identifier and are unaffected.
- `src/service/pipeline/mod.rs` — `enable_pipeline` now calls `check_nodes_belong_to_org()` before flipping `enabled=true`. This covers pipelines that were stored before the fix landed: they cannot be enabled cross-tenant even though they exist in the DB.

## Regression test

`src/config/src/meta/pipeline/mod.rs` — four new tests in `meta::pipeline::tests` assert the cross-tenant invariant on every node type the vulnerability could ride:

- `test_pipeline_validation_rejects_cross_tenant_output_node` — realtime pipeline whose output `Stream` node targets a different org.
- `test_pipeline_validation_rejects_cross_tenant_input_node` — realtime pipeline whose input `Stream` node references a foreign org.
- `test_pipeline_validation_rejects_cross_tenant_remote_stream_node` — realtime pipeline whose output `RemoteStream` node references a foreign org.
- `test_pipeline_validation_rejects_cross_tenant_derived_stream_source` — scheduled pipeline whose `DerivedStream` source targets a foreign org.

Paired same-org control `test_pipeline_validation_same_org_nodes_accepted` proves the rejection is specific to the cross-tenant case and not a fixture bug.

## Validation

Ran the pipeline-module tests against unfixed code first — the four regression tests failed exactly as designed, with the same-org control passing:

```
test meta::pipeline::tests::test_pipeline_validation_same_org_nodes_accepted ... ok
test meta::pipeline::tests::test_pipeline_validation_rejects_cross_tenant_output_node ... FAILED
test meta::pipeline::tests::test_pipeline_validation_rejects_cross_tenant_derived_stream_source ... FAILED
test meta::pipeline::tests::test_pipeline_validation_rejects_cross_tenant_remote_stream_node ... FAILED
test meta::pipeline::tests::test_pipeline_validation_rejects_cross_tenant_input_node ... FAILED

thread 'test_pipeline_validation_rejects_cross_tenant_output_node' panicked at
  src/config/src/meta/pipeline/mod.rs: pipeline with a cross-tenant output node must be rejected
```

After the fix (`cargo test -p config --lib meta::pipeline::tests::`):

```
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 1940 filtered out
```

## Full suite

`cargo test --lib` (full workspace, ~4038 tests): 4025 pass, 13 fail. Every failing test is pre-existing and unrelated to pipelines — they are UDS query-validation edge cases (`handler::http::request::search::utils::validate_query_edge_cases::*`), sourcemap I/O tests, an enrichment-table URL processor, and a job config-watcher — spot-checked against `main` and they fail there too (SQLite DB file access + pre-existing UDS assertions). All 79 pipeline-scope tests, including the 46 handler/service pipeline tests and the 26 config pipeline tests, pass.

## Residual risk

- The check compares the raw `org_id` string; if the handler layer ever normalizes org identifiers (case, trimming, alias resolution) that normalization must be applied before `validate()` runs, or a canonicalization helper must be reused here. Today `pipeline.org` and node `org_id` values both flow through unchanged, so this is not a live gap.
- Pipelines persisted before this defense with cross-tenant nodes remain in storage until deleted; they can no longer be enabled, but a follow-up cleanup pass (delete or auto-quarantine any stored pipeline where `check_nodes_belong_to_org()` fails) would remove the dead rows.
- Bulk enable (`POST /api/{org}/pipelines/bulk/enable`) calls the same `enable_user_pipeline` entry point and is covered transitively. If a future direct-mutation code path is added that skips `validate()` and `enable_pipeline`, it must call `check_nodes_belong_to_org()` explicitly.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_