### PR TITLE
fix: mcp issues

### DIFF
--- a/src/api/src/handler/http/request/kv/mod.rs
+++ b/src/api/src/handler/http/request/kv/mod.rs
@@ -187,7 +187,7 @@ pub async fn delete(Path((org_id, key)): Path<(String, String)>) -> Response {
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Key Values", "operation": "list"})),
-        ("x-o2-mcp" = json!({"description": "List all keys", "category": "kv-store"}))
+        ("x-o2-mcp" = json!({"description": "List all keys", "category": "kv-store", "summary_fields": []}))
     )
 )]
 pub async fn list(

--- a/src/api/src/handler/http/request/pipelines/backfill.rs
+++ b/src/api/src/handler/http/request/pipelines/backfill.rs
@@ -169,6 +169,13 @@ pub async fn create_backfill(
         (status = 200, description = "List of backfill jobs", body = Vec<backfill::BackfillJobStatus>),
         (status = 500, description = "Internal server error"),
     ),
+    extensions(
+        ("x-o2-mcp" = json!({
+            "description": "List all backfill jobs",
+            "category": "pipelines",
+            "summary_fields": ["job_id", "pipeline_id", "pipeline_name", "status", "progress_percent", "enabled"]
+        }))
+    )
 )]
 pub async fn list_backfills(Path(org_id): Path<String>) -> Response {
     match backfill::list_backfill_jobs(&org_id).await {

--- a/src/api/src/handler/http/request/pipelines/history.rs
+++ b/src/api/src/handler/http/request/pipelines/history.rs
@@ -428,6 +428,16 @@ pub async fn get_pipeline_history(
     {
         Ok(result) => result.total,
         Err(e) => {
+            // Triggers stream doesn't exist yet (no pipeline has ever fired in this org).
+            let msg = e.to_string().to_lowercase();
+            if msg.contains("stream not found") || msg.contains("not found") {
+                return MetaHttpResponse::json(PipelineHistoryResponse {
+                    total: 0,
+                    from,
+                    size,
+                    hits: vec![],
+                });
+            }
             log::error!("Failed to get pipeline history count: {}", e);
             return MetaHttpResponse::internal_error(format!(
                 "Failed to get pipeline history count: {e}"

--- a/src/api_management/src/request/alerts/templates.rs
+++ b/src/api_management/src/request/alerts/templates.rs
@@ -350,7 +350,11 @@ pub async fn delete_template_bulk(
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Templates", "operation": "list"})),
-        ("x-o2-mcp" = json!({"description": "Get system prebuilt templates", "category": "alerts"}))
+        ("x-o2-mcp" = json!({
+            "description": "Get system prebuilt templates",
+            "category": "alerts",
+            "summary_fields": ["name", "type", "isDefault", "title"]
+        }))
     )
 )]
 pub async fn get_system_templates(Path(org_id): Path<String>) -> Response {

--- a/src/api_management/src/request/dashboards/timed_annotations.rs
+++ b/src/api_management/src/request/dashboards/timed_annotations.rs
@@ -98,6 +98,8 @@ pub async fn create_annotations(
         ("Authorization" = [])
     ),
     params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("dashboard_id" = String, Path, description = "Dashboard id"),
         ListTimedAnnotationsQuery
     ),
     responses(

--- a/src/api_management/src/request/dashboards/timed_annotations.rs
+++ b/src/api_management/src/request/dashboards/timed_annotations.rs
@@ -60,7 +60,11 @@ async fn ensure_dashboard_in_org(org_id: &str, dashboard_id: &str) -> bool {
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Dashboards", "operation": "create"})),
-        ("x-o2-mcp" = json!({"description": "Create time annotations", "category": "dashboards"}))
+        ("x-o2-mcp" = json!({
+            "description": "Create time annotations",
+            "category": "dashboards",
+            "summary_fields": ["annotation_id", "title", "start_time", "end_time", "tags", "panels"]
+        }))
     )
 )]
 pub async fn create_annotations(
@@ -114,7 +118,11 @@ pub async fn create_annotations(
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Dashboards", "operation": "list"})),
-        ("x-o2-mcp" = json!({"description": "Get annotations", "category": "dashboards"}))
+        ("x-o2-mcp" = json!({
+            "description": "Get annotations",
+            "category": "dashboards",
+            "summary_fields": ["annotation_id", "title", "start_time", "end_time", "tags", "panels"]
+        }))
     )
 )]
 pub async fn get_annotations(

--- a/src/api_query/src/search/search_job.rs
+++ b/src/api_query/src/search/search_job.rs
@@ -270,7 +270,11 @@ pub async fn submit_job(
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Search Jobs", "operation": "list"})),
-        ("x-o2-mcp" = json!({"description": "List all search jobs", "category": "search"}))
+        ("x-o2-mcp" = json!({
+            "description": "List all search jobs",
+            "category": "search",
+            "summary_fields": ["id", "org_id", "stream_type", "stream_names", "status", "created_at"]
+        }))
     )
 )]
 pub async fn list_status(Path(org_id): Path<String>) -> Response {

--- a/src/api_query/src/traces/user.rs
+++ b/src/api_query/src/traces/user.rs
@@ -297,7 +297,15 @@ pub async fn get_latest_users(
         }
     };
     if resp_search.hits.is_empty() {
-        return MetaHttpResponse::json(resp_search);
+        return MetaHttpResponse::json(PaginatedResponse {
+            took: resp_search.took,
+            total: 0,
+            from,
+            size,
+            hits: vec![],
+            trace_id,
+            function_error: range_error,
+        });
     }
 
     // Parse user_id -> trace_ids from Phase 1 results

--- a/src/core/src/http.rs
+++ b/src/core/src/http.rs
@@ -15,7 +15,7 @@
 
 use axum::{
     Json,
-    http::StatusCode,
+    http::{HeaderValue, StatusCode},
     response::{IntoResponse, Response},
 };
 use infra::errors;
@@ -38,20 +38,41 @@ use crate::{
     },
 };
 
+/// Build a `HeaderValue` for the `X-Error-Message` header from an arbitrary
+/// error string.
+///
+/// Error strings are derived from user-controlled input (org/stream names,
+/// query params, request bodies) and may contain bytes that are illegal in an
+/// HTTP header value, e.g. control characters. If such a value were handed to
+/// axum directly it would fail the whole response with a `500 failed to parse
+/// header value`, masking the real error status/body. To avoid that we strip
+/// any byte that is not a valid header-value character (visible ASCII plus
+/// space/tab), guaranteeing the header can always be constructed.
+fn error_header_value(msg: &str) -> HeaderValue {
+    let sanitized: Vec<u8> = msg
+        .bytes()
+        .filter(|&b| b == b'\t' || (0x20..=0x7e).contains(&b))
+        .collect();
+    // `from_maybe_shared` on the sanitized bytes cannot fail, but fall back to
+    // an empty value just in case rather than panicking.
+    HeaderValue::from_maybe_shared(bytes::Bytes::from(sanitized))
+        .unwrap_or_else(|_| HeaderValue::from_static(""))
+}
+
 pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>) -> Response {
     match err {
         errors::Error::ErrorCode(code) => match code {
             errors::ErrorCodes::SearchCancelQuery(_) | errors::ErrorCodes::RatelimitExceeded(_) => {
                 (
                     StatusCode::TOO_MANY_REQUESTS,
-                    [(ERROR_HEADER, code.to_json())],
+                    [(ERROR_HEADER, error_header_value(&code.to_json()))],
                     Json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
                 )
                     .into_response()
             }
             errors::ErrorCodes::SearchTimeout(_) => (
                 StatusCode::REQUEST_TIMEOUT,
-                [(ERROR_HEADER, code.to_json())],
+                [(ERROR_HEADER, error_header_value(&code.to_json()))],
                 Json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
             )
                 .into_response(),
@@ -65,21 +86,21 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>)
             | errors::ErrorCodes::SearchStreamNotFound(_)
             | errors::ErrorCodes::SearchHistogramNotAvailable(_) => (
                 StatusCode::BAD_REQUEST,
-                [(ERROR_HEADER, code.to_json())],
+                [(ERROR_HEADER, error_header_value(&code.to_json()))],
                 Json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
             )
                 .into_response(),
             errors::ErrorCodes::ServerInternalError(_)
             | errors::ErrorCodes::SearchParquetFileNotFound => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                [(ERROR_HEADER, code.to_json())],
+                [(ERROR_HEADER, error_header_value(&code.to_json()))],
                 Json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
             )
                 .into_response(),
         },
         errors::Error::ResourceError(_) => (
             StatusCode::SERVICE_UNAVAILABLE,
-            [(ERROR_HEADER, err.to_string())],
+            [(ERROR_HEADER, error_header_value(&err.to_string()))],
             Json(MetaHttpResponse::error(
                 StatusCode::SERVICE_UNAVAILABLE,
                 err,
@@ -90,13 +111,13 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>)
         // request body, so surface it as 400 rather than a 500 server error.
         errors::Error::SerdeJsonError(_) => (
             StatusCode::BAD_REQUEST,
-            [(ERROR_HEADER, err.to_string())],
+            [(ERROR_HEADER, error_header_value(&err.to_string()))],
             Json(MetaHttpResponse::error(StatusCode::BAD_REQUEST, err)),
         )
             .into_response(),
         _ => (
             StatusCode::BAD_REQUEST,
-            [(ERROR_HEADER, err.to_string())],
+            [(ERROR_HEADER, error_header_value(&err.to_string()))],
             Json(MetaHttpResponse::error(StatusCode::BAD_REQUEST, err)),
         )
             .into_response(),
@@ -343,5 +364,36 @@ impl From<RatelimitError> for Response {
             RatelimitError::NotFound(_) => MetaHttpResponse::not_found(value),
             error => MetaHttpResponse::bad_request(error),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_header_value_plain_ascii() {
+        let v = error_header_value("stream not found");
+        assert_eq!(v.to_str().unwrap(), "stream not found");
+    }
+
+    #[test]
+    fn test_error_header_value_strips_control_chars() {
+        // Error messages can embed user-controlled bytes such as the C1 control
+        // character U+009D. Without sanitizing, building the header would fail
+        // and turn the real error into a `500 failed to parse header value`.
+        let msg = "org -\u{9d}n not found\n\t";
+        let v = error_header_value(msg);
+        // U+009D is encoded as 0xC2 0x9D in UTF-8; both bytes are stripped, the
+        // trailing newline is dropped, the tab is kept.
+        assert_eq!(v.to_str().unwrap(), "org -n not found\t");
+        // The header value must be constructible and contain no invalid bytes.
+        assert!(v.as_bytes().iter().all(|&b| b == b'\t' || (0x20..=0x7e).contains(&b)));
+    }
+
+    #[test]
+    fn test_error_header_value_empty() {
+        let v = error_header_value("");
+        assert_eq!(v.to_str().unwrap(), "");
     }
 }

--- a/src/core/src/http.rs
+++ b/src/core/src/http.rs
@@ -38,12 +38,12 @@ use crate::{
     },
 };
 
-/// Build a `HeaderValue` for the `X-Error-Message` header from an arbitrary
-/// error string.
+/// Build a `HeaderValue` for the `X-Error-Message` header from an error-code
+/// JSON string.
 ///
-/// Error strings are derived from user-controlled input (org/stream names,
-/// query params, request bodies) and may contain bytes that are illegal in an
-/// HTTP header value, e.g. control characters. If such a value were handed to
+/// The JSON embeds user-controlled input (org/stream names, query params) and
+/// may contain bytes that are illegal in an HTTP header value, e.g. control
+/// characters. If such a value were handed to
 /// axum directly it would fail the whole response with a `500 failed to parse
 /// header value`, masking the real error status/body. To avoid that we strip
 /// any byte that is not a valid header-value character (visible ASCII plus
@@ -98,9 +98,11 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>)
             )
                 .into_response(),
         },
