### PR TITLE
ci: refine e2e gate — label always runs + skip unrelated workflow changes

### DIFF
--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -47,11 +47,15 @@ jobs:
 
       - id: check
         run: |
-          # Skip the suite when a PR touches only docs, images, or frontend/UI-test files
-          # (none affect the API). Anything else — source, workflows (incl. this file) — runs it.
-          IGNORE_RE='(\.md$|^docs/|^web/|^tests/ui-testing/|^tests/playwright-tests/|\.(png|jpe?g|gif|svg|webp)$)'
+          # Skip when a PR touches only docs, images, frontend/UI-test files, or unrelated
+          # workflow files (none affect the API). Source and this workflow (api-testing.yml)
+          # still run the suite.
+          IGNORE_RE='(\.md$|^docs/|^web/|^tests/ui-testing/|^tests/playwright-tests/|\.(png|jpe?g|gif|svg|webp)$|^\.github/workflows/)'
           CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }} ${{ github.sha }})
-          if [ -z "$CHANGED" ] || echo "$CHANGED" | grep -qvE "$IGNORE_RE"; then
+          # Files not matching IGNORE_RE; captured (not `grep -qv`) so the check doesn't depend
+          # on grep -qv exit semantics, which differ across grep builds.
+          RELEVANT=$(printf '%s' "$CHANGED" | grep -vE "$IGNORE_RE" || true)
+          if [ -z "$CHANGED" ] || [ -n "$RELEVANT" ] || printf '%s' "$CHANGED" | grep -qE '^\.github/workflows/api-testing\.yml$'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -48,12 +48,14 @@ jobs:
       - id: check
         run: |
           # Skip when a PR touches only docs, images, frontend/UI-test files, or unrelated
-          # workflow files (none affect the API). Source and this workflow (api-testing.yml)
-          # still run the suite.
+          # workflow files (e.g. a dependabot bump to another workflow) — none affect the API.
+          # Source and this workflow (api-testing.yml) still run the suite.
           IGNORE_RE='(\.md$|^docs/|^web/|^tests/ui-testing/|^tests/playwright-tests/|\.(png|jpe?g|gif|svg|webp)$|^\.github/workflows/)'
           CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }} ${{ github.sha }})
-          # Files not matching IGNORE_RE; captured (not `grep -qv`) so the check doesn't depend
-          # on grep -qv exit semantics, which differ across grep builds.
+          # Files not matching IGNORE_RE. Captured (not `grep -qv`) so the check doesn't depend
+          # on grep -qv exit semantics, which differ across grep builds; the `|| true` keeps
+          # `set -e` from aborting when grep matches nothing (exit 1). The `grep -qE` below is a
+          # loop-safe `if`-condition term (`set -e` doesn't fire there), so it needs no `|| true`.
           RELEVANT=$(printf '%s' "$CHANGED" | grep -vE "$IGNORE_RE" || true)
           if [ -z "$CHANGED" ] || [ -n "$RELEVANT" ] || printf '%s' "$CHANGED" | grep -qE '^\.github/workflows/api-testing\.yml$'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -65,9 +65,10 @@ jobs:
     name: api_integration_tests
     needs: [check_changes]
     if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'e2e')) ||
+      (github.event_name != 'pull_request' &&
+       needs.check_changes.outputs.has_changes == 'true')
     runs-on: ubicloud-standard-4
     permissions:
       contents: read  # only need to checkout the repo
@@ -177,9 +178,10 @@ jobs:
     name: "api_query_agent / ${{ matrix.config.label }}"
     needs: [check_changes]
     if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'e2e')) ||
+      (github.event_name != 'pull_request' &&
+       needs.check_changes.outputs.has_changes == 'true')
     runs-on: ubicloud-standard-4
     # Run the full SQL regression suite with the single-node physical
     # optimizer both enabled (default) and disabled. The non-optimized
@@ -297,9 +299,10 @@ jobs:
     name: "api_regression / ${{ matrix.config.label }}"
     needs: [check_changes]
     if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'e2e')) ||
+      (github.event_name != 'pull_request' &&
+       needs.check_changes.outputs.has_changes == 'true')
     runs-on: ubicloud-standard-4
     permissions:
       contents: read  # only need to checkout the repo
@@ -414,9 +417,10 @@ jobs:
     name: api_fuzz_tests
     needs: [check_changes]
     if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'e2e')) ||
+      (github.event_name != 'pull_request' &&
+       needs.check_changes.outputs.has_changes == 'true')
     runs-on: ubicloud-standard-4
     continue-on-error: true
     permissions:
@@ -541,21 +545,25 @@ jobs:
             exit 1
           fi
 
