### PR TITLE
fix: prevent dialog focus loss from leaking page shortcuts

### DIFF
--- a/web/src/lib/forms/Select/OSelect.spec.ts
+++ b/web/src/lib/forms/Select/OSelect.spec.ts
@@ -165,4 +165,75 @@ describe("OSelect", () => {
     await flushPromises();
     expect(wrapper.emitted("create")).toBeFalsy();
   });
+
+  describe("trigger keyboard focus behavior", () => {
+    // The listbox-mode trigger must expose role="combobox" so the global
+    // shortcut manager's isInputFocused() guard treats a focused select as a
+    // text-entry widget — otherwise single-letter page shortcuts (logs "s",
+    // "r", "h") fire while the select has focus inside a dialog.
+    it("should expose role=combobox on the listbox trigger", () => {
+      wrapper = mount(OSelect, {
+        props: {
+          searchable: true,
+          options: [{ label: "Option A", value: "a" }],
+        },
+      });
+      const trigger = wrapper.find("button");
+      expect(trigger.attributes("role")).toBe("combobox");
+      expect(trigger.attributes("aria-expanded")).toBe("false");
+    });
+
+    it("should open the dropdown and seed the filter when a printable key is pressed on the closed trigger", async () => {
+      wrapper = mount(OSelect, {
+        attachTo: document.body,
+        props: {
+          searchable: true,
+          options: [
+            { label: "sample", value: "s1" },
+            { label: "other", value: "o1" },
+          ],
+        },
+      });
+      await wrapper.find("button").trigger("keydown", { key: "s" });
+      await flushPromises();
+
+      const input = document.body.querySelector(
+        'input[placeholder="Search..."]',
+      ) as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      expect(input!.value).toBe("s");
+    });
+
+    it("should not open the dropdown when a modifier combo is pressed on the trigger", async () => {
+      wrapper = mount(OSelect, {
+        attachTo: document.body,
+        props: {
+          searchable: true,
+          options: [{ label: "sample", value: "s1" }],
+        },
+      });
+      await wrapper.find("button").trigger("keydown", { key: "s", ctrlKey: true });
+      await flushPromises();
+      expect(
+        document.body.querySelector('input[placeholder="Search..."]'),
+      ).toBeNull();
+    });
+
+    it("should stop propagation of printable keys so page-level shortcuts never fire", async () => {
+      wrapper = mount(OSelect, {
+        attachTo: document.body,
+        props: {
+          searchable: true,
+          options: [{ label: "sample", value: "s1" }],
+        },
+      });
+      const docSpy = vi.fn();
+      document.addEventListener("keydown", docSpy);
+      (wrapper.find("button").element as HTMLElement).dispatchEvent(
+        new KeyboardEvent("keydown", { key: "s", bubbles: true, cancelable: true }),
+      );
+      document.removeEventListener("keydown", docSpy);
+      expect(docSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/web/src/lib/forms/Select/OSelect.vue
+++ b/web/src/lib/forms/Select/OSelect.vue
@@ -555,7 +555,27 @@ function close() {
   searchTerm.value = "";
 }
 
-defineExpose({ close });
+/** Focus the trigger programmatically (both listbox and native-select modes). */
+function focus() {
+  if (typeof document === "undefined") return;
+  document.getElementById(inputId.value)?.focus();
+}
+
+defineExpose({ close, focus });
+
+// Type-to-search on the closed trigger: a printable keystroke opens the
+// dropdown and seeds the filter, mirroring native <select> typeahead. The
+// event is consumed here so page-level single-letter shortcuts (logs "s",
+// "r", "h", …) never fire while the select has keyboard focus.
+function handleTriggerKeydown(e: KeyboardEvent) {
+  if (props.disabled) return;
+  if (e.ctrlKey || e.metaKey || e.altKey) return;
+  if (e.key.length !== 1 || e.key === " ") return;
+  e.preventDefault();
+  e.stopPropagation();
+  popoverOpen.value = true;
+  if (inputEnabled.value) searchTerm.value = searchTerm.value + e.key;
+}
 
 // ── Virtual scroll (listbox mode) ─────────────────────────────────────────
 // Items are virtualised whenever the listbox has more than 50 entries, keeping
@@ -1003,6 +1023,9 @@ const fieldWidthClass = computed(() => {
             :name="name"
             :disabled="disabled"
             :tabindex="inputTabindex"
+            role="combobox"
+            :aria-expanded="popoverOpen"
+            @keydown="handleTriggerKeydown"
             :data-test="
               parentDataTest ? `${parentDataTest}-trigger` : undefined
             "

--- a/web/src/lib/overlay/Dialog/ODialog.spec.ts
+++ b/web/src/lib/overlay/Dialog/ODialog.spec.ts
@@ -300,4 +300,55 @@ describe("ODialog", () => {
       expect(wrapper.emitted("update:open")).toBeFalsy();
     });
   });
+
+  // A bare printable key pressed on a non-field element inside the modal
+  // (footer button, panel itself) must not bubble to the window-level shortcut
+  // manager, where it would fire page shortcuts (e.g. logs "s" opening Saved
+  // Views on top of an open dialog). Keys typed in inputs, modifier combos,
+  // and non-printable keys (Escape) must keep propagating.
+  describe("modal keystroke containment", () => {
+    function dispatchKeydown(el: Element, init: KeyboardEventInit): boolean {
+      const spy = vi.fn();
+      document.addEventListener("keydown", spy);
+      el.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init }),
+      );
+      document.removeEventListener("keydown", spy);
+      return spy.mock.calls.length > 0;
+    }
+
+    it("should stop a printable key pressed on a footer button from reaching document", () => {
+      const wrapper = mount(ODialog, {
+        attachTo: document.body,
+        props: { open: true, title: "Test", primaryButtonLabel: "OK" },
+      });
+      const btn = wrapper.find('[data-test="o-dialog-primary-btn"]');
+      expect(btn.exists()).toBe(true);
+      expect(dispatchKeydown(btn.element, { key: "s" })).toBe(false);
+      wrapper.unmount();
+    });
+
+    it("should let a printable key typed inside an input propagate", () => {
+      const wrapper = mount(ODialog, {
+        attachTo: document.body,
+        props: { open: true, title: "Test" },
+        slots: { default: '<input data-testid="field" />' },
+      });
+      const input = wrapper.find('[data-testid="field"]');
+      expect(input.exists()).toBe(true);
+      expect(dispatchKeydown(input.element, { key: "s" })).toBe(true);
+      wrapper.unmount();
+    });
+
+    it("should let modifier combos and non-printable keys propagate", () => {
+      const wrapper = mount(ODialog, {
+        attachTo: document.body,
+        props: { open: true, title: "Test", primaryButtonLabel: "OK" },
+      });
+      const btn = wrapper.find('[data-test="o-dialog-primary-btn"]');
+      expect(dispatchKeydown(btn.element, { key: "s", ctrlKey: true })).toBe(true);
+      expect(dispatchKeydown(btn.element, { key: "Escape" })).toBe(true);
+      wrapper.unmount();
+    });
+  });
 });

