### PR TITLE
chore: raise ZO_QUERY_DEFAULT_LIMIT default from 1000 to 10000

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1630,7 +1630,7 @@ pub struct Limit {
         help = "Timeout for querier query, default equal to query_timeout"
     )]
     pub query_querier_timeout: u64,
-    #[env_config(name = "ZO_QUERY_DEFAULT_LIMIT", default = 1000)]
+    #[env_config(name = "ZO_QUERY_DEFAULT_LIMIT", default = 10000)]
     pub query_default_limit: i64,
     #[env_config(name = "ZO_QUERY_VALUES_DEFAULT_NUM", default = 10)]
     pub query_values_default_num: i64,
@@ -3301,7 +3301,7 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         cfg.limit.query_partition_max_num = 100;
     }
     if cfg.limit.query_default_limit == 0 {
-        cfg.limit.query_default_limit = 1000;
+        cfg.limit.query_default_limit = 10000;
     }
 
     if cfg.limit.inverted_index_footer_cache_max_size == 0 {


### PR DESCRIPTION
## Summary

Raises the default value of `ZO_QUERY_DEFAULT_LIMIT` from 1000 to 10000 (both the env default and the zero-value fallback).

## Why

With partitioned search, a query without an explicit limit is capped at 1000 records total. On dashboards (e.g. scatter charts) the first mini partition returns some data and the remaining big partition only fills up to the 1000-record cap, so most of the time range renders empty.

Deployments can still override via `ZO_QUERY_DEFAULT_LIMIT`.