### PR TITLE
chore: expose Claude skills to agents

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## Summary
- expose the complete .claude/skills directory through .agents/skills
- use a relative directory symlink so future Claude skills are automatically available to agents
- keep .claude/skills as the single source of truth

## Verification
- confirmed .agents/skills resolves to ../.claude/skills
- confirmed the UI architect SKILL.md remains readable through the agent path