### PR TITLE
[Security] Hide destination response body and drop client auth headers from alert webhooks

### DIFF
--- a/src/common/utils/http_forward.rs
+++ b/src/common/utils/http_forward.rs
@@ -1,0 +1,241 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Helpers that guard outbound webhook / alert-destination requests.
+//!
+//! Two invariants are enforced here:
+//!
+//! 1. **Client-supplied `Authorization` / `Cookie` / `X-Auth-*` headers must
+//!    not be forwarded verbatim to arbitrary destinations.** They are stripped
+//!    from the caller-supplied headers map before the outbound request is
+//!    dispatched.
+//! 2. **Third-party response bodies must not be echoed back to the API
+//!    caller.** The `test_destination` and `send_http_notification` paths
+//!    return only a size-capped shape summary (status code, length) instead of
+//!    the raw body.
+
+use std::collections::HashMap;
+
+/// Case-insensitive names of headers that must never be forwarded from a
+/// caller-supplied headers map to an outbound webhook or alert destination.
+///
+/// * `authorization` / `proxy-authorization` — server auth material for the
+///   caller's session or a proxy; forwarding lets a caller relay whatever
+///   credentials they hold through this server to a chosen URL (a form of
+///   confused-deputy).
+/// * `cookie` / `set-cookie` — session state for the caller (or the
+///   destination), same relay risk.
+/// * `www-authenticate` / `proxy-authenticate` — challenge headers that could
+///   induce a downstream to send credentials.
+/// * `x-auth-*` — a common product-specific auth-header namespace (e.g.
+///   `x-auth-token`, `x-auth-user`).
+///
+/// Invariant asserted by [`sanitize_forward_headers_strips_sensitive`].
+const SENSITIVE_HEADER_PREFIXES: &[&str] = &["x-auth-"];
+const SENSITIVE_HEADER_EXACT: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "www-authenticate",
+    "proxy-authenticate",
+];
+
+/// Return true if the given header name should be stripped from a
+/// caller-supplied headers map before the outbound webhook / alert-trigger
+/// request is dispatched. Matching is case-insensitive against
+/// [`SENSITIVE_HEADER_EXACT`] and any prefix in
+/// [`SENSITIVE_HEADER_PREFIXES`].
+pub fn is_sensitive_forward_header(name: &str) -> bool {
+    let lower = name.trim().to_ascii_lowercase();
+    if SENSITIVE_HEADER_EXACT.contains(&lower.as_str()) {
+        return true;
+    }
+    SENSITIVE_HEADER_PREFIXES
+        .iter()
+        .any(|prefix| lower.starts_with(prefix))
+}
+
+/// Strip any header in [`SENSITIVE_HEADER_EXACT`] or matching a prefix in
+/// [`SENSITIVE_HEADER_PREFIXES`] (case-insensitive) from a caller-supplied
+/// headers map. The returned map is safe to forward verbatim on the outbound
+/// webhook / alert-trigger request.
+///
+/// This does NOT touch the inbound API request's own `Authorization` header —
+/// that stays with the incoming request. Only the user-supplied `headers`
+/// field on the request body is sanitized here.
+pub fn sanitize_forward_headers(
+    headers: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    headers
+        .iter()
+        .filter(|(k, _)| !is_sensitive_forward_header(k))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+/// Format the error propagated to the API caller when an outbound webhook /
+/// alert-trigger request receives a non-2xx status. The upstream response
+/// body is intentionally not included — only the status code and the length
+/// of the body received. The full body is still logged server-side (see
+/// `send_http_notification`).
+pub fn format_upstream_error(resp_status: reqwest::StatusCode, resp_body: &str) -> String {
+    format!(
+        "sent error status: {}, upstream response body suppressed ({} bytes)",
+        resp_status,
+        resp_body.len()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hm(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // TC-31E5785D (prong 3): the webhook-test / alert-trigger endpoints must
+    // NOT forward caller-supplied `Authorization`, `Cookie`, or `X-Auth-*`
+    // headers to the outbound URL. Doing so lets an org-scoped caller relay
+    // whatever credentials they hold (e.g. root's `Basic` header) through
+    // this server to a chosen destination — a confused-deputy that in the
+    // finding was chained with an SSRF-guard bypass to read another
+    // tenant's data.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn sanitize_forward_headers_strips_sensitive() {
+        let raw = hm(&[
+            ("Authorization", "Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM="),
+            ("authorization", "Bearer abc"),
+            ("Proxy-Authorization", "Basic yy"),
+            ("Cookie", "session=deadbeef"),
+            ("SET-COOKIE", "session=deadbeef"),
+            ("WWW-Authenticate", "Basic realm=proxy"),
+            ("Proxy-Authenticate", "Basic realm=proxy"),
+            ("X-Auth-Token", "tok"),
+            ("x-auth-user", "u"),
+            // Legitimate app headers must be preserved.
+            ("Content-Type", "application/json"),
+            ("X-Custom-Header", "keep-me"),
+            ("X-Request-Id", "abc123"),
+        ]);
+
+        let cleaned = sanitize_forward_headers(&raw);
+
+        // Every case-insensitive spelling of every sensitive header is gone.
+        for stripped in [
+            "Authorization",
+            "authorization",
+            "Proxy-Authorization",
+            "Cookie",
+            "SET-COOKIE",
+            "WWW-Authenticate",
+            "Proxy-Authenticate",
+            "X-Auth-Token",
+            "x-auth-user",
+        ] {
+            assert!(
+                !cleaned.contains_key(stripped),
+                "sensitive header {stripped:?} was forwarded verbatim; \
+                 sanitize_forward_headers must strip it before outbound dispatch"
+            );
+        }
+
+        // Legitimate headers survive.
+        assert_eq!(cleaned.get("Content-Type").map(|s| s.as_str()), Some("application/json"));
+        assert_eq!(cleaned.get("X-Custom-Header").map(|s| s.as_str()), Some("keep-me"));
+        assert_eq!(cleaned.get("X-Request-Id").map(|s| s.as_str()), Some("abc123"));
+
+        // The specific `root@example.com` credential the PoC forwards must
+        // not survive as a value anywhere in the map.
+        for (_, v) in cleaned.iter() {
+            assert!(
+                !v.starts_with("Basic cm9vdEBleGFtcGxlLmNvbTp"),
+                "the root credential from the PoC survived sanitization: {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_sensitive_forward_header_is_case_insensitive() {
+        for name in [
+            "Authorization",
+            "AUTHORIZATION",
+            "authorization",
+            "Cookie",
+            "cookie",
+            "SET-COOKIE",
+            "X-Auth-Token",
+            "x-AUTH-anything",
+            "Proxy-Authorization",
+            "www-authenticate",
+        ] {
+            assert!(
+                is_sensitive_forward_header(name),
+                "{name} must be classified sensitive"
+            );
+        }
+        for name in ["Content-Type", "X-Custom-Header", "X-Request-Id", "Accept"] {
+            assert!(
+                !is_sensitive_forward_header(name),
+                "{name} must NOT be classified sensitive"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // TC-F56CF2EE (and TC-31E5785D prong 2): the error propagated to the API
+    // caller when the outbound webhook returns non-2xx must NOT include the
+    // raw response body. Only the status code + a size summary is safe.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn format_upstream_error_omits_body() {
+        // A distinctive marker string that only appears if the upstream body
+        // leaks into the error. Mirrors the "Example Domain" / "iana.org"
+        // markers the PoC uses against example.com.
+        let leaked_body = "<html><title>Example Domain</title> \
+            SECRET-TOKEN-abc123 iana.org</html>";
+        let msg = format_upstream_error(
+            reqwest::StatusCode::METHOD_NOT_ALLOWED,
+            leaked_body,
+        );
+
+        // Status is included — reviewers can still diagnose the failure.
+        assert!(
+            msg.contains("405") || msg.contains("Method Not Allowed"),
+            "error message must include the upstream status code, got: {msg}"
+        );
+
+        // The body must be suppressed. Assert none of its distinctive
+        // substrings survive.
+        for marker in [
+            "Example Domain",
+            "SECRET-TOKEN-abc123",
+            "iana.org",
+            "<html",
+            "<title>",
+        ] {
+            assert!(
+                !msg.contains(marker),
+                "upstream response body marker {marker:?} leaked into error: {msg}"
+            );
+        }
+    }
+}

--- a/src/common/utils/mod.rs
+++ b/src/common/utils/mod.rs
@@ -16,6 +16,7 @@
 pub mod auth;
 pub mod functions;
 pub mod http;
+pub mod http_forward;
 pub mod js;
 pub mod jwt;
 pub mod redirect_response;

--- a/src/handler/http/request/alerts/destinations.rs
+++ b/src/handler/http/request/alerts/destinations.rs
@@ -28,7 +28,9 @@ use crate::common::utils::auth::check_permissions;
 use crate::{
     common::{
         meta::http::HttpResponse as MetaHttpResponse,
-        utils::{auth::UserEmail, ssrf_guard::SsrfGuard},
+        utils::{
+            auth::UserEmail, http_forward::sanitize_forward_headers, ssrf_guard::SsrfGuard,
+        },
     },
     handler::http::{
         extractors::Headers,
@@ -148,6 +150,32 @@ async fn test_email_destination(org_id: &str, test_req: &TestDestinationRequest)
     }
 }
 
+/// Build the response payload returned by `POST /alerts/destinations/test`
+/// after the outbound HTTP request completes. Only a shape summary is
+/// returned to the API caller — the raw upstream body is intentionally
+/// suppressed so the endpoint cannot be used as a read-primitive against
+/// internal services (e.g. via SSRF) or against other tenants (via a
+/// confused-deputy header relay).
+///
+/// The `response_body` field is set to a short, fixed-shape summary of the
+/// form `"(response body suppressed, N bytes)"` so the UI can still show a
+/// success/failure indicator plus a hint that a body was received.
+pub(crate) fn build_http_test_response(
+    success: bool,
+    status_code: u16,
+    response_body: String,
+) -> TestDestinationResponse {
+    TestDestinationResponse {
+        success,
+        status_code: Some(status_code),
+        response_body: Some(format!(
+            "(response body suppressed, {} bytes)",
+            response_body.len()
+        )),
+        error: None,
+    }
+}
+
 async fn test_http_destination(test_req: &TestDestinationRequest) -> Response {
     let method = test_req
         .method
@@ -215,7 +243,10 @@ async fn test_http_destination(test_req: &TestDestinationRequest) -> Response {
         }
     };
 
-    // Add headers
+    // Add headers, first stripping any caller-supplied sensitive header
+    // (Authorization, Cookie, X-Auth-*, …) so this endpoint cannot be used
+    // to relay credentials the caller holds to an arbitrary destination.
+    let headers = sanitize_forward_headers(&headers);
     for (key, value) in headers {
         request_builder = request_builder.header(key, value);
     }
@@ -232,12 +263,11 @@ async fn test_http_destination(test_req: &TestDestinationRequest) -> Response {
             let success = response.status().is_success();
 
             match response.text().await {
-                Ok(response_body) => MetaHttpResponse::json(TestDestinationResponse {
+                Ok(response_body) => MetaHttpResponse::json(build_http_test_response(
                     success,
-                    status_code: Some(status_code),
-                    response_body: Some(response_body),
-                    error: None,
-                }),
+                    status_code,
+                    response_body,
+                )),
                 Err(e) => MetaHttpResponse::json(TestDestinationResponse {
                     success: false,
                     status_code: Some(status_code),
@@ -626,10 +656,65 @@ pub async fn list_prebuilt_destinations(Path(org_id): Path<String>) -> Response 
 mod tests {
     use axum::{http::StatusCode, response::Response};
 
+    use super::build_http_test_response;
     use crate::service::db::alerts::destinations::DestinationError;
 
     fn status(err: DestinationError) -> StatusCode {
         Response::from(err).status()
+    }
+
+    // -------------------------------------------------------------------
+    // TC-31E5785D (prong 2) and TC-F56CF2EE share a class of leak: the
+    // API caller learns the raw upstream response body. On the
+    // webhook-test path that surfaces via `TestDestinationResponse.
+    // response_body`. `build_http_test_response` MUST suppress that raw
+    // body — only status code + a shape summary is safe.
+    // -------------------------------------------------------------------
+    #[test]
+    fn build_http_test_response_suppresses_body() {
+        // Distinctive markers that only survive if the raw upstream body
+        // is echoed verbatim. Mirrors the PoC's orgB destinations list
+        // (`pentest-dest-b`) and the healthz shape from
+        // niro/findings/TC-31E5785D/poc.py.
+        let leaked_body = "[{\"name\":\"pentest-dest-b\",\
+            \"url\":\"https://example.com/pentest-sink\"}]\
+            {\"status\":\"ok\"}";
+        let resp = build_http_test_response(true, 200, leaked_body.to_string());
+
+        // Shape summary is still useful for the UI: keep success + status.
+        assert!(resp.success);
+        assert_eq!(resp.status_code, Some(200));
+        assert!(
+            resp.error.is_none(),
+            "successful upstream must not synthesise an error string"
+        );
+
+        // The raw body must not survive on the response.
+        match resp.response_body.as_deref() {
+            None => { /* fully suppressed — best case */ }
+            Some(body) => {
+                for marker in [
+                    "pentest-dest-b",
+                    "https://example.com/pentest-sink",
+                    "\"status\":\"ok\"",
+                ] {
+                    assert!(
+                        !body.contains(marker),
+                        "upstream body marker {marker:?} leaked into \
+                         TestDestinationResponse.response_body: {body}"
+                    );
+                }
+                // Any surviving string must be a fixed shape summary — no
+                // caller-controllable characters. A conservative rule of
+                // thumb: it must not be longer than the raw body itself.
+                assert!(
+                    body.len() < leaked_body.len(),
+                    "response_body must be a fixed shape summary, not the \
+                     raw upstream body ({} chars)",
+                    body.len()
+                );
+            }
+        }
     }
 
     // 404 Not Found

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -1283,10 +1283,19 @@ async fn send_http_notification(endpoint: &Endpoint, msg: String) -> Result<Stri
         HTTPType::GET => client.get(url),
     };
 
-    // Add additional headers if any from destination description
+    // Add additional headers from destination description, first stripping
+    // any caller-supplied sensitive header (Authorization, Cookie, X-Auth-*,
+    // …) so the alert-trigger path cannot relay credentials the caller
+    // holds to an arbitrary destination.
     let mut has_context_type = false;
-    if let Some(headers) = &endpoint.headers {
-        for (key, value) in headers.iter() {
+    if let Some(raw_headers) = &endpoint.headers {
+        for (key, value) in raw_headers.iter() {
+            // Skip caller-supplied sensitive headers (Authorization, Cookie,
+            // X-Auth-*, …) so a compromised destination configuration
+            // cannot relay credentials it holds to an arbitrary URL.
+            if crate::common::utils::http_forward::is_sensitive_forward_header(key) {
+                continue;
+            }
             if !key.is_empty() && !value.is_empty() {
                 if key.to_lowercase().trim() == "content-type" {
                     has_context_type = true;
@@ -1315,10 +1324,18 @@ async fn send_http_notification(endpoint: &Endpoint, msg: String) -> Result<Stri
         log::error!(
             "Alert http notification failed with status: {resp_status}, body: {resp_body}, payload: {msg}"
         );
+        // Return only a status-code error to the API caller. The raw
+        // upstream body may contain third-party HTML, cross-tenant data
+        // reached via a compromised destination, or secrets that leaked
+        // out of an internal service — none of which is safe to reflect
+        // to the caller who authored the trigger. The full body is still
+        // captured in the log::error! above for operator diagnostics.
         return Err(anyhow::anyhow!(
-            "sent error status: {}, err: {}",
-            resp_status,
-            resp_body
+            "{}",
+            crate::common::utils::http_forward::format_upstream_error(
+                resp_status,
+                &resp_body,
+            )
         ));
     }
 


### PR DESCRIPTION
## Summary

The webhook-test endpoint (`POST /api/{org}/alerts/destinations/test`) and the alert-trigger path (`PATCH /api/v2/{org}/alerts/{id}/trigger`) both echoed the raw upstream HTTP response body back to the API caller — the test endpoint via `TestDestinationResponse.response_body`, the trigger path via the `"sent error status: {status}, err: {body}"` error message. The webhook-test endpoint also forwarded any caller-supplied `Authorization` / `Cookie` / `X-Auth-*` headers verbatim to the outbound URL. This change strips those sensitive headers before dispatch and reflects only a shape summary (status code + body length) back to the caller; the full body is still logged server-side for operators.

## Consequence

**Finding 1 — webhook-test response body + header relay:**

> An org admin can drive the server into outbound HTTP requests to loopback and internal addresses via the webhook-test endpoint — attacker-chosen URL, method, headers, and the full response body echoed back — reading internal /metrics, /config, and cloud-metadata, and relaying any other-tenant credentials the caller already holds through localhost to that tenant's authenticated APIs.

**Finding 2 — alert-trigger error body leak:**

> Any org admin who triggers an alert receives the full HTTP response body from the webhook destination verbatim in the API error. For external destinations this exposes third-party error payloads. Pointed at an internal service via a destination URL using 0.0.0.0, the full internal error response body — including any tokens or secrets it emits — is returned to the caller.

## Reproduction

**Finding 1 — webhook-test response body + header relay** — actor: an org-scoped admin in orgA (substitute your own equivalent).

1. Confirm the actor cannot directly reach orgB's destinations — authz is alive:
   ```
   curl -sS -o /dev/null -w '%{http_code}\n' \
     -H "Authorization: Basic <orga-admin-basic-b64>" \
     "$TARGET/api/<orgB-id>/alerts/destinations"
   ```
   -> `401`

2. Drive the webhook-test endpoint at loopback via `0.0.0.0`, injecting an `Authorization` header carrying the *root* user's credentials:
   ```
   curl -sS -X POST \
     -H "Authorization: Basic <orga-admin-basic-b64>" \
     -H "Content-Type: application/json" \
     "$TARGET/api/<orgA-id>/alerts/destinations/test" \
     -d '{"url":"http://0.0.0.0:5080/api/<orgB-id>/alerts/destinations",
          "method":"get","type":"http",
          "headers":{"Authorization":"Basic <root-basic-b64>"},
          "template":{"name":"t","body":"{}","type":"http"},
          "skip_tls_verify":false}'
   ```
   -> `HTTP 200 {"success":true,"statusCode":200,"responseBody":"[{\"name\":\"pentest-dest-b\",\"url\":\"<orgB-destination-url — redacted>\", ...}]", "error":null}` — the full orgB destinations list (data orgA's admin has no authorization to read) is returned verbatim in `responseBody`, using root credentials the caller injected through the forwarded `Authorization` header.

3. Control — the same test with `127.0.0.1` (which the SSRF guard already blocks) is correctly refused:
   -> `HTTP 200 {"success":false, ..., "error":"URL uses private IP address"}` — proves the SSRF guard is alive; only the loopback representation and the two prongs fixed here were missing.

Expected secure: only a status-code + body-length shape summary in the response; caller-supplied `Authorization` / `Cookie` headers stripped from the outbound request.

**Finding 2 — alert-trigger reflects the destination's response body** — actor: an org-scoped admin in orgA (substitute your own equivalent).

1. The actor owns an alert bound to a destination that POSTs to `https://example.com/<path>` (which returns HTTP 405 with a distinctive HTML body).
2. Trigger the alert:
   ```
   curl -sS -X PATCH \
     -H "Authorization: Basic <orga-admin-basic-b64>" \
     -H "Content-Type: application/json" \
     "$TARGET/api/v2/<orgA-id>/alerts/<alert-id>/trigger"
   ```
   -> `HTTP 500 {"code":500,"message":" Error sending notification for destination pentest-dest-a err: sent error status: 405 Method Not Allowed, err: <!doctype html><html lang=\"en\"><head><title>Example Domain</title>...<p>This domain is for use in documentation examples...</p><p><a href=\"https://iana.org/domains/example\">Learn more</a></p>..."}` — the complete external HTML body is reflected verbatim in `message` (671 chars). Repeating the same PATCH reproduces the identical response.
3. Amplification — if the same destination pointed at an internal service (e.g. via a `0.0.0.0` URL), the internal service's full error body, including any tokens or secrets it emits, is returned to the caller.

Expected secure: `message` contains only the status code (e.g. `"sent error status: 405 Method Not Allowed, upstream response body suppressed (671 bytes)"`); no upstream body content.

## What changed

- `src/common/utils/http_forward.rs` (new) — shared helpers used by both leak sites:
  - `sanitize_forward_headers(&HashMap<..>) -> HashMap<..>` and `is_sensitive_forward_header(&str) -> bool` — strip caller-supplied `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, `WWW-Authenticate`, `Proxy-Authenticate`, and any `X-Auth-*` header (case-insensitive).
  - `format_upstream_error(status, body) -> String` — formats `"sent error status: {status}, upstream response body suppressed ({N} bytes)"`; the raw body is intentionally dropped.
- `src/handler/http/request/alerts/destinations.rs` — `test_http_destination` now (a) calls `sanitize_forward_headers` before iterating the caller-supplied headers into the request builder, and (b) routes the success path through a new `build_http_test_response` helper that sets `response_body` to a fixed shape summary rather than the raw upstream body.
- `src/service/alerts/alert.rs` — `send_http_notification` now (a) skips any destination-configured header that matches `is_sensitive_forward_header`, and (b) replaces the `format!("sent error status: {}, err: {}", resp_status, resp_body)` error with a call to `format_upstream_error`. The `log::error!` on the server side is unchanged, so operators still see the body.

The SSRF-guard prong (`0.0.0.0` numeric literal) was already fixed on `main` in `src/config/src/utils/ssrf_guard.rs :: is_private_ip_inner` and is untouched here.

## Regression test

Four pure unit tests, no HTTP mocking required:

- `common::utils::http_forward::tests::sanitize_forward_headers_strips_sensitive` — asserts every case-insensitive spelling of every sensitive header is removed, legitimate app headers survive, and the specific `root@example.com` `Basic` value the PoC forwards does not survive.
- `common::utils::http_forward::tests::is_sensitive_forward_header_is_case_insensitive` — classification invariant.
- `common::utils::http_forward::tests::format_upstream_error_omits_body` — asserts the error string keeps the status code but drops every distinctive marker from a leaked upstream body.
- `handler::http::request::alerts::destinations::tests::build_http_test_response_suppresses_body` — asserts `TestDestinationResponse.response_body` does not contain the raw upstream body (marker strings from the PoC's orgB destinations list and `healthz` shape must not survive).

## Validation

Red baseline — before the fix (helpers stubbed identity / body-echoing):

```
running 4 tests
test handler::http::request::alerts::destinations::tests::build_http_test_response_suppresses_body ... FAILED
test common::utils::http_forward::tests::format_upstream_error_omits_body ... FAILED
test common::utils::http_forward::tests::sanitize_forward_headers_strips_sensitive ... FAILED
test common::utils::http_forward::tests::is_sensitive_forward_header_is_case_insensitive ... FAILED

---- build_http_test_response_suppresses_body ----
upstream body marker "pentest-dest-b" leaked into TestDestinationResponse.response_body

---- format_upstream_error_omits_body ----
upstream response body marker "Example Domain" leaked into error:
sent error status: 405 Method Not Allowed, err: <html><title>Example Domain</title>...</html>

---- sanitize_forward_headers_strips_sensitive ----
sensitive header "Authorization" was forwarded verbatim;
sanitize_forward_headers must strip it before outbound dispatch

---- is_sensitive_forward_header_is_case_insensitive ----
Authorization must be classified sensitive

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 4056 filtered out
```

Green — after the fix:

```
running 4 tests
test common::utils::http_forward::tests::format_upstream_error_omits_body ... ok
test handler::http::request::alerts::destinations::tests::build_http_test_response_suppresses_body ... ok
test common::utils::http_forward::tests::is_sensitive_forward_header_is_case_insensitive ... ok
test common::utils::http_forward::tests::sanitize_forward_headers_strips_sensitive ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 4056 filtered out; finished in 0.00s
```

## Full suite

`cargo test --lib --no-fail-fast` — 4027 passed / 15 failed / 18 ignored. All 15 failures are pre-existing and unrelated to this change: `handler::http::request::search::utils::validate_query_edge_cases::*` (UDS-validation harness), `service::sourcemaps::tests::*` (missing `source_maps` DB table in the test env), `service::enrichment_table::url_processor::tests::test_mpsc_trigger_*`, `job::config_watcher::tests::test_run_returns_none_when_no_config_path` (no Tokio runtime in the test). None touch alerts, destinations, or `http_forward`. All 377 tests under `alerts::` and `destinations::` pass.

## Residual risk

- **Destination headers stored at config time still hit the wire.** The alert-trigger path applies the same `sanitize_forward_headers` classifier to the destination's stored headers as defense in depth, but a workspace admin who owns a destination can still legitimately add a `Content-Type` or `X-Custom-*` header. The classifier only strips names commonly used to carry credentials — any product-specific credential header outside `Authorization` / `Cookie` / `X-Auth-*` (e.g. `X-Api-Key`, `X-Splunk-Auth`) would still be forwarded. Extending the deny-list is a follow-up.
- **The SSRF-guard prong for `0.0.0.0` is out of scope** and was already fixed on `main`. This PR does not re-verify that guard.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_