--- a/web/src/lib/overlay/Dialog/ODialog.vue
+++ b/web/src/lib/overlay/Dialog/ODialog.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+// Copyright 2026 OpenObserve Inc.
+
 import type { DialogProps, DialogEmits, DialogSlots } from "./ODialog.types";
 import {
   DialogClose,
@@ -14,6 +16,7 @@ import { ref, watch, watchEffect, useSlots, computed, nextTick, useAttrs, inject
 import OButton from "@/lib/core/Button/OButton.vue";
 import { useScrollShadow } from "@/lib/overlay/useScrollShadow";
 import { FORM_SUBMIT_STATE_KEY } from "@/lib/forms/Form/OForm.types";
+import { isInputFocused } from "@/utils/keyboardShortcuts";
 
 defineOptions({ inheritAttrs: false });
 const $attrs = useAttrs();
@@ -83,6 +86,21 @@ function handleEscapeKeyDown(e: KeyboardEvent) {
   }
   clearBodyValidation();
   handleOpenChange(false);
+}
+
+// Modal keystroke containment. When focus sits on a non-field element inside
+// the dialog (a footer button, the panel itself after clicking empty space),
+// a bare printable key would bubble to the window-level shortcut manager and
+// fire page shortcuts on top of the open modal (e.g. logs "s" opening Saved
+// Views over Saved Functions). Swallow those here. Keys typed in input-like
+// elements pass through untouched (the shortcut manager already ignores
+// them), as do modifier combos (Ctrl/⌘ shortcuts stay app-wide by design) and
+// non-printable keys — Escape must keep reaching reka's dismiss layer.
+function handleContentKeydown(e: KeyboardEvent) {
+  if (e.ctrlKey || e.metaKey || e.altKey) return;
+  if (e.key.length !== 1) return;
+  if (isInputFocused(e.target)) return;
+  e.stopPropagation();
 }
 
 function handleInteractOutside(e: Event) {
@@ -224,24 +242,45 @@ function handleBodyFocusIn(e: FocusEvent) {
 const bodyRef = ref<HTMLElement | null>(null);
 const primaryBtnRef = ref<InstanceType<typeof OButton> | null>(null);
 
+// Text fields take priority; a select/combobox trigger (OSelect listbox
+// trigger, reka SelectTrigger, q-select) is the second tier so a dialog whose
+// only field is a select still keeps keyboard focus on a field — otherwise
+// keystrokes land on a plain button and leak to page-level single-letter
+// shortcuts (e.g. "s" on logs opening Save View over an open dialog).
+const AUTOFOCUS_TEXT_FIELDS = [
+  'input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="range"]):not([type="color"]):not([disabled])',
+  'textarea:not([disabled])',
+].join(', ');
+const AUTOFOCUS_COMBOBOX =
+  '[role="combobox"]:not([disabled]):not([aria-disabled="true"])';
+const AUTOFOCUS_ANY_FIELD = `${AUTOFOCUS_TEXT_FIELDS}, ${AUTOFOCUS_COMBOBOX}`;
+
+function findAutoFocusTarget(root: Element): HTMLElement | null {
+  const scan = (selector: string): HTMLElement[] => {
+    const nested = Array.from(root.querySelectorAll<HTMLElement>(selector));
+    return root.matches(selector) ? [root as HTMLElement, ...nested] : nested;
+  };
+  const textField = scan(AUTOFOCUS_TEXT_FIELDS).find(
+    (el) =>
+      !el.closest(
+        '.q-select, .o-select, [role="combobox"], [role="listbox"], [data-no-autofocus]',
+      ),
+  );
+  if (textField) return textField;
+  return (
+    scan(AUTOFOCUS_COMBOBOX).find((el) => !el.closest('[data-no-autofocus]')) ??
+    null
+  );
+}
+
 function handleOpenAutoFocus(event: Event) {
   event.preventDefault();
   nextTick(() => {
     const body = bodyRef.value;
-    if (body) {
-      const candidates = body.querySelectorAll<HTMLElement>(
-        [
-          'input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="range"]):not([type="color"]):not([disabled])',
-          'textarea:not([disabled])',
-        ].join(', ')
-      );
-      const firstField = Array.from(candidates).find(
-        (el) => !el.closest('.q-select, .o-select, [role="combobox"], [role="listbox"], [data-no-autofocus]')
-      );
-      if (firstField) {
-        firstField.focus();
-        return;
-      }
+    const field = body ? findAutoFocusTarget(body) : null;
+    if (field) {
+      field.focus();
+      return;
     }
     // No form field found → focus primary button (confirm dialog pattern)
     const btnEl = (primaryBtnRef.value as any)?.$el as HTMLElement | undefined;
@@ -250,6 +289,57 @@ function handleOpenAutoFocus(event: Event) {
     }
   });
 }
+
+// ── Focus repair on body content swaps ───────────────────────────────────────
+// A v-if/v-else swap inside the body (e.g. a Create/Update toggle replacing an
+// input with a select) leaves focus on whatever was clicked — a toggle button
+// — or drops it to <body> when the focused field itself was removed. Either
+// way the next keystroke bypasses the input-focus guard and fires page-level
+// single-letter shortcuts. When a mutation batch both removes and adds fields,
+// move focus to the first field of the newly added content — unless the user
+// is still focused in a field that survived the swap.
+watchEffect((cleanup) => {
+  if (!internalOpen.value) return;
+  const body = bodyRef.value;
+  if (!body) return;
+
+  const containsField = (node: Node): node is Element =>
+    node instanceof Element &&
+    (node.matches(AUTOFOCUS_ANY_FIELD) ||
+      !!node.querySelector(AUTOFOCUS_ANY_FIELD));
+
+  const observer = new MutationObserver((records) => {
+    const added = records
+      .flatMap((r) => Array.from(r.addedNodes))
+      .filter(containsField);
+    const removedField = records
+      .flatMap((r) => Array.from(r.removedNodes))
+      .some(containsField);
+    if (!added.length || !removedField) return;
+
+    const active = document.activeElement;
+    if (
+      active instanceof HTMLElement &&
+      body.contains(active) &&
+      active.matches(AUTOFOCUS_ANY_FIELD)
+    ) {
+      return;
+    }
+
+    nextTick(() => {
+      for (const el of added) {
+        if (!el.isConnected) continue;
+        const field = findAutoFocusTarget(el);
+        if (field) {
+          field.focus();
+          return;
+        }
+      }
+    });
+  });
+  observer.observe(body, { childList: true, subtree: true });
+  cleanup(() => observer.disconnect());
+});
 
 // ── Focus-trap workaround for portaled elements ─────────────────────────────
 // Same workaround as ODrawer — see the comment block there for full rationale.
@@ -356,6 +446,7 @@ watch(internalOpen, (open) => {
         @escape-key-down="handleEscapeKeyDown"
         @interact-outside="handleInteractOutside"
         @open-auto-focus="handleOpenAutoFocus"
+        @keydown="handleContentKeydown"
       >
         <!--
           DialogTitle is ALWAYS rendered for accessibility.


### PR DESCRIPTION
OSelect's trigger lacked role="combobox", so a focused select wasn't recognized as an input by the shortcut guard — pressing a single-letter key (e.g. "s" on logs) fired the page-level shortcut instead of typing into the select. ODialog's auto-focus also skipped selects entirely and never re-focused after a body swap (e.g. Create/Update toggle), leaving focus on a button where keystrokes leaked past the modal.

- OSelect: mark the trigger role="combobox" and add type-to-search so a focused, closed trigger opens the dropdown and seeds the filter.
- ODialog: auto-focus falls back to a combobox trigger when there's no text field, re-focuses the first field after body content swaps, and now swallows any bare printable keydown that doesn't land in an input-like element so page shortcuts can never fire while the dialog is open, regardless of what has focus.