### PR TITLE
feat: editable 24-hour absolute time picker(#12940)

### DIFF
--- a/web/src/components/DateTime.spec.ts
+++ b/web/src/components/DateTime.spec.ts
@@ -575,4 +575,144 @@ describe("DateTime Component", () => {
       expect(wrapper.emitted("on:date-change")).toBeTruthy();
     });
   });
+
+  describe("Editable top time range", () => {
+    it("should be editable only in absolute mode (not relative)", () => {
+      wrapper = createWrapper();
+      wrapper.vm.selectedType = "relative";
+      expect(wrapper.vm.isRangeEditable).toBe(false);
+      wrapper.vm.selectedType = "absolute";
+      expect(wrapper.vm.isRangeEditable).toBe(true);
+    });
+
+    it("should not be editable when disableRelative is set", () => {
+      wrapper = createWrapper({ disableRelative: true });
+      // disableRelative forces absolute mode but the date-only display is not
+      // exposed as an editable range.
+      expect(wrapper.vm.isRangeEditable).toBe(false);
+    });
+
+    it("should apply a pasted range with slash date separators", () => {
+      wrapper = createWrapper();
+      wrapper.vm.selectedType = "absolute";
+      wrapper.vm.editingRange =
+        "2026/06/30 14:30:00 - 2026/06/30 15:45:00";
+
+      wrapper.vm.commitRangeEdit(true);
+
+      expect(wrapper.vm.selectedType).toBe("absolute");
+      expect(wrapper.vm.selectedDate.from).toBe("2026/06/30");
+      expect(wrapper.vm.selectedDate.to).toBe("2026/06/30");
+      expect(wrapper.vm.selectedTime.startTime).toBe("14:30:00");
+      expect(wrapper.vm.selectedTime.endTime).toBe("15:45:00");
+      // Editing state is cleared after commit.
+      expect(wrapper.vm.editingRange).toBe(null);
+    });
+
+    it("should accept dash date separators and normalise to slashes", () => {
+      wrapper = createWrapper();
+      wrapper.vm.selectedType = "absolute";
+      wrapper.vm.editingRange =
+        "2026-06-30 14:30:00 - 2026-06-30 15:45:00";
+
+      wrapper.vm.commitRangeEdit(false);
+
+      expect(wrapper.vm.selectedDate.from).toBe("2026/06/30");
+      expect(wrapper.vm.selectedDate.to).toBe("2026/06/30");
+      expect(wrapper.vm.selectedTime.startTime).toBe("14:30:00");
+      expect(wrapper.vm.selectedTime.endTime).toBe("15:45:00");
+    });
+
+    it("should accept a range without seconds", () => {
+      wrapper = createWrapper();
+      wrapper.vm.selectedType = "absolute";
+      wrapper.vm.editingRange = "2026/06/30 08:05 - 2026/06/30 09:10";
+
+      wrapper.vm.commitRangeEdit(false);
+
+      expect(wrapper.vm.selectedTime.startTime).toBe("08:05:00");
+      expect(wrapper.vm.selectedTime.endTime).toBe("09:10:00");
+    });
+
+    it("should revert silently on an invalid range string", () => {
+      wrapper = createWrapper();
+      wrapper.vm.selectedType = "absolute";
+      wrapper.vm.selectedDate = { from: "2026/06/30", to: "2026/06/30" };
+      wrapper.vm.selectedTime = { startTime: "14:30:00", endTime: "15:45:00" };
+
+      wrapper.vm.editingRange = "not a valid timestamp";
+      wrapper.vm.commitRangeEdit(true);
+
+      // Values are unchanged; editing state is cleared.
+      expect(wrapper.vm.selectedDate.from).toBe("2026/06/30");
+      expect(wrapper.vm.selectedTime.startTime).toBe("14:30:00");
+      expect(wrapper.vm.editingRange).toBe(null);
+    });
+
+    it("should reject an impossible calendar date (Feb 30)", () => {
+      wrapper = createWrapper();
+      wrapper.vm.selectedType = "absolute";
+      wrapper.vm.selectedDate = { from: "2026/06/30", to: "2026/06/30" };
+      wrapper.vm.selectedTime = { startTime: "14:30:00", endTime: "15:45:00" };
+
+      wrapper.vm.editingRange = "2026/02/30 10:00:00 - 2026/02/30 11:00:00";
+      wrapper.vm.commitRangeEdit(true);
+
+      // Unchanged — Feb 30 is not a real date.
+      expect(wrapper.vm.selectedDate.from).toBe("2026/06/30");
+      expect(wrapper.vm.selectedTime.startTime).toBe("14:30:00");
+    });
+
+    it("should reject out-of-range time components", () => {
+      wrapper = createWrapper();
+      wrapper.vm.selectedType = "absolute";
+      wrapper.vm.selectedDate = { from: "2026/06/30", to: "2026/06/30" };
+      wrapper.vm.selectedTime = { startTime: "14:30:00", endTime: "15:45:00" };
+
+      wrapper.vm.editingRange = "2026/06/30 25:00:00 - 2026/06/30 26:00:00";
+      wrapper.vm.commitRangeEdit(true);
+
+      expect(wrapper.vm.selectedTime.startTime).toBe("14:30:00");
+    });
+
+    it("should do nothing when commit is called without active editing", () => {
+      wrapper = createWrapper();
+      wrapper.vm.selectedType = "absolute";
+      wrapper.vm.selectedDate = { from: "2026/06/30", to: "2026/06/30" };
+      wrapper.vm.editingRange = null;
+
+      // Should be a no-op (e.g. blur without prior edit).
+      expect(() => wrapper.vm.commitRangeEdit(false)).not.toThrow();
+      expect(wrapper.vm.selectedDate.from).toBe("2026/06/30");
+    });
+
+    it("should emit on:date-change when a valid range is committed (manual apply)", async () => {
+      wrapper = createWrapper({ autoApply: false });
+      store.state.savedViewFlag = false;
+      await wrapper.vm.$nextTick();
+
+      wrapper.vm.selectedType = "absolute";
+      wrapper.vm.editingRange =
+        "2026/06/30 14:30:00 - 2026/06/30 15:45:00";
+      wrapper.vm.commitRangeEdit(true);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted("on:date-change")).toBeTruthy();
+    });
+
+    it("should not open the popover while disabled (div trigger guard)", async () => {
+      wrapper = createWrapper({ disable: true });
+      // The trigger is a <div>, so a native disabled attribute can't block it;
+      // onMenuOpenChange must veto opening while disabled.
+      wrapper.vm.onMenuOpenChange(true);
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.menuOpen).toBe(false);
+    });
+
+    it("should not be editable while disabled", () => {
+      wrapper = createWrapper({ disable: true });
+      wrapper.vm.selectedType = "absolute";
+      expect(wrapper.vm.isRangeEditable).toBe(false);
+    });
+  });
 });

