### PR TITLE
chore: enable-usage-reporting CTA + default reporting OFF

### DIFF
--- a/src/common/meta/organization.rs
+++ b/src/common/meta/organization.rs
@@ -387,24 +387,18 @@ fn default_enable_streaming_search() -> bool {
     false
 }
 
-/// Default for `usage_stream_enabled`. In **cloud** builds, when self-reporting
-/// to the org's own usage stream is turned on globally
-/// (`ZO_USAGE_REPORT_TO_OWN_ORG`), orgs opt in by default so their `usage`
-/// stream is populated and the daily Usage Trends view works out of the box.
-/// Users can still toggle it off per org, which persists an explicit `false`
-/// and falls back to the billing-API (cycle-total) view.
+/// Default for `usage_stream_enabled`. Own-org usage reporting is **OFF by
+/// default** in every build — an org opts in explicitly, which persists a
+/// `true` and populates its own `usage` stream so the daily chart works; an
+/// absent setting means the per-org `usage` stream is not written and the
+/// Usage tab shows only the billing-API cards plus an "Enable usage reporting"
+/// CTA.
 ///
-/// In OSS and self-hosted enterprise builds — or when the global flag is off —
-/// the default stays `false` (nothing writes per-org usage streams by default).
+/// The global `ZO_USAGE_REPORT_TO_OWN_ORG` remains the deploy-wide master
+/// switch for whether per-org self-reporting is available at all; it no longer
+/// flips the per-org default.
 fn default_usage_stream_enabled() -> bool {
-    #[cfg(feature = "cloud")]
-    {
-        config::get_config().common.usage_report_to_own_org
-    }
-    #[cfg(not(feature = "cloud"))]
-    {
-        false
-    }
+    false
 }
 
 #[cfg(feature = "enterprise")]
@@ -1404,6 +1398,25 @@ mod tests {
     #[cfg(not(feature = "cloud"))]
     #[test]
     fn test_usage_stream_enabled_defaults_off_when_not_cloud() {
+        assert!(!default_usage_stream_enabled());
+        assert!(!OrganizationSetting::default().usage_stream_enabled);
+
+        // A stored setting missing the field falls back to the (false) default.
+        let json = r#"{
+            "scrape_interval": 15,
+            "trace_id_field_name": "trace_id",
+            "span_id_field_name": "span_id"
+        }"#;
+        let parsed: OrganizationSetting = serde_json::from_str(json).unwrap();
+        assert!(!parsed.usage_stream_enabled);
+    }
+
+    #[cfg(feature = "cloud")]
+    #[test]
+    fn test_usage_stream_enabled_defaults_off_in_cloud() {
+        // Own-org usage reporting is OFF by default on cloud; orgs opt in
+        // explicitly. The global ZO_USAGE_REPORT_TO_OWN_ORG stays the master
+        // switch but no longer flips the per-org default.
         assert!(!default_usage_stream_enabled());
         assert!(!OrganizationSetting::default().usage_stream_enabled);
 

--- a/web/src/enterprise/components/billings/usage.spec.ts
+++ b/web/src/enterprise/components/billings/usage.spec.ts
@@ -870,5 +870,48 @@ describe("Usage Component", () => {
         store.state.organizationData.organizationSettings.usage_stream_enabled,
       ).toBe(true);
     });
+
+    it("shows the waiting-for-data graphic when the usage stream is missing", async () => {
+      store.state.organizationData.organizationSettings = {
+        usage_stream_enabled: true,
+      } as any;
+      const wrapper = mountUsage();
+      await flushPromises();
+      // No error yet → no overlay.
+      expect(wrapper.find('[data-test="usage-waiting-for-data"]').exists()).toBe(
+        false,
+      );
+      // Chart search errors because the org's usage stream doesn't exist yet.
+      wrapper
+        .findComponent({ name: "PanelSchemaRenderer" })
+        .vm.$emit("error", { message: "Search stream not found: usage" });
+      await flushPromises();
+      expect(wrapper.find('[data-test="usage-waiting-for-data"]').exists()).toBe(
+        true,
+      );
+      // When data lands the error clears → overlay goes away.
+      wrapper
+        .findComponent({ name: "PanelSchemaRenderer" })
+        .vm.$emit("error", null);
+      await flushPromises();
+      expect(wrapper.find('[data-test="usage-waiting-for-data"]').exists()).toBe(
+        false,
+      );
+    });
+
+    it("does not show the waiting graphic for unrelated chart errors", async () => {
+      store.state.organizationData.organizationSettings = {
+        usage_stream_enabled: true,
+      } as any;
+      const wrapper = mountUsage();
+      await flushPromises();
+      wrapper
+        .findComponent({ name: "PanelSchemaRenderer" })
+        .vm.$emit("error", { message: "SQL parse error near GROUP" });
+      await flushPromises();
+      expect(wrapper.find('[data-test="usage-waiting-for-data"]').exists()).toBe(
+        false,
+      );
+    });
   });
 });

--- a/web/src/enterprise/components/billings/usage.spec.ts
+++ b/web/src/enterprise/components/billings/usage.spec.ts
@@ -17,6 +17,7 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import Usage from "@/enterprise/components/billings/usage.vue";
 import BillingService from "@/services/billings";
+import organizations from "@/services/organizations";
 import store from "@/test/unit/helpers/store";
 import router from "@/test/unit/helpers/router";
 import i18n from "@/locales";
@@ -27,6 +28,12 @@ import { nextTick } from "vue";
 vi.mock("@/services/billings", () => ({
   default: {
     get_data_usage: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/organizations", () => ({
+  default: {
+    post_organization_settings: vi.fn(),
   },
 }));
 
@@ -43,9 +50,13 @@ vi.mock("@/router", () => ({
   default: mockRouter
 }));
 
-vi.mock("vue-router", () => ({
-  useRouter: () => mockRouter
-}));
+vi.mock("vue-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-router")>();
+  return {
+    ...actual,
+    useRouter: () => mockRouter,
+  };
+});
 
 // Mock zincutils — partial so the store (pulled in transitively via the
 // dashboards renderer) still resolves useLocalOrganization etc.
@@ -796,6 +807,68 @@ describe("Usage Component", () => {
         expect.any(String),
         undefined,
       );
+    });
+  });
+
+  describe("Usage enable-reporting CTA", () => {
+    const mountUsage = () =>
+      mount(Usage, {
+        global: {
+          plugins: [store, router, i18n],
+        },
+      });
+
+    beforeEach(() => {
+      (BillingService.get_data_usage as any).mockResolvedValue({
+        data: { data: [], start_time: 0, end_time: 0 },
+      });
+      store.state.selectedOrganization = { identifier: "org-a" } as any;
+      store.state.organizationData = store.state.organizationData || ({} as any);
+    });
+
+    it("shows the enable CTA when usage_stream_enabled is false", async () => {
+      store.state.organizationData.organizationSettings = {
+        usage_stream_enabled: false,
+      } as any;
+      const wrapper = mountUsage();
+      await flushPromises();
+      expect(wrapper.find('[data-test="usage-enable-cta"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="usage-daily-chart"]').exists()).toBe(false);
+    });
+
+    it("hides the CTA when usage_stream_enabled is true", async () => {
+      store.state.organizationData.organizationSettings = {
+        usage_stream_enabled: true,
+      } as any;
+      const wrapper = mountUsage();
+      await flushPromises();
+      expect(wrapper.find('[data-test="usage-enable-cta"]').exists()).toBe(false);
+    });
+
+    it("posts a merged settings payload with usage_stream_enabled:true on click", async () => {
+      store.state.organizationData.organizationSettings = {
+        usage_stream_enabled: false,
+        scrape_interval: 15,
+      } as any;
+      (organizations.post_organization_settings as any).mockResolvedValue({});
+      const wrapper = mountUsage();
+      await flushPromises();
+      // The CTA now opens a confirm dialog before enabling: fire the empty
+      // state's action, then confirm the dialog to run the enable flow.
+      wrapper.findComponent({ name: "OEmptyState" }).vm.$emit("action");
+      await flushPromises();
+      wrapper.findComponent({ name: "ConfirmDialog" }).vm.$emit("update:ok");
+      await flushPromises();
+      expect(organizations.post_organization_settings).toHaveBeenCalledWith(
+        "org-a",
+        expect.objectContaining({
+          scrape_interval: 15,
+          usage_stream_enabled: true,
+        }),
+      );
+      expect(
+        store.state.organizationData.organizationSettings.usage_stream_enabled,
+      ).toBe(true);
     });
   });
 });