-          # 2. No API-relevant changes (docs/frontend/meta only) → the suite legitimately did
-          #    not run. Allow the merge; no 'e2e' label required.
-          if [ "${{ needs.check_changes.outputs.has_changes }}" != "true" ]; then
-            echo "✅ No API-relevant file changes — API suite not required for this PR."
+          # 2. On a pull_request WITHOUT the 'e2e' label the suite did not run: block (fail)
+          #    when the change is API-relevant so the author opts in, else bypass (pass).
+          #    Adding the 'e2e' label always runs the suite (see the test jobs' if).
+          if [ "${{ github.event_name }}" == "pull_request" ] && \
+             [ "${{ contains(github.event.pull_request.labels.*.name, 'e2e') }}" != "true" ]; then
+            if [ "${{ needs.check_changes.outputs.has_changes }}" == "true" ]; then
+              echo "::error::This PR changes API-relevant files but has no 'e2e' label, so the suite did not run."
+              echo "::error::Add the 'e2e' label to the PR to run the full test suite before merging."
+              exit 1
+            fi
+            echo "✅ No API-relevant changes and no 'e2e' label — suite not required for this PR."
             exit 0
           fi
 
-          # 3. The change IS API-relevant. On a pull_request it must carry the 'e2e' label,
-          #    otherwise the suite was intentionally not run and we BLOCK the merge until the
-          #    author opts in. (push to main / merge_group are never label-gated.)
-          if [ "${{ github.event_name }}" == "pull_request" ] && \
-             [ "${{ contains(github.event.pull_request.labels.*.name, 'e2e') }}" != "true" ]; then
-            echo "::error::This PR changes API-relevant files but has no 'e2e' label, so the API suite did not run."
-            echo "::error::Add the 'e2e' label to the PR to run the full test suite before merging."
-            exit 1
+          # 3. Non-PR event (push / merge queue) with nothing relevant → nothing ran → allow.
+          if [ "${{ github.event_name }}" != "pull_request" ] && \
+             [ "${{ needs.check_changes.outputs.has_changes }}" != "true" ]; then
+            echo "✅ No API-relevant changes — suite not required."
+            exit 0
           fi
 
           # 4. Suite was expected to run — the gating jobs must have succeeded.

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -68,11 +68,14 @@ jobs:
 
       - id: check
         run: |
-          # Skip the suite when a PR touches only docs or images. Anything else — source,
-          # web/, workflows (incl. this file) — runs the suite.
-          IGNORE_RE='(\.md$|^docs/|\.(png|jpe?g|gif|svg|webp)$)'
+          # Skip when a PR touches only docs, images, or unrelated workflow files. Source,
+          # web/, and this workflow (playwright.yml) still run the suite.
+          IGNORE_RE='(\.md$|^docs/|\.(png|jpe?g|gif|svg|webp)$|^\.github/workflows/)'
           CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }} ${{ github.sha }})
-          if [ -z "$CHANGED" ] || echo "$CHANGED" | grep -qvE "$IGNORE_RE"; then
+          # Files not matching IGNORE_RE; captured (not `grep -qv`) so the check doesn't depend
+          # on grep -qv exit semantics, which differ across grep builds.
+          RELEVANT=$(printf '%s' "$CHANGED" | grep -vE "$IGNORE_RE" || true)
+          if [ -z "$CHANGED" ] || [ -n "$RELEVANT" ] || printf '%s' "$CHANGED" | grep -qE '^\.github/workflows/playwright\.yml$'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -68,12 +68,15 @@ jobs:
 
       - id: check
         run: |
-          # Skip when a PR touches only docs, images, or unrelated workflow files. Source,
-          # web/, and this workflow (playwright.yml) still run the suite.
+          # Skip when a PR touches only docs, images, or unrelated workflow files (e.g. a
+          # dependabot bump to another workflow) — none can affect the app. Source, web/, and
+          # this workflow (playwright.yml) still run the suite.
           IGNORE_RE='(\.md$|^docs/|\.(png|jpe?g|gif|svg|webp)$|^\.github/workflows/)'
           CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }} ${{ github.sha }})
-          # Files not matching IGNORE_RE; captured (not `grep -qv`) so the check doesn't depend
-          # on grep -qv exit semantics, which differ across grep builds.
+          # Files not matching IGNORE_RE. Captured (not `grep -qv`) so the check doesn't depend
+          # on grep -qv exit semantics, which differ across grep builds; the `|| true` keeps
+          # `set -e` from aborting when grep matches nothing (exit 1). The `grep -qE` below is a
+          # loop-safe `if`-condition term (`set -e` doesn't fire there), so it needs no `|| true`.
           RELEVANT=$(printf '%s' "$CHANGED" | grep -vE "$IGNORE_RE" || true)
           if [ -z "$CHANGED" ] || [ -n "$RELEVANT" ] || printf '%s' "$CHANGED" | grep -qE '^\.github/workflows/playwright\.yml$'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -88,9 +88,10 @@ jobs:
     # Run when there are e2e-relevant changes AND either this is not a pull_request
     # (push to main / merge_group always run) or the PR carries the 'e2e' label.
     if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'e2e')) ||
