### PR TITLE
ci(test-assist): auto-post verdicts on /verify-bug

### DIFF
--- a/.github/workflows/test-assist-caller.yml
+++ b/.github/workflows/test-assist-caller.yml
@@ -91,9 +91,10 @@ jobs:
           if [ "$IS_DISPATCH" = "true" ]; then
             FIXTURE="$DISPATCH_FIXTURE"; WRITE="$DISPATCH_WRITE"; ACTOR="$DISPATCH_ACTOR"
           else
-            # Comment door defaults: fixture OFF (use the real issue), write OFF (dry-run).
-            # WRITE flip happens via manual dispatch until we trust verdict accuracy.
-            FIXTURE="false"; WRITE="false"; ACTOR="$COMMENT_LOGIN"
+            # Comment door defaults: fixture OFF (use the real issue), write ON (auto-post verdicts).
+            # Auto-post is additionally gated on the engine side by vars.TEST_ASSIST_AUTO_POST=='true'
+            # on o2-enterprise — that repo var is the kill switch to silence all posts org-wide.
+            FIXTURE="false"; WRITE="true"; ACTOR="$COMMENT_LOGIN"
           fi
           ACTOR=$(printf '%s' "$ACTOR" | tr -cd 'A-Za-z0-9-')   # GitHub login charset; defensive
           { echo "issue=$ISSUE"; echo "fixture=$FIXTURE"; echo "write=$WRITE"; echo "actor=$ACTOR"; } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Flip the `/verify-bug` comment door from dry-run to auto-post. Previously the caller hardcoded `WRITE="false"`, so verdicts landed only in the run artifact and never on the source issue — verified by yesterday's 4-bug batch (#12452 / #12647 / #12820 / #12603) where every verdict was silent.

**One-line change** at `.github/workflows/test-assist-caller.yml` line 96:
```
FIXTURE=\"false\"; WRITE=\"false\"; ACTOR=\"$COMMENT_LOGIN\"
                        ↓
FIXTURE=\"false\"; WRITE=\"true\";  ACTOR=\"$COMMENT_LOGIN\"
```

## Why now

- Engine plumbing has been proven end-to-end (dispatch → seed → analyze → MCP → verdict → artifact).
- Yesterday's batch produced correct verdicts:
  - #12452 FIXED HIGH — matched reality.
  - #12647 STILL_PRESENT HIGH — worth investigating whether the fix landed on `main`.
  - #12820 / #12603 INCONCLUSIVE — Analyst correctly refused to hallucinate steps (both issues are design-decision items or bundled tickets with no repro).
- The kill switch stays in place: engine gates the Reporter on `vars.TEST_ASSIST_AUTO_POST == 'true'` (o2-enterprise repo var). Flipping that var to `false` silences all posts org-wide without needing another PR here.

## Test plan

- [ ] Merge, then post `/verify-bug` on one bug with a clear repro and confirm the verdict comment appears on the source issue.
- [ ] Confirm the engine failure notice still works by simulating a dispatch failure (unchanged path).
- [ ] If `vars.TEST_ASSIST_AUTO_POST` is not yet set to `true` on o2-enterprise, engine will still silence posts (guard at test-assist.yml:509 forces WRITE=false with a `::warning::`) — safe default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)