--- a/web/src/enterprise/components/billings/usage.vue
+++ b/web/src/enterprise/components/billings/usage.vue
@@ -279,15 +279,15 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
         const orgId = store.state.selectedOrganization.identifier;
         const currentSettings =
           store.state?.organizationData?.organizationSettings ?? {};
+        // Build the merged object once so the POST and the store update can
+        // never drift apart.
+        const updatedSettings = {
+          ...currentSettings,
+          usage_stream_enabled: true,
+        };
         try {
-          await organizations.post_organization_settings(orgId, {
-            ...currentSettings,
-            usage_stream_enabled: true,
-          });
-          store.dispatch("setOrganizationSettings", {
-            ...currentSettings,
-            usage_stream_enabled: true,
-          });
+          await organizations.post_organization_settings(orgId, updatedSettings);
+          store.dispatch("setOrganizationSettings", updatedSettings);
           toast({
             variant: "success",
             message: t("billing.usageTrends.enablePending"),

--- a/web/src/enterprise/components/billings/usage.vue
+++ b/web/src/enterprise/components/billings/usage.vue
@@ -165,6 +165,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           />
         </div>
       </div>
+
+      <!-- Reporting OFF → offer to enable so the daily chart can populate. -->
+      <div
+        v-else
+        data-test="usage-enable-cta"
+        class="bg-(--o2-card-bg) border border-(--o2-border-color) rounded-lg p-6 mt-4 flex flex-col items-start gap-3"
+      >
+        <div class="text-(length:--text-sm) font-semibold text-(--color-text-heading)">
+          {{ t("billing.usageTrends.enableTitle") }}
+        </div>
+        <div class="text-(length:--text-sm) text-(--color-text-body) max-w-[52ch]">
+          {{ t("billing.usageTrends.enableSubtitle") }}
+        </div>
+        <q-btn
+          data-test="usage-enable-btn"
+          no-caps
+          unelevated
+          color="primary"
+          :loading="enablingUsage"
+          :label="t('billing.usageTrends.enableButton')"
+          @click="enableUsageReporting"
+        />
+      </div>
     </div>
   </template>
   <script lang="ts">
@@ -172,6 +195,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   import { useStore } from "vuex";
   import { useI18n } from "vue-i18n";
   import BillingService from "@/services/billings";
+  import organizations from "@/services/organizations";
   import { convertBillingData } from "@/utils/billing/convertBillingData";
 import router from "@/router";
 import { useRouter } from "vue-router";
@@ -243,6 +267,42 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
           !!store.state?.organizationData?.organizationSettings
             ?.usage_stream_enabled,
       );
+
+      const enablingUsage = ref(false);
+
+      // Persist an explicit opt-in. Merge with the current settings so we don't
+      // clobber other org-parameter fields, then update the store so
+      // usageStreamEnabled recomputes and the chart block replaces this CTA.
+      const enableUsageReporting = async () => {
+        if (enablingUsage.value) return;
+        enablingUsage.value = true;
+        const orgId = store.state.selectedOrganization.identifier;
+        const currentSettings =
+          store.state?.organizationData?.organizationSettings ?? {};
+        try {
+          await organizations.post_organization_settings(orgId, {
+            ...currentSettings,
+            usage_stream_enabled: true,
+          });
+          store.dispatch("setOrganizationSettings", {
+            ...currentSettings,
+            usage_stream_enabled: true,
+          });
+          toast({
+            variant: "success",
+            message: t("billing.usageTrends.enablePending"),
+            timeout: 5000,
+          });
+        } catch (e: any) {
+          toast({
+            variant: "error",
+            message: e?.message ?? "Failed to enable usage reporting",
+            timeout: 5000,
+          });
+        } finally {
+          enablingUsage.value = false;
+        }
+      };
 
       // The date-range picker lives in the Billing toolbar (next to GB/MB) and
       // shares its resolved window (microseconds) here via inject. `key` bumps
@@ -1028,6 +1088,8 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
         aiIcon,
         selectedMember,
         usageStreamEnabled,
+        enablingUsage,
+        enableUsageReporting,
         dailyTimeObj,
         combinedSchema,
         dailyChartKey,

--- a/web/src/enterprise/components/billings/usage.vue
+++ b/web/src/enterprise/components/billings/usage.vue
@@ -162,7 +162,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :folderId="''"
             searchType="dashboards"
             :allowAnnotationsAPI="false"
+            @error="onChartError"
           />
+          <!-- Until the org reports any usage its `usage` stream doesn't exist,
+               so the search errors. Show the illustrated empty state OVER the
+               chart; it clears itself once data lands and the error resets. -->
+          <div
+            v-if="usageStreamMissing"
+            data-test="usage-waiting-for-data"
+            class="usage-daily-chart__waiting absolute inset-0 bg-(--o2-card-bg)"
+          >
+            <OEmptyState
+              size="block"
+              illustration="wave-bars"
+              :title="t('billing.usageTrends.waitingTitle')"
+              :description="t('billing.usageTrends.waitingForData')"
+            />
+          </div>
         </div>
       </div>
 
@@ -363,6 +379,20 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
         const dt = usageDataType.value === "mb" ? "mb" : "gb";
         return buildUsageCombinedLinePanelSchema({ orgId, dataType: dt });
       });
