### PR TITLE
feat(ci): add e2e-council-batch scheduler for Needs-Automation regression coverage

### DIFF
--- a/.github/workflows/e2e-council-batch.yml
+++ b/.github/workflows/e2e-council-batch.yml
@@ -22,7 +22,15 @@ name: E2E Council Batch — Automate Regression from Needs-Automation
 #              tomorrow retries. Engine writes ALL runs to autoe2e/batch-<key> (shared branch,
 #              reuse-forced) so no cherry-pick step exists.
 #   finalize:  grep `Issue: #<n>` commit trailers on autoe2e/batch-<key> — that IS the success set.
-#              Empty set → skip PR (empty-day guard). Non-empty → open ONE PR against main.
+#              Empty set → skip PR (empty-day guard). Non-empty → THREE writes:
+#                (a) register every new RegressionSet/<Area>/*.spec.js in OSS `playwright_regression.yml`
+#                    (yq-append to <Area>-Regression's run_files) and commit to the same batch branch.
+#                (b) mirror-register the same filenames in ENT `playwright_regression.yml` on a
+#                    same-named ENT branch and open a yml-only ENT companion PR (mirrors what today's
+#                    `ent_register` job does for main `playwright.yml` — ENT CI pulls the spec files
+#                    from the OSS branch, so ENT only needs the run_files delta).
+#                (c) open ONE aggregated OSS PR against main containing the specs + OSS yml update
+#                    + a link to the ENT PR.
 #              mode=full only: for each SUCCESSFULLY-COVERED issue, remove `Needs-Automation`,
 #              add `Automated`. Failures keep the label → auto-retry on the next run.
 #
@@ -416,8 +424,8 @@ jobs:
             done <<< "$NEW_SPECS"
 
             if [ "$REG_CHANGES" -gt 0 ]; then
-              # Commit the yml update on the same batch branch via the Contents API (no checkout, no
-              # local git needed). Get current SHA of the file on the branch → PUT the new content.
+              # Commit the OSS yml update on the same batch branch via the Contents API (no
+              # checkout, no local git needed). Get current SHA of the file on the branch → PUT.
               SHA=$(gh api "/repos/${OSS_REPO}/contents/.github/workflows/playwright_regression.yml?ref=${WORK_BRANCH}" \
                 --jq '.sha' 2>/dev/null || true)
               B64=$(base64 -i "$WORKDIR/playwright_regression.yml" | tr -d '\n')
@@ -431,6 +439,112 @@ jobs:
                 echo "::warning::commit of playwright_regression.yml update failed — the PR will still open but the specs won't run in the scheduled regression cron until manually registered."
             else
               echo "No new RegressionSet specs to register (all filenames already in playwright_regression.yml)."
+            fi
+          fi
+
+          # ---- 2c. Mirror the registration into ENT playwright_regression.yml (yml-only ENT PR) ----
+          # Regression cron exists on BOTH openobserve/openobserve AND openobserve/o2-enterprise.
+          # ENT CI uses the "Determine OSS Branch" pattern the existing ent_register job uses: a
+          # same-named ENT branch holds JUST the yml delta; the spec files themselves live on the
+          # OSS batch branch (ENT CI reads them from there). This mirrors what the /e2e council
+          # does today for main playwright.yml — we're doing the equivalent for
+          # playwright_regression.yml so RegressionSet specs land in ENT regression too.
+          ENT_REG_CHANGES=0
+          ENT_PR_URL=""
+          if [ "${PLW_REG_SKIPPED:-0}" = "0" ] && [ -n "${NEW_SPECS:-}" ]; then
+            ENT_WORKDIR="$RUNNER_TEMP/reg-yml-ent"
+            rm -rf "$ENT_WORKDIR" && mkdir -p "$ENT_WORKDIR"
+            # Create the ENT batch branch off ENT main (same name as the OSS branch — that's the
+            # convention the existing ent_register job uses, and ENT CI's "Determine OSS Branch"
+            # lookup finds the OSS branch by this name). Idempotent: exists → reuse.
+            ENT_MAIN_SHA=$(gh api "/repos/${ENT_REPO}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)
+            if [ -z "$ENT_MAIN_SHA" ]; then
+              echo "::warning::couldn't read ENT main SHA — ENT registration skipped (check ORG_ADMIN_TOKEN access to ${ENT_REPO})."
+            else
+              gh api -X POST "/repos/${ENT_REPO}/git/refs" \
+                -f ref="refs/heads/${WORK_BRANCH}" -f sha="${ENT_MAIN_SHA}" >/dev/null 2>&1 \
+                && echo "Created ENT branch ${WORK_BRANCH}." \
+                || echo "ENT branch ${WORK_BRANCH} already exists — reusing."
+              # Fetch ENT's playwright_regression.yml from the branch head.
+              gh api "/repos/${ENT_REPO}/contents/.github/workflows/playwright_regression.yml?ref=${WORK_BRANCH}" \
+                --jq '.content' 2>/dev/null | base64 --decode > "$ENT_WORKDIR/playwright_regression.yml" || {
+                  echo "::warning::couldn't fetch ENT playwright_regression.yml — ENT registration skipped."
+                  PLW_REG_ENT_SKIPPED=1
+                }
+              if [ "${PLW_REG_ENT_SKIPPED:-0}" = "0" ]; then
+                # Same append loop as the OSS side. ENT's matrix mirrors OSS group names 1:1.
+                while IFS= read -r SPEC_PATH; do
+                  [ -z "$SPEC_PATH" ] && continue
+                  REL="${SPEC_PATH#tests/ui-testing/playwright-tests/RegressionSet/}"
+                  AREA_FOLDER="${REL%%/*}"
+                  FILENAME="${REL##*/}"
+                  case "$AREA_FOLDER" in
+                    Logs)        GROUP=Logs-Regression ;;
+                    Alerts)      GROUP=Alerts-Regression ;;
+                    Dashboards)  GROUP=Dashboard-Regression ;;
+                    Pipelines)   GROUP=Pipelines-Regression ;;
+                    Streams)     GROUP=Streams-Regression ;;
+                    Traces)      GROUP=Traces-Regression ;;
+                    Metrics)     GROUP=Metrics-Regression ;;
+                    Reports)     GROUP=Reports-Regression ;;
+                    DataSources) GROUP=DataSources-Regression ;;
+                    General)     GROUP=GeneralTests-Regression ;;
+                    *)           GROUP=GeneralTests-Regression ;;
+                  esac
+                  ENT_CURRENT=$(yq eval "(.jobs.playwright.strategy.matrix.include[] | select(.testfolder == \"${GROUP}\") | .run_files)" "$ENT_WORKDIR/playwright_regression.yml" 2>/dev/null || echo "")
+                  if printf '%s' "$ENT_CURRENT" | grep -qx "^- ${FILENAME}$" 2>/dev/null; then
+                    echo "::notice::ENT: already registered ${FILENAME} in ${GROUP}"
+                    continue
+                  fi
+                  yq eval -i "(.jobs.playwright.strategy.matrix.include[] | select(.testfolder == \"${GROUP}\") | .run_files) += [\"${FILENAME}\"]" \
+                    "$ENT_WORKDIR/playwright_regression.yml" || { echo "::warning::ENT yq append failed for ${GROUP}/${FILENAME}"; continue; }
+                  echo "::notice::ENT: registered ${FILENAME} → ${GROUP}"
+                  ENT_REG_CHANGES=$((ENT_REG_CHANGES + 1))
+                done <<< "$NEW_SPECS"
+
+                if [ "$ENT_REG_CHANGES" -gt 0 ]; then
+                  ENT_SHA=$(gh api "/repos/${ENT_REPO}/contents/.github/workflows/playwright_regression.yml?ref=${WORK_BRANCH}" \
+                    --jq '.sha' 2>/dev/null || true)
+                  ENT_B64=$(base64 -i "$ENT_WORKDIR/playwright_regression.yml" | tr -d '\n')
+                  gh api "/repos/${ENT_REPO}/contents/.github/workflows/playwright_regression.yml" \
+                    --method PUT \
+                    -f message="test(autoe2e): register ${ENT_REG_CHANGES} regression spec(s) from batch ${BATCH_KEY}" \
+                    -f content="$ENT_B64" \
+                    -f sha="$ENT_SHA" \
+                    -f branch="$WORK_BRANCH" >/dev/null 2>&1 \
+                    && echo "ENT playwright_regression.yml updated on ${WORK_BRANCH} (+${ENT_REG_CHANGES})" \
+                    || { echo "::warning::ENT commit failed — skipping ENT PR."; ENT_REG_CHANGES=0; }
+                fi
+
+                # Open the yml-only ENT PR (idempotent — re-runs reuse). NO merge gate: reviewer
+                # merges when happy. ENT CI already validated each spec on the enterprise binary
+                # during verify_heal, so this is just the ongoing-regression-suite entry.
+                if [ "$ENT_REG_CHANGES" -gt 0 ]; then
+                  ENT_EXISTING=$(gh pr list --repo "${ENT_REPO}" --head "${WORK_BRANCH}" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)
+                  if [ -n "$ENT_EXISTING" ]; then
+                    ENT_PR_URL="https://github.com/${ENT_REPO}/pull/${ENT_EXISTING}"
+                    echo "ENT PR already open: ${ENT_PR_URL}"
+                  else
+                    ENT_BODY_FILE="$RUNNER_TEMP/ent-pr-body.md"
+                    {
+                      echo "## Enterprise regression registration — batch ${BATCH_KEY}"
+                      echo ""
+                      echo "Auto-generated **yml-only** companion to the OSS batch PR. Adds ${ENT_REG_CHANGES} regression spec(s) to \`playwright_regression.yml\` \`run_files\` so the ENT scheduled regression suite runs them going forward."
+                      echo ""
+                      echo "The spec files themselves live on the OSS branch \`${WORK_BRANCH}\` — ENT CI's \"Determine OSS Branch\" lookup finds them there (mirror of what \`ent_register\` does today for the main \`playwright.yml\`)."
+                      echo ""
+                      echo "Each spec was already validated on the enterprise binary during \`verify_heal\`. **No merge gate** — merge to keep in ongoing enterprise regression, or close to opt out."
+                      echo ""
+                      echo "_Generated by \`e2e-council-batch.yml\`._"
+                    } > "$ENT_BODY_FILE"
+                    ENT_PR_URL=$(gh pr create --repo "${ENT_REPO}" \
+                      --base main --head "${WORK_BRANCH}" \
+                      --title "test(autoe2e): enterprise regression for batch ${BATCH_KEY} (${ENT_REG_CHANGES} spec(s))" \
+                      --body-file "$ENT_BODY_FILE" 2>&1 | grep -oE 'https://github.com/[^ ]+' | head -n1 || true)
+                    echo "Opened ENT PR: ${ENT_PR_URL:-<failed>}"
+                  fi
+                fi
+              fi
             fi
           fi
 
@@ -465,6 +579,13 @@ jobs:
             echo "- Each spec targets \`tests/ui-testing/playwright-tests/RegressionSet/<Area>/\`."
             echo "- The spec was verify-healed against the enterprise binary before landing on this branch."
             echo "- The existing Playwright CI on this PR re-validates the specs against the OSS binary."
+            echo "- OSS regression matrix updated: \`.github/workflows/playwright_regression.yml\` (+${REG_CHANGES:-0} run_files)."
+            if [ -n "${ENT_PR_URL:-}" ]; then
+              echo "- **Enterprise regression** — a yml-only companion PR is open on o2-enterprise: ${ENT_PR_URL}"
+              echo "  (mirror registration in ENT's \`playwright_regression.yml\`; ENT CI pulls the spec files from this OSS branch)."
+            elif [ "${ENT_REG_CHANGES:-0}" = "0" ] && [ -n "${NEW_SPECS:-}" ]; then
+              echo "- ENT regression: no ENT-side changes needed (all filenames already registered)."
+            fi
           } > "$BODY_FILE"
 
           # ---- 4. Open ONE aggregated PR (idempotent — reuse if today's PR already exists) ----
@@ -508,7 +629,8 @@ jobs:
             echo ""
             echo "- Batch: \`${BATCH_KEY}\`"
             echo "- Success: **${SUCCESS_COUNT}** issue(s)"
-            echo "- PR: ${PR_URL:-<none>}"
+            echo "- OSS PR: ${PR_URL:-<none>}  (+${REG_CHANGES:-0} OSS regression yml)"
+            echo "- ENT PR: ${ENT_PR_URL:-<none>}  (+${ENT_REG_CHANGES:-0} ENT regression yml)"
             if [ "$MODE" != "full" ]; then
               echo "- Labels unchanged (mode=${MODE})."
             fi

--- a/.github/workflows/e2e-council-batch.yml
+++ b/.github/workflows/e2e-council-batch.yml
@@ -9,11 +9,14 @@ name: E2E Council Batch — Automate Regression from Needs-Automation
 #   different failure semantics. Mixing batch orchestration into it would bloat the hot path,
 #   which every open PR reads on every comment. Cheap file separation now saves debugging later.
 #
-# THE FLOW (mode=full):
-#   plan:      kill-switch → resolve closed `Needs-Automation` issues → find each issue's fix PR
-#              → cap to `max_issues` → emit JSON queue.
+# THE FLOW (mode=full) — ISSUE-MODE (no fix-PR resolution):
+#   plan:      kill-switch → resolve closed `Needs-Automation` issues → derive target_dir from
+#              each issue's `area/*` label → cap to `max_issues` → emit JSON queue.
+#              We do NOT look up a fix PR per issue: the real repo rarely uses `closes #<n>`
+#              keywords, so that resolver would skip most issues. Instead the engine reads the
+#              ISSUE BODY as the feature description (see engine's issue-mode short-circuit).
 #   run:       per queued issue, dispatch the engine (workflow `e2e-council.yml` on o2-enterprise)
-#              with batch_key=regression-YYYY-MM-DD, pr_back_enabled=false,
+#              with issue_number=<n>, batch_key=regression-YYYY-MM-DD, pr_back_enabled=false,
 #              target_dir=<area folder derived from labels>. Wait per-run with a 45-min hard cap
 #              (`timeout 2700 gh run watch`). Failures don't abort the batch — the label stays,
 #              tomorrow retries. Engine writes ALL runs to autoe2e/batch-<key> (shared branch,
@@ -160,31 +163,16 @@ jobs:
           CAPPED=$(printf '%s\n' "$RAW" | head -n "${MAX_ISSUES:-10}")
           COUNT=$(printf '%s\n' "$CAPPED" | grep -c '^' || true)
 
-          # ---- 2. Resolve fix PR for each issue ----
-          # Preferred: gh issue view --json closedByPullRequestsReferences (GitHub's own "Closed by"
-          # timeline link, most reliable). Fallback for older issues without that: scan the timeline
-          # events for `closed_event` with a linked PR. Empty result → skip issue with a comment.
+          # ---- 2. Derive target_dir per issue (ISSUE-MODE — no fix-PR resolution needed) ----
+          # We used to resolve each issue → its fix PR → engine diffs the PR. That doesn't work
+          # against the real Needs-Automation backlog because fixes typically aren't linked with
+          # strict `closes #<n>` keywords. In ISSUE-MODE the engine reads the ISSUE BODY as the
+          # feature description (see e2e-council.yml's issue-mode short-circuit + the triage
+          # agent's ISSUE-MODE section) — the fix PR is irrelevant to test generation.
           QUEUE_JSON="["
           FIRST=1
-          SKIPPED_NO_PR=""
           while IFS= read -r ISSUE; do
             [ -z "$ISSUE" ] && continue
