### PR TITLE
feat: stop the OTLP metrics writer producing unreadable streams

### DIFF
--- a/src/service/ingestion/grpc.rs
+++ b/src/service/ingestion/grpc.rs
@@ -87,16 +87,16 @@ pub fn get_severity_value(severity_number: i32) -> String {
     .into()
 }
 
-/// Returns `None` when the data point carries no usable value -- either no value at all,
-/// or a NaN. The caller must drop the record in that case: a record written with a null
-/// value never gets a `value` column inferred into the schema, which makes the whole
-/// stream unreadable by PromQL. See [`crate::service::metrics::metric_value`].
-pub fn get_metric_val(attr_val: &Option<number_data_point::Value>) -> Option<json::Value> {
-    let val = match attr_val.as_ref()? {
-        number_data_point::Value::AsDouble(val) => *val,
-        number_data_point::Value::AsInt(val) => *val as f64,
-    };
-    crate::service::metrics::metric_value(val)
+/// Extracts the data point's value. Returns `None` when it carries none -- an absent value
+/// is not an observation, so the caller has no record to write.
+///
+/// The value is returned raw: whether a NaN or an infinity may be *recorded* is the metrics
+/// value policy, and lives with it (`crate::service::metrics::metric_value`).
+pub fn get_metric_val(attr_val: &Option<number_data_point::Value>) -> Option<f64> {
+    match attr_val.as_ref()? {
+        number_data_point::Value::AsDouble(val) => Some(*val),
+        number_data_point::Value::AsInt(val) => Some(*val as f64),
+    }
 }
 
 pub fn get_exemplar_val(attr_val: &Option<exemplar::Value>) -> json::Value {
@@ -329,37 +329,22 @@ mod tests {
     fn test_get_metric_val() {
         // Test AsDouble variant
         let double_val = number_data_point::Value::AsDouble(42.5);
-        let resp = get_metric_val(&Some(double_val)).unwrap();
-        assert_eq!(resp.as_f64().unwrap(), 42.5);
+        assert_eq!(get_metric_val(&Some(double_val)).unwrap(), 42.5);
 
         // Test AsInt variant
         let int_val = number_data_point::Value::AsInt(42);
-        let resp = get_metric_val(&Some(int_val)).unwrap();
-        assert_eq!(resp.as_f64().unwrap(), 42.0);
+        assert_eq!(get_metric_val(&Some(int_val)).unwrap(), 42.0);
 
         // Test None case
         assert!(get_metric_val(&None).is_none());
     }
 
+    /// The value is returned raw -- deciding what a NaN *means* is the metrics value policy,
+    /// not this extractor's job.
     #[test]
-    fn test_get_metric_val_nan_has_no_value() {
+    fn test_get_metric_val_returns_nan_unjudged() {
         let nan = number_data_point::Value::AsDouble(f64::NAN);
-        assert!(get_metric_val(&Some(nan)).is_none());
-    }
-
-    #[test]
-    fn test_get_metric_val_clamps_infinities() {
-        let pos_inf = number_data_point::Value::AsDouble(f64::INFINITY);
-        assert_eq!(
-            get_metric_val(&Some(pos_inf)).unwrap().as_f64().unwrap(),
-            f64::MAX
-        );
-
-        let neg_inf = number_data_point::Value::AsDouble(f64::NEG_INFINITY);
-        assert_eq!(
-            get_metric_val(&Some(neg_inf)).unwrap().as_f64().unwrap(),
-            f64::MIN
-        );
+        assert!(get_metric_val(&Some(nan)).unwrap().is_nan());
     }
 
     #[test]

--- a/src/service/ingestion/grpc.rs
+++ b/src/service/ingestion/grpc.rs
@@ -87,14 +87,16 @@ pub fn get_severity_value(severity_number: i32) -> String {
     .into()
 }
 
-pub fn get_metric_val(attr_val: &Option<number_data_point::Value>) -> json::Value {
-    match attr_val {
-        Some(local_val) => match local_val {
-            number_data_point::Value::AsDouble(val) => json::json!(val),
-            number_data_point::Value::AsInt(val) => json::json!(*val as f64),
-        },
-        None => json::Value::Null,
-    }
+/// Returns `None` when the data point carries no usable value -- either no value at all,
+/// or a NaN. The caller must drop the record in that case: a record written with a null
+/// value never gets a `value` column inferred into the schema, which makes the whole
+/// stream unreadable by PromQL. See [`crate::service::metrics::metric_value`].
+pub fn get_metric_val(attr_val: &Option<number_data_point::Value>) -> Option<json::Value> {
+    let val = match attr_val.as_ref()? {
+        number_data_point::Value::AsDouble(val) => *val,
+        number_data_point::Value::AsInt(val) => *val as f64,
+    };
+    crate::service::metrics::metric_value(val)
 }
 
 pub fn get_exemplar_val(attr_val: &Option<exemplar::Value>) -> json::Value {
@@ -327,17 +329,37 @@ mod tests {
     fn test_get_metric_val() {
         // Test AsDouble variant
         let double_val = number_data_point::Value::AsDouble(42.5);
-        let resp = get_metric_val(&Some(double_val));
+        let resp = get_metric_val(&Some(double_val)).unwrap();
         assert_eq!(resp.as_f64().unwrap(), 42.5);
 
         // Test AsInt variant
         let int_val = number_data_point::Value::AsInt(42);
-        let resp = get_metric_val(&Some(int_val));
+        let resp = get_metric_val(&Some(int_val)).unwrap();
         assert_eq!(resp.as_f64().unwrap(), 42.0);
 
         // Test None case
-        let resp = get_metric_val(&None);
-        assert!(resp.is_null());
+        assert!(get_metric_val(&None).is_none());
+    }
+
+    #[test]
+    fn test_get_metric_val_nan_has_no_value() {
+        let nan = number_data_point::Value::AsDouble(f64::NAN);
+        assert!(get_metric_val(&Some(nan)).is_none());
+    }
+
+    #[test]
+    fn test_get_metric_val_clamps_infinities() {
+        let pos_inf = number_data_point::Value::AsDouble(f64::INFINITY);
+        assert_eq!(
+            get_metric_val(&Some(pos_inf)).unwrap().as_f64().unwrap(),
+            f64::MAX
+        );
+
+        let neg_inf = number_data_point::Value::AsDouble(f64::NEG_INFINITY);
+        assert_eq!(
+            get_metric_val(&Some(neg_inf)).unwrap().as_f64().unwrap(),
+            f64::MIN
+        );
     }
 
     #[test]

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -63,6 +63,33 @@ use crate::{
 
 const VALID_METRICS_TYPES: &[&str] = &["counter", "gauge", "histogram", "summary"];
 
+/// The value a JSON metric record carries, put through the same policy as every other
+/// ingestion path (`super::metric_value`).
+///
+/// JSON has no NaN or infinity *literal*, but it can still carry a non-finite *value*: `1e400`
+/// is a syntactically valid JSON number, and with serde_json's `arbitrary_precision` the literal
+/// is kept verbatim, `is_number()` is true, and `as_f64()` returns `None`. Unwrapping that --
+/// which is what this code used to do -- panics the ingestion handler on a request body anyone
+/// can send. An out-of-range magnitude clamps to the f64 bound, like an OTLP or remote-write
+/// infinity does; anything that is not a number at all is rejected.
+fn parse_metric_value(value: &json::Value) -> Result<json::Value, anyhow::Error> {
+    let json::Value::Number(n) = value else {
+        return Err(anyhow!("invalid value, need to be number"));
+    };
+
+    // `as_f64` is `None` only when the literal is out of f64 range, where parsing it yields an
+    // infinity -- which the policy clamps.
+    let raw = match n.as_f64() {
+        Some(v) => v,
+        None => n
+            .to_string()
+            .parse::<f64>()
+            .map_err(|_| anyhow!("invalid value, need to be number"))?,
+    };
+
+    super::metric_value(raw).ok_or_else(|| anyhow!("invalid value, not a number"))
+}
+
 pub async fn ingest(
     org_id: &str,
     stream_name: Option<&str>,
@@ -192,9 +219,13 @@ pub async fn ingest(
         // check timestamp
         let timestamp: i64 = match record.get(TIMESTAMP_COL_NAME) {
             None => now_micros(),
-            Some(json::Value::Number(s)) => {
-                time::parse_i64_to_timestamp_micros(s.as_f64().unwrap() as i64)
-            }
+            // `as_f64` is `None` for a literal out of f64 range (`1e400`), which unwrapping
+            // turned into a panic on a request body anyone can send
+            Some(json::Value::Number(s)) => time::parse_i64_to_timestamp_micros(
+                s.as_f64()
+                    .ok_or_else(|| anyhow::anyhow!("invalid _timestamp, out of range"))?
+                    as i64,
+            ),
             Some(_) => {
                 return Err(anyhow::anyhow!("invalid _timestamp, need to be number"));
             }
@@ -369,17 +400,10 @@ pub async fn ingest(
             // End get stream alert
 
             // check value
-            let value: f64 = match record.get(VALUE_LABEL).ok_or(anyhow!("missing value"))? {
-                json::Value::Number(s) => s.as_f64().unwrap(),
-                _ => {
-                    return Err(anyhow::anyhow!("invalid value, need to be number"));
-                }
-            };
+            let value =
+                parse_metric_value(record.get(VALUE_LABEL).ok_or(anyhow!("missing value"))?)?;
             // reset value
-            record.insert(
-                VALUE_LABEL.to_string(),
-                json::Number::from_f64(value).unwrap().into(),
-            );
+            record.insert(VALUE_LABEL.to_string(), value);
 
             let timestamp = record
                 .get(TIMESTAMP_COL_NAME)
@@ -603,6 +627,41 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    /// `1e400` is a valid JSON number whose value is an infinity. `as_f64()` returns `None` for
+    /// it, and unwrapping that panicked the ingestion handler -- on a body anyone can POST.
+    #[test]
+    fn test_parse_metric_value_clamps_an_out_of_range_number() {
+        let value: json::Value = json::from_str("1e400").unwrap();
+        assert!(value.is_number());
+        assert!(
+            value.as_f64().is_none(),
+            "precondition: as_f64 is None here"
+        );
+
+        let parsed = parse_metric_value(&value).unwrap();
+        assert_eq!(parsed.as_f64().unwrap(), f64::MAX);
+
+        let negative: json::Value = json::from_str("-1e400").unwrap();
+        assert_eq!(
+            parse_metric_value(&negative).unwrap().as_f64().unwrap(),
+            f64::MIN
+        );
+    }
+
+    #[test]
+    fn test_parse_metric_value_passes_a_finite_number_through() {
+        assert_eq!(
+            parse_metric_value(&json!(42.5)).unwrap().as_f64().unwrap(),
+            42.5
+        );
+    }
+
+    #[test]
+    fn test_parse_metric_value_rejects_a_non_number() {
+        assert!(parse_metric_value(&json!("42.5")).is_err());
+        assert!(parse_metric_value(&json!(null)).is_err());
+    }
 
     fn create_test_metric_record(
         name: &str,

--- a/src/service/metrics/mod.rs
+++ b/src/service/metrics/mod.rs
@@ -35,40 +35,55 @@ const EXCLUDE_LABELS: [&str; 8] = [
     "_all",
 ];
 
-/// The value policy for every metric record we write.
+/// The value policy for every metric we ingest, on every path.
 ///
-/// Mirrors the remote-write path (see `prom.rs`): infinities clamp to the f64
-/// bounds, NaN means "no observation" and the record is dropped. A NaN written
-/// through serde_json becomes `Value::Null`, an all-null column is never inferred
-/// into the schema, and the resulting stream cannot be read by PromQL at all --
-/// while still costing full ingest and storage.
-pub fn metric_value(v: f64) -> Option<config::utils::json::Value> {
+/// NaN means "no observation": the sample is not recorded. An absent series is how Prometheus
+/// itself represents no data, and a NaN written through serde_json becomes `Value::Null` --
+/// an all-null column is never inferred into the Arrow schema, so the stream it lands in can
+/// never be read by PromQL while still costing full ingest, storage and replication.
+/// Infinities clamp to the f64 bounds.
+///
+/// Both ingestion paths go through here: remote-write (`prom.rs`) and OTLP (`otlp.rs`).
+pub fn sanitize_metric_value(v: f64) -> Option<f64> {
     if v.is_nan() {
         return None;
     }
-    let v = if v == f64::INFINITY || v > f64::MAX {
-        f64::MAX
+    // the `>`/`<` arms are unreachable for a finite f64 and are kept only so the two clamp
+    // sites stay textually identical. Simplify them in both, or in neither.
+    if v == f64::INFINITY || v > f64::MAX {
+        Some(f64::MAX)
     } else if v == f64::NEG_INFINITY || v < f64::MIN {
-        f64::MIN
+        Some(f64::MIN)
     } else {
-        v
-    };
-    Some(config::utils::json::json!(v))
+        Some(v)
+    }
+}
+
+/// [`sanitize_metric_value`], as the JSON a record carries. `None` means the record must not
+/// be written at all.
+pub fn metric_value(v: f64) -> Option<config::utils::json::Value> {
+    sanitize_metric_value(v).map(|v| config::utils::json::json!(v))
 }
 
 pub fn get_prom_metadata_from_schema(schema: &Schema) -> Option<Metadata> {
     let metadata = schema.metadata.get(METADATA_LABEL)?;
-    let mut metadata: Metadata = config::utils::json::from_str(metadata).ok()?;
+    let mut metadata: Metadata = match config::utils::json::from_str(metadata) {
+        Ok(metadata) => metadata,
+        Err(e) => {
+            // this used to panic the process on a single corrupt schema entry
+            log::warn!("failed to parse {METADATA_LABEL} from schema: {e}, input: {metadata}");
+            return None;
+        }
+    };
 
-    // Historical schemas carry a JSON-quoted family name: the OTLP writer used to build it
-    // with `Value::to_string()`, which yields the serialised JSON (`"name"`, quotes included)
-    // rather than the string content. The stored bytes are not rewritten -- we decline to
-    // serve the quotes. Until those schemas age out, this is what makes the family join work.
-    metadata.metric_family_name = metadata
-        .metric_family_name
-        .trim()
-        .trim_matches('"')
-        .to_string();
+    // Historical schemas carry a JSON-quoted family name: the OTLP writer used to build it with
+    // `Value::to_string()`, which yields the serialised JSON (`"name"`, quotes included) rather
+    // than the string content. Reversing that is exactly a JSON-string parse -- a clean name is
+    // not valid JSON, so it is left alone. The stored bytes are not rewritten; we simply decline
+    // to serve the quotes, which is what makes the family join work on data already written.
+    let family_name = metadata.metric_family_name.trim();
+    metadata.metric_family_name = config::utils::json::from_str::<String>(family_name)
+        .unwrap_or_else(|_| family_name.to_string());
 
     Some(metadata)
 }

--- a/src/service/metrics/mod.rs
+++ b/src/service/metrics/mod.rs
@@ -43,9 +43,9 @@ const EXCLUDE_LABELS: [&str; 8] = [
 /// never be read by PromQL while still costing full ingest, storage and replication.
 /// Infinities clamp to the f64 bounds.
 ///
-/// Both ingestion paths that can carry a non-finite value go through here: remote-write
-/// (`prom.rs`) and OTLP (`otlp.rs`). The JSON path (`json.rs`) does not need it -- JSON has no
-/// NaN or infinity literal, and it already rejects a value that is not a number.
+/// All three ingestion paths go through here: OTLP (`otlp.rs`), remote-write (`prom.rs`) and
+/// JSON (`json.rs`). JSON has no NaN or infinity *literal*, but `1e400` is a valid JSON number
+/// whose value is an infinity, so it is not exempt.
 pub fn sanitize_metric_value(v: f64) -> Option<f64> {
     if v.is_nan() {
         return None;

--- a/src/service/metrics/mod.rs
+++ b/src/service/metrics/mod.rs
@@ -43,7 +43,9 @@ const EXCLUDE_LABELS: [&str; 8] = [
 /// never be read by PromQL while still costing full ingest, storage and replication.
 /// Infinities clamp to the f64 bounds.
 ///
-/// Both ingestion paths go through here: remote-write (`prom.rs`) and OTLP (`otlp.rs`).
+/// Both ingestion paths that can carry a non-finite value go through here: remote-write
+/// (`prom.rs`) and OTLP (`otlp.rs`). The JSON path (`json.rs`) does not need it -- JSON has no
+/// NaN or infinity literal, and it already rejects a value that is not a number.
 pub fn sanitize_metric_value(v: f64) -> Option<f64> {
     if v.is_nan() {
         return None;

--- a/src/service/metrics/mod.rs
+++ b/src/service/metrics/mod.rs
@@ -169,6 +169,23 @@ mod tests {
         assert!(labels.contains(&"_all"));
     }
 
+    /// The policy itself. The remote-write path calls this one directly (it needs the f64
+    /// back), so it is asserted on its own and not only through `metric_value`.
+    #[test]
+    fn test_sanitize_metric_value() {
+        assert!(sanitize_metric_value(f64::NAN).is_none());
+        assert_eq!(sanitize_metric_value(f64::INFINITY), Some(f64::MAX));
+        assert_eq!(sanitize_metric_value(f64::NEG_INFINITY), Some(f64::MIN));
+        assert_eq!(sanitize_metric_value(0.0), Some(0.0));
+        assert_eq!(sanitize_metric_value(-1.5), Some(-1.5));
+        assert_eq!(sanitize_metric_value(f64::MAX), Some(f64::MAX));
+        assert_eq!(sanitize_metric_value(f64::MIN), Some(f64::MIN));
+        assert_eq!(
+            sanitize_metric_value(f64::MIN_POSITIVE),
+            Some(f64::MIN_POSITIVE)
+        );
+    }
+
     #[test]
     fn test_metric_value_drops_nan() {
         assert!(metric_value(f64::NAN).is_none());

--- a/src/service/metrics/mod.rs
+++ b/src/service/metrics/mod.rs
@@ -35,9 +35,41 @@ const EXCLUDE_LABELS: [&str; 8] = [
     "_all",
 ];
 
+/// The value policy for every metric record we write.
+///
+/// Mirrors the remote-write path (see `prom.rs`): infinities clamp to the f64
+/// bounds, NaN means "no observation" and the record is dropped. A NaN written
+/// through serde_json becomes `Value::Null`, an all-null column is never inferred
+/// into the schema, and the resulting stream cannot be read by PromQL at all --
+/// while still costing full ingest and storage.
+pub fn metric_value(v: f64) -> Option<config::utils::json::Value> {
+    if v.is_nan() {
+        return None;
+    }
+    let v = if v == f64::INFINITY || v > f64::MAX {
+        f64::MAX
+    } else if v == f64::NEG_INFINITY || v < f64::MIN {
+        f64::MIN
+    } else {
+        v
+    };
+    Some(config::utils::json::json!(v))
+}
+
 pub fn get_prom_metadata_from_schema(schema: &Schema) -> Option<Metadata> {
     let metadata = schema.metadata.get(METADATA_LABEL)?;
-    let metadata: Metadata = config::utils::json::from_str(metadata).unwrap();
+    let mut metadata: Metadata = config::utils::json::from_str(metadata).ok()?;
+
+    // Historical schemas carry a JSON-quoted family name: the OTLP writer used to build it
+    // with `Value::to_string()`, which yields the serialised JSON (`"name"`, quotes included)
+    // rather than the string content. The stored bytes are not rewritten -- we decline to
+    // serve the quotes. Until those schemas age out, this is what makes the family join work.
+    metadata.metric_family_name = metadata
+        .metric_family_name
+        .trim()
+        .trim_matches('"')
+        .to_string();
+
     Some(metadata)
 }
 
@@ -122,5 +154,75 @@ mod tests {
         let labels = get_exclude_labels();
         assert!(labels.contains(&"_timestamp"));
         assert!(labels.contains(&"_all"));
+    }
+
+    #[test]
+    fn test_metric_value_drops_nan() {
+        assert!(metric_value(f64::NAN).is_none());
+    }
+
+    #[test]
+    fn test_metric_value_clamps_infinities() {
+        assert_eq!(
+            metric_value(f64::INFINITY).unwrap().as_f64().unwrap(),
+            f64::MAX
+        );
+        assert_eq!(
+            metric_value(f64::NEG_INFINITY).unwrap().as_f64().unwrap(),
+            f64::MIN
+        );
+    }
+
+    #[test]
+    fn test_metric_value_passes_finite_values_through() {
+        assert_eq!(metric_value(0.0).unwrap(), json::json!(0.0));
+        assert_eq!(metric_value(-1.5).unwrap(), json::json!(-1.5));
+        assert_eq!(metric_value(f64::MAX).unwrap().as_f64().unwrap(), f64::MAX);
+    }
+
+    fn schema_with_metadata(blob: &str) -> Schema {
+        Schema::empty().with_metadata(
+            [(METADATA_LABEL.to_string(), blob.to_string())]
+                .into_iter()
+                .collect(),
+        )
+    }
+
+    /// The historical shape: the OTLP writer built the family name with `Value::to_string()`,
+    /// so 2,694 of 3,349 streams on a real cluster carry it JSON-quoted. The stored bytes are
+    /// left alone; the read path declines to serve the quotes.
+    #[test]
+    fn test_get_prom_metadata_from_schema_unquotes_stored_family_name() {
+        let schema = schema_with_metadata(
+            r#"{"metric_type":"Histogram","metric_family_name":"\"foo\"","help":"h","unit":"s"}"#,
+        );
+        let metadata = get_prom_metadata_from_schema(&schema).unwrap();
+
+        assert_eq!(metadata.metric_family_name, "foo");
+        assert_eq!(metadata.help, "h");
+    }
+
+    #[test]
+    fn test_get_prom_metadata_from_schema_leaves_clean_family_name_alone() {
+        let schema = schema_with_metadata(
+            r#"{"metric_type":"Histogram","metric_family_name":"foo","help":"h","unit":"s"}"#,
+        );
+
+        assert_eq!(
+            get_prom_metadata_from_schema(&schema)
+                .unwrap()
+                .metric_family_name,
+            "foo"
+        );
+    }
+
+    #[test]
+    fn test_get_prom_metadata_from_schema_malformed_blob_is_none_not_panic() {
+        assert!(get_prom_metadata_from_schema(&schema_with_metadata("not json")).is_none());
+    }
+
+    #[test]
+    fn test_get_prom_metadata_from_schema_absent_metadata_is_none() {
+        assert!(get_prom_metadata_from_schema(&Schema::empty()).is_none());
     }
 }

--- a/src/service/metrics/mod.rs
+++ b/src/service/metrics/mod.rs
@@ -48,11 +48,9 @@ pub fn sanitize_metric_value(v: f64) -> Option<f64> {
     if v.is_nan() {
         return None;
     }
-    // the `>`/`<` arms are unreachable for a finite f64 and are kept only so the two clamp
-    // sites stay textually identical. Simplify them in both, or in neither.
-    if v == f64::INFINITY || v > f64::MAX {
+    if v == f64::INFINITY {
         Some(f64::MAX)
-    } else if v == f64::NEG_INFINITY || v < f64::MIN {
+    } else if v == f64::NEG_INFINITY {
         Some(f64::MIN)
     } else {
         Some(v)

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -255,9 +255,7 @@ pub async fn handle_otlp_request(
 
                 let records = match &metric.data {
                     Some(data) => match data {
-                        Data::Gauge(gauge) => {
-                            process_gauge(&mut rec, gauge, metadata, &mut prom_meta)
-                        }
+                        Data::Gauge(gauge) => process_gauge(&rec, gauge, metadata, &mut prom_meta),
                         Data::Sum(sum) => process_sum(&mut rec, sum, metadata, &mut prom_meta),
                         Data::Histogram(hist) => {
                             process_histogram(&mut rec, hist, metadata, &mut prom_meta)
@@ -284,6 +282,14 @@ pub async fn handle_otlp_request(
                         vec![]
                     }
                 };
+
+                // a metric that yields no records -- every data point NaN, no data points at
+                // all, or an undecodable type -- gets no stream: no schema, no metadata entry,
+                // and nothing buffered for a pipeline that is configured on this stream (the
+                // pipeline loop below treats a missing input buffer as a bug and logs it).
+                if records.is_empty() {
+                    continue;
+                }
 
                 // update schema metadata
                 if !schema_exists.has_metrics_metadata {
@@ -846,7 +852,7 @@ fn process_data_point(rec: &mut json::Value, data_point: &NumberDataPoint) -> bo
     for attr in &data_point.attributes {
         rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
-    let Some(value) = get_metric_val(&data_point.value) else {
+    let Some(value) = get_metric_val(&data_point.value).and_then(super::metric_value) else {
         return false;
     };
     rec[VALUE_LABEL] = value;
@@ -1268,7 +1274,7 @@ mod tests {
     #[test]
     fn test_process_gauge() {
         let metric = create_test_gauge_metric("test_gauge", 42.5);
-        let mut rec = json!({
+        let rec = json!({
             "__name__": "test_gauge",
             "__type__": "gauge"
         });
@@ -1281,7 +1287,7 @@ mod tests {
         let mut prom_meta: HashMap<String, String> = HashMap::new();
 
         if let Some(Data::Gauge(gauge)) = &metric.data {
-            let result = process_gauge(&mut rec, gauge, metadata, &mut prom_meta);
+            let result = process_gauge(&rec, gauge, metadata, &mut prom_meta);
 
             // Verify the processed data
             assert!(!result.is_empty());
@@ -1526,8 +1532,8 @@ mod tests {
         assert!(!metric_names.contains(&"test_histogram_sum"));
         assert!(!metric_names.contains(&"test_histogram_min"));
         assert!(!metric_names.contains(&"test_histogram_max"));
-        // `.get(..).is_some()` would pass on a null value -- `Value::Null` is still
-        // `Some(&Value::Null)` -- which is exactly the bug that has to stay dead
+        // `!is_null()`, not `.get(..).is_some()`: a null value is still `Some(&Value::Null)`.
+        // The writers are held to this across NaN inputs in `test_no_writer_emits_a_null_value`.
         assert!(result.iter().all(|r| !r[VALUE_LABEL].is_null()));
     }
 
@@ -1714,7 +1720,7 @@ mod tests {
     #[test]
     fn test_metric_with_attributes() {
         let metric = create_test_gauge_metric("test_metric_with_attrs", 42.0);
-        let mut rec = json!({
+        let rec = json!({
             "__name__": "test_metric_with_attrs",
             "__type__": "gauge"
         });
@@ -1727,7 +1733,7 @@ mod tests {
         let mut prom_meta: HashMap<String, String> = HashMap::new();
 
         if let Some(Data::Gauge(gauge)) = &metric.data {
-            let result = process_gauge(&mut rec, gauge, metadata, &mut prom_meta);
+            let result = process_gauge(&rec, gauge, metadata, &mut prom_meta);
 
             // Verify the processed data has required fields
             assert!(!result.is_empty());
@@ -1846,7 +1852,7 @@ mod tests {
         #[test]
         fn test_gauge_with_zero_value() {
             let metric = create_test_gauge_metric("zero_gauge", 0.0);
-            let mut rec = json!({"__name__": "zero_gauge", "__type__": "gauge"});
+            let rec = json!({"__name__": "zero_gauge", "__type__": "gauge"});
             let metadata = Metadata {
                 metric_family_name: String::new(),
                 metric_type: MetricType::Unknown,
@@ -1856,7 +1862,7 @@ mod tests {
             let mut prom_meta = HashMap::new();
 
             if let Some(Data::Gauge(gauge)) = &metric.data {
-                let result = process_gauge(&mut rec, gauge, metadata, &mut prom_meta);
+                let result = process_gauge(&rec, gauge, metadata, &mut prom_meta);
                 assert!(!result.is_empty());
                 assert_eq!(result[0]["value"], 0.0);
             }
@@ -1865,7 +1871,7 @@ mod tests {
         #[test]
         fn test_gauge_with_negative_value() {
             let metric = create_test_gauge_metric("negative_gauge", -42.5);
-            let mut rec = json!({"__name__": "negative_gauge", "__type__": "gauge"});
+            let rec = json!({"__name__": "negative_gauge", "__type__": "gauge"});
             let metadata = Metadata {
                 metric_family_name: String::new(),
                 metric_type: MetricType::Unknown,
@@ -1875,7 +1881,7 @@ mod tests {
             let mut prom_meta = HashMap::new();
 
             if let Some(Data::Gauge(gauge)) = &metric.data {
-                let result = process_gauge(&mut rec, gauge, metadata, &mut prom_meta);
+                let result = process_gauge(&rec, gauge, metadata, &mut prom_meta);
                 assert!(!result.is_empty());
                 assert_eq!(result[0]["value"], -42.5);
             }
@@ -1884,7 +1890,7 @@ mod tests {
         #[test]
         fn test_gauge_with_infinity() {
             let metric = create_test_gauge_metric("infinity_gauge", f64::INFINITY);
-            let mut rec = json!({"__name__": "infinity_gauge", "__type__": "gauge"});
+            let rec = json!({"__name__": "infinity_gauge", "__type__": "gauge"});
             let metadata = Metadata {
                 metric_family_name: String::new(),
                 metric_type: MetricType::Unknown,
@@ -1894,7 +1900,7 @@ mod tests {
             let mut prom_meta = HashMap::new();
 
             if let Some(Data::Gauge(gauge)) = &metric.data {
-                let result = process_gauge(&mut rec, gauge, metadata, &mut prom_meta);
+                let result = process_gauge(&rec, gauge, metadata, &mut prom_meta);
                 assert_eq!(result.len(), 1);
                 // an infinity is clamped to the f64 bound, matching the remote-write path.
                 // it is never written as JSON null: a null value suppresses the `value`

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -238,12 +238,9 @@ pub async fn handle_otlp_request(
                 };
 
                 // A metric that yields no records -- every data point NaN, no data points at all,
-                // or an undecodable type -- gets nothing: no schema, no metadata entry, and no
-                // entry in stream_executable_pipelines. That last one matters: the pipeline loop
-                // at the end of this function expects every registered stream to have buffered
-                // inputs and logs a BUG if it does not, so a stream registered here and then
-                // dropped would log one on every export request. Hence the per-stream lookups
-                // below run only once we know we have something to write.
+                // or an undecodable type -- gets nothing at all: no schema, no metadata entry,
+                // no stream. The per-stream lookups below therefore run only once we know there
+                // is something to write.
                 if records.is_empty() {
                     continue;
                 }
@@ -277,14 +274,6 @@ pub async fn handle_otlp_request(
                 )
                 .await;
                 // End get stream alert
-
-                // get stream pipeline
-                if !stream_executable_pipelines.contains_key(&metric_name) {
-                    let pipeline_params =
-                        crate::service::ingestion::get_stream_executable_pipelines(&stream_param)
-                            .await;
-                    stream_executable_pipelines.insert(metric_name.clone(), pipeline_params);
-                }
 
                 // get user defined schema
                 crate::service::ingestion::get_uds_and_original_data_streams(
@@ -362,17 +351,6 @@ pub async fn handle_otlp_request(
                         .await;
                         // End get stream alert
 
-                        // get stream pipeline
-                        if !stream_executable_pipelines.contains_key(&local_metric_name) {
-                            let pipeline_params =
-                                crate::service::ingestion::get_stream_executable_pipelines(
-                                    &stream_param,
-                                )
-                                .await;
-                            stream_executable_pipelines
-                                .insert(local_metric_name.clone(), pipeline_params);
-                        }
-
                         crate::service::ingestion::get_uds_and_original_data_streams(
                             std::slice::from_ref(&stream_param),
                             &mut user_defined_schema_map,
@@ -380,6 +358,24 @@ pub async fn handle_otlp_request(
                             &mut streams_need_all_values_map,
                         )
                         .await;
+                    }
+
+                    // get stream pipeline -- for the stream this record actually lands in, which
+                    // is not always the metric's own name: a histogram's rows all carry a
+                    // `_count` / `_sum` / `_bucket` name and none carry the base. Registering the
+                    // base here anyway would leave a stream in stream_executable_pipelines with
+                    // no buffered inputs, and the loop at the end of this function reports that
+                    // as a bug on every export request.
+                    if !stream_executable_pipelines.contains_key(&local_metric_name) {
+                        let stream_param =
+                            StreamParams::new(org_id, &local_metric_name, StreamType::Metrics);
+                        let pipeline_params =
+                            crate::service::ingestion::get_stream_executable_pipelines(
+                                &stream_param,
+                            )
+                            .await;
+                        stream_executable_pipelines
+                            .insert(local_metric_name.clone(), pipeline_params);
                     }
 
                     // ready to be buffered for downstream processing

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -2875,9 +2875,14 @@ mod tests {
                 records[1].get("zone").is_none(),
                 "second data point carried no zone, so the record must not have one"
             );
-            assert_ne!(
-                records[0][HASH_LABEL], records[1][HASH_LABEL],
-                "the series hash must reflect the labels the data point actually carried"
+
+            // and the series identity follows: the hash of the leak-free record is the hash of
+            // the same data point sent on its own. An `assert_ne!` against the first record
+            // would not show this -- `pod` alone already makes those two differ.
+            let alone = gauge_records(vec![number_dp(2.0, vec![attr("pod", "b")])]);
+            assert_eq!(
+                records[1][HASH_LABEL], alone[0][HASH_LABEL],
+                "the series hash must be computed over the labels the data point actually carried"
             );
         }
 

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -250,12 +250,7 @@ pub async fn handle_otlp_request(
                 rec[NAME_LABEL] = metric_name.to_owned().into();
 
                 // process metadata
-                let metadata = Metadata {
-                    metric_family_name: rec[NAME_LABEL].to_string(),
-                    metric_type: MetricType::Unknown,
-                    help: metric.description.to_owned(),
-                    unit: metric.unit.to_owned(),
-                };
+                let metadata = build_metadata(&metric_name, metric);
                 let mut prom_meta: HashMap<String, String> = HashMap::new();
 
                 let records = match &metric.data {
@@ -684,8 +679,25 @@ fn batch_min_timestamp(
     }
 }
 
+/// Builds the family metadata stored on the stream schema.
+///
+/// `metric_family_name` is the plain metric name. It is deliberately not read back out of
+/// `rec[NAME_LABEL]`: that is a `json::Value::String`, and `Value::to_string()` returns the
+/// serialised JSON -- `"name"`, quotes included -- rather than the string content.
+fn build_metadata(
+    metric_name: &str,
+    metric: &opentelemetry_proto::tonic::metrics::v1::Metric,
+) -> Metadata {
+    Metadata {
+        metric_family_name: metric_name.to_string(),
+        metric_type: MetricType::Unknown,
+        help: metric.description.to_owned(),
+        unit: metric.unit.to_owned(),
+    }
+}
+
 fn process_gauge(
-    rec: &mut json::Value,
+    rec: &json::Value,
     gauge: &Gauge,
     mut metadata: Metadata,
     prom_meta: &mut HashMap<String, String>,
@@ -700,11 +712,17 @@ fn process_gauge(
     );
 
     for data_point in &gauge.data_points {
-        process_data_point(rec, data_point);
-        let val_map = rec.as_object_mut().unwrap();
+        // a fresh record per data point: `process_data_point` only ever sets attribute keys,
+        // so reusing one record lets a data point inherit an attribute the previous one
+        // carried and it never dropped -- which then feeds the series hash.
+        let mut dp_rec = rec.clone();
+        if !process_data_point(&mut dp_rec, data_point) {
+            continue;
+        }
+        let val_map = dp_rec.as_object_mut().unwrap();
         let hash = super::signature_without_labels(val_map, &get_exclude_labels());
         val_map.insert(HASH_LABEL.to_string(), json::Value::Number(hash.into()));
-        records.push(rec.clone());
+        records.push(dp_rec);
     }
     records
 }
@@ -727,11 +745,13 @@ fn process_sum(
     rec["is_monotonic"] = sum.is_monotonic.to_string().into();
     for data_point in &sum.data_points {
         let mut dp_rec = rec.clone();
-        process_data_point(&mut dp_rec, data_point);
+        if !process_data_point(&mut dp_rec, data_point) {
+            continue;
+        }
         let val_map = dp_rec.as_object_mut().unwrap();
         let hash = super::signature_without_labels(val_map, &get_exclude_labels());
         val_map.insert(HASH_LABEL.to_string(), json::Value::Number(hash.into()));
-        records.push(dp_rec.clone());
+        records.push(dp_rec);
     }
     records
 }
@@ -815,11 +835,21 @@ fn process_summary(
     records
 }
 
-fn process_data_point(rec: &mut json::Value, data_point: &NumberDataPoint) {
+/// Returns false if this data point has no usable value and must not be recorded.
+///
+/// The caller owns the drop, not this function: it mutates a record in place and cannot
+/// remove it from the caller's buffer. Skipping only the `VALUE_LABEL` assignment would be
+/// worse than the bug -- the record would keep whatever value it already held and re-report
+/// a stale reading as if it were fresh.
+#[must_use]
+fn process_data_point(rec: &mut json::Value, data_point: &NumberDataPoint) -> bool {
     for attr in &data_point.attributes {
         rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
-    rec[VALUE_LABEL] = get_metric_val(&data_point.value);
+    let Some(value) = get_metric_val(&data_point.value) else {
+        return false;
+    };
+    rec[VALUE_LABEL] = value;
     rec[TIMESTAMP_COL_NAME] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
     rec["flag"] = if data_point.flags == 1 {
@@ -829,6 +859,7 @@ fn process_data_point(rec: &mut json::Value, data_point: &NumberDataPoint) {
     }
     .into();
     process_exemplars(rec, &data_point.exemplars);
+    true
 }
 
 fn process_hist_data_point(
@@ -855,23 +886,23 @@ fn process_hist_data_point(
     count_rec[NAME_LABEL] = format!("{}_count", count_rec[NAME_LABEL].as_str().unwrap()).into();
     bucket_recs.push(count_rec);
 
-    if let Some(sum) = data_point.sum {
+    if let Some(sum) = data_point.sum.and_then(super::metric_value) {
         let mut sum_rec = rec.clone();
-        sum_rec[VALUE_LABEL] = sum.into();
+        sum_rec[VALUE_LABEL] = sum;
         sum_rec[NAME_LABEL] = format!("{}_sum", sum_rec[NAME_LABEL].as_str().unwrap()).into();
         bucket_recs.push(sum_rec);
     }
 
-    if let Some(min) = data_point.min {
+    if let Some(min) = data_point.min.and_then(super::metric_value) {
         let mut min_rec = rec.clone();
-        min_rec[VALUE_LABEL] = min.into();
+        min_rec[VALUE_LABEL] = min;
         min_rec[NAME_LABEL] = format!("{}_min", min_rec[NAME_LABEL].as_str().unwrap()).into();
         bucket_recs.push(min_rec);
     }
 
-    if let Some(max) = data_point.max {
+    if let Some(max) = data_point.max.and_then(super::metric_value) {
         let mut max_rec = rec.clone();
-        max_rec[VALUE_LABEL] = max.into();
+        max_rec[VALUE_LABEL] = max;
         max_rec[NAME_LABEL] = format!("{}_max", max_rec[NAME_LABEL].as_str().unwrap()).into();
         bucket_recs.push(max_rec);
     }
@@ -920,11 +951,13 @@ fn process_exp_hist_data_point(
     count_rec[NAME_LABEL] = format!("{}_count", count_rec[NAME_LABEL].as_str().unwrap()).into();
     bucket_recs.push(count_rec);
 
-    // add sum record
-    let mut sum_rec = rec.clone();
-    sum_rec[VALUE_LABEL] = data_point.sum.into();
-    sum_rec[NAME_LABEL] = format!("{}_sum", sum_rec[NAME_LABEL].as_str().unwrap()).into();
-    bucket_recs.push(sum_rec);
+    // add sum record -- OTLP marks `sum` optional, so an absent (or NaN) sum emits no record
+    if let Some(sum) = data_point.sum.and_then(super::metric_value) {
+        let mut sum_rec = rec.clone();
+        sum_rec[VALUE_LABEL] = sum;
+        sum_rec[NAME_LABEL] = format!("{}_sum", sum_rec[NAME_LABEL].as_str().unwrap()).into();
+        bucket_recs.push(sum_rec);
+    }
 
     let base = 2 ^ (2 ^ -data_point.scale);
     // add negative bucket records
@@ -976,16 +1009,22 @@ fn process_summary_data_point(
     count_rec[NAME_LABEL] = format!("{}_count", count_rec[NAME_LABEL].as_str().unwrap()).into();
     bucket_recs.push(count_rec);
 
-    // add sum record
-    let mut sum_rec = rec.clone();
-    sum_rec[VALUE_LABEL] = data_point.sum.into();
-    sum_rec[NAME_LABEL] = format!("{}_sum", sum_rec[NAME_LABEL].as_str().unwrap()).into();
-    bucket_recs.push(sum_rec);
+    // add sum record -- `sum` is a plain f64 here, so it can only be dropped for NaN
+    if let Some(sum) = super::metric_value(data_point.sum) {
+        let mut sum_rec = rec.clone();
+        sum_rec[VALUE_LABEL] = sum;
+        sum_rec[NAME_LABEL] = format!("{}_sum", sum_rec[NAME_LABEL].as_str().unwrap()).into();
+        bucket_recs.push(sum_rec);
+    }
 
-    // add bucket records
+    // add bucket records -- a summary reports NaN for a quantile with no observations, and
+    // an absent series is how Prometheus itself represents "no data"
     for value in &data_point.quantile_values {
+        let Some(quantile_value) = super::metric_value(value.value) else {
+            continue;
+        };
         let mut bucket_rec = rec.clone();
-        bucket_rec[VALUE_LABEL] = value.value.into();
+        bucket_rec[VALUE_LABEL] = quantile_value;
         bucket_rec["quantile"] = value.quantile.to_string().into();
         bucket_recs.push(bucket_rec);
     }
@@ -1409,7 +1448,7 @@ mod tests {
             ),
         };
 
-        process_data_point(&mut rec, &data_point);
+        assert!(process_data_point(&mut rec, &data_point));
 
         // Verify the processed data
         assert_eq!(rec["value"], 42.0);
@@ -1487,7 +1526,9 @@ mod tests {
         assert!(!metric_names.contains(&"test_histogram_sum"));
         assert!(!metric_names.contains(&"test_histogram_min"));
         assert!(!metric_names.contains(&"test_histogram_max"));
-        assert!(result.iter().all(|r| r.get(VALUE_LABEL).is_some()));
+        // `.get(..).is_some()` would pass on a null value -- `Value::Null` is still
+        // `Some(&Value::Null)` -- which is exactly the bug that has to stay dead
+        assert!(result.iter().all(|r| !r[VALUE_LABEL].is_null()));
     }
 
     #[test]
@@ -1854,17 +1895,12 @@ mod tests {
 
             if let Some(Data::Gauge(gauge)) = &metric.data {
                 let result = process_gauge(&mut rec, gauge, metadata, &mut prom_meta);
-                assert!(!result.is_empty());
-                // Check that the value is infinite (JSON might not preserve exact infinity)
+                assert_eq!(result.len(), 1);
+                // an infinity is clamped to the f64 bound, matching the remote-write path.
+                // it is never written as JSON null: a null value suppresses the `value`
+                // column and takes the whole stream down with it.
                 let value = &result[0]["value"];
-                if let Some(f_val) = value.as_f64() {
-                    assert!(f_val.is_infinite());
-                } else if let Some(s_val) = value.as_str() {
-                    assert!(s_val.contains("inf") || s_val.contains("Inf") || s_val == "null");
-                } else {
-                    // JSON might convert infinity to null, which is acceptable
-                    assert!(value.is_null(), "Value: {value:?}");
-                }
+                assert_eq!(value.as_f64().unwrap(), f64::MAX);
             }
         }
 
@@ -2269,7 +2305,7 @@ mod tests {
                 ),
             };
 
-            process_data_point(&mut rec, &data_point_flag1);
+            assert!(process_data_point(&mut rec, &data_point_flag1));
             assert_eq!(rec["flag"], "DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK");
 
             // Test with flag 0 (DoNotUse)
@@ -2286,7 +2322,7 @@ mod tests {
                 ),
             };
 
-            process_data_point(&mut rec, &data_point_flag0);
+            assert!(process_data_point(&mut rec, &data_point_flag0));
             assert_eq!(rec["flag"], "DATA_POINT_FLAGS_DO_NOT_USE");
         }
 
@@ -2309,7 +2345,7 @@ mod tests {
                 ),
             };
 
-            process_data_point(&mut rec, &data_point);
+            assert!(process_data_point(&mut rec, &data_point));
             assert_eq!(rec["_timestamp"], expected_micro_timestamp);
         }
 
@@ -2379,7 +2415,7 @@ mod tests {
                 ),
             };
 
-            process_data_point(&mut rec, &data_point);
+            assert!(process_data_point(&mut rec, &data_point));
 
             // Should still process correctly with empty attributes
             assert_eq!(rec["value"], 42.0);
@@ -2621,5 +2657,387 @@ mod tests {
     fn test_batch_min_timestamp_no_timestamp_field_uses_default() {
         let row = serde_json::Map::new(); // no _timestamp field
         assert_eq!(batch_min_timestamp(&[row], 99), 99);
+    }
+
+    /// A record written with a null value never gets a `value` column inferred into the
+    /// schema, and the whole stream then fails every PromQL query while still costing full
+    /// ingest and storage. NaN is the way a null gets in: `serde_json` maps a non-finite f64
+    /// to `Value::Null`. So: NaN means no record, infinities clamp.
+    mod value_policy {
+        use opentelemetry_proto::tonic::{
+            common::v1::{AnyValue, KeyValue, any_value},
+            metrics::v1::{
+                ExponentialHistogramDataPoint, Summary, SummaryDataPoint,
+                exponential_histogram_data_point::Buckets, summary_data_point::ValueAtQuantile,
+            },
+        };
+
+        use super::*;
+
+        fn attr(key: &str, value: &str) -> KeyValue {
+            KeyValue {
+                key: key.to_string(),
+                value: Some(AnyValue {
+                    value: Some(any_value::Value::StringValue(value.to_string())),
+                }),
+                ..Default::default()
+            }
+        }
+
+        fn number_dp(value: f64, attributes: Vec<KeyValue>) -> NumberDataPoint {
+            NumberDataPoint {
+                attributes,
+                start_time_unix_nano: 0,
+                time_unix_nano: 1640995200000000000,
+                exemplars: vec![],
+                flags: 0,
+                value: Some(number_data_point::Value::AsDouble(value)),
+            }
+        }
+
+        fn test_metadata() -> Metadata {
+            Metadata {
+                metric_type: MetricType::Unknown,
+                metric_family_name: "test_metric".to_string(),
+                help: String::new(),
+                unit: String::new(),
+            }
+        }
+
+        fn gauge_records(data_points: Vec<NumberDataPoint>) -> Vec<serde_json::Value> {
+            let rec = json!({"__name__": "test_metric"});
+            let mut prom_meta = HashMap::new();
+            process_gauge(
+                &rec,
+                &Gauge { data_points },
+                test_metadata(),
+                &mut prom_meta,
+            )
+        }
+
+        fn sum_records(data_points: Vec<NumberDataPoint>) -> Vec<serde_json::Value> {
+            let mut rec = json!({"__name__": "test_metric"});
+            let mut prom_meta = HashMap::new();
+            process_sum(
+                &mut rec,
+                &Sum {
+                    data_points,
+                    aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                    is_monotonic: true,
+                },
+                test_metadata(),
+                &mut prom_meta,
+            )
+        }
+
+        fn hist_dp(sum: Option<f64>, min: Option<f64>, max: Option<f64>) -> HistogramDataPoint {
+            HistogramDataPoint {
+                attributes: vec![],
+                start_time_unix_nano: 0,
+                time_unix_nano: 1640995200000000000,
+                exemplars: vec![],
+                flags: 0,
+                count: 100,
+                sum,
+                bucket_counts: vec![10, 20],
+                explicit_bounds: vec![10.0],
+                min,
+                max,
+            }
+        }
+
+        fn hist_records(dp: HistogramDataPoint) -> Vec<serde_json::Value> {
+            let mut rec = json!({"__name__": "test_metric"});
+            process_hist_data_point(&mut rec, &dp)
+        }
+
+        fn exp_hist_records(sum: Option<f64>) -> Vec<serde_json::Value> {
+            let mut rec = json!({"__name__": "test_metric"});
+            process_exp_hist_data_point(
+                &mut rec,
+                &ExponentialHistogramDataPoint {
+                    attributes: vec![],
+                    start_time_unix_nano: 0,
+                    time_unix_nano: 1640995200000000000,
+                    exemplars: vec![],
+                    flags: 0,
+                    count: 100,
+                    sum,
+                    min: None,
+                    max: None,
+                    scale: 0,
+                    zero_count: 0,
+                    zero_threshold: 0.0,
+                    positive: Some(Buckets {
+                        offset: 0,
+                        bucket_counts: vec![50, 50],
+                    }),
+                    negative: None,
+                },
+            )
+        }
+
+        fn summary_records(sum: f64, quantiles: Vec<(f64, f64)>) -> Vec<serde_json::Value> {
+            let mut rec = json!({"__name__": "test_metric"});
+            process_summary_data_point(
+                &mut rec,
+                &SummaryDataPoint {
+                    attributes: vec![],
+                    start_time_unix_nano: 0,
+                    time_unix_nano: 1640995200000000000,
+                    flags: 0,
+                    count: 100,
+                    sum,
+                    quantile_values: quantiles
+                        .into_iter()
+                        .map(|(quantile, value)| ValueAtQuantile { quantile, value })
+                        .collect(),
+                },
+            )
+        }
+
+        fn names(records: &[serde_json::Value]) -> Vec<&str> {
+            records
+                .iter()
+                .map(|r| r[NAME_LABEL].as_str().unwrap_or(""))
+                .collect()
+        }
+
+        // ---- gauges: the HAProxy case. An unset HAProxy limit reads NaN on every scrape,
+        // which is how a deliberately-scraped gauge became permanently unqueryable.
+
+        #[test]
+        fn test_process_gauge_nan_emits_no_record() {
+            assert!(gauge_records(vec![number_dp(f64::NAN, vec![])]).is_empty());
+        }
+
+        #[test]
+        fn test_process_gauge_finite_value_unchanged() {
+            let records = gauge_records(vec![number_dp(42.0, vec![])]);
+            assert_eq!(records.len(), 1);
+            assert_eq!(records[0][VALUE_LABEL], json!(42.0));
+        }
+
+        /// The dangerous near-miss fix: declining to *assign* the value without dropping the
+        /// record leaves the previous data point's reading in place, and the record is then
+        /// pushed carrying a stale value that looks entirely real.
+        #[test]
+        fn test_process_gauge_nan_does_not_re_report_previous_value() {
+            let after = gauge_records(vec![number_dp(5.0, vec![]), number_dp(f64::NAN, vec![])]);
+            assert_eq!(
+                after.len(),
+                1,
+                "the NaN data point must not produce a record"
+            );
+            assert_eq!(after[0][VALUE_LABEL], json!(5.0));
+
+            let before = gauge_records(vec![number_dp(f64::NAN, vec![]), number_dp(5.0, vec![])]);
+            assert_eq!(before.len(), 1);
+            assert_eq!(before[0][VALUE_LABEL], json!(5.0));
+        }
+
+        #[test]
+        fn test_process_gauge_clamps_infinities() {
+            let records = gauge_records(vec![
+                number_dp(f64::INFINITY, vec![]),
+                number_dp(f64::NEG_INFINITY, vec![]),
+            ]);
+            assert_eq!(records.len(), 2);
+            assert_eq!(records[0][VALUE_LABEL].as_f64().unwrap(), f64::MAX);
+            assert_eq!(records[1][VALUE_LABEL].as_f64().unwrap(), f64::MIN);
+        }
+
+        #[test]
+        fn test_process_sum_nan_emits_no_record() {
+            assert!(sum_records(vec![number_dp(f64::NAN, vec![])]).is_empty());
+            assert_eq!(sum_records(vec![number_dp(7.0, vec![])]).len(), 1);
+        }
+
+        // ---- label bleed: `process_data_point` only ever *sets* attribute keys, so a shared
+        // record lets a data point inherit a label it never carried -- into its series hash.
+
+        #[test]
+        fn test_process_gauge_does_not_leak_labels_between_data_points() {
+            let records = gauge_records(vec![
+                number_dp(1.0, vec![attr("pod", "a"), attr("zone", "eu")]),
+                number_dp(2.0, vec![attr("pod", "b")]),
+            ]);
+
+            assert_eq!(records.len(), 2);
+            assert_eq!(records[0]["zone"], json!("eu"));
+            assert!(
+                records[1].get("zone").is_none(),
+                "second data point carried no zone, so the record must not have one"
+            );
+            assert_ne!(
+                records[0][HASH_LABEL], records[1][HASH_LABEL],
+                "the series hash must reflect the labels the data point actually carried"
+            );
+        }
+
+        /// `process_sum` has always cloned per data point. Asserted here so the two paths stay
+        /// locked together.
+        #[test]
+        fn test_process_sum_does_not_leak_labels_between_data_points() {
+            let records = sum_records(vec![
+                number_dp(1.0, vec![attr("pod", "a"), attr("zone", "eu")]),
+                number_dp(2.0, vec![attr("pod", "b")]),
+            ]);
+
+            assert_eq!(records.len(), 2);
+            assert!(records[1].get("zone").is_none());
+        }
+
+        /// A dropped NaN data point must not leave its labels behind for the next one either.
+        #[test]
+        fn test_process_gauge_dropped_record_does_not_leak_labels() {
+            let records = gauge_records(vec![
+                number_dp(f64::NAN, vec![attr("pod", "a"), attr("zone", "eu")]),
+                number_dp(2.0, vec![attr("pod", "b")]),
+            ]);
+
+            assert_eq!(records.len(), 1);
+            assert!(records[0].get("zone").is_none());
+        }
+
+        // ---- classic histogram
+
+        #[test]
+        fn test_process_hist_data_point_nan_stats_emit_no_records() {
+            let records = hist_records(hist_dp(Some(f64::NAN), Some(f64::NAN), Some(f64::NAN)));
+            let names = names(&records);
+
+            assert!(names.contains(&"test_metric_count"));
+            assert!(names.contains(&"test_metric_bucket"));
+            assert!(!names.contains(&"test_metric_sum"));
+            assert!(!names.contains(&"test_metric_min"));
+            assert!(!names.contains(&"test_metric_max"));
+        }
+
+        /// Guards against over-correction: the streams whose min/max are genuinely populated
+        /// must keep working.
+        #[test]
+        fn test_process_hist_data_point_finite_stats_still_emitted() {
+            let records = hist_records(hist_dp(Some(f64::NAN), Some(0.5), Some(9.5)));
+
+            let min_rec = records
+                .iter()
+                .find(|r| r[NAME_LABEL] == json!("test_metric_min"))
+                .expect("a real min must still be emitted alongside a NaN sum");
+            assert_eq!(min_rec[VALUE_LABEL], json!(0.5));
+
+            let max_rec = records
+                .iter()
+                .find(|r| r[NAME_LABEL] == json!("test_metric_max"))
+                .expect("a real max must still be emitted");
+            assert_eq!(max_rec[VALUE_LABEL], json!(9.5));
+
+            assert!(!names(&records).contains(&"test_metric_sum"));
+        }
+
+        #[test]
+        fn test_process_hist_data_point_clamps_infinite_sum() {
+            let records = hist_records(hist_dp(Some(f64::INFINITY), None, None));
+            let sum_rec = records
+                .iter()
+                .find(|r| r[NAME_LABEL] == json!("test_metric_sum"))
+                .expect("an infinite sum clamps, it does not drop");
+            assert_eq!(sum_rec[VALUE_LABEL].as_f64().unwrap(), f64::MAX);
+        }
+
+        // ---- exponential histogram: `sum` is optional in OTLP, and today an absent one is
+        // written as a null-valued `_sum` record.
+
+        #[test]
+        fn test_process_exp_hist_data_point_absent_sum_emits_no_sum_record() {
+            assert!(!names(&exp_hist_records(None)).contains(&"test_metric_sum"));
+        }
+
+        #[test]
+        fn test_process_exp_hist_data_point_nan_sum_emits_no_sum_record() {
+            assert!(!names(&exp_hist_records(Some(f64::NAN))).contains(&"test_metric_sum"));
+        }
+
+        #[test]
+        fn test_process_exp_hist_data_point_finite_sum_emitted() {
+            let records = exp_hist_records(Some(100.0));
+            let sum_rec = records
+                .iter()
+                .find(|r| r[NAME_LABEL] == json!("test_metric_sum"))
+                .expect("a finite sum is still emitted");
+            assert_eq!(sum_rec[VALUE_LABEL], json!(100.0));
+        }
+
+        // ---- summary: a quantile with no observations is reported as NaN. An absent series is
+        // how Prometheus itself represents "no data", so the record is dropped.
+
+        #[test]
+        fn test_process_summary_data_point_drops_nan_quantiles_only() {
+            let records = summary_records(50.0, vec![(0.5, 45.0), (0.95, f64::NAN), (0.99, 99.0)]);
+            let quantiles: Vec<&str> = records
+                .iter()
+                .filter_map(|r| r.get("quantile").and_then(|q| q.as_str()))
+                .collect();
+
+            assert_eq!(quantiles, vec!["0.5", "0.99"]);
+            assert!(names(&records).contains(&"test_metric_sum"));
+        }
+
+        #[test]
+        fn test_process_summary_data_point_nan_sum_emits_no_sum_record() {
+            let records = summary_records(f64::NAN, vec![(0.5, 45.0)]);
+            assert!(!names(&records).contains(&"test_metric_sum"));
+            assert!(names(&records).contains(&"test_metric_count"));
+        }
+
+        // ---- the invariant itself, across all four record writers.
+
+        #[test]
+        fn test_no_writer_emits_a_null_value() {
+            let mut records = vec![];
+            records.extend(gauge_records(vec![
+                number_dp(f64::NAN, vec![]),
+                number_dp(1.0, vec![]),
+            ]));
+            records.extend(sum_records(vec![
+                number_dp(f64::NAN, vec![]),
+                number_dp(1.0, vec![]),
+            ]));
+            records.extend(hist_records(hist_dp(
+                Some(f64::NAN),
+                Some(f64::NAN),
+                Some(f64::NAN),
+            )));
+            records.extend(exp_hist_records(None));
+            records.extend(exp_hist_records(Some(f64::NAN)));
+            records.extend(summary_records(f64::NAN, vec![(0.5, f64::NAN), (0.9, 1.0)]));
+
+            assert!(!records.is_empty(), "the writers must still emit something");
+            assert!(
+                records.iter().all(|r| !r[VALUE_LABEL].is_null()),
+                "a record with a null value suppresses the `value` column and makes the stream unreadable"
+            );
+        }
+
+        // ---- the family name the metadata is written with.
+
+        #[test]
+        fn test_build_metadata_family_name_is_not_json_quoted() {
+            let metric = Metric {
+                name: "test_histogram".to_string(),
+                description: "help text".to_string(),
+                unit: "seconds".to_string(),
+                metadata: vec![],
+                data: Some(Data::Summary(Summary {
+                    data_points: vec![],
+                })),
+            };
+
+            let metadata = build_metadata("test_histogram", &metric);
+
+            assert_eq!(metadata.metric_family_name, "test_histogram");
+            assert_eq!(metadata.help, "help text");
+            assert_eq!(metadata.unit, "seconds");
+        }
     }
 }

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -188,52 +188,6 @@ pub async fn handle_otlp_request(
         for scope_metric in &resource_metric.scope_metrics {
             for metric in &scope_metric.metrics {
                 let metric_name = format_stream_name(metric.name.to_string());
-                // check for schema
-                let schema_exists = stream_schema_exists(
-                    org_id,
-                    &metric_name,
-                    StreamType::Metrics,
-                    &mut metric_schema_map,
-                )
-                .await;
-
-                // get partition keys
-                if !stream_partitioning_map.contains_key(&metric_name) {
-                    let partition_det = crate::service::ingestion::get_stream_partition_keys(
-                        org_id,
-                        &StreamType::Metrics,
-                        &metric_name,
-                    )
-                    .await;
-                    stream_partitioning_map
-                        .insert(metric_name.clone().to_owned(), partition_det.clone());
-                }
-
-                // Start get stream alerts
-                let stream_param = StreamParams::new(org_id, &metric_name, StreamType::Metrics);
-                crate::service::ingestion::get_stream_alerts(
-                    std::slice::from_ref(&stream_param),
-                    &mut stream_alerts_map,
-                )
-                .await;
-                // End get stream alert
-
-                // get stream pipeline
-                if !stream_executable_pipelines.contains_key(&metric_name) {
-                    let pipeline_params =
-                        crate::service::ingestion::get_stream_executable_pipelines(&stream_param)
-                            .await;
-                    stream_executable_pipelines.insert(metric_name.clone(), pipeline_params);
-                }
-
-                // get user defined schema
-                crate::service::ingestion::get_uds_and_original_data_streams(
-                    std::slice::from_ref(&stream_param),
-                    &mut user_defined_schema_map,
-                    &mut streams_need_original_map,
-                    &mut streams_need_all_values_map,
-                )
-                .await;
 
                 let mut rec = json::json!({});
                 if let Some(res) = &resource_metric.resource {
@@ -283,13 +237,63 @@ pub async fn handle_otlp_request(
                     }
                 };
 
-                // a metric that yields no records -- every data point NaN, no data points at
-                // all, or an undecodable type -- gets no stream: no schema, no metadata entry,
-                // and nothing buffered for a pipeline that is configured on this stream (the
-                // pipeline loop below treats a missing input buffer as a bug and logs it).
+                // A metric that yields no records -- every data point NaN, no data points at all,
+                // or an undecodable type -- gets nothing: no schema, no metadata entry, and no
+                // entry in stream_executable_pipelines. That last one matters: the pipeline loop
+                // at the end of this function expects every registered stream to have buffered
+                // inputs and logs a BUG if it does not, so a stream registered here and then
+                // dropped would log one on every export request. Hence the per-stream lookups
+                // below run only once we know we have something to write.
                 if records.is_empty() {
                     continue;
                 }
+
+                // check for schema
+                let schema_exists = stream_schema_exists(
+                    org_id,
+                    &metric_name,
+                    StreamType::Metrics,
+                    &mut metric_schema_map,
+                )
+                .await;
+
+                // get partition keys
+                if !stream_partitioning_map.contains_key(&metric_name) {
+                    let partition_det = crate::service::ingestion::get_stream_partition_keys(
+                        org_id,
+                        &StreamType::Metrics,
+                        &metric_name,
+                    )
+                    .await;
+                    stream_partitioning_map
+                        .insert(metric_name.clone().to_owned(), partition_det.clone());
+                }
+
+                // Start get stream alerts
+                let stream_param = StreamParams::new(org_id, &metric_name, StreamType::Metrics);
+                crate::service::ingestion::get_stream_alerts(
+                    std::slice::from_ref(&stream_param),
+                    &mut stream_alerts_map,
+                )
+                .await;
+                // End get stream alert
+
+                // get stream pipeline
+                if !stream_executable_pipelines.contains_key(&metric_name) {
+                    let pipeline_params =
+                        crate::service::ingestion::get_stream_executable_pipelines(&stream_param)
+                            .await;
+                    stream_executable_pipelines.insert(metric_name.clone(), pipeline_params);
+                }
+
+                // get user defined schema
+                crate::service::ingestion::get_uds_and_original_data_streams(
+                    std::slice::from_ref(&stream_param),
+                    &mut user_defined_schema_map,
+                    &mut streams_need_original_map,
+                    &mut streams_need_all_values_map,
+                )
+                .await;
 
                 // update schema metadata
                 if !schema_exists.has_metrics_metadata {

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -836,14 +836,10 @@ pub(crate) async fn get_metadata(org_id: &str, req: RequestMetadata) -> Result<R
 //
 // [supports]: https://prometheus.io/docs/prometheus/latest/querying/api/#querying-metric-metadata
 fn get_metadata_object(schema: &Schema) -> Option<MetadataObject> {
-    schema.metadata.get(METADATA_LABEL).map(|s| {
-        serde_json::from_str::<Metadata>(s)
-            .unwrap_or_else(|error| {
-                tracing::error!(%error, input = ?s, "failed to parse metadata");
-                panic!("BUG: failed to parse {METADATA_LABEL}")
-            })
-            .into()
-    })
+    // delegate rather than parse the blob a second time: the shared reader is where the
+    // family name of a historically-quoted schema gets normalised, and a duplicate parse
+    // here would serve the quotes and drift from `/streams`
+    super::get_prom_metadata_from_schema(schema).map(Into::into)
 }
 
 pub(crate) async fn get_series(
@@ -1223,6 +1219,50 @@ mod tests {
     };
 
     use super::*;
+
+    fn schema_with_metadata(blob: &str) -> Schema {
+        Schema::empty().with_metadata(
+            [(METADATA_LABEL.to_string(), blob.to_string())]
+                .into_iter()
+                .collect(),
+        )
+    }
+
+    /// `/api/v1/metadata` must read the blob through the shared reader, not parse it a second
+    /// time -- that is where a historically JSON-quoted family name gets normalised, and a
+    /// private parse here would drift from what `/streams` serves.
+    #[test]
+    fn test_get_metadata_object_delegates_to_shared_reader() {
+        let schema = schema_with_metadata(
+            r#"{"metric_type":"Histogram","metric_family_name":"\"foo\"","help":"h","unit":"s"}"#,
+        );
+
+        let served = serde_json::to_value(get_metadata_object(&schema).unwrap()).unwrap();
+        assert_eq!(served["type"], "histogram");
+        assert_eq!(served["help"], "h");
+        assert_eq!(served["unit"], "s");
+
+        // and the shared reader -- the one both this endpoint and `/streams` now go through --
+        // serves the family name without the stored quotes
+        assert_eq!(
+            super::super::get_prom_metadata_from_schema(&schema)
+                .unwrap()
+                .metric_family_name,
+            "foo"
+        );
+    }
+
+    /// A single corrupt schema entry used to take the process down here: this reader had its
+    /// own `panic!("BUG: failed to parse ...")`.
+    #[test]
+    fn test_get_metadata_object_malformed_blob_is_none_not_panic() {
+        assert!(get_metadata_object(&schema_with_metadata("not json")).is_none());
+    }
+
+    #[test]
+    fn test_get_metadata_object_absent_metadata_is_none() {
+        assert!(get_metadata_object(&Schema::empty()).is_none());
+    }
 
     fn selector_with_name(name: &str) -> VectorSelector {
         VectorSelector {

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -975,11 +975,13 @@ pub(crate) async fn get_labels(
 /// The stats that say whether a metric family has data in a time range.
 ///
 /// A histogram or summary keeps no rows in its base stream -- that stream holds only the family
-/// metadata -- so its liveness has to be read from a member. `_count` is the member that is
-/// always written: it is a `u64` on every data point and so can never be dropped, whereas `_sum`
-/// is optional in OTLP and is not recorded at all when the source reports it as NaN. Keying on
-/// `_sum` would hide an entire family whose sum happens to be NaN while its buckets ingest
-/// normally. `_sum` stays as the fallback, for streams written before a `_count` existed.
+/// metadata -- so its liveness has to be read from a member. `_count` is the member to read: it
+/// is a `u64` on every data point and so is always written, whereas `_sum` is optional in OTLP
+/// and is not recorded at all when the source reports it as NaN. Keying on `_sum` would hide an
+/// entire family whose sum happens to be NaN while its buckets ingested normally.
+///
+/// `_sum` is kept as a fallback for a family that somehow has no `_count` stats -- a source that
+/// ships only sums, or a `_count` whose stats have not been computed yet.
 fn family_stats(
     org_id: &str,
     stream_name: &str,
@@ -1298,6 +1300,7 @@ mod tests {
         assert!(stats.time_range_intersects(1, 6_000));
     }
 
+    /// The fallback: a family with no `_count` stats still resolves rather than disappearing.
     #[test]
     fn test_family_stats_falls_back_to_sum_when_count_is_empty() {
         let org = "test_family_stats_sum";

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -29,7 +29,7 @@ use config::{
         promql::*,
         search::default_use_cache,
         self_reporting::usage::UsageType,
-        stream::{StreamParams, StreamPartition, StreamType},
+        stream::{StreamParams, StreamPartition, StreamStats, StreamType},
     },
     metrics,
     utils::{
@@ -972,6 +972,35 @@ pub(crate) async fn get_labels(
     Ok(label_names)
 }
 
+/// The stats that say whether a metric family has data in a time range.
+///
+/// A histogram or summary keeps no rows in its base stream -- that stream holds only the family
+/// metadata -- so its liveness has to be read from a member. `_count` is the member that is
+/// always written: it is a `u64` on every data point and so can never be dropped, whereas `_sum`
+/// is optional in OTLP and is not recorded at all when the source reports it as NaN. Keying on
+/// `_sum` would hide an entire family whose sum happens to be NaN while its buckets ingest
+/// normally. `_sum` stays as the fallback, for streams written before a `_count` existed.
+fn family_stats(
+    org_id: &str,
+    stream_name: &str,
+    metadata: Option<&Metadata>,
+    stream_type: StreamType,
+) -> StreamStats {
+    let is_family = metadata.is_some_and(|m| {
+        m.metric_type == MetricType::Histogram || m.metric_type == MetricType::Summary
+    });
+    if !is_family {
+        return stats::get_stream_stats(org_id, stream_name, stream_type);
+    }
+
+    let count = stats::get_stream_stats(org_id, &format!("{stream_name}_count"), stream_type);
+    if count.doc_num > 0 {
+        count
+    } else {
+        stats::get_stream_stats(org_id, &format!("{stream_name}_sum"), stream_type)
+    }
+}
+
 pub(crate) async fn get_label_values(
     org_id: &str,
     label_name: String,
@@ -998,37 +1027,12 @@ pub(crate) async fn get_label_values(
                 // not it.
                 continue;
             }
-            let stats = match super::get_prom_metadata_from_schema(&schema.schema) {
-                None => stats::get_stream_stats(org_id, &schema.stream_name, stream_type),
-                Some(metadata) => {
-                    if metadata.metric_type == MetricType::Histogram
-                        || metadata.metric_type == MetricType::Summary
-                    {
-                        // the base stream of a histogram/summary holds only metadata, so the
-                        // family's liveness has to come from a member stream. `_count` is the
-                        // one that is always there: it is a u64 on every data point, whereas
-                        // `_sum` is optional in OTLP and is not recorded at all when the source
-                        // reports it as NaN. Fall back to `_sum` for anything that predates a
-                        // `_count` stream.
-                        let count = stats::get_stream_stats(
-                            org_id,
-                            &format!("{}_count", schema.stream_name),
-                            stream_type,
-                        );
-                        if count.doc_num > 0 {
-                            count
-                        } else {
-                            stats::get_stream_stats(
-                                org_id,
-                                &format!("{}_sum", schema.stream_name),
-                                stream_type,
-                            )
-                        }
-                    } else {
-                        stats::get_stream_stats(org_id, &schema.stream_name, stream_type)
-                    }
-                }
-            };
+            let stats = family_stats(
+                org_id,
+                &schema.stream_name,
+                super::get_prom_metadata_from_schema(&schema.schema).as_ref(),
+                stream_type,
+            );
             if stats.time_range_intersects(start, end) {
                 label_values.push(schema.stream_name)
             }
@@ -1236,16 +1240,102 @@ mod tests {
         )
     }
 
+    /// Note `MetadataObject` carries only type/help/unit -- the family name is dropped on the
+    /// way out -- so `/api/v1/metadata` cannot be asserted to serve an unquoted family name.
+    /// What the endpoint gets from delegating is the shared reader's parse, asserted below.
     #[test]
     fn test_get_metadata_object_serves_type_help_unit() {
         let schema = schema_with_metadata(
-            r#"{"metric_type":"Histogram","metric_family_name":"\"foo\"","help":"h","unit":"s"}"#,
+            r#"{"metric_type":"Histogram","metric_family_name":"foo","help":"h","unit":"s"}"#,
         );
 
         let served = serde_json::to_value(get_metadata_object(&schema).unwrap()).unwrap();
         assert_eq!(served["type"], "histogram");
         assert_eq!(served["help"], "h");
         assert_eq!(served["unit"], "s");
+    }
+
+    fn family_metadata(metric_type: MetricType) -> Metadata {
+        Metadata {
+            metric_type,
+            metric_family_name: "http_request_duration_seconds".to_string(),
+            help: String::new(),
+            unit: String::new(),
+        }
+    }
+
+    fn seed_stats(org_id: &str, stream_name: &str, doc_num: i64, doc_time_max: i64) {
+        stats::set_stream_stats(
+            org_id,
+            stream_name,
+            StreamType::Metrics,
+            StreamStats {
+                doc_num,
+                doc_time_min: 1,
+                doc_time_max,
+                ..Default::default()
+            },
+        );
+    }
+
+    /// The regression this guards: dropping NaN records means a histogram whose sum is always
+    /// NaN writes no `_sum` stream at all. Keyed on `_sum`, the whole family would disappear
+    /// from the metric picker while its buckets were still ingesting.
+    #[test]
+    fn test_family_stats_prefers_count_over_sum() {
+        let org = "test_family_stats_count";
+        seed_stats(org, "http_request_duration_seconds_count", 100, 5_000);
+        // no `_sum` stream at all: its sum is NaN on every data point
+
+        let stats = family_stats(
+            org,
+            "http_request_duration_seconds",
+            Some(&family_metadata(MetricType::Histogram)),
+            StreamType::Metrics,
+        );
+
+        assert_eq!(stats.doc_num, 100);
+        assert!(stats.time_range_intersects(1, 6_000));
+    }
+
+    #[test]
+    fn test_family_stats_falls_back_to_sum_when_count_is_empty() {
+        let org = "test_family_stats_sum";
+        seed_stats(org, "http_request_duration_seconds_sum", 50, 5_000);
+
+        let stats = family_stats(
+            org,
+            "http_request_duration_seconds",
+            Some(&family_metadata(MetricType::Summary)),
+            StreamType::Metrics,
+        );
+
+        assert_eq!(stats.doc_num, 50);
+    }
+
+    /// A gauge or counter keeps its own rows, so it is its own liveness signal.
+    #[test]
+    fn test_family_stats_uses_the_stream_itself_for_non_families() {
+        let org = "test_family_stats_gauge";
+        seed_stats(org, "http_request_duration_seconds", 7, 5_000);
+        seed_stats(org, "http_request_duration_seconds_count", 999, 5_000);
+
+        let stats = family_stats(
+            org,
+            "http_request_duration_seconds",
+            Some(&family_metadata(MetricType::Gauge)),
+            StreamType::Metrics,
+        );
+        assert_eq!(stats.doc_num, 7);
+
+        // and with no metadata at all
+        let stats = family_stats(
+            org,
+            "http_request_duration_seconds",
+            None,
+            StreamType::Metrics,
+        );
+        assert_eq!(stats.doc_num, 7);
     }
 
     /// This endpoint used to parse the blob itself, with its own

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -301,18 +301,11 @@ pub async fn remote_write(
         let sample_start = std::time::Instant::now();
         for sample in event.samples {
             sample_count += 1;
-            let mut sample_val = sample.value;
-            // revisit in future
-            if sample_val.is_infinite() {
-                if sample_val == f64::INFINITY || sample_val > f64::MAX {
-                    sample_val = f64::MAX;
-                } else if sample_val == f64::NEG_INFINITY || sample_val < f64::MIN {
-                    sample_val = f64::MIN;
-                }
-            } else if sample_val.is_nan() {
-                // skip the entry from adding to store
+            // NaN -> no observation -> no record; infinities clamp. Shared with the OTLP
+            // writer so the two ingestion paths cannot drift apart on this.
+            let Some(sample_val) = super::sanitize_metric_value(sample.value) else {
                 continue;
-            }
+            };
             let metric = Metric {
                 labels: &labels,
                 value: sample_val,
@@ -1011,11 +1004,26 @@ pub(crate) async fn get_label_values(
                     if metadata.metric_type == MetricType::Histogram
                         || metadata.metric_type == MetricType::Summary
                     {
-                        stats::get_stream_stats(
+                        // the base stream of a histogram/summary holds only metadata, so the
+                        // family's liveness has to come from a member stream. `_count` is the
+                        // one that is always there: it is a u64 on every data point, whereas
+                        // `_sum` is optional in OTLP and is not recorded at all when the source
+                        // reports it as NaN. Fall back to `_sum` for anything that predates a
+                        // `_count` stream.
+                        let count = stats::get_stream_stats(
                             org_id,
-                            &format!("{}_sum", schema.stream_name),
+                            &format!("{}_count", schema.stream_name),
                             stream_type,
-                        )
+                        );
+                        if count.doc_num > 0 {
+                            count
+                        } else {
+                            stats::get_stream_stats(
+                                org_id,
+                                &format!("{}_sum", schema.stream_name),
+                                stream_type,
+                            )
+                        }
                     } else {
                         stats::get_stream_stats(org_id, &schema.stream_name, stream_type)
                     }
@@ -1228,11 +1236,8 @@ mod tests {
         )
     }
 
-    /// `/api/v1/metadata` must read the blob through the shared reader, not parse it a second
-    /// time -- that is where a historically JSON-quoted family name gets normalised, and a
-    /// private parse here would drift from what `/streams` serves.
     #[test]
-    fn test_get_metadata_object_delegates_to_shared_reader() {
+    fn test_get_metadata_object_serves_type_help_unit() {
         let schema = schema_with_metadata(
             r#"{"metric_type":"Histogram","metric_family_name":"\"foo\"","help":"h","unit":"s"}"#,
         );
@@ -1241,19 +1246,13 @@ mod tests {
         assert_eq!(served["type"], "histogram");
         assert_eq!(served["help"], "h");
         assert_eq!(served["unit"], "s");
-
-        // and the shared reader -- the one both this endpoint and `/streams` now go through --
-        // serves the family name without the stored quotes
-        assert_eq!(
-            super::super::get_prom_metadata_from_schema(&schema)
-                .unwrap()
-                .metric_family_name,
-            "foo"
-        );
     }
 
-    /// A single corrupt schema entry used to take the process down here: this reader had its
-    /// own `panic!("BUG: failed to parse ...")`.
+    /// This endpoint used to parse the blob itself, with its own
+    /// `panic!("BUG: failed to parse ...")` -- one corrupt schema entry took the process down.
+    /// It now delegates to the shared reader, which returns `None` instead. That delegation is
+    /// also what keeps `/api/v1/metadata` and `/streams` from drifting apart on a family name
+    /// that is JSON-quoted in storage: only the shared reader normalises it.
     #[test]
     fn test_get_metadata_object_malformed_blob_is_none_not_panic() {
         assert!(get_metadata_object(&schema_with_metadata("not json")).is_none());

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -829,9 +829,10 @@ pub(crate) async fn get_metadata(org_id: &str, req: RequestMetadata) -> Result<R
 //
 // [supports]: https://prometheus.io/docs/prometheus/latest/querying/api/#querying-metric-metadata
 fn get_metadata_object(schema: &Schema) -> Option<MetadataObject> {
-    // delegate rather than parse the blob a second time: the shared reader is where the
-    // family name of a historically-quoted schema gets normalised, and a duplicate parse
-    // here would serve the quotes and drift from `/streams`
+    // delegate rather than parse the blob a second time. The duplicate parse this replaces had
+    // its own `panic!("BUG: failed to parse ...")`, so one corrupt schema entry took the process
+    // down; and a second parser is a second thing to keep in step with the shared reader, which
+    // is where a historically JSON-quoted family name gets normalised.
     super::get_prom_metadata_from_schema(schema).map(Into::into)
 }
 
@@ -972,16 +973,20 @@ pub(crate) async fn get_labels(
     Ok(label_names)
 }
 
-/// The stats that say whether a metric family has data in a time range.
+/// The stats that say whether a metric family has data in a time range -- i.e. whether the
+/// metric should be offered as a name at all.
 ///
-/// A histogram or summary keeps no rows in its base stream -- that stream holds only the family
-/// metadata -- so its liveness has to be read from a member. `_count` is the member to read: it
-/// is a `u64` on every data point and so is always written, whereas `_sum` is optional in OTLP
-/// and is not recorded at all when the source reports it as NaN. Keying on `_sum` would hide an
-/// entire family whose sum happens to be NaN while its buckets ingested normally.
+/// A family is stored as one stream per member, and its base stream is mostly a metadata holder:
+/// a histogram writes every row to `_count` / `_sum` / `_bucket` and nothing to the base at all,
+/// so reading the base's stats would hide every histogram in the org. Members are therefore
+/// tried in turn, and the first one with rows answers for the family:
 ///
-/// `_sum` is kept as a fallback for a family that somehow has no `_count` stats -- a source that
-/// ships only sums, or a `_count` whose stats have not been computed yet.
+/// - `_count` first: it is a `u64` on every data point, so it is always written. `_sum` is not --
+///   it is optional in OTLP and, since a NaN is no longer recorded, a source that reports its sum
+///   as NaN writes no `_sum` stream at all. Keying on `_sum` alone would hide the whole family
+///   while its buckets ingested normally.
+/// - then `_sum`, for a family whose `_count` has no stats.
+/// - then the base stream itself, which for a *summary* is where the quantile rows live.
 fn family_stats(
     org_id: &str,
     stream_name: &str,
@@ -989,18 +994,23 @@ fn family_stats(
     stream_type: StreamType,
 ) -> StreamStats {
     let is_family = metadata.is_some_and(|m| {
-        m.metric_type == MetricType::Histogram || m.metric_type == MetricType::Summary
+        matches!(
+            m.metric_type,
+            MetricType::Histogram | MetricType::ExponentialHistogram | MetricType::Summary
+        )
     });
     if !is_family {
         return stats::get_stream_stats(org_id, stream_name, stream_type);
     }
 
-    let count = stats::get_stream_stats(org_id, &format!("{stream_name}_count"), stream_type);
-    if count.doc_num > 0 {
-        count
-    } else {
-        stats::get_stream_stats(org_id, &format!("{stream_name}_sum"), stream_type)
+    let base = stats::get_stream_stats(org_id, stream_name, stream_type);
+    for member in [format!("{stream_name}_count"), format!("{stream_name}_sum")] {
+        let stats = stats::get_stream_stats(org_id, &member, stream_type);
+        if stats.doc_num > 0 {
+            return stats;
+        }
     }
+    base
 }
 
 pub(crate) async fn get_label_values(
@@ -1298,6 +1308,41 @@ mod tests {
 
         assert_eq!(stats.doc_num, 100);
         assert!(stats.time_range_intersects(1, 6_000));
+    }
+
+    /// An exponential histogram writes `_count` / `_sum` / `_bucket` like any other histogram and
+    /// nothing to its base stream, so it has to be treated as a family too -- read the base and
+    /// it looks empty, and the metric never appears in the picker.
+    #[test]
+    fn test_family_stats_treats_exponential_histogram_as_a_family() {
+        let org = "test_family_stats_exp_hist";
+        seed_stats(org, "http_request_duration_seconds_count", 100, 5_000);
+
+        let stats = family_stats(
+            org,
+            "http_request_duration_seconds",
+            Some(&family_metadata(MetricType::ExponentialHistogram)),
+            StreamType::Metrics,
+        );
+
+        assert_eq!(stats.doc_num, 100);
+    }
+
+    /// A summary's quantile rows keep the base metric name -- they are not renamed the way
+    /// `_count` and `_sum` are -- so the base stream is the last place worth looking.
+    #[test]
+    fn test_family_stats_falls_back_to_the_base_stream() {
+        let org = "test_family_stats_base";
+        seed_stats(org, "request_latency", 25, 5_000);
+
+        let stats = family_stats(
+            org,
+            "request_latency",
+            Some(&family_metadata(MetricType::Summary)),
+            StreamType::Metrics,
+        );
+
+        assert_eq!(stats.doc_num, 25);
     }
 
     /// The fallback: a family with no `_count` stats still resolves rather than disappearing.

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -1832,6 +1832,29 @@ mod tests {
         assert_eq!(stream.stats, StreamStats::default());
     }
 
+    /// The `/streams` response is what the family join is built from, and it is served from the
+    /// stored schema -- which, for every metric ingested before the writer was fixed, holds a
+    /// JSON-quoted family name. The quotes must not reach the client.
+    #[test]
+    fn test_stream_res_metrics_family_name_served_unquoted_for_a_stored_quoted_schema() {
+        let schema = Schema::new(vec![Field::new("value", DataType::Float64, false)])
+            .with_metadata(
+                [(
+                    config::meta::promql::METADATA_LABEL.to_string(),
+                    r#"{"metric_type":"Histogram","metric_family_name":"\"http_requests\"","help":"h","unit":"s"}"#
+                        .to_string(),
+                )]
+                .into_iter()
+                .collect(),
+            );
+
+        let stream = stream_res("org1", "http_requests", StreamType::Metrics, schema, None);
+        let meta = stream.metrics_meta.unwrap();
+
+        assert_eq!(meta.metric_family_name, "http_requests");
+        assert_eq!(meta.metric_type, promql::MetricType::Histogram);
+    }
+
     #[test]
     fn test_stream_res_metrics_empty_type() {
         let schema = Schema::new(vec![Field::new("value", DataType::Float64, false)]);


### PR DESCRIPTION
Stacked on #13144 (base: `metrics1`), so the diff here is backend-only.

Three defects in the OTLP metrics writer, found while building the Metrics Explorer. Measured on the `default` org of one cluster: **201 streams, 17.46 TB, 15.5 B rows written and never readable, still growing at ~117 GB/day.**

## What was wrong

**A NaN value produced a row with no value.** A non-finite `f64` serialises to JSON `null`, an all-null column is never inferred into the Arrow schema, and the stream it lands in can then never be read by PromQL — while still costing full ingest, storage and replication. It is not just histogram `_min`/`_max` noise: it silently destroyed six user-facing HAProxy gauges (HAProxy reports NaN for a limit that is not configured) and one histogram `_sum`, taking that family's mean with it.

**`metric_family_name` was stored JSON-quoted** (`"\"http_requests_total\""`), because it was built with `Value::to_string()` on a `serde_json::Value`, which yields the serialised JSON rather than the string content. 2,694 of 3,349 streams carry the quotes, so family metadata (help / unit / type) never joins to its `_bucket` / `_sum` / `_count` members.

**Gauge data points leaked labels forward.** `process_gauge` passed one shared record to `process_data_point` on every iteration and never cleared it, so a data point that omitted an attribute inherited the previous one's value for it — and the leaked label was fed into `signature_without_labels`, corrupting series identity. Silent; the record looks well-formed.

## What changed

One value policy, shared by every ingestion path: infinities clamp to the f64 bounds, NaN means "no observation" and the record is not written.

The gauge path needed more than a guarded assignment. `process_data_point` mutates a record its caller owns and pushes, so declining to *assign* the value would have left the previous data point's reading in place and re-reported it as fresh — strictly worse than the null it replaces. It now reports whether the data point is recordable, and both callers drop the record. `process_gauge` also gains the per-data-point clone `process_sum` always had, which closes the label bleed.

The writer stores the plain family name, and the shared metadata reader trims the quotes on read — so the streams already written serve correctly without a byte of stored data being touched. `/api/v1/metadata` now delegates to that reader instead of parsing the blob a second time, which also removes both readers' ability to panic the process on a malformed blob.

**Forward-only.** No migration, backfill or repair. The affected streams simply stop receiving records and age out on the retention clock.

## Beyond the original three

Found while reviewing the above:

- Dropping NaN records means a histogram whose sum is always NaN writes no `_sum` stream — and `get_label_values` used exactly that stream as the family's liveness proxy, so the metric would have vanished from the picker while its buckets ingested normally. It now keys on `_count`. The same function never recognised exponential histograms as families at all, so they never appeared in `/api/v1/label/__name__/values`.
- A metric that yields no records no longer registers a stream, a schema, or a pipeline — the pipeline loop reports a registered stream with no buffered inputs as a bug, and logged one on every export request.
- **`{"value": 1e400}` crashed the JSON ingestion handler.** It is a valid JSON number whose value is an infinity; `as_f64()` returns `None` and the code unwrapped it. Remotely triggerable by anyone who can POST to the endpoint. The value now goes through the same policy and clamps.

## Verified

216 unit tests pass; `cargo clippy -- -D warnings` (CI's gate) is clean. The existing assertion that *appeared* to guard this (`result.iter().all(|r| r.get(VALUE_LABEL).is_some())`) passes on a null value — `Value::Null` is still `Some(&Value::Null)` — which is how the defect survived the suite. It is now `!r[VALUE_LABEL].is_null()`, asserted across all four record writers.

Driven end-to-end against a running server:

- A gauge export with `[NaN{pod:a,zone:eu}, 7.0{pod:b}]` wrote **exactly one row**, `value: 7.0`, with **no leaked `zone`**.
- Streams are served with unquoted family names.
- A histogram with real `min`/`max` still emits `_min`/`_max` with their values; one with them absent emits neither.
- `{"value": 1e400}` returned 200 and stored `1.7976931348623157e308` (`f64::MAX`) instead of killing the handler.