### PR TITLE
fix(ci): stop rerun-detection crash + logs-9754 delete/re-ingest race

### DIFF
--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -318,11 +318,19 @@ jobs:
             ALL_JOBS_RESPONSE=$(curl -s -H "Authorization: token $GH_TOKEN" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?filter=all&per_page=100")
-            CURRENT_ATTEMPT_JOBS=$(echo "$ALL_JOBS_RESPONSE" | jq -r "[.jobs[] | select(.name | startswith(\"e2e /\")) | select(.run_attempt == $CURRENT_ATTEMPT) | select(.status != \"completed\")] | length")
-            TOTAL_MATRIX_JOBS=$(echo "$ALL_JOBS_RESPONSE" | jq -r "[.jobs[] | select(.name | startswith(\"e2e /\")) | select(.run_attempt == 1) | .name] | unique | length")
+            CURRENT_ATTEMPT_JOBS=$(echo "$ALL_JOBS_RESPONSE" | jq -r "[(.jobs // [])[] | select(.name | startswith(\"e2e /\")) | select(.run_attempt == $CURRENT_ATTEMPT) | select(.status != \"completed\")] | length" 2>/dev/null || echo "0")
+            TOTAL_MATRIX_JOBS=$(echo "$ALL_JOBS_RESPONSE" | jq -r "[(.jobs // [])[] | select(.name | startswith(\"e2e /\")) | select(.run_attempt == 1) | .name] | unique | length" 2>/dev/null || echo "0")
             echo "::notice::Total unique matrix job names: $TOTAL_MATRIX_JOBS"
             echo "::notice::Jobs running in current attempt $CURRENT_ATTEMPT: $CURRENT_ATTEMPT_JOBS"
-            if [ "$CURRENT_ATTEMPT_JOBS" -eq "$TOTAL_MATRIX_JOBS" ]; then
+            # If the jobs API returned an unexpected payload (a rate-limit/error body has no
+            # .jobs key, or curl failed) the counts above fall back to 0 via `.jobs // []`.
+            # Never let that crash the step: previously raw `.jobs[]` hit jq "Cannot iterate
+            # over null", exited 5 under `bash -e`, and skipped the entire test run. On any
+            # ambiguity, default to re-running ALL tests (safe, just not cost-optimized).
+            if ! [[ "$CURRENT_ATTEMPT_JOBS" =~ ^[0-9]+$ ]] || ! [[ "$TOTAL_MATRIX_JOBS" =~ ^[0-9]+$ ]] || [ "$TOTAL_MATRIX_JOBS" -eq 0 ]; then
+              echo "::warning::Could not determine rerun type from jobs API; defaulting to rerun_type=all (all tests)."
+              echo "rerun_type=all" >> $GITHUB_OUTPUT
+            elif [ "$CURRENT_ATTEMPT_JOBS" -eq "$TOTAL_MATRIX_JOBS" ]; then
               echo "::notice::✅ DETECTED: Re-run ALL jobs (all $TOTAL_MATRIX_JOBS matrix jobs running)"
               echo "rerun_type=all" >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -309,6 +309,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Rerun-detection strategy:
+          #  1. On a rerun, query the GitHub Jobs API for this run.
+          #  2. Compare non-completed jobs in the current attempt against total unique
+          #     matrix jobs: all present -> rerun ALL tests; a subset -> rerun FAILED only.
+          #  3. If the API returns an unexpected payload (rate-limit / error body with no
+          #     .jobs key), default to "all tests". Safe (everything runs), just not
+          #     cost-optimized — and it never crashes the step (see guard below).
           echo "::notice::GitHub run attempt: ${{ github.run_attempt }}"
           if [ "${{ github.run_attempt }}" -gt "1" ]; then
             echo "is_rerun=true" >> $GITHUB_OUTPUT

--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -732,19 +732,17 @@ pub async fn cache() -> Result<(), anyhow::Error> {
             continue;
         }
         schema_versions.sort_by_key(|k| k.0);
-        let latest_schema: Vec<Schema> =
-            match json::from_slice(&schema_versions.last().unwrap().1) {
-                Ok(s) => s,
-                Err(e) => {
-                    // A corrupt or empty schema entry (e.g. an empty or unreadable
-                    // value in the metadata store) must not bring down the whole process.
-                    // Log and skip this stream; it can be repaired manually.
-                    log::error!(
-                        "Error parsing schema, key: {item_key}, error: {e}; skipping"
-                    );
-                    continue;
-                }
-            };
+        let latest_schema: Vec<Schema> = match json::from_slice(&schema_versions.last().unwrap().1)
+        {
+            Ok(s) => s,
+            Err(e) => {
+                // A corrupt or empty schema entry (e.g. an empty or unreadable
+                // value in the metadata store) must not bring down the whole process.
+                // Log and skip this stream; it can be repaired manually.
+                log::error!("Error parsing schema, key: {item_key}, error: {e}; skipping");
+                continue;
+            }
+        };
         if latest_schema.is_empty() {
             continue;
         }
@@ -770,8 +768,8 @@ pub async fn cache() -> Result<(), anyhow::Error> {
         drop(w);
         let schema_versions = schema_versions
             .into_iter()
-            .filter_map(|(start_dt, data)| {
-                match json::from_slice::<Vec<Schema>>(&data) {
+            .filter_map(
+                |(start_dt, data)| match json::from_slice::<Vec<Schema>>(&data) {
                     Ok(mut v) => v.pop().map(|s| (start_dt, s)),
                     Err(e) => {
                         log::error!(
@@ -780,8 +778,8 @@ pub async fn cache() -> Result<(), anyhow::Error> {
                         );
                         None
                     }
-                }
-            })
+                },
+            )
             .collect::<Vec<_>>();
         let mut w = STREAM_SCHEMAS.write().await;
         w.insert(item_key.to_string(), schema_versions);

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-9754.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-9754.spec.js
@@ -146,6 +146,11 @@ const BUG_9754_TEST_LOGS = [
 
 const STREAM_NAME = 'e2e_highlighting_test';
 
+// Runs in serial mode because the tests share the e2e_highlighting_test stream (the @setup
+// test ingests data the later tests query). Serial mode means a failed test retries the
+// ENTIRE block (afterAll -> beforeEach -> setup), so afterAll blocks on stream deletion to
+// guarantee each retry starts from a clean slate — otherwise setup re-ingests into a
+// still-deleting stream and gets 400 "stream is being deleted".
 test.describe("Logs Highlighting Regression Bug Fixes", () => {
   test.describe.configure({ mode: 'serial' }); // Serial because tests depend on ingested data
   let pm;
@@ -435,8 +440,16 @@ test.describe("Logs Highlighting Regression Bug Fixes", () => {
       // still in-flight and gets 400 "stream [...] is being deleted", which cascades into
       // every downstream test and makes the built-in retry useless. Waiting here lets the
       // next attempt start from a clean slate so re-ingestion recreates the stream cleanly.
+      // Deliberately do NOT throw when the wait times out: this is an afterAll cleanup
+      // hook, so throwing would fail the whole describe even when every test passed. A
+      // slow-but-eventual deletion must not turn a green run red. If it hasn't settled,
+      // warn (so it's visible) and rely on the setup's own ingest retry loop as backstop.
       const deleted = await cleanupPm.apiCleanup.waitForStreamDeletion(STREAM_NAME, 120000, 3000);
-      testLogger.info(`Test stream ${STREAM_NAME} cleanup completed (deletion settled: ${deleted})`);
+      if (deleted) {
+        testLogger.info(`Test stream ${STREAM_NAME} cleanup completed (deletion settled)`);
+      } else {
+        testLogger.warn(`Test stream ${STREAM_NAME} deletion did not settle within 120s; setup's ingest retry will backstop the next attempt`);
+      }
     } catch (error) {
       testLogger.warn(`Failed to cleanup test stream: ${error.message}`);
     } finally {

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-9754.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-9754.spec.js
@@ -428,7 +428,15 @@ test.describe("Logs Highlighting Regression Bug Fixes", () => {
       // Delete the test stream via API
       const result = await cleanupPm.apiCleanup.deleteStream(STREAM_NAME);
       testLogger.info('Stream cleanup result:', result);
-      testLogger.info(`Test stream ${STREAM_NAME} cleanup completed`);
+
+      // Block until the deletion has fully settled server-side. This describe runs in
+      // serial mode, so a failing test retries the WHOLE block (afterAll -> beforeEach ->
+      // setup). Without this wait, the retry's setup re-ingests while this deletion is
+      // still in-flight and gets 400 "stream [...] is being deleted", which cascades into
+      // every downstream test and makes the built-in retry useless. Waiting here lets the
+      // next attempt start from a clean slate so re-ingestion recreates the stream cleanly.
+      const deleted = await cleanupPm.apiCleanup.waitForStreamDeletion(STREAM_NAME, 120000, 3000);
+      testLogger.info(`Test stream ${STREAM_NAME} cleanup completed (deletion settled: ${deleted})`);
     } catch (error) {
       testLogger.warn(`Failed to cleanup test stream: ${error.message}`);
     } finally {


### PR DESCRIPTION

Fixes two separate regression-suite CI failures observed in the scheduled Playwright Regression run (surfaced on both OSS and ENT).

## 1. `Check if this is a rerun` step crashes on reruns
On a rerun the step queries the jobs API and iterates `.jobs[]`. When the API returns a body **without** a `.jobs` key (rate-limit / error response), jq hits `Cannot iterate over null`, exits 5, and under `bash -e` the whole step dies — **skipping the entire test run**.

```
jq: error (at <stdin>:5): Cannot iterate over null (null)
##[error]Process completed with exit code 5.
```

`playwright.yml` was already hardened (`:-0` defaults + `2>/dev/null`), but the fix was never backported to `playwright_regression.yml` — the workflow that actually failed. This guards the jq with `(.jobs // [])` + `2>/dev/null || echo "0"` and adds an explicit fallback to `rerun_type=all` (run all tests — safe) when the counts aren't usable, so the step can never abort the run.

## 2. `logs-9754.spec.js` delete → re-ingest race
The primary failure is a transient `expectLogsTableVisible()` timeout on the `@P0 @highlighting` test. What turned that flake into a hard failure: the describe runs in `serial` mode, so a failed test retries the **whole block**. `afterAll` deletes the shared `e2e_highlighting_test` stream but returns immediately, so the retry's setup re-ingests into a still-deleting stream:

```
{"code":400,"message":"Error# stream [e2e_highlighting_test] is being deleted"}
```

The 5×3s setup retry window couldn't outlast the deletion, cascading every retry to failure. `afterAll` now blocks on the existing `waitForStreamDeletion()` helper so the next attempt starts from a clean slate and Playwright's built-in retry becomes effective again.

## Changes
- `.github/workflows/playwright_regression.yml` — harden rerun-detection jq + explicit fallback
- `tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-9754.spec.js` — `afterAll` waits for stream deletion to settle

The ENT side of the workflow fix is in a companion PR. The spec fix lives only here (the test folder is merged into ENT at CI time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)