--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -27,21 +27,48 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <template #trigger>
         <OButton
           :data-test="dataTestName"
+          as="div"
           id="date-time-button"
           ref="datetimeBtn"
           data-cy="date-time-button"
+          role="combobox"
+          :aria-expanded="menuOpen"
+          :aria-disabled="disable || undefined"
+          :tabindex="disable ? -1 : 0"
           :variant="variant"
           size="sm-toolbar"
           :class="{
             [selectedType + 'type']: !disableRelative,
             hideRelative: disableRelative,
-            'tw:min-w-[286px]': !disableRelative && selectedType === 'absolute',
+            'tw:min-w-[330px]': !disableRelative && selectedType === 'absolute',
             'tw:w-fit': disableRelative,
+            'tw:cursor-pointer tw:hover:bg-button-outline-hover-bg tw:hover:border-button-outline-hover-border':
+              !disable,
+            'tw:opacity-50 tw:cursor-not-allowed': disable,
           }"
-          :disabled="disable"
           icon-left="schedule"
+          @keydown="onTriggerKeydown"
         >
-          <span class="date-time-label tw:font-semibold tw:flex-1 tw:text-left">{{ getDisplayValue }}</span>
+          <input
+            v-if="isRangeEditable"
+            ref="rangeInputRef"
+            :data-test="`${dataTestName}-range-input`"
+            :value="editingRange ?? getDisplayValue"
+            spellcheck="false"
+            class="date-time-label tw:font-semibold tw:flex-1 tw:text-left tw:bg-transparent tw:outline-none tw:border-0 tw:p-0 tw:min-w-0 tw:cursor-text tw:tabular-nums tw:text-datepicker-text"
+            @mousedown.stop
+            @click.stop
+            @focus="onRangeFocus"
+            @input="editingRange = ($event.target as HTMLInputElement).value"
+            @keydown.enter.stop.prevent="commitRangeEdit(true)"
+            @keydown.esc.stop.prevent="cancelRangeEdit"
+            @blur="commitRangeEdit(false)"
+          />
+          <span
+            v-else
+            class="date-time-label tw:font-semibold tw:flex-1 tw:text-left"
+            >{{ getDisplayValue }}</span
+        >
           <template #icon-right
             ><OIcon name="arrow-drop-down" size="sm" class="date-time-arrow tw:transition-transform tw:duration-250 tw:ml-auto tw:text-[18px]!"
           /></template>
@@ -183,16 +210,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <div class="tw:pr-6 tw:pl-6 tw:text-[0.625rem]">{{ t("common.datetimeMessage") }}</div>
               <OSeparator v-if="!disableRelative" class="tw:my-2" />
 
-              <table v-if="!hideRelativeTime" class="tw:px-3 tw:w-[calc(100%-0.8rem)] tw:mx-[0.4rem] tw:mt-2 tw:mb-[0.3rem] startEndTime">
-                <tbody>
-                  <tr>
-                    <td class="label o-input-label tw:pr-1.5 tw:text-xs tw:font-semibold tw:w-1/2">Start time</td>
-                    <td class="label o-input-label tw:pl-1.5 tw:text-xs tw:font-semibold tw:w-1/2">End time</td>
-                  </tr>
-                  <tr>
-                    <td class="tw:pr-1.5 tw:w-1/2">
+              <div
+                v-if="!hideRelativeTime"
+                class="startEndTime tw:flex tw:px-3 tw:mt-2 tw:mb-[0.3rem]"
+              >
+                <div class="tw:flex-1 tw:flex tw:justify-center">
+                  <div class="tw:flex tw:flex-col tw:gap-1">
+                    <span class="label o-input-label tw:text-xs tw:font-semibold">Start time</span>
                       <OTime
-                        class="tw:w-full"
                         v-model="selectedTime.startTime"
                         with-seconds
                         data-test="datetime-start-time"
@@ -203,10 +228,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           )
                         "
                       />
-                    </td>
-                    <td class="tw:pl-1.5 tw:w-1/2">
+                  </div>
+                </div>
+                <div class="tw:flex-1 tw:flex tw:justify-center">
+                  <div class="tw:flex tw:flex-col tw:gap-1">
+                    <span class="label o-input-label tw:text-xs tw:font-semibold">End time</span>
                       <OTime
-                        class="tw:w-full"
                         v-model="selectedTime.endTime"
                         :with-seconds="true"
                         data-test="datetime-end-time"
@@ -217,10 +244,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           )
                         "
                       />
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+                  </div>
+                </div>
+              </div>
             </div>
           </OTabPanel>
         </OTabPanels>
@@ -933,6 +959,119 @@ export default defineComponent({
       }
     });
 
