### PR TITLE
fix: enrichment table query should ignore max query range

### DIFF
--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -389,7 +389,9 @@ pub async fn search(
             let max_query_range =
                 get_settings_max_query_range(settings.max_query_range, &org_id, Some(user_id))
                     .await;
-            if max_query_range > 0
+            // Enrichment tables have no retention and must be searched in full; skip the clamp.
+            if stream_type != StreamType::EnrichmentTables
+                && max_query_range > 0
                 && (req.query.end_time - req.query.start_time) > max_query_range * 3600 * 1_000_000
             {
                 req.query.start_time = req.query.end_time - max_query_range * 3600 * 1_000_000;
@@ -1927,7 +1929,9 @@ pub async fn result_schema(
             let max_query_range =
                 get_settings_max_query_range(settings.max_query_range, &org_id, Some(user_id))
                     .await;
-            if max_query_range > 0
+            // Enrichment tables have no retention and must be searched in full; skip the clamp.
+            if stream_type != StreamType::EnrichmentTables
+                && max_query_range > 0
                 && (req.query.end_time - req.query.start_time) > max_query_range * 3600 * 1_000_000
             {
                 req.query.start_time = req.query.end_time - max_query_range * 3600 * 1_000_000;

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -251,7 +251,9 @@ pub async fn search_multi(
             let max_query_range =
                 get_settings_max_query_range(settings.max_query_range, &org_id, Some(user_id))
                     .await;
-            if max_query_range > 0
+            // Enrichment tables have no retention and must be searched in full; skip the clamp.
+            if stream_type != StreamType::EnrichmentTables
+                && max_query_range > 0
                 && (req.query.end_time - req.query.start_time) > max_query_range * 3600 * 1_000_000
             {
                 req.query.start_time = req.query.end_time - max_query_range * 3600 * 1_000_000;

--- a/src/service/search/streaming/execution.rs
+++ b/src/service/search/streaming/execution.rs
@@ -66,8 +66,11 @@ pub async fn do_partitioned_search(
     is_multi_stream_search: bool,
 ) -> Result<(), infra::errors::Error> {
     // limit the search by max_query_range
+    // Enrichment tables have no retention and must be searched in full (the request spans
+    // [creation_time .. now]); clamping the range would drop older enrichment data, so skip it.
     let mut range_error = String::new();
-    if max_query_range > 0
+    if stream_type != StreamType::EnrichmentTables
+        && max_query_range > 0
         && (req.query.end_time - req.query.start_time) > max_query_range * 3600 * 1_000_000
     {
         req.query.start_time = req.query.end_time - max_query_range * 3600 * 1_000_000;

--- a/src/service/search/streaming/mod.rs
+++ b/src/service/search/streaming/mod.rs
@@ -347,12 +347,15 @@ pub async fn process_search_stream_request(
         if !cached_resp.is_empty() && cached_hits > 0 {
             // `max_query_range` is used initialize `remaining_query_range`
             // set max_query_range to `end_time - start_time` as hour if it is 0, to ensure
-            // unlimited query range for cache only search
-            let remaining_query_range = if max_query_range == 0 {
-                (req.query.end_time - req.query.start_time) / hour_micros(1) + 1
-            } else {
-                max_query_range
-            }; // hours
+            // unlimited query range for cache only search.
+            // Enrichment tables have no retention and must be searched in full, so treat them as
+            // unlimited too (otherwise old enrichment data is dropped by the range budget).
+            let remaining_query_range =
+                if max_query_range == 0 || stream_type == StreamType::EnrichmentTables {
+                    (req.query.end_time - req.query.start_time) / hour_micros(1) + 1
+                } else {
+                    max_query_range
+                }; // hours
 
             let size = req.query.size;
             // Step 1(a): handle cache responses & query the deltas


### PR DESCRIPTION
Enrichment table queries (top k values and search) should ignore max query range because enrichment tables, even stored as a stream in backend, are not exactly logically a stream. It contains the data used for enrichment like a csv file.