### PR TITLE
fix(web): clipboard copy fails silently over HTTP in focus-trapped drawers

### DIFF
--- a/web/src/enterprise/components/onlineEvals/forms/ScorerFormPage.vue
+++ b/web/src/enterprise/components/onlineEvals/forms/ScorerFormPage.vue
@@ -675,6 +675,7 @@ import ODialog from "@/lib/overlay/Dialog/ODialog.vue";
 import AppPageHeader from "@/components/common/AppPageHeader.vue";
 import OTag from "@/lib/core/Badge/OTag.vue";
 import { toast } from "@/lib/feedback/Toast/useToast";
+import { copyToClipboard as copyClipboard } from "@/utils/clipboard";
 import onlineEvalsService, {
   type ExtraMetadataField,
   type Provider,
@@ -917,13 +918,15 @@ const copyButtonLabel = computed(() =>
 
 async function copySchemaToClipboard() {
   if (!schemaPreview.value) return;
-  try {
-    await navigator.clipboard.writeText(schemaPreview.value);
+  const success = await copyClipboard(schemaPreview.value, {
+    silent: true,
+  });
+  if (success) {
     schemaJustCopied.value = true;
     window.setTimeout(() => {
       schemaJustCopied.value = false;
     }, 1500);
-  } catch {
+  } else {
     toast({
       variant: "error",
       message: t("onlineEvals.scorer.extraFields.schemaCopyFailed"),

--- a/web/src/lib/core/Code/OCode.vue
+++ b/web/src/lib/core/Code/OCode.vue
@@ -1,6 +1,7 @@
 ﻿<script setup lang="ts">
 import type { CodeProps, CodeSlots } from "./OCode.types";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
+import { copyToClipboard } from "@/utils/clipboard";
 import { ref } from "vue";
 
 const props = withDefaults(defineProps<CodeProps>(), {
@@ -22,16 +23,13 @@ async function copy() {
   const text = codeRef.value?.textContent?.trim() ?? "";
   if (!text) return;
 
-  try {
-    await navigator.clipboard.writeText(text);
+  const success = await copyToClipboard(text, { silent: true });
+  if (success) {
     copied.value = true;
     if (copyTimer) clearTimeout(copyTimer);
     copyTimer = setTimeout(() => {
       copied.value = false;
     }, 2000);
-  } catch {
-    // Clipboard API unavailable (non-secure context) — fail silently.
-    // Never alert or throw; this is a convenience feature, not critical.
   }
 }
 </script>

--- a/web/src/lib/core/Table/cells/OCodeCell.vue
+++ b/web/src/lib/core/Table/cells/OCodeCell.vue
@@ -10,6 +10,7 @@
 
 import { computed, ref } from "vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
+import { copyToClipboard } from "@/utils/clipboard";
 
 const props = withDefaults(
   defineProps<{
@@ -31,12 +32,10 @@ const copied = ref(false);
 async function handleCopy(e: MouseEvent) {
   e.stopPropagation();
   if (text.value === null) return;
-  try {
-    await navigator.clipboard.writeText(text.value);
+  const success = await copyToClipboard(text.value, { silent: true });
+  if (success) {
     copied.value = true;
     setTimeout(() => (copied.value = false), 1200);
-  } catch {
-    /* clipboard unavailable — no-op */
   }
 }
 </script>

--- a/web/src/utils/clipboard.ts
+++ b/web/src/utils/clipboard.ts
@@ -9,22 +9,82 @@ export interface CopyToClipboardOptions {
   silent?: boolean;
 }
 
+/**
+ * Fallback copy using execCommand for non-secure contexts (HTTP).
+ *
+ * Key fix: the textarea is appended to the currently focused element's
+ * closest dialog/drawer container (if any) instead of document.body.
+ * This prevents focus-trap components (e.g., reka-ui ODrawer) from
+ * stealing focus away and clearing the selection before execCommand runs.
+ *
+ * Additionally, we verify the selection length after .select() to avoid
+ * reporting success when the copy actually failed silently.
+ */
+function execCommandCopy(text: string): void {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "-9999px";
+  textarea.style.opacity = "0";
+
+  // Append inside the active dialog/drawer container to avoid focus-trap conflicts
+  const activeEl = document.activeElement;
+  const container =
+    activeEl?.closest("[role='dialog']") ||
+    activeEl?.closest("[data-radix-focus-guard]")?.parentElement ||
+    document.body;
+
+  container.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  // Verify the selection is actually set (focus-trap may have cleared it)
+  const selection = document.getSelection();
+  const selectedText = selection?.toString() || "";
+  if (selectedText.length === 0 && text.length > 0) {
+    container.removeChild(textarea);
+    throw new Error(
+      "execCommand copy failed: selection was cleared (likely by a focus trap)",
+    );
+  }
+
+  const success = document.execCommand("copy");
+  container.removeChild(textarea);
+
+  if (!success) {
+    throw new Error("execCommand copy failed");
+  }
+}
+
+/**
+ * Write text to clipboard.
+ *
+ * Strategy:
+ * 1. If secure context → use navigator.clipboard.writeText (modern API)
+ * 2. Otherwise → fall back to execCommand("copy")
+ * 3. If clipboard API exists but throws (e.g., permission denied in HTTP
+ *    context on some browsers) → also fall back to execCommand
+ */
 async function writeClipboard(text: string): Promise<void> {
-  if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
-    await navigator.clipboard.writeText(text);
-  } else {
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    textarea.style.position = "fixed";
-    textarea.style.opacity = "0";
-    document.body.appendChild(textarea);
-    textarea.select();
-    const success = document.execCommand("copy");
-    document.body.removeChild(textarea);
-    if (!success) {
-      throw new Error("execCommand copy failed");
+  // Only attempt clipboard API in secure contexts where it's reliable
+  if (
+    window.isSecureContext &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.writeText === "function"
+  ) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Clipboard API failed (e.g., document not focused, permission denied)
+      // Fall through to execCommand fallback
     }
   }
+
+  // Fallback: execCommand approach (works in HTTP contexts)
+  execCommandCopy(text);
 }
 
 export async function copyToClipboard(

--- a/web/src/views/About.vue
+++ b/web/src/views/About.vue
@@ -336,6 +336,7 @@ import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
 import OBanner from "@/lib/feedback/Banner/OBanner.vue";
 import OText from "@/lib/core/Typography/OText.vue";
 import { toast } from "@/lib/feedback/Toast/useToast";
+import { copyToClipboard as copyText } from "@/utils/clipboard";
 
 export default defineComponent({
   name: "PageAbout",
@@ -395,9 +396,7 @@ export default defineComponent({
     });
 
     const copyToClipboard = (text: string) => {
-      navigator.clipboard.writeText(text).then(() => {
-        toast({ message: "Copied to clipboard", variant: "success" });
-      });
+      copyText(text, { successMessage: "Copied to clipboard" });
     };
 
     const navigateToLicense = () => {


### PR DESCRIPTION
## Summary

Fixes #13062 — "Copy to Clipboard" in Source Details drawer silently fails over HTTP (non-secure context) but shows a success toast.

## Root Cause

1. **Non-secure context**: Site accessed via plain HTTP → `window.isSecureContext = false` → `navigator.clipboard.writeText()` either throws a DOMException or is unavailable. The existing code checked API presence but did **not** fall back to `execCommand` when `writeText()` was rejected.

2. **Focus-trap conflict**: The `execCommand` fallback created a hidden `<textarea>` and appended it to `document.body` (outside the drawer). The reka-ui ODrawer FocusScope immediately reclaimed focus, clearing the textarea selection. Chrome's `execCommand("copy")` returns `true` even with an empty selection → false success toast.

## Fix

### `web/src/utils/clipboard.ts` (core fix)

- **Check `window.isSecureContext`** before attempting clipboard API — skip directly to fallback in non-secure contexts
- **Catch clipboard API failures** (permission denied, etc.) and fall through to `execCommand` instead of throwing
- **Append textarea inside `[role=dialog]` container** (closest dialog/drawer ancestor of the active element) instead of `document.body` — avoids focus-trap interference
- **Verify selection length** after `.select()` — if selection was cleared (by focus trap), throw with an accurate error instead of false success

### Additional files (unified clipboard usage)

Migrated all remaining direct `navigator.clipboard.writeText()` calls to the shared utility:
- `web/src/lib/core/Table/cells/OCodeCell.vue`
- `web/src/lib/core/Code/OCode.vue`
- `web/src/views/About.vue`
- `web/src/enterprise/components/onlineEvals/forms/ScorerFormPage.vue`

## Testing

| Environment | Before | After |
|-------------|--------|-------|
| `https://` or `localhost` | ✅ Works | ✅ Works (clipboard API) |
| `http://` (non-localhost) in normal page | ❌ Silent fail | ✅ Works (execCommand fallback) |
| `http://` inside drawer (focus trap) | ❌ False success toast | ✅ Works (textarea inside dialog container) |
| `http://` + clipboard denied + focus trap | ❌ False success | ✅ Error toast shown |

## Checklist

- [x] Fix targets the root cause (not just symptoms)
- [x] All production `navigator.clipboard.writeText` usages unified through `@/utils/clipboard`
- [x] Backward compatible (HTTPS environments unchanged)
- [x] No new dependencies