### PR TITLE
feat: show trace event markers

### DIFF
--- a/web/src/plugins/traces/SpanBlock.spec.ts
+++ b/web/src/plugins/traces/SpanBlock.spec.ts
@@ -540,6 +540,52 @@ describe("SpanBlock", () => {
     });
   });
 
+  describe("span event markers", () => {
+    it("positions events on the trace timeline and distinguishes exceptions", async () => {
+      await wrapper.setProps({
+        spanData: {
+          ...mockSpanData,
+          events: JSON.stringify([
+            {
+              _timestamp:
+                mockBaseTracePosition.startTimeUs +
+                mockBaseTracePosition.durationUs * 0.25,
+              name: "cache.miss",
+            },
+            {
+              _timestamp:
+                mockBaseTracePosition.startTimeUs +
+                mockBaseTracePosition.durationUs * 0.75,
+              name: "exception",
+              "exception.type": "TimeoutError",
+            },
+          ]),
+        },
+      });
+
+      const markers = wrapper.findAll('[data-test="span-event-marker"]');
+      expect(markers).toHaveLength(2);
+      expect(markers[0].attributes("style")).toContain("left: 25%");
+      expect(markers[0].attributes("data-event-type")).toBe("event");
+      expect(markers[1].attributes("style")).toContain("left: 75%");
+      expect(markers[1].attributes("data-event-type")).toBe("exception");
+      expect(markers[1].attributes("title")).toContain("TimeoutError");
+    });
+
+    it("ignores malformed event payloads", async () => {
+      await wrapper.setProps({
+        spanData: {
+          ...mockSpanData,
+          events: "not-json",
+        },
+      });
+
+      expect(wrapper.findAll('[data-test="span-event-marker"]')).toHaveLength(
+        0,
+      );
+    });
+  });
+
   describe("pre-selected span_id scroll behavior", () => {
     let scrollSpy: ReturnType<typeof vi.fn>;
     let originalScrollIntoView: any;

--- a/web/src/plugins/traces/SpanBlock.vue
+++ b/web/src/plugins/traces/SpanBlock.vue
@@ -70,6 +70,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             }"
           />
         </div>
+        <button
+          v-for="eventMarker in eventMarkers"
+          :key="eventMarker.key"
+          type="button"
+          :style="{
+            position: 'absolute',
+            left: eventMarker.left + '%',
+            top: '50%',
+            width: '8px',
+            height: '8px',
+            padding: 0,
+            border: `1px solid ${store.state.theme === 'dark' ? '#1a1a1a' : '#ffffff'}`,
+            borderRadius: '50%',
+            backgroundColor: eventMarker.isException ? '#d32f2f' : '#f59e0b',
+            transform: 'translate(-50%, -50%)',
+            zIndex: 2,
+          }"
+          :title="eventMarker.title"
+          :aria-label="eventMarker.title"
+          :data-event-type="eventMarker.isException ? 'exception' : 'event'"
+          data-test="span-event-marker"
+          @click.stop="selectSpan(span.spanId)"
+        />
         <div
           :style="{
             position: 'absolute',
@@ -162,6 +185,63 @@ export default defineComponent({
     const leftPosition = ref(0);
 
     const spanWidth = ref(0);
+
+    const eventMarkers = computed(() => {
+      const rawEvents = props.spanData?.events;
+      let events: Record<string, unknown>[] = [];
+
+      if (Array.isArray(rawEvents)) {
+        events = rawEvents;
+      } else if (typeof rawEvents === "string" && rawEvents.trim()) {
+        try {
+          const parsed = JSON.parse(rawEvents);
+          if (Array.isArray(parsed)) {
+            events = parsed;
+          }
+        } catch {
+          return [];
+        }
+      }
+
+      const traceStart = Number(props.baseTracePosition?.startTimeUs);
+      const traceDuration = Number(props.baseTracePosition?.durationUs);
+      if (
+        !Number.isFinite(traceStart) ||
+        !Number.isFinite(traceDuration) ||
+        traceDuration <= 0
+      ) {
+        return [];
+      }
+
+      return events.flatMap((event, index) => {
+        const timestamp = Number(event?._timestamp);
+        if (!Number.isFinite(timestamp)) {
+          return [];
+        }
+
+        const left = ((timestamp - traceStart) / traceDuration) * 100;
+        if (left < 0 || left > 100) {
+          return [];
+        }
+
+        const isException =
+          event.name === "exception" ||
+          Object.keys(event).some((key) => key.startsWith("exception."));
+        const eventName = String(event.name || "span event");
+        const exceptionType = String(event["exception.type"] || eventName);
+
+        return [
+          {
+            key: `${timestamp}-${index}`,
+            left,
+            isException,
+            title: isException
+              ? `Exception: ${exceptionType}`
+              : `Event: ${eventName}`,
+          },
+        ];
+      });
+    });
 
     const selectSpan = (spanId: string) => {
       emit("selectSpan", spanId);
@@ -300,6 +380,7 @@ export default defineComponent({
       onSpanHover,
       durationStyle,
       searchObj,
+      eventMarkers,
     };
   },
 });


### PR DESCRIPTION
## Summary

- render span events at their trace-relative positions in the trace timeline
- distinguish exception events from regular events with a separate marker color and tooltip
- ignore malformed or out-of-range event payloads without disrupting the trace view

Fixes #3764

Design at: https://github.com/openobserve/openobserve/issues/3764

## Validation

- `NODE_OPTIONS=--localstorage-file=/private/tmp/openobserve-vitest-localstorage npm run test:unit -- --run plugins/traces/SpanBlock.spec.ts` — 32 passed
- `npx eslint src/plugins/traces/SpanBlock.vue src/plugins/traces/SpanBlock.spec.ts --no-fix`
- `npm run type-check`
- `NODE_OPTIONS=--max_old_space_size=8192 npm run build-only`
- `npm run copy`
- `git diff --check`

The repository-wide `./eslint.sh` command currently reports 54 pre-existing errors in vendored and unrelated files. The two files changed here pass targeted ESLint with no findings.

AI assistance: OpenAI Codex was used to prepare and validate this change.