+    // ── Editable top time range (absolute mode) ──────────────────
+    // Lets users type/paste a full range directly in the toolbar display,
+    // e.g. "2026/06/30 14:30:00 - 2026/06/30 15:00:00" (also accepts "-" date
+    // separators). Applies on Enter or blur; reverts silently on invalid input.
+    const rangeInputRef = ref<HTMLInputElement | null>(null);
+    // Holds the in-progress text while editing; null when not editing (the
+    // input then mirrors getDisplayValue).
+    const editingRange = ref<string | null>(null);
+    const isRangeEditable = computed(
+      () =>
+        !props.disable &&
+        !props.disableRelative &&
+        selectedType.value === "absolute",
+    );
+
+    const onRangeFocus = () => {
+      editingRange.value = getDisplayValue.value as string;
+      nextTick(() => rangeInputRef.value?.select?.());
+    };
+
+    const cancelRangeEdit = () => {
+      editingRange.value = null;
+      rangeInputRef.value?.blur?.();
+    };
+
+    // Parse a single "YYYY/MM/DD HH:MM[:SS]" (or "-" separated) chunk into the
+    // internal { date: 'YYYY/MM/DD', time: 'HH:MM:SS' } shape. Returns null when
+    // the string is not a valid calendar date/time.
+    const parseOneDateTime = (input: string) => {
+      const s = input.trim();
+      const m = s.match(
+        /^(\d{4})[/-](\d{1,2})[/-](\d{1,2})[ T]+(\d{1,2}):(\d{2})(?::(\d{2}))?$/,
+      );
+      if (!m) return null;
+      const year = +m[1];
+      const month = +m[2];
+      const day = +m[3];
+      const hour = +m[4];
+      const minute = +m[5];
+      const second = m[6] ? +m[6] : 0;
+      if (
+        month < 1 ||
+        month > 12 ||
+        day < 1 ||
+        day > 31 ||
+        hour > 23 ||
+        minute > 59 ||
+        second > 59
+      )
+        return null;
+      // Reject impossible dates (e.g. 2026/02/30) by round-tripping.
+      const dt = new Date(year, month - 1, day, hour, minute, second);
+      if (
+        dt.getFullYear() !== year ||
+        dt.getMonth() !== month - 1 ||
+        dt.getDate() !== day
+      )
+        return null;
+      const pad = (n: number) => String(n).padStart(2, "0");
+      return {
+        date: `${year}/${pad(month)}/${pad(day)}`,
+        time: `${pad(hour)}:${pad(minute)}:${pad(second)}`,
+      };
+    };
+
+    // Parse "START - END" (start/end separated by a space-dashed hyphen).
+    const parseRangeString = (raw: string) => {
+      if (!raw) return null;
+      const parts = raw.split(/\s+-\s+/);
+      if (parts.length !== 2) return null;
+      const start = parseOneDateTime(parts[0]);
+      const end = parseOneDateTime(parts[1]);
+      if (!start || !end) return null;
+      return {
+        from: start.date,
+        to: end.date,
+        startTime: start.time,
+        endTime: end.time,
+      };
+    };
+
+    const commitRangeEdit = (fromEnter: boolean) => {
+      // Not editing (e.g. blur without prior focus edit) — nothing to do.
+      if (editingRange.value === null) return;
+      const raw = editingRange.value.trim();
+      const parsed = parseRangeString(raw);
+      // Exit editing regardless; the input falls back to getDisplayValue.
+      editingRange.value = null;
+      if (!parsed) return; // invalid — revert silently to current value
+
+      selectedType.value = "absolute";
+      selectedDate.value.from = parsed.from;
+      selectedDate.value.to = parsed.to;
+      selectedTime.value.startTime = parsed.startTime;
+      selectedTime.value.endTime = parsed.endTime;
+
+      // autoApply consumers apply via the deep selectedDate/selectedTime watcher;
+      // for manual-apply consumers, honour the "apply on Enter/blur" behaviour.
+      if (!props.autoApply) saveDate("absolute");
+      if (fromEnter) rangeInputRef.value?.blur?.();
+    };
+
+    const onTriggerKeydown = (e: KeyboardEvent) => {
+      if (props.disable) return;
+      const onInput = e.target === rangeInputRef.value;
+      if (e.key === "ArrowDown") {
+        menuOpen.value = true;
+      } else if (!onInput && (e.key === "Enter" || e.key === " ")) {
+        e.preventDefault();
+        menuOpen.value = !menuOpen.value;
+      }
+    };
+
     const timezoneFilterFn = (val, update) => {
       filteredTimezone.value = filterColumns(timezoneOptions, val, update);
     };
