### PR TITLE
fix: gate GenAI Agent Mapping settings behind enterprise/cloud

### DIFF
--- a/web/src/components/settings/index.vue
+++ b/web/src/components/settings/index.vue
@@ -335,6 +335,7 @@ export default defineComponent({
           description: "Map GenAI spans to agent identifiers",
           icon: "smart-toy",
           to: { name: "genAiAgentMapping", query: { org_identifier: org } },
+          visible: (isEnt || isCloud) && !!z.online_evals_enabled,
           dataTest: "gen-ai-agent-mapping-tab",
           group: "Data & AI",
         },

--- a/web/src/composables/shared/useManagementRoutes.spec.ts
+++ b/web/src/composables/shared/useManagementRoutes.spec.ts
@@ -150,6 +150,11 @@ describe("useManagementRoutes", () => {
       expect(llmRoute).toBeUndefined();
     });
 
+    it("should NOT have genAiAgentMapping route in OSS builds", () => {
+      const genAiRoute = routes[0].children.find((child: any) => child.name === "genAiAgentMapping");
+      expect(genAiRoute).toBeUndefined();
+    });
+
     it("should have beforeEnter hook for general route", () => {
       const generalRoute = routes[0].children.find((child: any) => child.name === "general");
       expect(typeof generalRoute.beforeEnter).toBe("function");
@@ -357,7 +362,7 @@ describe("useManagementRoutes", () => {
 
     it("should have exactly 18 children routes when enterprise is enabled", () => {
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(18); // 7 base + llmProviders + 10 enterprise
+      expect(routes[0].children).toHaveLength(18); // 6 base + llmProviders + genAiAgentMapping + 10 enterprise
     });
   });
 
@@ -410,7 +415,7 @@ describe("useManagementRoutes", () => {
 
     it("should have exactly 9 children routes when cloud is enabled", () => {
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(9); // 7 base + llmProviders + 1 cloud
+      expect(routes[0].children).toHaveLength(9); // 6 base + llmProviders + genAiAgentMapping + 1 cloud
     });
   });
 
@@ -427,7 +432,7 @@ describe("useManagementRoutes", () => {
 
     it("should have exactly 19 children routes when both enterprise and cloud are enabled", () => {
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(19); // 7 base + llmProviders + 10 enterprise + 1 cloud
+      expect(routes[0].children).toHaveLength(19); // 6 base + llmProviders + genAiAgentMapping + 10 enterprise + 1 cloud
     });
 
     it("should have all enterprise routes when both are enabled", () => {
@@ -507,63 +512,63 @@ describe("useManagementRoutes", () => {
       config.isEnterprise = "false";
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // Base routes include gen_ai_agent_mapping; llm_providers is enterprise/cloud-only
+      expect(routes[0].children).toHaveLength(6); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only
     });
 
     it("should handle isCloud as string 'false'", () => {
       config.isEnterprise = "false";
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // Base routes include gen_ai_agent_mapping; llm_providers is enterprise/cloud-only
+      expect(routes[0].children).toHaveLength(6); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only
     });
 
     it("should handle isEnterprise as undefined", () => {
       (config as any).isEnterprise = undefined;
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // Base routes include gen_ai_agent_mapping; llm_providers is enterprise/cloud-only
+      expect(routes[0].children).toHaveLength(6); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only
     });
 
     it("should handle isCloud as undefined", () => {
       config.isEnterprise = "false";
       (config as any).isCloud = undefined;
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // Base routes include gen_ai_agent_mapping; llm_providers is enterprise/cloud-only
+      expect(routes[0].children).toHaveLength(6); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only
     });
 
     it("should handle both config values as undefined", () => {
       (config as any).isEnterprise = undefined;
       (config as any).isCloud = undefined;
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // Base routes include gen_ai_agent_mapping; llm_providers is enterprise/cloud-only
+      expect(routes[0].children).toHaveLength(6); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only
     });
 
     it("should handle isEnterprise as non-string truthy value", () => {
       (config as any).isEnterprise = true;
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // Base routes include gen_ai_agent_mapping; llm_providers is enterprise/cloud-only, since config comparison is strict "true"
+      expect(routes[0].children).toHaveLength(6); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only, since config comparison is strict "true"
     });
 
     it("should handle isCloud as non-string truthy value", () => {
       config.isEnterprise = "false";
       (config as any).isCloud = true;
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // Base routes include gen_ai_agent_mapping; llm_providers is enterprise/cloud-only, since config comparison is strict "true"
+      expect(routes[0].children).toHaveLength(6); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only, since config comparison is strict "true"
     });
 
     it("should handle empty string for isEnterprise", () => {
       config.isEnterprise = "";
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // Base routes include gen_ai_agent_mapping; llm_providers is enterprise/cloud-only
+      expect(routes[0].children).toHaveLength(6); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only
     });
 
     it("should handle empty string for isCloud", () => {
       config.isEnterprise = "false";
       config.isCloud = "";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // Base routes include gen_ai_agent_mapping; llm_providers is enterprise/cloud-only
+      expect(routes[0].children).toHaveLength(6); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only
     });
 
     it("should return the same structure on multiple calls", () => {

--- a/web/src/composables/shared/useManagementRoutes.ts
+++ b/web/src/composables/shared/useManagementRoutes.ts
@@ -89,24 +89,13 @@ const useManagementRoutes = () => {
             routeGuard(to, from, next);
           },
         },
-        {
-          path: "gen_ai_agent_mapping",
-          name: "genAiAgentMapping",
-          component: () =>
-            import("@/components/settings/GenAiAgentMappingSettings.vue"),
-          meta: {
-            keepAlive: true,
-            title: "GenAI Agent Mapping",
-          },
-          beforeEnter(to: any, from: any, next: any) {
-            routeGuard(to, from, next);
-          },
-        },
       ],
     },
   ];
-  // LLM Providers (used by the AI Observability / Online Evals flows) is an
-  // enterprise/cloud-only feature — not available in OSS builds.
+  // LLM Providers and GenAI Agent Mapping (used by the AI Observability /
+  // Online Evals flows) are enterprise/cloud-only features — the backend routes
+  // only exist behind the enterprise feature flag, so they must not be exposed
+  // in OSS builds.
   if (config.isEnterprise == "true" || config.isCloud == "true") {
     routes[0].children.push({
       path: "llm_providers",
@@ -115,6 +104,19 @@ const useManagementRoutes = () => {
         import("@/components/settings/LlmProvidersSettings.vue"),
       meta: {
         title: "LLM Providers",
+      },
+      beforeEnter(to: any, from: any, next: any) {
+        routeGuard(to, from, next);
+      },
+    });
+    routes[0].children.push({
+      path: "gen_ai_agent_mapping",
+      name: "genAiAgentMapping",
+      component: () =>
+        import("@/components/settings/GenAiAgentMappingSettings.vue"),
+      meta: {
+        keepAlive: true,
+        title: "GenAI Agent Mapping",
       },
       beforeEnter(to: any, from: any, next: any) {
         routeGuard(to, from, next);


### PR DESCRIPTION
## Problem

In an **OSS local build on latest main**, clicking **Settings → GenAI Agent Mapping** shows `Request failed with status code 404`.

## Root cause

GenAI Agent Mapping is an **enterprise-only** feature. The backend routes are registered only behind `#[cfg(feature = "enterprise")]` in `src/handler/http/router/mod.rs`, so in OSS builds `GET /api/{org}/settings/gen_ai/agent_mapping` is not registered and axum returns 404.

The frontend, however, exposed the feature unconditionally:
- The settings hub tile in `web/src/components/settings/index.vue` had **no `visible` gate** (defaults to shown).
- The route in `web/src/composables/shared/useManagementRoutes.ts` was added to the **base** routes array rather than the enterprise/cloud block.

So OSS users could open the page, which fires the enterprise-only API on mount → 404. The backend 404 is correct; the defect is purely frontend gating.

## Fix

Gate both the tile and the route exactly like the sibling **LLM Providers** feature:
- `index.vue`: `visible: (isEnt || isCloud) && !!z.online_evals_enabled`
- `useManagementRoutes.ts`: move the `genAiAgentMapping` route into the `if (isEnterprise || isCloud)` block.

Backend behavior is unchanged — the feature stays enterprise/cloud-only.

## Tests

- Updated `useManagementRoutes.spec.ts`: OSS base-route count 7 → 6, corrected comments, and added an assertion that the `genAiAgentMapping` route is absent in OSS builds.
- Enterprise/cloud/combined totals (18 / 9 / 19) are unchanged — the route only moved from the base array into the gated block.
- `npx vitest run src/composables/shared/useManagementRoutes.spec.ts` → **72/72 passing**.

## Note for reviewer

The tile is gated on `online_evals_enabled` (matching LLM Providers), so it won't appear on enterprise/cloud unless online evals are enabled. If GenAI Agent Mapping should be independent of that flag, say the word and I'll drop it to `(isEnt || isCloud)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)