### PR TITLE
fix: skip file column widen when already VARCHAR(1024)

### DIFF
--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -2726,6 +2726,26 @@ async fn apply_autovacuum_tuning(pool: &sqlx::Pool<Postgres>) -> Result<()> {
     Ok(())
 }
 
+const FILE_COLUMN_TARGET_WIDTH: i32 = 1024;
+
+/// Return the declared max length of a VARCHAR column, if the column exists.
+async fn get_varchar_column_width(
+    pool: &sqlx::Pool<Postgres>,
+    table: &str,
+    column: &str,
+) -> Result<Option<i32>> {
+    let width: Option<i32> = sqlx::query_scalar(
+        "SELECT character_maximum_length FROM information_schema.columns \
+         WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2",
+    )
+    .bind(table)
+    .bind(column)
+    .fetch_optional(pool)
+    .await?
+    .flatten();
+    Ok(width)
+}
+
 /// Apply column width compatibility for VARCHAR(file).
 async fn apply_column_width_compat(pool: &sqlx::Pool<Postgres>) -> Result<()> {
     let tables = [
@@ -2735,7 +2755,19 @@ async fn apply_column_width_compat(pool: &sqlx::Pool<Postgres>) -> Result<()> {
         "file_list_dump_stats",
     ];
     for table in &tables {
-        let sql = format!("ALTER TABLE IF EXISTS {table} ALTER COLUMN file TYPE VARCHAR(1024)");
+        match get_varchar_column_width(pool, table, "file").await? {
+            Some(width) if width >= FILE_COLUMN_TARGET_WIDTH => {
+                log::info!(
+                    "[POSTGRES] Skipping file column widen for {table}: already VARCHAR({width})"
+                );
+                continue;
+            }
+            _ => {}
+        }
+
+        let sql = format!(
+            "ALTER TABLE IF EXISTS {table} ALTER COLUMN file TYPE VARCHAR({FILE_COLUMN_TARGET_WIDTH})"
+        );
         if let Err(e) = sqlx::query(&sql).execute(pool).await {
             log::warn!("[POSTGRES] Failed to widen file column for {table}: {e}");
         }


### PR DESCRIPTION
## Summary
- Check `information_schema.columns` before widening the `file` column on PostgreSQL file_list tables
- Skip `ALTER COLUMN file TYPE VARCHAR(1024)` when the column is already at the target width
- Avoids expensive full-table rewrites on PostgreSQL 16 during startup on large deployments

## Test plan
- [x] Start OpenObserve against a PostgreSQL instance where `file_list.file` is already `VARCHAR(1024)` and confirm startup skips the ALTER with log: `Skipping file column widen for file_list: already VARCHAR(1024)`
- [x] Start against a database with an older narrower `file` column and confirm the one-time widen still runs successfully
- [x] Verify fresh installs and partitioned table migrations are unaffected


Made with [Cursor](https://cursor.com)