-            # Primary: the "closed by" back-link. Multiple linked PRs possible → take the merged one.
-            FIX_PR=$(gh issue view "$ISSUE" --repo "$OSS_REPO" \
-              --json closedByPullRequestsReferences \
-              --jq '[.closedByPullRequestsReferences[] | select(.state == "MERGED")] | sort_by(.number) | last | .number // empty' \
-              2>/dev/null || true)
-            # Fallback: scan issue timeline events.
-            if [ -z "$FIX_PR" ]; then
-              FIX_PR=$(gh api "/repos/${OSS_REPO}/issues/${ISSUE}/timeline" \
-                --jq '[.[] | select(.event=="closed" and .commit_id == null) | .source.issue.pull_request.merged_at // empty]' \
-                2>/dev/null | head -n1 || true)
-              # This fallback is best-effort; if it doesn't yield a PR number, we skip below.
-            fi
-            if [ -z "$FIX_PR" ] || ! printf '%s' "$FIX_PR" | grep -qE '^[0-9]+$'; then
-              SKIPPED_NO_PR="$SKIPPED_NO_PR $ISSUE"
-              continue
-            fi
 
             # Derive an advisory target_dir from the issue's `area/*` label, fallback to Bugs/.
             # awk here Title-cases "alerts" → "Alerts" (matches the RegressionSet/ folder convention).
@@ -196,7 +184,7 @@ jobs:
             TARGET_DIR="tests/ui-testing/playwright-tests/RegressionSet/${AREA}"
 
             [ $FIRST -eq 0 ] && QUEUE_JSON="${QUEUE_JSON},"
-            QUEUE_JSON="${QUEUE_JSON}{\"issue\":${ISSUE},\"fix_pr\":${FIX_PR},\"target_dir\":\"${TARGET_DIR}\"}"
+            QUEUE_JSON="${QUEUE_JSON}{\"issue\":${ISSUE},\"target_dir\":\"${TARGET_DIR}\"}"
             FIRST=0
           done <<< "$CAPPED"
           QUEUE_JSON="${QUEUE_JSON}]"
@@ -226,15 +214,10 @@ jobs:
             echo "- Engine ref: \`${ENGINE_REF}\`"
             echo "- Queued: **${QUEUE_COUNT}** issue(s) (cap: ${MAX_ISSUES:-10})"
             echo ""
-            if [ -n "$SKIPPED_NO_PR" ]; then
-              echo "### Skipped (no fix PR found)"
-              for I in $SKIPPED_NO_PR; do echo "- #${I} — no MERGED closing PR (label stays; add the PR link and it'll retry)"; done
-              echo ""
-            fi
             echo "### Queue"
-            echo "| Issue | Fix PR | Target dir |"
-            echo "|-------|--------|------------|"
-            printf '%s' "$QUEUE_JSON" | jq -r '.[] | "| #\(.issue) | #\(.fix_pr) | \(.target_dir) |"'
+            echo "| Issue | Target dir |"
+            echo "|-------|------------|"
+            printf '%s' "$QUEUE_JSON" | jq -r '.[] | "| #\(.issue) | \(.target_dir) |"'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dry-run stop (mode=dry_run reports the plan, does not dispatch)
@@ -255,33 +238,34 @@ jobs:
           RESULTS_FILE="$RUNNER_TEMP/batch-results.jsonl"
           : > "$RESULTS_FILE"
 
-          # Iterate the queue as JSON to preserve exact issue/PR pairing.
+          # Iterate the queue as JSON.
           echo "$QUEUE_JSON" | jq -c '.[]' | while IFS= read -r ITEM; do
             ISSUE=$(printf '%s' "$ITEM" | jq -r '.issue')
-            FIX_PR=$(printf '%s' "$ITEM" | jq -r '.fix_pr')
             TARGET_DIR=$(printf '%s' "$ITEM" | jq -r '.target_dir')
 
-            echo "::group::Issue #${ISSUE} — dispatch engine for fix PR #${FIX_PR} (target_dir=${TARGET_DIR})"
+            echo "::group::Issue #${ISSUE} — dispatch engine (issue-mode, target_dir=${TARGET_DIR})"
             START=$(date -u +%s)
 
-            # Dispatch the engine on the chosen ref. This mirrors the /e2e caller's dispatch shape
-            # (source_repo, pr_number, dry_run, force_overwrite, feature_hint, actor) + our three
-            # batch-mode inputs. `--ref` targets a specific branch of o2-enterprise so test-runs
+            # ISSUE-MODE dispatch. `issue_number` triggers the engine's issue-mode short-circuit;
+            # `pr_number` must still be passed (workflow_dispatch requires it as `required: true`)
+            # but is ignored downstream — we send the issue number as a placeholder so the field
+            # is a valid integer. `--ref` targets a specific branch of o2-enterprise so test-runs
             # can hit engine feat branches pre-merge.
             if ! gh workflow run e2e-council.yml \
               --repo "$ENT_REPO" \
               --ref "$ENGINE_REF" \
               -f source_repo=openobserve \
-              -f pr_number="$FIX_PR" \
+              -f pr_number="$ISSUE" \
+              -f issue_number="$ISSUE" \
               -f dry_run=false \
               -f force_overwrite=false \
-              -f feature_hint="regression coverage for issue #${ISSUE}" \
+              -f feature_hint="regression coverage for closed issue #${ISSUE}" \
               -f actor=e2e-council-batch \
               -f batch_key="$BATCH_KEY" \
               -f target_dir="$TARGET_DIR" \
               -f pr_back_enabled=false; then
-              printf '{"issue":%s,"fix_pr":%s,"status":"dispatch_failed","duration":0}\n' \
-                "$ISSUE" "$FIX_PR" >> "$RESULTS_FILE"
+              printf '{"issue":%s,"status":"dispatch_failed","duration":0}\n' \
+                "$ISSUE" >> "$RESULTS_FILE"
               echo "::error::dispatch failed for issue #${ISSUE}"
               echo "::endgroup::"
               continue
@@ -302,8 +286,8 @@ jobs:
               [ -n "$RUN_ID" ] && break
             done
             if [ -z "$RUN_ID" ]; then
-              printf '{"issue":%s,"fix_pr":%s,"status":"run_not_found","duration":0}\n' \
-                "$ISSUE" "$FIX_PR" >> "$RESULTS_FILE"
+              printf '{"issue":%s,"status":"run_not_found","duration":0}\n' \
+                "$ISSUE" >> "$RESULTS_FILE"
               echo "::warning::couldn't locate dispatched engine run for #${ISSUE} — continuing"
               echo "::endgroup::"
               continue
@@ -322,8 +306,8 @@ jobs:
             END=$(date -u +%s)
             DURATION=$((END - START))
 
-            printf '{"issue":%s,"fix_pr":%s,"status":"%s","duration":%s,"run_id":%s}\n' \
-              "$ISSUE" "$FIX_PR" "$STATUS" "$DURATION" "$RUN_ID" >> "$RESULTS_FILE"
+            printf '{"issue":%s,"status":"%s","duration":%s,"run_id":%s}\n' \
+              "$ISSUE" "$STATUS" "$DURATION" "$RUN_ID" >> "$RESULTS_FILE"
             echo "Issue #${ISSUE} → status=${STATUS} duration=${DURATION}s"
             echo "::endgroup::"
           done
@@ -385,24 +369,23 @@ jobs:
             echo "Generated by \`e2e-council-batch.yml\` — scheduled council-of-agents run over closed issues labelled \`Needs-Automation\`."
             echo ""
             echo "### Covered in this batch (${SUCCESS_COUNT} issues)"
-            echo "| Issue | Fix PR | Engine run |"
-            echo "|-------|--------|------------|"
+            echo "| Issue | Engine run |"
+            echo "|-------|------------|"
             for N in $SUCCESS_ISSUES; do
               LINE=$(grep -E "\"issue\":${N}," "$RESULTS_FILE" | head -n1 || true)
-              FIX_PR=$(printf '%s' "$LINE" | jq -r '.fix_pr // "?"' 2>/dev/null || echo "?")
               RUN_ID=$(printf '%s' "$LINE" | jq -r '.run_id // ""' 2>/dev/null || echo "")
               RUN_LINK="—"
               [ -n "$RUN_ID" ] && RUN_LINK="[run](https://github.com/${ENT_REPO}/actions/runs/${RUN_ID})"
