### PR TITLE
feat: add native histogram support (phases 0-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7627,6 +7627,7 @@ dependencies = [
  "ahash 0.8.12",
  "async-recursion",
  "async-trait",
+ "bytes",
  "chrono",
  "config",
  "datafusion",
@@ -7821,6 +7822,7 @@ name = "proto"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "cargo_metadata",
  "datafusion",
  "datafusion-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -357,7 +357,7 @@ aws-sdk-sns = { version = "1.97", default-features = false, features = [
     "rt-tokio",
 ] }
 base64 = "0.22"
-bytes = "1.11"
+bytes = { version = "1.11", features = ["serde"] }
 byteorder = "1.5"
 chromiumoxide = { git = "https://github.com/mattsse/chromiumoxide", features = [
     "tokio-runtime",

--- a/src/api_query/src/promql/mod.rs
+++ b/src/api_query/src/promql/mod.rs
@@ -1332,17 +1332,7 @@ async fn search(
     )
     .await
     {
-        Ok(data) if !req.query_exemplars => (
-            StatusCode::OK,
-            axum::Json(config::meta::promql::ApiFuncResponse::ok(
-                config::meta::promql::QueryResult {
-                    result_type: data.get_type().to_string(),
-                    result: data,
-                },
-                Some(trace_id.to_string()),
-            )),
-        )
-            .into_response(),
+        Ok(data) if !req.query_exemplars => promql_success_response(data, trace_id),
         Ok(data) => (
             StatusCode::OK,
             axum::Json(config::meta::promql::ApiFuncResponse::ok(
@@ -1365,6 +1355,49 @@ async fn search(
             )
                 .into_response()
         }
+    }
+}
+
+fn promql_success_response(data: config::meta::promql::value::Value, trace_id: &str) -> Response {
+    let contains_native_histograms = data.has_native_histogram_provenance();
+    let response = config::meta::promql::ApiFuncResponse::ok(
+        config::meta::promql::QueryResult {
+            result_type: data.get_type().to_string(),
+            result: data,
+        },
+        Some(trace_id.to_string()),
+    );
+    if !contains_native_histograms {
+        return (StatusCode::OK, axum::Json(response)).into_response();
+    }
+
+    match serde_json::to_vec(&response) {
+        Ok(bytes) if bytes.len() <= config::get_config().limit.metrics_nh_max_response_bytes => (
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            bytes,
+        )
+            .into_response(),
+        Ok(bytes) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            axum::Json(config::meta::promql::ApiFuncResponse::<()>::err_exec(
+                format!(
+                    "native histogram response size {} exceeds limit {}",
+                    bytes.len(),
+                    config::get_config().limit.metrics_nh_max_response_bytes
+                ),
+                Some(trace_id.to_string()),
+            )),
+        )
+            .into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(config::meta::promql::ApiFuncResponse::<()>::err_internal(
+                err,
+                Some(trace_id.to_string()),
+            )),
+        )
+            .into_response(),
     }
 }
 
@@ -1413,6 +1446,7 @@ async fn search_streaming(
         }
 
         let total_partitions = partitions.len();
+        let mut native_response_bytes = 0_usize;
         for (i, (start, end)) in partitions.into_iter().enumerate() {
             let mut req = req.clone();
             req.start = start;
@@ -1428,6 +1462,7 @@ async fn search_streaming(
             .await
             {
                 Ok(data) => {
+                    let native_provenance = data.has_native_histogram_provenance();
                     let res = StreamResponses::PromqlResponse {
                         data: config::meta::promql::QueryResult {
                             result_type: data.get_type().to_string(),
@@ -1435,6 +1470,34 @@ async fn search_streaming(
                         },
                         trace_id: Some(req_trace_id.clone()),
                     };
+                    if native_provenance {
+                        match serde_json::to_vec(&res) {
+                            Ok(bytes) => native_response_bytes += bytes.len(),
+                            Err(err) => {
+                                let _ = tx
+                                    .send(Ok(StreamResponses::Error {
+                                        code: 500,
+                                        message: err.to_string(),
+                                        error_detail: None,
+                                    }))
+                                    .await;
+                                break;
+                            }
+                        }
+                        let limit = config::get_config().limit.metrics_nh_max_response_bytes;
+                        if native_response_bytes > limit {
+                            let _ = tx
+                                .send(Ok(StreamResponses::Error {
+                                    code: 422,
+                                    message: format!(
+                                        "native histogram response exceeds {limit} bytes; narrow the range or increase the step"
+                                    ),
+                                    error_detail: None,
+                                }))
+                                .await;
+                            break;
+                        }
+                    }
                     if tx.send(Ok(res)).await.is_err() {
                         log::warn!(
                             "[HTTP2_STREAM PromQL trace_id {req_trace_id}] Sender is closed, stop sending data to client",

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1681,6 +1681,14 @@ pub struct Limit {
     pub metrics_max_points_per_series: usize,
     #[env_config(name = "ZO_METRICS_MAX_SERIES_RESPONSE", default = 40000)]
     pub metrics_max_series_response: usize,
+    #[env_config(name = "ZO_METRICS_NH_MAX_PAYLOAD_BYTES", default = 32768)]
+    pub metrics_nh_max_payload_bytes: usize,
+    #[env_config(name = "ZO_METRICS_NH_MAX_BUCKETS", default = 4096)]
+    pub metrics_nh_max_buckets: usize,
+    #[env_config(name = "ZO_METRICS_NH_MAX_SPANS", default = 1024)]
+    pub metrics_nh_max_spans: usize,
+    #[env_config(name = "ZO_METRICS_NH_MAX_RESPONSE_BYTES", default = 67108864)]
+    pub metrics_nh_max_response_bytes: usize,
     #[env_config(name = "ZO_METRICS_CACHE_MAX_ENTRIES", default = 10000)]
     pub metrics_cache_max_entries: usize,
     #[env_config(name = "ZO_METRICS_INLIST_FILTER_ENABLED", default = false)]
@@ -2380,6 +2388,10 @@ pub struct Prometheus {
     pub ha_cluster_label: String,
     #[env_config(name = "ZO_PROMETHEUS_HA_REPLICA", default = "__replica__")]
     pub ha_replica_label: String,
+    #[env_config(name = "ZO_METRICS_OTLP_EXP_HISTOGRAMS", default = "legacy")]
+    pub otlp_exp_histograms: String,
+    #[env_config(name = "ZO_METRICS_PROM_NATIVE_HISTOGRAMS", default = "drop")]
+    pub native_histograms: String,
 }
 
 #[derive(Serialize, Debug, EnvConfig, Default)]

--- a/src/config/src/meta/promql/grpc.rs
+++ b/src/config/src/meta/promql/grpc.rs
@@ -17,7 +17,10 @@ use std::sync::Arc;
 
 use proto::cluster_rpc;
 
-use super::value::*;
+use super::{
+    histogram::{HistogramError, HistogramSample},
+    value::*,
+};
 
 impl From<&cluster_rpc::Label> for Label {
     fn from(req: &cluster_rpc::Label) -> Self {
@@ -52,6 +55,23 @@ impl From<&Sample> for cluster_rpc::Sample {
     }
 }
 
+impl From<&cluster_rpc::NativeHistogramSample> for HistogramSample {
+    fn from(req: &cluster_rpc::NativeHistogramSample) -> Self {
+        HistogramSample::from_payload(req.time, req.histogram.clone())
+    }
+}
+
+impl TryFrom<&HistogramSample> for cluster_rpc::NativeHistogramSample {
+    type Error = Arc<HistogramError>;
+
+    fn try_from(req: &HistogramSample) -> Result<Self, Self::Error> {
+        Ok(Self {
+            time: req.timestamp,
+            histogram: req.histogram.payload()?.clone(),
+        })
+    }
+}
+
 impl From<&Exemplar> for cluster_rpc::Exemplar {
     fn from(req: &Exemplar) -> Self {
         cluster_rpc::Exemplar {
@@ -74,7 +94,9 @@ impl From<&cluster_rpc::Exemplar> for Exemplar {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
     use proto::cluster_rpc;
+    use tonic_prost::prost::Message;
 
     use super::*;
 
@@ -192,5 +214,20 @@ mod tests {
         assert_eq!(rpc.value, 5.0);
         assert_eq!(rpc.labels.len(), 1);
         assert_eq!(rpc.labels[0].name, "job");
+    }
+
+    #[test]
+    fn test_native_histogram_bytes_roundtrip_without_utf8_conversion() {
+        let payload = Bytes::from_static(b"{\"schema\":0}");
+        let rpc = cluster_rpc::NativeHistogramSample {
+            time: 123,
+            histogram: payload.clone(),
+        };
+        let wire = rpc.encode_to_vec();
+        let decoded = cluster_rpc::NativeHistogramSample::decode(wire.as_slice()).unwrap();
+        let sample = HistogramSample::from(&decoded);
+        let back = cluster_rpc::NativeHistogramSample::try_from(&sample).unwrap();
+        assert_eq!(back.time, 123);
+        assert_eq!(back.histogram, payload);
     }
 }

--- a/src/config/src/meta/promql/histogram.rs
+++ b/src/config/src/meta/promql/histogram.rs
@@ -1,0 +1,1366 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+//! Prometheus native (sparse) histogram data model.
+//!
+//! The persisted form mirrors Prometheus' integer/float histogram split. Integer
+//! bucket counts are delta encoded while query-side [`O2FloatHistogram`] bucket
+//! counts are absolute. The storage payload is a JSON string so schema-on-write
+//! never flattens the histogram into dynamic columns.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, OnceLock},
+};
+
+use bytes::Bytes;
+use datafusion::execution::memory_pool::MemoryReservation;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeSeq};
+use thiserror::Error;
+
+pub const STALE_NAN_BITS: u64 = 0x7ff0_0000_0000_0002;
+pub const STALE_NAN: f64 = f64::from_bits(STALE_NAN_BITS);
+pub const EXPONENTIAL_SCHEMA_MIN: i32 = -4;
+pub const EXPONENTIAL_SCHEMA_MAX: i32 = 8;
+pub const CUSTOM_BUCKETS_SCHEMA: i32 = -53;
+
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum HistogramError {
+    #[error("native histogram payload is too large: {actual} bytes exceeds {limit} bytes")]
+    PayloadTooLarge { actual: usize, limit: usize },
+    #[error("native histogram has too many buckets: {actual} exceeds {limit}")]
+    TooManyBuckets { actual: usize, limit: usize },
+    #[error("native histogram has too many spans: {actual} exceeds {limit}")]
+    TooManySpans { actual: usize, limit: usize },
+    #[error("unsupported native histogram schema {0}")]
+    UnsupportedSchema(i32),
+    #[error("invalid zero threshold {0}")]
+    InvalidZeroThreshold(f64),
+    #[error("{side} spans describe {expected} buckets but payload contains {actual}")]
+    SpanBucketMismatch {
+        side: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("{side} span {span} has negative offset {offset}")]
+    NegativeSpanOffset {
+        side: &'static str,
+        span: usize,
+        offset: i32,
+    },
+    #[error("{side} bucket {bucket} reconstructs to negative count {count}")]
+    NegativeBucketCount {
+        side: &'static str,
+        bucket: usize,
+        count: f64,
+    },
+    #[error("native histogram count {count} does not match bucket total {buckets}")]
+    CountMismatch { count: f64, buckets: f64 },
+    #[error("native histogram count {count} is smaller than bucket total {buckets}")]
+    CountTooSmall { count: f64, buckets: f64 },
+    #[error("native histogram count and zero-count variants do not match")]
+    CountVariantMismatch,
+    #[error("invalid native histogram JSON payload: {0}")]
+    Json(String),
+    #[error("native histogram has no decoded or encoded representation")]
+    EmptyLazyHistogram,
+    #[error("presence-only native histogram cannot be decoded")]
+    PresenceOnlyAccess,
+    #[error("native histogram query memory limit exceeded: {0}")]
+    Memory(String),
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum HistogramLoadMode {
+    PresenceOnly,
+    #[default]
+    RawLazy,
+    DecodeAfterSelection,
+    DecodedOnly,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistogramSpan {
+    pub offset: i32,
+    pub length: u32,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CounterResetHint {
+    #[default]
+    Unknown,
+    CounterReset,
+    NotCounterReset,
+    Gauge,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum NativeHistogramCounts {
+    Integer {
+        zero_count: u64,
+        count: u64,
+        positive_buckets: Vec<i64>,
+        negative_buckets: Vec<i64>,
+    },
+    Float {
+        #[serde(with = "tagged_f64")]
+        zero_count: f64,
+        #[serde(with = "tagged_f64")]
+        count: f64,
+        #[serde(with = "tagged_f64_vec")]
+        positive_buckets: Vec<f64>,
+        #[serde(with = "tagged_f64_vec")]
+        negative_buckets: Vec<f64>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NativeHistogram {
+    pub schema: i32,
+    #[serde(with = "tagged_f64")]
+    pub zero_threshold: f64,
+    #[serde(with = "tagged_f64")]
+    pub sum: f64,
+    #[serde(default)]
+    pub start_time: i64,
+    pub positive_spans: Vec<HistogramSpan>,
+    pub negative_spans: Vec<HistogramSpan>,
+    pub counter_reset_hint: CounterResetHint,
+    pub counts: NativeHistogramCounts,
+}
+
+impl NativeHistogram {
+    pub fn bucket_count(&self) -> usize {
+        match &self.counts {
+            NativeHistogramCounts::Integer {
+                positive_buckets,
+                negative_buckets,
+                ..
+            } => positive_buckets.len() + negative_buckets.len(),
+            NativeHistogramCounts::Float {
+                positive_buckets,
+                negative_buckets,
+                ..
+            } => positive_buckets.len() + negative_buckets.len(),
+        }
+    }
+
+    pub fn span_count(&self) -> usize {
+        self.positive_spans.len() + self.negative_spans.len()
+    }
+
+    pub fn to_payload(&self) -> Result<String, HistogramError> {
+        serde_json::to_string(self).map_err(|err| HistogramError::Json(err.to_string()))
+    }
+
+    pub fn from_payload(payload: &[u8]) -> Result<Self, HistogramError> {
+        serde_json::from_slice(payload).map_err(|err| HistogramError::Json(err.to_string()))
+    }
+
+    pub fn validate(&self) -> Result<(), HistogramError> {
+        validate_common(
+            self.schema,
+            self.zero_threshold,
+            &self.positive_spans,
+            &self.negative_spans,
+            self.positive_bucket_len(),
+            self.negative_bucket_len(),
+        )?;
+
+        match &self.counts {
+            NativeHistogramCounts::Integer {
+                zero_count,
+                count,
+                positive_buckets,
+                negative_buckets,
+            } => {
+                let positive = decode_integer_buckets("positive", positive_buckets)?;
+                let negative = decode_integer_buckets("negative", negative_buckets)?;
+                let bucket_total = positive.iter().sum::<f64>()
+                    + negative.iter().sum::<f64>()
+                    + *zero_count as f64;
+                let count = *count as f64;
+                if self.sum.is_nan() {
+                    if bucket_total > count {
+                        return Err(HistogramError::CountTooSmall {
+                            count,
+                            buckets: bucket_total,
+                        });
+                    }
+                } else if bucket_total != count {
+                    return Err(HistogramError::CountMismatch {
+                        count,
+                        buckets: bucket_total,
+                    });
+                }
+            }
+            NativeHistogramCounts::Float {
+                zero_count,
+                count,
+                positive_buckets,
+                negative_buckets,
+            } => {
+                validate_float_count("zero", 0, *zero_count)?;
+                validate_float_count("count", 0, *count)?;
+                for (idx, value) in positive_buckets.iter().enumerate() {
+                    validate_float_count("positive", idx, *value)?;
+                }
+                for (idx, value) in negative_buckets.iter().enumerate() {
+                    validate_float_count("negative", idx, *value)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn validate_limits(
+        &self,
+        payload_bytes: usize,
+        max_payload_bytes: usize,
+        max_buckets: usize,
+        max_spans: usize,
+    ) -> Result<(), HistogramError> {
+        if payload_bytes > max_payload_bytes {
+            return Err(HistogramError::PayloadTooLarge {
+                actual: payload_bytes,
+                limit: max_payload_bytes,
+            });
+        }
+        if self.bucket_count() > max_buckets {
+            return Err(HistogramError::TooManyBuckets {
+                actual: self.bucket_count(),
+                limit: max_buckets,
+            });
+        }
+        if self.span_count() > max_spans {
+            return Err(HistogramError::TooManySpans {
+                actual: self.span_count(),
+                limit: max_spans,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn to_float(&self) -> Result<O2FloatHistogram, HistogramError> {
+        self.validate()?;
+        let (zero_count, count, positive_buckets, negative_buckets) = match &self.counts {
+            NativeHistogramCounts::Integer {
+                zero_count,
+                count,
+                positive_buckets,
+                negative_buckets,
+            } => (
+                *zero_count as f64,
+                *count as f64,
+                decode_integer_buckets("positive", positive_buckets)?,
+                decode_integer_buckets("negative", negative_buckets)?,
+            ),
+            NativeHistogramCounts::Float {
+                zero_count,
+                count,
+                positive_buckets,
+                negative_buckets,
+            } => (
+                *zero_count,
+                *count,
+                positive_buckets.clone(),
+                negative_buckets.clone(),
+            ),
+        };
+        Ok(O2FloatHistogram {
+            schema: self.schema,
+            zero_threshold: self.zero_threshold,
+            zero_count,
+            count,
+            sum: self.sum,
+            positive_spans: self.positive_spans.clone(),
+            negative_spans: self.negative_spans.clone(),
+            positive_buckets,
+            negative_buckets,
+            counter_reset_hint: self.counter_reset_hint,
+            start_time: self.start_time,
+        })
+    }
+
+    fn positive_bucket_len(&self) -> usize {
+        match &self.counts {
+            NativeHistogramCounts::Integer {
+                positive_buckets, ..
+            } => positive_buckets.len(),
+            NativeHistogramCounts::Float {
+                positive_buckets, ..
+            } => positive_buckets.len(),
+        }
+    }
+
+    fn negative_bucket_len(&self) -> usize {
+        match &self.counts {
+            NativeHistogramCounts::Integer {
+                negative_buckets, ..
+            } => negative_buckets.len(),
+            NativeHistogramCounts::Float {
+                negative_buckets, ..
+            } => negative_buckets.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct O2FloatHistogram {
+    pub schema: i32,
+    pub zero_threshold: f64,
+    pub zero_count: f64,
+    pub count: f64,
+    pub sum: f64,
+    pub positive_spans: Vec<HistogramSpan>,
+    pub negative_spans: Vec<HistogramSpan>,
+    /// Absolute bucket counts aligned with `positive_spans`.
+    pub positive_buckets: Vec<f64>,
+    /// Absolute bucket counts aligned with `negative_spans`.
+    pub negative_buckets: Vec<f64>,
+    pub counter_reset_hint: CounterResetHint,
+    pub start_time: i64,
+}
+
+impl O2FloatHistogram {
+    pub fn empty(schema: i32) -> Self {
+        Self {
+            schema,
+            zero_threshold: 0.0,
+            zero_count: 0.0,
+            count: 0.0,
+            sum: 0.0,
+            positive_spans: Vec::new(),
+            negative_spans: Vec::new(),
+            positive_buckets: Vec::new(),
+            negative_buckets: Vec::new(),
+            counter_reset_hint: CounterResetHint::Unknown,
+            start_time: 0,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), HistogramError> {
+        validate_common(
+            self.schema,
+            self.zero_threshold,
+            &self.positive_spans,
+            &self.negative_spans,
+            self.positive_buckets.len(),
+            self.negative_buckets.len(),
+        )?;
+        validate_float_count("zero", 0, self.zero_count)?;
+        validate_float_count("count", 0, self.count)?;
+        for (idx, value) in self.positive_buckets.iter().enumerate() {
+            validate_float_count("positive", idx, *value)?;
+        }
+        for (idx, value) in self.negative_buckets.iter().enumerate() {
+            validate_float_count("negative", idx, *value)?;
+        }
+        Ok(())
+    }
+
+    pub fn is_stale(&self) -> bool {
+        self.sum.to_bits() == STALE_NAN_BITS
+    }
+
+    pub fn encoded_size(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + self.positive_spans.len() * std::mem::size_of::<HistogramSpan>()
+            + self.negative_spans.len() * std::mem::size_of::<HistogramSpan>()
+            + (self.positive_buckets.len() + self.negative_buckets.len())
+                * std::mem::size_of::<f64>()
+    }
+
+    pub fn has_overflow(&self) -> bool {
+        self.zero_count.is_infinite()
+            || self.count.is_infinite()
+            || self.sum.is_infinite()
+            || self
+                .positive_buckets
+                .iter()
+                .any(|value| value.is_infinite())
+            || self
+                .negative_buckets
+                .iter()
+                .any(|value| value.is_infinite())
+    }
+
+    pub fn to_native_float(&self) -> NativeHistogram {
+        NativeHistogram {
+            schema: self.schema,
+            zero_threshold: self.zero_threshold,
+            sum: self.sum,
+            start_time: self.start_time,
+            positive_spans: self.positive_spans.clone(),
+            negative_spans: self.negative_spans.clone(),
+            counter_reset_hint: self.counter_reset_hint,
+            counts: NativeHistogramCounts::Float {
+                zero_count: self.zero_count,
+                count: self.count,
+                positive_buckets: self.positive_buckets.clone(),
+                negative_buckets: self.negative_buckets.clone(),
+            },
+        }
+    }
+
+    pub fn indexed_positive(&self) -> Result<BTreeMap<i32, f64>, HistogramError> {
+        indexed_buckets("positive", &self.positive_spans, &self.positive_buckets)
+    }
+
+    pub fn indexed_negative(&self) -> Result<BTreeMap<i32, f64>, HistogramError> {
+        indexed_buckets("negative", &self.negative_spans, &self.negative_buckets)
+    }
+
+    pub fn all_buckets(&self) -> Result<Vec<HistogramBucket>, HistogramError> {
+        let mut buckets =
+            Vec::with_capacity(self.positive_buckets.len() + self.negative_buckets.len() + 1);
+        for (idx, count) in self.indexed_negative()?.into_iter().rev() {
+            buckets.push(HistogramBucket {
+                lower: -get_bound_exponential(idx, self.schema),
+                upper: -get_bound_exponential(idx - 1, self.schema),
+                lower_inclusive: true,
+                upper_inclusive: false,
+                count,
+            });
+        }
+        buckets.push(HistogramBucket {
+            lower: -self.zero_threshold,
+            upper: self.zero_threshold,
+            lower_inclusive: true,
+            upper_inclusive: true,
+            count: self.zero_count,
+        });
+        for (idx, count) in self.indexed_positive()? {
+            buckets.push(HistogramBucket {
+                lower: get_bound_exponential(idx - 1, self.schema),
+                upper: get_bound_exponential(idx, self.schema),
+                lower_inclusive: false,
+                upper_inclusive: true,
+                count,
+            });
+        }
+        Ok(buckets)
+    }
+
+    pub fn reduce_resolution(&mut self, target_schema: i32) -> Result<(), HistogramError> {
+        if !(EXPONENTIAL_SCHEMA_MIN..=EXPONENTIAL_SCHEMA_MAX).contains(&target_schema) {
+            return Err(HistogramError::UnsupportedSchema(target_schema));
+        }
+        if target_schema >= self.schema {
+            return Ok(());
+        }
+        let shift = self.schema - target_schema;
+        let reduce = |source: BTreeMap<i32, f64>| {
+            let mut target = BTreeMap::new();
+            for (idx, count) in source {
+                let target_idx = ((idx - 1) >> shift) + 1;
+                *target.entry(target_idx).or_insert(0.0) += count;
+            }
+            target
+        };
+        let positive = reduce(self.indexed_positive()?);
+        let negative = reduce(self.indexed_negative()?);
+        (self.positive_spans, self.positive_buckets) = spans_from_indexed(positive);
+        (self.negative_spans, self.negative_buckets) = spans_from_indexed(negative);
+        self.schema = target_schema;
+        Ok(())
+    }
+
+    pub fn raise_zero_threshold(&mut self, threshold: f64) -> Result<(), HistogramError> {
+        if threshold <= self.zero_threshold {
+            return Ok(());
+        }
+        let mut threshold = threshold;
+        for map in [self.indexed_positive()?, self.indexed_negative()?] {
+            for (idx, count) in map {
+                if count == 0.0 {
+                    continue;
+                }
+                let lower = get_bound_exponential(idx - 1, self.schema);
+                let upper = get_bound_exponential(idx, self.schema);
+                if lower < threshold && upper > threshold {
+                    threshold = upper;
+                }
+            }
+        }
+        let fold = |source: BTreeMap<i32, f64>, zero: &mut f64| {
+            let mut target = BTreeMap::new();
+            for (idx, count) in source {
+                if get_bound_exponential(idx, self.schema) <= threshold {
+                    *zero += count;
+                } else {
+                    target.insert(idx, count);
+                }
+            }
+            target
+        };
+        let mut zero = self.zero_count;
+        let positive = fold(self.indexed_positive()?, &mut zero);
+        let negative = fold(self.indexed_negative()?, &mut zero);
+        (self.positive_spans, self.positive_buckets) = spans_from_indexed(positive);
+        (self.negative_spans, self.negative_buckets) = spans_from_indexed(negative);
+        self.zero_count = zero;
+        self.zero_threshold = threshold;
+        Ok(())
+    }
+
+    pub fn add_assign(&mut self, other: &Self) -> Result<(), HistogramError> {
+        self.combine_assign(other, 1.0)
+    }
+
+    /// Add a histogram with Neumaier/Kahan compensation for every scalar and bucket count.
+    /// `compensation` is kept as a histogram so schema and zero-threshold reconciliation apply
+    /// identically to the running value and its residuals.
+    pub fn kahan_add_assign(
+        &mut self,
+        other: &Self,
+        compensation: &mut Self,
+    ) -> Result<(), HistogramError> {
+        let target_schema = self.schema.min(other.schema).min(compensation.schema);
+        self.reduce_resolution(target_schema)?;
+        compensation.reduce_resolution(target_schema)?;
+        let mut other = other.clone();
+        other.reduce_resolution(target_schema)?;
+
+        let threshold = self
+            .zero_threshold
+            .max(other.zero_threshold)
+            .max(compensation.zero_threshold);
+        self.raise_zero_threshold(threshold)?;
+        compensation.raise_zero_threshold(threshold)?;
+        other.raise_zero_threshold(threshold)?;
+
+        let increment = |value: f64, sum: f64, residual: f64| {
+            let updated_sum = sum + value;
+            if updated_sum.is_infinite() {
+                return (updated_sum, 0.0);
+            }
+            let rounding = if sum.abs() >= value.abs() {
+                (sum - updated_sum) + value
+            } else {
+                (value - updated_sum) + sum
+            };
+            (updated_sum, residual + rounding)
+        };
+        let add_maps = |mut sum: BTreeMap<i32, f64>,
+                        mut residual: BTreeMap<i32, f64>,
+                        values: BTreeMap<i32, f64>| {
+            for (index, value) in values {
+                let (updated, updated_residual) = increment(
+                    value,
+                    sum.get(&index).copied().unwrap_or_default(),
+                    residual.get(&index).copied().unwrap_or_default(),
+                );
+                sum.insert(index, updated);
+                if updated_residual == 0.0 {
+                    residual.remove(&index);
+                } else {
+                    residual.insert(index, updated_residual);
+                }
+            }
+            (sum, residual)
+        };
+
+        let (positive, positive_compensation) = add_maps(
+            self.indexed_positive()?,
+            compensation.indexed_positive()?,
+            other.indexed_positive()?,
+        );
+        let (negative, negative_compensation) = add_maps(
+            self.indexed_negative()?,
+            compensation.indexed_negative()?,
+            other.indexed_negative()?,
+        );
+        (self.positive_spans, self.positive_buckets) = spans_from_indexed(positive);
+        (self.negative_spans, self.negative_buckets) = spans_from_indexed(negative);
+        (compensation.positive_spans, compensation.positive_buckets) =
+            spans_from_indexed(positive_compensation);
+        (compensation.negative_spans, compensation.negative_buckets) =
+            spans_from_indexed(negative_compensation);
+
+        (self.zero_count, compensation.zero_count) =
+            increment(other.zero_count, self.zero_count, compensation.zero_count);
+        (self.count, compensation.count) = increment(other.count, self.count, compensation.count);
+        (self.sum, compensation.sum) = increment(other.sum, self.sum, compensation.sum);
+        self.adjust_counter_reset_hint(other.counter_reset_hint);
+        self.start_time = self.start_time.max(other.start_time);
+        Ok(())
+    }
+
+    pub fn sub_assign(&mut self, other: &Self) -> Result<(), HistogramError> {
+        self.combine_assign(other, -1.0)
+    }
+
+    fn combine_assign(&mut self, other: &Self, factor: f64) -> Result<(), HistogramError> {
+        let target_schema = self.schema.min(other.schema);
+        self.reduce_resolution(target_schema)?;
+        let mut other = other.clone();
+        other.reduce_resolution(target_schema)?;
+
+        let threshold = self.zero_threshold.max(other.zero_threshold);
+        self.raise_zero_threshold(threshold)?;
+        other.raise_zero_threshold(self.zero_threshold)?;
+        if other.zero_threshold > self.zero_threshold {
+            self.raise_zero_threshold(other.zero_threshold)?;
+        }
+
+        let combine = |mut left: BTreeMap<i32, f64>, right: BTreeMap<i32, f64>| {
+            for (idx, count) in right {
+                *left.entry(idx).or_insert(0.0) += factor * count;
+            }
+            left.retain(|_, count| *count != 0.0);
+            left
+        };
+        let positive = combine(self.indexed_positive()?, other.indexed_positive()?);
+        let negative = combine(self.indexed_negative()?, other.indexed_negative()?);
+        (self.positive_spans, self.positive_buckets) = spans_from_indexed(positive);
+        (self.negative_spans, self.negative_buckets) = spans_from_indexed(negative);
+        self.zero_count += factor * other.zero_count;
+        self.count += factor * other.count;
+        self.sum += factor * other.sum;
+        self.start_time = self.start_time.max(other.start_time);
+        self.adjust_counter_reset_hint(other.counter_reset_hint);
+        Ok(())
+    }
+
+    fn adjust_counter_reset_hint(&mut self, other: CounterResetHint) {
+        use CounterResetHint::*;
+        self.counter_reset_hint = match (self.counter_reset_hint, other) {
+            (left, right) if left == right => left,
+            (Gauge, _) | (_, Gauge) => Gauge,
+            (Unknown, _) | (_, Unknown) => Unknown,
+            (CounterReset, NotCounterReset) | (NotCounterReset, CounterReset) => Unknown,
+            _ => Unknown,
+        };
+    }
+
+    pub fn scale(&mut self, factor: f64) {
+        self.zero_count *= factor;
+        self.count *= factor;
+        self.sum *= factor;
+        for bucket in &mut self.positive_buckets {
+            *bucket *= factor;
+        }
+        for bucket in &mut self.negative_buckets {
+            *bucket *= factor;
+        }
+    }
+
+    pub fn detect_reset(&self, previous: &Self) -> Result<bool, HistogramError> {
+        if self.counter_reset_hint == CounterResetHint::CounterReset {
+            return Ok(true);
+        }
+        if self.counter_reset_hint == CounterResetHint::NotCounterReset {
+            return Ok(false);
+        }
+        if self.count < previous.count
+            || self.schema > previous.schema
+            || self.zero_threshold < previous.zero_threshold
+        {
+            return Ok(true);
+        }
+        let mut previous = previous.clone();
+        previous.reduce_resolution(self.schema)?;
+        previous.raise_zero_threshold(self.zero_threshold)?;
+        if self.zero_count < previous.zero_count {
+            return Ok(true);
+        }
+        let current_positive = self.indexed_positive()?;
+        let current_negative = self.indexed_negative()?;
+        for (idx, count) in previous.indexed_positive()? {
+            if current_positive.get(&idx).copied().unwrap_or(0.0) < count {
+                return Ok(true);
+            }
+        }
+        for (idx, count) in previous.indexed_negative()? {
+            if current_negative.get(&idx).copied().unwrap_or(0.0) < count {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HistogramBucket {
+    pub lower: f64,
+    pub upper: f64,
+    pub lower_inclusive: bool,
+    pub upper_inclusive: bool,
+    pub count: f64,
+}
+
+impl HistogramBucket {
+    pub fn boundaries_code(&self) -> u8 {
+        match (self.lower_inclusive, self.upper_inclusive) {
+            (false, true) => 0,
+            (true, false) => 1,
+            (false, false) => 2,
+            (true, true) => 3,
+        }
+    }
+}
+
+/// A histogram sample keeps either encoded or decoded state and memoizes the
+/// other representation on demand, including decode failures.
+#[derive(Debug)]
+pub struct LazyHistogram {
+    encoded: OnceLock<Bytes>,
+    decoded: OnceLock<Result<O2FloatHistogram, Arc<HistogramError>>>,
+    presence_stale: Option<bool>,
+    _reservation: Option<MemoryReservation>,
+}
+
+impl LazyHistogram {
+    pub fn from_payload(payload: Bytes) -> Self {
+        Self::from_payload_reserved(payload, None)
+    }
+
+    fn from_payload_reserved(payload: Bytes, reservation: Option<MemoryReservation>) -> Self {
+        let encoded = OnceLock::new();
+        let _ = encoded.set(payload);
+        Self {
+            encoded,
+            decoded: OnceLock::new(),
+            presence_stale: None,
+            _reservation: reservation,
+        }
+    }
+
+    pub fn from_decoded(histogram: O2FloatHistogram) -> Self {
+        Self::from_decoded_reserved(histogram, None)
+    }
+
+    fn from_decoded_reserved(
+        histogram: O2FloatHistogram,
+        reservation: Option<MemoryReservation>,
+    ) -> Self {
+        let decoded = OnceLock::new();
+        let _ = decoded.set(Ok(histogram));
+        Self {
+            encoded: OnceLock::new(),
+            decoded,
+            presence_stale: None,
+            _reservation: reservation,
+        }
+    }
+
+    pub fn from_presence(is_stale: bool) -> Self {
+        Self::from_presence_reserved(is_stale, None)
+    }
+
+    fn from_presence_reserved(is_stale: bool, reservation: Option<MemoryReservation>) -> Self {
+        Self {
+            encoded: OnceLock::new(),
+            decoded: OnceLock::new(),
+            presence_stale: Some(is_stale),
+            _reservation: reservation,
+        }
+    }
+
+    pub fn float(&self) -> Result<&O2FloatHistogram, Arc<HistogramError>> {
+        if self.presence_stale.is_some() {
+            return Err(Arc::new(HistogramError::PresenceOnlyAccess));
+        }
+        self.decoded
+            .get_or_init(|| {
+                let payload = self
+                    .encoded
+                    .get()
+                    .ok_or_else(|| Arc::new(HistogramError::EmptyLazyHistogram))?;
+                let limits = &crate::get_config().limit;
+                if payload.len() > limits.metrics_nh_max_payload_bytes {
+                    return Err(Arc::new(HistogramError::PayloadTooLarge {
+                        actual: payload.len(),
+                        limit: limits.metrics_nh_max_payload_bytes,
+                    }));
+                }
+                let native = NativeHistogram::from_payload(payload).map_err(Arc::new)?;
+                native
+                    .validate_limits(
+                        payload.len(),
+                        limits.metrics_nh_max_payload_bytes,
+                        limits.metrics_nh_max_buckets,
+                        limits.metrics_nh_max_spans,
+                    )
+                    .map_err(Arc::new)?;
+                native.validate().map_err(Arc::new)?;
+                native.to_float().map_err(Arc::new)
+            })
+            .as_ref()
+            .map_err(Arc::clone)
+    }
+
+    pub fn payload(&self) -> Result<&Bytes, Arc<HistogramError>> {
+        if let Some(payload) = self.encoded.get() {
+            return Ok(payload);
+        }
+        let histogram = self.float()?;
+        let payload = histogram
+            .to_native_float()
+            .to_payload()
+            .map(Bytes::from)
+            .map_err(Arc::new)?;
+        let _ = self.encoded.set(payload);
+        self.encoded
+            .get()
+            .ok_or_else(|| Arc::new(HistogramError::EmptyLazyHistogram))
+    }
+
+    pub fn is_stale(&self) -> Result<bool, Arc<HistogramError>> {
+        if let Some(is_stale) = self.presence_stale {
+            return Ok(is_stale);
+        }
+        Ok(self.float()?.is_stale())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HistogramSample {
+    /// Timestamp in microseconds.
+    pub timestamp: i64,
+    pub histogram: Arc<LazyHistogram>,
+}
+
+impl HistogramSample {
+    pub fn from_payload(timestamp: i64, payload: Bytes) -> Self {
+        Self {
+            timestamp,
+            histogram: Arc::new(LazyHistogram::from_payload(payload)),
+        }
+    }
+
+    pub fn from_decoded(timestamp: i64, histogram: O2FloatHistogram) -> Self {
+        Self {
+            timestamp,
+            histogram: Arc::new(LazyHistogram::from_decoded(histogram)),
+        }
+    }
+
+    pub fn from_computed(
+        timestamp: i64,
+        histogram: O2FloatHistogram,
+        parent: &LazyHistogram,
+    ) -> Result<Self, HistogramError> {
+        let reservation = parent
+            ._reservation
+            .as_ref()
+            .map(MemoryReservation::new_empty);
+        charge_reservation(reservation.as_ref(), histogram.encoded_size())?;
+        Ok(Self {
+            timestamp,
+            histogram: Arc::new(LazyHistogram::from_decoded_reserved(histogram, reservation)),
+        })
+    }
+
+    pub fn from_payload_mode(
+        timestamp: i64,
+        payload: Bytes,
+        mode: HistogramLoadMode,
+    ) -> Result<Self, HistogramError> {
+        Self::from_payload_mode_reserved(timestamp, payload, mode, None)
+    }
+
+    pub fn from_payload_mode_reserved(
+        timestamp: i64,
+        payload: Bytes,
+        mode: HistogramLoadMode,
+        reservation: Option<MemoryReservation>,
+    ) -> Result<Self, HistogramError> {
+        let limits = &crate::get_config().limit;
+        if payload.len() > limits.metrics_nh_max_payload_bytes {
+            return Err(HistogramError::PayloadTooLarge {
+                actual: payload.len(),
+                limit: limits.metrics_nh_max_payload_bytes,
+            });
+        }
+        match mode {
+            HistogramLoadMode::PresenceOnly => {
+                #[derive(Deserialize)]
+                struct SumOnly {
+                    #[serde(with = "tagged_f64")]
+                    sum: f64,
+                }
+                let value = serde_json::from_slice::<SumOnly>(&payload)
+                    .map_err(|err| HistogramError::Json(err.to_string()))?;
+                charge_reservation(reservation.as_ref(), std::mem::size_of::<LazyHistogram>())?;
+                Ok(Self {
+                    timestamp,
+                    histogram: Arc::new(LazyHistogram::from_presence_reserved(
+                        value.sum.to_bits() == STALE_NAN_BITS,
+                        reservation,
+                    )),
+                })
+            }
+            HistogramLoadMode::RawLazy | HistogramLoadMode::DecodeAfterSelection => {
+                charge_reservation(reservation.as_ref(), payload.len())?;
+                Ok(Self {
+                    timestamp,
+                    histogram: Arc::new(LazyHistogram::from_payload_reserved(payload, reservation)),
+                })
+            }
+            HistogramLoadMode::DecodedOnly => {
+                let native = NativeHistogram::from_payload(&payload)?;
+                native.validate_limits(
+                    payload.len(),
+                    limits.metrics_nh_max_payload_bytes,
+                    limits.metrics_nh_max_buckets,
+                    limits.metrics_nh_max_spans,
+                )?;
+                let float = native.to_float()?;
+                charge_reservation(reservation.as_ref(), float.encoded_size())?;
+                Ok(Self {
+                    timestamp,
+                    histogram: Arc::new(LazyHistogram::from_decoded_reserved(float, reservation)),
+                })
+            }
+        }
+    }
+}
+
+fn charge_reservation(
+    reservation: Option<&MemoryReservation>,
+    bytes: usize,
+) -> Result<(), HistogramError> {
+    if let Some(reservation) = reservation {
+        reservation
+            .try_grow(bytes)
+            .map_err(|err| HistogramError::Memory(err.to_string()))?;
+    }
+    Ok(())
+}
+
+fn validate_common(
+    schema: i32,
+    zero_threshold: f64,
+    positive_spans: &[HistogramSpan],
+    negative_spans: &[HistogramSpan],
+    positive_buckets: usize,
+    negative_buckets: usize,
+) -> Result<(), HistogramError> {
+    if schema == CUSTOM_BUCKETS_SCHEMA
+        || !(EXPONENTIAL_SCHEMA_MIN..=EXPONENTIAL_SCHEMA_MAX).contains(&schema)
+    {
+        return Err(HistogramError::UnsupportedSchema(schema));
+    }
+    if !zero_threshold.is_finite() || zero_threshold < 0.0 {
+        return Err(HistogramError::InvalidZeroThreshold(zero_threshold));
+    }
+    validate_spans("positive", positive_spans, positive_buckets)?;
+    validate_spans("negative", negative_spans, negative_buckets)?;
+    Ok(())
+}
+
+fn validate_spans(
+    side: &'static str,
+    spans: &[HistogramSpan],
+    buckets: usize,
+) -> Result<(), HistogramError> {
+    let expected = spans.iter().map(|span| span.length as usize).sum::<usize>();
+    if expected != buckets {
+        return Err(HistogramError::SpanBucketMismatch {
+            side,
+            expected,
+            actual: buckets,
+        });
+    }
+    for (idx, span) in spans.iter().enumerate().skip(1) {
+        if span.offset < 0 {
+            return Err(HistogramError::NegativeSpanOffset {
+                side,
+                span: idx,
+                offset: span.offset,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_float_count(
+    side: &'static str,
+    bucket: usize,
+    count: f64,
+) -> Result<(), HistogramError> {
+    // Match Prometheus FloatHistogram.Validate: NaN and +Inf pass because
+    // IEEE comparisons with NaN are false; only values `< 0` are rejected.
+    if count < 0.0 {
+        return Err(HistogramError::NegativeBucketCount {
+            side,
+            bucket,
+            count,
+        });
+    }
+    Ok(())
+}
+
+fn decode_integer_buckets(side: &'static str, deltas: &[i64]) -> Result<Vec<f64>, HistogramError> {
+    let mut current = 0_i128;
+    let mut result = Vec::with_capacity(deltas.len());
+    for (idx, delta) in deltas.iter().enumerate() {
+        current += *delta as i128;
+        if current < 0 {
+            return Err(HistogramError::NegativeBucketCount {
+                side,
+                bucket: idx,
+                count: current as f64,
+            });
+        }
+        result.push(current as f64);
+    }
+    Ok(result)
+}
+
+fn indexed_buckets(
+    side: &'static str,
+    spans: &[HistogramSpan],
+    buckets: &[f64],
+) -> Result<BTreeMap<i32, f64>, HistogramError> {
+    validate_spans(side, spans, buckets.len())?;
+    let mut result = BTreeMap::new();
+    let mut bucket_position = 0;
+    let mut current_index = 0_i32;
+    for (span_idx, span) in spans.iter().enumerate() {
+        if span_idx == 0 {
+            current_index = span.offset;
+        } else {
+            current_index = current_index.saturating_add(1).saturating_add(span.offset);
+        }
+        for offset in 0..span.length {
+            let index = current_index.saturating_add(offset as i32);
+            result.insert(index, buckets[bucket_position]);
+            bucket_position += 1;
+        }
+        if span.length > 0 {
+            current_index = current_index.saturating_add(span.length as i32 - 1);
+        }
+    }
+    Ok(result)
+}
+
+fn spans_from_indexed(indexed: BTreeMap<i32, f64>) -> (Vec<HistogramSpan>, Vec<f64>) {
+    let mut spans = Vec::<HistogramSpan>::new();
+    let mut buckets = Vec::with_capacity(indexed.len());
+    let mut previous = None;
+    for (index, count) in indexed {
+        match previous {
+            None => spans.push(HistogramSpan {
+                offset: index,
+                length: 1,
+            }),
+            Some(prev) if index == prev + 1 => {
+                spans.last_mut().expect("span exists").length += 1;
+            }
+            Some(prev) => spans.push(HistogramSpan {
+                offset: index - prev - 1,
+                length: 1,
+            }),
+        }
+        previous = Some(index);
+        buckets.push(count);
+    }
+    (spans, buckets)
+}
+
+/// Prometheus exponential bucket upper bound for `idx` and `schema`.
+///
+/// The exponent is applied separately from the fractional bucket boundary so
+/// the last finite bucket remains `f64::MAX` instead of collapsing into the
+/// dedicated infinity bucket.
+pub fn get_bound_exponential(idx: i32, schema: i32) -> f64 {
+    debug_assert!((EXPONENTIAL_SCHEMA_MIN..=EXPONENTIAL_SCHEMA_MAX).contains(&schema));
+    if schema < 0 {
+        let exponent = idx.saturating_mul(1_i32 << (-schema));
+        if exponent == 1024 {
+            return f64::MAX;
+        }
+        return ldexp(1.0, exponent);
+    }
+    let buckets_per_power = 1_i32 << schema;
+    let fraction_index = idx & (buckets_per_power - 1);
+    let fraction = 2.0_f64.powf(fraction_index as f64 / buckets_per_power as f64 - 1.0);
+    let exponent = (idx >> schema) + 1;
+    if fraction == 0.5 && exponent == 1025 {
+        return f64::MAX;
+    }
+    ldexp(fraction, exponent)
+}
+
+fn ldexp(value: f64, exponent: i32) -> f64 {
+    if exponent > 1023 {
+        value * 2.0_f64.powi(1023) * 2.0_f64.powi(exponent - 1023)
+    } else if exponent < -1022 {
+        value * 2.0_f64.powi(-1022) * 2.0_f64.powi(exponent + 1022)
+    } else {
+        value * 2.0_f64.powi(exponent)
+    }
+}
+
+mod tagged_f64 {
+    use super::*;
+
+    pub fn serialize<S>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        TaggedF64(*value).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<f64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        TaggedF64::deserialize(deserializer).map(|value| value.0)
+    }
+}
+
+mod tagged_f64_vec {
+    use super::*;
+
+    pub fn serialize<S>(values: &[f64], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(values.len()))?;
+        for value in values {
+            seq.serialize_element(&TaggedF64(*value))?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<f64>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<TaggedF64>::deserialize(deserializer)
+            .map(|values| values.into_iter().map(|value| value.0).collect())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TaggedF64(f64);
+
+impl Serialize for TaggedF64 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.0 {
+            value if value.is_finite() => serializer.serialize_f64(value),
+            value if value.to_bits() == STALE_NAN_BITS => serializer.serialize_str("stale"),
+            value if value.is_nan() => serializer.serialize_str("NaN"),
+            value if value.is_sign_positive() => serializer.serialize_str("+Inf"),
+            _ => serializer.serialize_str("-Inf"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TaggedF64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Number(serde_json::Number),
+            Text(String),
+        }
+
+        match Repr::deserialize(deserializer)? {
+            Repr::Number(value) => value
+                .as_f64()
+                .map(TaggedF64)
+                .ok_or_else(|| serde::de::Error::custom("number does not fit in f64")),
+            Repr::Text(value) => match value.as_str() {
+                "stale" => Ok(TaggedF64(STALE_NAN)),
+                "NaN" => Ok(TaggedF64(f64::NAN)),
+                "+Inf" => Ok(TaggedF64(f64::INFINITY)),
+                "-Inf" => Ok(TaggedF64(f64::NEG_INFINITY)),
+                _ => Err(serde::de::Error::custom(format!(
+                    "invalid tagged f64 value {value}"
+                ))),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn integer_histogram() -> NativeHistogram {
+        NativeHistogram {
+            schema: 0,
+            zero_threshold: 0.001,
+            sum: 20.0,
+            start_time: 0,
+            positive_spans: vec![
+                HistogramSpan {
+                    offset: 0,
+                    length: 2,
+                },
+                HistogramSpan {
+                    offset: 1,
+                    length: 1,
+                },
+            ],
+            negative_spans: vec![],
+            counter_reset_hint: CounterResetHint::Unknown,
+            counts: NativeHistogramCounts::Integer {
+                zero_count: 0,
+                count: 10,
+                positive_buckets: vec![3, 1, -1],
+                negative_buckets: vec![],
+            },
+        }
+    }
+
+    #[test]
+    fn span_delta_decode_matches_prometheus() {
+        let histogram = integer_histogram();
+        histogram.validate().unwrap();
+        let float = histogram.to_float().unwrap();
+        assert_eq!(float.positive_buckets, vec![3.0, 4.0, 3.0]);
+        assert_eq!(
+            float
+                .indexed_positive()
+                .unwrap()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            vec![(0, 3.0), (1, 4.0), (3, 3.0)]
+        );
+    }
+
+    #[test]
+    fn tagged_non_finite_values_round_trip() {
+        assert_eq!(serde_json::from_str::<TaggedF64>("0.0").unwrap().0, 0.0);
+        assert_eq!(
+            serde_json::from_str::<TaggedF64>(r#""stale""#)
+                .unwrap()
+                .0
+                .to_bits(),
+            STALE_NAN_BITS
+        );
+        let values = [STALE_NAN, f64::NAN, f64::INFINITY, f64::NEG_INFINITY, 1.5];
+        for value in values {
+            let histogram = NativeHistogram {
+                schema: 0,
+                zero_threshold: 0.0,
+                sum: value,
+                start_time: 0,
+                positive_spans: vec![],
+                negative_spans: vec![],
+                counter_reset_hint: CounterResetHint::Unknown,
+                counts: NativeHistogramCounts::Float {
+                    zero_count: value,
+                    count: value,
+                    positive_buckets: vec![],
+                    negative_buckets: vec![],
+                },
+            };
+            let payload = histogram.to_payload().unwrap();
+            let decoded = NativeHistogram::from_payload(payload.as_bytes()).unwrap();
+            if value.to_bits() == STALE_NAN_BITS {
+                assert_eq!(decoded.sum.to_bits(), STALE_NAN_BITS);
+            } else if value.is_nan() {
+                assert!(decoded.sum.is_nan());
+                assert_ne!(decoded.sum.to_bits(), STALE_NAN_BITS);
+            } else {
+                assert_eq!(decoded.sum, value);
+            }
+        }
+    }
+
+    #[test]
+    fn exponential_extreme_boundaries_keep_inf_bucket_distinct() {
+        for schema in EXPONENTIAL_SCHEMA_MIN..=EXPONENTIAL_SCHEMA_MAX {
+            let last = if schema < 0 {
+                1024 >> -schema
+            } else {
+                1024 << schema
+            };
+            assert_eq!(get_bound_exponential(last, schema), f64::MAX);
+            assert_eq!(get_bound_exponential(last + 1, schema), f64::INFINITY);
+        }
+    }
+
+    #[test]
+    fn rejects_custom_bucket_schema() {
+        let mut histogram = integer_histogram();
+        histogram.schema = CUSTOM_BUCKETS_SCHEMA;
+        assert_eq!(
+            histogram.validate(),
+            Err(HistogramError::UnsupportedSchema(CUSTOM_BUCKETS_SCHEMA))
+        );
+    }
+
+    #[test]
+    fn reduce_resolution_uses_prometheus_index_mapping() {
+        let mut histogram = O2FloatHistogram {
+            schema: 2,
+            zero_threshold: 0.0,
+            zero_count: 0.0,
+            count: 6.0,
+            sum: 6.0,
+            positive_spans: vec![HistogramSpan {
+                offset: 1,
+                length: 3,
+            }],
+            negative_spans: vec![],
+            positive_buckets: vec![1.0, 2.0, 3.0],
+            negative_buckets: vec![],
+            counter_reset_hint: CounterResetHint::Unknown,
+            start_time: 0,
+        };
+        histogram.reduce_resolution(0).unwrap();
+        assert_eq!(histogram.indexed_positive().unwrap().get(&1), Some(&6.0));
+    }
+
+    #[test]
+    fn histogram_load_modes_preserve_lazy_and_presence_semantics() {
+        let payload = Bytes::from(integer_histogram().to_payload().unwrap());
+
+        let presence = HistogramSample::from_payload_mode(
+            10,
+            payload.clone(),
+            HistogramLoadMode::PresenceOnly,
+        )
+        .unwrap();
+        assert!(!presence.histogram.is_stale().unwrap());
+        assert_eq!(
+            presence.histogram.float().unwrap_err().as_ref(),
+            &HistogramError::PresenceOnlyAccess
+        );
+
+        let raw =
+            HistogramSample::from_payload_mode(10, payload.clone(), HistogramLoadMode::RawLazy)
+                .unwrap();
+        assert_eq!(raw.histogram.payload().unwrap().as_ref(), payload.as_ref());
+        assert_eq!(raw.histogram.float().unwrap().count, 10.0);
+
+        let decoded =
+            HistogramSample::from_payload_mode(10, payload, HistogramLoadMode::DecodedOnly)
+                .unwrap();
+        assert_eq!(decoded.histogram.float().unwrap().count, 10.0);
+        assert!(decoded.histogram.payload().unwrap().starts_with(b"{"));
+    }
+
+    #[test]
+    fn presence_mode_recognizes_stale_marker_without_materializing_histogram() {
+        let mut histogram = integer_histogram();
+        histogram.sum = STALE_NAN;
+        let sample = HistogramSample::from_payload_mode(
+            10,
+            Bytes::from(histogram.to_payload().unwrap()),
+            HistogramLoadMode::PresenceOnly,
+        )
+        .unwrap();
+        assert!(sample.histogram.is_stale().unwrap());
+    }
+}

--- a/src/config/src/meta/promql/mod.rs
+++ b/src/config/src/meta/promql/mod.rs
@@ -65,6 +65,7 @@ where
 }
 
 pub mod grpc;
+pub mod histogram;
 pub mod value;
 
 pub const NAME_LABEL: &str = "__name__";
@@ -75,6 +76,8 @@ pub const BUCKET_LABEL: &str = "le";
 pub const QUANTILE_LABEL: &str = "quantile";
 pub const METADATA_LABEL: &str = "prom_metadata"; // for schema metadata key
 pub const EXEMPLARS_LABEL: &str = "exemplars";
+/// Reserved column carrying a versioned Prometheus native-histogram payload.
+pub const NATIVE_HISTOGRAM_LABEL: &str = "__native_histogram__";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Metric<'a> {
@@ -402,6 +405,14 @@ impl<T: Serialize> ApiFuncResponse<T> {
     pub fn err_internal(error: impl ToString, trace_id: Option<String>) -> Self {
         ApiFuncResponse::Error {
             error_type: ApiErrorType::Internal,
+            error: error.to_string(),
+            trace_id,
+        }
+    }
+
+    pub fn err_exec(error: impl ToString, trace_id: Option<String>) -> Self {
+        ApiFuncResponse::Error {
+            error_type: ApiErrorType::Exec,
             error: error.to_string(),
             trace_id,
         }

--- a/src/config/src/meta/promql/value.rs
+++ b/src/config/src/meta/promql/value.rs
@@ -30,7 +30,13 @@ use serde::{
 
 use crate::{
     FxIndexMap,
-    meta::{promql::NAME_LABEL, search::SearchEventType},
+    meta::{
+        promql::{
+            NAME_LABEL,
+            histogram::{HistogramSample, O2FloatHistogram},
+        },
+        search::SearchEventType,
+    },
     utils::{json, sort::sort_float},
 };
 
@@ -238,6 +244,20 @@ impl Sample {
     }
 }
 
+struct ApiPromSample<'a>(&'a Sample);
+
+impl Serialize for ApiPromSample<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(2))?;
+        seq.serialize_element(&PromTimestamp(self.0.timestamp))?;
+        seq.serialize_element(&PromFloat(self.0.value))?;
+        seq.end()
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct Exemplar {
     /// Time in microseconds
@@ -351,10 +371,154 @@ impl From<&json::Map<String, json::Value>> for Exemplar {
     }
 }
 
+struct ApiHistogramSample<'a>(&'a HistogramSample);
+
+impl Serialize for ApiHistogramSample<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(2))?;
+        seq.serialize_element(&PromTimestamp(self.0.timestamp))?;
+        let histogram = self
+            .0
+            .histogram
+            .float()
+            .map_err(serde::ser::Error::custom)?;
+        seq.serialize_element(&ApiHistogram(histogram))?;
+        seq.end()
+    }
+}
+
+struct ApiHistogram<'a>(&'a O2FloatHistogram);
+
+impl Serialize for ApiHistogram<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let buckets = self.0.all_buckets().map_err(serde::ser::Error::custom)?;
+        let buckets = buckets
+            .into_iter()
+            .filter(|bucket| bucket.count != 0.0)
+            .collect::<Vec<_>>();
+        let mut object = serializer
+            .serialize_struct("native_histogram", if buckets.is_empty() { 2 } else { 3 })?;
+        object.serialize_field("count", &PromFloat(self.0.count))?;
+        object.serialize_field("sum", &PromFloat(self.0.sum))?;
+        if !buckets.is_empty() {
+            object.serialize_field("buckets", &ApiHistogramBuckets(&buckets))?;
+        }
+        object.end()
+    }
+}
+
+struct ApiHistogramBuckets<'a>(&'a [super::histogram::HistogramBucket]);
+
+impl Serialize for ApiHistogramBuckets<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for bucket in self.0 {
+            seq.serialize_element(&ApiHistogramBucket(bucket))?;
+        }
+        seq.end()
+    }
+}
+
+struct ApiHistogramBucket<'a>(&'a super::histogram::HistogramBucket);
+
+impl Serialize for ApiHistogramBucket<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(4))?;
+        seq.serialize_element(&self.0.boundaries_code())?;
+        seq.serialize_element(&PromFloat(self.0.lower))?;
+        seq.serialize_element(&PromFloat(self.0.upper))?;
+        seq.serialize_element(&PromFloat(self.0.count))?;
+        seq.end()
+    }
+}
+
+struct PromTimestamp(i64);
+
+impl Serialize for PromTimestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Prometheus emits millisecond-precision decimal seconds.
+        serializer.serialize_f64((self.0 / 1_000) as f64 / 1_000.0)
+    }
+}
+
+struct PromFloat(f64);
+
+impl Serialize for PromFloat {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = if self.0.is_nan() {
+            "NaN".to_string()
+        } else if self.0 == f64::INFINITY {
+            "+Inf".to_string()
+        } else if self.0 == f64::NEG_INFINITY {
+            "-Inf".to_string()
+        } else if self.0 != 0.0 && (self.0.abs() < 1e-6 || self.0.abs() >= 1e21) {
+            let scientific = format!("{:e}", self.0);
+            let (mantissa, exponent) = scientific
+                .split_once('e')
+                .expect("Rust scientific formatting always contains an exponent");
+            let exponent = exponent.parse::<i32>().expect("valid decimal exponent");
+            format!("{mantissa}e{exponent:+}")
+        } else {
+            self.0.to_string()
+        };
+        serializer.serialize_str(&value)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct InstantValue {
     pub labels: Labels,
-    pub sample: Sample,
+    pub sample: InstantPoint,
+}
+
+#[derive(Debug, Clone)]
+pub enum InstantPoint {
+    Float(Sample),
+    /// Scalar result derived from a native histogram. It uses Prometheus wire formatting while
+    /// ordinary float-only queries retain OpenObserve's existing serializer.
+    PromFloat(Sample),
+    Histogram(HistogramSample),
+}
+
+impl InstantPoint {
+    pub fn timestamp(&self) -> i64 {
+        match self {
+            Self::Float(sample) | Self::PromFloat(sample) => sample.timestamp,
+            Self::Histogram(sample) => sample.timestamp,
+        }
+    }
+
+    pub fn as_float(&self) -> Option<&Sample> {
+        match self {
+            Self::Float(sample) | Self::PromFloat(sample) => Some(sample),
+            Self::Histogram(_) => None,
+        }
+    }
+
+    pub fn into_float(self) -> Option<Sample> {
+        match self {
+            Self::Float(sample) | Self::PromFloat(sample) => Some(sample),
+            Self::Histogram(_) => None,
+        }
+    }
 }
 
 impl Serialize for InstantValue {
@@ -369,7 +533,15 @@ impl Serialize for InstantValue {
             .map(|l| (l.name.as_str(), l.value.as_str()))
             .collect::<FxIndexMap<_, _>>();
         seq.serialize_field("metric", &labels_map)?;
-        seq.serialize_field("value", &self.sample)?;
+        match &self.sample {
+            InstantPoint::Float(sample) => seq.serialize_field("value", sample)?,
+            InstantPoint::PromFloat(sample) => {
+                seq.serialize_field("value", &ApiPromSample(sample))?
+            }
+            InstantPoint::Histogram(sample) => {
+                seq.serialize_field("histogram", &ApiHistogramSample(sample))?
+            }
+        }
         seq.end()
     }
 }
@@ -452,6 +624,7 @@ pub struct QueryContext {
 pub struct RangeValue {
     pub labels: Labels,
     pub samples: Vec<Sample>,
+    pub histogram_samples: Option<Vec<HistogramSample>>,
     pub exemplars: Option<Vec<Arc<Exemplar>>>,
     pub time_window: Option<TimeWindow>,
 }
@@ -465,6 +638,15 @@ impl RangeValue {
     pub fn extend(&mut self, other: RangeValue) {
         if !other.samples.is_empty() {
             self.samples.extend(other.samples);
+        }
+        if let Some(histograms) = other.histogram_samples
+            && !histograms.is_empty()
+        {
+            if let Some(self_histograms) = &mut self.histogram_samples {
+                self_histograms.extend(histograms);
+            } else {
+                self.histogram_samples = Some(histograms);
+            }
         }
         // check exemplars
         if let Some(exemplars) = other.exemplars
@@ -497,14 +679,37 @@ impl Serialize for RangeValue {
                 seq.end()
             }
             None => {
-                let mut seq = serializer.serialize_struct("range_value", 2)?;
+                let has_histograms = self
+                    .histogram_samples
+                    .as_ref()
+                    .is_some_and(|samples| !samples.is_empty());
+                let mut seq = serializer.serialize_struct(
+                    "range_value",
+                    1 + usize::from(!self.samples.is_empty()) + usize::from(has_histograms),
+                )?;
                 let labels_map = self
                     .labels
                     .iter()
                     .map(|l| (l.name.as_str(), l.value.as_str()))
                     .collect::<FxIndexMap<_, _>>();
                 seq.serialize_field("metric", &labels_map)?;
-                seq.serialize_field("values", &self.samples)?;
+                if !self.samples.is_empty() {
+                    if self.histogram_samples.is_some() {
+                        let samples = self.samples.iter().map(ApiPromSample).collect::<Vec<_>>();
+                        seq.serialize_field("values", &samples)?;
+                    } else {
+                        seq.serialize_field("values", &self.samples)?;
+                    }
+                }
+                if let Some(histograms) = &self.histogram_samples
+                    && !histograms.is_empty()
+                {
+                    let histograms = histograms
+                        .iter()
+                        .map(ApiHistogramSample)
+                        .collect::<Vec<_>>();
+                    seq.serialize_field("histograms", &histograms)?;
+                }
                 seq.end()
             }
         }
@@ -560,6 +765,7 @@ impl<'de> Deserialize<'de> for RangeValue {
                 Ok(RangeValue {
                     labels,
                     samples: samples.unwrap_or_default(),
+                    histogram_samples: None,
                     exemplars,
                     time_window: None,
                 })
@@ -578,6 +784,7 @@ impl RangeValue {
         Self {
             labels,
             samples: Vec::from_iter(samples),
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }
@@ -590,13 +797,14 @@ impl RangeValue {
         Self {
             labels,
             samples: vec![],
+            histogram_samples: None,
             exemplars: Some(Vec::from_iter(exemplars)),
             time_window: None,
         }
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum ExtrapolationKind {
     /// Calculate the per-second average rate of increase of the time series.
     /// Adjust for breaks in monotonicity (counter resets).
@@ -757,6 +965,64 @@ pub enum Value {
 }
 
 impl Value {
+    pub fn mark_native_histogram_provenance(&mut self) {
+        match self {
+            Value::Instant(value) => {
+                if let InstantPoint::Float(sample) = &value.sample {
+                    value.sample = InstantPoint::PromFloat(*sample);
+                }
+            }
+            Value::Range(value) => {
+                value.histogram_samples.get_or_insert_with(Vec::new);
+            }
+            Value::Vector(values) => {
+                for value in values {
+                    if let InstantPoint::Float(sample) = &value.sample {
+                        value.sample = InstantPoint::PromFloat(*sample);
+                    }
+                }
+            }
+            Value::Matrix(values) => {
+                for value in values {
+                    value.histogram_samples.get_or_insert_with(Vec::new);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn has_native_histogram_provenance(&self) -> bool {
+        match self {
+            Value::Instant(value) => !matches!(&value.sample, InstantPoint::Float(_)),
+            Value::Range(value) => value.histogram_samples.is_some(),
+            Value::Vector(values) => values
+                .iter()
+                .any(|value| !matches!(&value.sample, InstantPoint::Float(_))),
+            Value::Matrix(values) => values.iter().any(|value| value.histogram_samples.is_some()),
+            _ => false,
+        }
+    }
+
+    pub fn contains_native_histograms(&self) -> bool {
+        match self {
+            Value::Instant(value) => matches!(&value.sample, InstantPoint::Histogram(_)),
+            Value::Range(value) => value
+                .histogram_samples
+                .as_ref()
+                .is_some_and(|samples| !samples.is_empty()),
+            Value::Vector(values) => values
+                .iter()
+                .any(|value| matches!(&value.sample, InstantPoint::Histogram(_))),
+            Value::Matrix(values) => values.iter().any(|value| {
+                value
+                    .histogram_samples
+                    .as_ref()
+                    .is_some_and(|samples| !samples.is_empty())
+            }),
+            _ => false,
+        }
+    }
+
     pub fn get_ref_matrix_values(&self) -> Option<&Vec<RangeValue>> {
         match self {
             Value::Matrix(values) => Some(values),
@@ -808,7 +1074,12 @@ impl Value {
     pub fn sort(&mut self) {
         match self {
             Value::Vector(v) => {
-                v.sort_by(|a, b| sort_float(&b.sample.value, &a.sample.value));
+                v.sort_by(|a, b| match (a.sample.as_float(), b.sample.as_float()) {
+                    (Some(a), Some(b)) => sort_float(&b.value, &a.value),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => std::cmp::Ordering::Equal,
+                });
             }
             Value::Matrix(v) => {
                 v.sort_by(|a, b| {
@@ -892,6 +1163,9 @@ mod tests {
     use float_cmp::approx_eq;
 
     use super::*;
+    use crate::meta::promql::histogram::{
+        CounterResetHint, HistogramSample, HistogramSpan, O2FloatHistogram,
+    };
 
     fn generate_test_labels() -> Labels {
         let labels: Labels = vec![
@@ -913,6 +1187,66 @@ mod tests {
             }),
         ];
         labels
+    }
+
+    fn api_histogram_sample(timestamp: i64) -> HistogramSample {
+        HistogramSample::from_decoded(
+            timestamp,
+            O2FloatHistogram {
+                schema: 0,
+                zero_threshold: 0.0,
+                zero_count: 0.0,
+                count: 2.0,
+                sum: f64::INFINITY,
+                positive_spans: vec![HistogramSpan {
+                    offset: 0,
+                    length: 2,
+                }],
+                negative_spans: vec![],
+                positive_buckets: vec![2.0, 0.0],
+                negative_buckets: vec![],
+                counter_reset_hint: CounterResetHint::Gauge,
+                start_time: 0,
+            },
+        )
+    }
+
+    #[test]
+    fn native_histogram_api_uses_prometheus_shape_and_omits_zero_buckets() {
+        let value = RangeValue {
+            labels: vec![],
+            samples: vec![],
+            histogram_samples: Some(vec![api_histogram_sample(1_234_567)]),
+            exemplars: None,
+            time_window: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&value).unwrap(),
+            r#"{"metric":{},"histograms":[[1.234,{"count":"2","sum":"+Inf","buckets":[[0,"0.5","1","2"]]}]]}"#
+        );
+    }
+
+    #[test]
+    fn native_scalar_provenance_uses_prometheus_timestamp_and_float_format() {
+        let range = RangeValue {
+            labels: vec![],
+            samples: vec![Sample::new(1_234_567, 1e21)],
+            histogram_samples: Some(Vec::new()),
+            exemplars: None,
+            time_window: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&range).unwrap(),
+            r#"{"metric":{},"values":[[1.234,"1e+21"]]}"#
+        );
+        let instant = InstantValue {
+            labels: vec![],
+            sample: InstantPoint::PromFloat(Sample::new(1_234_567, f64::INFINITY)),
+        };
+        assert_eq!(
+            serde_json::to_string(&instant).unwrap(),
+            r#"{"metric":{},"value":[1.234,"+Inf"]}"#
+        );
     }
     #[test]
     fn test_signature_without_labels() {
@@ -1201,6 +1535,7 @@ mod tests {
         let mut range_value1 = RangeValue {
             labels: vec![],
             samples: vec![],
+            histogram_samples: None,
             exemplars: Some(vec![Arc::new(Exemplar {
                 timestamp: 1000,
                 value: 1.0,
@@ -1212,6 +1547,7 @@ mod tests {
         let range_value2 = RangeValue {
             labels: vec![],
             samples: vec![],
+            histogram_samples: None,
             exemplars: Some(vec![Arc::new(Exemplar {
                 timestamp: 2000,
                 value: 2.0,
@@ -1252,7 +1588,7 @@ mod tests {
     fn test_value_get_methods() {
         let instant_value = InstantValue {
             labels: vec![],
-            sample: Sample::new(1000, 1.0),
+            sample: InstantPoint::Float(Sample::new(1000, 1.0)),
         };
         let vector = vec![instant_value.clone()];
         let range_value = RangeValue::new(vec![], vec![Sample::new(1000, 1.0)]);
@@ -1278,7 +1614,7 @@ mod tests {
         assert_eq!(
             Value::Instant(InstantValue {
                 labels: vec![],
-                sample: Sample::new(1000, 1.0)
+                sample: InstantPoint::Float(Sample::new(1000, 1.0))
             })
             .get_type(),
             "vector"
@@ -1305,11 +1641,11 @@ mod tests {
         let vector_unique = Value::Vector(vec![
             InstantValue {
                 labels: label1.clone(),
-                sample: Sample::new(1000, 1.0),
+                sample: InstantPoint::Float(Sample::new(1000, 1.0)),
             },
             InstantValue {
                 labels: label2.clone(),
-                sample: Sample::new(2000, 2.0),
+                sample: InstantPoint::Float(Sample::new(2000, 2.0)),
             },
         ]);
         assert!(!vector_unique.contains_same_label_set());
@@ -1318,11 +1654,11 @@ mod tests {
         let vector_duplicate = Value::Vector(vec![
             InstantValue {
                 labels: label1.clone(),
-                sample: Sample::new(1000, 1.0),
+                sample: InstantPoint::Float(Sample::new(1000, 1.0)),
             },
             InstantValue {
                 labels: label1_dup.clone(),
-                sample: Sample::new(2000, 2.0),
+                sample: InstantPoint::Float(Sample::new(2000, 2.0)),
             },
         ]);
         assert!(vector_duplicate.contains_same_label_set());
@@ -1344,7 +1680,7 @@ mod tests {
         // Test single element cases
         let single_vector = Value::Vector(vec![InstantValue {
             labels: label1.clone(),
-            sample: Sample::new(1000, 1.0),
+            sample: InstantPoint::Float(Sample::new(1000, 1.0)),
         }]);
         assert!(!single_vector.contains_same_label_set());
 
@@ -1360,24 +1696,24 @@ mod tests {
         let mut vector = Value::Vector(vec![
             InstantValue {
                 labels: vec![],
-                sample: Sample::new(1000, 1.0),
+                sample: InstantPoint::Float(Sample::new(1000, 1.0)),
             },
             InstantValue {
                 labels: vec![],
-                sample: Sample::new(2000, 3.0),
+                sample: InstantPoint::Float(Sample::new(2000, 3.0)),
             },
             InstantValue {
                 labels: vec![],
-                sample: Sample::new(3000, 2.0),
+                sample: InstantPoint::Float(Sample::new(3000, 2.0)),
             },
         ]);
 
         vector.sort();
 
         if let Value::Vector(ref v) = vector {
-            assert_eq!(v[0].sample.value, 3.0); // Highest value first
-            assert_eq!(v[1].sample.value, 2.0);
-            assert_eq!(v[2].sample.value, 1.0); // Lowest value last
+            assert_eq!(v[0].sample.as_float().unwrap().value, 3.0); // Highest value first
+            assert_eq!(v[1].sample.as_float().unwrap().value, 2.0);
+            assert_eq!(v[2].sample.as_float().unwrap().value, 1.0); // Lowest value last
         }
 
         let mut matrix = Value::Matrix(vec![
@@ -1531,7 +1867,7 @@ mod tests {
     fn test_value_get_vector() {
         let iv = InstantValue {
             labels: vec![],
-            sample: Sample::new(1000, 5.0),
+            sample: InstantPoint::Float(Sample::new(1000, 5.0)),
         };
         let val = Value::Vector(vec![iv]);
         assert!(val.get_vector().is_some());
@@ -1605,15 +1941,15 @@ mod tests {
         let v = Value::Vector(vec![
             InstantValue {
                 labels: label_a,
-                sample: Sample::new(1, 1.0),
+                sample: InstantPoint::Float(Sample::new(1, 1.0)),
             },
             InstantValue {
                 labels: label_b,
-                sample: Sample::new(2, 2.0),
+                sample: InstantPoint::Float(Sample::new(2, 2.0)),
             },
             InstantValue {
                 labels: label_c,
-                sample: Sample::new(3, 3.0),
+                sample: InstantPoint::Float(Sample::new(3, 3.0)),
             },
         ]);
         assert!(!v.contains_same_label_set());
@@ -1627,15 +1963,15 @@ mod tests {
         let v = Value::Vector(vec![
             InstantValue {
                 labels: label_a,
-                sample: Sample::new(1, 1.0),
+                sample: InstantPoint::Float(Sample::new(1, 1.0)),
             },
             InstantValue {
                 labels: label_b,
-                sample: Sample::new(2, 2.0),
+                sample: InstantPoint::Float(Sample::new(2, 2.0)),
             },
             InstantValue {
                 labels: label_a2,
-                sample: Sample::new(3, 3.0),
+                sample: InstantPoint::Float(Sample::new(3, 3.0)),
             },
         ]);
         assert!(v.contains_same_label_set());

--- a/src/config/src/utils/parquet.rs
+++ b/src/config/src/utils/parquet.rs
@@ -34,7 +34,10 @@ use futures::{Stream, TryStreamExt};
 use parquet::{
     arrow::{AsyncArrowWriter, ParquetRecordBatchStreamBuilder, arrow_reader::ArrowReaderMetadata},
     basic::{Compression, Encoding},
-    file::{metadata::KeyValue, properties::WriterProperties},
+    file::{
+        metadata::KeyValue,
+        properties::{EnabledStatistics, WriterProperties},
+    },
 };
 #[cfg(feature = "vortex")]
 use vortex::{
@@ -69,6 +72,18 @@ pub fn new_parquet_writer<'a>(
         .set_column_encoding(
             TIMESTAMP_COL_NAME.into(),
             Encoding::DELTA_BINARY_PACKED,
+        )
+        .set_column_dictionary_enabled(
+            crate::meta::promql::NATIVE_HISTOGRAM_LABEL.into(),
+            false,
+        )
+        .set_column_statistics_enabled(
+            crate::meta::promql::NATIVE_HISTOGRAM_LABEL.into(),
+            EnabledStatistics::None,
+        )
+        .set_column_encoding(
+            crate::meta::promql::NATIVE_HISTOGRAM_LABEL.into(),
+            Encoding::DELTA_LENGTH_BYTE_ARRAY,
         );
     if cfg.common.timestamp_compression_disabled {
         writer_props = writer_props
@@ -95,6 +110,7 @@ pub fn new_parquet_writer<'a>(
     }
     if cfg.common.bloom_filter_parquet_enabled {
         let mut fields = bloom_filter_fields.to_vec();
+        fields.retain(|field| field != crate::meta::promql::NATIVE_HISTOGRAM_LABEL);
         fields.sort();
         fields.dedup();
         for field in fields {

--- a/src/core/src/service/compact/mod.rs
+++ b/src/core/src/service/compact/mod.rs
@@ -14,6 +14,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
+#[cfg(feature = "enterprise")]
+use config::meta::promql::NATIVE_HISTOGRAM_LABEL;
 use config::{
     COMPACT_OLD_DATA_STREAM_SET,
     cluster::LOCAL_NODE,
@@ -204,6 +206,15 @@ pub async fn run_generate_downsampling_job() -> Result<(), anyhow::Error> {
         let stream_type = StreamType::Metrics;
         let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
         for stream_name in streams {
+            let schema = infra::schema::get(&org_id, &stream_name, stream_type)
+                .await
+                .unwrap_or_else(|_| datafusion::arrow::datatypes::Schema::empty());
+            if schema.field_with_name(NATIVE_HISTOGRAM_LABEL).is_ok() {
+                log::info!(
+                    "[DOWNSAMPLING] skipping native histogram stream [{org_id}/{stream_type}/{stream_name}]"
+                );
+                continue;
+            }
             let Some(node_name) =
                 get_node_from_consistent_hash(&stream_name, &Role::Compactor, None).await
             else {

--- a/src/core/src/service/ingestion/mod.rs
+++ b/src/core/src/service/ingestion/mod.rs
@@ -614,7 +614,8 @@ pub fn refactor_map(
     let mut has_elements = false;
     non_schema_map.write_all(b"{").unwrap();
     for (key, value) in original_map {
-        if defined_schema_keys.contains(&key) {
+        if defined_schema_keys.contains(&key) || key == config::meta::promql::NATIVE_HISTOGRAM_LABEL
+        {
             new_map.insert(key, value);
         } else {
             if has_elements {

--- a/src/core/src/service/metrics/json.rs
+++ b/src/core/src/service/metrics/json.rs
@@ -26,7 +26,10 @@ use config::{
     TIMESTAMP_COL_NAME,
     meta::{
         alerts::alert::Alert,
-        promql::{HASH_LABEL, METADATA_LABEL, Metadata, NAME_LABEL, TYPE_LABEL, VALUE_LABEL},
+        promql::{
+            HASH_LABEL, METADATA_LABEL, Metadata, NAME_LABEL, NATIVE_HISTOGRAM_LABEL, TYPE_LABEL,
+            VALUE_LABEL,
+        },
         self_reporting::usage::UsageType,
         stream::{StreamParams, StreamPartition, StreamType},
     },
@@ -146,6 +149,11 @@ pub async fn ingest(
         let mut record = flatten::flatten(record)?;
         // check data type
         let record = record.as_object_mut().unwrap();
+        if record.contains_key(NATIVE_HISTOGRAM_LABEL) {
+            return Err(anyhow!(
+                "{NATIVE_HISTOGRAM_LABEL} is reserved for native histogram storage"
+            ));
+        }
         let stream_name = match stream_name {
             Some(name) => name.to_string(),
             None => match record.get(NAME_LABEL).ok_or(anyhow!("missing __name__"))? {
@@ -330,6 +338,8 @@ pub async fn ingest(
                                 _ => unreachable!(),
                             };
 
+                            super::strip_reserved_pipeline_field(&mut local_val, "METRICS:JSON");
+
                             if let Some(Some(fields)) =
                                 user_defined_schema_map.get(&destination_stream)
                             {
@@ -354,6 +364,8 @@ pub async fn ingest(
                     json::Value::Object(val) => val,
                     _ => unreachable!(),
                 };
+
+                super::strip_reserved_pipeline_field(&mut local_val, "METRICS:JSON");
 
                 if let Some(Some(fields)) = user_defined_schema_map.get(stream_name) {
                     local_val = crate::service::ingestion::refactor_map(local_val, fields);
@@ -385,6 +397,11 @@ pub async fn ingest(
         let partition_time_level = get_partition_time_level(StreamType::Metrics);
 
         for (mut record, metric_type) in json_data {
+            if record.contains_key(NATIVE_HISTOGRAM_LABEL) {
+                return Err(anyhow!(
+                    "{NATIVE_HISTOGRAM_LABEL} is reserved for native histogram storage"
+                ));
+            }
             // Start get stream alerts
             if !stream_alerts_map.contains_key(&stream_name) {
                 crate::service::ingestion::get_stream_alerts(

--- a/src/core/src/service/metrics/mod.rs
+++ b/src/core/src/service/metrics/mod.rs
@@ -14,7 +14,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use config::{
-    meta::promql::{EXEMPLARS_LABEL, HASH_LABEL, METADATA_LABEL, Metadata, VALUE_LABEL},
+    meta::promql::{
+        EXEMPLARS_LABEL, HASH_LABEL, METADATA_LABEL, Metadata, NATIVE_HISTOGRAM_LABEL, VALUE_LABEL,
+    },
     utils::hash::{Sum64, gxhash},
 };
 use datafusion::arrow::datatypes::Schema;
@@ -24,7 +26,56 @@ pub mod otlp;
 mod otlp_json_compat;
 pub mod prom;
 
-const EXCLUDE_LABELS: [&str; 8] = [
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OtlpExpHistogramMode {
+    Legacy,
+    Dual,
+    Native,
+}
+
+fn otlp_exp_histogram_mode() -> OtlpExpHistogramMode {
+    match config::get_config()
+        .prom
+        .otlp_exp_histograms
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "dual" => OtlpExpHistogramMode::Dual,
+        "native" => OtlpExpHistogramMode::Native,
+        value if value != "legacy" => {
+            log::warn!("invalid ZO_METRICS_OTLP_EXP_HISTOGRAMS={value:?}; falling back to legacy");
+            OtlpExpHistogramMode::Legacy
+        }
+        _ => OtlpExpHistogramMode::Legacy,
+    }
+}
+
+fn accept_prom_native_histograms() -> bool {
+    match config::get_config()
+        .prom
+        .native_histograms
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "accept" => true,
+        value if value != "drop" => {
+            log::warn!("invalid ZO_METRICS_PROM_NATIVE_HISTOGRAMS={value:?}; falling back to drop");
+            false
+        }
+        _ => false,
+    }
+}
+
+fn strip_reserved_pipeline_field(
+    record: &mut config::utils::json::Map<String, config::utils::json::Value>,
+    source: &str,
+) {
+    if record.remove(NATIVE_HISTOGRAM_LABEL).is_some() {
+        log::warn!("[{source}] stripped reserved pipeline output field {NATIVE_HISTOGRAM_LABEL}");
+    }
+}
+
+const EXCLUDE_LABELS: [&str; 9] = [
     VALUE_LABEL,
     HASH_LABEL,
     EXEMPLARS_LABEL,
@@ -33,6 +84,7 @@ const EXCLUDE_LABELS: [&str; 8] = [
     "span_id",
     "_timestamp",
     "_all",
+    NATIVE_HISTOGRAM_LABEL,
 ];
 
 /// The value policy for every metric we ingest, on every path.

--- a/src/core/src/service/metrics/otlp.rs
+++ b/src/core/src/service/metrics/otlp.rs
@@ -30,7 +30,13 @@ use config::{
     meta::{
         alerts::alert,
         otlp::OtlpRequestType,
-        promql::*,
+        promql::{
+            histogram::{
+                CounterResetHint, HistogramError, HistogramSpan, NativeHistogram,
+                NativeHistogramCounts, STALE_NAN, STALE_NAN_BITS,
+            },
+            *,
+        },
         self_reporting::usage::UsageType,
         stream::{StreamParams, StreamPartition, StreamType},
     },
@@ -48,6 +54,7 @@ use opentelemetry_proto::tonic::{
     collector::metrics::v1::{
         ExportMetricsPartialSuccess, ExportMetricsServiceRequest, ExportMetricsServiceResponse,
     },
+    common::v1::KeyValue,
     metrics::v1::{metric::Data, *},
 };
 use prost::Message;
@@ -180,6 +187,7 @@ pub async fn handle_otlp_request(
 
     // records buffer
     let mut json_data_by_stream: HashMap<String, Vec<_>> = HashMap::new();
+    let mut native_json_data_by_stream: HashMap<String, Vec<_>> = HashMap::new();
 
     for resource_metric in &request.resource_metrics {
         if resource_metric.scope_metrics.is_empty() {
@@ -192,7 +200,7 @@ pub async fn handle_otlp_request(
                 let mut rec = json::json!({});
                 if let Some(res) = &resource_metric.resource {
                     for item in &res.attributes {
-                        rec[format_label_name(item.key.as_str())] = get_val(&item.value.as_ref());
+                        insert_otlp_attribute(&mut rec, item);
                     }
                 }
                 if let Some(lib) = &scope_metric.scope {
@@ -360,6 +368,18 @@ pub async fn handle_otlp_request(
                         .await;
                     }
 
+                    if rec.get(NATIVE_HISTOGRAM_LABEL).is_some() {
+                        let local_val = match rec.take() {
+                            json::Value::Object(value) => value,
+                            _ => unreachable!(),
+                        };
+                        native_json_data_by_stream
+                            .entry(local_metric_name)
+                            .or_default()
+                            .push(local_val);
+                        continue;
+                    }
+
                     // get stream pipeline -- for the stream this record actually lands in, which
                     // is not always the metric's own name: a histogram's rows all carry a
                     // `_count` / `_sum` / `_bucket` name and none carry the base. Registering the
@@ -468,6 +488,7 @@ pub async fn handle_otlp_request(
                                 json::Value::Object(v) => v,
                                 _ => unreachable!(),
                             };
+                            super::strip_reserved_pipeline_field(&mut local_val, "METRICS:OTLP");
 
                             if let Some(Some(fields)) =
                                 user_defined_schema_map.get(&destination_stream)
@@ -504,6 +525,13 @@ pub async fn handle_otlp_request(
                     .push(local_val);
             }
         }
+    }
+
+    for (stream_name, records) in native_json_data_by_stream {
+        json_data_by_stream
+            .entry(stream_name)
+            .or_default()
+            .extend(records);
     }
 
     for (local_metric_name, json_data) in json_data_by_stream {
@@ -801,15 +829,32 @@ fn process_exponential_histogram(
         METADATA_LABEL.to_string(),
         json::to_string(&metadata).unwrap(),
     );
+    let mode = super::otlp_exp_histogram_mode();
     let mut records = vec![];
     process_aggregation_temporality(rec, hist.aggregation_temporality);
     for data_point in &hist.data_points {
-        let mut dp_rec = rec.clone();
-        for mut bucket_rec in process_exp_hist_data_point(&mut dp_rec, data_point) {
-            let val_map = bucket_rec.as_object_mut().unwrap();
-            let hash = super::signature_without_labels(val_map, &get_exclude_labels());
-            val_map.insert(HASH_LABEL.to_string(), json::Value::Number(hash.into()));
-            records.push(bucket_rec);
+        if mode != super::OtlpExpHistogramMode::Native {
+            let mut dp_rec = rec.clone();
+            for mut bucket_rec in process_exp_hist_data_point(&mut dp_rec, data_point) {
+                let val_map = bucket_rec.as_object_mut().unwrap();
+                let hash = super::signature_without_labels(val_map, &get_exclude_labels());
+                val_map.insert(HASH_LABEL.to_string(), json::Value::Number(hash.into()));
+                records.push(bucket_rec);
+            }
+        }
+        if mode != super::OtlpExpHistogramMode::Legacy {
+            match process_native_exp_hist_data_point(rec, data_point, hist.aggregation_temporality)
+            {
+                Ok(mut native_rec) => {
+                    let val_map = native_rec.as_object_mut().unwrap();
+                    let hash = super::signature_without_labels(val_map, &get_exclude_labels());
+                    val_map.insert(HASH_LABEL.to_string(), json::Value::Number(hash.into()));
+                    records.push(native_rec);
+                }
+                Err(err) => {
+                    log::warn!("[METRICS:OTLP] rejected native histogram data point: {err}");
+                }
+            }
         }
     }
     records
@@ -841,6 +886,15 @@ fn process_summary(
     records
 }
 
+fn insert_otlp_attribute(rec: &mut json::Value, attribute: &KeyValue) {
+    let name = format_label_name(attribute.key.as_str());
+    if name == NATIVE_HISTOGRAM_LABEL {
+        log::warn!("[METRICS:OTLP] stripped reserved metric attribute {NATIVE_HISTOGRAM_LABEL}");
+        return;
+    }
+    rec[name] = get_val(&attribute.value.as_ref());
+}
+
 /// Returns false if this data point has no usable value and must not be recorded.
 ///
 /// The caller owns the drop, not this function: it mutates a record in place and cannot
@@ -850,7 +904,7 @@ fn process_summary(
 #[must_use]
 fn process_data_point(rec: &mut json::Value, data_point: &NumberDataPoint) -> bool {
     for attr in &data_point.attributes {
-        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
+        insert_otlp_attribute(rec, attr);
     }
     let Some(value) = get_metric_val(&data_point.value).and_then(super::metric_value) else {
         return false;
@@ -875,7 +929,7 @@ fn process_hist_data_point(
     let mut bucket_recs = vec![];
 
     for attr in &data_point.attributes {
-        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
+        insert_otlp_attribute(rec, attr);
     }
     rec[TIMESTAMP_COL_NAME] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
@@ -940,7 +994,7 @@ fn process_exp_hist_data_point(
     let mut bucket_recs = vec![];
 
     for attr in &data_point.attributes {
-        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
+        insert_otlp_attribute(rec, attr);
     }
     rec[TIMESTAMP_COL_NAME] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
@@ -996,6 +1050,170 @@ fn process_exp_hist_data_point(
     bucket_recs
 }
 
+fn process_native_exp_hist_data_point(
+    rec: &json::Value,
+    data_point: &ExponentialHistogramDataPoint,
+    aggregation_temporality: i32,
+) -> Result<json::Value, HistogramError> {
+    let mut native_rec = rec.clone();
+    if let Some(object) = native_rec.as_object_mut() {
+        object.remove("aggregation_temporality");
+    }
+    for attr in &data_point.attributes {
+        insert_otlp_attribute(&mut native_rec, attr);
+    }
+    native_rec[TIMESTAMP_COL_NAME] = (data_point.time_unix_nano / 1000).into();
+    process_exemplars(&mut native_rec, &data_point.exemplars);
+
+    let native = native_histogram_from_otlp(data_point, aggregation_temporality)?;
+    let payload = native.to_payload()?;
+    let limits = &config::get_config().limit;
+    native.validate_limits(
+        payload.len(),
+        limits.metrics_nh_max_payload_bytes,
+        limits.metrics_nh_max_buckets,
+        limits.metrics_nh_max_spans,
+    )?;
+    native_rec[NATIVE_HISTOGRAM_LABEL] = payload.into();
+    Ok(native_rec)
+}
+
+fn native_histogram_from_otlp(
+    data_point: &ExponentialHistogramDataPoint,
+    aggregation_temporality: i32,
+) -> Result<NativeHistogram, HistogramError> {
+    let mut schema = data_point.scale;
+    if schema < config::meta::promql::histogram::EXPONENTIAL_SCHEMA_MIN {
+        return Err(HistogramError::UnsupportedSchema(schema));
+    }
+    let scale_down = if schema > config::meta::promql::histogram::EXPONENTIAL_SCHEMA_MAX {
+        let scale_down = schema - config::meta::promql::histogram::EXPONENTIAL_SCHEMA_MAX;
+        schema = config::meta::promql::histogram::EXPONENTIAL_SCHEMA_MAX;
+        scale_down
+    } else {
+        0
+    };
+
+    let (positive_spans, positive_buckets) = data_point
+        .positive
+        .as_ref()
+        .map(|buckets| {
+            convert_otlp_buckets_layout(&buckets.bucket_counts, buckets.offset, scale_down)
+        })
+        .unwrap_or_default();
+    let (negative_spans, negative_buckets) = data_point
+        .negative
+        .as_ref()
+        .map(|buckets| {
+            convert_otlp_buckets_layout(&buckets.bucket_counts, buckets.offset, scale_down)
+        })
+        .unwrap_or_default();
+
+    let is_stale = data_point.flags & 1 != 0;
+    let temporality = AggregationTemporality::try_from(aggregation_temporality)
+        .unwrap_or(AggregationTemporality::Unspecified);
+    let native = NativeHistogram {
+        schema,
+        zero_threshold: data_point.zero_threshold,
+        sum: if is_stale {
+            STALE_NAN
+        } else {
+            data_point.sum.unwrap_or(0.0)
+        },
+        start_time: (data_point.start_time_unix_nano / 1000) as i64,
+        positive_spans,
+        negative_spans,
+        counter_reset_hint: if temporality == AggregationTemporality::Delta {
+            CounterResetHint::Gauge
+        } else {
+            CounterResetHint::Unknown
+        },
+        counts: NativeHistogramCounts::Integer {
+            zero_count: data_point.zero_count,
+            count: if is_stale {
+                STALE_NAN_BITS
+            } else {
+                data_point.count
+            },
+            positive_buckets,
+            negative_buckets,
+        },
+    };
+    native.validate()?;
+    Ok(native)
+}
+
+/// Convert OTLP dense exponential buckets into Prometheus sparse spans and
+/// delta counts. OTLP index `i` maps to Prometheus index `i + 1`.
+fn convert_otlp_buckets_layout(
+    bucket_counts: &[u64],
+    offset: i32,
+    scale_down: i32,
+) -> (Vec<HistogramSpan>, Vec<i64>) {
+    if bucket_counts.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+
+    let mut spans = vec![HistogramSpan {
+        offset: (offset >> scale_down) + 1,
+        length: 0,
+    }];
+    let mut deltas = Vec::new();
+    let mut count = 0_i64;
+    let mut previous_count = 0_i64;
+    let mut bucket_index = (offset >> scale_down) + 1;
+
+    let append_delta = |count: i64,
+                        spans: &mut Vec<HistogramSpan>,
+                        deltas: &mut Vec<i64>,
+                        previous_count: &mut i64| {
+        spans.last_mut().expect("initial span exists").length += 1;
+        deltas.push(count - *previous_count);
+        *previous_count = count;
+    };
+
+    for (position, bucket_count) in bucket_counts.iter().enumerate() {
+        let next_bucket_index = ((position as i32 + offset) >> scale_down) + 1;
+        if bucket_index == next_bucket_index {
+            count += *bucket_count as i64;
+            continue;
+        }
+        if count == 0 {
+            count = *bucket_count as i64;
+            continue;
+        }
+        let gap = next_bucket_index - bucket_index - 1;
+        if gap > 2 {
+            spans.push(HistogramSpan {
+                offset: gap,
+                length: 0,
+            });
+        } else {
+            for _ in 0..gap {
+                append_delta(0, &mut spans, &mut deltas, &mut previous_count);
+            }
+        }
+        append_delta(count, &mut spans, &mut deltas, &mut previous_count);
+        count = *bucket_count as i64;
+        bucket_index = next_bucket_index;
+    }
+
+    let final_index = (((bucket_counts.len() as i32) + offset - 1) >> scale_down) + 1;
+    let gap = final_index - bucket_index;
+    if gap > 2 {
+        spans.push(HistogramSpan {
+            offset: gap,
+            length: 0,
+        });
+    } else {
+        for _ in 0..gap {
+            append_delta(0, &mut spans, &mut deltas, &mut previous_count);
+        }
+    }
+    append_delta(count, &mut spans, &mut deltas, &mut previous_count);
+    (spans, deltas)
+}
+
 fn process_summary_data_point(
     rec: &mut json::Value,
     data_point: &SummaryDataPoint,
@@ -1003,7 +1221,7 @@ fn process_summary_data_point(
     let mut bucket_recs = vec![];
 
     for attr in &data_point.attributes {
-        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
+        insert_otlp_attribute(rec, attr);
     }
     rec[TIMESTAMP_COL_NAME] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
@@ -1234,7 +1452,7 @@ mod tests {
                     zero_threshold: 0.0,
                     positive: Some(opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
                         offset: 0,
-                        bucket_counts: vec![50, 30, 20],
+                        bucket_counts: vec![40, 30, 20],
                     }),
                     negative: Some(opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
                         offset: 0,
@@ -1244,6 +1462,46 @@ mod tests {
                 aggregation_temporality: AggregationTemporality::Cumulative as i32,
             })),
         }
+    }
+
+    #[test]
+    fn test_otlp_native_histogram_conversion() {
+        let metric = create_test_exponential_histogram_metric("test_exp_histogram");
+        let Data::ExponentialHistogram(histogram) = metric.data.unwrap() else {
+            panic!("exponential histogram expected")
+        };
+        let native = native_histogram_from_otlp(
+            &histogram.data_points[0],
+            histogram.aggregation_temporality,
+        )
+        .unwrap();
+        let decoded = native.to_float().unwrap();
+        assert_eq!(decoded.schema, 0);
+        assert_eq!(decoded.count, 100.0);
+        assert_eq!(decoded.zero_count, 10.0);
+        assert_eq!(decoded.positive_buckets, vec![40.0, 30.0, 20.0]);
+        assert_eq!(decoded.start_time, 0);
+    }
+
+    #[test]
+    fn test_otlp_bucket_downscale_coalesces_counts() {
+        let (spans, deltas) = convert_otlp_buckets_layout(&[1, 2, 3, 4], 0, 1);
+        let native = NativeHistogram {
+            schema: 7,
+            zero_threshold: 0.0,
+            sum: 10.0,
+            start_time: 0,
+            positive_spans: spans,
+            negative_spans: vec![],
+            counter_reset_hint: CounterResetHint::Unknown,
+            counts: NativeHistogramCounts::Integer {
+                zero_count: 0,
+                count: 10,
+                positive_buckets: deltas,
+                negative_buckets: vec![],
+            },
+        };
+        assert_eq!(native.to_float().unwrap().positive_buckets, vec![3.0, 7.0]);
     }
 
     fn create_test_summary_metric(name: &str) -> Metric {

--- a/src/core/src/service/metrics/prom.rs
+++ b/src/core/src/service/metrics/prom.rs
@@ -26,7 +26,13 @@ use config::{
     get_config,
     meta::{
         alerts::alert,
-        promql::*,
+        promql::{
+            histogram::{
+                CounterResetHint, HistogramError, HistogramSpan, NativeHistogram,
+                NativeHistogramCounts,
+            },
+            *,
+        },
         search::default_use_cache,
         self_reporting::usage::UsageType,
         stream::{StreamParams, StreamPartition, StreamStats, StreamType},
@@ -45,7 +51,10 @@ use infra::{
     errors::{Error, Result},
     schema::{SchemaCache, get_partition_time_level},
 };
-use promql_parser::{label::MatchOp, parser};
+use promql_parser::{
+    label::{MatchOp, Matcher},
+    parser,
+};
 use prost::Message;
 use proto::prometheus_rpc;
 
@@ -79,6 +88,7 @@ pub async fn remote_write(
     let started_at = Utc::now().timestamp_micros();
 
     let cfg = get_config();
+    let accept_native_histograms = super::accept_prom_native_histograms();
     let dedup_enabled = cfg.common.metrics_dedup_enabled;
     let election_interval = cfg.limit.metrics_leader_election_interval * 1000000;
     let mut last_received: i64 = 0;
@@ -112,6 +122,11 @@ pub async fn remote_write(
 
     // records buffer
     let mut json_data_by_stream: HashMap<String, Vec<_>> = HashMap::new();
+    // Native histograms bypass executable pipelines and are merged only after
+    // the scalar pipeline fallback has run. Merging earlier can make the
+    // fallback's `contains_key` guard drop scalar samples for the same stream.
+    let mut native_json_data_by_stream: HashMap<String, Vec<_>> = HashMap::new();
+    let mut native_metadata_streams = HashSet::new();
 
     // parse metadata
     for item in request.metadata {
@@ -286,7 +301,17 @@ pub async fn remote_write(
                     true
                 }
             })
-            .map(|label| (format_label_name(&label.name), label.value))
+            .filter_map(|label| {
+                let name = format_label_name(&label.name);
+                if name == NATIVE_HISTOGRAM_LABEL {
+                    log::warn!(
+                        "[remote_write] stripped reserved metric label {NATIVE_HISTOGRAM_LABEL}"
+                    );
+                    None
+                } else {
+                    Some((name, label.value))
+                }
+            })
             .collect();
 
         let metric_name = match labels.get(NAME_LABEL) {
@@ -296,6 +321,68 @@ pub async fn remote_write(
 
         // Note: All configurations (pipeline, UDS, schema, partition, alerts) are now pre-loaded
         // before the loop to avoid repeated async queries
+
+        let has_records =
+            !event.samples.is_empty() || (accept_native_histograms && !event.histograms.is_empty());
+        if !has_records {
+            continue;
+        }
+
+        // Run HA election for the first scalar or histogram record. Keeping it
+        // outside the scalar loop is required for histogram-only requests.
+        if first_line && dedup_enabled && !cluster_name.is_empty() {
+            let lock = METRIC_CLUSTER_LEADER.read().await;
+            match lock.get(&cluster_name) {
+                Some(leader) => {
+                    last_received = leader.last_received;
+                    has_entry = true;
+                }
+                None => {
+                    has_entry = false;
+                }
+            }
+            drop(lock);
+            accept_record = if !replica_label.is_empty() {
+                prom_ha_handler(
+                    has_entry,
+                    &cluster_name,
+                    &replica_label,
+                    last_received,
+                    election_interval,
+                )
+                .await
+            } else {
+                true
+            };
+            has_entry = true;
+            first_line = false;
+        } else {
+            accept_record = true;
+        }
+        if !accept_record {
+            let time = start.elapsed().as_secs_f64();
+            metrics::HTTP_RESPONSE_TIME
+                .with_label_values(&[
+                    "/prometheus/api/v1/write",
+                    "200",
+                    org_id,
+                    StreamType::Metrics.as_str(),
+                    "",
+                    "",
+                ])
+                .observe(time);
+            metrics::HTTP_INCOMING_REQUESTS
+                .with_label_values(&[
+                    "/prometheus/api/v1/write",
+                    "200",
+                    org_id,
+                    StreamType::Metrics.as_str(),
+                    "",
+                    "",
+                ])
+                .inc();
+            return Ok(());
+        }
 
         // parse samples
         let sample_start = std::time::Instant::now();
@@ -310,61 +397,6 @@ pub async fn remote_write(
                 labels: &labels,
                 value: sample_val,
             };
-
-            if first_line && dedup_enabled && !cluster_name.is_empty() {
-                let lock = METRIC_CLUSTER_LEADER.read().await;
-                match lock.get(&cluster_name) {
-                    Some(leader) => {
-                        last_received = leader.last_received;
-                        has_entry = true;
-                    }
-                    None => {
-                        has_entry = false;
-                    }
-                }
-                drop(lock);
-                accept_record = if !replica_label.is_empty() {
-                    prom_ha_handler(
-                        has_entry,
-                        &cluster_name,
-                        &replica_label,
-                        last_received,
-                        election_interval,
-                    )
-                    .await
-                } else {
-                    true
-                };
-                has_entry = true;
-                first_line = false;
-            } else {
-                accept_record = true
-            }
-            if !accept_record {
-                // do not accept any entries for request
-                let time = start.elapsed().as_secs_f64();
-                metrics::HTTP_RESPONSE_TIME
-                    .with_label_values(&[
-                        "/prometheus/api/v1/write",
-                        "200",
-                        org_id,
-                        StreamType::Metrics.as_str(),
-                        "",
-                        "",
-                    ])
-                    .observe(time);
-                metrics::HTTP_INCOMING_REQUESTS
-                    .with_label_values(&[
-                        "/prometheus/api/v1/write",
-                        "200",
-                        org_id,
-                        StreamType::Metrics.as_str(),
-                        "",
-                        "",
-                    ])
-                    .inc();
-                return Ok(());
-            }
 
             let mut value: json::Value = json::to_value(&metric).unwrap();
             let timestamp = parse_i64_to_timestamp_micros(sample.timestamp);
@@ -399,6 +431,84 @@ pub async fn remote_write(
                     .entry(metric_name.clone())
                     .or_default()
                     .push((local_val, timestamp));
+            }
+        }
+
+        if accept_native_histograms {
+            for histogram in event.histograms {
+                let native = match native_histogram_from_prometheus(&histogram) {
+                    Ok(native) => native,
+                    Err(err) => {
+                        log::warn!(
+                            "[remote_write] rejected native histogram for {metric_name}: {err}"
+                        );
+                        continue;
+                    }
+                };
+                let payload = match native.to_payload() {
+                    Ok(payload) => payload,
+                    Err(err) => {
+                        log::warn!(
+                            "[remote_write] failed to encode native histogram for {metric_name}: {err}"
+                        );
+                        continue;
+                    }
+                };
+                let limit = &cfg.limit;
+                if let Err(err) = native.validate_limits(
+                    payload.len(),
+                    limit.metrics_nh_max_payload_bytes,
+                    limit.metrics_nh_max_buckets,
+                    limit.metrics_nh_max_spans,
+                ) {
+                    log::warn!("[remote_write] rejected native histogram for {metric_name}: {err}");
+                    continue;
+                }
+
+                if native_metadata_streams.insert(metric_name.clone()) {
+                    let schema = infra::schema::get(org_id, &metric_name, StreamType::Metrics)
+                        .await
+                        .unwrap_or_else(|_| Schema::empty());
+                    if !schema.metadata().contains_key(METADATA_LABEL) {
+                        let metadata = Metadata {
+                            metric_family_name: metric_name.clone(),
+                            metric_type: MetricType::ExponentialHistogram,
+                            help: String::new(),
+                            unit: String::new(),
+                        };
+                        let mut extra_metadata = HashMap::new();
+                        extra_metadata.insert(
+                            METADATA_LABEL.to_string(),
+                            json::to_string(&metadata).unwrap(),
+                        );
+                        if let Err(err) = db::schema::update_setting(
+                            org_id,
+                            &metric_name,
+                            StreamType::Metrics,
+                            extra_metadata,
+                        )
+                        .await
+                        {
+                            log::warn!(
+                                "failed to store native histogram metadata for {metric_name}: {err}"
+                            );
+                        }
+                    }
+                }
+
+                let mut value = json::Map::new();
+                for (name, value_str) in &labels {
+                    value.insert(name.clone(), json::Value::String(value_str.clone()));
+                }
+                value.insert(
+                    NATIVE_HISTOGRAM_LABEL.to_string(),
+                    json::Value::String(payload),
+                );
+                let timestamp = parse_i64_to_timestamp_micros(histogram.timestamp);
+                native_json_data_by_stream
+                    .entry(metric_name.clone())
+                    .or_default()
+                    .push((value, timestamp));
             }
         }
         sample_processing_time += sample_start.elapsed().as_micros();
@@ -479,6 +589,10 @@ pub async fn remote_write(
                                 json::Value::Object(v) => v,
                                 _ => unreachable!(),
                             };
+                            super::strip_reserved_pipeline_field(
+                                &mut local_val,
+                                "METRICS:REMOTE_WRITE",
+                            );
 
                             if let Some(Some(fields)) =
                                 user_defined_schema_map.get(&destination_stream)
@@ -517,6 +631,13 @@ pub async fn remote_write(
         }
     }
 
+    for (stream_name, records) in native_json_data_by_stream {
+        json_data_by_stream
+            .entry(stream_name)
+            .or_default()
+            .extend(records);
+    }
+
     let step_start = std::time::Instant::now();
     for (stream_name, json_data) in json_data_by_stream {
         // get partition keys
@@ -527,7 +648,11 @@ pub async fn remote_write(
         let partition_time_level = get_partition_time_level(StreamType::Metrics);
 
         for (mut val_map, timestamp) in json_data {
-            let hash = super::signature_without_labels(&val_map, &[VALUE_LABEL]);
+            let hash = if val_map.contains_key(NATIVE_HISTOGRAM_LABEL) {
+                super::signature_without_labels(&val_map, &[VALUE_LABEL, NATIVE_HISTOGRAM_LABEL])
+            } else {
+                super::signature_without_labels(&val_map, &[VALUE_LABEL])
+            };
             val_map.insert(HASH_LABEL.to_string(), json::Value::Number(hash.into()));
             val_map.insert(
                 TIMESTAMP_COL_NAME.to_string(),
@@ -836,6 +961,20 @@ fn get_metadata_object(schema: &Schema) -> Option<MetadataObject> {
     super::get_prom_metadata_from_schema(schema).map(Into::into)
 }
 
+/// Internal storage columns are absent from the Prometheus label set. Return how a matcher on
+/// the native histogram column evaluates against that absent label.
+fn internal_label_matcher_result(matcher: &Matcher) -> Option<bool> {
+    if matcher.name != NATIVE_HISTOGRAM_LABEL {
+        return None;
+    }
+    Some(match &matcher.op {
+        MatchOp::Equal => matcher.value.is_empty(),
+        MatchOp::NotEqual => !matcher.value.is_empty(),
+        MatchOp::Re(regex) => regex.is_match(""),
+        MatchOp::NotRe(regex) => !regex.is_match(""),
+    })
+}
+
 pub async fn get_series(
     org_id: &str,
     selector: Option<parser::VectorSelector>,
@@ -860,7 +999,12 @@ pub async fn get_series(
         .fields()
         .iter()
         .map(|f| f.name().as_str())
-        .filter(|&s| s != TIMESTAMP_COL_NAME && s != VALUE_LABEL && s != HASH_LABEL)
+        .filter(|&s| {
+            s != TIMESTAMP_COL_NAME
+                && s != VALUE_LABEL
+                && s != HASH_LABEL
+                && s != NATIVE_HISTOGRAM_LABEL
+        })
         .collect::<Vec<_>>()
         .join("\", \"");
     if label_names.is_empty() {
@@ -871,6 +1015,12 @@ pub async fn get_series(
     let mut sql_where = Vec::new();
     if let Some(selector) = selector {
         for mat in selector.matchers.matchers.iter() {
+            if let Some(matches_absent) = internal_label_matcher_result(mat) {
+                if !matches_absent {
+                    sql_where.push("1 = 0".to_string());
+                }
+                continue;
+            }
             if mat.name == TIMESTAMP_COL_NAME
                 || mat.name == VALUE_LABEL
                 || schema.field_with_name(&mat.name).is_err()
@@ -947,6 +1097,7 @@ pub async fn get_labels(
         Err(_) => return Ok(vec![]),
         Ok(schemas) => schemas,
     };
+    let exclude_labels = super::get_exclude_labels();
     let mut label_names = hashbrown::HashSet::new();
     for schema in stream_schemas {
         if let Some(ref metric_name) = opt_metric_name
@@ -963,7 +1114,7 @@ pub async fn get_labels(
                 .fields()
                 .iter()
                 .map(|f| f.name())
-                .filter(|&s| s != TIMESTAMP_COL_NAME && s != VALUE_LABEL && s != HASH_LABEL)
+                .filter(|&name| !exclude_labels.contains(&name.as_str()))
                 .cloned();
             label_names.extend(field_names);
         }
@@ -1003,14 +1154,13 @@ fn family_stats(
         return stats::get_stream_stats(org_id, stream_name, stream_type);
     }
 
+    // Merge base + family-member liveness. During a dual-write cutover the historical `_count`
+    // stream can be idle while the base native stream is current; preferring the first non-empty
+    // sibling would hide the metric from discovery after cutover.
     let base = stats::get_stream_stats(org_id, stream_name, stream_type);
-    for member in [format!("{stream_name}_count"), format!("{stream_name}_sum")] {
-        let stats = stats::get_stream_stats(org_id, &member, stream_type);
-        if stats.doc_num > 0 {
-            return stats;
-        }
-    }
-    base
+    let count = stats::get_stream_stats(org_id, &format!("{stream_name}_count"), stream_type);
+    let sum = stats::get_stream_stats(org_id, &format!("{stream_name}_sum"), stream_type);
+    &(&base + &count) + &sum
 }
 
 pub async fn get_label_values(
@@ -1020,6 +1170,9 @@ pub async fn get_label_values(
     start: i64,
     end: i64,
 ) -> Result<Vec<String>> {
+    if label_name != NAME_LABEL && super::get_exclude_labels().contains(&label_name.as_str()) {
+        return Ok(Vec::new());
+    }
     let opt_metric_name = selector.as_ref().and_then(try_into_metric_name);
     let stream_type = StreamType::Metrics;
 
@@ -1079,6 +1232,12 @@ pub async fn get_label_values(
 
     if let Some(selector) = selector {
         for mat in selector.matchers.matchers.iter() {
+            if let Some(matches_absent) = internal_label_matcher_result(mat) {
+                if !matches_absent {
+                    sql_where.push("1 = 0".to_string());
+                }
+                continue;
+            }
             // Skip special fields and fields that don't exist in the schema
             if mat.name == TIMESTAMP_COL_NAME
                 || mat.name == VALUE_LABEL
@@ -1164,6 +1323,60 @@ pub fn try_into_metric_name(selector: &parser::VectorSelector) -> Option<String>
     }
 }
 
+fn native_histogram_from_prometheus(
+    histogram: &prometheus_rpc::Histogram,
+) -> std::result::Result<NativeHistogram, HistogramError> {
+    use prometheus_rpc::histogram::{Count, ResetHint, ZeroCount};
+
+    let counts = match (&histogram.count, &histogram.zero_count) {
+        (Some(Count::CountInt(count)), Some(ZeroCount::ZeroCountInt(zero_count))) => {
+            NativeHistogramCounts::Integer {
+                zero_count: *zero_count,
+                count: *count,
+                positive_buckets: histogram.positive_deltas.clone(),
+                negative_buckets: histogram.negative_deltas.clone(),
+            }
+        }
+        (Some(Count::CountFloat(count)), Some(ZeroCount::ZeroCountFloat(zero_count))) => {
+            NativeHistogramCounts::Float {
+                zero_count: *zero_count,
+                count: *count,
+                positive_buckets: histogram.positive_counts.clone(),
+                negative_buckets: histogram.negative_counts.clone(),
+            }
+        }
+        _ => return Err(HistogramError::CountVariantMismatch),
+    };
+
+    let spans = |spans: &[prometheus_rpc::BucketSpan]| {
+        spans
+            .iter()
+            .map(|span| HistogramSpan {
+                offset: span.offset,
+                length: span.length,
+            })
+            .collect::<Vec<_>>()
+    };
+    let reset_hint = match ResetHint::try_from(histogram.reset_hint).unwrap_or(ResetHint::Unknown) {
+        ResetHint::Unknown => CounterResetHint::Unknown,
+        ResetHint::Yes => CounterResetHint::CounterReset,
+        ResetHint::No => CounterResetHint::NotCounterReset,
+        ResetHint::Gauge => CounterResetHint::Gauge,
+    };
+    let native = NativeHistogram {
+        schema: histogram.schema,
+        zero_threshold: histogram.zero_threshold,
+        sum: histogram.sum,
+        start_time: 0,
+        positive_spans: spans(&histogram.positive_spans),
+        negative_spans: spans(&histogram.negative_spans),
+        counter_reset_hint: reset_hint,
+        counts,
+    };
+    native.validate()?;
+    Ok(native)
+}
+
 async fn prom_ha_handler(
     has_entry: bool,
     cluster_name: &str,
@@ -1241,8 +1454,37 @@ mod tests {
         label::{MatchOp, Matcher, Matchers},
         parser::VectorSelector,
     };
+    use proto::prometheus_rpc::{BucketSpan, Histogram, histogram};
 
     use super::*;
+
+    #[test]
+    fn test_remote_write_native_histogram_conversion() {
+        let histogram = Histogram {
+            count: Some(histogram::Count::CountInt(7)),
+            zero_count: Some(histogram::ZeroCount::ZeroCountInt(1)),
+            sum: 8.0,
+            schema: 0,
+            zero_threshold: 0.001,
+            positive_spans: vec![BucketSpan {
+                offset: 0,
+                length: 2,
+            }],
+            positive_deltas: vec![2, 2],
+            reset_hint: histogram::ResetHint::No as i32,
+            timestamp: 1_000,
+            ..Default::default()
+        };
+        let native = native_histogram_from_prometheus(&histogram).unwrap();
+        let decoded = native.to_float().unwrap();
+        assert_eq!(decoded.count, 7.0);
+        assert_eq!(decoded.positive_buckets, vec![2.0, 4.0]);
+        assert_eq!(
+            decoded.counter_reset_hint,
+            CounterResetHint::NotCounterReset
+        );
+        assert!(native.to_payload().unwrap().starts_with('{'));
+    }
 
     fn schema_with_metadata(blob: &str) -> Schema {
         Schema::empty().with_metadata(
@@ -1326,6 +1568,23 @@ mod tests {
         );
 
         assert_eq!(stats.doc_num, 100);
+    }
+
+    #[test]
+    fn test_family_stats_merges_legacy_and_native_cutover_ranges() {
+        let org = "test_family_stats_native_cutover";
+        seed_stats(org, "http_request_duration_seconds_count", 100, 5_000);
+        seed_stats(org, "http_request_duration_seconds", 50, 50_000);
+
+        let stats = family_stats(
+            org,
+            "http_request_duration_seconds",
+            Some(&family_metadata(MetricType::ExponentialHistogram)),
+            StreamType::Metrics,
+        );
+
+        assert_eq!(stats.doc_num, 150);
+        assert!(stats.time_range_intersects(40_000, 60_000));
     }
 
     /// A summary's quantile rows keep the base metric name -- they are not renamed the way

--- a/src/core/src/service/promql/search/cache/mod.rs
+++ b/src/core/src/service/promql/search/cache/mod.rs
@@ -184,6 +184,23 @@ pub async fn get(
             series.samples.drain(last_i..);
         }
 
+        let value_n = series.histogram_samples.len();
+        let mut first_i = 0;
+        while first_i < value_n && series.histogram_samples[first_i].time < start {
+            first_i += 1;
+        }
+        if first_i > 0 {
+            series.histogram_samples.drain(0..first_i);
+        }
+        let value_n = series.histogram_samples.len();
+        let mut last_i = value_n;
+        while last_i > 0 && series.histogram_samples[last_i - 1].time > end {
+            last_i -= 1;
+        }
+        if last_i < value_n {
+            series.histogram_samples.drain(last_i..);
+        }
+
         // filter the exemplars, remove the exemplars over time range
         if let Some(exemplars) = series.exemplars.as_mut() {
             let value_n = exemplars.exemplars.len();
@@ -205,11 +222,21 @@ pub async fn get(
         }
 
         // update the new start
-        let ns = if let Some(exemplars) = series.exemplars.as_ref() {
-            exemplars.exemplars.last().map(|v| v.time).unwrap_or(0)
-        } else {
-            series.samples.last().map(|v| v.time).unwrap_or(0)
-        };
+        let ns = series
+            .samples
+            .last()
+            .map(|v| v.time)
+            .into_iter()
+            .chain(series.histogram_samples.last().map(|v| v.time))
+            .chain(
+                series
+                    .exemplars
+                    .as_ref()
+                    .and_then(|values| values.exemplars.last())
+                    .map(|v| v.time),
+            )
+            .max()
+            .unwrap_or(0);
         if ns > new_start {
             new_start = ns;
         }
@@ -300,6 +327,13 @@ pub async fn set(
                 series.samples.drain(last_i + 1..);
             }
 
+            if let Some(histograms) = series.histogram_samples.as_mut() {
+                histograms.retain(|sample| sample.timestamp < max_ts);
+                if !histograms.is_empty() {
+                    empty_data = false;
+                }
+            }
+
             // check exemplars
             if let Some(exemplars) = series.exemplars.as_mut() {
                 empty_data = false;
@@ -339,6 +373,16 @@ pub async fn set(
     let mut resp = proto::cluster_rpc::MetricsQueryResponse::default();
     super::grpc::add_value(&mut resp, Value::Matrix(range_values));
     let bytes_data = resp.encode_to_vec();
+    let cluster_admission_limit = cfg.grpc.max_message_size * 1024 * 1024 / 2;
+    let cache_admission_limit = cfg.disk_cache.result_max_size.min(cluster_admission_limit);
+    if bytes_data.len() > cache_admission_limit {
+        log::warn!(
+            "[trace_id {trace_id}] promql->search->cache: skip {} byte entry above result cache admission limit {}",
+            bytes_data.len(),
+            cache_admission_limit
+        );
+        return Ok(());
+    }
 
     // store the series to disk cache
     let cache_key = get_cache_item_key(&key, org, start, new_end);
@@ -548,6 +592,7 @@ mod tests {
         let mut range_values = vec![RangeValue {
             labels: Labels::new(),
             samples: vec![],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }];
@@ -605,6 +650,7 @@ mod tests {
                     timestamp: start,
                     value: i as f64,
                 }],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             }];
@@ -708,6 +754,7 @@ mod tests {
                 timestamp: start,
                 value: 42.0,
             }],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }];

--- a/src/core/src/service/promql/search/grpc/mod.rs
+++ b/src/core/src/service/promql/search/grpc/mod.rs
@@ -32,6 +32,7 @@ use datafusion::{arrow::datatypes::Schema, error::DataFusionError, prelude::Sess
 use hashbrown::HashSet;
 use infra::errors::Result;
 use promql_parser::{label::Matchers, parser};
+use prost::Message;
 use proto::cluster_rpc;
 use rayon::slice::ParallelSliceMut;
 use tokio::sync::mpsc;
@@ -202,8 +203,22 @@ pub async fn search(
         scan_stats.add(&stats);
     }
     resp.scan_stats = Some(cluster_rpc::ScanStats::from(&scan_stats));
+    ensure_grpc_response_size(&resp)?;
 
     Ok(resp)
+}
+
+fn ensure_grpc_response_size(resp: &cluster_rpc::MetricsQueryResponse) -> Result<()> {
+    let encoded = resp.encoded_len();
+    // Keep half of the transport maximum for protobuf framing, labels, scan stats, and version
+    // skew. This is the same admission budget used by the result cache.
+    let limit = config::get_config().grpc.max_message_size * 1024 * 1024 / 2;
+    if encoded > limit {
+        return Err(infra::errors::Error::Message(format!(
+            "PromQL gRPC response is {encoded} bytes, exceeding ZO_GRPC_MAX_MESSAGE_SIZE ({limit} bytes); reduce the query range or step"
+        )));
+    }
+    Ok(())
 }
 
 #[tracing::instrument(name = "promql:search:grpc:data", skip_all, fields(org_id = req.org_id))]
@@ -240,6 +255,12 @@ pub async fn data(
 
                     add_value(&mut resp, value);
                     resp.scan_stats = Some(cluster_rpc::ScanStats::from(&stats));
+                    if let Err(err) = ensure_grpc_response_size(&resp) {
+                        let _ = tx
+                            .send(Err(tonic::Status::resource_exhausted(err.to_string())))
+                            .await;
+                        continue;
+                    }
                     if let Err(e) = tx.send(Ok(resp)).await {
                         log::error!(
                             "[trace_id {data_trace_id}] promql->data->grpc: group[{start}, {end}] data streaming error: {e}",
@@ -491,39 +512,66 @@ pub(crate) fn add_value(resp: &mut cluster_rpc::MetricsQueryResponse, value: val
     match value {
         value::Value::None => {}
         value::Value::Instant(v) => {
-            resp.series.push(cluster_rpc::Series {
+            let mut series = cluster_rpc::Series {
                 metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
-                sample: Some((&v.sample).into()),
                 ..Default::default()
-            });
+            };
+            match &v.sample {
+                value::InstantPoint::Float(sample) => series.sample = Some(sample.into()),
+                value::InstantPoint::PromFloat(sample) => {
+                    series.sample = Some(sample.into());
+                    series.native_histogram_provenance = true;
+                }
+                value::InstantPoint::Histogram(sample) => {
+                    series.histogram_sample = encode_histogram_sample(sample);
+                    series.native_histogram_provenance = true;
+                }
+            }
+            resp.series.push(series);
         }
         value::Value::Range(v) => {
             resp.series.push(cluster_rpc::Series {
                 metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
                 samples: v.samples.iter().map(|x| x.into()).collect(),
+                histogram_samples: encode_histogram_samples(v.histogram_samples.as_deref()),
+                native_histogram_provenance: v.histogram_samples.is_some(),
                 ..Default::default()
             });
         }
         value::Value::Vector(v) => {
             v.iter().for_each(|v| {
-                resp.series.push(cluster_rpc::Series {
+                let mut series = cluster_rpc::Series {
                     metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
-                    sample: Some((&v.sample).into()),
                     ..Default::default()
-                });
+                };
+                match &v.sample {
+                    value::InstantPoint::Float(sample) => series.sample = Some(sample.into()),
+                    value::InstantPoint::PromFloat(sample) => {
+                        series.sample = Some(sample.into());
+                        series.native_histogram_provenance = true;
+                    }
+                    value::InstantPoint::Histogram(sample) => {
+                        series.histogram_sample = encode_histogram_sample(sample);
+                        series.native_histogram_provenance = true;
+                    }
+                }
+                resp.series.push(series);
             });
         }
         value::Value::Matrix(v) => {
             v.iter().for_each(|v| {
                 let samples = v.samples.iter().map(|x| x.into()).collect::<Vec<_>>();
+                let histogram_samples = encode_histogram_samples(v.histogram_samples.as_deref());
                 let exemplars = v.exemplars.as_ref().map(|v| {
                     let exemplars = v.iter().map(|x| x.as_ref().into()).collect::<Vec<_>>();
                     cluster_rpc::Exemplars { exemplars }
                 });
-                if !samples.is_empty() || exemplars.is_some() {
+                if !samples.is_empty() || !histogram_samples.is_empty() || exemplars.is_some() {
                     resp.series.push(cluster_rpc::Series {
                         metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
                         samples,
+                        histogram_samples,
+                        native_histogram_provenance: v.histogram_samples.is_some(),
                         exemplars,
                         ..Default::default()
                     });
@@ -549,6 +597,28 @@ pub(crate) fn add_value(resp: &mut cluster_rpc::MetricsQueryResponse, value: val
             });
         }
     }
+}
+
+fn encode_histogram_sample(
+    sample: &config::meta::promql::histogram::HistogramSample,
+) -> Option<cluster_rpc::NativeHistogramSample> {
+    match sample.try_into() {
+        Ok(sample) => Some(sample),
+        Err(err) => {
+            log::warn!("dropping invalid native histogram from cluster response: {err}");
+            None
+        }
+    }
+}
+
+fn encode_histogram_samples(
+    samples: Option<&[config::meta::promql::histogram::HistogramSample]>,
+) -> Vec<cluster_rpc::NativeHistogramSample> {
+    samples
+        .unwrap_or_default()
+        .iter()
+        .filter_map(encode_histogram_sample)
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/core/src/service/promql/search/grpc/storage.rs
+++ b/src/core/src/service/promql/search/grpc/storage.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use config::{
     TIMESTAMP_COL_NAME, get_config,
     meta::{
-        promql::VALUE_LABEL,
+        promql::{NATIVE_HISTOGRAM_LABEL, VALUE_LABEL},
         search::{Session as SearchSession, StorageType},
         stream::{FileKey, PartitionTimeLevel, StreamParams, StreamPartition, StreamType},
     },
@@ -309,6 +309,7 @@ fn convert_matchers_to_index_condition(
     for mat in matchers.matchers.iter() {
         if mat.name == TIMESTAMP_COL_NAME
             || mat.name == VALUE_LABEL
+            || mat.name == NATIVE_HISTOGRAM_LABEL
             || !index_fields.contains(&mat.name)
             || schema.field_with_name(&mat.name).is_err()
         {

--- a/src/core/src/service/promql/search/mod.rs
+++ b/src/core/src/service/promql/search/mod.rs
@@ -23,7 +23,7 @@ use config::{
     get_config,
     meta::{
         cluster::{Node, RoleGroup},
-        promql::value::*,
+        promql::{histogram::HistogramSample, value::*},
         search::ScanStats,
         self_reporting::usage::{RequestStats, UsageType},
         stream::StreamType,
@@ -557,6 +557,8 @@ async fn search_in_cluster(
 
 async fn merge_matrix_query(series: &[cluster_rpc::Series], org_id: &str) -> Result<Value> {
     let mut merged_data = HashMap::new();
+    let mut merged_histograms = HashMap::new();
+    let mut native_provenance = hashbrown::HashSet::new();
     let mut merged_metrics = HashMap::new();
     for ser in series {
         let labels: Labels = ser
@@ -570,7 +572,17 @@ async fn merge_matrix_query(series: &[cluster_rpc::Series], org_id: &str) -> Res
         ser.samples.iter().for_each(|v| {
             entry.insert(v.time, v.value);
         });
-        merged_metrics.insert(signature(&labels), labels);
+        let signature = signature(&labels);
+        if ser.native_histogram_provenance {
+            native_provenance.insert(signature);
+        }
+        let histogram_entry = merged_histograms
+            .entry(signature)
+            .or_insert_with(HashMap::new);
+        ser.histogram_samples.iter().for_each(|sample| {
+            histogram_entry.insert(sample.time, HistogramSample::from(sample));
+        });
+        merged_metrics.insert(signature, labels);
     }
     let mut merged_data = merged_data
         .into_iter()
@@ -583,7 +595,18 @@ async fn merge_matrix_query(series: &[cluster_rpc::Series], org_id: &str) -> Res
                 })
                 .collect::<Vec<_>>();
             samples.sort_by_key(|k| k.timestamp);
-            RangeValue::new(merged_metrics.get(&sig).unwrap().to_owned(), samples)
+            let mut range = RangeValue::new(merged_metrics.get(&sig).unwrap().to_owned(), samples);
+            if let Some(histograms) = merged_histograms.remove(&sig) {
+                let mut histograms = histograms.into_values().collect::<Vec<_>>();
+                histograms.sort_by_key(|sample| sample.timestamp);
+                if !histograms.is_empty() {
+                    range.histogram_samples = Some(histograms);
+                }
+            }
+            if native_provenance.contains(&sig) && range.histogram_samples.is_none() {
+                range.histogram_samples = Some(Vec::new());
+            }
+            range
         })
         .collect::<Vec<_>>();
 
@@ -599,7 +622,7 @@ async fn merge_matrix_query(series: &[cluster_rpc::Series], org_id: &str) -> Res
 }
 
 async fn merge_vector_query(series: &[cluster_rpc::Series], org_id: &str) -> Result<Value> {
-    let mut merged_data = HashMap::new();
+    let mut merged_data: HashMap<u64, InstantPoint> = HashMap::new();
     let mut merged_metrics: HashMap<u64, Vec<Arc<Label>>> = HashMap::new();
     for ser in series {
         let labels: Labels = ser
@@ -609,7 +632,20 @@ async fn merge_vector_query(series: &[cluster_rpc::Series], org_id: &str) -> Res
             .collect();
         if let Some(sample) = ser.sample.as_ref() {
             let sample: Sample = sample.into();
-            merged_data.insert(signature(&labels), sample);
+            merged_data.insert(
+                signature(&labels),
+                if ser.native_histogram_provenance {
+                    InstantPoint::PromFloat(sample)
+                } else {
+                    InstantPoint::Float(sample)
+                },
+            );
+            merged_metrics.insert(signature(&labels), labels);
+        } else if let Some(sample) = ser.histogram_sample.as_ref() {
+            merged_data.insert(
+                signature(&labels),
+                InstantPoint::Histogram(HistogramSample::from(sample)),
+            );
             merged_metrics.insert(signature(&labels), labels);
         }
     }

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -13,6 +13,7 @@ enterprise = ["dep:o2_enterprise"]
 ahash.workspace = true
 async-recursion.workspace = true
 async-trait.workspace = true
+bytes.workspace = true
 chrono.workspace = true
 config.workspace = true
 datafusion.workspace = true

--- a/src/promql/src/aggregations/avg.rs
+++ b/src/promql/src/aggregations/avg.rs
@@ -30,7 +30,19 @@ pub fn avg(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -
         eval_ctx.trace_id,
     );
 
-    let result = super::eval_aggregate(param, data, Avg, eval_ctx);
+    let has_histograms = data.get_ref_matrix_values().is_some_and(|matrix| {
+        matrix.iter().any(|series| {
+            series
+                .histogram_samples
+                .as_ref()
+                .is_some_and(|samples| !samples.is_empty())
+        })
+    });
+    let result = if has_histograms {
+        super::eval_aggregate_with_histograms(param, data, Avg, true, eval_ctx)
+    } else {
+        super::eval_aggregate(param, data, Avg, eval_ctx)
+    };
     log::info!(
         "[trace_id: {}] [PromQL Timing] avg() execution took: {:?}",
         eval_ctx.trace_id,
@@ -155,18 +167,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 10.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 20.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 30.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/aggregations/bottomk.rs
+++ b/src/promql/src/aggregations/bottomk.rs
@@ -111,18 +111,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 15.3)], // Highest value
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 8.2)], // Lowest value
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels3.clone(),
                 samples: vec![Sample::new(timestamp, 12.1)], // Middle value
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
@@ -180,6 +183,7 @@ mod tests {
         let data = Value::Matrix(vec![RangeValue {
             labels: labels.clone(),
             samples: vec![Sample::new(timestamp, 10.5)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }]);

--- a/src/promql/src/aggregations/count.rs
+++ b/src/promql/src/aggregations/count.rs
@@ -136,18 +136,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 10.5)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 15.3)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 8.2)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/aggregations/count_values.rs
+++ b/src/promql/src/aggregations/count_values.rs
@@ -217,6 +217,7 @@ pub fn count_values(
         .map(|(labels, samples)| RangeValue {
             labels,
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         })
@@ -274,18 +275,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 10.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 10.0)], // Same value
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 20.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
@@ -330,6 +334,7 @@ mod tests {
         let data = Value::Matrix(vec![RangeValue {
             labels: labels.clone(),
             samples: vec![Sample::new(timestamp, 10.5)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }]);
@@ -387,6 +392,7 @@ mod tests {
                     Sample::new(timestamp2, 20.0),
                     Sample::new(timestamp3, 10.0),
                 ],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
@@ -397,6 +403,7 @@ mod tests {
                     Sample::new(timestamp2, 10.0),
                     Sample::new(timestamp3, 30.0),
                 ],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/aggregations/group.rs
+++ b/src/promql/src/aggregations/group.rs
@@ -135,18 +135,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 10.5)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 15.3)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 8.2)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/aggregations/max.rs
+++ b/src/promql/src/aggregations/max.rs
@@ -144,18 +144,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 10.5)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 15.3)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 8.2)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/aggregations/min.rs
+++ b/src/promql/src/aggregations/min.rs
@@ -142,18 +142,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 10.5)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 15.3)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 8.2)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/aggregations/mod.rs
+++ b/src/promql/src/aggregations/mod.rs
@@ -18,6 +18,7 @@ use std::{collections::HashMap, hash::Hasher, sync::Arc};
 use config::{
     meta::promql::{
         NAME_LABEL,
+        histogram::{CounterResetHint, HistogramSample, LazyHistogram, O2FloatHistogram},
         value::{EvalContext, Label, Labels, RangeValue, Sample, Value},
     },
     utils::hash::gxhash,
@@ -290,6 +291,9 @@ where
         .map(|(_, series_indices)| {
             // Get the labels for this group (from the first series in the group)
             let labels = projected_labels(param, &matrix[series_indices[0]].labels);
+            let native_provenance = series_indices
+                .iter()
+                .any(|&index| matrix[index].histogram_samples.is_some());
 
             let accumulate_chunk = |chunk: &[usize]| {
                 let mut acc = func.build();
@@ -331,6 +335,7 @@ where
             RangeValue {
                 labels,
                 samples,
+                histogram_samples: native_provenance.then(Vec::new),
                 exemplars: None,
                 time_window: None,
             }
@@ -352,6 +357,297 @@ where
         start4.elapsed()
     );
 
+    Ok(Value::Matrix(results))
+}
+
+#[derive(Default)]
+struct HistogramAggregationState {
+    histograms: HashMap<i64, O2FloatHistogram>,
+    parents: HashMap<i64, Arc<LazyHistogram>>,
+    compensations: HashMap<i64, O2FloatHistogram>,
+    counts: HashMap<i64, usize>,
+    timestamps: std::collections::HashSet<i64>,
+    incremental_mean_timestamps: std::collections::HashSet<i64>,
+    counter_reset_timestamps: std::collections::HashSet<i64>,
+    not_counter_reset_timestamps: std::collections::HashSet<i64>,
+}
+
+impl HistogramAggregationState {
+    fn accumulate(&mut self, sample: &HistogramSample, average: bool) -> Result<()> {
+        let timestamp = sample.timestamp;
+        self.timestamps.insert(timestamp);
+        let histogram = sample
+            .histogram
+            .float()
+            .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+        match histogram.counter_reset_hint {
+            CounterResetHint::CounterReset => {
+                self.counter_reset_timestamps.insert(timestamp);
+            }
+            CounterResetHint::NotCounterReset => {
+                self.not_counter_reset_timestamps.insert(timestamp);
+            }
+            _ => {}
+        }
+        if let Some(sum) = self.histograms.get_mut(&timestamp) {
+            let current_count = self.counts[&timestamp];
+            let next_count = current_count + 1;
+            let compensation = self
+                .compensations
+                .get_mut(&timestamp)
+                .expect("compensation initialized with histogram sum");
+            if average && self.incremental_mean_timestamps.contains(&timestamp) {
+                let mut delta = histogram.clone();
+                delta
+                    .sub_assign(sum)
+                    .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+                delta.scale(1.0 / next_count as f64);
+                sum.add_assign(&delta)
+                    .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+            } else if average {
+                let mut candidate = sum.clone();
+                let mut candidate_compensation = compensation.clone();
+                candidate
+                    .kahan_add_assign(histogram, &mut candidate_compensation)
+                    .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+                let candidate_hint = candidate.counter_reset_hint;
+                let mut finalized = candidate.clone();
+                finalized
+                    .add_assign(&candidate_compensation)
+                    .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+                finalized.counter_reset_hint = candidate_hint;
+                if finalized.has_overflow() && !sum.has_overflow() && !histogram.has_overflow() {
+                    let hint = sum.counter_reset_hint;
+                    sum.add_assign(compensation)
+                        .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+                    sum.counter_reset_hint = hint;
+                    sum.scale(1.0 / current_count as f64);
+                    let mut delta = histogram.clone();
+                    delta
+                        .sub_assign(sum)
+                        .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+                    delta.scale(1.0 / next_count as f64);
+                    sum.add_assign(&delta)
+                        .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+                    *compensation = O2FloatHistogram::empty(sum.schema);
+                    compensation.zero_threshold = sum.zero_threshold;
+                    self.incremental_mean_timestamps.insert(timestamp);
+                } else {
+                    *sum = candidate;
+                    *compensation = candidate_compensation;
+                }
+            } else {
+                sum.kahan_add_assign(histogram, compensation)
+                    .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+            }
+        } else {
+            self.histograms.insert(timestamp, histogram.clone());
+            self.parents.insert(timestamp, sample.histogram.clone());
+            let mut compensation = O2FloatHistogram::empty(histogram.schema);
+            compensation.zero_threshold = histogram.zero_threshold;
+            self.compensations.insert(timestamp, compensation);
+        }
+        *self.counts.entry(timestamp).or_insert(0) += 1;
+        Ok(())
+    }
+
+    /// Merge a partial histogram sum. Both the partial's main histogram and
+    /// compensation histogram must be folded as separate Kahan increments;
+    /// adding the compensations together first loses residuals during
+    /// cancellation across chunk boundaries.
+    fn merge_sum(&mut self, other: Self) -> Result<()> {
+        let Self {
+            histograms,
+            parents,
+            mut compensations,
+            counts,
+            timestamps,
+            incremental_mean_timestamps: _,
+            counter_reset_timestamps,
+            not_counter_reset_timestamps,
+        } = other;
+        for (timestamp, histogram) in histograms {
+            let other_compensation = compensations
+                .remove(&timestamp)
+                .expect("partial histogram has compensation");
+            if let Some(sum) = self.histograms.get_mut(&timestamp) {
+                let compensation = self
+                    .compensations
+                    .get_mut(&timestamp)
+                    .expect("histogram sum has compensation");
+                sum.kahan_add_assign(&histogram, compensation)
+                    .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+                sum.kahan_add_assign(&other_compensation, compensation)
+                    .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+                *self.counts.entry(timestamp).or_insert(0) += counts[&timestamp];
+            } else {
+                self.histograms.insert(timestamp, histogram);
+                self.compensations.insert(timestamp, other_compensation);
+                self.counts.insert(timestamp, counts[&timestamp]);
+                self.parents.insert(timestamp, parents[&timestamp].clone());
+            }
+        }
+        self.timestamps.extend(timestamps);
+        self.counter_reset_timestamps
+            .extend(counter_reset_timestamps);
+        self.not_counter_reset_timestamps
+            .extend(not_counter_reset_timestamps);
+        Ok(())
+    }
+}
+
+pub(crate) fn eval_aggregate_with_histograms<F>(
+    param: &Option<LabelModifier>,
+    data: Value,
+    func: F,
+    average: bool,
+    eval_ctx: &EvalContext,
+) -> Result<Value>
+where
+    F: AggFunc,
+{
+    let matrix = match data {
+        Value::Matrix(matrix) => matrix,
+        Value::None => return Ok(Value::None),
+        _ => {
+            return Err(DataFusionError::Plan(format!(
+                "[{}] function only accepts vector or matrix values",
+                func.name()
+            )));
+        }
+    };
+    if matrix.is_empty() {
+        return Ok(Value::None);
+    }
+    let eval_timestamps = eval_ctx
+        .timestamps()
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+    let groups = group_series_by_labels(&matrix, param);
+    let results = groups
+        .par_iter()
+        .map(|(_, series_indices)| -> Result<RangeValue> {
+            let labels = projected_labels(param, &matrix[series_indices[0]].labels);
+            let mut float_accumulator = func.build();
+            let mut float_timestamps = std::collections::HashSet::new();
+            for &series_index in series_indices {
+                let series = &matrix[series_index];
+                for sample in &series.samples {
+                    if eval_timestamps.contains(&sample.timestamp) {
+                        float_timestamps.insert(sample.timestamp);
+                        float_accumulator.accumulate(sample);
+                    }
+                }
+            }
+
+            let accumulate_histograms = |indices: &[usize]| -> Result<HistogramAggregationState> {
+                let mut state = HistogramAggregationState::default();
+                for &series_index in indices {
+                    for sample in matrix[series_index]
+                        .histogram_samples
+                        .as_deref()
+                        .unwrap_or_default()
+                    {
+                        if eval_timestamps.contains(&sample.timestamp) {
+                            state.accumulate(sample, average)?;
+                        }
+                    }
+                }
+                Ok(state)
+            };
+            let mut histogram_state =
+                if !average && series_indices.len() >= 2 * AGG_PARALLEL_CHUNK {
+                    let partials = series_indices
+                        .par_chunks(AGG_PARALLEL_CHUNK)
+                        .map(accumulate_histograms)
+                        .collect::<Vec<_>>();
+                    let mut merged = HistogramAggregationState::default();
+                    for partial in partials {
+                        merged.merge_sum(partial?)?;
+                    }
+                    merged
+                } else {
+                    // Histogram averages deliberately remain sequential: once
+                    // overflow forces incremental-mean state, no proven merge
+                    // formula exists for independently computed partials.
+                    accumulate_histograms(series_indices)?
+                };
+            let mixed_timestamps = float_timestamps
+                .intersection(&histogram_state.timestamps)
+                .copied()
+                .collect::<std::collections::HashSet<_>>();
+            if !mixed_timestamps.is_empty() {
+                log::warn!(
+                    "[trace_id: {}] {} omitted {} mixed float/histogram aggregation points",
+                    eval_ctx.trace_id,
+                    func.name(),
+                    mixed_timestamps.len()
+                );
+            }
+            let hint_collisions = histogram_state
+                .counter_reset_timestamps
+                .intersection(&histogram_state.not_counter_reset_timestamps)
+                .count();
+            if hint_collisions != 0 {
+                log::warn!(
+                    "[trace_id: {}] {} observed CounterReset and NotCounterReset hints at {} timestamps",
+                    eval_ctx.trace_id,
+                    func.name(),
+                    hint_collisions
+                );
+            }
+            let mut samples = float_accumulator.evaluate();
+            samples.retain(|sample| !mixed_timestamps.contains(&sample.timestamp));
+            samples.sort_by_key(|sample| sample.timestamp);
+            let mut histogram_samples =
+                Vec::with_capacity(histogram_state.histograms.len());
+            for (timestamp, mut histogram) in histogram_state.histograms {
+                if mixed_timestamps.contains(&timestamp) {
+                    continue;
+                }
+                if !histogram_state
+                    .incremental_mean_timestamps
+                    .contains(&timestamp)
+                    && let Some(compensation) =
+                        histogram_state.compensations.remove(&timestamp)
+                {
+                    let reset_hint = histogram.counter_reset_hint;
+                    if let Err(err) = histogram.add_assign(&compensation) {
+                        log::warn!(
+                            "[trace_id: {}] {} omitted incompatible compensated histogram at {timestamp}: {err}",
+                            eval_ctx.trace_id,
+                            func.name()
+                        );
+                        continue;
+                    }
+                    histogram.counter_reset_hint = reset_hint;
+                }
+                if average
+                    && !histogram_state
+                        .incremental_mean_timestamps
+                        .contains(&timestamp)
+                {
+                    histogram.scale(1.0 / histogram_state.counts[&timestamp] as f64);
+                }
+                histogram_samples.push(
+                    HistogramSample::from_computed(
+                        timestamp,
+                        histogram,
+                        histogram_state.parents[&timestamp].as_ref(),
+                    )
+                    .map_err(|err| DataFusionError::ResourcesExhausted(err.to_string()))?,
+                );
+            }
+            histogram_samples.sort_by_key(|sample| sample.timestamp);
+            Ok(RangeValue {
+                labels,
+                samples,
+                histogram_samples: (!histogram_samples.is_empty()).then_some(histogram_samples),
+                exemplars: None,
+                time_window: None,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
     Ok(Value::Matrix(results))
 }
 
@@ -435,6 +731,7 @@ mod tests {
             .map(|&v| RangeValue {
                 labels: Labels::default(),
                 samples: vec![Sample::new(ts, v)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             })
@@ -567,6 +864,7 @@ mod tests {
             RangeValue {
                 labels: labels1,
                 samples: vec![Sample::new(1000, 1.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: Some(TimeWindow {
                     range: Duration::from_secs(1),
@@ -576,6 +874,7 @@ mod tests {
             RangeValue {
                 labels: labels2,
                 samples: vec![Sample::new(1000, 2.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: Some(TimeWindow {
                     range: Duration::from_secs(1),
@@ -610,6 +909,7 @@ mod tests {
             RangeValue {
                 labels: labels_a,
                 samples: vec![Sample::new(1000, 1.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: Some(TimeWindow {
                     range: Duration::from_secs(1),
@@ -619,6 +919,7 @@ mod tests {
             RangeValue {
                 labels: labels_b,
                 samples: vec![Sample::new(1000, 2.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: Some(TimeWindow {
                     range: Duration::from_secs(1),
@@ -633,5 +934,142 @@ mod tests {
         }));
         let groups = group_series_by_labels(&matrix, &modifier);
         assert_eq!(groups.len(), 1);
+    }
+
+    #[test]
+    fn test_native_histogram_sum_and_avg() {
+        use config::meta::promql::histogram::{
+            CounterResetHint, HistogramSample, HistogramSpan, O2FloatHistogram,
+        };
+
+        let sample = |count| {
+            HistogramSample::from_decoded(
+                1_000_000,
+                O2FloatHistogram {
+                    schema: 0,
+                    zero_threshold: 0.0,
+                    zero_count: 0.0,
+                    count,
+                    sum: count,
+                    positive_spans: vec![HistogramSpan {
+                        offset: 0,
+                        length: 1,
+                    }],
+                    negative_spans: vec![],
+                    positive_buckets: vec![count],
+                    negative_buckets: vec![],
+                    counter_reset_hint: CounterResetHint::Gauge,
+                    start_time: 0,
+                },
+            )
+        };
+        let input = Value::Matrix(vec![
+            RangeValue {
+                labels: vec![],
+                samples: vec![],
+                histogram_samples: Some(vec![sample(2.0)]),
+                exemplars: None,
+                time_window: None,
+            },
+            RangeValue {
+                labels: vec![],
+                samples: vec![],
+                histogram_samples: Some(vec![sample(4.0)]),
+                exemplars: None,
+                time_window: None,
+            },
+        ]);
+        let eval_ctx = EvalContext::new(1_000_000, 1_000_000, 1, "test".into());
+        let Value::Matrix(sum) = sum::sum(&None, input.clone(), &eval_ctx).unwrap() else {
+            panic!("sum matrix expected")
+        };
+        assert_eq!(
+            sum[0].histogram_samples.as_ref().unwrap()[0]
+                .histogram
+                .float()
+                .unwrap()
+                .count,
+            6.0
+        );
+        let Value::Matrix(avg) = avg::avg(&None, input, &eval_ctx).unwrap() else {
+            panic!("avg matrix expected")
+        };
+        assert_eq!(
+            avg[0].histogram_samples.as_ref().unwrap()[0]
+                .histogram
+                .float()
+                .unwrap()
+                .count,
+            3.0
+        );
+    }
+
+    fn histogram_matrix(values: &[f64]) -> Value {
+        let timestamp = 1_000_000;
+        Value::Matrix(
+            values
+                .iter()
+                .map(|&value| RangeValue {
+                    labels: Vec::new(),
+                    samples: Vec::new(),
+                    histogram_samples: Some(vec![HistogramSample::from_decoded(
+                        timestamp,
+                        O2FloatHistogram {
+                            schema: 0,
+                            zero_threshold: 0.0,
+                            zero_count: 0.0,
+                            count: value,
+                            sum: value,
+                            positive_spans: vec![config::meta::promql::histogram::HistogramSpan {
+                                offset: 0,
+                                length: 1,
+                            }],
+                            negative_spans: Vec::new(),
+                            positive_buckets: vec![value],
+                            negative_buckets: Vec::new(),
+                            counter_reset_hint: CounterResetHint::Gauge,
+                            start_time: 0,
+                        },
+                    )]),
+                    exemplars: None,
+                    time_window: None,
+                })
+                .collect(),
+        )
+    }
+
+    fn only_histogram(value: Value) -> O2FloatHistogram {
+        let Value::Matrix(matrix) = value else {
+            panic!("matrix expected")
+        };
+        matrix[0].histogram_samples.as_ref().unwrap()[0]
+            .histogram
+            .float()
+            .unwrap()
+            .clone()
+    }
+
+    #[test]
+    fn test_native_histogram_sum_crosses_parallel_merge_with_cancellation() {
+        let mut values = vec![0.0; 2 * AGG_PARALLEL_CHUNK + 1];
+        values[0] = 1e16;
+        values[AGG_PARALLEL_CHUNK + 100] = -1e16;
+        values[AGG_PARALLEL_CHUNK + 200] = 1.0;
+        let eval_ctx = EvalContext::new(1_000_000, 1_000_000, 1, "test".into());
+        let result = sum::sum(&None, histogram_matrix(&values), &eval_ctx).unwrap();
+        let histogram = only_histogram(result);
+        assert_eq!(histogram.count, 1.0);
+        assert_eq!(histogram.sum, 1.0);
+        assert_eq!(histogram.positive_buckets, vec![1.0]);
+    }
+
+    #[test]
+    fn test_native_histogram_avg_uses_incremental_mean_on_overflow() {
+        let eval_ctx = EvalContext::new(1_000_000, 1_000_000, 1, "test".into());
+        let result = avg::avg(&None, histogram_matrix(&[f64::MAX, f64::MAX]), &eval_ctx).unwrap();
+        let histogram = only_histogram(result);
+        assert_eq!(histogram.count, f64::MAX);
+        assert_eq!(histogram.sum, f64::MAX);
+        assert_eq!(histogram.positive_buckets, vec![f64::MAX]);
     }
 }

--- a/src/promql/src/aggregations/quantile.rs
+++ b/src/promql/src/aggregations/quantile.rs
@@ -45,6 +45,7 @@ pub fn quantile(qtile: f64, data: Value, eval_ctx: &EvalContext) -> Result<Value
         let range_value = RangeValue {
             labels: Default::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         };

--- a/src/promql/src/aggregations/stddev.rs
+++ b/src/promql/src/aggregations/stddev.rs
@@ -157,18 +157,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 10.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 20.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 30.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/aggregations/stdvar.rs
+++ b/src/promql/src/aggregations/stdvar.rs
@@ -157,18 +157,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 10.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 20.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 30.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/aggregations/sum.rs
+++ b/src/promql/src/aggregations/sum.rs
@@ -31,7 +31,19 @@ pub fn sum(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -
         eval_ctx.trace_id
     );
 
-    let result = super::eval_aggregate(param, data, Sum, eval_ctx);
+    let has_histograms = data.get_ref_matrix_values().is_some_and(|matrix| {
+        matrix.iter().any(|series| {
+            series
+                .histogram_samples
+                .as_ref()
+                .is_some_and(|samples| !samples.is_empty())
+        })
+    });
+    let result = if has_histograms {
+        super::eval_aggregate_with_histograms(param, data, Sum, false, eval_ctx)
+    } else {
+        super::eval_aggregate(param, data, Sum, eval_ctx)
+    };
     log::info!(
         "[trace_id: {}] [PromQL Timing] sum() execution took: {:?}",
         eval_ctx.trace_id,
@@ -158,6 +170,7 @@ mod tests {
                     Sample::new(ts2, 20.0),
                     Sample::new(ts3, 30.0),
                 ],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
@@ -168,6 +181,7 @@ mod tests {
                     Sample::new(ts2, 15.0),
                     Sample::new(ts3, 25.0),
                 ],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
@@ -178,6 +192,7 @@ mod tests {
                     Sample::new(ts2, 4.0),
                     Sample::new(ts3, 6.0),
                 ],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/aggregations/topk.rs
+++ b/src/promql/src/aggregations/topk.rs
@@ -164,6 +164,7 @@ pub(super) fn select_topk_series(
             result.push(RangeValue {
                 labels: series.labels.clone(),
                 samples: filtered_samples,
+                histogram_samples: None,
                 exemplars: series.exemplars.clone(),
                 time_window: series.time_window.clone(),
             });
@@ -205,18 +206,21 @@ mod tests {
             RangeValue {
                 labels: labels1.clone(),
                 samples: vec![Sample::new(timestamp, 10.5)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels2.clone(),
                 samples: vec![Sample::new(timestamp, 15.3)], // Highest value
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: labels3.clone(),
                 samples: vec![Sample::new(timestamp, 8.2)], // Lowest value
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
@@ -274,6 +278,7 @@ mod tests {
         let data = Value::Matrix(vec![RangeValue {
             labels: labels.clone(),
             samples: vec![Sample::new(timestamp, 10.5)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }]);
@@ -313,6 +318,7 @@ mod tests {
         let matrix = vec![RangeValue {
             labels: vec![Arc::new(Label::new("k", "v"))],
             samples: vec![Sample::new(timestamp, 1.0)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }];
@@ -329,12 +335,14 @@ mod tests {
             RangeValue {
                 labels: vec![Arc::new(Label::new("i", "1"))],
                 samples: vec![Sample::new(timestamp, 5.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },
             RangeValue {
                 labels: vec![Arc::new(Label::new("i", "2"))],
                 samples: vec![Sample::new(timestamp, 3.0)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             },

--- a/src/promql/src/binaries/vector_operations.rs
+++ b/src/promql/src/binaries/vector_operations.rs
@@ -102,6 +102,7 @@ pub async fn vector_scalar_bin_op(
                 Some(RangeValue {
                     labels,
                     samples: new_samples,
+                    histogram_samples: None,
                     exemplars: range.exemplars,
                     time_window: range.time_window,
                 })
@@ -337,6 +338,7 @@ fn vector_arithmetic_operators(
                 Some(RangeValue {
                     labels,
                     samples: new_samples,
+                    histogram_samples: None,
                     exemplars: lhs_range.exemplars,
                     time_window: lhs_range.time_window,
                 })
@@ -414,6 +416,7 @@ mod tests {
         RangeValue {
             labels,
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }

--- a/src/promql/src/engine.rs
+++ b/src/promql/src/engine.rs
@@ -16,7 +16,11 @@
 use std::{str::FromStr, sync::Arc, time::Duration};
 
 use async_recursion::async_recursion;
-use config::meta::promql::{NAME_LABEL, value::*};
+use config::meta::promql::{
+    NAME_LABEL,
+    histogram::{HistogramLoadMode, HistogramSample},
+    value::*,
+};
 use datafusion::error::{DataFusionError, Result};
 use futures::future::try_join_all;
 use hashbrown::{HashMap, HashSet};
@@ -38,6 +42,114 @@ use super::{
 };
 use crate::{aggregations, binaries, functions, micros, rewrite::remove_filter_all};
 
+fn histogram_load_mode_for_expr(expr: &PromExpr) -> HistogramLoadMode {
+    let child_requirement = |expressions: &[Box<PromExpr>]| {
+        expressions
+            .iter()
+            .map(|expr| histogram_load_mode_for_expr(expr.as_ref()))
+            .fold(HistogramLoadMode::PresenceOnly, strongest_histogram_mode)
+    };
+    match expr {
+        PromExpr::VectorSelector(_) | PromExpr::MatrixSelector(_) | PromExpr::Extension(_) => {
+            HistogramLoadMode::RawLazy
+        }
+        PromExpr::Paren(ParenExpr { expr }) => histogram_load_mode_for_expr(expr),
+        PromExpr::Subquery(expr) => histogram_load_mode_for_expr(&expr.expr),
+        PromExpr::Call(Call { func, args }) => {
+            let child = child_requirement(&args.args);
+            match func.name {
+                "rate" | "increase" | "delta" => HistogramLoadMode::DecodedOnly,
+                "histogram_avg" | "histogram_count" | "histogram_fraction"
+                | "histogram_quantile" | "histogram_sum" | "timestamp" => {
+                    if child == HistogramLoadMode::DecodedOnly {
+                        child
+                    } else {
+                        HistogramLoadMode::DecodeAfterSelection
+                    }
+                }
+                "label_join" | "label_replace" | "last_over_time" => {
+                    if matches!(
+                        child,
+                        HistogramLoadMode::DecodedOnly | HistogramLoadMode::DecodeAfterSelection
+                    ) {
+                        child
+                    } else {
+                        HistogramLoadMode::RawLazy
+                    }
+                }
+                _ if matches!(
+                    child,
+                    HistogramLoadMode::DecodedOnly | HistogramLoadMode::DecodeAfterSelection
+                ) =>
+                {
+                    child
+                }
+                _ => HistogramLoadMode::PresenceOnly,
+            }
+        }
+        PromExpr::Aggregate(AggregateExpr { op, expr, .. }) => {
+            let child = histogram_load_mode_for_expr(expr);
+            if matches!(op.id(), token::T_SUM | token::T_AVG) {
+                if child == HistogramLoadMode::DecodedOnly {
+                    child
+                } else {
+                    HistogramLoadMode::DecodeAfterSelection
+                }
+            } else if matches!(
+                child,
+                HistogramLoadMode::DecodedOnly | HistogramLoadMode::DecodeAfterSelection
+            ) {
+                child
+            } else {
+                HistogramLoadMode::PresenceOnly
+            }
+        }
+        PromExpr::Binary(BinaryExpr { lhs, rhs, .. }) => {
+            let child = strongest_histogram_mode(
+                histogram_load_mode_for_expr(lhs),
+                histogram_load_mode_for_expr(rhs),
+            );
+            if matches!(
+                child,
+                HistogramLoadMode::DecodedOnly | HistogramLoadMode::DecodeAfterSelection
+            ) {
+                child
+            } else {
+                HistogramLoadMode::PresenceOnly
+            }
+        }
+        PromExpr::Unary(UnaryExpr { expr }) => {
+            let child = histogram_load_mode_for_expr(expr);
+            if matches!(
+                child,
+                HistogramLoadMode::DecodedOnly | HistogramLoadMode::DecodeAfterSelection
+            ) {
+                child
+            } else {
+                HistogramLoadMode::PresenceOnly
+            }
+        }
+        _ => HistogramLoadMode::PresenceOnly,
+    }
+}
+
+fn strongest_histogram_mode(
+    left: HistogramLoadMode,
+    right: HistogramLoadMode,
+) -> HistogramLoadMode {
+    let rank = |mode| match mode {
+        HistogramLoadMode::PresenceOnly => 0,
+        HistogramLoadMode::RawLazy => 1,
+        HistogramLoadMode::DecodeAfterSelection => 2,
+        HistogramLoadMode::DecodedOnly => 3,
+    };
+    if rank(left) >= rank(right) {
+        left
+    } else {
+        right
+    }
+}
+
 pub struct Engine {
     trace_id: String,
     /// PromQL evaluation context
@@ -57,6 +169,7 @@ pub struct Engine {
     skip_labels: bool,
     /// The result type of the query
     result_type: Option<String>,
+    histogram_load_mode: HistogramLoadMode,
 }
 
 impl Engine {
@@ -68,6 +181,7 @@ impl Engine {
             disable_label_selector: false,
             skip_labels: false,
             result_type: None,
+            histogram_load_mode: HistogramLoadMode::RawLazy,
             trace_id: trace_id.to_string(),
         }
     }
@@ -83,6 +197,7 @@ impl Engine {
     }
 
     pub async fn exec(&mut self, prom_expr: &PromExpr) -> Result<(Value, Option<String>)> {
+        self.histogram_load_mode = histogram_load_mode_for_expr(prom_expr);
         self.extract_columns_from_prom_expr(prom_expr)?;
         if self.disable_label_selector {
             self.label_selector.clear();
@@ -205,6 +320,18 @@ impl Engine {
                 let val = self.exec_expr(expr).await?;
                 match val {
                     Value::Matrix(m) => {
+                        let native_provenance =
+                            m.iter().any(|range| range.histogram_samples.is_some());
+                        if m.iter().any(|range| {
+                            range
+                                .histogram_samples
+                                .as_ref()
+                                .is_some_and(|samples| !samples.is_empty())
+                        }) {
+                            return Err(DataFusionError::NotImplemented(
+                                "unary operations on native histograms are not supported".into(),
+                            ));
+                        }
                         let out = m
                             .into_iter()
                             .map(|mut range| RangeValue {
@@ -217,6 +344,7 @@ impl Engine {
                                         value: -s.value,
                                     })
                                     .collect(),
+                                histogram_samples: native_provenance.then(Vec::new),
                                 exemplars: range.exemplars,
                                 time_window: range.time_window,
                             })
@@ -234,6 +362,13 @@ impl Engine {
             PromExpr::Binary(expr) => {
                 let lhs = self.exec_expr(&expr.lhs).await?;
                 let rhs = self.exec_expr(&expr.rhs).await?;
+                let native_provenance =
+                    lhs.has_native_histogram_provenance() || rhs.has_native_histogram_provenance();
+                if lhs.contains_native_histograms() || rhs.contains_native_histograms() {
+                    return Err(DataFusionError::NotImplemented(
+                        "binary operations on native histograms are not supported".into(),
+                    ));
+                }
                 let token = expr.op.id();
                 let return_bool = expr.return_bool();
                 let op = expr.op.is_comparison_operator();
@@ -247,7 +382,7 @@ impl Engine {
                     }
                     _ => rhs,
                 };
-                match (lhs, rhs) {
+                let mut result = match (lhs, rhs) {
                     (Value::Float(left), Value::Float(right)) => {
                         let value = binaries::scalar_binary_operations(
                             token,
@@ -275,7 +410,11 @@ impl Engine {
                         );
                         Value::Matrix(vec![])
                     }
+                };
+                if native_provenance {
+                    result.mark_native_histogram_provenance();
                 }
+                result
             }
             PromExpr::Paren(ParenExpr { expr }) => self.exec_expr(expr).await?,
             PromExpr::Subquery(expr) => {
@@ -392,6 +531,7 @@ impl Engine {
         let mut result = Vec::with_capacity(metrics_cache.len());
         for metric in metrics_cache {
             let mut selected_samples = Vec::with_capacity(eval_timestamps.len());
+            let mut selected_histograms = Vec::with_capacity(eval_timestamps.len());
 
             for &eval_ts in &eval_timestamps {
                 // Calculate lookback window for this evaluation timestamp
@@ -416,8 +556,64 @@ impl Engine {
                     None
                 };
 
-                // Add the matched sample (already validated to be within range)
-                if let Some(sample) = match_sample {
+                let histogram_end_index = metric
+                    .histogram_samples
+                    .as_deref()
+                    .unwrap_or_default()
+                    .partition_point(|v| v.timestamp + offset_modifier <= eval_ts);
+                let match_histogram = if histogram_end_index > 0 {
+                    metric
+                        .histogram_samples
+                        .as_deref()
+                        .and_then(|samples| samples.get(histogram_end_index - 1))
+                        .filter(|sample| {
+                            let adjusted_ts = sample.timestamp + offset_modifier;
+                            adjusted_ts >= start && adjusted_ts <= eval_ts
+                        })
+                } else {
+                    None
+                };
+
+                // A series can switch between float and histogram samples. Only the
+                // most recent sample in the lookback window is visible.
+                let use_histogram = match (match_sample, match_histogram) {
+                    (None, Some(_)) => true,
+                    (Some(float), Some(histogram)) => histogram.timestamp >= float.timestamp,
+                    _ => false,
+                };
+                if use_histogram {
+                    let histogram = match_histogram.expect("histogram sample must exist");
+                    match histogram.histogram.is_stale() {
+                        Ok(false) => {
+                            let histogram = if self.histogram_load_mode
+                                == HistogramLoadMode::DecodeAfterSelection
+                            {
+                                HistogramSample::from_computed(
+                                    eval_ts,
+                                    histogram
+                                        .histogram
+                                        .float()
+                                        .map_err(|err| DataFusionError::Execution(err.to_string()))?
+                                        .clone(),
+                                    histogram.histogram.as_ref(),
+                                )
+                                .map_err(|err| {
+                                    DataFusionError::ResourcesExhausted(err.to_string())
+                                })?
+                            } else {
+                                let mut histogram = histogram.clone();
+                                histogram.timestamp = eval_ts;
+                                histogram
+                            };
+                            selected_histograms.push(histogram);
+                        }
+                        Ok(true) => {}
+                        Err(err) => log::warn!(
+                            "[trace_id: {}] dropping invalid native histogram: {err}",
+                            self.trace_id
+                        ),
+                    }
+                } else if let Some(sample) = match_sample {
                     // Use eval_ts as the timestamp for the selected sample
                     // See https://promlabs.com/blog/2020/06/18/the-anatomy-of-a-promql-query/#instant-queries
                     selected_samples.push(Sample::new(eval_ts, sample.value));
@@ -425,10 +621,12 @@ impl Engine {
             }
 
             // Only include metrics that have at least one sample
-            if !selected_samples.is_empty() {
+            if !selected_samples.is_empty() || !selected_histograms.is_empty() {
                 result.push(RangeValue {
                     labels: metric.labels,
                     samples: selected_samples,
+                    histogram_samples: (!selected_histograms.is_empty())
+                        .then_some(selected_histograms),
                     exemplars: metric.exemplars,
                     time_window: metric.time_window,
                 });
@@ -477,13 +675,29 @@ impl Engine {
         };
 
         let start = std::time::Instant::now();
+        let trace_id = self.trace_id.clone();
         let mut values = values
             .into_par_iter()
-            .map(|rv| RangeValue {
-                labels: rv.labels,
-                samples: rv.samples,
-                exemplars: rv.exemplars,
-                time_window: Some(TimeWindow::new(range)),
+            .map(|mut rv| {
+                if let Some(histograms) = &mut rv.histogram_samples {
+                    histograms.retain(|sample| match sample.histogram.is_stale() {
+                        Ok(is_stale) => !is_stale,
+                        Err(err) => {
+                            log::warn!(
+                                "[trace_id: {}] dropping invalid native histogram: {err}",
+                                trace_id
+                            );
+                            false
+                        }
+                    });
+                }
+                RangeValue {
+                    labels: rv.labels,
+                    samples: rv.samples,
+                    histogram_samples: rv.histogram_samples,
+                    exemplars: rv.exemplars,
+                    time_window: Some(TimeWindow::new(range)),
+                }
             })
             .collect::<Vec<_>>();
 
@@ -500,6 +714,11 @@ impl Engine {
                 rv.samples
                     .iter_mut()
                     .for_each(|s| s.timestamp += offset_modifier);
+                if let Some(histograms) = &mut rv.histogram_samples {
+                    histograms
+                        .iter_mut()
+                        .for_each(|sample| sample.timestamp += offset_modifier);
+                }
             });
         }
 
@@ -589,6 +808,25 @@ impl Engine {
         // check for super cluster
         let trace_id = self.ctx.query_ctx.trace_id.clone();
         #[cfg(feature = "enterprise")]
+        if self.ctx.query_ctx.is_super_cluster {
+            let schema = infra::schema::get(
+                &self.ctx.query_ctx.org_id,
+                table_name,
+                config::meta::stream::StreamType::Metrics,
+            )
+            .await
+            .map_err(|err| DataFusionError::External(Box::new(err)))?;
+            if schema
+                .field_with_name(config::meta::promql::NATIVE_HISTOGRAM_LABEL)
+                .is_ok()
+            {
+                return Err(DataFusionError::Plan(
+                    "native histogram queries are not supported across super clusters in Phase 0-3"
+                        .into(),
+                ));
+            }
+        }
+        #[cfg(feature = "enterprise")]
         let (super_tx, mut super_rx) = tokio::sync::mpsc::channel::<
             Result<(HashMap<u64, RangeValue>, config::meta::search::ScanStats)>,
         >(1);
@@ -658,6 +896,7 @@ impl Engine {
         let lookback = range.map_or(self.ctx.lookback_delta, micros);
 
         let skip_labels = self.skip_labels;
+        let histogram_load_mode = self.histogram_load_mode;
         let mut tasks = Vec::with_capacity(ctxs.len());
         let mut abort_handles = Vec::with_capacity(ctxs.len());
         for (ctx, schema, scan_stats, keep_filters) in ctxs {
@@ -681,6 +920,7 @@ impl Engine {
                         step,
                         lookback,
                         skip_labels,
+                        histogram_load_mode,
                     ),
                 )
                 .await
@@ -815,6 +1055,22 @@ impl Engine {
         modifier: &Option<LabelModifier>,
     ) -> Result<Value> {
         let input = self.exec_expr(expr).await?;
+
+        if input.contains_native_histograms()
+            && !matches!(
+                op.id(),
+                token::T_SUM | token::T_AVG | token::T_TOPK | token::T_BOTTOMK
+            )
+        {
+            return Err(DataFusionError::NotImplemented(format!(
+                "aggregation {} does not support native histogram samples",
+                op
+            )));
+        }
+        if input.contains_native_histograms() && matches!(op.id(), token::T_TOPK | token::T_BOTTOMK)
+        {
+            log::warn!("aggregation {op} omitted native histogram samples");
+        }
 
         let eval_ctx = self.eval_ctx.clone();
 
@@ -978,6 +1234,7 @@ impl Engine {
                     let default_now_matrix = vec![RangeValue {
                         labels: Labels::default(),
                         samples,
+                        histogram_samples: None,
                         exemplars: None,
                         time_window: None,
                     }];
@@ -999,6 +1256,29 @@ impl Engine {
             }
         };
 
+        if input.contains_native_histograms()
+            && !matches!(
+                func_name,
+                Func::HistogramAvg
+                    | Func::HistogramCount
+                    | Func::HistogramFraction
+                    | Func::HistogramQuantile
+                    | Func::HistogramSum
+                    | Func::Rate
+                    | Func::Increase
+                    | Func::Delta
+                    | Func::LastOverTime
+                    | Func::LabelJoin
+                    | Func::LabelReplace
+                    | Func::Timestamp
+            )
+        {
+            return Err(DataFusionError::NotImplemented(format!(
+                "{} does not support native histogram samples",
+                func.name
+            )));
+        }
+
         Ok(match func_name {
             Func::Abs => functions::abs(input)?,
             Func::Absent => functions::absent(input, &self.eval_ctx)?,
@@ -1012,6 +1292,11 @@ impl Engine {
                 self.ensure_three_args(args, err)?;
 
                 let input = self.call_expr_first_arg(args).await?;
+                if input.contains_native_histograms() {
+                    return Err(DataFusionError::NotImplemented(
+                        "clamp does not support native histogram samples".into(),
+                    ));
+                }
                 let min = self.call_expr_second_arg(args).await?;
                 let max = self.call_expr_third_arg(args).await?;
 
@@ -1033,6 +1318,11 @@ impl Engine {
                 self.ensure_two_args(args, err)?;
 
                 let input = self.call_expr_first_arg(args).await?;
+                if input.contains_native_histograms() {
+                    return Err(DataFusionError::NotImplemented(
+                        "clamp_max does not support native histogram samples".into(),
+                    ));
+                }
                 let max = self.call_expr_second_arg(args).await?;
                 let max_f = match max {
                     Value::Float(max) => max,
@@ -1047,6 +1337,11 @@ impl Engine {
                 self.ensure_two_args(args, err)?;
 
                 let input = self.call_expr_first_arg(args).await?;
+                if input.contains_native_histograms() {
+                    return Err(DataFusionError::NotImplemented(
+                        "clamp_min does not support native histogram samples".into(),
+                    ));
+                }
                 let min = self.call_expr_second_arg(args).await?;
                 let min_f = match min {
                     Value::Float(min) => min,
@@ -1065,15 +1360,19 @@ impl Engine {
             Func::Deriv => functions::deriv(input, &self.eval_ctx)?,
             Func::Exp => functions::exp(input)?,
             Func::Floor => functions::floor(input)?,
-            Func::HistogramCount => {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Unsupported Function: {func_name:?}"
-                )));
-            }
+            Func::HistogramAvg => functions::histogram_avg(input)?,
+            Func::HistogramCount => functions::histogram_count(input)?,
             Func::HistogramFraction => {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Unsupported Function: {func_name:?}"
-                )));
+                let err =
+                    "Invalid args, expected histogram_fraction(lower scalar, upper scalar, vector)";
+                self.ensure_three_args(args, err)?;
+                let lower = self.call_expr_first_arg(args).await?;
+                let upper = self.call_expr_second_arg(args).await?;
+                functions::histogram_fraction(
+                    self.parse_f64_else_err(&lower, err)?,
+                    self.parse_f64_else_err(&upper, err)?,
+                    input,
+                )?
             }
             Func::HistogramQuantile => {
                 let args = &args.args;
@@ -1099,17 +1398,18 @@ impl Engine {
                 // Use range version if we have an eval context
                 functions::histogram_quantile(phi, input, &self.eval_ctx)?
             }
-            Func::HistogramSum => {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Unsupported Function: {func_name:?}"
-                )));
-            }
+            Func::HistogramSum => functions::histogram_sum(input)?,
             Func::HoltWinters => {
                 let err =
                     "Invalid args, expected \"holt_winters(v range-vector, sf scalar, tf scalar)\"";
                 self.ensure_three_args(args, err)?;
 
                 let input = self.call_expr_first_arg(args).await?;
+                if input.contains_native_histograms() {
+                    return Err(DataFusionError::NotImplemented(
+                        "holt_winters does not support native histogram samples".into(),
+                    ));
+                }
                 let sf = self.call_expr_second_arg(args).await?;
                 let tf = self.call_expr_third_arg(args).await?;
 
@@ -1183,6 +1483,11 @@ impl Engine {
 
                 self.ensure_two_args(args, err)?;
                 let input = self.call_expr_first_arg(args).await?;
+                if input.contains_native_histograms() {
+                    return Err(DataFusionError::NotImplemented(
+                        "predict_linear does not support native histogram samples".into(),
+                    ));
+                }
 
                 let prediction_steps = self.call_expr_second_arg(args).await?.get_float().ok_or(
                     DataFusionError::NotImplemented(
@@ -1204,6 +1509,11 @@ impl Engine {
                     }
                 };
                 let input = self.call_expr_second_arg(args).await?;
+                if input.contains_native_histograms() {
+                    return Err(DataFusionError::NotImplemented(
+                        "quantile_over_time does not support native histogram samples".into(),
+                    ));
+                }
                 functions::quantile_over_time(phi_quantile, input, &self.eval_ctx)?
             }
             Func::Rate => functions::rate(input, &self.eval_ctx)?,
@@ -1344,6 +1654,7 @@ mod tests {
         RangeValue {
             labels: vec![],
             samples: vec![Sample::new(timestamp, value)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }
@@ -2044,7 +2355,7 @@ mod tests {
         let sample = Sample::new(1640995200000000i64, 42.0);
         let instant = InstantValue {
             labels: vec![Arc::new(Label::new("env", "prod"))],
-            sample,
+            sample: InstantPoint::Float(sample),
         };
         let _vector = Value::Vector(vec![instant]);
         let vector_expr = PromExpr::Extension(Extension {
@@ -2211,7 +2522,7 @@ mod tests {
         let sample = Sample::new(1640995200000000i64, 42.0);
         let _instant = InstantValue {
             labels: vec![Arc::new(Label::new("env", "prod"))],
-            sample,
+            sample: InstantPoint::Float(sample),
         };
         let vector = PromExpr::Extension(Extension {
             expr: Arc::new(TestExtension),
@@ -3019,5 +3330,21 @@ mod tests {
     fn test_get_offset_modifier_negative() {
         let result = get_offset_modifier(Some(Offset::Neg(Duration::from_secs(30))));
         assert_eq!(result, -30_000_000); // -30s in micros
+    }
+
+    #[test]
+    fn test_histogram_load_mode_classifier() {
+        let mode = |query: &str| {
+            let expr = promql_parser::parser::parse(query).unwrap();
+            histogram_load_mode_for_expr(&expr)
+        };
+        assert_eq!(mode("metric"), HistogramLoadMode::RawLazy);
+        assert_eq!(mode("abs(metric)"), HistogramLoadMode::PresenceOnly);
+        assert_eq!(mode("sum(metric)"), HistogramLoadMode::DecodeAfterSelection);
+        assert_eq!(mode("rate(metric[5m])"), HistogramLoadMode::DecodedOnly);
+        assert_eq!(
+            mode("histogram_count(rate(metric[5m]))"),
+            HistogramLoadMode::DecodedOnly
+        );
     }
 }

--- a/src/promql/src/exec.rs
+++ b/src/promql/src/exec.rs
@@ -95,13 +95,34 @@ impl PromqlContext {
             // For instant queries, convert Matrix to Vector format
             match value {
                 Value::Matrix(matrix) => {
-                    // Convert each RangeValue to InstantValue (take first sample)
+                    // Convert each RangeValue to the newest float or histogram sample.
                     let vector: Vec<InstantValue> = matrix
                         .into_iter()
                         .filter_map(|range_val| {
-                            range_val.samples.first().map(|sample| InstantValue {
-                                labels: range_val.labels.clone(),
-                                sample: *sample,
+                            let native_provenance = range_val.histogram_samples.is_some();
+                            let float = range_val.samples.iter().max_by_key(|s| s.timestamp);
+                            let histogram = range_val
+                                .histogram_samples
+                                .as_deref()
+                                .and_then(|samples| samples.iter().max_by_key(|s| s.timestamp));
+                            let sample = match (float, histogram) {
+                                (Some(float), Some(histogram))
+                                    if histogram.timestamp >= float.timestamp =>
+                                {
+                                    InstantPoint::Histogram(histogram.clone())
+                                }
+                                (Some(float), _) if native_provenance => {
+                                    InstantPoint::PromFloat(*float)
+                                }
+                                (Some(float), _) => InstantPoint::Float(*float),
+                                (None, Some(histogram)) => {
+                                    InstantPoint::Histogram(histogram.clone())
+                                }
+                                (None, None) => return None,
+                            };
+                            Some(InstantValue {
+                                labels: range_val.labels,
+                                sample,
                             })
                         })
                         .collect();
@@ -132,6 +153,7 @@ impl PromqlContext {
                     let range_value = RangeValue {
                         labels: Labels::default(),
                         samples,
+                        histogram_samples: None,
                         exemplars: None,
                         time_window: None,
                     };

--- a/src/promql/src/functions/absent.rs
+++ b/src/promql/src/functions/absent.rs
@@ -30,6 +30,7 @@ fn generate_absent_matrix(eval_ctx: &EvalContext) -> Value {
     let range_value = RangeValue {
         labels: Labels::default(),
         samples,
+        histogram_samples: None,
         exemplars: None,
         time_window: None,
     };
@@ -53,6 +54,11 @@ pub(crate) fn absent(data: Value, eval_ctx: &EvalContext) -> Result<Value> {
                 for sample in &range_value.samples {
                     timestamps_with_data.insert(sample.timestamp);
                 }
+                if let Some(histograms) = &range_value.histogram_samples {
+                    for sample in histograms {
+                        timestamps_with_data.insert(sample.timestamp);
+                    }
+                }
             }
 
             // Generate samples for timestamps that DON'T have data
@@ -74,6 +80,7 @@ pub(crate) fn absent(data: Value, eval_ctx: &EvalContext) -> Result<Value> {
             let range_value = RangeValue {
                 labels: Labels::default(),
                 samples: absent_samples,
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             };
@@ -156,6 +163,7 @@ mod tests {
                 Sample::new(1001, 43.0),
                 Sample::new(1002, 44.0),
             ],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }]);
@@ -174,6 +182,7 @@ mod tests {
                 // 1001 is missing
                 Sample::new(1002, 44.0),
             ],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         }]);

--- a/src/promql/src/functions/avg_over_time.rs
+++ b/src/promql/src/functions/avg_over_time.rs
@@ -89,6 +89,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/changes.rs
+++ b/src/promql/src/functions/changes.rs
@@ -98,6 +98,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(3),

--- a/src/promql/src/functions/clamp.rs
+++ b/src/promql/src/functions/clamp.rs
@@ -37,6 +37,7 @@ pub(crate) fn clamp(data: Value, min: f64, max: f64) -> Result<Value> {
                     RangeValue {
                         labels: std::mem::take(&mut range_value.labels).without_metric_name(),
                         samples,
+                        histogram_samples: None,
                         exemplars: range_value.exemplars,
                         time_window: range_value.time_window,
                     }
@@ -67,6 +68,7 @@ mod tests {
             .map(|val| RangeValue {
                 labels: Labels::default(),
                 samples: vec![Sample::new(eval_ts, val)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: Some(TimeWindow {
                     range: Duration::from_secs(5),

--- a/src/promql/src/functions/count_over_time.rs
+++ b/src/promql/src/functions/count_over_time.rs
@@ -88,6 +88,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/delta.rs
+++ b/src/promql/src/functions/delta.rs
@@ -23,7 +23,7 @@ use datafusion::error::Result;
 use crate::functions::RangeFunc;
 
 pub(crate) fn delta(data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    super::eval_range(data, DeltaFunc::new(), eval_ctx)
+    super::eval_rate_like(data, DeltaFunc::new(), ExtrapolationKind::Delta, eval_ctx)
 }
 
 pub struct DeltaFunc;
@@ -72,6 +72,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),
@@ -99,6 +100,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/deriv.rs
+++ b/src/promql/src/functions/deriv.rs
@@ -96,6 +96,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/histogram.rs
+++ b/src/promql/src/functions/histogram.rs
@@ -16,6 +16,7 @@
 use config::{
     meta::promql::{
         BUCKET_LABEL, HASH_LABEL, NAME_LABEL,
+        histogram::O2FloatHistogram,
         value::{EvalContext, LabelsExt, RangeValue, Sample, Value, signature_without_labels},
     },
     utils::sort::sort_float,
@@ -57,7 +58,31 @@ pub(crate) fn histogram_quantile(phi: f64, data: Value, eval_ctx: &EvalContext) 
     // Group metrics by their signature (without bucket label)
     let mut metrics_by_sig: HashMap<u64, Vec<RangeValue>> = HashMap::default();
 
-    for rv in in_matrix {
+    let mut range_values = Vec::new();
+    for mut rv in in_matrix {
+        if let Some(histograms) = rv.histogram_samples.take()
+            && !histograms.is_empty()
+        {
+            let mut samples = Vec::with_capacity(histograms.len());
+            for sample in histograms {
+                let histogram = sample
+                    .histogram
+                    .float()
+                    .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+                samples.push(Sample::new(
+                    sample.timestamp,
+                    native_histogram_quantile(phi, histogram)?,
+                ));
+            }
+            range_values.push(RangeValue {
+                labels: rv.labels.without_metric_name(),
+                samples,
+                histogram_samples: Some(Vec::new()),
+                exemplars: None,
+                time_window: None,
+            });
+            continue;
+        }
         // Verify this metric has a bucket label
         if rv.labels.get_value(BUCKET_LABEL).parse::<f64>().is_err() {
             continue;
@@ -66,8 +91,6 @@ pub(crate) fn histogram_quantile(phi: f64, data: Value, eval_ctx: &EvalContext) 
         let sig = signature_without_labels(&rv.labels, &[HASH_LABEL, NAME_LABEL, BUCKET_LABEL]);
         metrics_by_sig.entry(sig).or_default().push(rv);
     }
-
-    let mut range_values = Vec::new();
 
     for (_sig, bucket_series) in metrics_by_sig {
         // Get the labels (without bucket label) from the first series
@@ -109,6 +132,7 @@ pub(crate) fn histogram_quantile(phi: f64, data: Value, eval_ctx: &EvalContext) 
             range_values.push(RangeValue {
                 labels: base_labels,
                 samples,
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             });
@@ -116,6 +140,230 @@ pub(crate) fn histogram_quantile(phi: f64, data: Value, eval_ctx: &EvalContext) 
     }
 
     Ok(Value::Matrix(range_values))
+}
+
+pub(crate) fn histogram_count(data: Value) -> Result<Value> {
+    histogram_scalar(data, |histogram| histogram.count)
+}
+
+pub(crate) fn histogram_sum(data: Value) -> Result<Value> {
+    histogram_scalar(data, |histogram| histogram.sum)
+}
+
+pub(crate) fn histogram_avg(data: Value) -> Result<Value> {
+    histogram_scalar(data, |histogram| histogram.sum / histogram.count)
+}
+
+pub(crate) fn histogram_fraction(lower: f64, upper: f64, data: Value) -> Result<Value> {
+    let Value::Matrix(matrix) = data else {
+        return if matches!(data, Value::None) {
+            Ok(Value::None)
+        } else {
+            Err(DataFusionError::Plan(
+                "histogram_fraction: vector or matrix argument expected".into(),
+            ))
+        };
+    };
+    let mut output = Vec::new();
+    for rv in matrix {
+        let Some(histograms) = rv.histogram_samples else {
+            continue;
+        };
+        let mut samples = Vec::with_capacity(histograms.len());
+        for sample in histograms {
+            let histogram = sample
+                .histogram
+                .float()
+                .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+            samples.push(Sample::new(
+                sample.timestamp,
+                native_histogram_fraction(lower, upper, histogram)?,
+            ));
+        }
+        if !samples.is_empty() {
+            output.push(RangeValue {
+                labels: rv.labels.without_metric_name(),
+                samples,
+                histogram_samples: Some(Vec::new()),
+                exemplars: None,
+                time_window: rv.time_window,
+            });
+        }
+    }
+    Ok(Value::Matrix(output))
+}
+
+fn histogram_scalar(data: Value, value: impl Fn(&O2FloatHistogram) -> f64) -> Result<Value> {
+    let Value::Matrix(matrix) = data else {
+        return if matches!(data, Value::None) {
+            Ok(Value::None)
+        } else {
+            Err(DataFusionError::Plan(
+                "native histogram vector or matrix argument expected".into(),
+            ))
+        };
+    };
+    let mut output = Vec::new();
+    for rv in matrix {
+        let Some(histograms) = rv.histogram_samples else {
+            continue;
+        };
+        let mut samples = Vec::with_capacity(histograms.len());
+        for sample in histograms {
+            let histogram = sample
+                .histogram
+                .float()
+                .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+            samples.push(Sample::new(sample.timestamp, value(histogram)));
+        }
+        if !samples.is_empty() {
+            output.push(RangeValue {
+                labels: rv.labels.without_metric_name(),
+                samples,
+                histogram_samples: Some(Vec::new()),
+                exemplars: None,
+                time_window: rv.time_window,
+            });
+        }
+    }
+    Ok(Value::Matrix(output))
+}
+
+fn native_histogram_quantile(phi: f64, histogram: &O2FloatHistogram) -> Result<f64> {
+    if phi < 0.0 {
+        return Ok(f64::NEG_INFINITY);
+    }
+    if phi > 1.0 {
+        return Ok(f64::INFINITY);
+    }
+    if histogram.count == 0.0 || phi.is_nan() {
+        return Ok(f64::NAN);
+    }
+
+    let buckets = histogram
+        .all_buckets()
+        .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+    let reverse = !histogram.sum.is_nan() && phi >= 0.5;
+    let mut rank = if reverse {
+        (1.0 - phi) * histogram.count
+    } else {
+        phi * histogram.count
+    };
+    let mut count = 0.0;
+    let mut selected = None;
+    let iterator: Box<dyn Iterator<Item = _>> = if reverse {
+        Box::new(buckets.iter().rev().copied())
+    } else {
+        Box::new(buckets.iter().copied())
+    };
+    for bucket in iterator {
+        if bucket.count == 0.0 {
+            continue;
+        }
+        count += bucket.count;
+        selected = Some(bucket);
+        if count >= rank {
+            break;
+        }
+    }
+    let Some(mut bucket) = selected else {
+        return Ok(f64::NAN);
+    };
+    if bucket.lower < 0.0 && bucket.upper > 0.0 {
+        if histogram.negative_buckets.is_empty() && !histogram.positive_buckets.is_empty() {
+            bucket.lower = 0.0;
+        } else if histogram.positive_buckets.is_empty() && !histogram.negative_buckets.is_empty() {
+            bucket.upper = 0.0;
+        }
+    }
+    count = count.min(histogram.count);
+    if count < rank {
+        return if histogram.sum.is_nan() {
+            Ok(f64::NAN)
+        } else {
+            Ok(bucket.upper)
+        };
+    }
+    if reverse {
+        rank = count - rank;
+    } else {
+        rank -= count - bucket.count;
+    }
+    let fraction = rank / bucket.count;
+    if bucket.lower <= 0.0 && bucket.upper >= 0.0 {
+        return Ok(bucket.lower + (bucket.upper - bucket.lower) * fraction);
+    }
+    let log_lower = bucket.lower.abs().log2();
+    let log_upper = bucket.upper.abs().log2();
+    if bucket.lower > 0.0 {
+        Ok(2.0_f64.powf(log_lower + (log_upper - log_lower) * fraction))
+    } else {
+        Ok(-2.0_f64.powf(log_upper + (log_lower - log_upper) * (1.0 - fraction)))
+    }
+}
+
+fn native_histogram_fraction(lower: f64, upper: f64, histogram: &O2FloatHistogram) -> Result<f64> {
+    if histogram.count == 0.0 || lower.is_nan() || upper.is_nan() {
+        return Ok(f64::NAN);
+    }
+    if lower >= upper {
+        return Ok(0.0);
+    }
+    let buckets = histogram
+        .all_buckets()
+        .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+    let mut rank = 0.0;
+    let mut lower_rank = None;
+    let mut upper_rank = None;
+    for mut bucket in buckets {
+        let zero_bucket = bucket.lower <= 0.0 && bucket.upper >= 0.0;
+        if zero_bucket {
+            if histogram.negative_buckets.is_empty() && !histogram.positive_buckets.is_empty() {
+                bucket.lower = 0.0;
+            } else if histogram.positive_buckets.is_empty()
+                && !histogram.negative_buckets.is_empty()
+            {
+                bucket.upper = 0.0;
+            }
+        }
+        let interpolate = |bound: f64| {
+            if zero_bucket {
+                rank + bucket.count * (bound - bucket.lower) / (bucket.upper - bucket.lower)
+            } else {
+                let log_lower = bucket.lower.abs().log2();
+                let log_upper = bucket.upper.abs().log2();
+                let log_bound = bound.abs().log2();
+                let fraction = if bound > 0.0 {
+                    (log_bound - log_lower) / (log_upper - log_lower)
+                } else {
+                    1.0 - (log_bound - log_upper) / (log_lower - log_upper)
+                };
+                rank + bucket.count * fraction
+            }
+        };
+        if lower_rank.is_none() {
+            if bucket.lower >= lower {
+                lower_rank = Some(rank);
+            } else if bucket.lower < lower && bucket.upper > lower {
+                lower_rank = Some(interpolate(lower));
+            }
+        }
+        if upper_rank.is_none() {
+            if bucket.lower >= upper {
+                upper_rank = Some(rank);
+            } else if bucket.lower < upper && bucket.upper > upper {
+                upper_rank = Some(interpolate(upper));
+            }
+        }
+        if lower_rank.is_some() && upper_rank.is_some() {
+            break;
+        }
+        rank += bucket.count;
+    }
+    let count = histogram.count;
+    let lower_rank = lower_rank.unwrap_or(count).min(count);
+    let upper_rank = upper_rank.unwrap_or(count).min(count);
+    Ok((upper_rank - lower_rank) / count)
 }
 
 // cf. https://github.com/prometheus/prometheus/blob/cf1bea344a3c390a90c35ea8764c4a468b345d5e/promql/quantile.go#L76
@@ -217,9 +465,61 @@ fn ensure_monotonic(buckets: &mut [Bucket]) {
 
 #[cfg(test)]
 mod tests {
+    use config::meta::promql::histogram::{
+        CounterResetHint, HistogramSample, HistogramSpan, O2FloatHistogram,
+    };
     use expect_test::expect;
 
     use super::*;
+
+    fn native_value() -> Value {
+        let histogram = O2FloatHistogram {
+            schema: 0,
+            zero_threshold: 0.0,
+            zero_count: 0.0,
+            count: 4.0,
+            sum: 5.0,
+            positive_spans: vec![HistogramSpan {
+                offset: 0,
+                length: 2,
+            }],
+            negative_spans: vec![],
+            positive_buckets: vec![2.0, 2.0],
+            negative_buckets: vec![],
+            counter_reset_hint: CounterResetHint::Gauge,
+            start_time: 0,
+        };
+        Value::Matrix(vec![RangeValue {
+            labels: vec![],
+            samples: vec![],
+            histogram_samples: Some(vec![HistogramSample::from_decoded(1_000_000, histogram)]),
+            exemplars: None,
+            time_window: None,
+        }])
+    }
+
+    fn only_float(value: Value) -> f64 {
+        let Value::Matrix(matrix) = value else {
+            panic!("matrix expected")
+        };
+        matrix[0].samples[0].value
+    }
+
+    #[test]
+    fn test_native_histogram_functions() {
+        let eval_ctx = EvalContext::new(1_000_000, 1_000_000, 1, "test".into());
+        assert_eq!(only_float(histogram_count(native_value()).unwrap()), 4.0);
+        assert_eq!(only_float(histogram_sum(native_value()).unwrap()), 5.0);
+        assert_eq!(only_float(histogram_avg(native_value()).unwrap()), 1.25);
+        assert_eq!(
+            only_float(histogram_quantile(0.5, native_value(), &eval_ctx).unwrap()),
+            1.0
+        );
+        assert_eq!(
+            only_float(histogram_fraction(0.0, 1.0, native_value()).unwrap()),
+            0.5
+        );
+    }
 
     #[test]
     fn test_coalesce_buckets() {

--- a/src/promql/src/functions/holt_winters.rs
+++ b/src/promql/src/functions/holt_winters.rs
@@ -137,6 +137,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/idelta.rs
+++ b/src/promql/src/functions/idelta.rs
@@ -92,6 +92,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/increase.rs
+++ b/src/promql/src/functions/increase.rs
@@ -23,7 +23,12 @@ use datafusion::error::Result;
 use crate::functions::RangeFunc;
 
 pub(crate) fn increase(data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    super::eval_range(data, IncreaseFunc::new(), eval_ctx)
+    super::eval_rate_like(
+        data,
+        IncreaseFunc::new(),
+        ExtrapolationKind::Increase,
+        eval_ctx,
+    )
 }
 
 pub struct IncreaseFunc;
@@ -83,6 +88,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/irate.rs
+++ b/src/promql/src/functions/irate.rs
@@ -94,6 +94,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/label_join.rs
+++ b/src/promql/src/functions/label_join.rs
@@ -54,6 +54,7 @@ pub(crate) fn label_join(
                     RangeValue {
                         labels,
                         samples: range_value.samples,
+                        histogram_samples: range_value.histogram_samples,
                         exemplars: range_value.exemplars,
                         time_window: range_value.time_window,
                     }
@@ -99,6 +100,7 @@ mod tests {
         let range_value1 = RangeValue {
             labels: labels1,
             samples: vec![Sample::new(eval_ts, 42.0)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         };
@@ -111,6 +113,7 @@ mod tests {
         let range_value2 = RangeValue {
             labels: labels2,
             samples: vec![Sample::new(eval_ts, 43.0)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         };

--- a/src/promql/src/functions/label_replace.rs
+++ b/src/promql/src/functions/label_replace.rs
@@ -60,6 +60,7 @@ pub(crate) fn label_replace(
                     RangeValue {
                         labels,
                         samples: range_value.samples,
+                        histogram_samples: range_value.histogram_samples,
                         exemplars: range_value.exemplars,
                         time_window: range_value.time_window,
                     }
@@ -105,6 +106,7 @@ mod tests {
         let range_value = RangeValue {
             labels,
             samples: vec![Sample::new(eval_ts, 42.0)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         };
@@ -145,6 +147,7 @@ mod tests {
         let range_value = RangeValue {
             labels,
             samples: vec![Sample::new(1000, 1.0)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         };
@@ -169,6 +172,7 @@ mod tests {
         let range_value = RangeValue {
             labels,
             samples: vec![Sample::new(1000, 1.0)],
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
         };

--- a/src/promql/src/functions/last_over_time.rs
+++ b/src/promql/src/functions/last_over_time.rs
@@ -13,25 +13,111 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#[cfg(test)]
 use std::time::Duration;
 
-use config::meta::promql::value::{EvalContext, Sample, Value};
-use datafusion::error::Result;
+use config::meta::promql::value::{EvalContext, RangeValue, Sample, Value};
+use datafusion::error::{DataFusionError, Result};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
+#[cfg(test)]
 use crate::functions::RangeFunc;
+use crate::micros;
 
 pub(crate) fn last_over_time(data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    super::eval_range(data, LastOverTimeFunc::new(), eval_ctx)
+    let matrix = match data {
+        Value::Matrix(matrix) => matrix,
+        Value::None => return Ok(Value::None),
+        value => {
+            return Err(DataFusionError::Plan(format!(
+                "last_over_time: matrix argument expected but got {}",
+                value.get_type()
+            )));
+        }
+    };
+    let timestamps = eval_ctx.timestamps();
+    let results: Vec<Result<Option<RangeValue>>> = matrix
+        .into_par_iter()
+        .map(|metric| {
+            let time_window = metric.time_window.clone().ok_or_else(|| {
+                DataFusionError::Plan("last_over_time: range selector required".into())
+            })?;
+            let range_micros = micros(time_window.range);
+            let histograms = metric.histogram_samples.as_deref().unwrap_or_default();
+            let mut float_output = Vec::new();
+            let mut histogram_output = Vec::new();
+            let mut float_start = 0;
+            let mut float_end = 0;
+            let mut histogram_start = 0;
+            let mut histogram_end = 0;
+            for &eval_ts in &timestamps {
+                let window_start = eval_ts - range_micros;
+                let floats = super::advance_sample_window(
+                    &metric.samples,
+                    window_start,
+                    eval_ts,
+                    &mut float_start,
+                    &mut float_end,
+                );
+                let histograms = super::advance_histogram_window(
+                    histograms,
+                    window_start,
+                    eval_ts,
+                    &mut histogram_start,
+                    &mut histogram_end,
+                );
+                let latest_float = floats.last();
+                let latest_histogram = histograms.last();
+                if latest_histogram.is_some_and(|histogram| {
+                    latest_float.is_none_or(|float| histogram.timestamp >= float.timestamp)
+                }) {
+                    let histogram = latest_histogram.expect("latest histogram must exist");
+                    if histogram
+                        .histogram
+                        .is_stale()
+                        .map_err(|err| DataFusionError::Execution(err.to_string()))?
+                    {
+                        continue;
+                    }
+                    let mut histogram = histogram.clone();
+                    histogram.timestamp = eval_ts;
+                    histogram_output.push(histogram);
+                } else if let Some(sample) = latest_float {
+                    float_output.push(Sample::new(eval_ts, sample.value));
+                }
+            }
+            if float_output.is_empty() && histogram_output.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(RangeValue {
+                labels: metric.labels,
+                samples: float_output,
+                histogram_samples: (!histogram_output.is_empty()).then_some(histogram_output),
+                exemplars: None,
+                time_window: Some(time_window),
+            }))
+        })
+        .collect();
+    let output = results
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+    Ok(Value::Matrix(output))
 }
 
+#[cfg(test)]
 pub struct LastOverTimeFunc;
 
+#[cfg(test)]
 impl LastOverTimeFunc {
     pub fn new() -> Self {
         LastOverTimeFunc {}
     }
 }
 
+#[cfg(test)]
 impl RangeFunc for LastOverTimeFunc {
     fn name(&self) -> &'static str {
         "last_over_time"
@@ -94,6 +180,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/math_operations.rs
+++ b/src/promql/src/functions/math_operations.rs
@@ -109,6 +109,7 @@ fn exec(data: Value, op: &MathOperationsType) -> Result<Value> {
                     RangeValue {
                         labels: std::mem::take(&mut range_value.labels).without_metric_name(),
                         samples,
+                        histogram_samples: None,
                         exemplars: range_value.exemplars,
                         time_window: range_value.time_window,
                     }
@@ -139,6 +140,7 @@ mod tests {
             .map(|val| RangeValue {
                 labels: Labels::default(),
                 samples: vec![Sample::new(eval_ts, val)],
+                histogram_samples: None,
                 exemplars: None,
                 time_window: Some(TimeWindow {
                     range: Duration::from_secs(5),

--- a/src/promql/src/functions/max_over_time.rs
+++ b/src/promql/src/functions/max_over_time.rs
@@ -91,6 +91,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/min_over_time.rs
+++ b/src/promql/src/functions/min_over_time.rs
@@ -91,6 +91,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/mod.rs
+++ b/src/promql/src/functions/mod.rs
@@ -15,7 +15,10 @@
 
 use std::{collections::HashSet, sync::LazyLock as Lazy, time::Duration};
 
-use config::meta::promql::value::{EvalContext, LabelsExt, RangeValue, Sample, Value};
+use config::meta::promql::{
+    histogram::{CounterResetHint, HistogramSample, O2FloatHistogram},
+    value::{EvalContext, ExtrapolationKind, LabelsExt, RangeValue, Sample, Value},
+};
 use datafusion::error::{DataFusionError, Result};
 use rayon::prelude::*;
 use strum::EnumString;
@@ -60,7 +63,9 @@ pub(crate) use clamp::clamp;
 pub(crate) use count_over_time::count_over_time;
 pub(crate) use delta::delta;
 pub(crate) use deriv::deriv;
-pub(crate) use histogram::histogram_quantile;
+pub(crate) use histogram::{
+    histogram_avg, histogram_count, histogram_fraction, histogram_quantile, histogram_sum,
+};
 pub(crate) use holt_winters::holt_winters;
 pub(crate) use idelta::idelta;
 pub(crate) use increase::increase;
@@ -104,6 +109,7 @@ pub(crate) enum Func {
     Deriv,
     Exp,
     Floor,
+    HistogramAvg,
     HistogramCount,
     HistogramFraction,
     HistogramQuantile,
@@ -246,6 +252,7 @@ where
     let results: Vec<RangeValue> = data
         .into_par_iter()
         .flat_map(|mut metric| {
+            let native_provenance = metric.histogram_samples.is_some();
             let mut labels = std::mem::take(&mut metric.labels);
             if !KEEP_METRIC_NAME_FUNC.contains(func.name()) {
                 labels = labels.without_metric_name();
@@ -284,6 +291,7 @@ where
                 Some(RangeValue {
                     labels,
                     samples: result_samples,
+                    histogram_samples: native_provenance.then(Vec::new),
                     exemplars: None,
                     time_window: metric.time_window,
                 })
@@ -299,6 +307,208 @@ where
         results.len()
     );
     Ok(Value::Matrix(results))
+}
+
+/// Evaluate rate/increase/delta for either float or native-histogram windows.
+/// Both sample streams use monotonic cursors, keeping evaluation O(samples + steps).
+pub(crate) fn eval_rate_like<F>(
+    data: Value,
+    func: F,
+    kind: ExtrapolationKind,
+    eval_ctx: &EvalContext,
+) -> Result<Value>
+where
+    F: RangeFunc,
+{
+    let data = match data {
+        Value::Matrix(values) => values,
+        Value::None => return Ok(Value::None),
+        value => {
+            return Err(DataFusionError::Plan(format!(
+                "{}: matrix argument expected but got {}",
+                func.name(),
+                value.get_type()
+            )));
+        }
+    };
+    let timestamps = eval_ctx.timestamps();
+    let results: Vec<Result<Option<RangeValue>>> = data
+        .into_par_iter()
+        .map(|mut metric| {
+        let time_window = metric.time_window.clone().ok_or_else(|| {
+            DataFusionError::Plan(format!("{}: range selector required", func.name()))
+        })?;
+        let range = time_window.range;
+        let range_micros = micros(range);
+        let mut float_output = Vec::with_capacity(timestamps.len());
+        let mut histogram_output = Vec::with_capacity(timestamps.len());
+        let mut float_start = 0;
+        let mut float_end = 0;
+        let mut histogram_start = 0;
+        let mut histogram_end = 0;
+        let histograms = metric.histogram_samples.as_deref().unwrap_or_default();
+        for &eval_ts in &timestamps {
+            let window_start = eval_ts - range_micros;
+            let float_window = advance_sample_window(
+                &metric.samples,
+                window_start,
+                eval_ts,
+                &mut float_start,
+                &mut float_end,
+            );
+            let histogram_window = advance_histogram_window(
+                histograms,
+                window_start,
+                eval_ts,
+                &mut histogram_start,
+                &mut histogram_end,
+            );
+            if !float_window.is_empty() && !histogram_window.is_empty() {
+                log::warn!(
+                    "[trace_id: {}] {} omitted a window containing mixed float and histogram samples",
+                    eval_ctx.trace_id,
+                    func.name()
+                );
+                continue;
+            }
+            if !histogram_window.is_empty() {
+                if let Some(histogram) =
+                    extrapolated_histogram(histogram_window, eval_ts, range, kind)?
+                {
+                    histogram_output.push(
+                        HistogramSample::from_computed(
+                            eval_ts,
+                            histogram,
+                            histogram_window[0].histogram.as_ref(),
+                        )
+                        .map_err(|err| DataFusionError::ResourcesExhausted(err.to_string()))?,
+                    );
+                }
+            } else if let Some(value) = func.exec(float_window, eval_ts, &range) {
+                float_output.push(Sample::new(eval_ts, value));
+            }
+        }
+        if float_output.is_empty() && histogram_output.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(RangeValue {
+            labels: std::mem::take(&mut metric.labels).without_metric_name(),
+            samples: float_output,
+            histogram_samples: (!histogram_output.is_empty()).then_some(histogram_output),
+            exemplars: None,
+            time_window: Some(time_window),
+        }))
+    })
+    .collect();
+    let output = results
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+    Ok(Value::Matrix(output))
+}
+
+fn advance_histogram_window<'a>(
+    samples: &'a [HistogramSample],
+    window_start: i64,
+    window_end: i64,
+    start_index: &mut usize,
+    end_index: &mut usize,
+) -> &'a [HistogramSample] {
+    while *start_index < samples.len() && samples[*start_index].timestamp < window_start {
+        *start_index += 1;
+    }
+    if *end_index < *start_index {
+        *end_index = *start_index;
+    }
+    while *end_index < samples.len() && samples[*end_index].timestamp <= window_end {
+        *end_index += 1;
+    }
+    &samples[*start_index..*end_index]
+}
+
+fn extrapolated_histogram(
+    samples: &[HistogramSample],
+    eval_ts: i64,
+    range: Duration,
+    kind: ExtrapolationKind,
+) -> Result<Option<O2FloatHistogram>> {
+    if samples.len() < 2 {
+        return Ok(None);
+    }
+    let decoded = samples
+        .iter()
+        .map(|sample| {
+            sample
+                .histogram
+                .float()
+                .map_err(|err| DataFusionError::Execution(err.to_string()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if decoded.iter().any(|histogram| histogram.is_stale()) {
+        return Ok(None);
+    }
+
+    let is_counter = matches!(kind, ExtrapolationKind::Rate | ExtrapolationKind::Increase);
+    if is_counter
+        && decoded
+            .iter()
+            .any(|histogram| histogram.counter_reset_hint == CounterResetHint::Gauge)
+    {
+        log::warn!("rate/increase applied to a gauge-hint native histogram");
+    }
+    let mut result = (*decoded.last().expect("at least two histograms")).clone();
+    result
+        .sub_assign(&decoded[0])
+        .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+    if is_counter {
+        for index in 1..decoded.len() {
+            if decoded[index]
+                .detect_reset(&decoded[index - 1])
+                .map_err(|err| DataFusionError::Execution(err.to_string()))?
+            {
+                result
+                    .add_assign(&decoded[index - 1])
+                    .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+            }
+        }
+    }
+
+    let first_timestamp = samples[0].timestamp;
+    let last_timestamp = samples.last().expect("at least two samples").timestamp;
+    let sampled_interval = (last_timestamp - first_timestamp) as f64 / 1_000.0;
+    if sampled_interval <= 0.0 {
+        return Ok(None);
+    }
+    let window_start = eval_ts - micros(range);
+    let mut duration_to_start = (first_timestamp - window_start) as f64 / 1_000.0;
+    let duration_to_end = (eval_ts - last_timestamp) as f64 / 1_000.0;
+    if is_counter && result.count > 0.0 && decoded[0].count >= 0.0 {
+        duration_to_start =
+            duration_to_start.min(sampled_interval * decoded[0].count / result.count);
+    }
+    let average_interval = sampled_interval / (samples.len() - 1) as f64;
+    let threshold = average_interval * 1.1;
+    let mut extrapolated_interval = sampled_interval;
+    extrapolated_interval += if duration_to_start < threshold {
+        duration_to_start
+    } else {
+        average_interval / 2.0
+    };
+    extrapolated_interval += if duration_to_end < threshold {
+        duration_to_end
+    } else {
+        average_interval / 2.0
+    };
+    let mut factor = extrapolated_interval / sampled_interval;
+    if matches!(kind, ExtrapolationKind::Rate) {
+        factor /= range.as_secs_f64();
+    }
+    result.scale(factor);
+    result.counter_reset_hint = CounterResetHint::Gauge;
+    result.start_time = 0;
+    Ok(Some(result))
 }
 
 /// Advance two indices through sorted samples for monotonically increasing
@@ -445,5 +655,46 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_extrapolated_histogram_rate_handles_reset() {
+        use config::meta::promql::histogram::HistogramSpan;
+
+        let make = |timestamp, count, hint| {
+            HistogramSample::from_decoded(
+                timestamp,
+                O2FloatHistogram {
+                    schema: 0,
+                    zero_threshold: 0.0,
+                    zero_count: 0.0,
+                    count,
+                    sum: count,
+                    positive_spans: vec![HistogramSpan {
+                        offset: 0,
+                        length: 1,
+                    }],
+                    negative_spans: vec![],
+                    positive_buckets: vec![count],
+                    negative_buckets: vec![],
+                    counter_reset_hint: hint,
+                    start_time: 0,
+                },
+            )
+        };
+        let samples = vec![
+            make(10_000_000, 10.0, CounterResetHint::Unknown),
+            make(70_000_000, 3.0, CounterResetHint::CounterReset),
+        ];
+        let rate = extrapolated_histogram(
+            &samples,
+            70_000_000,
+            Duration::from_secs(60),
+            ExtrapolationKind::Rate,
+        )
+        .unwrap()
+        .unwrap();
+        assert!((rate.count - 0.05).abs() < 1e-12);
+        assert_eq!(rate.counter_reset_hint, CounterResetHint::Gauge);
     }
 }

--- a/src/promql/src/functions/predict_linear.rs
+++ b/src/promql/src/functions/predict_linear.rs
@@ -83,6 +83,7 @@ mod tests {
         let range_value = RangeValue {
             labels: Labels::default(),
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: Some(TimeWindow {
                 range: Duration::from_secs(2),

--- a/src/promql/src/functions/rate.rs
+++ b/src/promql/src/functions/rate.rs
@@ -23,7 +23,7 @@ use datafusion::error::Result;
 use crate::functions::RangeFunc;
 
 pub(crate) fn rate(data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    super::eval_range(data, RateFunc::new(), eval_ctx)
+    super::eval_rate_like(data, RateFunc::new(), ExtrapolationKind::Rate, eval_ctx)
 }
 
 pub struct RateFunc;

--- a/src/promql/src/functions/resets.rs
+++ b/src/promql/src/functions/resets.rs
@@ -63,6 +63,7 @@ mod tests {
             .collect();
         RangeValue {
             samples,
+            histogram_samples: None,
             exemplars: None,
             time_window: None,
             labels: Default::default(),

--- a/src/promql/src/functions/scalar.rs
+++ b/src/promql/src/functions/scalar.rs
@@ -30,6 +30,7 @@ pub(crate) fn scalar(data: Value, eval_ctx: &EvalContext) -> Result<Value> {
             Ok(Value::Matrix(vec![RangeValue {
                 labels: Labels::default(),
                 samples,
+                histogram_samples: None,
                 exemplars: None,
                 time_window: None,
             }]))

--- a/src/promql/src/functions/time_operations.rs
+++ b/src/promql/src/functions/time_operations.rs
@@ -103,18 +103,26 @@ pub(crate) fn timestamp(data: Value) -> Result<Value> {
             let out: Vec<RangeValue> = matrix
                 .into_par_iter()
                 .map(|mut range_value| {
+                    let native_provenance = range_value.histogram_samples.is_some();
                     // Convert timestamp from microseconds to seconds for all samples
-                    let samples: Vec<Sample> = range_value
+                    let mut samples: Vec<Sample> = range_value
                         .samples
                         .into_iter()
                         .map(|sample| {
-                            Sample::new(sample.timestamp, (sample.timestamp / 1_000_000) as f64)
+                            Sample::new(sample.timestamp, sample.timestamp as f64 / 1_000_000.0)
                         })
                         .collect();
+                    if let Some(histograms) = range_value.histogram_samples.take() {
+                        samples.extend(histograms.into_iter().map(|sample| {
+                            Sample::new(sample.timestamp, sample.timestamp as f64 / 1_000_000.0)
+                        }));
+                        samples.sort_by_key(|sample| sample.timestamp);
+                    }
 
                     RangeValue {
                         labels: std::mem::take(&mut range_value.labels).without_metric_name(),
                         samples,
+                        histogram_samples: native_provenance.then(Vec::new),
                         exemplars: range_value.exemplars,
                         time_window: range_value.time_window,
                     }
@@ -136,6 +144,7 @@ fn exec(data: Value, op: &TimeOperationType) -> Result<Value> {
             let out: Vec<RangeValue> = matrix
                 .into_par_iter()
                 .map(|mut range_value| {
+                    let native_provenance = range_value.histogram_samples.is_some();
                     // Apply the time operation to all samples in this range
                     let samples: Vec<Sample> = range_value
                         .samples
@@ -149,6 +158,7 @@ fn exec(data: Value, op: &TimeOperationType) -> Result<Value> {
                     RangeValue {
                         labels: std::mem::take(&mut range_value.labels).without_metric_name(),
                         samples,
+                        histogram_samples: native_provenance.then(Vec::new),
                         exemplars: range_value.exemplars,
                         time_window: range_value.time_window,
                     }

--- a/src/promql/src/functions/vector.rs
+++ b/src/promql/src/functions/vector.rs
@@ -37,6 +37,7 @@ pub(crate) fn vector(data: Value, eval_ctx: &EvalContext) -> Result<Value> {
     let range_value = RangeValue {
         labels: Labels::default(),
         samples,
+        histogram_samples: None,
         exemplars: None,
         time_window: None,
     };

--- a/src/promql/src/selector_loader.rs
+++ b/src/promql/src/selector_loader.rs
@@ -18,10 +18,12 @@
 
 use std::sync::Arc;
 
+use bytes::Bytes;
 use config::{
     TIMESTAMP_COL_NAME,
     meta::promql::{
-        EXEMPLARS_LABEL, HASH_LABEL, VALUE_LABEL,
+        EXEMPLARS_LABEL, HASH_LABEL, NATIVE_HISTOGRAM_LABEL, VALUE_LABEL,
+        histogram::{HistogramLoadMode, HistogramSample},
         value::{Exemplar, QueryContext, RangeValue, Sample},
     },
     utils::{
@@ -31,10 +33,11 @@ use config::{
 };
 use datafusion::{
     arrow::{
-        array::{Float64Array, Int64Array, StringArray, UInt64Array},
+        array::{Array, Float64Array, Int64Array, LargeStringArray, StringArray, UInt64Array},
         datatypes::{DataType, Schema},
     },
     error::{DataFusionError, Result},
+    execution::memory_pool::MemoryConsumer,
     logical_expr::utils::disjunction,
     physical_plan::{
         Partitioning, execute_stream_partitioned, expressions::Column, repartition::RepartitionExec,
@@ -81,6 +84,7 @@ pub(super) async fn selector_load_data_from_datafusion(
     step: i64,
     lookback: i64,
     skip_labels: bool,
+    histogram_load_mode: HistogramLoadMode,
 ) -> Result<LoadedMetrics> {
     let start_time = std::time::Instant::now();
     let table_name = selector.name.as_ref().unwrap();
@@ -150,7 +154,11 @@ pub(super) async fn selector_load_data_from_datafusion(
         .iter()
         .filter_map(|field| {
             let name = field.name();
-            if name == TIMESTAMP_COL_NAME || name == VALUE_LABEL || name == EXEMPLARS_LABEL {
+            if name == TIMESTAMP_COL_NAME
+                || name == VALUE_LABEL
+                || name == NATIVE_HISTOGRAM_LABEL
+                || name == EXEMPLARS_LABEL
+            {
                 None
             } else {
                 Some(name.to_string())
@@ -177,6 +185,7 @@ pub(super) async fn selector_load_data_from_datafusion(
             hash_field_type,
             df_group.clone(),
             !skip_labels,
+            histogram_load_mode,
         )
         .await?
     };
@@ -228,11 +237,22 @@ pub(super) async fn load_samples_from_datafusion(
     hash_field_type: &DataType,
     df: DataFrame,
     collect_timestamps: bool,
+    histogram_load_mode: HistogramLoadMode,
 ) -> Result<(PartitionedMetrics, HashSet<i64>)> {
     let ctx = Arc::new(df.task_ctx());
     let target_partitions = ctx.session_config().target_partitions();
+    let input_schema = df.schema().as_arrow();
+    let has_float_samples = input_schema.field_with_name(VALUE_LABEL).is_ok();
+    let has_histogram_samples = input_schema.field_with_name(NATIVE_HISTOGRAM_LABEL).is_ok();
+    let mut projection = vec![TIMESTAMP_COL_NAME, HASH_LABEL];
+    if has_float_samples {
+        projection.push(VALUE_LABEL);
+    }
+    if has_histogram_samples {
+        projection.push(NATIVE_HISTOGRAM_LABEL);
+    }
     let plan = df
-        .select_columns(&[TIMESTAMP_COL_NAME, HASH_LABEL, VALUE_LABEL])?
+        .select_columns(&projection)?
         .create_physical_plan()
         .await?;
     let schema = plan.schema();
@@ -251,10 +271,12 @@ pub(super) async fn load_samples_from_datafusion(
         );
     }
 
-    let streams = execute_stream_partitioned(plan, ctx)?;
+    let streams = execute_stream_partitioned(plan, Arc::clone(&ctx))?;
     let mut tasks = Vec::with_capacity(streams.len());
     for mut stream in streams {
         let hash_field_type = hash_field_type.clone();
+        let memory_reservation =
+            MemoryConsumer::new("promql-native-histogram").register(ctx.memory_pool());
         let task: TokioResult = tokio::task::spawn(async move {
             let mut metrics: HashMap<u64, RangeValue> = HashMap::new();
             loop {
@@ -268,10 +290,8 @@ pub(super) async fn load_samples_from_datafusion(
                             .unwrap();
                         let value_values = batch
                             .column_by_name(VALUE_LABEL)
-                            .unwrap()
-                            .as_any()
-                            .downcast_ref::<Float64Array>()
-                            .unwrap();
+                            .and_then(|array| array.as_any().downcast_ref::<Float64Array>());
+                        let histogram_values = batch.column_by_name(NATIVE_HISTOGRAM_LABEL);
 
                         if hash_field_type == DataType::UInt64 {
                             let hash_values = batch
@@ -286,12 +306,31 @@ pub(super) async fn load_samples_from_datafusion(
                                 let entry = metrics.entry(hash).or_insert_with(|| RangeValue {
                                     labels: vec![],
                                     samples: vec![],
+                                    histogram_samples: None,
                                     exemplars: None,
                                     time_window: None,
                                 });
-                                entry
-                                    .samples
-                                    .push(Sample::new(timestamp, value_values.value(i)));
+                                if let Some(values) = value_values
+                                    && !values.is_null(i)
+                                {
+                                    entry.samples.push(Sample::new(timestamp, values.value(i)));
+                                }
+                                if let Some(payload) = histogram_payload(histogram_values, i) {
+                                    match HistogramSample::from_payload_mode_reserved(
+                                        timestamp,
+                                        Bytes::copy_from_slice(payload.as_bytes()),
+                                        histogram_load_mode,
+                                        Some(memory_reservation.new_empty()),
+                                    ) {
+                                        Ok(sample) => entry
+                                            .histogram_samples
+                                            .get_or_insert_default()
+                                            .push(sample),
+                                        Err(err) => log::warn!(
+                                            "dropping invalid native histogram while loading: {err}"
+                                        ),
+                                    }
+                                }
                             }
                         } else {
                             let hash_values = batch
@@ -306,12 +345,31 @@ pub(super) async fn load_samples_from_datafusion(
                                 let entry = metrics.entry(hash).or_insert_with(|| RangeValue {
                                     labels: vec![],
                                     samples: vec![],
+                                    histogram_samples: None,
                                     exemplars: None,
                                     time_window: None,
                                 });
-                                entry
-                                    .samples
-                                    .push(Sample::new(timestamp, value_values.value(i)));
+                                if let Some(values) = value_values
+                                    && !values.is_null(i)
+                                {
+                                    entry.samples.push(Sample::new(timestamp, values.value(i)));
+                                }
+                                if let Some(payload) = histogram_payload(histogram_values, i) {
+                                    match HistogramSample::from_payload_mode_reserved(
+                                        timestamp,
+                                        Bytes::copy_from_slice(payload.as_bytes()),
+                                        histogram_load_mode,
+                                        Some(memory_reservation.new_empty()),
+                                    ) {
+                                        Ok(sample) => entry
+                                            .histogram_samples
+                                            .get_or_insert_default()
+                                            .push(sample),
+                                        Err(err) => log::warn!(
+                                            "dropping invalid native histogram while loading: {err}"
+                                        ),
+                                    }
+                                }
                             }
                         }
                     }
@@ -324,11 +382,26 @@ pub(super) async fn load_samples_from_datafusion(
             }
             let mut unique_timestamps = HashSet::new();
             if collect_timestamps {
-                for metric in metrics.values() {
-                    if let Some(max_timestamp) =
-                        metric.samples.iter().map(|sample| sample.timestamp).max()
-                    {
+                for metric in metrics.values_mut() {
+                    metric.samples.sort_by_key(|sample| sample.timestamp);
+                    if let Some(histograms) = &mut metric.histogram_samples {
+                        histograms.sort_by_key(|sample| sample.timestamp);
+                    }
+                    let max_float = metric.samples.last().map(|sample| sample.timestamp);
+                    let max_histogram = metric
+                        .histogram_samples
+                        .as_ref()
+                        .and_then(|samples| samples.last())
+                        .map(|sample| sample.timestamp);
+                    if let Some(max_timestamp) = max_float.max(max_histogram) {
                         unique_timestamps.insert(max_timestamp);
+                    }
+                }
+            } else {
+                for metric in metrics.values_mut() {
+                    metric.samples.sort_by_key(|sample| sample.timestamp);
+                    if let Some(histograms) = &mut metric.histogram_samples {
+                        histograms.sort_by_key(|sample| sample.timestamp);
                     }
                 }
             }
@@ -348,6 +421,24 @@ pub(super) async fn load_samples_from_datafusion(
     }
 
     Ok((metrics, all_unique_timestamps))
+}
+
+fn histogram_payload(array: Option<&Arc<dyn Array>>, index: usize) -> Option<&str> {
+    let array = array?;
+    if array.is_null(index) {
+        return None;
+    }
+    match array.data_type() {
+        DataType::Utf8 => array
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .map(|values| values.value(index)),
+        DataType::LargeUtf8 => array
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .map(|values| values.value(index)),
+        _ => None,
+    }
 }
 
 async fn load_exemplars_from_datafusion(
@@ -409,6 +500,7 @@ async fn load_exemplars_from_datafusion(
                                     let entry = metrics.entry(hash).or_insert_with(|| RangeValue {
                                         labels: vec![],
                                         samples: vec![],
+                                        histogram_samples: None,
                                         exemplars: Some(vec![]),
                                         time_window: None,
                                     });
@@ -435,6 +527,7 @@ async fn load_exemplars_from_datafusion(
                                     let entry = metrics.entry(hash).or_insert_with(|| RangeValue {
                                         labels: vec![],
                                         samples: vec![],
+                                        histogram_samples: None,
                                         exemplars: Some(vec![]),
                                         time_window: None,
                                     });
@@ -550,19 +643,29 @@ mod tests {
         let ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(4));
         let df = ctx.read_batch(batch).unwrap();
 
-        let (metrics_without_timestamps, skipped_timestamps) =
-            load_samples_from_datafusion("test", &DataType::UInt64, df.clone(), false)
-                .await
-                .unwrap();
+        let (metrics_without_timestamps, skipped_timestamps) = load_samples_from_datafusion(
+            "test",
+            &DataType::UInt64,
+            df.clone(),
+            false,
+            HistogramLoadMode::RawLazy,
+        )
+        .await
+        .unwrap();
         assert!(skipped_timestamps.is_empty());
         assert_eq!(metrics_without_timestamps.len(), 4);
         let metrics_without_timestamps = merge_partitioned_metrics(metrics_without_timestamps);
         assert_eq!(metrics_without_timestamps[&11].samples.len(), 2);
 
-        let (metrics, timestamps) =
-            load_samples_from_datafusion("test", &DataType::UInt64, df, true)
-                .await
-                .unwrap();
+        let (metrics, timestamps) = load_samples_from_datafusion(
+            "test",
+            &DataType::UInt64,
+            df,
+            true,
+            HistogramLoadMode::RawLazy,
+        )
+        .await
+        .unwrap();
         let metrics = merge_partitioned_metrics(metrics);
 
         assert_eq!(timestamps, HashSet::from([150, 200]));

--- a/src/promql/src/series_labels.rs
+++ b/src/promql/src/series_labels.rs
@@ -455,6 +455,7 @@ mod tests {
             &DataType::UInt64,
             sample_df,
             false,
+            config::meta::promql::histogram::HistogramLoadMode::RawLazy,
         )
         .await
         .unwrap();

--- a/src/promql/src/utils.rs
+++ b/src/promql/src/utils.rs
@@ -17,7 +17,7 @@ use std::ops::Not;
 
 use config::{
     TIMESTAMP_COL_NAME,
-    meta::promql::{BUCKET_LABEL, HASH_LABEL, VALUE_LABEL},
+    meta::promql::{BUCKET_LABEL, HASH_LABEL, NATIVE_HISTOGRAM_LABEL, VALUE_LABEL},
 };
 use datafusion::{
     arrow::datatypes::Schema,
@@ -31,6 +31,18 @@ use promql_parser::label::{MatchOp, Matchers};
 pub fn apply_matchers(df: DataFrame, schema: &Schema, matchers: &Matchers) -> Result<DataFrame> {
     let mut df = df;
     for mat in matchers.matchers.iter() {
+        // The native histogram payload is a physical storage column, not a Prometheus label.
+        // Match it exactly as Prometheus matches any label that is absent from a series.
+        if mat.name == NATIVE_HISTOGRAM_LABEL {
+            let matches_absent = match &mat.op {
+                MatchOp::Equal => mat.value.is_empty(),
+                MatchOp::NotEqual => !mat.value.is_empty(),
+                MatchOp::Re(regex) => regex.is_match(""),
+                MatchOp::NotRe(regex) => !regex.is_match(""),
+            };
+            df = df.filter(lit(matches_absent))?;
+            continue;
+        }
         if mat.name == TIMESTAMP_COL_NAME
             || mat.name == VALUE_LABEL
             || schema.field_with_name(&mat.name).is_err()
@@ -72,6 +84,7 @@ pub fn apply_label_selector(
         let mut def_labels = vec![
             HASH_LABEL.to_string(),
             VALUE_LABEL.to_string(),
+            NATIVE_HISTOGRAM_LABEL.to_string(),
             BUCKET_LABEL.to_string(),
             TIMESTAMP_COL_NAME.to_string(),
         ];
@@ -260,5 +273,33 @@ mod tests {
             batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn test_native_histogram_storage_column_matches_as_absent_label() {
+        use promql_parser::label::Matcher;
+
+        for (op, value, expected_rows) in [
+            (MatchOp::Equal, "", 3),
+            (MatchOp::Equal, "payload", 0),
+            (MatchOp::NotEqual, "", 0),
+            (MatchOp::NotEqual, "payload", 3),
+        ] {
+            let (df, schema) = make_df();
+            let matchers = Matchers::new(vec![Matcher {
+                op,
+                name: NATIVE_HISTOGRAM_LABEL.to_string(),
+                value: value.to_string(),
+            }]);
+            let batches = apply_matchers(df, &schema, &matchers)
+                .unwrap()
+                .collect()
+                .await
+                .unwrap();
+            assert_eq!(
+                batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+                expected_rows
+            );
+        }
     }
 }

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+bytes.workspace = true
 datafusion.workspace = true
 datafusion-proto.workspace = true
 prost.workspace = true

--- a/src/proto/build.rs
+++ b/src/proto/build.rs
@@ -52,6 +52,11 @@ fn main() -> Result<()> {
         .type_attribute("Series", "#[derive(serde::Serialize)]")
         .type_attribute("Label", "#[derive(serde::Deserialize,serde::Serialize)]")
         .type_attribute("Sample", "#[derive(serde::Deserialize,serde::Serialize)]")
+        .type_attribute(
+            "NativeHistogramSample",
+            "#[derive(serde::Deserialize,serde::Serialize)]",
+        )
+        .bytes(".cluster.NativeHistogramSample.histogram")
         .type_attribute("Exemplar", "#[derive(serde::Deserialize,serde::Serialize)]")
         .type_attribute(
             "Exemplars",

--- a/src/proto/proto/cluster/metrics.proto
+++ b/src/proto/proto/cluster/metrics.proto
@@ -53,6 +53,9 @@ message Series {
     optional double  scalar = 4;
     optional string stringliteral = 5;
     optional Exemplars  exemplars = 6;
+    repeated NativeHistogramSample histogram_samples = 7;
+    optional NativeHistogramSample histogram_sample = 8;
+    bool native_histogram_provenance = 9;
 }
 
 message Label {
@@ -63,6 +66,11 @@ message Label {
 message Sample {
     int64   time = 1;
     double value = 2;
+}
+
+message NativeHistogramSample {
+    int64 time = 1;
+    bytes histogram = 2;
 }
 
 message Exemplars {

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -555,6 +555,12 @@ pub struct Series {
     pub stringliteral: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag = "6")]
     pub exemplars: ::core::option::Option<Exemplars>,
+    #[prost(message, repeated, tag = "7")]
+    pub histogram_samples: ::prost::alloc::vec::Vec<NativeHistogramSample>,
+    #[prost(message, optional, tag = "8")]
+    pub histogram_sample: ::core::option::Option<NativeHistogramSample>,
+    #[prost(bool, tag = "9")]
+    pub native_histogram_provenance: bool,
 }
 #[derive(serde::Deserialize, serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -571,6 +577,14 @@ pub struct Sample {
     pub time: i64,
     #[prost(double, tag = "2")]
     pub value: f64,
+}
+#[derive(serde::Deserialize, serde::Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct NativeHistogramSample {
+    #[prost(int64, tag = "1")]
+    pub time: i64,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub histogram: ::prost::bytes::Bytes,
 }
 #[derive(serde::Deserialize, serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/tree/main/native-histograms

## Summary

- add the native histogram model, validation, arithmetic, schema alignment, lazy decoding, and memory accounting
- support Prometheus remote-write native histograms and OTLP exponential histogram legacy, dual, and native ingestion modes
- add Parquet storage hygiene, compaction/downsampling safeguards, and reserved-column handling
- propagate native histogram samples through PromQL selectors, range functions, aggregation, API responses, cache, and cluster gRPC
- implement histogram_quantile, histogram_count, histogram_sum, histogram_fraction, rate/increase/delta, last-over-time, sum, and avg behavior
- preserve the existing rollout defaults: legacy for OTLP and drop for remote write
- intentionally leave promql-parser unchanged; parser exposure for histogram_avg is deferred

This PR covers phases 0–3 of the native histograms design:
https://github.com/openobserve/designs/tree/main/native-histograms

## Benchmark calibration

Local Apple M4, 10 cores / 32 GB, release-profiling + mimalloc, with ZO_COMPACT_ENABLED=false.

Workload: 8 series x 30 points with 20, 160, 1,024, and 4,096 buckets.

- native ingestion throughput improved from 1.85x at 20 buckets to 32.10x at 4,096 buckets
- ingestion CPU decreased from 6.33s to 0.29s (-95.4%)
- peak RSS decreased from 842 MiB to 230 MiB (-72.7%)
- local data size decreased from 102.0 MiB to 10.5 MiB (-89.7%)
- native query p50 improved for 20/160 buckets, but regressed by 17.9% at 1,024 buckets and 6.9% at 4,096 buckets

The benchmark driver and temporary benchmark data are intentionally not included in this PR.

## Validation

- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] cargo check -p config -p promql -p openobserve-core -p openobserve-api-query
- [x] cargo test -p promql (370 passed)
- [x] focused native histogram config, ingestion, conversion, aggregation, API, cache, and gRPC tests
- [x] API-query PromQL tests (22 passed)
- [ ] full cargo test -p openobserve-api-query: 127 passed; 10 UDS search-utils tests failed in an unmodified file on the local environment

## Follow-up before rollout

- profile the large-histogram query decode path
- complete longer-running and clustered qualification
- keep feature defaults unchanged until rollout gates are satisfied
