### PR TITLE
fix: self_reporting_timeout_errors and self_reporting_dropped_triggers metrics label mismatch

### DIFF
--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -1597,7 +1597,7 @@ pub static SELF_REPORTING_DROPPED_TRIGGERS: Lazy<IntCounterVec> = Lazy::new(|| {
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &[],
+        &["queue_type"], // "usage" or "error"
     )
     .expect("Metric created")
 });
@@ -1610,7 +1610,7 @@ pub static SELF_REPORTING_TIMEOUT_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &[],
+        &["queue_type"], // "usage" or "error"
     )
     .expect("Metric created")
 });

--- a/src/service/self_reporting/mod.rs
+++ b/src/service/self_reporting/mod.rs
@@ -309,7 +309,7 @@ pub fn publish_triggers_usage(trigger: TriggerData) {
 
             // Increment dropped triggers metric
             metrics::SELF_REPORTING_DROPPED_TRIGGERS
-                .with_label_values(&[""])
+                .with_label_values(&["usage"])
                 .inc();
         }
         Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
@@ -377,7 +377,7 @@ pub async fn publish_error(error_data: ErrorData) {
                 error_source
             );
             metrics::SELF_REPORTING_TIMEOUT_ERRORS
-                .with_label_values(&[""])
+                .with_label_values(&["error"])
                 .inc();
         }
         Err(EnqueueError::SendFailed(e)) => {


### PR DESCRIPTION
The two metrics were using an empty string as the label name even though no label names were registered in the metrics. Hence, whenever this metric is emitted, there is a runtime panic. This pr fixes that.