### PR TITLE
fix: prevent scheduled job deadlocks

### DIFF
--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -31,6 +31,40 @@ use crate::{
     errors::{DbError, Error, Result},
 };
 
+const PULL_QUERY: &str = r#"
+WITH jobs_to_pull AS (
+    SELECT id
+    FROM scheduled_jobs
+    WHERE status = $6 AND next_run_at <= $7 AND NOT (is_realtime = $8 AND is_silenced = $9)
+    ORDER BY next_run_at, id
+    LIMIT $10
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE scheduled_jobs AS jobs
+SET status = $1, start_time = $2,
+    end_time = CASE
+        WHEN jobs.module = $3 THEN $4
+        ELSE $5
+    END
+FROM jobs_to_pull
+WHERE jobs.id = jobs_to_pull.id
+RETURNING jobs.*;
+"#;
+
+const WATCH_TIMEOUT_QUERY: &str = r#"
+WITH timed_out_jobs AS (
+    SELECT id
+    FROM scheduled_jobs
+    WHERE status = $2 AND end_time <= $3
+    ORDER BY id
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE scheduled_jobs AS jobs
+SET status = $1, retries = jobs.retries + 1
+FROM timed_out_jobs
+WHERE jobs.id = timed_out_jobs.id;
+"#;
+
 pub struct PostgresScheduler {}
 
 impl PostgresScheduler {
@@ -612,24 +646,9 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
                 .unwrap()
                 .num_microseconds()
                 .unwrap();
-        let query = r#"UPDATE scheduled_jobs
-SET status = $1, start_time = $2,
-    end_time = CASE
-        WHEN module = $3 THEN $4
-        ELSE $5
-    END
-WHERE id IN (
-    SELECT id
-    FROM scheduled_jobs
-    WHERE status = $6 AND next_run_at <= $7 AND NOT (is_realtime = $8 AND is_silenced = $9)
-    ORDER BY next_run_at
-    LIMIT $10
-)
-RETURNING *;"#;
-
         let mut tx = pool.begin().await?;
 
-        // Lock the table for the duration of the transaction
+        // Serialize scheduler pullers for the duration of the transaction.
         let lock_key = "scheduler_pull_lock";
         let lock_id = config::utils::hash::gxhash::new().sum64(lock_key);
         let lock_id = if lock_id > i64::MAX as u64 {
@@ -651,7 +670,7 @@ RETURNING *;"#;
         DB_QUERY_NUMS
             .with_label_values(&["update", "scheduled_jobs"])
             .inc();
-        let jobs: Vec<Trigger> = match sqlx::query_as::<_, Trigger>(query)
+        let jobs: Vec<Trigger> = match sqlx::query_as::<_, Trigger>(PULL_QUERY)
             .bind(TriggerStatus::Processing)
             .bind(now)
             .bind(TriggerModule::Report)
@@ -774,9 +793,8 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
 
     /// Background job that watches for timeout of a job
     /// Steps:
-    /// - Select all the records with status = "Processing"
-    /// - calculate the current timestamp and difference from `start_time` of each record
-    /// - Get the record ids with difference more than the given timeout
+    /// - Select records with status = "Processing" whose `end_time` has passed
+    /// - Lock candidates in id order, skipping rows being handled by another transaction
     /// - Update their status back to "Waiting" and increase their "retries" by 1
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
@@ -784,17 +802,12 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
             .with_label_values(&["update", "scheduled_jobs"])
             .inc();
         let now = now_micros();
-        let res = sqlx::query(
-            r#"UPDATE scheduled_jobs
-SET status = $1, retries = retries + 1
-WHERE status = $2 AND end_time <= $3;
-                "#,
-        )
-        .bind(TriggerStatus::Waiting)
-        .bind(TriggerStatus::Processing)
-        .bind(now)
-        .execute(&pool)
-        .await?;
+        let res = sqlx::query(WATCH_TIMEOUT_QUERY)
+            .bind(TriggerStatus::Waiting)
+            .bind(TriggerStatus::Processing)
+            .bind(now)
+            .execute(&pool)
+            .await?;
         log::debug!(
             "[SCHEDULER] watch_timeout for scheduler updated {} rows",
             res.rows_affected()
@@ -864,4 +877,17 @@ async fn add_data_column() -> Result<()> {
         return Err(e.into());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PULL_QUERY, WATCH_TIMEOUT_QUERY};
+
+    #[test]
+    fn scheduler_updates_lock_candidates_in_a_stable_order() {
+        assert!(PULL_QUERY.contains("ORDER BY next_run_at, id"));
+        assert!(PULL_QUERY.contains("FOR UPDATE SKIP LOCKED"));
+        assert!(WATCH_TIMEOUT_QUERY.contains("ORDER BY id"));
+        assert!(WATCH_TIMEOUT_QUERY.contains("FOR UPDATE SKIP LOCKED"));
+    }
 }


### PR DESCRIPTION
## Summary

- lock scheduler pull candidates in deterministic `next_run_at, id` order
- lock timed-out jobs in deterministic `id` order
- use `FOR UPDATE SKIP LOCKED` in both paths so concurrent scheduler updates do not wait on the same rows

## Root cause

The scheduler pull advisory lock serializes pullers, but it does not cover the timeout watcher. The pull and timeout watcher each performed a multi-row `UPDATE` without explicitly ordering and locking their candidate rows. Under concurrency, PostgreSQL could acquire row locks in different orders and detect a deadlock between the two statements.

## Impact

This avoids aborting scheduler transactions with PostgreSQL `40P01` errors and reduces lock pressure that can contribute to SQLx pool acquisition timeouts.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p infra scheduler::postgres::tests`
- `cargo clippy -p infra --lib -- -D warnings`
- PostgreSQL 18 concurrency check: with one candidate row held by another transaction and a 1-second statement timeout, both scheduler paths completed immediately, skipped the locked row, and updated/returned the unlocked row