-              echo "| #${N} | #${FIX_PR} | ${RUN_LINK} |"
+              echo "| #${N} | ${RUN_LINK} |"
             done
             echo ""
             # Failures worth surfacing (non-success statuses from the dispatch loop).
             FAILURES=$(jq -c 'select(.status != "success")' "$RESULTS_FILE" 2>/dev/null || true)
             if [ -n "$FAILURES" ]; then
               echo "### Not covered (label stays \`Needs-Automation\`, will retry)"
-              echo "| Issue | Fix PR | Reason |"
-              echo "|-------|--------|--------|"
-              printf '%s\n' "$FAILURES" | jq -r '"| #\(.issue) | #\(.fix_pr) | \(.status) |"'
+              echo "| Issue | Reason |"
+              echo "|-------|--------|"
+              printf '%s\n' "$FAILURES" | jq -r '"| #\(.issue) | \(.status) |"'
               echo ""
             fi
             echo "### Review guidance"

--- a/.github/workflows/e2e-council-batch.yml
+++ b/.github/workflows/e2e-council-batch.yml
@@ -1,0 +1,459 @@
+name: E2E Council Batch — Automate Regression from Needs-Automation
+
+# Scheduled/manual BATCH orchestrator that fires the E2E Council engine across every CLOSED issue
+# labelled `Needs-Automation`, aggregates the generated regression tests under
+# tests/ui-testing/playwright-tests/RegressionSet/, and opens ONE PR per run for QA to review.
+#
+# WHY A SEPARATE FILE (not adding to e2e-council-caller.yml):
+#   The `/e2e` caller is a THIN per-PR gate + dispatch — different trigger, different lifecycle,
+#   different failure semantics. Mixing batch orchestration into it would bloat the hot path,
+#   which every open PR reads on every comment. Cheap file separation now saves debugging later.
+#
+# THE FLOW (mode=full):
+#   plan:      kill-switch → resolve closed `Needs-Automation` issues → find each issue's fix PR
+#              → cap to `max_issues` → emit JSON queue.
+#   run:       per queued issue, dispatch the engine (workflow `e2e-council.yml` on o2-enterprise)
+#              with batch_key=regression-YYYY-MM-DD, pr_back_enabled=false,
+#              target_dir=<area folder derived from labels>. Wait per-run with a 45-min hard cap
+#              (`timeout 2700 gh run watch`). Failures don't abort the batch — the label stays,
+#              tomorrow retries. Engine writes ALL runs to autoe2e/batch-<key> (shared branch,
+#              reuse-forced) so no cherry-pick step exists.
+#   finalize:  grep `Issue: #<n>` commit trailers on autoe2e/batch-<key> — that IS the success set.
+#              Empty set → skip PR (empty-day guard). Non-empty → open ONE PR against main.
+#              mode=full only: for each SUCCESSFULLY-COVERED issue, remove `Needs-Automation`,
+#              add `Automated`. Failures keep the label → auto-retry on the next run.
+#
+# MODES (input `mode`, 3-way choice):
+#   dry_run    — resolve issues + fix PRs, report what WOULD run. NO engine dispatch, NO writes.
+#   test       — engine runs, a real PR opens, but NO label mutation on real issues. Safe pre-merge
+#                testing and safe against fixture / hand-picked issues.
+#   full       — everything, including label writes. What the cron will use.
+#
+# TEST-RUN BEFORE MERGE (invariant we promised):
+#   `workflow_dispatch` runs a workflow at ANY ref — you don't need this file on `main` yet. To
+#   test the full stack from the feature branches before opening PRs:
+#     gh workflow run e2e-council-batch.yml \
+#        --repo openobserve/openobserve \
+#        --ref feat/automate-regression-council \
+#        -f mode=test \
+#        -f engine_ref=feat/engine-batch-inputs \
+#        -f issue_numbers=<one-known-good-closed-Needs-Automation-issue>
+#   Watch the resulting PR + engine logs. When green: open o2-enterprise PR first, merge, then
+#   open openobserve PR. `engine_ref` defaults to `main` so post-merge nothing has to change.
+#
+# EXISTING /e2e IS UNTOUCHED:
+#   This workflow never fires on issue_comment or PR events. The engine changes it depends on
+#   (batch_key/target_dir/pr_back_enabled inputs) are additive with backward-compat defaults, so
+#   `/e2e` reads the same code paths it always did.
+#
+# KILL SWITCHES:
+#   vars.E2E_COUNCIL_DISABLED       — global engine kill (shared with /e2e).
+#   vars.E2E_AUTO_REGRESSION_DISABLED — batch-only kill (pause nightly without killing /e2e).
+#
+# REQUIRED SECRET: secrets.ORG_ADMIN_TOKEN — SAME PAT the /e2e caller uses. Needs:
+#   o2-enterprise: Actions R/W (dispatch the engine).
+#   openobserve:   Contents R/W (create branches/PR), Issues R/W (labels + comments), Pull-requests R/W.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry_run: report only, no engine, no writes. test: engine runs + PR opens, NO label mutation. full: everything (what cron uses)."
+        required: true
+        default: "dry_run"
+        type: choice
+        options: [dry_run, test, full]
+      issue_numbers:
+        description: "Optional comma-separated closed-issue numbers to force-include (e.g. 12345,12401). Empty = query GitHub by label:Needs-Automation + state:closed."
+        required: false
+        default: ""
+      max_issues:
+        description: "Cap issues per batch. Extras roll to tomorrow (they still have the label). Default 10."
+        required: false
+        default: "10"
+      engine_ref:
+        description: "Ref of o2-enterprise to dispatch the engine on. Set to a feat branch for test-before-merge of engine changes. Default: main."
+        required: false
+        default: "main"
+  # NOTE: schedule: is intentionally commented out until we've had 3 successful manual runs.
+  # Enable via a one-line follow-up PR. Recommended: `0 13 * * 1-5` (6:30 PM IST, weekdays only).
+  # schedule:
+  #   - cron: "0 13 * * 1-5"
+
+permissions:
+  contents: read       # step-level checkout only (no PR-code checkout)
+  pull-requests: write # open the aggregated PR
+  issues: write        # label + comment writes on source issues
+
+# Batch runs must NEVER race — the engine writes all runs of one batch to the same shared branch.
+# Group is fixed (one queue for the whole workflow), cancel-in-progress=false so a mid-batch
+# cancellation doesn't leave partial commits on autoe2e/batch-<key>.
+concurrency:
+  group: e2e-council-batch-oss
+  cancel-in-progress: false
+
+jobs:
+  batch:
+    if: vars.E2E_COUNCIL_DISABLED != 'true' && vars.E2E_AUTO_REGRESSION_DISABLED != 'true'
+    runs-on: ubuntu-latest
+    # Hard cap: max 10 issues × ~30-min engine run + PR-open + label writes. 6h is defense-in-depth.
+    timeout-minutes: 360
+    env:
+      # ORG_ADMIN_TOKEN is required for cross-repo dispatch (o2-enterprise Actions R/W) and for
+      # openobserve writes (PR branches on main, label + comment writes). Scoped job-wide is
+      # acceptable here because THIS workflow never checks out or executes PR code — no
+      # untrusted-code surface can steal the token.
+      GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
+      MODE: ${{ inputs.mode }}
+      MAX_ISSUES: ${{ inputs.max_issues }}
+      ENGINE_REF: ${{ inputs.engine_ref }}
+      IN_ISSUE_NUMBERS: ${{ inputs.issue_numbers }}
+      OSS_REPO: openobserve/openobserve
+      ENT_REPO: openobserve/o2-enterprise
+    outputs:
+      batch_key: ${{ steps.plan.outputs.batch_key }}
+      work_branch: ${{ steps.plan.outputs.work_branch }}
+      queue_count: ${{ steps.plan.outputs.queue_count }}
+      success_count: ${{ steps.finalize.outputs.success_count }}
+    steps:
+      - name: Plan — resolve issue list, fix PRs, and cap
+        id: plan
+        # Untrusted event data → env vars, never spliced into commands. This step reads GitHub API
+        # (issues + timeline) but never checks out or runs PR code.
+        run: |
+          set -euo pipefail
+
+          # ---- 1. Compose the queue ----
+          # Explicit issue_numbers (workflow_dispatch override) win over the label query. This lets
+          # QA force-include specific issues without waiting for the cron, or replay a bad run.
+          if [ -n "${IN_ISSUE_NUMBERS:-}" ]; then
+            # Split on commas, trim whitespace, keep only digits.
+            RAW=$(printf '%s' "$IN_ISSUE_NUMBERS" | tr ',' '\n' | sed 's/[^0-9]//g' | grep -v '^$' || true)
+            echo "Explicit issue_numbers input received: $(echo "$RAW" | tr '\n' ' ')"
+          else
+            # Label query: closed, has Needs-Automation, NOT already Automated (defensive: catches
+            # a stale re-label). Highest N by number = FIFO drain of oldest backlog first.
+            RAW=$(gh issue list \
+              --repo "$OSS_REPO" \
+              --state closed \
+              --label "Needs-Automation" \
+              --limit 100 \
+              --json number,labels \
+              --jq '[.[] | select([.labels[].name] | index("Automated") | not)] | sort_by(.number) | .[].number' || true)
+            echo "Label-query result: $(echo "$RAW" | tr '\n' ' ')"
+          fi
+
+          if [ -z "${RAW:-}" ]; then
+            echo "queue_count=0" >> "$GITHUB_OUTPUT"
+            echo "batch_key=" >> "$GITHUB_OUTPUT"
+            echo "work_branch=" >> "$GITHUB_OUTPUT"
+            echo "queue_json=[]" >> "$GITHUB_OUTPUT"
+            {
+              echo "## E2E Council Batch — Nothing to do"
+              echo ""
+              echo "No closed issues matched \`Needs-Automation\` (or the explicit input was empty). Exiting cleanly."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Cap and preserve FIFO (oldest first).
+          CAPPED=$(printf '%s\n' "$RAW" | head -n "${MAX_ISSUES:-10}")
+          COUNT=$(printf '%s\n' "$CAPPED" | grep -c '^' || true)
+
+          # ---- 2. Resolve fix PR for each issue ----
+          # Preferred: gh issue view --json closedByPullRequestsReferences (GitHub's own "Closed by"
+          # timeline link, most reliable). Fallback for older issues without that: scan the timeline
+          # events for `closed_event` with a linked PR. Empty result → skip issue with a comment.
+          QUEUE_JSON="["
+          FIRST=1
+          SKIPPED_NO_PR=""
+          while IFS= read -r ISSUE; do
+            [ -z "$ISSUE" ] && continue
+            # Primary: the "closed by" back-link. Multiple linked PRs possible → take the merged one.
+            FIX_PR=$(gh issue view "$ISSUE" --repo "$OSS_REPO" \
+              --json closedByPullRequestsReferences \
+              --jq '[.closedByPullRequestsReferences[] | select(.state == "MERGED")] | sort_by(.number) | last | .number // empty' \
+              2>/dev/null || true)
+            # Fallback: scan issue timeline events.
+            if [ -z "$FIX_PR" ]; then
+              FIX_PR=$(gh api "/repos/${OSS_REPO}/issues/${ISSUE}/timeline" \
+                --jq '[.[] | select(.event=="closed" and .commit_id == null) | .source.issue.pull_request.merged_at // empty]' \
+                2>/dev/null | head -n1 || true)
+              # This fallback is best-effort; if it doesn't yield a PR number, we skip below.
+            fi
+            if [ -z "$FIX_PR" ] || ! printf '%s' "$FIX_PR" | grep -qE '^[0-9]+$'; then
+              SKIPPED_NO_PR="$SKIPPED_NO_PR $ISSUE"
+              continue
+            fi
+
+            # Derive an advisory target_dir from the issue's `area/*` label, fallback to Bugs/.
+            # awk here Title-cases "alerts" → "Alerts" (matches the RegressionSet/ folder convention).
+            AREA=$(gh issue view "$ISSUE" --repo "$OSS_REPO" --json labels \
+              --jq '[.labels[].name | select(startswith("area/"))] | first // ""' 2>/dev/null || true)
+            AREA=$(printf '%s' "$AREA" | sed 's|^area/||' \
+              | awk '{ if (length($0) > 0) printf "%s%s", toupper(substr($0,1,1)), substr($0,2) }')
+            [ -z "$AREA" ] && AREA="Bugs"
+            TARGET_DIR="tests/ui-testing/playwright-tests/RegressionSet/${AREA}"
+
+            [ $FIRST -eq 0 ] && QUEUE_JSON="${QUEUE_JSON},"
+            QUEUE_JSON="${QUEUE_JSON}{\"issue\":${ISSUE},\"fix_pr\":${FIX_PR},\"target_dir\":\"${TARGET_DIR}\"}"
+            FIRST=0
+          done <<< "$CAPPED"
+          QUEUE_JSON="${QUEUE_JSON}]"
+
+          QUEUE_COUNT=$(printf '%s' "$QUEUE_JSON" | jq 'length')
+
+          # ---- 3. Compute batch_key + work_branch (deterministic per calendar day) ----
+          BATCH_KEY="regression-$(date -u +%Y-%m-%d)"
+          WORK_BRANCH="autoe2e/batch-${BATCH_KEY}"
+
+          # Emit for later steps.
+          {
+            echo "batch_key=${BATCH_KEY}"
+            echo "work_branch=${WORK_BRANCH}"
+            echo "queue_count=${QUEUE_COUNT}"
+          } >> "$GITHUB_OUTPUT"
+          # Multi-line JSON via heredoc-delimited $GITHUB_OUTPUT write.
+          DELIM="qEOF_$(openssl rand -hex 16 2>/dev/null || echo "${RANDOM}${RANDOM}${RANDOM}")"
+          printf 'queue_json<<%s\n%s\n%s\n' "$DELIM" "$QUEUE_JSON" "$DELIM" >> "$GITHUB_OUTPUT"
+
+          # ---- 4. Human-facing plan summary ----
+          {
+            echo "## E2E Council Batch — Plan (mode=${MODE})"
+            echo ""
+            echo "- Batch key: \`${BATCH_KEY}\`"
+            echo "- Work branch (engine will write here): \`${WORK_BRANCH}\`"
+            echo "- Engine ref: \`${ENGINE_REF}\`"
+            echo "- Queued: **${QUEUE_COUNT}** issue(s) (cap: ${MAX_ISSUES:-10})"
+            echo ""
+            if [ -n "$SKIPPED_NO_PR" ]; then
+              echo "### Skipped (no fix PR found)"
+              for I in $SKIPPED_NO_PR; do echo "- #${I} — no MERGED closing PR (label stays; add the PR link and it'll retry)"; done
+              echo ""
+            fi
+            echo "### Queue"
+            echo "| Issue | Fix PR | Target dir |"
+            echo "|-------|--------|------------|"
+            printf '%s' "$QUEUE_JSON" | jq -r '.[] | "| #\(.issue) | #\(.fix_pr) | \(.target_dir) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dry-run stop (mode=dry_run reports the plan, does not dispatch)
+        if: inputs.mode == 'dry_run' || steps.plan.outputs.queue_count == '0'
+        run: |
+          echo "mode=${MODE}, queue_count=${{ steps.plan.outputs.queue_count }} — plan reported, exiting without dispatching."
+
+      - name: Dispatch engine per issue (sequential, per-run 45-min cap)
+        if: inputs.mode != 'dry_run' && steps.plan.outputs.queue_count != '0'
+        env:
+          QUEUE_JSON: ${{ steps.plan.outputs.queue_json }}
+          BATCH_KEY: ${{ steps.plan.outputs.batch_key }}
+        run: |
+          set -uo pipefail
+          # Sequential loop. GitHub's concurrency group on the engine (e2e-council-batch-<key>) will
+          # ALSO serialize us defensively even if two batch runs raced, but we drive one-at-a-time
+          # here so we can poll each run's exit status and give the batch summary rich per-issue data.
+          RESULTS_FILE="$RUNNER_TEMP/batch-results.jsonl"
+          : > "$RESULTS_FILE"
+
+          # Iterate the queue as JSON to preserve exact issue/PR pairing.
+          echo "$QUEUE_JSON" | jq -c '.[]' | while IFS= read -r ITEM; do
+            ISSUE=$(printf '%s' "$ITEM" | jq -r '.issue')
+            FIX_PR=$(printf '%s' "$ITEM" | jq -r '.fix_pr')
+            TARGET_DIR=$(printf '%s' "$ITEM" | jq -r '.target_dir')
+
+            echo "::group::Issue #${ISSUE} — dispatch engine for fix PR #${FIX_PR} (target_dir=${TARGET_DIR})"
+            START=$(date -u +%s)
+
+            # Dispatch the engine on the chosen ref. This mirrors the /e2e caller's dispatch shape
+            # (source_repo, pr_number, dry_run, force_overwrite, feature_hint, actor) + our three
+            # batch-mode inputs. `--ref` targets a specific branch of o2-enterprise so test-runs
+            # can hit engine feat branches pre-merge.
+            if ! gh workflow run e2e-council.yml \
+              --repo "$ENT_REPO" \
+              --ref "$ENGINE_REF" \
+              -f source_repo=openobserve \
+              -f pr_number="$FIX_PR" \
+              -f dry_run=false \
+              -f force_overwrite=false \
+              -f feature_hint="regression coverage for issue #${ISSUE}" \
+              -f actor=e2e-council-batch \
+              -f batch_key="$BATCH_KEY" \
+              -f target_dir="$TARGET_DIR" \
+              -f pr_back_enabled=false; then
+              printf '{"issue":%s,"fix_pr":%s,"status":"dispatch_failed","duration":0}\n' \
+                "$ISSUE" "$FIX_PR" >> "$RESULTS_FILE"
+              echo "::error::dispatch failed for issue #${ISSUE}"
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Find the run we just triggered. `gh run list` on the ENT repo, filtered to the engine
+            # workflow, newest first. Retry a few times: workflow_dispatch takes 2-10s to appear.
+            RUN_ID=""
+            for _ in 1 2 3 4 5 6 7 8 9 10; do
+              sleep 3
+              RUN_ID=$(gh run list \
+                --repo "$ENT_REPO" \
+                --workflow e2e-council.yml \
+                --limit 5 \
+                --json databaseId,createdAt,event,status \
+                --jq "[.[] | select(.event==\"workflow_dispatch\" and .status != \"completed\")] | first | .databaseId // \"\"" \
+                2>/dev/null || true)
+              [ -n "$RUN_ID" ] && break
+            done
+            if [ -z "$RUN_ID" ]; then
+              printf '{"issue":%s,"fix_pr":%s,"status":"run_not_found","duration":0}\n' \
+                "$ISSUE" "$FIX_PR" >> "$RESULTS_FILE"
+              echo "::warning::couldn't locate dispatched engine run for #${ISSUE} — continuing"
+              echo "::endgroup::"
+              continue
+            fi
+            echo "Engine run id: $RUN_ID  → https://github.com/${ENT_REPO}/actions/runs/${RUN_ID}"
+
+            # Wait up to 45 min. `gh run watch --exit-status` returns non-zero on any non-success
+            # completion. `timeout` returns 124 on the wall-clock cap.
+            STATUS="unknown"
+            if timeout 2700 gh run watch "$RUN_ID" --repo "$ENT_REPO" --exit-status >/dev/null 2>&1; then
+              STATUS="success"
+            else
+              RC=$?
+              if [ "$RC" = "124" ]; then STATUS="timeout"; else STATUS="engine_failed"; fi
+            fi
+            END=$(date -u +%s)
+            DURATION=$((END - START))
+
+            printf '{"issue":%s,"fix_pr":%s,"status":"%s","duration":%s,"run_id":%s}\n' \
+              "$ISSUE" "$FIX_PR" "$STATUS" "$DURATION" "$RUN_ID" >> "$RESULTS_FILE"
+            echo "Issue #${ISSUE} → status=${STATUS} duration=${DURATION}s"
+            echo "::endgroup::"
+          done
+
+          # Persist for the finalize step.
+          echo "results_file=$RESULTS_FILE" >> "$GITHUB_OUTPUT"
+        id: dispatch
+
+      - name: Finalize — grep trailers, open PR, label lifecycle
+        id: finalize
+        if: inputs.mode != 'dry_run' && steps.plan.outputs.queue_count != '0'
+        env:
+          BATCH_KEY: ${{ steps.plan.outputs.batch_key }}
+          WORK_BRANCH: ${{ steps.plan.outputs.work_branch }}
+          RESULTS_FILE: ${{ steps.dispatch.outputs.results_file }}
+        run: |
+          set -uo pipefail
+
+          # ---- 1. Does the batch branch even exist? ----
+          # If no engine run committed anything (all timed-out / dispatch-failed / triage said skip),
+          # the branch was never created. Empty-day guard: skip PR creation.
+          if ! gh api "/repos/${OSS_REPO}/branches/${WORK_BRANCH}" >/dev/null 2>&1; then
+            echo "success_count=0" >> "$GITHUB_OUTPUT"
+            {
+              echo "## E2E Council Batch — No PR opened"
+              echo ""
+              echo "The batch branch \`${WORK_BRANCH}\` was never created — no engine run produced a commit."
+              echo "This is normal on days when every queued issue's triage returned action=none."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # ---- 2. Grep Issue: trailers on the branch → success set ----
+          # Each successful engine commit under batch mode ends with `Issue: #<n>`. The set of
+          # such n's is the source-of-truth for which issues actually got regression coverage.
+          COMMITS=$(gh api "/repos/${OSS_REPO}/commits?sha=${WORK_BRANCH}&per_page=100" \
+            --jq '.[].commit.message' 2>/dev/null || true)
+          SUCCESS_ISSUES=$(printf '%s' "$COMMITS" | grep -oE 'Issue: #[0-9]+' | grep -oE '[0-9]+' | sort -u || true)
+          SUCCESS_COUNT=$(printf '%s\n' "$SUCCESS_ISSUES" | grep -c '^' || true)
+          [ -z "$SUCCESS_ISSUES" ] && SUCCESS_COUNT=0
+          echo "success_count=$SUCCESS_COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$SUCCESS_COUNT" -eq 0 ]; then
+            {
+              echo "## E2E Council Batch — No PR opened"
+              echo ""
+              echo "The branch \`${WORK_BRANCH}\` exists but contains no \`Issue: #<n>\` trailers."
+              echo "That means every engine run reached the branch but none of them landed generated tests"
+              echo "(healing failed or Sentinel rejected all attempts). Labels unchanged; retry tomorrow."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # ---- 3. Build the PR body table ----
+          BODY_FILE="$RUNNER_TEMP/pr-body.md"
+          {
+            echo "## Automated Regression Batch — ${BATCH_KEY}"
+            echo ""
+            echo "Generated by \`e2e-council-batch.yml\` — scheduled council-of-agents run over closed issues labelled \`Needs-Automation\`."
+            echo ""
+            echo "### Covered in this batch (${SUCCESS_COUNT} issues)"
+            echo "| Issue | Fix PR | Engine run |"
+            echo "|-------|--------|------------|"
+            for N in $SUCCESS_ISSUES; do
+              LINE=$(grep -E "\"issue\":${N}," "$RESULTS_FILE" | head -n1 || true)
+              FIX_PR=$(printf '%s' "$LINE" | jq -r '.fix_pr // "?"' 2>/dev/null || echo "?")
+              RUN_ID=$(printf '%s' "$LINE" | jq -r '.run_id // ""' 2>/dev/null || echo "")
+              RUN_LINK="—"
+              [ -n "$RUN_ID" ] && RUN_LINK="[run](https://github.com/${ENT_REPO}/actions/runs/${RUN_ID})"
+              echo "| #${N} | #${FIX_PR} | ${RUN_LINK} |"
+            done
+            echo ""
+            # Failures worth surfacing (non-success statuses from the dispatch loop).
+            FAILURES=$(jq -c 'select(.status != "success")' "$RESULTS_FILE" 2>/dev/null || true)
+            if [ -n "$FAILURES" ]; then
+              echo "### Not covered (label stays \`Needs-Automation\`, will retry)"
+              echo "| Issue | Fix PR | Reason |"
+              echo "|-------|--------|--------|"
+              printf '%s\n' "$FAILURES" | jq -r '"| #\(.issue) | #\(.fix_pr) | \(.status) |"'
+              echo ""
+            fi
+            echo "### Review guidance"
+            echo "- Each spec targets \`tests/ui-testing/playwright-tests/RegressionSet/<Area>/\`."
+            echo "- The spec was verify-healed against the enterprise binary before landing on this branch."
+            echo "- The existing Playwright CI on this PR re-validates the specs against the OSS binary."
+          } > "$BODY_FILE"
+
+          # ---- 4. Open ONE aggregated PR (idempotent — reuse if today's PR already exists) ----
+          PR_TITLE="regression(auto): batch ${BATCH_KEY} — ${SUCCESS_COUNT} issue(s)"
+          EXISTING_PR=$(gh pr list --repo "$OSS_REPO" --head "$WORK_BRANCH" --state open \
+            --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" --repo "$OSS_REPO" \
+              --title "$PR_TITLE" --body-file "$BODY_FILE"
+            PR_URL="https://github.com/${OSS_REPO}/pull/${EXISTING_PR}"
+            echo "Refreshed existing PR: $PR_URL"
+          else
+            PR_URL=$(gh pr create --repo "$OSS_REPO" \
+              --base main --head "$WORK_BRANCH" \
+              --title "$PR_TITLE" --body-file "$BODY_FILE" 2>&1 | grep -oE 'https://github.com/[^ ]+' | head -n1 || true)
+            echo "Opened PR: $PR_URL"
+          fi
+
+          # ---- 5. Label lifecycle (mode=full only) ----
+          # `test` mode never touches real-issue labels — that's the whole point of the mode split.
+          if [ "$MODE" = "full" ]; then
+            # Ensure the `Automated` label exists on the repo. Idempotent: no-op if already present.
+            gh label create "Automated" --repo "$OSS_REPO" \
+              --color "0e8a16" --description "Regression test coverage added by the E2E Council batch" \
+              2>/dev/null || true
+            for N in $SUCCESS_ISSUES; do
+              gh issue edit "$N" --repo "$OSS_REPO" \
+                --remove-label "Needs-Automation" \
+                --add-label "Automated" 2>/dev/null || echo "::warning::label update failed for #${N}"
+              gh issue comment "$N" --repo "$OSS_REPO" --body \
+                "Regression coverage added by the E2E Council batch. See ${PR_URL:-the batch PR} for the generated spec." \
+                2>/dev/null || true
+            done
+          else
+            echo "mode=${MODE} — skipping label writes (test mode)."
+          fi
+
+          # ---- 6. Job summary ----
+          {
+            echo "## E2E Council Batch — Done (mode=${MODE})"
+            echo ""
+            echo "- Batch: \`${BATCH_KEY}\`"
+            echo "- Success: **${SUCCESS_COUNT}** issue(s)"
+            echo "- PR: ${PR_URL:-<none>}"
+            if [ "$MODE" != "full" ]; then
+              echo "- Labels unchanged (mode=${MODE})."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-council-batch.yml
+++ b/.github/workflows/e2e-council-batch.yml
@@ -251,6 +251,9 @@ jobs:
             # but is ignored downstream — we send the issue number as a placeholder so the field
             # is a valid integer. `--ref` targets a specific branch of o2-enterprise so test-runs
             # can hit engine feat branches pre-merge.
+            # target_dir is intentionally NOT passed: the engine's issue-mode rewrites run-context.json
+            # to RegressionSet/<Area>/ deterministically from the issue's area/* labels, so an
+            # advisory target_dir would just be a redundant + conflict-prone third signal.
             if ! gh workflow run e2e-council.yml \
               --repo "$ENT_REPO" \
               --ref "$ENGINE_REF" \
@@ -262,7 +265,6 @@ jobs:
               -f feature_hint="regression coverage for closed issue #${ISSUE}" \
               -f actor=e2e-council-batch \
               -f batch_key="$BATCH_KEY" \
-              -f target_dir="$TARGET_DIR" \
               -f pr_back_enabled=false; then
               printf '{"issue":%s,"status":"dispatch_failed","duration":0}\n' \
                 "$ISSUE" >> "$RESULTS_FILE"
@@ -359,6 +361,77 @@ jobs:
               echo "(healing failed or Sentinel rejected all attempts). Labels unchanged; retry tomorrow."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
+          fi
+
+          # ---- 2b. Register new RegressionSet specs in playwright_regression.yml ----
+          # Engine's issue-mode drops specs at tests/ui-testing/playwright-tests/RegressionSet/<Area>/,
+          # but the scheduled regression cron (playwright_regression.yml) only picks up files listed
+          # in its matrix `run_files`. We update that YAML on the same batch branch so the same PR
+          # ships both the specs AND their CI registration. Folder → group mapping mirrors the case
+          # statement in playwright_regression.yml itself (Dashboards → Dashboard-Regression, etc.).
+          # yq is preinstalled on ubuntu-latest runners.
+          WORKDIR="$RUNNER_TEMP/reg-yml"
+          rm -rf "$WORKDIR" && mkdir -p "$WORKDIR"
+          # Sparse-shallow checkout: fetch only the yml (via API) — no PR-code checkout, no PAT surface widening.
+          gh api "/repos/${OSS_REPO}/contents/.github/workflows/playwright_regression.yml?ref=${WORK_BRANCH}" \
+            --jq '.content' 2>/dev/null | base64 --decode > "$WORKDIR/playwright_regression.yml" || {
+              echo "::warning::couldn't fetch playwright_regression.yml from ${WORK_BRANCH} — skipping registration."
+              PLW_REG_SKIPPED=1
+            }
+          if [ "${PLW_REG_SKIPPED:-0}" = "0" ]; then
+            # List spec files added on the batch branch under RegressionSet/. Compare vs main to know NEW ones.
+            NEW_SPECS=$(gh api "/repos/${OSS_REPO}/compare/main...${WORK_BRANCH}?per_page=100" \
+              --jq '[.files[] | select(.status=="added" and (.filename | startswith("tests/ui-testing/playwright-tests/RegressionSet/") and endswith(".spec.js"))) | .filename] | .[]' \
+              2>/dev/null || true)
+            REG_CHANGES=0
+            while IFS= read -r SPEC_PATH; do
+              [ -z "$SPEC_PATH" ] && continue
+              # Extract Area folder + filename: "tests/ui-testing/playwright-tests/RegressionSet/Pipelines/foo.spec.js" → Pipelines, foo.spec.js
+              REL="${SPEC_PATH#tests/ui-testing/playwright-tests/RegressionSet/}"
+              AREA_FOLDER="${REL%%/*}"
+              FILENAME="${REL##*/}"
+              case "$AREA_FOLDER" in
+                Logs)        GROUP=Logs-Regression ;;
+                Alerts)      GROUP=Alerts-Regression ;;
+                Dashboards)  GROUP=Dashboard-Regression ;;
+                Pipelines)   GROUP=Pipelines-Regression ;;
+                Streams)     GROUP=Streams-Regression ;;
+                Traces)      GROUP=Traces-Regression ;;
+                Metrics)     GROUP=Metrics-Regression ;;
+                Reports)     GROUP=Reports-Regression ;;
+                DataSources) GROUP=DataSources-Regression ;;
+                General)     GROUP=GeneralTests-Regression ;;
+                *)           GROUP=GeneralTests-Regression ;;
+              esac
+              # Idempotent: only add if not already present.
+              CURRENT=$(yq eval "(.jobs.playwright.strategy.matrix.include[] | select(.testfolder == \"${GROUP}\") | .run_files)" "$WORKDIR/playwright_regression.yml" 2>/dev/null || echo "")
+              if printf '%s' "$CURRENT" | grep -qx "^- ${FILENAME}$" 2>/dev/null; then
+                echo "::notice::already registered: ${FILENAME} in ${GROUP}"
+                continue
+              fi
+              yq eval -i "(.jobs.playwright.strategy.matrix.include[] | select(.testfolder == \"${GROUP}\") | .run_files) += [\"${FILENAME}\"]" \
+                "$WORKDIR/playwright_regression.yml" || { echo "::warning::yq append failed for ${GROUP}/${FILENAME}"; continue; }
+              echo "::notice::registered: ${FILENAME} → ${GROUP} in playwright_regression.yml"
+              REG_CHANGES=$((REG_CHANGES + 1))
+            done <<< "$NEW_SPECS"
+
+            if [ "$REG_CHANGES" -gt 0 ]; then
+              # Commit the yml update on the same batch branch via the Contents API (no checkout, no
+              # local git needed). Get current SHA of the file on the branch → PUT the new content.
+              SHA=$(gh api "/repos/${OSS_REPO}/contents/.github/workflows/playwright_regression.yml?ref=${WORK_BRANCH}" \
+                --jq '.sha' 2>/dev/null || true)
+              B64=$(base64 -i "$WORKDIR/playwright_regression.yml" | tr -d '\n')
+              gh api "/repos/${OSS_REPO}/contents/.github/workflows/playwright_regression.yml" \
+                --method PUT \
+                -f message="ci(regression): register ${REG_CHANGES} spec(s) added by batch ${BATCH_KEY}" \
+                -f content="$B64" \
+                -f sha="$SHA" \
+                -f branch="$WORK_BRANCH" >/dev/null 2>&1 && \
+                echo "playwright_regression.yml updated on ${WORK_BRANCH} (+${REG_CHANGES} run_files)" || \
+                echo "::warning::commit of playwright_regression.yml update failed — the PR will still open but the specs won't run in the scheduled regression cron until manually registered."
+            else
+              echo "No new RegressionSet specs to register (all filenames already in playwright_regression.yml)."
+            fi
           fi
 
           # ---- 3. Build the PR body table ----

