### PR TITLE
[Security] Enforce Admin/Root role and caller-matches-target on v2 system-settings handlers

### DIFF
--- a/src/handler/http/request/organization/system_settings.rs
+++ b/src/handler/http/request/organization/system_settings.rs
@@ -28,7 +28,67 @@ use config::meta::system_settings::{
     SettingScope, SystemSetting, SystemSettingPayload, SystemSettingQuery,
 };
 
-use crate::{common::meta::http::HttpResponse as MetaHttpResponse, service::db::system_settings};
+use crate::{
+    common::{meta::http::HttpResponse as MetaHttpResponse, utils::auth::UserEmail},
+    handler::http::extractors::Headers,
+    service::db::system_settings,
+};
+
+/// OSS-only Admin/Root role gate for the v2 system-settings mutating
+/// handlers. In the OSS build there is no RBAC middleware and
+/// `check_permissions` returns `true` for every authenticated caller, so
+/// each admin-only handler has to reject non-admin roles itself. Returns
+/// `Err(Response)` with a pre-built HTTP 403 when the caller is not an
+/// Admin or Root in `org_id`; the handler propagates that response
+/// unchanged.
+///
+/// This helper is intentionally private to this module. The v1 settings
+/// handler in `settings.rs` has an equivalent gate on the
+/// `security/enforce-admin-oss-endpoints` branch; once that branch lands
+/// (introducing `crate::handler::http::auth::oss_role_gate`), this
+/// private helper should be replaced with the shared one. Keeping it
+/// private here avoids a public-API conflict with that in-flight PR.
+#[cfg(not(feature = "enterprise"))]
+async fn assert_admin_role_oss(org_id: &str, user_id: &str) -> Result<(), Response> {
+    use config::meta::user::UserRole;
+
+    use crate::common::utils::auth::is_root_user;
+
+    if is_root_user(user_id) {
+        return Ok(());
+    }
+    match crate::service::users::get_user(Some(org_id), user_id).await {
+        Some(initiator)
+            if initiator.role == UserRole::Admin || initiator.role == UserRole::Root =>
+        {
+            Ok(())
+        }
+        _ => Err(MetaHttpResponse::forbidden(
+            "Admin or Root role required for this action",
+        )),
+    }
+}
+
+/// OSS-only self-or-admin gate for user-level v2 system-settings
+/// mutations. The `user_id` path param names the target account whose
+/// setting is being written. Personal preferences are legitimately
+/// mutable by the owning user, so we allow the call when the
+/// authenticated caller's `user_id` matches the target path segment
+/// (compared case-insensitively to mirror how the auth layer normalizes
+/// email identifiers). Everything else must clear the Admin/Root role
+/// gate — otherwise any authenticated org member could overwrite an
+/// admin's user-level settings via BFLA.
+#[cfg(not(feature = "enterprise"))]
+async fn assert_self_or_admin_oss(
+    org_id: &str,
+    caller_user_id: &str,
+    target_user_id: &str,
+) -> Result<(), Response> {
+    if caller_user_id.eq_ignore_ascii_case(target_user_id) {
+        return Ok(());
+    }
+    assert_admin_role_oss(org_id, caller_user_id).await
+}
 
 /// Get a specific system setting with resolution (user -> org -> system)
 #[utoipa::path(
