### PR TITLE
fix: traces duration filter issue

### DIFF
--- a/web/src/composables/useTraces.ts
+++ b/web/src/composables/useTraces.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { reactive, computed, nextTick } from "vue";
+import { reactive, computed, nextTick, shallowRef } from "vue";
 import {
   b64EncodeStandard,
   b64EncodeUnicode,
@@ -193,6 +193,27 @@ export const DEFAULT_TRACE_COLUMNS: Record<"traces" | "spans", string[]> = {
     "status",
     "service_latency",
   ],
+};
+
+// Shared SQL parser singleton — loaded once by Index.vue in onBeforeMount,
+// then reused across all child components (SearchBar, IndexList, TracesMetricsDashboard).
+// This avoids redundant WASM loads and prevents timing issues where a component's
+// onMounted calls loadDashboard before its own parser finishes loading.
+const tracesParser = shallowRef<any>(null);
+let _loadTracesParserPromise: Promise<void> | null = null;
+
+const loadTracesParser = async (): Promise<void> => {
+  if (tracesParser.value) return;
+  if (_loadTracesParserPromise) {
+    await _loadTracesParserPromise;
+    return;
+  }
+  _loadTracesParserPromise = (async () => {
+    const useSqlParser: any = await import("@/composables/useParser");
+    const { sqlParser }: any = useSqlParser.default();
+    tracesParser.value = await sqlParser();
+  })();
+  await _loadTracesParserPromise;
 };
 
 const useTraces = () => {
@@ -533,6 +554,8 @@ const useTraces = () => {
     formatTracesMetaData,
     setServiceColors,
     getOrSetServiceColor,
+    tracesParser,
+    loadTracesParser,
   };
 };
 

--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -213,6 +213,8 @@ vi.mock("@/composables/useTraces", () => ({
     setServiceColors: mockSetServiceColors,
     loadLocalLogFilterField: vi.fn(),
     updatedLocalLogFilterField: vi.fn(),
+    loadTracesParser: vi.fn().mockResolvedValue(undefined),
+    tracesParser: { value: { astify: vi.fn() } },
   }),
 }));
 

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -417,6 +417,8 @@ const {
   setServiceColors,
   loadLocalLogFilterField,
   updatedLocalLogFilterField,
+  loadTracesParser,
+  tracesParser,
 } = useTraces();
 const { fnParsedSQL } = logsUtils();
 
@@ -439,7 +441,6 @@ const searchBarRef = ref(null);
 const serviceGraphRef = ref<any>(null);
 const servicesCatalogRef = ref<any>(null);
 const splitterModel = ref(90);
-let parser: any;
 const fieldValues = ref({});
 const { showErrorNotification } = useNotifications();
 const disableMoreErrorDetails = ref(false);
@@ -488,12 +489,6 @@ const selectedStreamName = computed(
 );
 
 const isLLMSpanPresent = ref(false);