--- a/.github/workflows/e2e-council-caller.yml
+++ b/.github/workflows/e2e-council-caller.yml
@@ -4,6 +4,12 @@ name: E2E Council Caller (openobserve)
 # auto-on-merge), DISPATCH the E2E Council engine that lives in the PRIVATE o2-enterprise repo,
 # authenticated with the org-admin PAT. This mirrors docgen-caller.yml.
 #
+# SEE ALSO: `e2e-council-batch.yml` — scheduled/manual BATCH orchestrator that fires the same
+# engine across every CLOSED issue labelled `Needs-Automation` and aggregates into ONE regression
+# PR. Kept as a separate file because it has a different trigger surface (workflow_dispatch +
+# schedule, no comment door), different failure semantics (partial success is normal), and a
+# different auth model (no per-commenter gate). Both callers dispatch the same `e2e-council.yml`.
+#
 # WHY DISPATCH (not `workflow_call`/`uses:`): a cross-repo reusable-workflow call would require the
 # private repo to grant this repo an Actions *access policy*. A PAT with `Actions: R/W` on
 # o2-enterprise can trigger its `workflow_dispatch` with no such org/repo setting. The engine then


### PR DESCRIPTION
## Summary

Adds `.github/workflows/e2e-council-batch.yml` — a workflow_dispatch orchestrator (cron ready but commented out) that fires the E2E Council engine across every CLOSED issue labelled `Needs-Automation`, generates a Playwright regression spec for each, aggregates them onto one shared branch, and opens **two coordinated PRs per batch** (OSS + ENT) for QA to review.

**Depends on**: openobserve/o2-enterprise#2106 — adds `batch_key` / `pr_back_enabled` / `issue_number` inputs this workflow relies on. **Cannot merge until the engine PR lands**.

## How it works

**Three modes** (input `mode`):
- `dry_run` (default) — plan the queue + report, don't dispatch anything.
- `test` — real engine dispatch + real aggregated PRs open, but NO label mutation on real issues.
- `full` — everything, incl. label writes. What cron will use.

**Flow (one run)**:
1. **Plan** — query closed `Needs-Automation` issues (excluding `Automated`), cap to `max_issues` (default 10, FIFO oldest-first), derive target folder per issue's `area/*` label.
2. **Dispatch loop** — sequential per-issue engine dispatches with 45-min per-run cap, `pr_back_enabled=false`, `issue_number=<n>`, `batch_key=regression-YYYY-MM-DD`. Failures don't abort the batch — the label stays, tomorrow retries.
3. **Register in OSS regression matrix** — after dispatches finish, for each new `RegressionSet/<Area>/*.spec.js` on the batch branch, `yq`-append the filename to the correct `<Area>-Regression` group's `run_files` in OSS `playwright_regression.yml`. Commit on the same batch branch.
4. **Mirror-register in ENT regression matrix** — create the same-named ENT batch branch off ENT main, mirror the same `run_files` additions into ENT `playwright_regression.yml`, commit via Contents API, and open ONE yml-only ENT companion PR. Mirrors what today's `ent_register` job does for main `playwright.yml` — ENT CI pulls the spec files from the OSS branch, so ENT only carries the yml delta.
5. **PR + labels** — grep `Issue: #<n>` trailers on the batch branch → success set. Open ONE aggregated OSS PR against main (contains specs + OSS yml update + link to ENT PR). In `mode=full`, remove `Needs-Automation` and add `Automated` on each successful issue; failures keep the label so tomorrow retries.

