### PR TITLE
fix: keep NATS local node cache in sync

### DIFF
--- a/src/common/infra/cluster/nats.rs
+++ b/src/common/infra/cluster/nats.rs
@@ -260,6 +260,7 @@ pub(crate) async fn set_status(status: NodeStatus) -> Result<()> {
     if let Err(e) = client.put(&key, val.into(), NEED_WATCH, None).await {
         return Err(Error::Message(format!("online node error: {e}")));
     }
+    add_node_to_cache(node).await;
 
     Ok(())
 }
@@ -282,6 +283,7 @@ pub(crate) async fn update_local_node(node: &Node) -> Result<()> {
     if let Err(e) = client.put(&key, val.into(), NEED_WATCH, None).await {
         return Err(Error::Message(format!("update node error: {e}")));
     }
+    add_node_to_cache(node.clone()).await;
     Ok(())
 }
 

--- a/src/common/infra/cluster/nats.rs
+++ b/src/common/infra/cluster/nats.rs
@@ -329,4 +329,35 @@ mod tests {
         println!("[CLUSTER::TEST] test_nats_register: {ret:?}");
         assert!(ret.is_ok());
     }
+
+    #[tokio::test]
+    async fn test_nats_update_local_node_updates_cache() {
+        config::cache_instance_id("instance");
+        infra::db_init().await.unwrap();
+        register().await.unwrap();
+
+        let mut node = get_node_by_uuid(&LOCAL_NODE.uuid).await.unwrap();
+        node.scheduled = true;
+        update_local_node(&node).await.unwrap();
+
+        let cached = get_node_by_uuid(&LOCAL_NODE.uuid).await.unwrap();
+        assert!(cached.scheduled);
+    }
+
+    #[tokio::test]
+    async fn test_nats_set_status_preserves_cached_scheduled() {
+        config::cache_instance_id("instance");
+        infra::db_init().await.unwrap();
+        register().await.unwrap();
+
+        let mut node = get_node_by_uuid(&LOCAL_NODE.uuid).await.unwrap();
+        node.scheduled = true;
+        update_local_node(&node).await.unwrap();
+
+        set_status(NodeStatus::Online).await.unwrap();
+
+        let cached = get_node_by_uuid(&LOCAL_NODE.uuid).await.unwrap();
+        assert!(cached.scheduled);
+        assert_eq!(cached.status, NodeStatus::Online);
+    }
 }


### PR DESCRIPTION
Closes #13137.

This updates the process-local node cache after successful NATS writes in both `update_local_node` and `set_status`. Heartbeats therefore retain the current `scheduled` value instead of republishing stale state.

Regression coverage verifies that local-node updates are immediately visible in cache and that a subsequent status heartbeat preserves `scheduled=true`.

Validation:
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- Focused Rust test build attempted, but this environment does not have the required `protoc` executable.