### PR TITLE
fix: correct web UI embed folder path after api crate move

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -143,7 +143,7 @@ jobs:
           GIT_HASH_OVERRIDE: ${{ github.sha }}
         run: |
           bash -c "cd web && npm run build && cp -r ./dist /tmp/dist" &
-          sed -i 's|folder = "web/dist/"|folder = "/tmp/dist/"|' src/api/src/handler/http/router/ui.rs
+          sed -i 's|folder = "../../web/dist/"|folder = "/tmp/dist/"|' src/api/src/handler/http/router/ui.rs
           cargo build --profile release-ci --target x86_64-unknown-linux-gnu
           wait
 

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -146,7 +146,7 @@ jobs:
           GIT_HASH_OVERRIDE: ${{ github.sha }}
         run: |
           bash -c "cd web && npm run build && cp -r ./dist /tmp/dist" &
-          sed -i 's|folder = "web/dist/"|folder = "/tmp/dist/"|' src/api/src/handler/http/router/ui.rs
+          sed -i 's|folder = "../../web/dist/"|folder = "/tmp/dist/"|' src/api/src/handler/http/router/ui.rs
           cargo build --profile release-ci --target x86_64-unknown-linux-gnu
           wait
 

--- a/src/api/src/handler/http/router/ui.rs
+++ b/src/api/src/handler/http/router/ui.rs
@@ -26,7 +26,7 @@ use config::get_config;
 use rust_embed_for_web::{EmbedableFile, RustEmbed};
 
 #[derive(RustEmbed)]
-#[folder = "web/dist/"]
+#[folder = "../../web/dist/"]
 struct WebAssets;
 
 /// Serve static files from embedded web assets


### PR DESCRIPTION
## Problem

The web UI returns **HTTP 404 for all `/web/*` paths** on builds from current `main`. The router process itself is healthy (`/config`, `/healthz` return 200; `/` redirects to `/web/`) — only the UI is missing.

## Root cause

The static UI assets are embedded at compile time in `src/api/src/handler/http/router/ui.rs`:

```rust
#[derive(RustEmbed)]
#[folder = "web/dist/"]
struct WebAssets;
```

`rust-embed-for-web` resolves a relative `folder` against the crate's `CARGO_MANIFEST_DIR`. When the HTTP handlers were moved into the new `src/api/` sub-crate, this path was left as `web/dist/`, so it now resolves to `src/api/web/dist/` — which does not exist. `rust-embed-for-web` does not fail the build on a missing folder; it simply embeds **zero** assets. The binary compiles cleanly and ships with an empty UI, so `WebAssets::get()` returns `None` and the handler returns `404 Not Found` for every asset (including `index.html`).

Previously (before the `src/api/` move) this file lived in the root crate, where `web/dist/` correctly resolved to the workspace-root `web/dist/`.

## Fix

Point the embed folder back at the workspace-root `web/dist` relative to `src/api/`:

```rust
#[folder = "../../web/dist/"]
```

## Notes

- The Playwright workflows already `sed` this path to an absolute `/tmp/dist/`, which is why CI didn't catch the regression — the production build relies on the relative path.