### PR TITLE
feat: expose trace/session analysis endpoints via MCP

### DIFF
--- a/src/api/src/handler/http/router/openapi.rs
+++ b/src/api/src/handler/http/router/openapi.rs
@@ -63,6 +63,7 @@ use crate::{common::meta, handler::http::request};
         request::traces::traces_write,
         request::traces::get_latest_traces,
         request::traces::session::get_latest_sessions,
+        request::traces::session::get_session_details,
         request::traces::user::get_latest_users,
         request::traces::dag::get_trace_dag,
         request::metrics::ingest::json,

--- a/src/api_query/src/traces/dag.rs
+++ b/src/api_query/src/traces/dag.rs
@@ -75,6 +75,9 @@ use crate::{
         })),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
+    ),
+    extensions(
+        ("x-o2-mcp" = json!({"description": "Get the span DAG (nodes and parent-child edges) for a specific trace by trace_id.", "category": "traces"}))
     )
 )]
 pub async fn get_trace_dag(

--- a/src/api_query/src/traces/mod.rs
+++ b/src/api_query/src/traces/mod.rs
@@ -196,6 +196,9 @@ pub async fn traces_write(
         })),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
+    ),
+    extensions(
+        ("x-o2-mcp" = json!({"description": "List recent traces with summaries (trace_id, span count, service names, duration). Supports filter and sort by start_time/duration.", "category": "traces", "pinned": true}))
     )
 )]
 pub async fn get_latest_traces(

--- a/src/api_query/src/traces/session.rs
+++ b/src/api_query/src/traces/session.rs
@@ -85,6 +85,9 @@ use crate::{
         })),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
+    ),
+    extensions(
+        ("x-o2-mcp" = json!({"description": "List recent LLM sessions from a trace stream: session_id, trace count, token usage, cost, error count.", "category": "traces"}))
     )
 )]
 pub async fn get_latest_sessions(
@@ -647,6 +650,9 @@ pub async fn get_latest_sessions(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
+    ),
+    extensions(
+        ("x-o2-mcp" = json!({"description": "Get per-turn trace summaries for a single LLM session by session_id.", "category": "traces"}))
     )
 )]
 pub async fn get_session_details(

--- a/src/api_query/src/traces/user.rs
+++ b/src/api_query/src/traces/user.rs
@@ -80,6 +80,9 @@ use crate::{
         })),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
+    ),
+    extensions(
+        ("x-o2-mcp" = json!({"description": "List recent LLM users from a trace stream: user_id, event count, token usage, cost.", "category": "traces"}))
     )
 )]
 pub async fn get_latest_users(


### PR DESCRIPTION
Design at: #13235 (design described in this PR description)

## Summary

MCP tools are auto-generated from the OpenAPI spec, filtered/described via the `x-o2-mcp` extension. Two gaps kept trace/session analysis from working well over MCP:

1. **`GetSessionDetails` was not an MCP tool at all.** The endpoint (`/{org_id}/{stream_name}/traces/session/details`) was registered in the axum router but missing from the `paths()` list in `openapi.rs`, so it never entered the OpenAPI spec and was invisible to MCP. Without it an LLM can list sessions but cannot drill into a session's per-turn traces.
2. **The traces endpoints had no `x-o2-mcp` metadata.** `GetLatestTraces`, `GetLatestSessions`, `GetLatestUsers`, `GetTraceDAG` were exposed only with their long OpenAPI descriptions and no `category`, hurting `tool_search` (BM25) discoverability and wasting tokens.

## Changes

- Register `get_session_details` in `openapi.rs` → becomes MCP tool `GetSessionDetails`
- Add `x-o2-mcp` with `category: "traces"` and short descriptions to `GetLatestTraces`, `GetLatestSessions`, `GetSessionDetails`, `GetLatestUsers`, `GetTraceDAG`
- Mark `GetLatestTraces` as `pinned: true` so it appears directly in `tools/list` (alongside SearchSQL/StreamList/GetSchema/QueryRangeMetrics/GetIncident), letting LLMs start trace analysis without a `tool_search` round-trip

No behavior change for regular HTTP API consumers; `GetSessionDetails` additionally becomes visible in Swagger.

## Testing

- `cargo check -p openobserve-api-query -p openobserve-api` passes