-
-const importSqlParser = async () => {
-  const useSqlParser: any = await import("@/composables/useParser");
-  const { sqlParser }: any = useSqlParser.default();
-  parser = await sqlParser();
-};
 
 function getQueryTransform() {
   try {
@@ -772,7 +767,7 @@ function buildSearch() {
       // Convert human-readable duration suffixes (e.g. '1.50ms') to raw µs.
       const durationParseResult = parseDurationWhereClause(
         whereClause,
-        parser,
+        tracesParser.value,
         searchObj.data.stream.selectedStream.value,
       );
       if (typeof durationParseResult === "string") {
@@ -782,7 +777,7 @@ function buildSearch() {
       // Convert span_kind display labels (e.g. 'Server') to numeric OTEL keys (e.g. '2').
       whereClause = parseSpanKindWhereClause(
         whereClause,
-        parser,
+        tracesParser.value,
         searchObj.data.stream.selectedStream.value,
       );
 
@@ -991,7 +986,7 @@ async function getQueryData(
     ).trim();
     const filterParseResult = parseDurationWhereClause(
       filter,
-      parser,
+      tracesParser.value,
       searchObj.data.stream.selectedStream.value,
     );
     if (typeof filterParseResult === "string") {
@@ -1001,7 +996,7 @@ async function getQueryData(
     // Convert span_kind display labels (e.g. 'Server') to numeric OTEL keys (e.g. '2').
     filter = parseSpanKindWhereClause(
       filter,
-      parser,
+      tracesParser.value,
       searchObj.data.stream.selectedStream.value,
     );
 
@@ -1605,7 +1600,7 @@ onBeforeMount(async () => {
   }
   setupContextProvider();
   restoreUrlQueryParams();
-  await importSqlParser();
+  await loadTracesParser();
   if (!searchObj.loading) {
     await loadPageData();
   }
@@ -1740,7 +1735,7 @@ const restoreFilters = (query: string) => {
 
   const defaultQuery = `SELECT * FROM "${selectedStreamName.value}" WHERE `;
 
-  const parsedQuery = parser.astify(defaultQuery + query);
+  const parsedQuery = tracesParser.value.astify(defaultQuery + query);
 
   restoreFiltersFromQuery(parsedQuery.where);
 };

--- a/web/src/plugins/traces/IndexList.vue
+++ b/web/src/plugins/traces/IndexList.vue
@@ -170,7 +170,7 @@ import { defineComponent, ref, computed, watch, defineAsyncComponent, onMounted 
 import { useI18n } from "vue-i18n";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
-import useTraces, { DEFAULT_TRACE_COLUMNS } from "../../composables/useTraces";
+import useTraces, { DEFAULT_TRACE_COLUMNS } from "@/composables/useTraces";
 import { getImageURL, b64EncodeUnicode, b64DecodeUnicode, formatTimeWithSuffix } from "../../utils/zincutils";
 import FieldRow from "@/components/common/FieldRow.vue";
 import OButton from "@/lib/core/Button/OButton.vue";
@@ -180,7 +180,6 @@ import OInput from "@/lib/forms/Input/OInput.vue";
 import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
 import useFieldValuesStream from "@/composables/useFieldValuesStream";
 import useDurationPercentiles, { parseDurationWhereClause } from "@/composables/useDurationPercentiles";
-import useParser from "@/composables/useParser";
 import { SPAN_KIND_MAP, parseSpanKindWhereClause } from "@/utils/traces/constants";
 import { removeFieldFromWhereAST, logsUtils } from "@/composables/useLogs/logsUtils";
 
@@ -225,7 +224,7 @@ export default defineComponent({
     const store = useStore();
     const router = useRouter();
     const { t } = useI18n();
-    const { searchObj } = useTraces();
+    const { searchObj, tracesParser } = useTraces();
     const streamOptions: any = ref(searchObj.data.stream.streamLists);
 
     const pagination = ref({
@@ -366,13 +365,6 @@ export default defineComponent({
       errMsg: durationPercentileErrMsg,
     } = useDurationPercentiles();
 
-    const sqlParser = ref<any>(null);
-
-    onMounted(async () => {
-      const { sqlParser: loadSqlParser } = useParser();
-      sqlParser.value = await loadSqlParser();
-    });
-
     const PERCENTILE_LABELS = [
       { key: "p25", label: "P25" },
       { key: "p50", label: "P50" },
@@ -413,7 +405,7 @@ export default defineComponent({
 
       const durationParseResult = parseDurationWhereClause(
         whereClause,
-        sqlParser.value,
+        tracesParser.value,
         searchObj.data.stream.selectedStream.value,
       );
       if (typeof durationParseResult === "string") {
@@ -422,7 +414,7 @@ export default defineComponent({
 
       whereClause = parseSpanKindWhereClause(
         whereClause,
-        sqlParser.value,
+        tracesParser.value,
         searchObj.data.stream.selectedStream.value,
       );
 

--- a/web/src/plugins/traces/SearchBar.vue
+++ b/web/src/plugins/traces/SearchBar.vue
@@ -503,7 +503,7 @@ export default defineComponent({
     const store = useStore();
     const btnRefreshInterval = ref(null);
 
-    const { searchObj, tracesShareURL } = useTraces();
+    const { searchObj, tracesShareURL, tracesParser } = useTraces();
     const queryEditorRef = ref(null);
 
     const { onFocus: _sqlOnFocus, onBlur: _sqlOnBlur, onQueryChange: _sqlOnQueryChange } =
@@ -524,7 +524,6 @@ export default defineComponent({
       await _sqlOnBlur();
     };
 
-    let parser: any;
     let streamName = "";
     const dateTimeRef = ref(null);
 
@@ -538,16 +537,6 @@ export default defineComponent({
       updateFieldKeywords,
       updateStreamKeywords,
     } = useSqlSuggestions();
-
-    const importSqlParser = async () => {
-      const useSqlParser: any = await import("@/composables/useParser");
-      const { sqlParser }: any = useSqlParser.default();
-      parser = await sqlParser();
-    };
-
-    onBeforeUnmount(async () => {
-      await importSqlParser();
-    });
 
     onActivated(async () => {
       await nextTick();
@@ -612,7 +601,7 @@ export default defineComponent({
       _sqlOnQueryChange();
       updateAutoComplete(value);
       if (searchObj.meta.sqlMode == true) {
-        searchObj.data.parsedQuery = parser.astify(value);
+        searchObj.data.parsedQuery = tracesParser.value?.astify(value);
         if (searchObj.data.parsedQuery?.from?.length > 0) {
           if (
             searchObj.data.parsedQuery.from[0].table !==

--- a/web/src/plugins/traces/metrics/TracesMetricsDashboard.spec.ts
+++ b/web/src/plugins/traces/metrics/TracesMetricsDashboard.spec.ts
@@ -61,7 +61,10 @@ const mockSearchObj = reactive({
 });
 
 vi.mock("@/composables/useTraces", () => ({
-  default: () => ({ searchObj: mockSearchObj }),
+  default: () => ({
+    searchObj: mockSearchObj,
+    tracesParser: { value: null },
+  }),
 }));
 
 vi.mock("@/composables/useNotifications", () => ({

--- a/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
+++ b/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
@@ -87,7 +87,6 @@ import { deepCopy, formatTimeWithSuffix } from "@/utils/zincutils";
 import useTraces from "@/composables/useTraces";
 import { parseDurationWhereClause } from "@/composables/useDurationPercentiles";
 import { parseSpanKindWhereClause } from "@/utils/traces/constants";
-import useParser from "@/composables/useParser";
 
 const RenderDashboardCharts = defineAsyncComponent(
   () => import("@/views/Dashboards/RenderDashboardCharts.vue"),
@@ -119,7 +118,7 @@ const emit = defineEmits<{
 
 const { showErrorNotification } = useNotifications();
 const store = useStore();
-const { searchObj } = useTraces();
+const { searchObj, tracesParser } = useTraces();
 const { t } = useI18n();
 
 
@@ -208,7 +207,6 @@ const contextMenuPosition = ref({ x: 0, y: 0 });
 const contextMenuValue = ref(0);
 const contextMenuFieldName = ref("");
 const contextMenuData = ref<any>(null);
-const sqlParser = ref<any>(null);
 
 const getBaseFilters = () => {
   let baseFilters = [];
@@ -232,13 +230,13 @@ const getBaseFilters = () => {
   if (effectiveFilter.value?.trim().length) {
     const parsed = parseDurationWhereClause(
       effectiveFilter.value.trim(),
-      sqlParser.value,
+      tracesParser.value,
       searchObj.data.stream.selectedStream.value,
     );
     baseFilters.push(
       parseSpanKindWhereClause(
         typeof parsed === "string" ? parsed : effectiveFilter.value.trim(),
-        sqlParser.value,
+        tracesParser.value,
         searchObj.data.stream.selectedStream.value,
       ),
     );
@@ -275,7 +273,7 @@ const loadDashboard = async () => {
           // and span_kind labels back to numeric OTEL keys.
           const parsedFilter = parseDurationWhereClause(
             effectiveFilter.value.trim(),
-            sqlParser.value,
+            tracesParser.value,
             searchObj.data.stream.selectedStream.value,
           );
           errorFilters.push(
@@ -283,7 +281,7 @@ const loadDashboard = async () => {
               typeof parsedFilter === "string"
                 ? parsedFilter
                 : effectiveFilter.value.trim(),
-              sqlParser.value,
+              tracesParser.value,
               searchObj.data.stream.selectedStream.value,
             ),
           );
@@ -702,10 +700,8 @@ const stopAutoRefresh = () => {
   }
 };
 
-onMounted(async () => {
+onMounted(() => {
   loadDashboard();
-  const { sqlParser: loadSqlParser } = useParser();
-  sqlParser.value = await loadSqlParser();
 });
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## What changed

- **Traces duration filter fix**: Centralized SQL parser loading into a shared module-level singleton (`tracesParser` / `loadTracesParser` in `useTraces.ts`) instead of each child component (`IndexList.vue`, `SearchBar.vue`, `TracesMetricsDashboard.vue`) loading its own parser instance. `Index.vue` now calls `loadTracesParser()` once in `onBeforeMount` and all consumers use the shared `tracesParser` ref.
- **SearchBar.vue cleanup**: Removed unused local `parser` variable and orphaned `importSqlParser` / `onBeforeUnmount` hook; applied Prettier formatting pass.
- **TracesMetricsDashboard.vue cleanup**: Removed unused `useParser` import.

## Why

Duration filters were intermittently failing because `SearchBar.vue`, `IndexList.vue`, and `TracesMetricsDashboard.vue` each loaded their own WASM SQL parser instance in `onMounted`. The parser wasn't guaranteed to be ready when `parseDurationWhereClause` (called from `Index.vue`'s `buildSearch`) ran — particularly on fast navigations or when `loadDashboard` triggered before the child component's parser finished loading.