@@ -1171,6 +1310,13 @@ export default defineComponent({
 
     const menuOpen = ref(false);
     const onMenuOpenChange = (open: boolean) => {
+      // The trigger renders as a <div> (to host the editable range input), so a
+      // native `disabled` attribute can't block interaction the way it did on a
+      // <button>. Guard here: never allow the popover to open while disabled.
+      if (open && props.disable) {
+        menuOpen.value = false;
+        return;
+      }
       if (open) {
         onBeforeShow();
         onShow();
@@ -1216,6 +1362,13 @@ export default defineComponent({
       setAbsoluteTime,
       setRelativeTime,
       getDisplayValue,
+      rangeInputRef,
+      editingRange,
+      isRangeEditable,
+      onRangeFocus,
+      cancelRangeEdit,
+      commitRangeEdit,
+      onTriggerKeydown,
       relativePeriodsMaxValue,
       relativePeriodsSelect,
       computeRelativePeriod,

--- a/web/src/lib/forms/Time/OTime.spec.ts
+++ b/web/src/lib/forms/Time/OTime.spec.ts
@@ -114,19 +114,56 @@ describe("OTime", () => {
     }).not.toThrow();
   });
 
-  it("should display the current time value in the trigger", () => {
+  it("should display the current time value in the trigger (24-hour text input)", () => {
     wrapper = mount(OTime, {
       attachTo: document.body,
       props: { modelValue: "09:30" },
     });
-    // The time value is bound to the native <input type="time"> via :value prop
-    // .text() does not return input values; check the input element's value attribute
-    const input = wrapper.find('input[type="time"]');
+    // The value is bound to a plain text input (24-hour format), not the native
+    // <input type="time"> which renders locale-dependent AM/PM. .text() does not
+    // return input values; check the input element's value directly.
+    const input = wrapper.find('input[type="text"]');
     expect(input.exists()).toBe(true);
-    expect(input.element.value).toBe("09:30");
+    expect((input.element as HTMLInputElement).value).toBe("09:30");
   });
 
-  it("should render the clock face popup after opening", async () => {
+  it("should keep the displayed value in 24-hour format for afternoon times", () => {
+    wrapper = mount(OTime, {
+      attachTo: document.body,
+      props: { modelValue: "14:30:00", withSeconds: true },
+    });
+    const input = wrapper.find('input[type="text"]');
+    expect((input.element as HTMLInputElement).value).toBe("14:30:00");
+  });
+
+  it("should commit a valid typed value on change", async () => {
+    wrapper = mount(OTime, {
+      attachTo: document.body,
+      props: { modelValue: "09:30" },
+    });
+    const input = wrapper.find('input[type="text"]');
+    await input.setValue("18:45");
+    await input.trigger("change");
+    expect(wrapper.emitted("update:modelValue")!.at(-1)![0]).toBe("18:45");
+    expect(wrapper.emitted("change")!.at(-1)![0]).toBe("18:45");
+  });
+
+  it("should reject an invalid typed value and revert to the current value", async () => {
+    wrapper = mount(OTime, {
+      attachTo: document.body,
+      props: { modelValue: "09:30" },
+    });
+    const input = wrapper.find('input[type="text"]');
+    await input.setValue("99:99");
+    await input.trigger("change");
+    // The invalid value must never be committed, and the field reverts to the
+    // last valid value.
+    const emits = wrapper.emitted("update:modelValue") ?? [];
+    expect(emits.some((e) => e[0] === "99:99")).toBe(false);
+    expect((input.element as HTMLInputElement).value).toBe("09:30");
+  });
+
+  it("should render the scroll-picker popup after opening", async () => {
     wrapper = mount(OTime, { attachTo: document.body });
     // Click the PopoverTrigger button (the clock icon button), not the role="group" div
     await wrapper.find('[aria-label="Open time picker"]').trigger("click");
@@ -134,21 +171,57 @@ describe("OTime", () => {
     expect(document.body.querySelector('[data-test="otime-popup"]')).toBeTruthy();
   });
 
-  it("should render the clock face SVG inside the popup", async () => {
+  it("should render hour and minute scroll columns inside the popup", async () => {
     wrapper = mount(OTime, { attachTo: document.body });
     await wrapper.find('[aria-label="Open time picker"]').trigger("click");
     await flushPromises();
     expect(
-      document.body.querySelector('[data-test="otime-clock-face"]'),
+      document.body.querySelector('[role="listbox"][aria-label="Hour"]'),
+    ).toBeTruthy();
+    expect(
+      document.body.querySelector('[role="listbox"][aria-label="Minute"]'),
     ).toBeTruthy();
   });
 
-  it("should render a Close button in the popup", async () => {
-    wrapper = mount(OTime, { attachTo: document.body });
+  it("should render a second scroll column only when withSeconds is set", async () => {
+    wrapper = mount(OTime, {
+      attachTo: document.body,
+      props: { withSeconds: true },
+    });
     await wrapper.find('[aria-label="Open time picker"]').trigger("click");
     await flushPromises();
     expect(
-      document.body.querySelector('[data-test="otime-close"]'),
+      document.body.querySelector('[role="listbox"][aria-label="Second"]'),
     ).toBeTruthy();
+  });
+
+  it("should offer 24 hour options (0-23) in the hour column", async () => {
+    wrapper = mount(OTime, { attachTo: document.body });
+    await wrapper.find('[aria-label="Open time picker"]').trigger("click");
+    await flushPromises();
+    const hourCol = document.body.querySelector(
+      '[role="listbox"][aria-label="Hour"]',
+    );
+    const options = hourCol!.querySelectorAll('[role="option"]');
+    expect(options.length).toBe(24);
+    expect(options[0].textContent?.trim()).toBe("00");
+    expect(options[23].textContent?.trim()).toBe("23");
+  });
+
+  it("should emit the selected hour when a scroll option is clicked", async () => {
+    wrapper = mount(OTime, {
+      attachTo: document.body,
+      props: { modelValue: "09:30" },
+    });
+    await wrapper.find('[aria-label="Open time picker"]').trigger("click");
+    await flushPromises();
+    const hourCol = document.body.querySelector(
+      '[role="listbox"][aria-label="Hour"]',
+    );
+    const options = hourCol!.querySelectorAll('[role="option"]');
+    // Click hour "14"
+    (options[14] as HTMLElement).click();
+    await flushPromises();
+    expect(wrapper.emitted("update:modelValue")!.at(-1)![0]).toBe("14:30");
   });
 });

--- a/web/src/lib/forms/Time/OTime.vue
+++ b/web/src/lib/forms/Time/OTime.vue
@@ -2,7 +2,7 @@
 // Copyright 2026 OpenObserve Inc.
 
 import type { TimeProps, TimeEmits, TimeSlots } from "./OTime.types";
-import { computed, ref, useAttrs, useId, watch } from "vue";
+import { computed, ref, useAttrs, useId, watch, nextTick } from "vue";
 import { PopoverRoot, PopoverTrigger, PopoverContent } from "reka-ui";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
 
@@ -10,7 +10,6 @@ defineOptions({ inheritAttrs: false });
 const $attrs = useAttrs();
 const parentDataTest = computed(() => $attrs["data-test"] as string | undefined);
 
-// Forward tabindex to the real control; keep it off the wrapper (avoids a double tab-stop).
 const inputTabindex = computed(() => $attrs["tabindex"] as number | string | undefined);
 const wrapperAttrs = computed(() => {
   const { tabindex, ...rest } = $attrs;
@@ -39,28 +38,31 @@ const hasError = computed(() => !!effectiveError.value);
 // ── Popover state ──────────────────────────────────────────────
 const popoverOpen = ref(false);
 
-// ── Analog clock state ─────────────────────────────────────────
-type ClockMode = "hour" | "minute" | "second";
-const clockMode = ref<ClockMode>("hour");
-const internalHour = ref(0);   // 0-23
-const internalMinute = ref(0); // 0-59
-const internalSecond = ref(0); // 0-59
+// ── Internal time state ────────────────────────────────────────
+const internalHour = ref(0);
+const internalMinute = ref(0);
+const internalSecond = ref(0);
 
-const isAM = computed(() => internalHour.value < 12);
+// ── Scroll column refs ─────────────────────────────────────────
+const hourColRef = ref<HTMLElement | null>(null);
+const minuteColRef = ref<HTMLElement | null>(null);
+const secondColRef = ref<HTMLElement | null>(null);
+
+const ITEM_HEIGHT = 32; // px per item row
 
 watch(popoverOpen, (open) => {
   if (!open) return;
-  clockMode.value = "hour";
   if (!props.modelValue) {
     internalHour.value = 0;
     internalMinute.value = 0;
     internalSecond.value = 0;
-    return;
-  }
+  } else {
   const parts = props.modelValue.split(":").map(Number);
   internalHour.value = parts[0] ?? 0;
   internalMinute.value = parts[1] ?? 0;
   internalSecond.value = parts[2] ?? 0;
+  }
+  nextTick(() => scrollAllToSelected());
 });
 
 watch(
@@ -74,102 +76,38 @@ watch(
   },
 );
 
-// ── SVG clock geometry ─────────────────────────────────────────
-const SVG_CX = 110;
-const SVG_CY = 110;
-const NUM_RADIUS = 82;
-const HAND_RADIUS = 68;
-
-function calcPos(index: number, total: number, radius: number) {
-  const angle = (index / total) * 2 * Math.PI - Math.PI / 2;
-  return {
-    x: SVG_CX + radius * Math.cos(angle),
-    y: SVG_CY + radius * Math.sin(angle),
-  };
+// ── Scroll helpers ─────────────────────────────────────────────
+function scrollToItem(container: HTMLElement | null, index: number) {
+  if (!container) return;
+  container.scrollTo({ top: index * ITEM_HEIGHT, behavior: "smooth" });
 }
 
-interface ClockNum {
-  value: number;
-  label: string;
-  x: number;
-  y: number;
+function scrollAllToSelected() {
+  scrollToItem(hourColRef.value, internalHour.value);
+  scrollToItem(minuteColRef.value, internalMinute.value);
+  scrollToItem(secondColRef.value, internalSecond.value);
 }
 
-const clockNumbers = computed((): ClockNum[] => {
-  if (clockMode.value === "hour") {
-    return Array.from({ length: 12 }, (_, i) => {
-      const h = i + 1;
-      const index = h % 12;
-      const pos = calcPos(index, 12, NUM_RADIUS);
-      return { value: h, label: String(h), ...pos };
-    });
-  }
-  return Array.from({ length: 12 }, (_, i) => {
-    const pos = calcPos(i, 12, NUM_RADIUS);
-    return { value: i * 5, label: String(i * 5).padStart(2, "0"), ...pos };
-  });
-});
-
-const handPos = computed(() => {
-  let index: number;
-  if (clockMode.value === "hour") {
-    index = internalHour.value % 12;
-  } else {
-    const val =
-      clockMode.value === "minute" ? internalMinute.value : internalSecond.value;
-    index = Math.floor(val / 5) % 12;
-  }
-  return calcPos(index, 12, HAND_RADIUS);
-});
-
-function isClockNumSelected(num: ClockNum): boolean {
-  if (clockMode.value === "hour") {
-    return (internalHour.value % 12 || 12) === num.value;
-  }
-  const val =
-    clockMode.value === "minute" ? internalMinute.value : internalSecond.value;
-  return Math.floor(val / 5) * 5 === num.value;
-}
-
-// ── Clock interactions ─────────────────────────────────────────
-function onClockClick(num: ClockNum) {
+// ── Selection handlers ─────────────────────────────────────────
+function selectHour(h: number) {
   if (props.disabled || props.readonly) return;
-
-  if (clockMode.value === "hour") {
-    const h12 = num.value;
-    const h24 = isAM.value
-      ? h12 === 12 ? 0 : h12
-      : h12 === 12 ? 12 : h12 + 12;
-    internalHour.value = h24;
-    clockMode.value = "minute";
+  internalHour.value = h;
     emitCurrentValue();
-  } else if (clockMode.value === "minute") {
-    internalMinute.value = num.value;
-    emitCurrentValue();
-    if (props.withSeconds) {
-      clockMode.value = "second";
-    } else {
-      popoverOpen.value = false;
-    }
-  } else {
-    internalSecond.value = num.value;
-    emitCurrentValue();
-    popoverOpen.value = false;
-  }
+  scrollToItem(hourColRef.value, h);
 }
 
-function setAM() {
-  if (!isAM.value) {
-    internalHour.value -= 12;
+function selectMinute(m: number) {
+  if (props.disabled || props.readonly) return;
+  internalMinute.value = m;
     emitCurrentValue();
-  }
+  scrollToItem(minuteColRef.value, m);
 }
 
-function setPM() {
-  if (isAM.value) {
-    internalHour.value += 12;
+function selectSecond(s: number) {
+  if (props.disabled || props.readonly) return;
+  internalSecond.value = s;
     emitCurrentValue();
-  }
+  scrollToItem(secondColRef.value, s);
 }
 
 function emitCurrentValue() {
@@ -182,17 +120,6 @@ function emitCurrentValue() {
   emit("change", str);
 }
 
-// ── Header display ─────────────────────────────────────────────
-const displayHour = computed(() =>
-  String(internalHour.value % 12 || 12).padStart(2, "0"),
-);
-const displayMinute = computed(() =>
-  String(internalMinute.value).padStart(2, "0"),
-);
-const displaySecond = computed(() =>
-  String(internalSecond.value).padStart(2, "0"),
-);
-
 // ── Clear ──────────────────────────────────────────────────────
 function handleClear(e: Event) {
   e.stopPropagation();
@@ -200,12 +127,24 @@ function handleClear(e: Event) {
   emit("clear");
 }
 
-// ── Native time input handler ───────────────────────────────
-function handleNativeTimeChange(e: Event) {
-  const val = (e.target as HTMLInputElement).value;
+// ── Time text input handler (24-hour format) ────────────────
+const displayTimeText = computed(() => {
+  if (!props.modelValue) return "";
+  return props.modelValue;
+});
+
+function handleTextTimeChange(e: Event) {
+  const val = (e.target as HTMLInputElement).value.trim();
   if (!val) {
     emit("update:modelValue", "");
     emit("change", "");
+    return;
+  }
+  const timeRegex = props.withSeconds
+    ? /^([01]\d|2[0-3]):([0-5]\d):([0-5]\d)$/
+    : /^([01]\d|2[0-3]):([0-5]\d)$/;
+  if (!timeRegex.test(val)) {
+    (e.target as HTMLInputElement).value = props.modelValue ?? "";
     return;
   }
   const parts = val.split(":").map(Number);
@@ -216,6 +155,11 @@ function handleNativeTimeChange(e: Event) {
   emit("change", val);
 }
 
+// ── Lists for scroll columns ───────────────────────────────────
+const hours = Array.from({ length: 24 }, (_, i) => i);
+const minutes = Array.from({ length: 60 }, (_, i) => i);
+const seconds = Array.from({ length: 60 }, (_, i) => i);
+
 // ── Field wrapper classes ──────────────────────────────────────
 const heightClasses: Record<NonNullable<TimeProps["size"]>, string> = {
   sm: "tw:h-8 tw:text-xs",
@@ -223,7 +167,7 @@ const heightClasses: Record<NonNullable<TimeProps["size"]>, string> = {
 };
 
 const fieldClasses = computed(() => [
-  "tw:flex tw:items-center tw:w-full tw:rounded-md tw:border tw:transition-[color,background-color,border-color,box-shadow] tw:duration-150",
+  "tw:inline-flex tw:items-center tw:w-fit tw:min-w-0 tw:rounded-md tw:border tw:transition-[color,background-color,border-color,box-shadow] tw:duration-150",
   "tw:ring-offset-1 tw:ring-offset-surface-base",
   "tw:bg-datepicker-bg",
   hasError.value
@@ -237,7 +181,7 @@ const fieldClasses = computed(() => [
 </script>
 
 <template>
-  <div v-bind="wrapperAttrs" class="tw:flex tw:flex-col tw:gap-1 tw:w-full">
+  <div v-bind="wrapperAttrs" class="tw:flex tw:flex-col tw:gap-1 tw:w-fit tw:min-w-0">
     <label
       v-if="$slots.label || label || $slots.tooltip"
       :for="inputId"
@@ -275,17 +219,18 @@ const fieldClasses = computed(() => [
         </PopoverTrigger>
 
         <input
-          type="time"
-          :value="modelValue ?? ''"
+          type="text"
+          :value="displayTimeText"
+          :placeholder="withSeconds ? '00:00:00' : '00:00'"
+          :size="withSeconds ? 8 : 5"
           :tabindex="inputTabindex"
-          :step="withSeconds ? 1 : 60"
           :disabled="disabled || undefined"
           :readonly="readonly || undefined"
           :class="[
-            'tw:flex-1 tw:min-w-0 tw:ps-2 tw:bg-transparent tw:outline-none tw:text-datepicker-text',
+            'otime-input tw:min-w-0 tw:ps-2 tw:bg-transparent tw:outline-none tw:text-datepicker-text',
             clearable ? 'tw:pe-2' : 'tw:pe-3',
           ]"
-          @input="handleNativeTimeChange"
+          @change="handleTextTimeChange"
           @focus="emit('focus', $event)"
           @blur="emit('blur', $event)"
         />
@@ -315,189 +260,78 @@ const fieldClasses = computed(() => [
         align="start"
         :class="[
           'tw:z-60 tw:rounded-lg tw:border tw:shadow-md tw:overflow-hidden tw:bg-datepicker-popup-bg tw:border-datepicker-popup-border tw:outline-none',
-          withSeconds ? 'tw:w-64' : 'tw:w-56',
+          withSeconds ? 'tw:w-52' : 'tw:w-36',
         ]"
         data-test="otime-popup"
       >
-        <!-- Time display + AM/PM pill (no heavy header band) -->
-        <div class="tw:flex tw:items-center tw:justify-between tw:px-4 tw:pt-4 tw:pb-2">
-          <!-- Segmented time display -->
-          <div class="tw:flex tw:items-end tw:gap-0.5">
-            <button
-              type="button"
-              :class="[
-                'tw:text-2xl tw:font-semibold tw:tabular-nums tw:rounded-sm tw:px-1 tw:pb-0.5 tw:outline-none tw:ring-offset-1 tw:ring-offset-surface-base tw:transition-[color,background-color,border-color,box-shadow] tw:duration-150 tw:border-b-2 tw:focus-visible:ring-2 tw:focus-visible:ring-datepicker-focus-ring',
-                clockMode === 'hour'
-                  ? 'tw:text-datepicker-day-selected-bg tw:border-datepicker-day-selected-bg'
-                  : 'tw:text-datepicker-heading-text tw:border-transparent tw:hover:text-datepicker-day-selected-bg',
-              ]"
-              :aria-label="`Hour: ${displayHour}`"
-              @click="clockMode = 'hour'"
-            >{{ displayHour }}</button>
-            <span class="tw:text-2xl tw:font-semibold tw:text-datepicker-weekday-text tw:pb-0.5 tw:select-none">:</span>
-            <button
-              type="button"
-              :class="[
-                'tw:text-2xl tw:font-semibold tw:tabular-nums tw:rounded-sm tw:px-1 tw:pb-0.5 tw:outline-none tw:ring-offset-1 tw:ring-offset-surface-base tw:transition-[color,background-color,border-color,box-shadow] tw:duration-150 tw:border-b-2 tw:focus-visible:ring-2 tw:focus-visible:ring-datepicker-focus-ring',
-                clockMode === 'minute'
-                  ? 'tw:text-datepicker-day-selected-bg tw:border-datepicker-day-selected-bg'
-                  : 'tw:text-datepicker-heading-text tw:border-transparent tw:hover:text-datepicker-day-selected-bg',
-              ]"
-              :aria-label="`Minute: ${displayMinute}`"
-              @click="clockMode = 'minute'"
-            >{{ displayMinute }}</button>
-            <template v-if="withSeconds">
-              <span class="tw:text-2xl tw:font-semibold tw:text-datepicker-weekday-text tw:pb-0.5 tw:select-none">:</span>
-              <button
-                type="button"
-                :class="[
-                  'tw:text-2xl tw:font-semibold tw:tabular-nums tw:rounded-sm tw:px-1 tw:pb-0.5 tw:outline-none tw:ring-offset-1 tw:ring-offset-surface-base tw:transition-[color,background-color,border-color,box-shadow] tw:duration-150 tw:border-b-2 tw:focus-visible:ring-2 tw:focus-visible:ring-datepicker-focus-ring',
-                  clockMode === 'second'
-                    ? 'tw:text-datepicker-day-selected-bg tw:border-datepicker-day-selected-bg'
-                    : 'tw:text-datepicker-heading-text tw:border-transparent tw:hover:text-datepicker-day-selected-bg',
-                ]"
-                :aria-label="`Second: ${displaySecond}`"
-                @click="clockMode = 'second'"
-              >{{ displaySecond }}</button>
-            </template>
-          </div>
-
-          <!-- AM / PM horizontal pill -->
+        <!-- Scroll columns -->
+        <div class="tw:flex tw:divide-x tw:divide-datepicker-border otime-scroll-columns">
+          <!-- Hour column -->
           <div
-            class="tw:flex tw:rounded-md tw:border tw:border-datepicker-border tw:overflow-hidden tw:ms-3 tw:shrink-0"
+            ref="hourColRef"
+            class="tw:flex-1 tw:overflow-y-auto tw:h-[224px] otime-scroll-col"
+            role="listbox"
+            aria-label="Hour"
           >
-            <button
-              type="button"
-              :class="[
-                'tw:px-2.5 tw:py-1 tw:text-xs tw:font-medium tw:outline-none tw:ring-offset-1 tw:ring-offset-surface-base tw:transition-[color,background-color,border-color,box-shadow] tw:duration-150 tw:focus-visible:ring-2 tw:focus-visible:ring-datepicker-focus-ring',
-                isAM
-                  ? 'tw:bg-datepicker-day-selected-bg tw:text-datepicker-day-selected-text'
-                  : 'tw:text-datepicker-weekday-text tw:hover:bg-datepicker-clock-hover-bg',
-              ]"
-              aria-label="AM"
-              @click="setAM"
-            >AM</button>
-            <div class="tw:w-px tw:bg-datepicker-border tw:shrink-0" aria-hidden="true" />
-            <button
-              type="button"
-              :class="[
-                'tw:px-2.5 tw:py-1 tw:text-xs tw:font-medium tw:outline-none tw:ring-offset-1 tw:ring-offset-surface-base tw:transition-[color,background-color,border-color,box-shadow] tw:duration-150 tw:focus-visible:ring-2 tw:focus-visible:ring-datepicker-focus-ring',
-                !isAM
-                  ? 'tw:bg-datepicker-day-selected-bg tw:text-datepicker-day-selected-text'
-                  : 'tw:text-datepicker-weekday-text tw:hover:bg-datepicker-clock-hover-bg',
-              ]"
-              aria-label="PM"
-              @click="setPM"
-            >PM</button>
+            <div
+              v-for="h in hours"
+              :key="h"
+              role="option"
+              :aria-selected="h === internalHour"
+                :class="[
+                'tw:h-8 tw:flex tw:items-center tw:justify-center tw:text-sm tw:cursor-pointer tw:select-none tw:tabular-nums tw:transition-colors tw:duration-100',
+                h === internalHour
+                  ? 'tw:text-datepicker-day-selected-bg tw:font-semibold tw:border tw:border-datepicker-day-selected-bg tw:rounded-sm tw:mx-1'
+                  : 'tw:text-datepicker-day-text tw:hover:bg-datepicker-clock-hover-bg tw:mx-1 tw:rounded-sm',
+                ]"
+              @click="selectHour(h)"
+            >{{ String(h).padStart(2, '0') }}</div>
           </div>
-        </div>
 
-        <!-- Clock face SVG -->
-        <div class="tw:px-3 tw:pb-1 tw:flex tw:justify-center">
-          <svg
-            viewBox="0 0 220 220"
-            width="200"
-            height="200"
-            role="img"
-            :aria-label="`Select ${clockMode}`"
-            data-test="otime-clock-face"
+          <!-- Minute column -->
+          <div
+            ref="minuteColRef"
+            class="tw:flex-1 tw:overflow-y-auto tw:h-[224px] otime-scroll-col"
+            role="listbox"
+            aria-label="Minute"
           >
-            <circle
-              cx="110"
-              cy="110"
-              r="100"
-              class="tw:fill-datepicker-clock-face-bg tw:stroke-datepicker-popup-border"
-              stroke-width="1"
-            />
-            <line
-              x1="110"
-              y1="110"
-              :x2="handPos.x"
-              :y2="handPos.y"
-              class="tw:stroke-datepicker-clock-hand"
-              stroke-width="2"
-              stroke-linecap="round"
-            />
-            <circle cx="110" cy="110" r="4" class="tw:fill-datepicker-clock-hand" />
-            <g
-              v-for="num in clockNumbers"
-              :key="num.value"
-              role="button"
-              tabindex="0"
-              :aria-label="`${num.label} ${clockMode}`"
-              :aria-pressed="isClockNumSelected(num)"
-              class="tw:cursor-pointer tw:group"
-              @click="onClockClick(num)"
-              @keydown.enter.prevent="onClockClick(num)"
-              @keydown.space.prevent="onClockClick(num)"
-            >
-              <circle
-                :cx="num.x"
-                :cy="num.y"
-                r="15"
-                :class="isClockNumSelected(num)
-                  ? 'tw:fill-datepicker-clock-selected-bg'
-                  : 'tw:fill-transparent tw:group-hover:fill-datepicker-clock-hover-bg'"
-              />
-              <text
-                :x="num.x"
-                :y="num.y"
-                text-anchor="middle"
-                dominant-baseline="central"
-                font-size="13"
-                class="tw:pointer-events-none tw:select-none"
-                :class="isClockNumSelected(num)
-                  ? 'tw:fill-datepicker-clock-selected-text'
-                  : 'tw:fill-datepicker-day-text'"
-              >{{ num.label }}</text>
-            </g>
-          </svg>
+            <div
+              v-for="m in minutes"
+              :key="m"
+              role="option"
+              :aria-selected="m === internalMinute"
+              :class="[
+                'tw:h-8 tw:flex tw:items-center tw:justify-center tw:text-sm tw:cursor-pointer tw:select-none tw:tabular-nums tw:transition-colors tw:duration-100',
+                m === internalMinute
+                  ? 'tw:text-datepicker-day-selected-bg tw:font-semibold tw:border tw:border-datepicker-day-selected-bg tw:rounded-sm tw:mx-1'
+                  : 'tw:text-datepicker-day-text tw:hover:bg-datepicker-clock-hover-bg tw:mx-1 tw:rounded-sm',
+              ]"
+              @click="selectMinute(m)"
+            >{{ String(m).padStart(2, '0') }}</div>
         </div>
 
-        <!-- Footer: step dots + Close -->
-        <div class="tw:flex tw:items-center tw:justify-between tw:px-4 tw:pb-3">
-          <div class="tw:flex tw:items-center tw:gap-1.5" role="group" aria-label="Step">
-            <button
-              type="button"
-              :class="[
-                'tw:rounded-full tw:transition-all tw:outline-none tw:ring-offset-1 tw:ring-offset-surface-base tw:focus-visible:ring-2 tw:focus-visible:ring-datepicker-focus-ring',
-                clockMode === 'hour'
-                  ? 'tw:w-4 tw:h-2 tw:bg-datepicker-day-selected-bg'
-                  : 'tw:size-2 tw:bg-datepicker-border tw:hover:bg-datepicker-weekday-text',
-              ]"
-              aria-label="Hour"
-              @click="clockMode = 'hour'"
-            />
-            <button
-              type="button"
-              :class="[
-                'tw:rounded-full tw:transition-all tw:outline-none tw:ring-offset-1 tw:ring-offset-surface-base tw:focus-visible:ring-2 tw:focus-visible:ring-datepicker-focus-ring',
-                clockMode === 'minute'
-                  ? 'tw:w-4 tw:h-2 tw:bg-datepicker-day-selected-bg'
-                  : 'tw:size-2 tw:bg-datepicker-border tw:hover:bg-datepicker-weekday-text',
-              ]"
-              aria-label="Minute"
-              @click="clockMode = 'minute'"
-            />
-            <button
+          <!-- Second column (conditional) -->
+          <div
               v-if="withSeconds"
-              type="button"
+            ref="secondColRef"
+            class="tw:flex-1 tw:overflow-y-auto tw:h-[224px] otime-scroll-col"
+            role="listbox"
+            aria-label="Second"
+          >
+            <div
+              v-for="s in seconds"
+              :key="s"
+              role="option"
+              :aria-selected="s === internalSecond"
               :class="[
-                'tw:rounded-full tw:transition-all tw:outline-none tw:ring-offset-1 tw:ring-offset-surface-base tw:focus-visible:ring-2 tw:focus-visible:ring-datepicker-focus-ring',
-                clockMode === 'second'
-                  ? 'tw:w-4 tw:h-2 tw:bg-datepicker-day-selected-bg'
-                  : 'tw:size-2 tw:bg-datepicker-border tw:hover:bg-datepicker-weekday-text',
+                'tw:h-8 tw:flex tw:items-center tw:justify-center tw:text-sm tw:cursor-pointer tw:select-none tw:tabular-nums tw:transition-colors tw:duration-100',
+                s === internalSecond
+                  ? 'tw:text-datepicker-day-selected-bg tw:font-semibold tw:border tw:border-datepicker-day-selected-bg tw:rounded-sm tw:mx-1'
+                  : 'tw:text-datepicker-day-text tw:hover:bg-datepicker-clock-hover-bg tw:mx-1 tw:rounded-sm',
               ]"
-              aria-label="Second"
-              @click="clockMode = 'second'"
-            />
+              @click="selectSecond(s)"
+            >{{ String(s).padStart(2, '0') }}</div>
           </div>
-          <button
-            type="button"
-            class="tw:text-xs tw:font-medium tw:text-datepicker-day-selected-bg tw:outline-none tw:ring-offset-1 tw:ring-offset-surface-base tw:hover:opacity-80 tw:focus-visible:ring-2 tw:focus-visible:ring-datepicker-focus-ring tw:transition-[box-shadow] tw:duration-150"
-            data-test="otime-close"
-            @click="popoverOpen = false"
-          >Close</button>
         </div>
       </PopoverContent>
     </PopoverRoot>
@@ -524,8 +358,20 @@ const fieldClasses = computed(() => [
 </template>
 
 <style>
-/* Hide the native browser clock picker dropdown */
-input[type="time"]::-webkit-calendar-picker-indicator {
-  display: none;
+/* Size the input exactly to its content where supported (Chrome/Edge/Safari).
+   The `size` attribute remains as a fallback for browsers without field-sizing. */
+.otime-input {
+  field-sizing: content;
+}
+
+.otime-scroll-col::-webkit-scrollbar {
+  width: 4px;
+}
+.otime-scroll-col::-webkit-scrollbar-thumb {
+  background-color: var(--o2-border, #ddd);
+  border-radius: 2px;
+}
+.otime-scroll-col::-webkit-scrollbar-track {
+  background: transparent;
 }
 </style>


### PR DESCRIPTION
Reworks the absolute time range picker for log investigation (#12940):

- Switch time inputs to 24-hour format, replacing the locale-dependent native <input type="time"> (which rendered AM/PM) with a validated 24-hour text field.
- Replace the analog clock popup with a scrollable hour/minute/second column picker (hours 0-23).
- Make the top time-range display editable: type or paste a full range (e.g. 2026/06/30 14:30:00 - 2026/06/30 15:45:00, accepts "-" or "/" date separators), applied on Enter or blur, reverted on invalid input.
- Lay out Start/End time fields as two centered halves with labels at the top-left, and widen the trigger so the full range is not clipped.

Guards the div-based trigger against opening while disabled and updates the OTime/DateTime unit tests to cover the new behavior.

---
Developed with AI assistance (Kiro).