### PR TITLE
chore(build): skip updating latest docker tags for pre-release versions

### DIFF
--- a/deploy/build/buildspec-tag-amd64.yml
+++ b/deploy/build/buildspec-tag-amd64.yml
@@ -15,6 +15,9 @@ phases:
       - swapon /swapfile || true
       - pwd
       - GIT_TAG="$(git describe --tags --abbrev=0)"
+      # pre-release tags like 0.91.0-rc2 should not update the latest tags
+      - PUSH_LATEST=true
+      - case "$GIT_TAG" in *-rc*|*-beta*|*-alpha*) PUSH_LATEST=false ;; esac
 
       # simd version
       - docker build -t openobserve:latest-amd64-simd -f deploy/build/Dockerfile.tag-simd.amd64 .
@@ -22,7 +25,7 @@ phases:
       - docker tag openobserve:latest-amd64-simd public.ecr.aws/zinclabs/openobserve:latest-amd64-simd
       
       - docker push public.ecr.aws/zinclabs/openobserve:$GIT_TAG-amd64-simd
-      - docker push public.ecr.aws/zinclabs/openobserve:latest-amd64-simd
+      - if [ "$PUSH_LATEST" = "true" ]; then docker push public.ecr.aws/zinclabs/openobserve:latest-amd64-simd; fi
 
       # common version
       - docker build -t openobserve:latest-amd64 -f deploy/build/Dockerfile.tag.amd64 .
@@ -30,7 +33,7 @@ phases:
       - docker tag openobserve:latest-amd64 public.ecr.aws/zinclabs/openobserve:latest-amd64
       
       - docker push public.ecr.aws/zinclabs/openobserve:$GIT_TAG-amd64
-      - docker push public.ecr.aws/zinclabs/openobserve:latest-amd64
+      - if [ "$PUSH_LATEST" = "true" ]; then docker push public.ecr.aws/zinclabs/openobserve:latest-amd64; fi
 
       # debug version
       - docker build -t openobserve:latest-amd64-debug -f deploy/build/Dockerfile.tag-debug.amd64 .
@@ -40,28 +43,28 @@ phases:
       # create manifests for simd version
       - echo 'Pull arm64 image'
       - docker pull public.ecr.aws/zinclabs/openobserve:$GIT_TAG-arm64-simd
-      - docker pull public.ecr.aws/zinclabs/openobserve:latest-arm64-simd
+      - if [ "$PUSH_LATEST" = "true" ]; then docker pull public.ecr.aws/zinclabs/openobserve:latest-arm64-simd; fi
        
       - echo 'Create manifests'
       - docker manifest create public.ecr.aws/zinclabs/openobserve:$GIT_TAG-simd --amend public.ecr.aws/zinclabs/openobserve:$GIT_TAG-amd64-simd --amend public.ecr.aws/zinclabs/openobserve:$GIT_TAG-arm64-simd
-      - docker manifest create public.ecr.aws/zinclabs/openobserve:latest-simd --amend public.ecr.aws/zinclabs/openobserve:latest-amd64-simd --amend public.ecr.aws/zinclabs/openobserve:latest-arm64-simd
+      - if [ "$PUSH_LATEST" = "true" ]; then docker manifest create public.ecr.aws/zinclabs/openobserve:latest-simd --amend public.ecr.aws/zinclabs/openobserve:latest-amd64-simd --amend public.ecr.aws/zinclabs/openobserve:latest-arm64-simd; fi
       
       - echo 'Push manifests'
       - docker manifest push public.ecr.aws/zinclabs/openobserve:$GIT_TAG-simd
-      - docker manifest push public.ecr.aws/zinclabs/openobserve:latest-simd
+      - if [ "$PUSH_LATEST" = "true" ]; then docker manifest push public.ecr.aws/zinclabs/openobserve:latest-simd; fi
 
       # create manifests for common version
       - echo 'Pull arm64 image'
       - docker pull public.ecr.aws/zinclabs/openobserve:$GIT_TAG-arm64
-      - docker pull public.ecr.aws/zinclabs/openobserve:latest-arm64
+      - if [ "$PUSH_LATEST" = "true" ]; then docker pull public.ecr.aws/zinclabs/openobserve:latest-arm64; fi
        
       - echo 'Create manifests'
       - docker manifest create public.ecr.aws/zinclabs/openobserve:$GIT_TAG --amend public.ecr.aws/zinclabs/openobserve:$GIT_TAG-amd64 --amend public.ecr.aws/zinclabs/openobserve:$GIT_TAG-arm64