@@ -138,8 +198,17 @@ pub async fn list_settings(
 )]
 pub async fn set_org_setting(
     Path(org_id): Path<String>,
+    Headers(user_email): Headers<UserEmail>,
     Json(payload): Json<SystemSettingPayload>,
 ) -> Response {
+    // OSS: no RBAC middleware, so require Admin/Root role explicitly here.
+    // Enterprise builds enforce this in their auth middleware and skip the
+    // check.
+    #[cfg(not(feature = "enterprise"))]
+    if let Err(resp) = assert_admin_role_oss(&org_id, &user_email.user_id).await {
+        return resp;
+    }
+    let _ = &user_email; // silence unused warning on enterprise builds
     let mut setting = SystemSetting::new_org(&org_id, &payload.setting_key, payload.setting_value);
     if let Some(cat) = payload.setting_category.as_deref() {
         setting.setting_category = Some(cat.to_string());
@@ -183,8 +252,17 @@ pub async fn set_org_setting(
 )]
 pub async fn set_user_setting(
     Path((org_id, user_id)): Path<(String, String)>,
+    Headers(user_email): Headers<UserEmail>,
     Json(payload): Json<SystemSettingPayload>,
 ) -> Response {
+    // OSS: no RBAC middleware, so require caller == target OR Admin/Root.
+    // Self-mutation stays open so users can still write their own prefs;
+    // cross-user writes are the BFLA path we're closing.
+    #[cfg(not(feature = "enterprise"))]
+    if let Err(resp) = assert_self_or_admin_oss(&org_id, &user_email.user_id, &user_id).await {
+        return resp;
+    }
+    let _ = &user_email;
     let mut setting = SystemSetting::new_user(
         &org_id,
         &user_id,
@@ -231,7 +309,16 @@ pub async fn set_user_setting(
         ("x-o2-mcp" = json!({"description": "Delete org system setting", "category": "system", "requires_confirmation": true}))
     )
 )]
-pub async fn delete_org_setting(Path((org_id, key)): Path<(String, String)>) -> Response {
+pub async fn delete_org_setting(
+    Path((org_id, key)): Path<(String, String)>,
+    Headers(user_email): Headers<UserEmail>,
+) -> Response {
+    // OSS: no RBAC middleware, so require Admin/Root role explicitly here.
+    #[cfg(not(feature = "enterprise"))]
+    if let Err(resp) = assert_admin_role_oss(&org_id, &user_email.user_id).await {
+        return resp;
+    }
+    let _ = &user_email;
     match system_settings::delete(&SettingScope::Org, Some(&org_id), None, &key).await {
         Ok(true) => (StatusCode::OK, Json(serde_json::json!({"deleted": true}))).into_response(),
         Ok(false) => MetaHttpResponse::not_found("Setting not found"),
@@ -269,10 +356,292 @@ pub async fn delete_org_setting(Path((org_id, key)): Path<(String, String)>) -> 
 )]
 pub async fn delete_user_setting(
     Path((org_id, user_id, key)): Path<(String, String, String)>,
+    Headers(user_email): Headers<UserEmail>,
 ) -> Response {
+    // OSS: no RBAC middleware, so require caller == target OR Admin/Root.
+    #[cfg(not(feature = "enterprise"))]
+    if let Err(resp) = assert_self_or_admin_oss(&org_id, &user_email.user_id, &user_id).await {
+        return resp;
+    }
+    let _ = &user_email;
     match system_settings::delete(&SettingScope::User, Some(&org_id), Some(&user_id), &key).await {
         Ok(true) => (StatusCode::OK, Json(serde_json::json!({"deleted": true}))).into_response(),
         Ok(false) => MetaHttpResponse::not_found("Setting not found"),
         Err(e) => MetaHttpResponse::bad_request(e.to_string().as_str()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for the v2 system-settings mutating handlers.
+    //!
+    //! Invariants asserted here (OSS build; enterprise builds delegate the
+    //! same check to their RBAC middleware):
+    //!
+    //! - Org-level mutations (POST /settings/v2, DELETE /settings/v2/{key})
+    //!   require Admin/Root role. A `service_account` role must be rejected
+    //!   with HTTP 403 before any write hits the store.
+    //! - User-level mutations (POST/DELETE /settings/v2/user/{user_id}[/{key}])
+    //!   must reject a caller whose authenticated `user_id` does not match
+    //!   the path `user_id`, unless the caller holds Admin/Root role.
+    //!   Self-mutation is allowed for any authenticated org member so
+    //!   personal preferences remain writable by the owning user.
+    //!
+    //! These tests exercise the handler functions directly (not through the
+    //! router) so no HTTP server, no DB, and no auth middleware is required
+    //! — the OSS-mode `#[cfg(not(feature = "enterprise"))]` gate itself is
+    //! what we're regression-testing. The USERS + ORG_USERS in-memory caches
+    //! are pre-seeded so `service::users::get_user` resolves synchronously.
+    #![cfg(not(feature = "enterprise"))]
+    #![allow(clippy::items_after_test_module)]
+
+    use axum::{Json, extract::Path};
+    use config::meta::{
+        system_settings::SystemSettingPayload,
+        user::{UserRole, UserType},
+    };
+    use infra::table::{org_users::OrgUserRecord, users::UserRecord};
+    use serde_json::json;
+
+    use super::{delete_org_setting, delete_user_setting, set_org_setting, set_user_setting};
+    use crate::{
+        common::{
+            infra::config::{ORG_USERS, USERS},
+            utils::auth::UserEmail,
+        },
+        handler::http::extractors::Headers as HeadersExtractor,
+    };
+
+    /// Seed both the USERS and ORG_USERS caches so `service::users::get_user`
+    /// (called by the gate helper) resolves without a DB round-trip. Both
+    /// entries are required — miss either and the cached lookup falls
+    /// through to the persistent DB (returns None), which would collapse
+    /// "Admin" to "unknown user" and misreport the gate as too strict.
+    fn seed_org_user(org_id: &str, email: &str, role: UserRole) {
+        USERS.insert(
+            email.to_string(),
+            UserRecord {
+                email: email.to_string(),
+                password: "test-pass".to_string(),
+                salt: String::new(),
+                first_name: "Test".to_string(),
+                last_name: "User".to_string(),
+                password_ext: None,
+                user_type: UserType::Internal,
+                is_root: false,
+                created_at: 0,
+                updated_at: 0,
+            },
+        );
+        ORG_USERS.insert(
+            format!("{org_id}/{email}"),
+            OrgUserRecord {
+                email: email.to_string(),
+                org_id: org_id.to_string(),
+                role,
+                token: "test-token".to_string(),
+                rum_token: None,
+                created_at: 0,
+                allow_static_token: true,
+            },
+        );
+    }
+
+    fn payload(key: &str, value: &str) -> SystemSettingPayload {
+        SystemSettingPayload {
+            setting_key: key.to_string(),
+            setting_value: json!(value),
+            setting_category: None,
+            description: None,
+        }
+    }
+
+    /// TC-8EBA40D2 (org-level POST):
+    /// A `service_account`-role principal must NOT be able to create or
+    /// overwrite an org-level v2 setting via
+    /// `POST /api/{org_id}/settings/v2`. Fails on the unfixed handler
+    /// (returned HTTP 200 and persisted the caller's payload) and passes
+    /// once the handler rejects the caller with HTTP 403 before touching
+    /// the store.
+    #[tokio::test]
+    async fn service_account_cannot_set_org_v2_setting() {
+        let org = "org-v2-sys-set-sa";
+        let sa = "sa-v2-set@example.test";
+        seed_org_user(org, sa, UserRole::ServiceAccount);
+
+        let resp = set_org_setting_with_caller(org, sa, payload("theme", "dark")).await;
+        assert_eq!(
+            resp.status().as_u16(),
+            403,
+            "service_account must be blocked from setting org-level v2 settings"
+        );
+    }
+
+    /// TC-8EBA40D2 (org-level DELETE):
+    /// A `service_account`-role principal must NOT be able to delete an
+    /// org-level v2 setting via `DELETE /api/{org_id}/settings/v2/{key}`.
+    #[tokio::test]
+    async fn service_account_cannot_delete_org_v2_setting() {
+        let org = "org-v2-sys-del-sa";
+        let sa = "sa-v2-del@example.test";
+        seed_org_user(org, sa, UserRole::ServiceAccount);
+
+        let resp = delete_org_setting_with_caller(org, sa, "some_key").await;
+        assert_eq!(
+            resp.status().as_u16(),
+            403,
+            "service_account must be blocked from deleting org-level v2 settings"
+        );
+    }
+
+    /// TC-F8888344 / TC-573B213C (user-level BFLA on POST):
+    /// A caller must NOT be able to write user-level settings for a
+    /// DIFFERENT user's account unless they hold Admin/Root. Fails on the
+    /// unfixed handler (any authenticated org member could overwrite an
+    /// admin's user-level settings) and passes once the handler enforces
+    /// caller == target OR caller-is-admin.
+    #[tokio::test]
+    async fn service_account_cannot_set_v2_setting_for_another_user() {
+        let org = "org-v2-sys-user-bfla-post";
+        let sa = "sa-bfla-post@example.test";
+        let victim = "admina-victim@example.test";
+        seed_org_user(org, sa, UserRole::ServiceAccount);
+        seed_org_user(org, victim, UserRole::Admin);
+
+        let resp =
+            set_user_setting_with_caller(org, victim, sa, payload("pref_theme", "hacked")).await;
+        assert_eq!(
+            resp.status().as_u16(),
+            403,
+            "service_account must not overwrite another user's settings"
+        );
+    }
+
+    /// TC-F8888344 / TC-573B213C (user-level BFLA on DELETE):
+    /// Same invariant on the delete verb.
+    #[tokio::test]
+    async fn service_account_cannot_delete_v2_setting_for_another_user() {
+        let org = "org-v2-sys-user-bfla-del";
+        let sa = "sa-bfla-del@example.test";
+        let victim = "admina-victim-del@example.test";
+        seed_org_user(org, sa, UserRole::ServiceAccount);
+        seed_org_user(org, victim, UserRole::Admin);
+
+        let resp = delete_user_setting_with_caller(org, victim, sa, "pref_theme").await;
+        assert_eq!(
+            resp.status().as_u16(),
+            403,
+            "service_account must not delete another user's settings"
+        );
+    }
+
+    /// Self-mutation baseline: a non-admin caller writing user-level
+    /// settings for THEMSELVES must NOT be blocked by the gate. This is
+    /// the paired green legitimate case that proves the 403s above are the
+    /// BFLA invariant, not a "reject everyone" over-fix. The call may
+    /// return a non-200 later (DB unavailable in tests), but it must NOT
+    /// be 403 — no auth rejection.
+    #[tokio::test]
+    async fn service_account_can_set_v2_setting_for_self_is_not_forbidden() {
+        let org = "org-v2-sys-user-self";
+        let sa = "sa-self@example.test";
+        seed_org_user(org, sa, UserRole::ServiceAccount);
+
+        let resp = set_user_setting_with_caller(org, sa, sa, payload("pref_theme", "dark")).await;
+        assert_ne!(
+            resp.status().as_u16(),
+            403,
+            "self-mutation of user-level settings must not be forbidden"
+        );
+    }
+
+    /// Admin baseline for the org-level gate: an Admin-role caller MUST be
+    /// allowed past the role gate on `POST /settings/v2` — so the 403s
+    /// above are the role gate firing, not a broken environment. The call
+    /// may return a non-200 later (DB unavailable in tests), but it must
+    /// NOT be 403 — no auth rejection.
+    #[tokio::test]
+    async fn admin_is_not_forbidden_on_set_org_v2_setting() {
+        let org = "org-v2-sys-set-admin";
+        let admin = "admin-v2-set@example.test";
+        seed_org_user(org, admin, UserRole::Admin);
+
+        let resp = set_org_setting_with_caller(org, admin, payload("theme", "dark")).await;
+        assert_ne!(
+            resp.status().as_u16(),
+            403,
+            "Admin-role caller must not be blocked by the OSS role gate"
+        );
+    }
+
+    // --- Test helpers ---------------------------------------------------
+    //
+    // Wrap the handler invocations so we assemble the handler args in one
+    // place — if the handler signature evolves (e.g. an extra extractor
+    // like `UserEmail` is added), only the helper changes, and every test
+    // above still exercises the same intent.
+
+    async fn set_org_setting_with_caller(
+        org: &str,
+        caller_user_id: &str,
+        payload: SystemSettingPayload,
+    ) -> axum::response::Response {
+        set_org_setting(
+            Path(org.to_string()),
+            HeadersExtractor(UserEmail {
+                user_id: caller_user_id.to_string(),
+            }),
+            Json(payload),
+        )
+        .await
+    }
+
+    async fn delete_org_setting_with_caller(
+        org: &str,
+        caller_user_id: &str,
+        key: &str,
+    ) -> axum::response::Response {
+        delete_org_setting(
+            Path((org.to_string(), key.to_string())),
+            HeadersExtractor(UserEmail {
+                user_id: caller_user_id.to_string(),
+            }),
+        )
+        .await
+    }
+
+    async fn set_user_setting_with_caller(
+        org: &str,
+        target_user_id: &str,
+        caller_user_id: &str,
+        payload: SystemSettingPayload,
+    ) -> axum::response::Response {
+        set_user_setting(
+            Path((org.to_string(), target_user_id.to_string())),
+            HeadersExtractor(UserEmail {
+                user_id: caller_user_id.to_string(),
+            }),
+            Json(payload),
+        )
+        .await
+    }
+
+    async fn delete_user_setting_with_caller(
+        org: &str,
+        target_user_id: &str,
+        caller_user_id: &str,
+        key: &str,
+    ) -> axum::response::Response {
+        delete_user_setting(
+            Path((
+                org.to_string(),
+                target_user_id.to_string(),
+                key.to_string(),
+            )),
+            HeadersExtractor(UserEmail {
+                user_id: caller_user_id.to_string(),
+            }),
+        )
+        .await
     }
 }


### PR DESCRIPTION
## Summary

The v2 system-settings HTTP handlers in `src/handler/http/request/organization/system_settings.rs` shipped without any authorization checks. In OSS builds, this let any authenticated `service_account` mutate org-wide v2 settings and overwrite user-level v2 settings for other users (including admins). This PR gates the four mutating handlers behind an OSS-only Admin/Root check (org-level) and a self-or-Admin check (user-level).

## Consequence

**Org-level (`POST` / `DELETE` `/api/{org_id}/settings/v2[/{key}]`):** Any authenticated service account within an org can create, overwrite, or delete org-level v2 settings that apply to all users in the organization, allowing a low-privilege principal to corrupt org-wide configuration or remove settings that all org members depend on.

**User-level (`POST` / `DELETE` `/api/{org_id}/settings/v2/user/{user_id}[/{key}]`):** Any authenticated service account within an org can create, overwrite, or delete user-level v2 settings for any other user in the org, including administrators, because the `user_id` path parameter is not validated against the authenticated caller. Depending on what settings control (UI layout, alert preferences, notification endpoints, etc.), this could cause persistent disruption to other users or inject malicious configuration.

## Reproduction

**Org-level BFLA — actor: a `service_account` role in the org (substitute your own equivalent service-account credentials).**

1. Create an org-level v2 setting as the service account:
   ```
   curl -s -w "\nHTTP_STATUS:%{http_code}" \
     -u "<sa-email>:<sa-token>" \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"setting_key":"sa_exploit","setting_value":"pwned_by_sa"}' \
     "$TARGET/api/{org_id}/settings/v2"
   ```
   -> HTTP 200, `{"id":14,"scope":"org","org_id":"…","setting_key":"sa_exploit","setting_value":"pwned_by_sa",…}` — the service account persisted org-wide state it should not own.

2. Delete the org-level setting as the same service account:
   ```
   curl -s -w "\nHTTP_STATUS:%{http_code}" \
     -u "<sa-email>:<sa-token>" \
     -X DELETE \
     "$TARGET/api/{org_id}/settings/v2/sa_exploit"
   ```
   -> HTTP 200, `{"deleted":true}` — same principal can also remove org-level settings all members depend on.

3. Control — the same POST as an org admin:
   -> HTTP 200 — proves the endpoint is reachable and functional; the SA 200 above is a role-check gap, not a broken environment.

Expected secure: HTTP 403 `"Admin or Root role required for this action"` for both the POST and the DELETE.

**User-level BFLA — actor: a `service_account` role in the org (substitute your own equivalent service-account credentials).**

1. As the service account, POST a setting for a DIFFERENT user (an admin):
   ```
   curl -s -X POST \
     -u "<sa-email>:<sa-token>" \
     -H "Content-Type: application/json" \
     -d '{"setting_key":"pref_theme","setting_value":"hacked"}' \
     "$TARGET/api/{org_id}/settings/v2/user/<other-user-email>"
   ```
   -> HTTP 200, `{"id":2,"scope":"user","user_id":"<other-user-email>","setting_key":"pref_theme","setting_value":"hacked",…}` — the SA wrote user-scoped state for another account without any check that the path `user_id` matched the authenticated caller.

2. Control — the same POST targeting the SA's own `user_id` (self-mutation):
   -> HTTP 200 — legitimate personal-preference write; must remain allowed after the fix.

Expected secure: HTTP 403 for step 1 (target is not the caller and the caller is not Admin/Root); HTTP 200 for step 2 (self-mutation of personal preferences stays open).

## What changed

- `src/handler/http/request/organization/system_settings.rs`:
  - Two new file-private, OSS-only helpers:
    - `assert_admin_role_oss(org_id, user_id)` — HTTP 403 unless the caller is Admin or Root in the org (uses the cached USERS/ORG_USERS lookup via `service::users::get_user`, and honors `is_root_user`).
    - `assert_self_or_admin_oss(org_id, caller, target)` — allows the call when `caller.eq_ignore_ascii_case(target)`, otherwise delegates to `assert_admin_role_oss`.
  - `set_org_setting` and `delete_org_setting` gain a `Headers(user_email): Headers<UserEmail>` extractor and call `assert_admin_role_oss` under `#[cfg(not(feature = "enterprise"))]`.
  - `set_user_setting` and `delete_user_setting` gain the same extractor and call `assert_self_or_admin_oss` under `#[cfg(not(feature = "enterprise"))]`.
  - Reads (`get_setting`, `list_settings`) are unchanged — the finding is scoped to write/delete BFLA and the read-scope policy is a separate call that lives with the v1 handler owner.
- Enterprise builds skip the gate via `cfg` — their existing RBAC middleware continues to enforce authorization.
- Helpers are file-private on purpose. An open PR against `settings.rs` (the v1 handler) introduces a public `crate::handler::http::auth::oss_role_gate::assert_admin_role`; keeping this fix's helpers private avoids a public-API conflict, and once that lands, this file can dedup onto the shared helper.

## Regression test

New `#[cfg(test)] mod tests` at the bottom of `src/handler/http/request/organization/system_settings.rs`, invoking the handler functions directly (no router, no HTTP server, no DB — the OSS `#[cfg]` gate itself is what is under test):

- `service_account_cannot_set_org_v2_setting` — SA POST → 403 (invariant: Admin/Root required).
- `service_account_cannot_delete_org_v2_setting` — SA DELETE → 403 (same invariant).
- `service_account_cannot_set_v2_setting_for_another_user` — SA POST to another user's `user_id` → 403 (invariant: caller must equal target or be Admin/Root).
- `service_account_cannot_delete_v2_setting_for_another_user` — SA DELETE for another user → 403 (same invariant).
- `service_account_can_set_v2_setting_for_self_is_not_forbidden` — SA POST for own `user_id` → not 403 (legitimate self-mutation stays open — the paired green control).
- `admin_is_not_forbidden_on_set_org_v2_setting` — Admin POST → not 403 (proves the 403s above are the role gate firing, not a broken environment).

## Validation

Red before the fix, green after — the tests exercise the same invariant, only the observed behaviour changes.

Red (extractor wired, gate NOT yet installed — the four negative-case assertions fire on the actual `POST` / `DELETE` handler behavior; the DB round-trip returns 400 in the unit-test env because auth never rejected the call first):

```
running 6 tests
test ...admin_is_not_forbidden_on_set_org_v2_setting ... ok
test ...service_account_can_set_v2_setting_for_self_is_not_forbidden ... ok
test ...service_account_cannot_delete_org_v2_setting ... FAILED
test ...service_account_cannot_delete_v2_setting_for_another_user ... FAILED
test ...service_account_cannot_set_org_v2_setting ... FAILED
test ...service_account_cannot_set_v2_setting_for_another_user ... FAILED

failures:
  assertion `left == right` failed: service_account must be blocked from setting org-level v2 settings
    left: 400
   right: 403
  ... (and equivalent for the other three)

test result: FAILED. 2 passed; 4 failed; 0 ignored; 0 measured; 4056 filtered out
```

Green (gate installed):

```
running 6 tests
test ...service_account_cannot_delete_v2_setting_for_another_user ... ok
test ...service_account_cannot_set_v2_setting_for_another_user ... ok
test ...service_account_cannot_set_org_v2_setting ... ok
test ...service_account_cannot_delete_org_v2_setting ... ok
test ...admin_is_not_forbidden_on_set_org_v2_setting ... ok
test ...service_account_can_set_v2_setting_for_self_is_not_forbidden ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 4056 filtered out
```

## Full suite

`cargo test --lib -p openobserve` on this branch: **4028 passed, 16 failed, 18 ignored**. All 6 new regression tests pass. The 16 failures are pre-existing on `main` and unrelated to this change — they fall in `handler::http::request::search::utils::*` (SQL/UDS query-validator tests), `service::sourcemaps::tests` (`no such table: source_maps` in the unit-test SQLite schema), `service::enrichment_table::url_processor::tests`, and `job::config_watcher::tests`. None of them touch `handler::http::request::organization::system_settings` or any file changed by this PR.

## Residual risk

- The reads (`GET /api/{org}/settings/v2` and `GET /api/{org}/settings/v2/{key}`) are intentionally left ungated by this PR — the findings are scoped to writes/deletes, and whether org-level reads should require Admin is a policy call that lives with the v1 handler owner. If a matching read-side finding is opened, the same `assert_admin_role_oss` gate can be applied on the `Path` extractor of the read handlers with no other changes.
- Enterprise builds still rely on their existing middleware for authorization — this PR does not change that path.
- The two helpers duplicate the shape of the shared `oss_role_gate::assert_admin_role` introduced by the parallel open PR against `settings.rs`. This is intentional (private surface, no conflict) and is called out in the code comments so the dedup can land once that PR merges.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_