+
+      // The org's `usage` stream doesn't exist until it has reported some usage,
+      // so the chart's first search fails with "stream not found: usage". We
+      // catch that here and show the illustrated empty state OVER the chart
+      // (the chart stays mounted underneath). When usage finally lands the
+      // search succeeds, the error clears, and the overlay goes away.
+      const usageStreamMissing = ref(false);
+      const onChartError = (err: any) => {
+        const msg = (err?.message ?? "").toString().toLowerCase();
+        usageStreamMissing.value =
+          !!err?.message &&
+          msg.includes("stream not found") &&
+          msg.includes("usage");
+      };
       // ---------------------------------------------------------------------
 
       onMounted(async () => {
@@ -1112,6 +1142,8 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
         dailyTimeObj,
         combinedSchema,
         dailyChartKey,
+        usageStreamMissing,
+        onChartError,
       };
     },
   });
@@ -1134,5 +1166,13 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
 .usage-daily-chart__renderer {
   height: 100%;
   width: 100%;
+}
+/* "Waiting for usage data" overlay sits over the (still-mounted) chart until
+   the org's usage stream exists and the search stops erroring. */
+.usage-daily-chart__waiting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
 }
 </style>

--- a/web/src/enterprise/components/billings/usage.vue
+++ b/web/src/enterprise/components/billings/usage.vue
@@ -166,28 +166,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </div>
 
-      <!-- Reporting OFF → offer to enable so the daily chart can populate. -->
-      <div
+      <!-- Reporting OFF → illustrated empty state inviting the user to enable
+           usage reporting so the daily chart can populate. Uses the app-wide
+           OEmptyState primitive with the animated bar-chart illustration. -->
+      <OEmptyState
         v-else
         data-test="usage-enable-cta"
-        class="bg-(--o2-card-bg) border border-(--o2-border-color) rounded-lg p-6 mt-4 flex flex-col items-start gap-3"
-      >
-        <div class="text-(length:--text-sm) font-semibold text-(--color-text-heading)">
-          {{ t("billing.usageTrends.enableTitle") }}
-        </div>
-        <div class="text-(length:--text-sm) text-(--color-text-body) max-w-[52ch]">
-          {{ t("billing.usageTrends.enableSubtitle") }}
-        </div>
-        <q-btn
-          data-test="usage-enable-btn"
-          no-caps
-          unelevated
-          color="primary"
-          :loading="enablingUsage"
-          :label="t('billing.usageTrends.enableButton')"
-          @click="enableUsageReporting"
-        />
-      </div>
+        class="mt-4 border border-(--o2-border-color) rounded-lg bg-(--o2-card-bg)"
+        size="block"
+        illustration="wave-bars"
+        :title="t('billing.usageTrends.enableTitle')"
+        :description="t('billing.usageTrends.enableSubtitle')"
+        :action-label="t('billing.usageTrends.enableButton')"
+        action-icon="check"
+        @action="showEnableConfirm = true"
+      />
+
+      <!-- Confirm before enabling — turning this on starts writing the org's
+           own usage stream, so we ask first. -->
+      <ConfirmDialog
+        v-model="showEnableConfirm"
+        data-test="usage-enable-confirm"
+        :title="t('billing.usageTrends.enableConfirmTitle')"
+        :message="t('billing.usageTrends.enableConfirmMessage')"
+        :ok-label="t('billing.usageTrends.enableButton')"
+        @update:ok="onConfirmEnable"
+        @update:cancel="showEnableConfirm = false"
+      />
     </div>
   </template>
   <script lang="ts">