-      - docker manifest create public.ecr.aws/zinclabs/openobserve:latest --amend public.ecr.aws/zinclabs/openobserve:latest-amd64 --amend public.ecr.aws/zinclabs/openobserve:latest-arm64
+      - if [ "$PUSH_LATEST" = "true" ]; then docker manifest create public.ecr.aws/zinclabs/openobserve:latest --amend public.ecr.aws/zinclabs/openobserve:latest-amd64 --amend public.ecr.aws/zinclabs/openobserve:latest-arm64; fi
       
       - echo 'Push manifests'
       - docker manifest push public.ecr.aws/zinclabs/openobserve:$GIT_TAG
-      - docker manifest push public.ecr.aws/zinclabs/openobserve:latest
+      - if [ "$PUSH_LATEST" = "true" ]; then docker manifest push public.ecr.aws/zinclabs/openobserve:latest; fi
 
       # create manifests for debug version
       - echo 'Create debug manifests'
@@ -74,32 +77,32 @@ phases:
       - docker tag openobserve:latest-amd64 openobserve/openobserve:$GIT_TAG-amd64
       - docker tag openobserve:latest-amd64 openobserve/openobserve:latest-amd64
       - docker push openobserve/openobserve:$GIT_TAG-amd64
-      - docker push openobserve/openobserve:latest-amd64
+      - if [ "$PUSH_LATEST" = "true" ]; then docker push openobserve/openobserve:latest-amd64; fi
       - echo 'Pull amd64-simd image'
       - docker tag openobserve:latest-amd64-simd openobserve/openobserve:$GIT_TAG-amd64-simd
       - docker tag openobserve:latest-amd64-simd openobserve/openobserve:latest-amd64-simd
       - docker push openobserve/openobserve:$GIT_TAG-amd64-simd
-      - docker push openobserve/openobserve:latest-amd64-simd
+      - if [ "$PUSH_LATEST" = "true" ]; then docker push openobserve/openobserve:latest-amd64-simd; fi
       # create manifests for common version
       - echo 'Pull arm64 image'
       - docker pull openobserve/openobserve:$GIT_TAG-arm64
-      - docker pull openobserve/openobserve:latest-arm64
+      - if [ "$PUSH_LATEST" = "true" ]; then docker pull openobserve/openobserve:latest-arm64; fi
       - echo 'Create manifests'
       - docker manifest create openobserve/openobserve:$GIT_TAG --amend openobserve/openobserve:$GIT_TAG-amd64 --amend openobserve/openobserve:$GIT_TAG-arm64
-      - docker manifest create openobserve/openobserve:latest --amend openobserve/openobserve:latest-amd64 --amend openobserve/openobserve:latest-arm64
+      - if [ "$PUSH_LATEST" = "true" ]; then docker manifest create openobserve/openobserve:latest --amend openobserve/openobserve:latest-amd64 --amend openobserve/openobserve:latest-arm64; fi
       - echo 'Push manifests'
       - docker manifest push openobserve/openobserve:$GIT_TAG
-      - docker manifest push openobserve/openobserve:latest
+      - if [ "$PUSH_LATEST" = "true" ]; then docker manifest push openobserve/openobserve:latest; fi
       # create manifests for simd version
       - echo 'Pull arm64 image'
       - docker pull openobserve/openobserve:$GIT_TAG-arm64-simd
-      - docker pull openobserve/openobserve:latest-arm64-simd
+      - if [ "$PUSH_LATEST" = "true" ]; then docker pull openobserve/openobserve:latest-arm64-simd; fi
       - echo 'Create manifests'
       - docker manifest create openobserve/openobserve:$GIT_TAG-simd --amend openobserve/openobserve:$GIT_TAG-amd64-simd --amend openobserve/openobserve:$GIT_TAG-arm64-simd
-      - docker manifest create openobserve/openobserve:latest-simd --amend openobserve/openobserve:latest-amd64-simd --amend openobserve/openobserve:latest-arm64-simd
+      - if [ "$PUSH_LATEST" = "true" ]; then docker manifest create openobserve/openobserve:latest-simd --amend openobserve/openobserve:latest-amd64-simd --amend openobserve/openobserve:latest-arm64-simd; fi
       - echo 'Push manifests'
       - docker manifest push openobserve/openobserve:$GIT_TAG-simd
-      - docker manifest push openobserve/openobserve:latest-simd 
+      - if [ "$PUSH_LATEST" = "true" ]; then docker manifest push openobserve/openobserve:latest-simd; fi
       # create manifests for debug version
       - docker tag openobserve:latest-amd64-debug openobserve/openobserve:$GIT_TAG-amd64-debug
       - docker push openobserve/openobserve:$GIT_TAG-amd64-debug

