### PR TITLE
fix: function test query ignores selected stream type (always queries logs)

### DIFF
--- a/web/src/components/functions/TestFunction.vue
+++ b/web/src/components/functions/TestFunction.vue
@@ -633,7 +633,7 @@ const getResults = async () => {
     .search({
       org_identifier: store.state.selectedOrganization.identifier,
       query,
-      page_type: "logs",
+      page_type: selectedStream.value.type,
     })
     .then((res: any) => {
       expandState.value.stream = false;


### PR DESCRIPTION
## Problem

Fixes #7228 (新建函数查询时数据流类型无效 — "Data stream type is invalid when creating a new function query").

In the function editor's **Run query** test panel, selecting **Traces** (or **Metrics**) as the stream type still queries **logs**. The user-selected stream type is ignored.

## Root cause

`TestFunction.vue` → `getResults()` hardcoded `page_type: "logs"` when calling `searchService.search()`:

```js
searchService.search({
  org_identifier: store.state.selectedOrganization.identifier,
  query,
  page_type: "logs",   // ignored the dropdown selection
})
```

`page_type` becomes the `type=` query param in `search.ts` (`/api/{org}/_search?type=logs&...`), so the request always hit the logs store regardless of the Stream Type dropdown.

## Fix

Pass the user-selected stream type instead — the same value the rest of the component already uses for the stream list, field keywords, and auto-suggest:

```diff
-  page_type: "logs",
+  page_type: selectedStream.value.type,
```

`selectedStream.value.type` is typed `"logs" | "metrics" | "traces"` and is bound to the Stream Type `OSelect`.

## Blast radius (reviewed)

- **Only consumer of the hardcoded value:** `getResults()` (the "Run query" button), which fetches sample events into the Events panel to feed the VRL test. Line 636 was the only hardcoded `page_type`/`"logs"` in the file — every other reference already uses `selectedStream.value.type`.
- **Traces:** now correctly reaches the `page_type === "traces"` branch in `search.ts`, which applies the nanosecond-timestamp response patch (`patchNsFieldsInJson`) — previously never triggered from this panel.
- **Metrics:** SQL search against metrics streams via `_search?type=metrics` is valid.
- **Not affected:** the toolbar "Test Function" button (runs the VRL against the events JSON via the jstransform API — independent of stream type), saving the function, and the multi-stream `_search_multi` branch (unused here since `query.query.sql` is always a string).
- **Tests:** `TestFunction.spec.js` / `.spec.ts` mock `searchService.search` and don't assert `page_type`, so no test changes are required.

## How to verify

1. **Pipelines → Functions → Add Function** → expand the **Query** section in the test panel.
2. Set **Stream Type → Traces**, pick a traces stream, enter a query, click **Run query**.
3. Network tab: the request now goes to `POST /api/{org}/_search?type=traces...` (was `type=logs`) and returns trace data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)