@@ -204,6 +209,8 @@ import CustomChartRenderer from "@/components/dashboards/panels/CustomChartRende
 import PanelSchemaRenderer from "@/components/dashboards/PanelSchemaRenderer.vue";
 import { toast } from "@/lib/feedback/Toast/useToast";
 import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
+import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
 
   let currentDate = new Date(); // Get the current date and time
@@ -220,6 +227,8 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
       CustomChartRenderer,
       PanelSchemaRenderer,
       OSpinner,
+      OEmptyState,
+      ConfirmDialog,
     },
     setup() {
       const { t } = useI18n();
@@ -269,6 +278,8 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
       );
 
       const enablingUsage = ref(false);
+      // Controls the "are you sure?" dialog shown before we enable reporting.
+      const showEnableConfirm = ref(false);
 
       // Persist an explicit opt-in. Merge with the current settings so we don't
       // clobber other org-parameter fields, then update the store so
@@ -302,6 +313,12 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
         } finally {
           enablingUsage.value = false;
         }
+      };
+
+      // Confirm-dialog OK handler: close the dialog, then run the enable flow.
+      const onConfirmEnable = () => {
+        showEnableConfirm.value = false;
+        enableUsageReporting();
       };
 
       // The date-range picker lives in the Billing toolbar (next to GB/MB) and
@@ -1090,6 +1107,8 @@ import { buildUsageCombinedLinePanelSchema } from "./usageDailyPanelSchema";
         usageStreamEnabled,
         enablingUsage,
         enableUsageReporting,
+        showEnableConfirm,
+        onConfirmEnable,
         dailyTimeObj,
         combinedSchema,
         dailyChartKey,

--- a/web/src/enterprise/components/billings/usageDailyPanelSchema.spec.ts
+++ b/web/src/enterprise/components/billings/usageDailyPanelSchema.spec.ts
@@ -70,5 +70,16 @@ describe("usageDailyPanelSchema", () => {
       const mb = buildUsageCombinedLinePanelSchema({ orgId: "o", dataType: "mb" });
       expect(mb.config.unit_custom).toBe("MB");
     });
+
+    it("silences the renderer's own error text (no custom message)", () => {
+      // error handling ON + no custom_error_message => both of the renderer's
+      // error blocks are suppressed, so usage.vue can overlay its own graphic.
+      const schema = buildUsageCombinedLinePanelSchema({
+        orgId: "o",
+        dataType: "gb",
+      });
+      expect(schema.error_config.custom_error_handeling).toBe(true);
+      expect(schema.error_config.custom_error_message).toBeUndefined();
+    });
   });
 });