--- a/deploy/build/buildspec-tag-arm64.yml
+++ b/deploy/build/buildspec-tag-arm64.yml
@@ -15,14 +15,17 @@ phases:
       - swapon /swapfile || true
       - pwd
       - GIT_TAG="$(git describe --tags --abbrev=0)"
-      
+      # pre-release tags like 0.91.0-rc2 should not update the latest tags
+      - PUSH_LATEST=true
+      - case "$GIT_TAG" in *-rc*|*-beta*|*-alpha*) PUSH_LATEST=false ;; esac
+
       # simd version
       - docker build -t openobserve:latest-arm64 -f deploy/build/Dockerfile.tag.aarch64 .
       - docker tag openobserve:latest-arm64 public.ecr.aws/zinclabs/openobserve:$GIT_TAG-arm64-simd
       - docker tag openobserve:latest-arm64 public.ecr.aws/zinclabs/openobserve:latest-arm64-simd
       
       - docker push public.ecr.aws/zinclabs/openobserve:$GIT_TAG-arm64-simd
-      - docker push public.ecr.aws/zinclabs/openobserve:latest-arm64-simd
+      - if [ "$PUSH_LATEST" = "true" ]; then docker push public.ecr.aws/zinclabs/openobserve:latest-arm64-simd; fi
 
       # common version
       # ARM version default enable NEON feature, so don't need build again
@@ -32,7 +35,7 @@ phases:
       - docker tag openobserve:latest-arm64 public.ecr.aws/zinclabs/openobserve:latest-arm64
       
       - docker push public.ecr.aws/zinclabs/openobserve:$GIT_TAG-arm64
-      - docker push public.ecr.aws/zinclabs/openobserve:latest-arm64
+      - if [ "$PUSH_LATEST" = "true" ]; then docker push public.ecr.aws/zinclabs/openobserve:latest-arm64; fi
 
       # debug version
       - docker build -t openobserve:latest-arm64-debug -f deploy/build/Dockerfile.tag-debug.aarch64 .
@@ -44,12 +47,12 @@ phases:
       - docker tag openobserve:latest-arm64 openobserve/openobserve:$GIT_TAG-arm64
       - docker tag openobserve:latest-arm64 openobserve/openobserve:latest-arm64
       - docker push openobserve/openobserve:$GIT_TAG-arm64
-      - docker push openobserve/openobserve:latest-arm64
+      - if [ "$PUSH_LATEST" = "true" ]; then docker push openobserve/openobserve:latest-arm64; fi
       - echo 'Pull arm64-simd image'
       - docker tag openobserve:latest-arm64 openobserve/openobserve:$GIT_TAG-arm64-simd
       - docker tag openobserve:latest-arm64 openobserve/openobserve:latest-arm64-simd
       - docker push openobserve/openobserve:$GIT_TAG-arm64-simd
-      - docker push openobserve/openobserve:latest-arm64-simd
+      - if [ "$PUSH_LATEST" = "true" ]; then docker push openobserve/openobserve:latest-arm64-simd; fi
       - echo 'Pull arm64-debug image'
       - docker tag openobserve:latest-arm64-debug openobserve/openobserve:$GIT_TAG-arm64-debug
       - docker push openobserve/openobserve:$GIT_TAG-arm64-debug


### PR DESCRIPTION
Design at: #13166

## Summary

When a pre-release tag like `0.91.0-rc2` is built, the tagged CodeBuild specs currently also move the `latest*` docker tags (and multi-arch `latest` manifests) to the RC image. This PR makes pre-release builds publish only the versioned `$GIT_TAG-*` tags and leave `latest` untouched.

## Changes

- After `GIT_TAG` is resolved, detect pre-release tags: `case "$GIT_TAG" in *-rc*|*-beta*|*-alpha*) PUSH_LATEST=false ;; esac` (commands in a CodeBuild phase share one shell session, same as the existing `GIT_TAG` usage).
- `buildspec-tag-arm64.yml`: guard the 4 `latest-arm64` / `latest-arm64-simd` pushes (ECR + Docker Hub) with `if [ "$PUSH_LATEST" = "true" ]`.
- `buildspec-tag-amd64.yml`: guard the `latest-amd64*` pushes, plus the whole `latest` / `latest-simd` manifest chain (pull `latest-arm64*`, `manifest create`, `manifest push`) on both ECR and Docker Hub. Guarding the manifests also prevents an RC build from stitching a `latest` manifest out of the RC amd64 image and the previous release's arm64 image.

Stable tags (e.g. `v0.91.0`) behave exactly as before.

## Testing

- Both files validated as YAML.
- Detection logic tested in POSIX sh: `v0.91.0` → pushes latest; `0.91.0-rc2`, `0.92.0-beta1`, `v1.0.0-alpha3` → skip latest.
