### PR TITLE
fix: standardize service account credential terminology in web UI

### DIFF
--- a/tests/ui-testing/playwright-tests/GeneralTests/serviceAccount.spec.js
+++ b/tests/ui-testing/playwright-tests/GeneralTests/serviceAccount.spec.js
@@ -50,7 +50,7 @@ test.describe("Service Account for API access", () => {
         await pageManager.iamPage.iamPageAddServiceAccount();
         await pageManager.iamPage.enterNameServiceAccount(uniqueName);
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account created successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account created successfully.');
 
         testLogger.info('Test completed successfully');
     });
@@ -67,7 +67,7 @@ test.describe("Service Account for API access", () => {
         await pageManager.iamPage.iamPageAddServiceAccount();
         await pageManager.iamPage.enterNameServiceAccount(uniqueName);
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account created successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account created successfully.');
         await pageManager.iamPage.clickServiceAccountPopUpClosed();
 
         // Creating the same name again synthesizes the same identifier email,
@@ -109,7 +109,7 @@ test.describe("Service Account for API access", () => {
         await pageManager.iamPage.iamPageAddServiceAccount();
         await pageManager.iamPage.enterNameServiceAccount(uniqueName);
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account created successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account created successfully.');
         await pageManager.iamPage.clickCopyToken();
 
         testLogger.info('Test completed successfully');
@@ -127,7 +127,7 @@ test.describe("Service Account for API access", () => {
         await pageManager.iamPage.iamPageAddServiceAccount();
         await pageManager.iamPage.enterNameServiceAccount(uniqueName);
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account created successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account created successfully.');
         await pageManager.iamPage.clickServiceAccountPopUpClosed();
 
         testLogger.info('Test completed successfully');
@@ -147,13 +147,13 @@ test.describe("Service Account for API access", () => {
         await pageManager.iamPage.iamPageAddServiceAccount();
         await pageManager.iamPage.enterNameServiceAccount(uniqueName);
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account created successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account created successfully.');
         await pageManager.iamPage.clickServiceAccountPopUpClosed();
         await pageManager.iamPage.reloadServiceAccountPage();
         await waitForServiceAccountsPage(page);
         await pageManager.iamPage.deletedServiceAccount(uniqueEmail);
         await pageManager.iamPage.requestServiceAccountOk();
-        await pageManager.iamPage.verifySuccessMessage('Service Account deleted successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account deleted successfully.');
 
         testLogger.info('Test completed successfully');
     });
@@ -172,7 +172,7 @@ test.describe("Service Account for API access", () => {
         await pageManager.iamPage.iamPageAddServiceAccount();
         await pageManager.iamPage.enterNameServiceAccount(uniqueName);
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account created successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account created successfully.');
         await pageManager.iamPage.clickServiceAccountPopUpClosed();
         await pageManager.iamPage.reloadServiceAccountPage();
         await waitForServiceAccountsPage(page);
@@ -196,14 +196,14 @@ test.describe("Service Account for API access", () => {
         await pageManager.iamPage.iamPageAddServiceAccount();
         await pageManager.iamPage.enterNameServiceAccount(uniqueName);
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account created successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account created successfully.');
         await pageManager.iamPage.clickServiceAccountPopUpClosed();
         await pageManager.iamPage.reloadServiceAccountPage();
         await waitForServiceAccountsPage(page);
         await pageManager.iamPage.updatedServiceAccount(uniqueEmail);
         await pageManager.iamPage.enterDescriptionSA();
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account updated successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account updated successfully.');
 
         testLogger.info('Test completed successfully');
     });
@@ -222,13 +222,13 @@ test.describe("Service Account for API access", () => {
         await pageManager.iamPage.iamPageAddServiceAccount();
         await pageManager.iamPage.enterNameServiceAccount(uniqueName);
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account created successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account created successfully.');
         await pageManager.iamPage.clickServiceAccountPopUpClosed();
         await pageManager.iamPage.reloadServiceAccountPage();
         await waitForServiceAccountsPage(page);
         await pageManager.iamPage.refreshServiceAccount(uniqueEmail);
         await pageManager.iamPage.requestServiceAccountOk();
-        await pageManager.iamPage.verifySuccessMessage('Service token refreshed successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Token rotated successfully.');
 
         testLogger.info('Test completed successfully');
     });
@@ -246,7 +246,7 @@ test.describe("Service Account for API access", () => {
         await pageManager.iamPage.iamPageAddServiceAccount();
         await pageManager.iamPage.enterNameServiceAccount(uniqueName);
         await pageManager.iamPage.clickSaveServiceAccount();
-        await pageManager.iamPage.verifySuccessMessage('Service Account created successfully.');
+        await pageManager.iamPage.verifySuccessMessage('Service account created successfully.');
 
         // The token reveal is a single screen now (access is granted in the
         // create form itself): token snippets + a grant nudge for accounts

--- a/web/src/components/iam/serviceAccounts/ServiceAccountsList.vue
+++ b/web/src/components/iam/serviceAccounts/ServiceAccountsList.vue
@@ -280,7 +280,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               variant="outline"
               size="icon-md"
               :title="t('serviceAccounts.copyToken')"
-              @click.stop="copyToClipboard(serviceToken, { successMessage: t('iam.serviceAccountsList.tokenCopied'), timeout: 5000 })"
+              @click.stop="copyToClipboard(serviceToken, { successMessage: t('serviceAccounts.toast.tokenCopied'), timeout: 5000 })"
             >
               <OIcon name="content-copy" size="sm" />
             </OButton>
@@ -735,7 +735,7 @@ export default defineComponent({
     const getServiceAccountsUsers = async () =>{
       const dismiss = toast({
         variant: "loading",
-        message: t("iam.serviceAccountsList.loading"),
+        message: t("serviceAccounts.toast.loading"),
               timeout: 0,
 });
 
@@ -865,7 +865,7 @@ export default defineComponent({
       if (res.code == 200 ) {
         if (operationType == "created") {
             toast({
-              message: t("iam.serviceAccountsList.createdSuccess"),
+              message: t("serviceAccounts.toast.created"),
               variant: "success",
             });
 
@@ -909,7 +909,7 @@ export default defineComponent({
         } else {
           setTimeout(() => {
             toast({
-              message: t("iam.serviceAccountsList.updatedSuccess"),
+              message: t("serviceAccounts.toast.updated"),
               variant: "success",
             });
           }, 2000);
@@ -936,7 +936,7 @@ export default defineComponent({
         .then(async (res: any) => {
           if (res.data.code == 200) {
             toast({
-              message: t("iam.serviceAccountsList.deletedSuccess"),
+              message: t("serviceAccounts.toast.deleted"),
               variant: "success",
             });
             await getServiceAccountsUsers();
@@ -945,7 +945,7 @@ export default defineComponent({
         .catch((err: any) => {
           if(err.response?.status != 403){
             toast({
-            message: err.response?.data?.message || t("iam.serviceAccountsList.deleteError"),
+            message: err.response?.data?.message || t("serviceAccounts.toast.deleteError"),
             variant: "error",
             });
           }
@@ -971,17 +971,17 @@ export default defineComponent({
 
         if (successful.length > 0 && unsuccessful.length === 0) {
           toast({
-            message: t("iam.serviceAccountsList.bulkDeleteSuccess", { count: successful.length }),
+            message: t("serviceAccounts.toast.bulkDeleteSuccess", { count: successful.length }),
             variant: "success",
           });
         } else if (successful.length > 0 && unsuccessful.length > 0) {
           toast({
-            message: t("iam.serviceAccountsList.bulkDeletePartial", { count: successful.length, failed: unsuccessful.length }),
+            message: t("serviceAccounts.toast.bulkDeletePartial", { successful: successful.length, failed: unsuccessful.length }),
             variant: "warning",
           });
         } else if (unsuccessful.length > 0) {
           toast({
-            message: t("iam.serviceAccountsList.bulkDeleteFailed", { count: unsuccessful.length }),
+            message: t("serviceAccounts.toast.bulkDeleteFailed", { failed: unsuccessful.length }),
             variant: "error",
           });
         }
@@ -992,7 +992,7 @@ export default defineComponent({
       } catch (err: any) {
         if (err.response?.status != 403 || err?.status != 403) {
           toast({
-            message: err?.response?.data?.message || err?.message || t("iam.serviceAccountsList.bulkDeleteError"),
+            message: err?.response?.data?.message || err?.message || t("serviceAccounts.toast.bulkDeleteError"),
             variant: "error",
           });
         }
@@ -1006,7 +1006,7 @@ export default defineComponent({
           revealToken(res.data.token, row.email);
 
         toast({
-          message: t("iam.serviceAccountsList.tokenRefreshedSuccess"),
+          message: t("serviceAccounts.toast.rotated"),
           variant: "success",
         });
 
@@ -1014,7 +1014,7 @@ export default defineComponent({
       }).catch((err)=>{
         if(err.response?.status != 403){
           toast({
-          message: err.response?.data?.message || t("iam.serviceAccountsList.refreshTokenError"),
+          message: err.response?.data?.message || t("serviceAccounts.toast.rotateError"),
           variant: "error",
           });
         }

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -1465,10 +1465,10 @@
     "updateFailed": "Failed to update the service account. Please try again.",
     "headerSubtitle": "Programmatic access tokens for APIs",
     "search": "Search Service Account",
-    "refresh": "Refresh Service Token",
+    "refresh": "Rotate Token",
     "rotate": "Rotate Token",
-    "showToken": "Show Service Token",
-    "hideToken": "Hide Service Token",
+    "showToken": "Show Token",
+    "hideToken": "Hide Token",
     "delete": "Delete",
     "deleteServiceAccount": "Delete Service Account",
     "update": "Update Service Account",
@@ -1478,7 +1478,7 @@
     "confirmDeleteHead": "Delete Service Account",
     "confirmDeleteBtn": "Delete account",
     "confirmRefreshMsg": "Are you sure you want to rotate the token for {identifier}?",
-    "confirmRefreshHead": "Rotate Service Token",
+    "confirmRefreshHead": "Rotate Token",
     "confirmRefreshBtn": "Rotate token",
     "confirmBulkDeleteHead": "Delete Service Accounts",
     "confirmBulkDeleteMsg": "Are you sure you want to delete {count} service account(s)?",
@@ -1541,10 +1541,25 @@
       "checkboxTooltip": "System-managed accounts are excluded from bulk operations"
     },
     "bulkDelete": "Delete",
-    "bulkDeleteNotice": "System-managed accounts are excluded from bulk operations"
+    "bulkDeleteNotice": "System-managed accounts are excluded from bulk operations",
+    "toast": {
+      "loading": "Loading service accounts…",
+      "created": "Service account created successfully.",
+      "updated": "Service account updated successfully.",
+      "deleted": "Service account deleted successfully.",
+      "rotated": "Token rotated successfully.",
+      "tokenCopied": "Token copied to clipboard.",
+      "deleteError": "Error while deleting service account.",
+      "rotateError": "Error while rotating token.",
+      "bulkDeleteError": "Error while deleting service accounts.",
+      "bulkDeleteSuccess": "Deleted {count} service account(s).",
+      "bulkDeletePartial": "Deleted {successful} service account(s); {failed} failed.",
+      "bulkDeleteFailed": "Failed to delete {failed} service account(s)."
+    }
   },
   "iam": {
     "users": "Users",
+    "permissions": "Permissions",
     "sectionAccess": "Access",
     "sectionPermissions": "Permissions",
     "sectionOrganization": "Organization",
@@ -1765,20 +1780,6 @@
       "top50": "Top 50",
       "resourcesSearchHint": "resources (Search to get specific resource)",
       "noResourcesPresent": "No Resources Present"
-    },
-    "serviceAccountsList": {
-      "tokenCopied": "Token Copied Successfully!",
-      "loading": "Please wait while loading service accounts...",
-      "createdSuccess": "Service Account created successfully.",
-      "updatedSuccess": "Service Account updated successfully.",
-      "deletedSuccess": "Service Account deleted successfully.",
-      "deleteError": "Error while deleting user.",
-      "bulkDeleteSuccess": "Successfully deleted {count} service account(s)",
-      "bulkDeletePartial": "Deleted {count} service account(s), but {failed} failed",
-      "bulkDeleteFailed": "Failed to delete {count} service account(s)",
-      "bulkDeleteError": "Error while deleting service accounts",
-      "tokenRefreshedSuccess": "Service token refreshed successfully.",
-      "refreshTokenError": "Error while refreshing token."
     },
     "addUser": {
       "passwordChanged": "Password Changed",

--- a/web/src/views/Ingestion.spec.ts
+++ b/web/src/views/Ingestion.spec.ts
@@ -476,7 +476,7 @@ describe("Ingestion", () => {
 
       expect(mockNotify).toHaveBeenCalledWith({
         variant: "error",
-        message: "API Key not found.",
+        message: "Passcode not found.",
         timeout: 5000,
       });
     });
@@ -565,7 +565,7 @@ describe("Ingestion", () => {
 
       expect(mockNotify).toHaveBeenCalledWith({
         variant: "error",
-        message: "API Key not found.",
+        message: "Passcode not found.",
         timeout: 5000,
       });
     });

--- a/web/src/views/Ingestion.vue
+++ b/web/src/views/Ingestion.vue
@@ -352,7 +352,7 @@ export default defineComponent({
           if (res.data.data.passcode == "") {
             toast({
               variant: "error",
-              message: "API Key not found.",
+              message: "Passcode not found.",
               timeout: 5000,
             });
           } else {
@@ -384,7 +384,7 @@ export default defineComponent({
           if (res.data.data.passcode == "") {
             toast({
               variant: "error",
-              message: "API Key not found.",
+              message: "Passcode not found.",
               timeout: 5000,
             });
           } else {


### PR DESCRIPTION
## What

Cleans up the wording and i18n coverage around **service accounts** in the web UI so the credential is consistently called a **token**, and fixes a mislabeled toast.

### Changes
- **Standardized credential wording** — `en.json` service-account labels drifted between "Service Token", "Service Account Token", and "Token". Unified on **"Token"** (kept "Service Account Token" only as the standalone reveal-dialog title).
- **Localized hardcoded strings** — moved all `ServiceAccountsList.vue` toasts (create / update / delete / rotate / loading / copy / bulk-delete) into a new `serviceAccounts.toast.*` namespace; localized the tab labels in `EditRole.vue` / `EditGroup.vue` and the search placeholder in `GroupServiceAccounts.vue` (added `iam.permissions`).
- **Fixed a mislabeled toast** — the org-passcode flow in `Ingestion.vue` showed `"API Key not found."`; it's the org **passcode** (sibling button is "Update Passcode"), so it now reads `"Passcode not found."` (spec updated to match).

### Notes
- `en.json` is updated as the source of truth; the other locale files sync via the normal translation flow.
- Dead `apikeyLabel` / `copyapikey` / `deleteAPIKeyMessage` keys (no component references) were left untouched — out of scope for this change.

## Testing
- `vitest` unit suite for the touched files passes (134/134, incl. updated `Ingestion.spec.ts` assertions).

## Related
- Docs counterpart (new Service Accounts page + credential comparison): openobserve/openobserve-docs PR.