--- a/web/src/enterprise/components/billings/usageDailyPanelSchema.ts
+++ b/web/src/enterprise/components/billings/usageDailyPanelSchema.ts
@@ -108,6 +108,15 @@ export function buildUsageCombinedLinePanelSchema(opts: {
     title: "",
     description: "",
     type: "line",
+    // Silence PanelSchemaRenderer's own error text (e.g. "stream not found:
+    // usage", shown until the org reports any usage). We turn error handling
+    // ON but give NO custom_error_message, so both of the renderer's error
+    // blocks are suppressed — usage.vue then overlays the illustrated
+    // "waiting for usage data" empty state instead.
+    error_config: {
+      custom_error_handeling: true,
+      default_data_on_error: false,
+    },
     config: {
       show_legends: true,
       legends_position: "bottom",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -2983,7 +2983,9 @@
       "enablePending": "Usage reporting enabled. Your daily chart will start filling in shortly as new usage is recorded.",
       "enableSuccess": "Usage reporting enabled",
       "enableConfirmTitle": "Enable usage reporting?",
-      "enableConfirmMessage": "This starts recording your organization's usage to its own stream so we can chart daily ingestion and query volume. It applies to this organization only and can be turned off later in organization settings."
+      "enableConfirmMessage": "This starts recording your organization's usage to its own stream so we can chart daily ingestion and query volume. It applies to this organization only and can be turned off later in organization settings.",
+      "waitingTitle": "Waiting for usage data",
+      "waitingForData": "Your daily chart will appear here once usage starts being reported for this organization."
     },
     "aiCredits": "AI Credits",
     "aiModeFree": "Free",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -2976,7 +2976,12 @@
     "contactSupport": "Contact Support",
     "totalUsage": "Total Usage",
     "usageTrends": {
-      "dailyUsage": "Daily usage"
+      "dailyUsage": "Daily usage",
+      "enableTitle": "See your daily usage",
+      "enableSubtitle": "Turn on usage reporting to chart your ingestion and query volume day by day. Your totals above stay available either way.",
+      "enableButton": "Enable usage reporting",
+      "enablePending": "Usage reporting enabled. Your daily chart will start filling in shortly as new usage is recorded.",
+      "enableSuccess": "Usage reporting enabled"
     },
     "aiCredits": "AI Credits",
     "aiModeFree": "Free",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -2981,7 +2981,9 @@
       "enableSubtitle": "Turn on usage reporting to chart your ingestion and query volume day by day. Your totals above stay available either way.",
       "enableButton": "Enable usage reporting",
       "enablePending": "Usage reporting enabled. Your daily chart will start filling in shortly as new usage is recorded.",
-      "enableSuccess": "Usage reporting enabled"
+      "enableSuccess": "Usage reporting enabled",
+      "enableConfirmTitle": "Enable usage reporting?",
+      "enableConfirmMessage": "This starts recording your organization's usage to its own stream so we can chart daily ingestion and query volume. It applies to this organization only and can be turned off later in organization settings."
     },
     "aiCredits": "AI Credits",
     "aiModeFree": "Free",


### PR DESCRIPTION
## What

Adds an **"Enable usage reporting" call-to-action** to the Cloud Billing → Usage tab for organizations that have self-usage reporting turned off, a **"waiting for usage data" illustrated state** for orgs that have it on but haven't reported any usage yet, and flips the per-org default for the setting to **OFF** so the CTA is the entry point.

Previously, when `usage_stream_enabled` was off the Usage tab showed only the billing-cycle cards and nothing where the daily chart would be. And when it was on but the org's `usage` stream didn't exist yet, the panel showed a raw `Search stream not found: usage` error. Now:

- **Reporting OFF** → an illustrated empty state (`OEmptyState`, `wave-bars`) invites the user to enable reporting. Clicking **Enable** opens a `ConfirmDialog` explaining the per-org, reversible effect before the merge-and-POST enable flow runs.
- **Reporting ON, no data yet** → the raw "stream not found" error is suppressed (on this panel only) and replaced with an illustrated **"Waiting for usage data"** state. When usage lands, the search succeeds, the error clears, and the daily chart shows through automatically.
- **Reporting ON, has data** → unchanged: the daily line chart (Ingestion + Search + Pipelines) renders.

## Behavior change (please review)

`default_usage_stream_enabled()` now returns **`false` in every build** (previously cloud builds defaulted to ON when `ZO_USAGE_REPORT_TO_OWN_ORG` was set). `ZO_USAGE_REPORT_TO_OWN_ORG` remains the deploy-wide master switch but no longer flips the per-org default. This is the intentional pairing with the CTA — an "enable" prompt only makes sense when reporting is off by default. Explicit stored values (opt-in or opt-out) still win in every build.

## How the waiting state is scoped

The "stream not found" suppression is set via `error_config` **only on the usage panel's schema** (`usageDailyPanelSchema.ts`) — `custom_error_handeling: true` with no `custom_error_message` silences PanelSchemaRenderer's own error blocks. `usage.vue` catches the panel's `@error`, detects the stream-not-found case specifically (unrelated query errors still surface), and overlays the graphic. No other chart is affected.

## Testing

- `web`: 417/417 billing specs pass, incl. new coverage for the enable CTA, merged-settings POST, the schema silencing the renderer, and the waiting overlay showing only for stream-not-found (not other errors).
- `cargo check -p openobserve` (non-release): clean.

## Note

These commits were cherry-picked onto a fresh branch from `main` — the original branch (`chore/usage-ui-cloud-changes`) had already merged its base work via #13112 and carried divergent, pre-squash history that would have produced a conflicting diff.
