### PR TITLE
fix: function test query ignores selected stream type (always queries logs)

### DIFF
--- a/web/src/components/functions/TestFunction.vue
+++ b/web/src/components/functions/TestFunction.vue
@@ -633,7 +633,7 @@ const getResults = async () => {
     .search({
       org_identifier: store.state.selectedOrganization.identifier,
       query,
-      page_type: "logs",
+      page_type: selectedStream.value.type,
     })
     .then((res: any) => {
       expandState.value.stream = false;


### PR DESCRIPTION
Backport of #13163 to `branch-v0.92.0`.

## Problem

Fixes #7228 (新建函数查询时数据流类型无效 — "Data stream type is invalid when creating a new function query").

In the function editor's **Run query** test panel, selecting **Traces** (or **Metrics**) as the stream type still queries **logs** — the selected stream type is ignored.

## Root cause

`TestFunction.vue` → `getResults()` hardcoded `page_type: "logs"` when calling `searchService.search()`, which becomes the `type=` query param (`/api/{org}/_search?type=logs&...`). So the request always hit the logs store regardless of the Stream Type dropdown.

## Fix

```diff
-  page_type: "logs",
+  page_type: selectedStream.value.type,
```

`selectedStream.value.type` (`"logs" | "metrics" | "traces"`) is bound to the Stream Type dropdown and is already used everywhere else in the component (stream list fetch, field keywords, auto-suggest). This is the only hardcoded `page_type` in the file.

## Notes

Identical one-line change to the main-branch PR (#13163); the file is byte-identical on this release branch at line 636. No test changes required — `TestFunction.spec.js`/`.ts` mock `searchService.search` and don't assert `page_type`.

## How to verify

1. **Pipelines → Functions → Add Function** → expand the **Query** section in the test panel.
2. Set **Stream Type → Traces**, pick a traces stream, enter a query, click **Run query**.
3. Network tab: the request now goes to `POST /api/{org}/_search?type=traces...` (was `type=logs`) and returns trace data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)