### PR TITLE
refactor: reduce some warm up for index search

### DIFF
--- a/src/service/search/datafusion/table_provider/listing_adapter.rs
+++ b/src/service/search/datafusion/table_provider/listing_adapter.rs
@@ -264,7 +264,7 @@ fn handler_tantivy_index(
         let mut config = config.clone();
         config.file_groups = new_file_groups;
         let mut plan = Arc::new(DataSourceExec::new(Arc::new(config))) as Arc<dyn ExecutionPlan>;
-        // skip repartitioning when `reverse` is true, becuase is already have many groups
+        // skip repartitioning when `reverse` is true, becuase it is already have many groups
         if !reverse
             && let Ok(Some(repartition_plan)) =
                 plan.repartitioned(target_partitions, state.config_options())

--- a/src/service/search/index.rs
+++ b/src/service/search/index.rs
@@ -472,12 +472,12 @@ impl Condition {
         })
     }
 
+    /// Fields whose queries enumerate terms and therefore require full postings.
+    /// Exact positive and negative terms are exposed by `Query::query_terms`.
     pub fn need_all_term_fields(&self) -> HashSet<String> {
         let mut fields = HashSet::new();
         match self {
-            Condition::StrMatch(field, ..)
-            | Condition::Regex(field, _)
-            | Condition::NotEqual(field, _) => {
+            Condition::StrMatch(field, ..) | Condition::Regex(field, _) => {
                 fields.insert(field.clone());
             }
             Condition::MatchAll(value) => {
@@ -493,18 +493,17 @@ impl Condition {
                 fields.extend(right.need_all_term_fields());
             }
             Condition::Not(condition) => {
-                // not operator will need get all term for each fields
-                fields.extend(condition.get_tantivy_fields());
+                fields.extend(condition.need_all_term_fields());
             }
-            Condition::In(field, _, negated) if *negated => {
-                fields.insert(field.clone());
-            }
-            Condition::All() | Condition::Equal(..) | Condition::In(..) => {}
+            Condition::All()
+            | Condition::Equal(..)
+            | Condition::NotEqual(..)
+            | Condition::In(..) => {}
         }
         fields
     }
 
-    // get the fields use for search in tantivy
+    #[allow(dead_code)]
     pub fn get_tantivy_fields(&self) -> HashSet<String> {
         let mut fields = HashSet::new();
         match self {
@@ -1262,16 +1261,14 @@ mod tests {
     fn test_condition_need_all_term_fields_not_equal() {
         let condition = Condition::NotEqual("field1".to_string(), "value".to_string());
         let fields = condition.need_all_term_fields();
-        assert_eq!(fields.len(), 1);
-        assert!(fields.contains("field1"));
+        assert!(fields.is_empty());
     }
 
     #[test]
     fn test_condition_need_all_term_fields_in_negated() {
         let condition = Condition::In("field1".to_string(), vec!["value1".to_string()], true);
         let fields = condition.need_all_term_fields();
-        assert_eq!(fields.len(), 1);
-        assert!(fields.contains("field1"));
+        assert!(fields.is_empty());
     }
 
     #[test]
@@ -1280,9 +1277,26 @@ mod tests {
         let right = Condition::NotEqual("field2".to_string(), "value".to_string());
         let condition = Condition::Or(Box::new(left), Box::new(right));
         let fields = condition.need_all_term_fields();
-        assert_eq!(fields.len(), 2);
+        assert_eq!(fields.len(), 1);
         assert!(fields.contains("field1"));
-        assert!(fields.contains("field2"));
+    }
+
+    #[test]
+    fn test_condition_need_all_term_fields_not_exact_and_expansion() {
+        let exact = Condition::Not(Box::new(Condition::Equal(
+            "field1".to_string(),
+            "value".to_string(),
+        )));
+        assert!(exact.need_all_term_fields().is_empty());
+
+        let expansion = Condition::Not(Box::new(Condition::Regex(
+            "field1".to_string(),
+            "value.*".to_string(),
+        )));
+        assert_eq!(
+            expansion.need_all_term_fields(),
+            HashSet::from(["field1".to_string()])
+        );
     }
 
     #[test]

--- a/src/service/search/tantivy/mod.rs
+++ b/src/service/search/tantivy/mod.rs
@@ -18,8 +18,9 @@ mod partition;
 mod pruner;
 mod result;
 pub mod search;
+mod warm;
 
-use std::{collections::HashSet, ops::Bound, sync::Arc};
+use std::{ops::Bound, sync::Arc};
 
 use arrow::{
     buffer::{BooleanBuffer, MutableBuffer},
@@ -46,14 +47,11 @@ pub use result::{TantivyMultiResult, TantivyMultiResultBuilder};
 pub use search::TantivyResult;
 use tantivy::{
     Directory, ReloadPolicy, Term,
-    query::{BooleanQuery, Occur, Query, RangeQuery},
-    schema::Field,
+    query::{BooleanQuery, Occur, RangeQuery},
 };
 use tantivy_utils::puffin_directory::{
-    PROP_ROW_GROUP_SIZE,
-    caching_directory::CachingDirectory,
-    footer_cache::FooterCache,
-    reader::{PuffinDirReader, warm_up_terms},
+    PROP_ROW_GROUP_SIZE, caching_directory::CachingDirectory, footer_cache::FooterCache,
+    reader::PuffinDirReader,
 };
 use tokio::sync::Semaphore;
 use tokio_stream::StreamExt as _;
@@ -61,6 +59,7 @@ use tokio_stream::StreamExt as _;
 use self::{
     cache::{self as tantivy_result_cache, CacheEntry},
     partition::partition_tantivy_files,
+    warm::WarmPlan,
 };
 use crate::service::search::{
     grpc::{QueryParams, calc_target_partitions, storage::cache_files},
@@ -485,52 +484,15 @@ async fn search_tantivy_index(
         ]));
     }
 
-    let need_all_term_fields = condition
-        .need_all_term_fields()
-        .into_iter()
-        .chain(get_simple_distinct_field(&idx_optimize_rule))
-        .filter_map(|filed| tantivy_schema.get_field(&filed).ok())
-        .collect::<HashSet<_>>();
-
-    // warm up the terms in the query
-    let mut warm_terms: HashMap<Field, HashMap<Term, bool>> = HashMap::new();
-    query.query_terms(&mut |term, need_position| {
-        let field = term.field();
-        let entry = warm_terms.entry(field).or_default();
-        entry.insert(term.clone(), need_position);
-    });
-
-    let mut need_fast_field = HashSet::new();
-    if let Some(rule) = &idx_optimize_rule {
-        match rule {
-            IndexOptimizeMode::SimpleHistogram(..) => {
-                need_fast_field.insert(TIMESTAMP_COL_NAME.to_string());
-            }
-            IndexOptimizeMode::SimpleMultiHistogram(.., name) => {
-                need_fast_field.insert(TIMESTAMP_COL_NAME.to_string());
-                need_fast_field.insert(name.clone());
-            }
-            IndexOptimizeMode::SimpleTopN(fields, ..) => {
-                for field in fields {
-                    need_fast_field.insert(field.clone());
-                }
-            }
-            IndexOptimizeMode::SimpleSelect(..) if !has_skipped_conditions => {
-                need_fast_field.insert(TIMESTAMP_COL_NAME.to_string());
-            }
-            _ => {}
-        }
-    }
-    if !file_in_range {
-        need_fast_field.insert(TIMESTAMP_COL_NAME.to_string());
-    }
-
-    warm_up_terms(
-        searcher.segment_reader(0),
-        &warm_terms,
-        need_all_term_fields,
-        need_fast_field,
+    WarmPlan::build(
+        &condition,
+        query.as_ref(),
+        &idx_optimize_rule,
+        &tantivy_schema,
+        file_in_range,
+        has_skipped_conditions,
     )
+    .execute(searcher.segment_reader(0))
     .await?;
 
     // search the index
@@ -681,15 +643,6 @@ fn selection_from_row_ids(num_rows: usize, row_ids: impl Iterator<Item = u32>) -
     BooleanBuffer::new(buffer.into(), 0, num_rows)
 }
 
-/// if simple distinct without filter, we need to warm up the field
-fn get_simple_distinct_field(idx_optimize_rule: &Option<IndexOptimizeMode>) -> Vec<String> {
-    if let Some(IndexOptimizeMode::SimpleDistinct(field, ..)) = idx_optimize_rule {
-        vec![field.to_string()]
-    } else {
-        vec![]
-    }
-}
-
 fn get_cache_entry(tantivy_result: TantivyResult) -> CacheEntry {
     match tantivy_result {
         TantivyResult::RowIdsSelection {
@@ -731,6 +684,8 @@ fn generate_cache_key(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use arrow::buffer::BooleanBuffer;
     use config::{TIMESTAMP_COL_NAME, meta::stream::FileMeta};
 
@@ -786,33 +741,6 @@ mod tests {
         );
         let histogram = searcher.search(&all_query, &histogram_collector).unwrap();
         assert_eq!(histogram, vec![1, 1, 0, 1]);
-    }
-
-    #[test]
-    fn test_get_simple_distinct_field_none() {
-        let idx_optimize_rule = None;
-        let result = get_simple_distinct_field(&idx_optimize_rule);
-        assert_eq!(result, Vec::<String>::new());
-    }
-
-    #[test]
-    fn test_get_simple_distinct_field_simple_distinct() {
-        let idx_optimize_rule = Some(
-            config::meta::inverted_index::IndexOptimizeMode::SimpleDistinct(
-                "test_field".to_string(),
-                100,
-                false,
-            ),
-        );
-        let result = get_simple_distinct_field(&idx_optimize_rule);
-        assert_eq!(result, vec!["test_field".to_string()]);
-    }
-
-    #[test]
-    fn test_get_simple_distinct_field_other_mode() {
-        let idx_optimize_rule = Some(config::meta::inverted_index::IndexOptimizeMode::SimpleCount);
-        let result = get_simple_distinct_field(&idx_optimize_rule);
-        assert_eq!(result, Vec::<String>::new());
     }
 
     #[test]

--- a/src/service/search/tantivy/search.rs
+++ b/src/service/search/tantivy/search.rs
@@ -159,12 +159,15 @@ impl TantivyResult {
         let candidates = res
             .into_iter()
             .map(|(_, doc)| {
-                let ts = ts_col
-                    .first(doc.doc_id)
-                    .expect("_timestamp fast field has one value per doc");
-                (ts, doc.doc_id)
+                let ts = ts_col.first(doc.doc_id).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "missing {TIMESTAMP_COL_NAME} fast-field value for doc_id {}",
+                        doc.doc_id
+                    )
+                })?;
+                Ok((ts, doc.doc_id))
             })
-            .collect();
+            .collect::<anyhow::Result<Vec<_>>>()?;
         Ok(Self::SelectCandidates {
             candidates: Arc::new(candidates),
             row_group_size: None,
@@ -394,6 +397,30 @@ mod tests {
             }
             other => panic!("expected SelectCandidates, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_handle_simple_select_missing_timestamp_returns_error() {
+        let mut schema_builder = tantivy::schema::SchemaBuilder::new();
+        schema_builder.add_i64_field(TIMESTAMP_COL_NAME, tantivy::schema::FAST);
+        let index = tantivy::index::Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_with_num_threads(1, 15_000_000).unwrap();
+        writer.add_document(tantivy::doc!()).unwrap();
+        writer.commit().unwrap();
+        let searcher = index.reader().unwrap().searcher();
+
+        let error = TantivyResult::handle_simple_select(
+            &searcher,
+            Box::new(tantivy::query::AllQuery),
+            1,
+            false,
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("missing _timestamp fast-field value for doc_id 0")
+        );
     }
 
     #[test]

--- a/src/service/search/tantivy/warm.rs
+++ b/src/service/search/tantivy/warm.rs
@@ -1,0 +1,553 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Builds a Tantivy warm-up plan from query requirements and optimizer rules.
+
+use std::collections::HashSet;
+
+use config::{TIMESTAMP_COL_NAME, meta::inverted_index::IndexOptimizeMode};
+use hashbrown::HashMap;
+use tantivy::{
+    SegmentReader, Term,
+    query::{Query, TermQuery},
+    schema::{Field, Schema},
+};
+use tantivy_utils::puffin_directory::reader::warm_up_terms;
+
+use crate::service::search::index::IndexCondition;
+
+#[derive(Default)]
+pub(super) struct WarmPlan {
+    exact_postings: HashMap<Field, HashMap<Term, bool>>,
+    exact_term_info: Option<Term>,
+    full_posting_fields: HashSet<Field>,
+    dictionary_field: Option<Field>,
+    fast_fields: HashSet<String>,
+}
+
+impl WarmPlan {
+    pub(super) fn build(
+        condition: &IndexCondition,
+        query: &dyn Query,
+        idx_optimize_rule: &Option<IndexOptimizeMode>,
+        schema: &Schema,
+        file_in_range: bool,
+        has_skipped_conditions: bool,
+    ) -> Self {
+        // Query requirements are fixed and independent of the optimizer.
+        let mut plan = Self::from_query(condition, query, schema);
+
+        // The optimizer may replace or extend the query plan.
+        plan.apply_optimizer_rule(
+            idx_optimize_rule,
+            query,
+            schema,
+            file_in_range,
+            has_skipped_conditions,
+        );
+
+        plan.normalize();
+        plan
+    }
+
+    fn from_query(condition: &IndexCondition, query: &dyn Query, schema: &Schema) -> Self {
+        // Expansion queries are not exposed by Query::query_terms.
+        let full_posting_fields = condition
+            .need_all_term_fields()
+            .into_iter()
+            .filter_map(|field| schema.get_field(&field).ok())
+            .collect();
+
+        let mut exact_postings: HashMap<Field, HashMap<Term, bool>> = HashMap::new();
+        query.query_terms(&mut |term, need_position| {
+            // The same term may be used by both basic and phrase queries.
+            exact_postings
+                .entry(term.field())
+                .or_default()
+                .entry(term.clone())
+                .and_modify(|position| *position |= need_position)
+                .or_insert(need_position);
+        });
+
+        Self {
+            exact_postings,
+            full_posting_fields,
+            ..Default::default()
+        }
+    }
+
+    fn apply_optimizer_rule(
+        &mut self,
+        rule: &Option<IndexOptimizeMode>,
+        query: &dyn Query,
+        schema: &Schema,
+        file_in_range: bool,
+        has_skipped_conditions: bool,
+    ) {
+        if !file_in_range {
+            self.fast_fields.insert(TIMESTAMP_COL_NAME.to_string());
+        }
+
+        match rule {
+            None => {}
+            Some(IndexOptimizeMode::SimpleDistinct(field, ..)) => {
+                // This collector reads only the target term dictionary and
+                // does not execute the Tantivy query.
+                debug_assert!(
+                    file_in_range,
+                    "SimpleDistinct files must be fully covered by the query time range"
+                );
+                *self = Self::default();
+                if let Ok(field) = schema.get_field(field) {
+                    self.dictionary_field = Some(field);
+                }
+            }
+            Some(IndexOptimizeMode::SimpleCount) => {
+                // Count(TermQuery) can use doc_freq only for a complete query
+                // and a fully covered file.
+                if file_in_range
+                    && !has_skipped_conditions
+                    && let Some(term_query) = query.downcast_ref::<TermQuery>()
+                {
+                    self.exact_postings.clear();
+                    self.exact_term_info = Some(term_query.term().clone());
+                }
+            }
+            Some(IndexOptimizeMode::SimpleHistogram(..)) => {
+                self.fast_fields.insert(TIMESTAMP_COL_NAME.to_string());
+            }
+            Some(IndexOptimizeMode::SimpleMultiHistogram(.., field)) => {
+                self.fast_fields.insert(TIMESTAMP_COL_NAME.to_string());
+                self.fast_fields.insert(field.clone());
+            }
+            Some(IndexOptimizeMode::SimpleTopN(fields, ..)) => {
+                self.fast_fields.extend(fields.iter().cloned());
+            }
+            Some(IndexOptimizeMode::SimpleSelect(..)) if !has_skipped_conditions => {
+                self.fast_fields.insert(TIMESTAMP_COL_NAME.to_string());
+            }
+            Some(IndexOptimizeMode::SimpleSelect(..)) => {}
+        }
+    }
+
+    fn normalize(&mut self) {
+        for (field, terms) in &mut self.exact_postings {
+            if self.full_posting_fields.contains(field) {
+                // Full warm-up excludes positions, so phrase terms remain.
+                terms.retain(|_, need_positions| *need_positions);
+            }
+        }
+        self.exact_postings.retain(|_, terms| !terms.is_empty());
+    }
+
+    pub(super) async fn execute(self, segment_reader: &SegmentReader) -> anyhow::Result<()> {
+        let exact_postings = self.exact_postings;
+        let base_warmup = warm_up_terms(
+            segment_reader,
+            &exact_postings,
+            self.full_posting_fields,
+            self.fast_fields,
+        );
+        let dictionary_warmup = warm_dictionary(segment_reader, self.dictionary_field);
+        let term_info_warmup = warm_term_info(segment_reader, self.exact_term_info);
+        tokio::try_join!(base_warmup, dictionary_warmup, term_info_warmup)?;
+        Ok(())
+    }
+}
+
+async fn warm_dictionary(
+    segment_reader: &SegmentReader,
+    field: Option<Field>,
+) -> anyhow::Result<()> {
+    if let Some(field) = field {
+        let inverted_index = segment_reader.inverted_index(field)?;
+        inverted_index.terms().warm_up_dictionary().await?;
+    }
+    Ok(())
+}
+
+async fn warm_term_info(segment_reader: &SegmentReader, term: Option<Term>) -> anyhow::Result<()> {
+    if let Some(term) = term {
+        // Immutable .ttv files have no deletes, so doc_freq is the exact count.
+        let inverted_index = segment_reader.inverted_index(term.field())?;
+        inverted_index.doc_freq_async(&term).await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use config::INDEX_FIELD_NAME_FOR_ALL;
+    use tantivy::{
+        Index, Searcher,
+        collector::Count,
+        doc,
+        query::PhraseQuery,
+        schema::{FAST, Schema, TEXT},
+    };
+
+    use super::*;
+    use crate::service::search::index::Condition;
+
+    fn schema() -> Schema {
+        let mut builder = Schema::builder();
+        builder.add_text_field("tag", TEXT);
+        builder.add_text_field(INDEX_FIELD_NAME_FOR_ALL, TEXT);
+        builder.add_i64_field(TIMESTAMP_COL_NAME, FAST);
+        builder.build()
+    }
+
+    fn build_plan(
+        condition: Condition,
+        optimize_rule: Option<IndexOptimizeMode>,
+        file_in_range: bool,
+        has_skipped_conditions: bool,
+    ) -> (WarmPlan, Schema) {
+        let schema = schema();
+        let default_field = schema.get_field(INDEX_FIELD_NAME_FOR_ALL).ok();
+        let mut index_condition = IndexCondition::new();
+        index_condition.add_condition(condition);
+        let (query, _) = index_condition
+            .to_tantivy_query("test", schema.clone(), default_field)
+            .unwrap();
+        let plan = WarmPlan::build(
+            &index_condition,
+            query.as_ref(),
+            &optimize_rule,
+            &schema,
+            file_in_range,
+            has_skipped_conditions,
+        );
+        (plan, schema)
+    }
+
+    fn exact_terms(plan: &WarmPlan) -> HashSet<Term> {
+        plan.exact_postings
+            .values()
+            .flat_map(|terms| terms.keys().cloned())
+            .collect()
+    }
+
+    fn build_searcher() -> Searcher {
+        let schema = schema();
+        let tag = schema.get_field("tag").unwrap();
+        let index = Index::create_in_ram(schema);
+        let mut writer = index.writer_with_num_threads(1, 15_000_000).unwrap();
+        writer.add_document(doc!(tag => "a")).unwrap();
+        writer.add_document(doc!(tag => "b")).unwrap();
+        writer.commit().unwrap();
+        drop(writer);
+        index.reader().unwrap().searcher()
+    }
+
+    #[test]
+    fn str_match_preserves_full_posting_warmup() {
+        let (plan, schema) = build_plan(
+            Condition::StrMatch("tag".into(), "needle".into(), true),
+            None,
+            true,
+            false,
+        );
+        assert_eq!(
+            plan.full_posting_fields,
+            HashSet::from([schema.get_field("tag").unwrap()])
+        );
+        assert!(plan.exact_postings.is_empty());
+    }
+
+    #[test]
+    fn not_equal_warms_only_exact_posting() {
+        let (plan, schema) = build_plan(
+            Condition::NotEqual("tag".into(), "value".into()),
+            None,
+            true,
+            false,
+        );
+        let tag = schema.get_field("tag").unwrap();
+        assert!(plan.full_posting_fields.is_empty());
+        assert_eq!(
+            plan.exact_postings.get(&tag),
+            Some(&HashMap::from([(
+                Term::from_field_text(tag, "value"),
+                false
+            )]))
+        );
+    }
+
+    #[test]
+    fn negative_exact_queries_do_not_warm_full_fields() {
+        let (not_in, schema) = build_plan(
+            Condition::In("tag".into(), vec!["a".into(), "b".into(), "a".into()], true),
+            None,
+            true,
+            false,
+        );
+        let tag = schema.get_field("tag").unwrap();
+        assert_eq!(
+            exact_terms(&not_in),
+            HashSet::from([
+                Term::from_field_text(tag, "a"),
+                Term::from_field_text(tag, "b"),
+            ])
+        );
+        assert!(not_in.full_posting_fields.is_empty());
+
+        let (not_equal, _) = build_plan(
+            Condition::Not(Box::new(Condition::Equal("tag".into(), "a".into()))),
+            None,
+            true,
+            false,
+        );
+        assert_eq!(exact_terms(&not_equal).len(), 1);
+        assert!(not_equal.full_posting_fields.is_empty());
+    }
+
+    #[test]
+    fn simple_distinct_is_dictionary_only() {
+        let (plan, schema) = build_plan(
+            Condition::StrMatch("tag".into(), "needle".into(), true),
+            Some(IndexOptimizeMode::SimpleDistinct("tag".into(), 10, true)),
+            true,
+            false,
+        );
+        assert_eq!(
+            plan.dictionary_field,
+            Some(schema.get_field("tag").unwrap())
+        );
+        assert!(plan.exact_postings.is_empty());
+        assert!(plan.exact_term_info.is_none());
+        assert!(plan.full_posting_fields.is_empty());
+        assert!(plan.fast_fields.is_empty());
+    }
+
+    #[test]
+    fn full_postings_drop_basic_exact_terms_but_keep_positions() {
+        let schema = schema();
+        let all = schema.get_field(INDEX_FIELD_NAME_FOR_ALL).unwrap();
+        let basic = Term::from_field_text(all, "basic");
+        let first = Term::from_field_text(all, "first");
+        let second = Term::from_field_text(all, "second");
+        let query = PhraseQuery::new(vec![first.clone(), second.clone()]);
+        let mut condition = IndexCondition::new();
+        condition.add_condition(Condition::StrMatch(
+            INDEX_FIELD_NAME_FOR_ALL.into(),
+            "needle".into(),
+            true,
+        ));
+        let basic_query =
+            tantivy::query::TermQuery::new(basic, tantivy::schema::IndexRecordOption::Basic);
+        let combined = tantivy::query::BooleanQuery::intersection(vec![
+            Box::new(query),
+            Box::new(basic_query),
+        ]);
+        let plan = WarmPlan::build(&condition, &combined, &None, &schema, true, false);
+        assert_eq!(
+            plan.exact_postings.get(&all),
+            Some(&HashMap::from([(first, true), (second, true)]))
+        );
+    }
+
+    #[test]
+    fn duplicate_exact_term_preserves_position_requirement() {
+        let schema = schema();
+        let tag = schema.get_field("tag").unwrap();
+        let term = Term::from_field_text(tag, "value");
+        let other = Term::from_field_text(tag, "other");
+        let basic =
+            tantivy::query::TermQuery::new(term.clone(), tantivy::schema::IndexRecordOption::Basic);
+        let positioned = PhraseQuery::new(vec![term.clone(), other.clone()]);
+        let query =
+            tantivy::query::BooleanQuery::intersection(vec![Box::new(basic), Box::new(positioned)]);
+        let mut condition = IndexCondition::new();
+        condition.add_condition(Condition::Equal("tag".into(), "value".into()));
+        let plan = WarmPlan::build(&condition, &query, &None, &schema, true, false);
+        assert_eq!(
+            plan.exact_postings.get(&tag),
+            Some(&HashMap::from([(term, true), (other, true)]))
+        );
+    }
+
+    #[test]
+    fn simple_count_term_uses_term_info_only() {
+        let (plan, schema) = build_plan(
+            Condition::Equal("tag".into(), "a".into()),
+            Some(IndexOptimizeMode::SimpleCount),
+            true,
+            false,
+        );
+        let tag = schema.get_field("tag").unwrap();
+        assert_eq!(plan.exact_term_info, Some(Term::from_field_text(tag, "a")));
+        assert!(plan.exact_postings.is_empty());
+    }
+
+    #[test]
+    fn regular_equal_still_warms_exact_posting() {
+        let (plan, _) = build_plan(
+            Condition::Equal("tag".into(), "a".into()),
+            None,
+            true,
+            false,
+        );
+        assert_eq!(exact_terms(&plan).len(), 1);
+        assert!(plan.exact_term_info.is_none());
+    }
+
+    #[test]
+    fn simple_count_all_needs_no_warmup() {
+        let (plan, _) = build_plan(
+            Condition::All(),
+            Some(IndexOptimizeMode::SimpleCount),
+            true,
+            false,
+        );
+        assert!(plan.exact_postings.is_empty());
+        assert!(plan.exact_term_info.is_none());
+        assert!(plan.full_posting_fields.is_empty());
+        assert!(plan.dictionary_field.is_none());
+        assert!(plan.fast_fields.is_empty());
+    }
+
+    #[test]
+    fn compound_simple_count_keeps_postings() {
+        let schema = schema();
+        let tag = schema.get_field("tag").unwrap();
+        let left = tantivy::query::TermQuery::new(
+            Term::from_field_text(tag, "a"),
+            tantivy::schema::IndexRecordOption::Basic,
+        );
+        let right = tantivy::query::TermQuery::new(
+            Term::from_field_text(tag, "b"),
+            tantivy::schema::IndexRecordOption::Basic,
+        );
+        let query =
+            tantivy::query::BooleanQuery::intersection(vec![Box::new(left), Box::new(right)]);
+        let mut condition = IndexCondition::new();
+        condition.add_condition(Condition::And(
+            Box::new(Condition::Equal("tag".into(), "a".into())),
+            Box::new(Condition::Equal("tag".into(), "b".into())),
+        ));
+        let plan = WarmPlan::build(
+            &condition,
+            &query,
+            &Some(IndexOptimizeMode::SimpleCount),
+            &schema,
+            true,
+            false,
+        );
+        assert_eq!(exact_terms(&plan).len(), 2);
+        assert!(plan.exact_term_info.is_none());
+    }
+
+    #[test]
+    fn simple_count_falls_back_for_partial_or_skipped_queries() {
+        let (partial, _) = build_plan(
+            Condition::Equal("tag".into(), "a".into()),
+            Some(IndexOptimizeMode::SimpleCount),
+            false,
+            false,
+        );
+        assert_eq!(exact_terms(&partial).len(), 1);
+        assert!(partial.exact_term_info.is_none());
+        assert_eq!(
+            partial.fast_fields,
+            HashSet::from([TIMESTAMP_COL_NAME.to_string()])
+        );
+
+        let (skipped, _) = build_plan(
+            Condition::Equal("tag".into(), "a".into()),
+            Some(IndexOptimizeMode::SimpleCount),
+            true,
+            true,
+        );
+        assert_eq!(exact_terms(&skipped).len(), 1);
+        assert!(skipped.exact_term_info.is_none());
+    }
+
+    #[tokio::test]
+    async fn simple_count_executes_from_term_info() {
+        let searcher = build_searcher();
+        let schema = searcher.schema().clone();
+        let tag = schema.get_field("tag").unwrap();
+        let query = tantivy::query::TermQuery::new(
+            Term::from_field_text(tag, "a"),
+            tantivy::schema::IndexRecordOption::Basic,
+        );
+        let mut condition = IndexCondition::new();
+        condition.add_condition(Condition::Equal("tag".into(), "a".into()));
+        let plan = WarmPlan::build(
+            &condition,
+            &query,
+            &Some(IndexOptimizeMode::SimpleCount),
+            &schema,
+            true,
+            false,
+        );
+        plan.execute(searcher.segment_reader(0)).await.unwrap();
+        assert_eq!(searcher.search(&query, &Count).unwrap(), 1);
+    }
+
+    #[test]
+    fn collector_fast_fields_are_preserved() {
+        let (histogram, _) = build_plan(
+            Condition::All(),
+            Some(IndexOptimizeMode::SimpleHistogram(0, 100, 10, 0)),
+            true,
+            false,
+        );
+        assert_eq!(
+            histogram.fast_fields,
+            HashSet::from([TIMESTAMP_COL_NAME.to_string()])
+        );
+
+        let (top_n, _) = build_plan(
+            Condition::All(),
+            Some(IndexOptimizeMode::SimpleTopN(vec!["tag".into()], 10, true)),
+            true,
+            false,
+        );
+        assert_eq!(top_n.fast_fields, HashSet::from(["tag".to_string()]));
+    }
+
+    #[test]
+    fn partial_file_preserves_timestamp_warmup() {
+        let (plan, _) = build_plan(Condition::All(), None, false, false);
+        assert_eq!(
+            plan.fast_fields,
+            HashSet::from([TIMESTAMP_COL_NAME.to_string()])
+        );
+    }
+
+    #[test]
+    fn skipped_simple_select_preserves_existing_fast_field_behavior() {
+        let (skipped, _) = build_plan(
+            Condition::All(),
+            Some(IndexOptimizeMode::SimpleSelect(10, true)),
+            true,
+            true,
+        );
+        assert!(skipped.fast_fields.is_empty());
+
+        let (complete, _) = build_plan(
+            Condition::All(),
+            Some(IndexOptimizeMode::SimpleSelect(10, true)),
+            true,
+            false,
+        );
+        assert_eq!(
+            complete.fast_fields,
+            HashSet::from([TIMESTAMP_COL_NAME.to_string()])
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR reduces unnecessary Tantivy index warm-up work by building a warm-up plan based on the actual query and index optimization mode.

Previously, some exact negative queries and optimized collectors warmed more index data than they consumed. The new planning logic distinguishes between exact postings, full postings, term dictionaries, term metadata, and fast fields, allowing each search path to warm only the required data.

## Changes

- Introduce `WarmPlan` to centralize Tantivy warm-up planning and execution.
- Avoid full-posting warm-up for exact negative queries such as `!=`, `NOT IN`, and `NOT Equal`.
- Keep full-posting warm-up for term-expansion queries such as regex and string match.
- Warm only the term dictionary for `SimpleDistinct`.
- Use term metadata (`doc_freq`) instead of postings for eligible single-term `SimpleCount` queries.
- Preserve required fast-field warm-up for histogram, multi-histogram, Top N, select, and partially covered files.
- Deduplicate exact terms while preserving position requirements for phrase queries.
- Return an error instead of panicking when `_timestamp` is missing during simple-select processing.

## Testing

Added and updated unit tests covering:

- Exact and expansion query warm-up requirements.
- Negative exact queries.
- Dictionary-only distinct queries.
- Term-info-only count queries and fallback paths.
- Phrase-query position requirements.
- Collector fast fields and partial file ranges.
- Missing `_timestamp` handling.