### PR TITLE
[Security] Prevent service accounts from escalating role via PUT /users/{email}

### DIFF
--- a/src/handler/http/request/users/mod.rs
+++ b/src/handler/http/request/users/mod.rs
@@ -291,6 +291,43 @@ pub async fn update(
             .unwrap();
     }
 
+    let initiator_id = &user_email.user_id;
+    let update_mode = if user_email.user_id.eq(&email_id) {
+        UserUpdateMode::SelfUpdate
+    } else {
+        UserUpdateMode::OtherUpdate
+    };
+
+    // OSS-only initiator-role gate.
+    //
+    // In the enterprise build, RBAC middleware (`check_permissions`) has
+    // already vetted the caller before this handler runs. In OSS there is
+    // no such middleware — the auth extractor `bypass_check=true` lets any
+    // authenticated principal reach the handler, including a
+    // `service_account` role. Combined with the historical OSS behaviour
+    // below (unconditionally rewrite `user.role` to `Admin` for every
+    // update), that let a low-privilege service account promote any target
+    // user to org admin through `PUT /users/{email}` and, in the same
+    // handler, rewrite any target user's profile fields. Reject
+    // cross-user updates here unless the initiator is Admin or Root.
+    // Self-update remains permitted; the service layer's existing
+    // "Self role cannot be upgraded" check still guards role changes on
+    // self.
+    #[cfg(not(feature = "enterprise"))]
+    if matches!(update_mode, UserUpdateMode::OtherUpdate)
+        && !crate::common::utils::auth::is_root_user(initiator_id)
+    {
+        let initiator_is_admin = match users::get_user(Some(&org_id), initiator_id).await {
+            Some(u) => u.role == UserRole::Admin || u.role == UserRole::Root,
+            None => false,
+        };
+        if !initiator_is_admin {
+            return MetaHttpResponse::forbidden(
+                "Admin or Root role required to update other users",
+            );
+        }
+    }
+
     #[cfg(not(feature = "enterprise"))]
     {
         user.role = Some(UserRoleRequest {
@@ -298,12 +335,6 @@ pub async fn update(
             custom: None,
         });
     }
-    let initiator_id = &user_email.user_id;
-    let update_mode = if user_email.user_id.eq(&email_id) {
-        UserUpdateMode::SelfUpdate
-    } else {
-        UserUpdateMode::OtherUpdate
-    };
     match users::update_user(&org_id, &email_id, update_mode, initiator_id, user).await {
         Ok(resp) => resp,
         Err(e) => MetaHttpResponse::internal_error(e),
@@ -1210,5 +1241,178 @@ mod tests {
         assert!(result.is_some());
         let role_response = result.unwrap();
         assert_eq!(role_response.value, "admin");
+    }
+
+    // ---------- OSS `PUT /api/{org}/users/{email}` privilege-gate regressions ----------
+    //
+    // These tests pin the invariant that a `service_account` principal MUST
+    // NOT be able to mutate another user's fields (first_name / last_name /
+    // role / token) through the OSS update handler. In the pre-fix code the
+    // handler both (a) unconditionally rewrote the incoming role to Admin
+    // and (b) never checked the initiator's role — so a low-privilege
+    // service account could rename any user in the org and promote them to
+    // admin. Each test seeds the initiator + target directly into the
+    // in-memory `ORG_USERS` / `USERS` caches (matching the pattern used by
+    // the `list` regression next to it) and drives the axum handler at the
+    // surface where the gate lives.
+
+    #[cfg(not(feature = "enterprise"))]
+    fn seed_user_and_membership(org_id: &str, email: &str, role: UserRole) {
+        use config::meta::user::UserType;
+        use infra::table::{org_users::OrgUserRecord, users::UserRecord};
+
+        use crate::common::infra::config::{ORG_USERS, USERS};
+
+        USERS.insert(
+            email.to_string(),
+            UserRecord {
+                email: email.to_string(),
+                password: "test-pass".to_string(),
+                salt: String::new(),
+                first_name: "Test".to_string(),
+                last_name: "User".to_string(),
+                password_ext: None,
+                user_type: UserType::Internal,
+                is_root: false,
+                created_at: 0,
+                updated_at: 0,
+            },
+        );
+        ORG_USERS.insert(
+            format!("{org_id}/{email}"),
+            OrgUserRecord {
+                email: email.to_string(),
+                org_id: org_id.to_string(),
+                role,
+                token: "test-token".to_string(),
+                rum_token: None,
+                created_at: 0,
+                allow_static_token: true,
+            },
+        );
+    }
+
+    /// Regression for the role-escalation half of the cluster:
+    /// a `service_account`-role initiator MUST NOT be able to update the
+    /// role of another user in the org via `PUT /api/{org}/users/{email}`.
+    /// Before the fix, the OSS handler unconditionally clobbered the
+    /// incoming role to `Admin` and never checked the initiator's role, so
+    /// this call returned HTTP 200 and promoted the target to org admin.
+    #[cfg(not(feature = "enterprise"))]
+    #[tokio::test]
+    async fn service_account_cannot_update_other_user_role_regression() {
+        use axum::extract::Path;
+
+        use crate::handler::http::extractors::Headers as HeadersExtractor;
+
+        let org = "org-user-update-role-regression";
+        let sa_email = "user-update-sa-role-regression@example.test";
+        let victim_email = "user-update-victim-role-regression@example.test";
+        seed_user_and_membership(org, sa_email, UserRole::ServiceAccount);
+        seed_user_and_membership(org, victim_email, UserRole::ServiceAccount);
+
+        let body = UpdateUser {
+            first_name: Some("Owned".to_string()),
+            last_name: Some("ByMemberA".to_string()),
+            ..UpdateUser::default()
+        };
+
+        let resp = update(
+            Path((org.to_string(), victim_email.to_string())),
+            HeadersExtractor(UserEmail {
+                user_id: sa_email.to_string(),
+            }),
+            axum::Json(body),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status().as_u16(),
+            403,
+            "OSS service_account must be blocked from updating another user (role escalation vector)"
+        );
+    }
+
+    /// Regression for the profile-tampering half of the cluster:
+    /// even without touching the role field, a `service_account`-role
+    /// initiator MUST NOT be able to rewrite another user's `first_name` /
+    /// `last_name`. Before the fix, this returned HTTP 200 and persisted
+    /// the change on the victim's account.
+    #[cfg(not(feature = "enterprise"))]
+    #[tokio::test]
+    async fn service_account_cannot_update_other_user_profile_regression() {
+        use axum::extract::Path;
+
+        use crate::handler::http::extractors::Headers as HeadersExtractor;
+
+        let org = "org-user-update-profile-regression";
+        let sa_email = "user-update-sa-profile-regression@example.test";
+        let victim_email = "user-update-victim-profile-regression@example.test";
+        seed_user_and_membership(org, sa_email, UserRole::ServiceAccount);
+        // Target is a regular admin — the pre-fix bug let a service account
+        // rewrite adminA's profile fields, so exercise that exact shape.
+        seed_user_and_membership(org, victim_email, UserRole::Admin);
+
+        let body = UpdateUser {
+            first_name: Some("Hijacked".to_string()),
+            last_name: Some("User".to_string()),
+            ..UpdateUser::default()
+        };
+
+        let resp = update(
+            Path((org.to_string(), victim_email.to_string())),
+            HeadersExtractor(UserEmail {
+                user_id: sa_email.to_string(),
+            }),
+            axum::Json(body),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status().as_u16(),
+            403,
+            "OSS service_account must be blocked from mutating another user's profile fields"
+        );
+    }
+
+    /// Baseline: an Admin initiator must NOT be blocked by the gate on the
+    /// same code path. This proves the 403 above is provably the invariant
+    /// (initiator role), not a broken setup that fails everyone — matches
+    /// the "isolated red" requirement in the remediator playbook.
+    #[cfg(not(feature = "enterprise"))]
+    #[tokio::test]
+    async fn admin_is_not_blocked_by_update_gate() {
+        use axum::extract::Path;
+
+        use crate::handler::http::extractors::Headers as HeadersExtractor;
+
+        let org = "org-user-update-admin-baseline";
+        let admin_email = "user-update-admin-baseline@example.test";
+        let target_email = "user-update-target-baseline@example.test";
+        seed_user_and_membership(org, admin_email, UserRole::Admin);
+        seed_user_and_membership(org, target_email, UserRole::ServiceAccount);
+
+        let body = UpdateUser {
+            first_name: Some("Renamed".to_string()),
+            ..UpdateUser::default()
+        };
+
+        let resp = update(
+            Path((org.to_string(), target_email.to_string())),
+            HeadersExtractor(UserEmail {
+                user_id: admin_email.to_string(),
+            }),
+            axum::Json(body),
+        )
+        .await;
+
+        // The gate must let an Admin initiator through. The downstream
+        // service layer may or may not fully persist (DB backends vary in
+        // this unit-test harness), but it must NOT be the gate's 403.
+        assert_ne!(
+            resp.status().as_u16(),
+            403,
+            "Admin initiator must not be blocked by the OSS update gate; got 403"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes a privilege-escalation path in the OSS `PUT /api/{org}/users/{email}` handler: a `service_account`-role caller could rewrite any other user's `role`, `first_name`, `last_name`, or `token` — promoting a chosen target to org admin and then authenticating as that admin — because the handler unconditionally rewrote the target's role to `Admin` and never checked the initiator's role. Adds an OSS-only initiator gate: cross-user updates are rejected with HTTP 403 unless the caller is Admin or Root.

## Consequence

**Role escalation via cross-user role rewrite.** A low-privilege `service_account` principal in an organization can promote any other user in that organization (including other service accounts they can create) to org `admin` through a single authenticated `PUT /api/{org}/users/{email}` call. Combining that with a subsequent password reset by any existing admin — or with the same handler's ability to rewrite the target's `token` — the attacker reaches org-admin capability and can then manage users, streams, dashboards, alerts, functions, and pipelines in the org.

**Cross-user profile tampering.** The same `service_account` principal can also silently rewrite any other user's `first_name` and `last_name` fields on their account via the same endpoint, regardless of whether they intend to escalate — a data-integrity and social-engineering surface distinct from the escalation above.

## Reproduction

### Role escalation — actor: `service_account` in the target org (substitute your own equivalents)

1. As an admin, seed a disposable target service account so the exploit runs against an isolated victim:
   ```
   curl -s -u "$ADMIN_EMAIL:<admin-password>" \
     -H "Content-Type: application/json" \
     -X POST "$TARGET/api/$ORG_ID/service_accounts" \
     -d '{"email":"<victim-sa>@example.local","first_name":"TC","last_name":"Victim"}'
   ```
   → HTTP 200; victim appears in `/service_accounts` with `role: "service_account"`.

2. As the low-priv service-account attacker, `PUT` an update on the victim with only profile fields — no `role` in the body:
   ```
   curl -s -u "<sa-attacker>@example.local:<sa-token>" \
     -H "Content-Type: application/json" \
     -X PUT "$TARGET/api/$ORG_ID/users/<victim-sa>@example.local" \
     -d '{"first_name":"Owned","last_name":"ByAttacker"}'
   ```
   → HTTP 200 `{"code":200,"message":"User updated successfully"}`.

3. Read back as admin — the victim has moved from `/service_accounts` to `/users` and their role is now `admin`:
   ```
   curl -s -u "$ADMIN_EMAIL:<admin-password>" "$TARGET/api/$ORG_ID/users"
   ```
   → `{"data":[{"email":"<victim-sa>@example.local","role":"admin", ...}]}` — escalation confirmed.

4. Control — the same PUT issued by an actual admin succeeds legitimately (proves the bug is initiator-role-specific, not a broken endpoint):
   → HTTP 200; victim role change is an intentional admin action.

**Expected secure:** step 2 must be rejected with HTTP 403 before any mutation, because the caller is not Admin or Root.

### Cross-user profile tampering — actor: `service_account` in the target org (substitute your own equivalents)

1. As the low-priv service-account attacker, `PUT` a profile-only update against an existing admin in the same org:
   ```
   curl -s -u "<sa-attacker>@example.local:<sa-token>" \
     -H "Content-Type: application/json" \
     -X PUT "$TARGET/api/$ORG_ID/users/<admin-target>@example.local" \
     -d '{"first_name":"Hijacked","last_name":"User"}'
   ```
   → HTTP 200 `{"code":200,"message":"User updated successfully"}`.

2. Read back as the target admin — their own profile has been rewritten by another org member:
   ```
   curl -s -u "<admin-target>@example.local:<admin-target-password>" "$TARGET/api/$ORG_ID/users"
   ```
   → the admin's record now shows `first_name: "Hijacked", last_name: "User"` — tampering confirmed.

3. Control — the admin issuing the same PUT against themselves (self-update) or against a target user in their own admin capacity succeeds, proving the endpoint isn't broken outright.

**Expected secure:** step 1 must be rejected with HTTP 403 before any mutation, because the caller is not Admin or Root.

## What changed

- `src/handler/http/request/users/mod.rs::update` now enforces an OSS-only initiator gate. Before the OSS role clobber runs, if the resolved `update_mode` is `OtherUpdate` and the initiator is not Root and not the org's `Admin`/`Root` member, the handler returns HTTP 403 `Admin or Root role required to update other users`.
- The gate lives inside `#[cfg(not(feature = "enterprise"))]`, so enterprise builds — which have RBAC middleware (`check_permissions`) upstream — are untouched.
- Self-update (`user_email == email_id`) is still permitted, because personal profile edits are legitimate. The service layer's existing `"Self role cannot be upgraded"` check in `src/service/users.rs::update_user` still guards role changes on self.

## Regression test

Three new tests in `src/handler/http/request/users/mod.rs::tests`, gated with `#[cfg(not(feature = "enterprise"))]`, pin the invariant at the axum handler surface:

- `service_account_cannot_update_other_user_role_regression` — asserts a `service_account`-role initiator PUT-ing another user is rejected with 403 (the role-escalation vector).
- `service_account_cannot_update_other_user_profile_regression` — same, but the PUT only carries `first_name`/`last_name` against an existing Admin target (the profile-tampering vector).
- `admin_is_not_blocked_by_update_gate` — baseline positive control: an Admin initiator on the same code path must not receive 403, so the two rejections above are provably the initiator-role invariant, not a broken test setup.

## Validation

Red on the unfixed handler (both regression tests panic with a status mismatch, admin baseline passes):

```
test handler::http::request::users::tests::service_account_cannot_update_other_user_role_regression ... FAILED
test handler::http::request::users::tests::service_account_cannot_update_other_user_profile_regression ... FAILED

---- service_account_cannot_update_other_user_role_regression stdout ----
assertion `left == right` failed: OSS service_account must be blocked from updating another user (role escalation vector)
  left: 500
 right: 403

---- service_account_cannot_update_other_user_profile_regression stdout ----
assertion `left == right` failed: OSS service_account must be blocked from mutating another user's profile fields
  left: 500
 right: 403

test handler::http::request::users::tests::admin_is_not_blocked_by_update_gate ... ok
```

(The pre-fix response is `500` in the unit-test harness because the exploit reaches the DB write layer before any gate; the invariant asserted is that the request should never have gotten past the initiator-role check — the exact same handler serves the `200 OK` observed in the black-box PoC against a running server.)

Green after this change (`cargo test --lib --no-default-features -p openobserve "handler::http::request::users::tests"`):

```
running 9 tests
test handler::http::request::users::tests::test_check_role_available_filters_sre_agent ... ok
test handler::http::request::users::tests::test_check_role_available_filters_service_account ... ok
test handler::http::request::users::tests::test_check_role_available_filters_root ... ok
test handler::http::request::users::tests::test_presigned_url_generator_default ... ok
test handler::http::request::users::tests::test_check_role_available_allows_admin ... ok
test handler::http::request::users::tests::test_presigned_url_generator_response_serialization ... ok
test handler::http::request::users::tests::service_account_cannot_update_other_user_profile_regression ... ok
test handler::http::request::users::tests::service_account_cannot_update_other_user_role_regression ... ok
test handler::http::request::users::tests::admin_is_not_blocked_by_update_gate ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 4050 filtered out
```

`service::users` unit tests (adjacent user-service coverage) also green:

```
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 4042 filtered out
```

## Full suite

`cargo test --lib --no-default-features -p openobserve` — 4025 passed, 16 failed, 18 ignored. All 16 failures pre-exist on `main` and are unrelated to this change: they live in `service::sourcemaps::*` (missing `source_maps` table in the local test-harness DB), `service::enrichment_table::url_processor::*`, `handler::http::request::search::utils::*` (query-validation edge cases), and `job::config_watcher::test_run_returns_none_when_no_config_path`. The change here only edits `src/handler/http/request/users/mod.rs`, which those failing tests do not touch.

## Residual risk

- The gate is enforced at the OSS handler surface. On the enterprise build, the fix relies on the pre-existing `check_permissions` RBAC middleware; if that middleware were bypassed for this route on enterprise, this specific handler would fall back to the un-gated pre-fix behaviour. That risk is out of scope for this PR — enterprise RBAC is a separate concern.
- Self-update is intentionally still permitted; the service layer's `"Self role cannot be upgraded"` continues to prevent a user from promoting themselves. Token rewrite on self is likewise permitted (it's the existing OSS behaviour), which is not the escalation vector this PR targets.
- This branch edits the same file as open PR #13035 (`security/enforce-admin-oss-endpoints`), which adds a similar gate on the `list` handler. A merge conflict is expected at review time — the reviewer will resolve.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_
