### PR TITLE
test: repro vortex utf8→i64 cast pushdown bug (o2-enterprise#2179)

### DIFF
--- a/tests/api-testing/tests/query_agent/test_3_vortex.py
+++ b/tests/api-testing/tests/query_agent/test_3_vortex.py
@@ -8,7 +8,9 @@ Enterprise CI only — do not add this file to the OSS api-testing.yml.
 
 Test plan: scenarios 26–46 (Section 3 — Query Correctness, vortex phase).
 """
+import json
 import logging
+import os as _os
 import time
 
 import pytest
@@ -119,6 +121,107 @@ class TestVortexJoin:
             assert "pallet_id" in h, "join result missing pallet_id column"
             assert "b_pallet" in h, "join result missing b_pallet column"
             assert h["pallet_id"] != h["b_pallet"], "ON condition not enforced"
+
+
+class TestVortexUtf8Int64CastPushdown:
+    """Regression: vortex cast pushdown must not blow up on utf8 > int.
+
+    Repros the bug fixed by o2-enterprise#2179: when a field is ingested
+    first as i64 and later as utf8, the effective schema becomes utf8.
+    DataFusion then coerces ``WHERE field > 0`` to
+    ``CAST(field AS Int64) > 0``.  Before the fix, vortex accepted this
+    cast for pushdown but had no utf8 -> i64 cast kernel, so execution
+    failed with e.g. ``No CastReduce to cast constant array from utf8? to i64?``.
+
+    This test forces that exact shape:
+      1. ingest a batch with ``value`` as int (42, 100, ...)
+      2. ingest a batch with ``value`` as string ("abc", "hello", "17") -> schema widens to utf8
+      3. flush so a vortex file is generated
+      4. run ``SELECT * FROM stream WHERE value > 0``
+      5. assert 200 + empty partial_error (the query must not 5xx or partially fail)
+    """
+
+    @pytest.fixture(scope="class")
+    def utf8_int64_stream(self):
+        """Ingest i64-then-utf8 data into a fresh stream and flush to vortex."""
+        from datetime import datetime, timedelta, UTC
+        from support.wait import wait_until
+
+        client = OpenObserveClient()
+        stream = f"vortex_utf8_i64_cast_{int(time.time() * 1000)}_{_os.getpid()}"
+
+        now = datetime.now(UTC)
+        base_us = int(now.timestamp() * 1_000_000)
+
+        # Batch 1: numeric values -> schema starts as i64.
+        int_records = [
+            {"_timestamp": base_us + i * 1_000_000, "value": v, "tag": f"i_{i}"}
+            for i, v in enumerate([42, 100, 7, 250, 1])
+        ]
+        r1 = client.post(f"{stream}/_json", data=json.dumps(int_records),
+                         headers={"Content-Type": "application/json"})
+        assert r1.status_code == 200, f"int ingest failed: {r1.status_code} {r1.text[:300]}"
+
+        # Batch 2: string values on the SAME field -> schema widens to utf8.
+        # Includes numeric-looking strings ("17") to exercise the coercion path.
+        str_records = [
+            {"_timestamp": base_us + (10 + i) * 1_000_000, "value": v, "tag": f"s_{i}"}
+            for i, v in enumerate(["abc", "hello", "17", "world", "3"])
+        ]
+        r2 = client.post(f"{stream}/_json", data=json.dumps(str_records),
+                         headers={"Content-Type": "application/json"})
+        assert r2.status_code == 200, f"utf8 ingest failed: {r2.status_code} {r2.text[:300]}"
+
+        # Flush so a vortex file is generated with the widened utf8 schema.
+        flush_r = client.put("node/flush", prefix="")
+        logging.info("utf8/i64 cast fixture: flush -> %s", flush_r.status_code)
+        time.sleep(2)
+
+        # Wait for the flushed data to be searchable (vortex file registered).
+        end_us = base_us + 3_600_000_000
+        start_us = int((now - timedelta(weeks=4)).timestamp() * 1_000_000)
+
+        def _searchable():
+            r = client.post("_search?type=logs", json={
+                "query": {
+                    "sql": f'SELECT COUNT(*) AS c FROM "{stream}"',
+                    "start_time": start_us, "end_time": end_us,
+                    "from": 0, "size": 1,
+                }
+            })
+            if r.status_code != 200:
+                return False
+            hits = r.json().get("hits", [])
+            return bool(hits and hits[0].get("c", 0) >= len(int_records) + len(str_records))
+
+        wait_until(_searchable, timeout=120, interval=2.0,
+                   msg=f"{stream}: utf8+i64 data not searchable after flush")
+
+        return {"stream": stream, "start_us": start_us, "end_us": end_us}
+
+    def test_utf8_column_gt_int_does_not_crash_vortex(self, client, utf8_int64_stream):
+        """SELECT * WHERE value > 0 must return 200 (no cast-pushdown 5xx)."""
+        from support.factories import search_payload
+
+        stream = utf8_int64_stream["stream"]
+        payload = search_payload(
+            f'SELECT * FROM "{stream}" WHERE value > 0',
+            start_time=utf8_int64_stream["start_us"],
+            end_time=utf8_int64_stream["end_us"],
+            size=100,
+        )
+        resp = client.post("_search?type=logs", json=payload)
+
+        # The bug manifested as an error surfaced via partial_error / 5xx —
+        # message contained "No CastReduce" or "No CastKernel ... utf8 ... i64".
+        assert resp.status_code == 200, (
+            f"utf8>int on vortex failed with {resp.status_code}: {resp.text[:600]}"
+        )
+        body = resp.json()
+        pe = body.get("partial_error")
+        assert not pe, (
+            f"partial_error set — cast-pushdown regression: {pe!r}"
+        )
 
 
 def _make_test(cat, queries):


### PR DESCRIPTION
## Summary
- Adds `TestVortexUtf8Int64CastPushdown` in [tests/api-testing/tests/query_agent/test_3_vortex.py](tests/api-testing/tests/query_agent/test_3_vortex.py) — regression coverage for the bug fixed by [o2-enterprise#2179](https://github.com/openobserve/o2-enterprise/pull/2179).
- The fixture ingests a batch as **i64** and then a batch as **utf8** on the same field into a fresh stream, flushes to force vortex file generation, then runs `SELECT * FROM {stream} WHERE value > 0`.
- The bug: DataFusion coerces the predicate to `CAST(value AS Int64) > 0`; vortex used to accept the cast for pushdown but had no `utf8→i64` cast kernel, so execution failed with `No CastReduce to cast constant array from utf8? to i64?` / `No CastKernel …`.
- Assertion: status 200 + empty `partial_error` — the query must not 5xx or partially fail.

## Where this runs
- Runs in the enterprise `api_query_agent_vortex` job (server booted with `ZO_FILE_FORMAT=vortex`).
- Not enabled in OSS `api-testing.yml` (test file is enterprise-only per the file header).

## Test plan
- [ ] `api_query_agent_vortex` on the paired ent PR passes
- [ ] Ent PR (same branch name) needed to fire ent's `api-testing.yml` — the OSS `ent-build-status-check` only runs `cargo check/test`, not the Python vortex suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)