+      (github.event_name != 'pull_request' &&
+       needs.check_changes.outputs.has_changes == 'true')
     runs-on:
       labels: ubicloud-standard-16
     permissions:
@@ -1284,21 +1285,25 @@ jobs:
             exit 1
           fi
 
-          # 2. No e2e-relevant changes (docs/images/meta only) → the suite legitimately did
-          #    not run. Allow the merge; no 'e2e' label required.
-          if [ "${{ needs.check_changes.outputs.has_changes }}" != "true" ]; then
-            echo "✅ No e2e-relevant file changes — Playwright suite not required for this PR."
+          # 2. On a pull_request WITHOUT the 'e2e' label the suite did not run: block (fail)
+          #    when the change is Playwright-relevant so the author opts in, else bypass (pass).
+          #    Adding the 'e2e' label always runs the suite (see build_binary's if).
+          if [ "${{ github.event_name }}" == "pull_request" ] && \
+             [ "${{ contains(github.event.pull_request.labels.*.name, 'e2e') }}" != "true" ]; then
+            if [ "${{ needs.check_changes.outputs.has_changes }}" == "true" ]; then
+              echo "::error::This PR changes Playwright-relevant files but has no 'e2e' label, so the suite did not run."
+              echo "::error::Add the 'e2e' label to the PR to run the full Playwright suite before merging."
+              exit 1
+            fi
+            echo "✅ No Playwright-relevant changes and no 'e2e' label — suite not required for this PR."
             exit 0
           fi
 
-          # 3. The change IS e2e-relevant. On a pull_request it must carry the 'e2e' label,
-          #    otherwise the suite was intentionally not run and we BLOCK the merge until the
-          #    author opts in. (push to main / merge_group are never label-gated.)
-          if [ "${{ github.event_name }}" == "pull_request" ] && \
-             [ "${{ contains(github.event.pull_request.labels.*.name, 'e2e') }}" != "true" ]; then
-            echo "::error::This PR changes e2e-relevant files but has no 'e2e' label, so the Playwright suite did not run."
-            echo "::error::Add the 'e2e' label to the PR to run the full Playwright suite before merging."
-            exit 1
+          # 3. Non-PR event (push / merge queue) with nothing relevant → nothing ran → allow.
+          if [ "${{ github.event_name }}" != "pull_request" ] && \
+             [ "${{ needs.check_changes.outputs.has_changes }}" != "true" ]; then
+            echo "✅ No Playwright-relevant changes — suite not required."
+            exit 0
           fi
 
           # 4. Suite was expected to run — pass only if build + tests actually succeeded.


### PR DESCRIPTION
Two refinements to the `e2e` label gate (Playwright + API, OSS + ENT).

## 1. Adding the `e2e` label always runs the suite

Previously the auto-bypass could override the label — add `e2e` to an otherwise-skippable PR and nothing ran, which was confusing. Now the label is an explicit **"run it"**: it always runs the full suite. Without the label, the skip logic still decides.

| Event | `e2e` label | Change | Result |
|---|---|---|---|
| PR | **yes** | anything (even docs) | **run full suite** → pass/fail on results |
| PR | no | relevant (code) | **block** (fail, "add label") |
| PR | no | skip category (docs / unrelated workflow) | **pass, no run** |
| push / merge queue / dispatch | n/a | relevant | run |
| push / merge queue / dispatch | n/a | nothing relevant | pass, no run |

Gate flips from `has_changes && (non-PR || label)` to `(PR && label) || (non-PR && has_changes)`; the summary is reworked to match.

## 2. Unrelated workflow changes no longer require e2e

`check_changes` treated **any** `.github/workflows/**` change as relevant, so a Dependabot bump to an unrelated workflow (openobserve#13060, `update-translations.yml`) demanded the label. Now workflow files are bypassed by default; only a change to the suite's **own** workflow (`playwright.yml` / `api-testing.yml`) triggers it. Implemented with captured non-ignored lines instead of `grep -qv` (portable across grep builds).

## Note

This PR changes `playwright.yml` + `api-testing.yml`, so it correctly **needs the `e2e` label** to run. Sibling PR on the other repo uses the same branch `ci/e2e-skip-unrelated-workflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)