### PR TITLE
fix: accept new Power Automate webhook URLs for Microsoft Teams destinations

### DIFF
--- a/web/src/utils/prebuilt-templates/msteams.spec.ts
+++ b/web/src/utils/prebuilt-templates/msteams.spec.ts
@@ -58,9 +58,24 @@ describe('msteams template', () => {
       expect(typeof msteamsConfig.urlValidator).toBe('function');
     });
 
-    it('URL validator accepts valid MS Teams webhook URLs', () => {
+    it('URL validator accepts valid legacy MS Teams webhook URLs', () => {
       expect(msteamsConfig.urlValidator('https://outlook.office.com/webhook/xxx')).toBe(true);
       expect(msteamsConfig.urlValidator('https://webhook.office.com/webhookb2/xxx')).toBe(true);
+      expect(msteamsConfig.urlValidator('https://default.logic.azure.com/workflows/xxx/triggers/manual/paths/invoke')).toBe(true);
+    });
+
+    it('URL validator accepts valid Power Automate webhook URLs', () => {
+      expect(
+        msteamsConfig.urlValidator(
+          'https://default.1.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sig=abc123'
+        )
+      ).toBe(true);
+      // Optional "cu/<n>" segment some tenants show (appears before "workflows")
+      expect(
+        msteamsConfig.urlValidator(
+          'https://default.1.environment.api.powerplatform.com/powerautomate/automations/direct/cu/1/workflows/abc123/triggers/manual/paths/invoke'
+        )
+      ).toBe(true);
     });
 
     it('URL validator rejects invalid URLs', () => {
@@ -68,6 +83,12 @@ describe('msteams template', () => {
       expect(msteamsConfig.urlValidator('http://outlook.office.com/webhook/xxx')).toBe(false);
       expect(msteamsConfig.urlValidator('https://evil.com?outlook.office.com=fake')).toBe(false);
       expect(msteamsConfig.urlValidator('invalid-url')).toBe(false);
+      expect(
+        msteamsConfig.urlValidator(
+          'https://default.1.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/wrong'
+        )
+      ).toBe(false);
+      expect(msteamsConfig.urlValidator('http://default.1.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke')).toBe(false);
     });
 
     it('webhook URL validator validates MS Teams URLs', () => {

--- a/web/src/utils/prebuilt-templates/msteams.ts
+++ b/web/src/utils/prebuilt-templates/msteams.ts
@@ -15,15 +15,29 @@
 import { PrebuiltConfig } from './types';
 
 const TEAMS_WEBHOOK_ALLOWED_HOSTS = ['outlook.office.com', 'webhook.office.com'];
+const LOGIC_APPS_HOST_REGEX = /(^|\.)logic\.azure\.com$/;
+
+const POWER_AUTOMATE_HOST_REGEX =
+  /^[a-z0-9]+\.[0-9]+\.environment\.api\.powerplatform\.com$/;
+const POWER_AUTOMATE_PATH_REGEX =
+  /^\/powerautomate\/automations\/direct(?:\/cu\/[0-9]+)?\/workflows\/[a-f0-9-]+\/triggers\/manual\/paths\/invoke\/?$/;
 
 function isValidTeamsWebhookUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') return false;
+
     const hostname = parsed.hostname.toLowerCase();
-    return (
-      parsed.protocol === 'https:' &&
-      TEAMS_WEBHOOK_ALLOWED_HOSTS.includes(hostname)
-    );
+
+    const isLegacyWebhook =
+      TEAMS_WEBHOOK_ALLOWED_HOSTS.includes(hostname) ||
+      LOGIC_APPS_HOST_REGEX.test(hostname);
+
+    const isPowerAutomateWebhook =
+      POWER_AUTOMATE_HOST_REGEX.test(hostname) &&
+      POWER_AUTOMATE_PATH_REGEX.test(parsed.pathname);
+
+    return isLegacyWebhook || isPowerAutomateWebhook;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
Microsoft deprecated the legacy Teams "Incoming Webhook" connector (`webhook.office.com`/`outlook.office.com`) starting August 2024 and fully retired it December 25, 2025, migrating users to Power Automate workflow URLs instead (`*.environment.api.powerplatform.com`). OpenObserve's Teams destination validator only recognized the legacy hosts, so it rejected every valid new-format webhook with "Invalid Microsoft Teams webhook URL", blocking users from creating Teams alert destinations.

Fixes #12773

## Changes
`web/src/utils/prebuilt-templates/msteams.ts`:
- Kept the legacy `outlook.office.com` / `webhook.office.com` allow-list, and added `logic.azure.com` (and its regional subdomains, e.g. `prod-31.westus.logic.azure.com`) as a legacy host, since some workflow-hosted webhooks use that domain too.
- Added support for the current Power Automate host/path shape:
  - Host: `<env-id>.<region>.environment.api.powerplatform.com`
  - Path: `/powerautomate/automations/direct[/cu/<n>]/workflows/<workflow-id>/triggers/manual/paths/invoke`, where the optional `cu/<n>` segment (some tenants show this) appears before `workflows`.
- Still requires `https:` for both formats; query string (`api-version`, `sp`, `sv`, `sig`) is left unrestricted since it varies per tenant/signature.

## Testing
- Validated the new host/path regex directly against a real, live Power Automate Teams webhook URL (structure confirmed to include the `cu/<n>` segment before `workflows`, not after the workflow ID as the issue's redacted example suggested) — not committed to the repo for obvious credential-exposure reasons, but confirmed the fixed regex matches it and the original regex did not.
- Added unit tests in `msteams.spec.ts` covering: legacy `webhook.office.com`/`outlook.office.com` URLs, `logic.azure.com` workflow URLs, Power Automate URLs with and without the `cu/<n>` segment, and negative cases (wrong path suffix, `http://` instead of `https://`, unrelated hosts).

## Related

PR #12872 also addresses this issue, using a slightly different approach (checking if the host ends with a known suffix, and if the path contains certain segments). That works for the common cases, but it's a bit more permissive than needed, it can match paths and hosts that aren't quite right structurally.

This PR takes a stricter approach: it checks the full expected shape of the URL (host format + exact path structure) using a real Power Automate webhook URL to confirm the pattern, including a `cu/<n>` segment some tenants have (which appears *before* `workflows`, not after the workflow ID). Happy to help reconcile the two approaches if that's useful for the maintainers.

