### PR TITLE
test(e2e): stabilize alpha1 Traces & Pipelines shards (error-toggle data seeding + flyout-nav / loading-button / indexing races)

### DIFF
--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -368,14 +368,28 @@ export class PipelinesPage {
     // Methods from PipelinePage
     async openPipelineMenu() {
         await openNavFlyoutChild(this.page, 'pipeline');
-        // pipelineTab.click() auto-waits for actionability, so the pre-click sleep
-        // was redundant. After the click, wait for the pipeline list page to render
-        // instead of a blind 2s — resolves in ~0.5-1s on the common path. Best-effort
-        // (.catch) so callers that immediately page.goto elsewhere aren't blocked.
-        await this.pipelineTab.click();
-        await this.page.locator('[data-test="pipeline-list-page"]')
+        // openNavFlyoutChild navigates via a hover-flyout force-click that can
+        // intermittently miss (the flyout self-closes on settle), leaving us on the
+        // previous page. That was the dominant Pipelines-shard flake: the follow-up
+        // pipelineTab.click() then timed out at the 45s action timeout because the
+        // streamPipelines tab only exists on the pipeline list page. Confirm we
+        // actually landed; if not, navigate directly — a goto is deterministic and
+        // needs no flyout.
+        const onPipelinePage = await this.page.locator('[data-test="pipeline-list-page"]')
             .waitFor({ state: 'visible', timeout: 15000 })
-            .catch(() => {});
+            .then(() => true)
+            .catch(() => false);
+        if (!onPipelinePage) {
+            await this.page.goto(
+                `${process.env.ZO_BASE_URL}/web/pipeline/pipelines?org_identifier=${process.env["ORGNAME"]}`
+            );
+            await this.page.locator('[data-test="pipeline-list-page"]')
+                .waitFor({ state: 'visible', timeout: 30000 });
+        }
+        // Ensure the Stream Pipelines section tab is selected. Wait for it to render
+        // before clicking so the click never races the page mount.
+        await this.pipelineTab.waitFor({ state: 'visible', timeout: 15000 });
+        await this.pipelineTab.click();
     }
 
     async addPipeline() {
@@ -1122,11 +1136,34 @@ export class PipelinesPage {
     }
 
     async navigateToStreams() {
+        // `menu-link-/streams-item` is the "Data" nav group tile: it both opens a
+        // hover flyout and navigates. A plain click can register as the hover-open
+        // (flyout appears, page stays blank) without navigating — the same flyout
+        // race that hit openPipelineMenu. Confirm the streams page rendered; if not,
+        // navigate directly. A blind 1s wait previously let refreshStreamStats() fire
+        // against a page that had not loaded.
         await this.streamsMenuItem.click();
-        await this.page.waitForTimeout(1000);
+        const onStreamsPage = await this.page.locator('[data-test="log-stream-table"]')
+            .waitFor({ state: 'visible', timeout: 15000 })
+            .then(() => true)
+            .catch(() => false);
+        if (!onStreamsPage) {
+            await this.page.goto(
+                `${process.env.ZO_BASE_URL}/web/streams?org_identifier=${process.env["ORGNAME"]}`
+            );
+            await this.page.locator('[data-test="log-stream-table"]')
+                .waitFor({ state: 'visible', timeout: 30000 });
+        }
     }
 
     async refreshStreamStats() {
+        // The refresh button is an OButton with :loading bound to the stream-stats
+        // fetch; while loading it is rendered disabled. Clicking during that window
+        // makes Playwright wait on actionability and time out at 45s under CI load
+        // (the pipeline-dynamic flake). Wait for it to settle (visible + enabled)
+        // before clicking.
+        await this.refreshStatsButton.waitFor({ state: 'visible', timeout: 30000 });
+        await expect(this.refreshStatsButton).toBeEnabled({ timeout: 30000 });
         await this.refreshStatsButton.click();
         await this.page.waitForTimeout(1000);
     }
@@ -1144,6 +1181,22 @@ export class PipelinesPage {
     }
 
     async openTimestampMenu() {
+        // The destination-stream data ingested by exploreStreamAndNavigateToPipeline
+        // may not be indexed yet when the logs explorer first renders (indexing
+        // latency is high on loaded envs), so the first row can be absent and a bare
+        // click dead-waits the full 45s action timeout (the pipeline-core:56 flake
+        // once navigation stopped failing earlier). Re-run the query until a row
+        // appears instead of clicking into an empty table.
+        const runQueryBtn = this.page.locator('[data-test="logs-search-bar-refresh-btn"]');
+        for (let attempt = 1; attempt <= 6; attempt++) {
+            if (await this.timestampColumnMenu.isVisible({ timeout: 10000 }).catch(() => false)) {
+                break;
+            }
+            // Re-trigger the search so newly-indexed rows are picked up.
+            await runQueryBtn.first().click({ timeout: 5000 }).catch(() => {});
+            await this.page.waitForTimeout(3000);
+        }
+        await this.timestampColumnMenu.waitFor({ state: 'visible', timeout: 15000 });
         await this.timestampColumnMenu.click();
     }
 

--- a/tests/ui-testing/pages/tracesPages/tracesPage.js
+++ b/tests/ui-testing/pages/tracesPages/tracesPage.js
@@ -1153,7 +1153,12 @@ export class TracesPage {
       .first();
     if (await errorRow.isVisible({ timeout: 5000 }).catch(() => false)) {
       await errorRow.click();
-      await this.page.waitForTimeout(2000);
+      // Wait for the trace-details panel to actually open instead of a blind 2s.
+      // Under CI load the details tree can take longer to render, and the caller
+      // immediately asserts on it — a fixed wait raced the render and flaked.
+      await this.page.locator(this.traceDetailsTree)
+        .waitFor({ state: 'visible', timeout: 15000 })
+        .catch(() => {});
       return true;
     }
     return false;
@@ -1803,6 +1808,31 @@ export class TracesPage {
    */
   async isErrorOnlyToggleVisible() {
     return await this.page.locator(this.errorOnlyToggle).isVisible({ timeout: 5000 }).catch(() => false);
+  }
+
+  /**
+   * Deterministically wait for the error-count badge (which doubles as the
+   * error-only toggle) to appear. The badge renders only when the current search
+   * returns at least one error span (SearchResult.vue: v-if errorCount>0), so
+   * freshly-ingested error traces may not show on the first search due to backend
+   * indexing latency. Re-run the search until the badge appears. Used by tests
+   * that ingest guaranteed error traces in beforeAll — this converts a
+   * data/timing dependency into a bounded wait for backend processing.
+   * @param {number} [maxAttempts=8]
+   * @returns {Promise<boolean>} true once the badge is visible
+   */
+  async waitForErrorBadgeAfterSearch(maxAttempts = 8) {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      await this.setupTraceSearch();
+      await this.waitForTraceSearchResults();
+      if (await this.isErrorOnlyToggleVisible()) {
+        return true;
+      }
+      // Give the backend a moment to index the just-ingested error traces
+      // before re-running the search.
+      await this.page.waitForTimeout(3000);
+    }
+    return false;
   }
 
   /**

--- a/tests/ui-testing/playwright-tests/Traces/tracesAnalyzeDimensions.spec.js
+++ b/tests/ui-testing/playwright-tests/Traces/tracesAnalyzeDimensions.spec.js
@@ -5,9 +5,38 @@
 const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
 const testLogger = require('../utils/test-logger.js');
 const PageManager = require('../../pages/page-manager.js');
+const { ingestTraces } = require('../utils/trace-ingestion.js');
 
 test.describe("Traces Analyze Dimensions testcases", () => {
   let pm;
+
+  // Seed guaranteed error traces into the `default` stream ONCE for the file.
+  // The error-count badge (which is the error-only toggle) renders only when the
+  // search returns at least one error span. The shared `default` stream has no
+  // guaranteed error data in the 15m window, which made "P0: Error-only toggle"
+  // fail deterministically on runners where the recent window happened to hold no
+  // errors (and pass on runners where it did). Ingesting forced-error traces here
+  // removes that data dependency.
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(120000);
+    const context = await browser.newContext({
+      storageState: 'playwright-tests/utils/auth/user.json',
+    });
+    const page = await context.newPage();
+    try {
+      const result = await ingestTraces(page, 8, { forceScenario: 'error' });
+      testLogger.info('Seeded error traces for analyze-dimensions', {
+        successful: result.successful,
+        failed: result.failed,
+      });
+    } catch (e) {
+      // Non-fatal: the error-only test still has a bounded retry to surface the
+      // badge, and the other tests in this file don't need error data.
+      testLogger.warn('Error-trace seeding failed (continuing)', { error: e.message });
+    } finally {
+      await context.close();
+    }
+  });
 
   test.beforeEach(async ({ page }, testInfo) => {
     testLogger.testStart(testInfo.title, testInfo.file);
@@ -91,9 +120,9 @@ test.describe("Traces Analyze Dimensions testcases", () => {
 
     testLogger.info('Testing error-only toggle functionality');
 
-    await searchAndAssertResults();
-
-    const errorToggleVisible = await pm.tracesPage.isErrorOnlyToggleVisible();
+    // Re-runs the search until the seeded error traces are indexed and the
+    // error-count badge appears — deterministic given beforeAll seeded errors.
+    const errorToggleVisible = await pm.tracesPage.waitForErrorBadgeAfterSearch();
     expect(errorToggleVisible, 'Error-only toggle must be visible').toBeTruthy();
 
     // Toggle error-only filter ON

--- a/tests/ui-testing/playwright-tests/utils/trace-ingestion.js
+++ b/tests/ui-testing/playwright-tests/utils/trace-ingestion.js
@@ -27,9 +27,15 @@ function getTimestampNs() {
 /**
  * Generate a single distributed trace
  * @param {number} iteration - Trace iteration number
+ * @param {Object} [options]
+ * @param {'error'|'success'} [options.forceScenario] - Deterministically pick an
+ *   error (spanStatus=2) or success (spanStatus=1) scenario instead of a random
+ *   one. Used by tests that must guarantee error traces exist (e.g. the traces
+ *   error-only toggle), removing the data-dependent flake where a random draw
+ *   produced no error spans.
  * @returns {Object} OTLP trace data
  */
-function generateTrace(iteration) {
+function generateTrace(iteration, options = {}) {
   // Generate IDs
   const traceId = generateHexId(16);
   const rootSpanId = generateHexId(8);
@@ -92,7 +98,19 @@ function generateTrace(iteration) {
     }
   ];
 
-  const selected = scenarios[Math.floor(Math.random() * scenarios.length)];
+  // Scenario selection. `forceScenario` makes the error/success mix deterministic
+  // (round-robin within the matching subset) so callers can guarantee at least one
+  // error span; without it we keep the original random draw.
+  let selected;
+  if (options.forceScenario === 'error') {
+    const errorScenarios = scenarios.filter((s) => s.spanStatus === 2);
+    selected = errorScenarios[iteration % errorScenarios.length];
+  } else if (options.forceScenario === 'success') {
+    const successScenarios = scenarios.filter((s) => s.spanStatus === 1);
+    selected = successScenarios[iteration % successScenarios.length];
+  } else {
+    selected = scenarios[Math.floor(Math.random() * scenarios.length)];
+  }
 
   // Calculate timestamps for distributed trace spans
   const clientStart = Number(startTime) + 1000000;
@@ -234,8 +252,8 @@ function generateTrace(iteration) {
  * @param {number} traceCount - Number of traces to generate and ingest
  * @returns {Promise<Object>} Ingestion result
  */
-async function ingestTraces(page, traceCount = 10) {
-  testLogger.info(`Starting trace ingestion`, { traceCount });
+async function ingestTraces(page, traceCount = 10, options = {}) {
+  testLogger.info(`Starting trace ingestion`, { traceCount, forceScenario: options.forceScenario });
 
   const orgId = getOrgIdentifier() || "default";
   const headers = getAuthHeaders();
@@ -245,7 +263,7 @@ async function ingestTraces(page, traceCount = 10) {
   const traceIds = [];
 
   for (let i = 1; i <= traceCount; i++) {
-    const traceData = generateTrace(i);
+    const traceData = generateTrace(i, options);
     traceIds.push(traceData.resourceSpans[0].scopeSpans[0].spans[0].traceId);
 
     try {


### PR DESCRIPTION
## What

Stabilizes the **Traces** and **Pipelines** shards of the alpha1 cloud E2E suite
(`playwright_alpha1.yml`) to green. Rebased on `main` — builds on #13191's
protocol-aware ingestion agent (`selectAgent`), so no duplicate transport fix here.

The failing run had 1 hard failure + 1 flake in Traces and 7 failures + 1 flake in
Pipelines. Root causes: a data dependency (error traces not guaranteed), hover-flyout
navigation force-clicks that miss, a refresh button disabled while loading, and logs
indexing latency. All fixed with deterministic data/waits — no `waitForTimeout` as a
fix, no `force:true`, no retry-count bumps, no weakened assertions.

## Root cause & fixes

**Traces**

1. **`tracesAnalyzeDimensions` "P0: Error-only toggle filters trace results"** (hard fail,
   both attempts). The error-only toggle is the error-count badge in `SearchResult.vue`,
   rendered `v-if="errorCount != null && errorCount > 0"` — it exists only when the search
   returns an error span. The shared `default` trace stream has no guaranteed error traces
   (global-setup ingests only logs), so the badge was present or absent by luck of the
   window (hence the intermittent CI greens). Fix: `beforeAll` seeds guaranteed error
   traces via a new `ingestTraces(page, n, { forceScenario: 'error' })` option in
   `trace-ingestion.js`, and `tracesPage.waitForErrorBadgeAfterSearch()` re-runs the search
   until the seeded errors are indexed — a bounded wait for backend processing, not a sleep.

2. **`traceQueryEditor` "P2: View error spans and their details"** (flaky). `clickFirstErrorTrace()`
   used a blind `waitForTimeout(2000)` that raced the trace-details render before the test
   asserted on it. Now waits for `trace-details-tree` to be visible.

**Pipelines** (`pipelinesPage.js`)

3. **`pipeline-section-tab-streamPipelines` 45s timeout** (5 tests: `pipeline-core:56/159/238`,
   `pipelines:479`, `pipeline-conditions:297`). `openPipelineMenu()` / `navigateToStreams()`
   navigate via `openNavFlyoutChild`, which hovers a nav group tile and force-clicks the
   teleported flyout child. The flyout self-closes on settle, so the click can miss and the
   page never navigates — the follow-up tab/refresh click then dead-waits the 45s action
   timeout. Both now verify the target page rendered (`pipeline-list-page` / `log-stream-table`)
   and fall back to a direct `page.goto()` of the route otherwise. (A failure screenshot showed
   exactly this: the Data flyout open over a blank page.)

4. **`log-stream-refresh-stats-btn` 45s timeout** (3 tests: `pipeline-dynamic:72/97/113`). The
   refresh button is an `OButton` with `:loading` bound to the stream-stats fetch, and `OButton`
   renders `:disabled="disabled || loading"`. Clicking during the (slow, on loaded alpha) stats
   load waited on actionability until timeout. `refreshStreamStats()` now waits `toBeEnabled()`
   before clicking; `navigateToStreams()` waits for the table instead of a blind 1s.

5. **`openTimestampMenu` empty-table dead-wait.** After exploring the destination stream, a bare
   `.click()` on the first logs row timed out 45s when the freshly-ingested rows weren't indexed
   yet (high indexing latency on loaded envs) — a latent flake exposed once fix 3 let the test
   reach this step. Now re-runs the logs query until a row appears, then clicks.

## Validation

- **CI — both shards green (workers=3, alpha cloud):**
  https://github.com/openobserve/o2-enterprise/actions/runs/29563931877
  (`alpha1-e2e / Traces` ✅ · `alpha1-e2e / Pipelines` ✅)
- **Original failing run:** https://github.com/openobserve/o2-enterprise/actions/runs/29481437880
- **Local (alpha, CI conditions):** each previously-failing test re-run to green —
  Traces error-toggle & error-spans; `pipeline-core:56/159/238`; `pipeline-dynamic:72`.

## Notes

- Only 4 files change (`pipelinesPage.js`, `tracesPage.js`, `tracesAnalyzeDimensions.spec.js`,
  `trace-ingestion.js`). The https-ingestion agent fix these depend on already landed on `main`
  in #13191 — this branch relies on it rather than re-adding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
