### PR TITLE
fix: Issue 13137 Ingester scheduled flag latching to false (starves pipeline/backfill load balancing)

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -101,9 +101,11 @@ pub async fn update_local_node(node: &Node) -> Result<()> {
     }
 
     match cfg.common.cluster_coordinator.as_str().into() {
-        MetaStore::Nats => nats::update_local_node(node).await,
-        _ => nats::update_local_node(node).await,
+        MetaStore::Nats => nats::update_local_node(node).await?,
+        _ => nats::update_local_node(node).await?,
     }
+    add_node_to_cache(node.clone()).await;
+    Ok(())
 }
 
 pub async fn set_unschedulable() -> Result<()> {
@@ -117,10 +119,21 @@ pub async fn set_unschedulable() -> Result<()> {
 
 pub async fn set_schedulable() -> Result<()> {
     let node_id = LOCAL_NODE.uuid.clone();
-    if let Some(mut node) = get_node_by_uuid(&node_id).await {
-        node.scheduled = true;
-        update_local_node(&node).await?;
-    };
+    let mut node = None;
+    for _ in 0..10 {
+      if let Some(n) = get_node_by_uuid(&node_id).await {
+          node = Some(n);
+          break;
+      }
+      tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+    let mut node = node.unwrap_or_else(|| {
+        let mut n = LOCAL_NODE.clone();
+        n.status = NodeStatus::Online;
+        n
+    });
+    node.scheduled = true;
+    update_local_node(&node).await?;
     Ok(())
 }
 


### PR DESCRIPTION
Problem

  Scheduler/pipeline/backfill writes only target ingesters flagged scheduled=true. On main, an ingester can get
  permanently stuck at scheduled=false, so it receives zero ingest/transform work and all load concentrates on the
  remaining nodes. In a 4-ingester cluster we saw 2 nodes stuck, overloading the other 2. The state is persistent and
  node-specific (same nodes across restarts), not intermittent — which is what makes it confusing to diagnose.

  Root cause

  Two stacked defects, both in src/common/infra/cluster/mod.rs:

  1. update_local_node() writes the coordinator (NATS) but never the in-memory NODES cache.
  The keep-alive heartbeat (nats::set_status, every ~`ZO_NODE_HEARTBEAT_TTL/4) reads scheduledfrom that stale local
  cache and republishes the full node record to NATS. So anyscheduled=truewrite — viaPUT /node/enable?value=trueor
  startupset_schedulable()— is reverted within one heartbeat.GET /node/list` reads the same local cache, so the flag
  appears to never change even though the write reached NATS.

  2. set_schedulable() silently no-ops at startup, arming the latch.
  It early-returns without persisting if the node isn't yet in its own local cache. In register() the node lists NATS
  before putting itself and relies on the watch stream to deliver its own record back. A node slow to receive that watch
  event loses the race, set_schedulable() no-ops, and the node latches at false. Because the race outcome is governed
  by boot/watch-delivery timing, the same nodes lose on every restart.

  Fix

  - update_local_node(): propagate errors from the coordinator write and mirror the record into the local cache via
  add_node_to_cache(node.clone()) before returning. This is the core fix — the heartbeat now reads the correct value
  instead of clobbering it. Covers enable_node, set_schedulable, and set_unschedulable, which all route through this
  function.
  - set_schedulable(): replace the silent no-op with a bounded wait (10×1s) for the node's own record, falling back to
  LOCAL_NODE (status forced Online) so scheduled=true is always persisted regardless of watch-delivery timing at
  startup.

  How to reproduce (before this patch)

  curl -u user:pass -X PUT 'http://<ingester-ip>:5080/node/enable?value=true'   # returns 200 true
  curl -u user:pass 'http://<ingester-ip>:5080/node/list'                        # still "scheduled": false

  The value never sticks, and restarting the node doesn't help. Forcing a resync from NATS (GET
  /node/refresh_nodes_list) between the two calls shows true briefly, then the next heartbeat reverts it — confirming
  the write reaches NATS but not the local cache.

  Verification

  - cargo check -p openobserve --lib passes against the pinned toolchain (nightly-2026-05-20).
  - Both edited functions use only symbols already in scope; no new imports.

  Notes / follow-ups (out of scope here)

  - Ingester selection for scheduler/backfill writes is uniform-random (get_rand_element, src/service/grpc.rs), not
  load-aware. The weighted select_best_node selector exists but is wired only into the HTTP router's dispatch strategy
  (ZO_ROUTE_STRATEGY). A single benched ingester therefore has outsized impact — worth a separate look.
  - Node UUID regenerates every process start (ider::uuid()), leaving stale /nodes/{uuid} records to TTL out. Not
  addressed here.