## Two PRs per batch, coordinated

Same pattern the existing `/e2e` council uses (OSS test PR from `pr_back` + ENT registration PR from `ent_register`) — just applied to the `playwright_regression.yml` matrix instead of the main `playwright.yml`:

| PR | Repo | Contents | Merge |
|----|------|----------|-------|
| **OSS batch PR** | openobserve/openobserve | Generated specs + OSS `playwright_regression.yml` yml delta | Review + merge to add to OSS regression cron |
| **ENT companion PR** | openobserve/o2-enterprise | ENT `playwright_regression.yml` yml delta ONLY (spec files stay on OSS branch) | No merge gate — merge to add to ENT regression cron, close to opt out |

**Kill switches**:
- `vars.E2E_COUNCIL_DISABLED` (shared with /e2e)
- `vars.E2E_AUTO_REGRESSION_DISABLED` (batch-only, safe to pause the nightly without killing /e2e)

**Test-before-merge**: `engine_ref` input lets the workflow dispatch a specific engine branch pre-merge (used during pilot).

## Why a separate file (not adding to e2e-council-caller.yml)

The `/e2e` caller is a **thin per-PR gate + dispatch**. This workflow has a different trigger (dispatch + cron, no comment door), different lifecycle (loop + fan-in), different failure semantics (partial success is normal), and no per-commenter gate. Mixing them would bloat the hot path every open PR reads on every comment.

## What's NOT enabled yet

- **Cron trigger is intentionally commented out** in this PR. Recommended enablement plan:
  1. Merge this + the engine PR.
  2. Run 2–3 manual `mode=test` batches against hand-picked closed issues.
  3. Follow-up 1-line PR uncomments the cron (recommended: `0 13 * * 1-5` = 6:30 PM IST weekdays).
- **`Automated` label** — auto-created on first `mode=full` run (idempotent). Or create manually beforehand.

## Verified

Engine smoke test [openobserve/o2-enterprise#28699383732](https://github.com/openobserve/o2-enterprise/actions/runs/28699383732) — issue-mode + `RegressionSet/` placement + `verify_heal` against the real enterprise binary all green. Generated spec reviewable at openobserve/openobserve#13037 (do-not-merge smoke-test PR).

The ENT-side registration + companion PR is a straight mirror of the OSS logic; will be verified end-to-end in the first post-merge `mode=test` batch run.

## Test plan

- [x] YAML syntax valid
- [x] Kill-switch gating verified in the workflow's job-level `if:`
- [ ] Post-merge: `mode=dry_run` run — verify queue resolution + no dispatch, no PRs
- [ ] Post-merge: `mode=test` run against 1–2 hand-picked issues — verify OSS PR + ENT companion PR both open correctly and no labels are touched
- [ ] Post-merge: `mode=full` run against a small pilot batch — verify label lifecycle + both matrix registrations
- [ ] After 3 successful runs: 1-line PR enabling the schedule cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)