### PR TITLE
feat: skip file download cache for data older than configurable max age

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6423,7 +6423,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openobserve"
-version = "0.92.0"
+version = "0.93.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = [
 license = "AGPL-3.0"
 name = "openobserve"
 repository = "https://github.com/openobserve/openobserve/"
-version = "0.92.0"
+version = "0.93.0"
 publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/api/src/handler/grpc/request/event.rs
+++ b/src/api/src/handler/grpc/request/event.rs
@@ -64,6 +64,14 @@ impl Event for Eventer {
 
             // Collect files to download
             for item in put_items.iter() {
+                // files with data older than the cache max age should not be
+                // cached, e.g. merged files from compaction of old partitions
+                if crate::service::file_downloader::exceeds_cache_max_age(
+                    item.meta.max_ts,
+                    CacheType::Disk,
+                ) {
+                    continue;
+                }
                 // cache parquet
                 if cfg.cache_latest_files.cache_parquet {
                     files_to_download.push((

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2160,6 +2160,10 @@ pub struct MemoryCache {
     pub gc_size: usize,
     #[env_config(name = "ZO_MEMORY_CACHE_GC_INTERVAL", default = 60)] // seconds
     pub gc_interval: u64,
+    // Days, files with data older than this will not be downloaded into the cache,
+    // queries read them directly from object storage. default 0 means no limit
+    #[env_config(name = "ZO_MEMORY_CACHE_MAX_AGE_DAYS", default = 0)]
+    pub max_age_days: i64,
     #[env_config(name = "ZO_MEMORY_CACHE_SKIP_DISK_CHECK", default = false)]
     pub skip_disk_check: bool,
     // MB, default is 50% of system memory
@@ -2198,6 +2202,10 @@ pub struct DiskCache {
     pub gc_size: usize,
     #[env_config(name = "ZO_DISK_CACHE_GC_INTERVAL", default = 60)] // seconds
     pub gc_interval: u64,
+    // Days, files with data older than this will not be downloaded into the cache,
+    // queries read them directly from object storage. default 0 means no limit
+    #[env_config(name = "ZO_DISK_CACHE_MAX_AGE_DAYS", default = 0)]
+    pub max_age_days: i64,
     #[env_config(name = "ZO_DISK_CACHE_MULTI_DIR", default = "")] // dir1,dir2,dir3...
     pub multi_dir: String,
 }

--- a/src/core/src/service/file_downloader.rs
+++ b/src/core/src/service/file_downloader.rs
@@ -23,7 +23,7 @@ use config::{
     get_config,
     meta::cluster::{Role, RoleGroup, get_internal_grpc_token},
     metrics,
-    utils::time::now_micros,
+    utils::time::{day_micros, now_micros},
 };
 use futures_util::StreamExt;
 use hashbrown::{HashMap, HashSet};
@@ -497,6 +497,19 @@ pub async fn queue_download(
         "[FILE_CACHE_DOWNLOAD:JOB] [trace_id {trace_id}] enqueue file: {file}, size: {size}, ts: {ts}"
     );
 
+    // files with data older than the cache max age are not worth caching: with
+    // time_lru they become the oldest bucket and are evicted first, so the
+    // download would be wasted work. Skip the queue and let the query read
+    // them directly from object storage.
+    if exceeds_cache_max_age(ts, cache_type) {
+        log::debug!(
+            "[FILE_CACHE_DOWNLOAD:JOB] [trace_id {trace_id}] skip file: {file}, data is older than the cache max age"
+        );
+        return Ok(());
+    }
+
+    let cfg = get_config();
+
     // skip if already queued or already being downloaded
     if !queued_files::try_add(&file) {
         return Ok(());
@@ -506,7 +519,6 @@ pub async fn queue_download(
         return Ok(());
     }
 
-    let cfg = get_config();
     if cfg.limit.file_download_enable_priority_queue
         && should_prioritize_file(ts, cfg.limit.file_download_priority_queue_window_secs)
     {
@@ -560,9 +572,61 @@ fn should_prioritize_file(ts: i64, window_secs: i64) -> bool {
     ts > now - window_micros
 }
 
+/// Returns true if the file's data is older than the cache max age and should
+/// not be downloaded into the cache.
+pub fn exceeds_cache_max_age(ts: i64, cache_type: file_data::CacheType) -> bool {
+    let cfg = get_config();
+    let max_age_days = match cache_type {
+        file_data::CacheType::Memory => cfg.memory_cache.max_age_days,
+        file_data::CacheType::Disk => cfg.disk_cache.max_age_days,
+        file_data::CacheType::None => 0,
+    };
+    exceeds_max_age(ts, max_age_days)
+}
+
+// if the file data is older than max_age_days, it should not be cached.
+// max_age_days == 0 means no limit, ts <= 0 means the timestamp is unknown.
+fn exceeds_max_age(ts: i64, max_age_days: i64) -> bool {
+    if max_age_days <= 0 || ts <= 0 {
+        return false;
+    }
+    ts < now_micros() - day_micros(max_age_days)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{FileInfo, PriorityDownloadQueue, file_data, processing_files, queued_files};
+    use config::utils::time::{day_micros, hour_micros, now_micros};
+
+    use super::{
+        FileInfo, PriorityDownloadQueue, exceeds_max_age, file_data, processing_files, queued_files,
+    };
+
+    #[test]
+    fn test_exceeds_max_age_disabled() {
+        // max_age_days == 0 means no limit, nothing is too old
+        let one_year_ago = now_micros() - day_micros(365);
+        assert!(!exceeds_max_age(one_year_ago, 0));
+        assert!(!exceeds_max_age(one_year_ago, -1));
+    }
+
+    #[test]
+    fn test_exceeds_max_age_unknown_ts() {
+        // unknown timestamp should not be skipped
+        assert!(!exceeds_max_age(0, 3));
+        assert!(!exceeds_max_age(-1, 3));
+    }
+
+    #[test]
+    fn test_exceeds_max_age_recent_file() {
+        let one_hour_ago = now_micros() - hour_micros(1);
+        assert!(!exceeds_max_age(one_hour_ago, 3));
+    }
+
+    #[test]
+    fn test_exceeds_max_age_old_file() {
+        let thirty_days_ago = now_micros() - day_micros(30);
+        assert!(exceeds_max_age(thirty_days_ago, 3));
+    }
 
     #[test]
     fn test_is_processing_false_initially() {


### PR DESCRIPTION
Design at: #13200

## What changed

Adds a max-age admission policy for the file download cache:

- New configs `ZO_DISK_CACHE_MAX_AGE_DAYS` and `ZO_MEMORY_CACHE_MAX_AGE_DAYS` (default `0` = disabled, current behavior unchanged).
- `queue_download()` now skips files whose `max_ts` is older than the configured max age — they never enter the download queue; queries read them directly from object storage (the existing cache-miss fallback).
- The `cache_latest_files` gRPC event handler applies the same filter when collecting files, covering the batch `download_from_node` path that writes to the cache via `file_data::set` without going through the queue (e.g. merged files produced by compaction of old partitions).
- The check is exposed as `file_downloader::exceeds_cache_max_age(ts, cache_type)`; `ts <= 0` (unknown timestamp) is never skipped.

## Why

`time_lru` has an eviction policy but no admission policy. With a cache sized for the recent hot window (e.g. 3 days), a query on old data (e.g. 30 days ago):

1. Triggers gc **before** insert: the first old-file insert evicts `max(release_size, data_size * 100)` — by default ~10% of the cache — from the oldest hours of the *hot* window.
2. Once inserted, the old files themselves become the oldest `time_lru` bucket and are evicted first, often within the same query — S3 download → disk write → immediate delete, pure wasted work with zero retention for repeat queries.

With a max age matching the cache window, deep-history queries no longer disturb the hot cache or waste S3 bandwidth and disk IO.

## Coverage

All query-side download paths funnel through `queue_download()` with the file's real `max_ts` and are covered: search (parquet), tantivy index (`.ttv`), promql/metrics, and file_list dump. Deliberately **not** gated: compactor working downloads (`cache_remote_files` and merge-output writes — required reads/writes, not speculative caching) and the results/aggregations/metrics_results caches (separate concern).

## Tests

Unit tests for the age check (disabled, unknown ts, recent file, old file); `cargo test -p openobserve-core --lib file_downloader` passes.
