### PR TITLE
refactor: speed up embedded web asset compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8742,9 +8742,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-for-web"
-version = "11.3.0"
+version = "11.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e575354a7a8828ce39379d7e31135cd2358a8edbbc07f86e782e4ce550169b"
+checksum = "cc9de9fc1c7cb74c76c770e9ae5454c050aead66420ad59cdad7544e1a5d85fc"
 dependencies = [
  "rust-embed-for-web-impl",
  "rust-embed-for-web-utils",
@@ -8753,9 +8753,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-for-web-impl"
-version = "11.3.0"
+version = "11.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86772bd192343b5305aba01078be9e55e2c7b169b9e69dcee637473120bff9d7"
+checksum = "8527f04d3f734ff9ebab526fcc3e03d61d66386975b2cf898d6b2a221f7dee29"
 dependencies = [
  "brotli",
  "flate2",
@@ -8770,15 +8770,15 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-for-web-utils"
-version = "11.3.0"
+version = "11.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a9c32c0e9a4d0f9eabc75413252215a8632acad4ec56f27232a2c70f738b58"
+checksum = "d05939009fc97b73cd5ccee07f5af565b2e3f676a60de30fe8c29419dd33b2c2"
 dependencies = [
  "base85rs",
  "chrono",
  "globset",
  "new_mime_guess",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ multer = "3.1"
 pprof = { version = "0.15", features = ["flamegraph", "protobuf-codec"] }
 promql-parser = { version = "0.6", git = "https://github.com/openobserve/promql-parser", branch = "openobserve" }
 rcgen = "0.14.4"
-rust-embed-for-web = "11.3"
+rust-embed-for-web = "11.4.1"
 sourcemap = "9.3.2"
 tikv-jemalloc-ctl = { version = "0.6", features = [
     "use_std",

--- a/src/web/src/lib.rs
+++ b/src/web/src/lib.rs
@@ -23,6 +23,7 @@ use rust_embed_for_web::RustEmbed;
 
 #[derive(RustEmbed)]
 #[folder = "../../web/dist/"]
+#[allow_missing = true]
 #[gzip = false]
 #[br = false]
 pub struct WebAssets;

--- a/src/web/src/lib.rs
+++ b/src/web/src/lib.rs
@@ -23,4 +23,6 @@ use rust_embed_for_web::RustEmbed;
 
 #[derive(RustEmbed)]
 #[folder = "../../web/dist/"]
+#[gzip = false]
+#[br = false]
 pub struct WebAssets;


### PR DESCRIPTION
## Summary

- upgrade rust-embed-for-web from 11.3 to 11.4.1
- disable unused compile-time gzip and Brotli generation for embedded UI assets
- keep browser response compression through the global tower-http CompressionLayer

Related enterprise PR: https://github.com/openobserve/o2-enterprise/pull/2192

## Benchmark

Clean release-profiling build with mimalloc:

- before: 21m 13s
- after: 15m 45s
- improvement: 5m 28s, or 25.8%

Focused web crate compilation improved from 546.66s to 98.55s.

## Testing

- cargo metadata --locked --no-deps --format-version 1
- cargo clean
- cargo build --features mimalloc --profile release-profiling