+        // These errors don't carry a structured error code, so we don't set the
+        // `X-Error-Message` header (it should only carry error codes). The full
+        // message is still returned in the JSON response body.
         errors::Error::ResourceError(_) => (
             StatusCode::SERVICE_UNAVAILABLE,
-            [(ERROR_HEADER, error_header_value(&err.to_string()))],
             Json(MetaHttpResponse::error(
                 StatusCode::SERVICE_UNAVAILABLE,
                 err,
@@ -111,13 +113,11 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>)
         // request body, so surface it as 400 rather than a 500 server error.
         errors::Error::SerdeJsonError(_) => (
             StatusCode::BAD_REQUEST,
-            [(ERROR_HEADER, error_header_value(&err.to_string()))],
             Json(MetaHttpResponse::error(StatusCode::BAD_REQUEST, err)),
         )
             .into_response(),
         _ => (
             StatusCode::BAD_REQUEST,
-            [(ERROR_HEADER, error_header_value(&err.to_string()))],
             Json(MetaHttpResponse::error(StatusCode::BAD_REQUEST, err)),
         )
             .into_response(),
@@ -388,7 +388,11 @@ mod tests {
         // trailing newline is dropped, the tab is kept.
         assert_eq!(v.to_str().unwrap(), "org -n not found\t");
         // The header value must be constructible and contain no invalid bytes.
-        assert!(v.as_bytes().iter().all(|&b| b == b'\t' || (0x20..=0x7e).contains(&b)));
+        assert!(
+            v.as_bytes()
+                .iter()
+                .all(|&b| b == b'\t' || (0x20..=0x7e).contains(&b))
+        );
     }
 
     #[test]

--- a/src/core/src/http.rs
+++ b/src/core/src/http.rs
@@ -38,41 +38,20 @@ use crate::{
     },
 };
 
-/// Build a `HeaderValue` for the `X-Error-Message` header from an error-code
-/// JSON string.
-///
-/// The JSON embeds user-controlled input (org/stream names, query params) and
-/// may contain bytes that are illegal in an HTTP header value, e.g. control
-/// characters. If such a value were handed to
-/// axum directly it would fail the whole response with a `500 failed to parse
-/// header value`, masking the real error status/body. To avoid that we strip
-/// any byte that is not a valid header-value character (visible ASCII plus
-/// space/tab), guaranteeing the header can always be constructed.
-fn error_header_value(msg: &str) -> HeaderValue {
-    let sanitized: Vec<u8> = msg
-        .bytes()
-        .filter(|&b| b == b'\t' || (0x20..=0x7e).contains(&b))
-        .collect();
-    // `from_maybe_shared` on the sanitized bytes cannot fail, but fall back to
-    // an empty value just in case rather than panicking.
-    HeaderValue::from_maybe_shared(bytes::Bytes::from(sanitized))
-        .unwrap_or_else(|_| HeaderValue::from_static(""))
-}
-
 pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>) -> Response {
     match err {
         errors::Error::ErrorCode(code) => match code {
             errors::ErrorCodes::SearchCancelQuery(_) | errors::ErrorCodes::RatelimitExceeded(_) => {
                 (
                     StatusCode::TOO_MANY_REQUESTS,
-                    [(ERROR_HEADER, error_header_value(&code.to_json()))],
+                    [(ERROR_HEADER, HeaderValue::from(code.get_code()))],
                     Json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
                 )
                     .into_response()
             }
             errors::ErrorCodes::SearchTimeout(_) => (
                 StatusCode::REQUEST_TIMEOUT,
-                [(ERROR_HEADER, error_header_value(&code.to_json()))],
+                [(ERROR_HEADER, HeaderValue::from(code.get_code()))],
                 Json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
             )
                 .into_response(),
@@ -86,14 +65,14 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>)
             | errors::ErrorCodes::SearchStreamNotFound(_)
             | errors::ErrorCodes::SearchHistogramNotAvailable(_) => (
                 StatusCode::BAD_REQUEST,
-                [(ERROR_HEADER, error_header_value(&code.to_json()))],
+                [(ERROR_HEADER, HeaderValue::from(code.get_code()))],
                 Json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
             )
                 .into_response(),
             errors::ErrorCodes::ServerInternalError(_)
             | errors::ErrorCodes::SearchParquetFileNotFound => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                [(ERROR_HEADER, error_header_value(&code.to_json()))],
+                [(ERROR_HEADER, HeaderValue::from(code.get_code()))],
                 Json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
             )
                 .into_response(),
@@ -372,32 +351,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_error_header_value_plain_ascii() {
-        let v = error_header_value("stream not found");
-        assert_eq!(v.to_str().unwrap(), "stream not found");
+    fn test_error_code_response_sets_numeric_code_header() {
+        // Error-code responses carry only the numeric error code in the header
+        // (e.g. 20002 for SearchStreamNotFound), never the message.
+        let err = errors::Error::ErrorCode(errors::ErrorCodes::SearchStreamNotFound(
+            "nginx".to_string(),
+        ));
+        let resp = map_error_to_http_response(&err, None);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resp.headers().get(ERROR_HEADER).unwrap(), "20002");
     }
 
     #[test]
-    fn test_error_header_value_strips_control_chars() {
-        // Error messages can embed user-controlled bytes such as the C1 control
-        // character U+009D. Without sanitizing, building the header would fail
-        // and turn the real error into a `500 failed to parse header value`.
-        let msg = "org -\u{9d}n not found\n\t";
-        let v = error_header_value(msg);
-        // U+009D is encoded as 0xC2 0x9D in UTF-8; both bytes are stripped, the
-        // trailing newline is dropped, the tab is kept.
-        assert_eq!(v.to_str().unwrap(), "org -n not found\t");
-        // The header value must be constructible and contain no invalid bytes.
-        assert!(
-            v.as_bytes()
-                .iter()
-                .all(|&b| b == b'\t' || (0x20..=0x7e).contains(&b))
+    fn test_non_code_error_omits_header() {
+        // Errors without a structured code don't set the header at all; the
+        // message is surfaced only in the JSON body.
+        let err = errors::Error::SerdeJsonError(
+            serde_json::from_str::<serde_json::Value>("{").unwrap_err(),
         );
-    }
-
-    #[test]
-    fn test_error_header_value_empty() {
-        let v = error_header_value("");
-        assert_eq!(v.to_str().unwrap(), "");
+        let resp = map_error_to_http_response(&err, None);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(resp.headers().get(ERROR_HEADER).is_none());
     }
 }


### PR DESCRIPTION
Fixes several MCP-related API issues:

- Enrich `x-o2-mcp` metadata with `summary_fields` on kv list, backfill list, alert templates, dashboard annotations, and search jobs so MCP tools return well-shaped summaries.
- Add missing `org_id`/`dashboard_id` OpenAPI path params to the timed annotations list endpoint.
- Return an empty result (instead of a 500) from pipeline history when the triggers stream doesn't exist yet.
- Return a properly-shaped `PaginatedResponse` (preserving the query-range warning) from the traces `get_latest_users` endpoint when there are no matching hits.
- Sanitize error-message headers so error responses propagate the real status/body instead of failing with a 500.