### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ docker run -d \
       public.ecr.aws/zinclabs/openobserve:latest
 ```
 
+### ☁️ Managed hosting
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/openobserve)
+
+One-click managed OpenObserve with storage, backups and a free subdomain included. No server to run.
+
 
 For other ways to quickly install OpenObserve or use OpenObserve cloud, check [quickstart documentation](https://openobserve.ai/docs/quickstart).
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added OpenObserve to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Getting Started (links to https://zenith.hosting/host/openobserve).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting