### PR TITLE
chore: make "switch back to Logs" discoverable in stream explorer

### DIFF
--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -640,7 +640,7 @@
     "logs": "Logs",
     "traces": "Traces",
     "enrichmentTables": "Enrichment Tables",
-    "switchToLogs": "click to switch back to Logs",
+    "switchToLogs": "Switch back to Logs",
     "savedViewsLabel": "Saved View",
     "savedViewsNotFound": "Saved view not found!",
     "savedViewAction": "Create/Update Saved View",

--- a/web/src/plugins/logs/IndexList.spec.ts
+++ b/web/src/plugins/logs/IndexList.spec.ts
@@ -3009,3 +3009,65 @@ describe("Field filter isolation: values API vs search/histogram APIs", () => {
     expect(valuesSql).not.toBe(wrapper.vm.searchObj.data.query);
   });
 });
+
+describe("Back to Logs control", () => {
+  let wrapper: any;
+
+  const mountList = async () => {
+    wrapper = mount(IndexList, {
+      attachTo: "#app",
+      global: {
+        provide: { store },
+        plugins: [i18n, router],
+        stubs: {},
+      },
+    });
+    await flushPromises();
+    return wrapper;
+  };
+
+  const BTN = '[data-test="log-search-index-list-back-to-logs-btn"]';
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.restoreAllMocks();
+  });
+
+  it("is hidden when the stream type is logs", async () => {
+    await mountList();
+    wrapper.vm.searchObj.data.stream.streamType = "logs";
+    await nextTick();
+    expect(wrapper.find(BTN).exists()).toBe(false);
+  });
+
+  it("is shown when the stream type is a non-logs type (e.g. metrics)", async () => {
+    await mountList();
+    wrapper.vm.searchObj.data.stream.streamType = "metrics";
+    await nextTick();
+    expect(wrapper.find(BTN).exists()).toBe(true);
+  });
+
+  it("uses the switch (swap-horiz) icon, not the stream-type icon", async () => {
+    await mountList();
+    wrapper.vm.searchObj.data.stream.streamType = "metrics";
+    await nextTick();
+    // The glyph is a fixed switcher affordance regardless of stream type —
+    // assert via the OIcon `name` prop (icon renders as an inline SVG, not text).
+    const icon = wrapper
+      .find(BTN)
+      .findComponent({ name: "OIcon" });
+    expect(icon.exists()).toBe(true);
+    expect(icon.props("name")).toBe("swap-horiz");
+  });
+
+  it("switches back to logs on click (behavior preserved)", async () => {
+    await mountList();
+    wrapper.vm.searchObj.data.stream.streamType = "metrics";
+    await nextTick();
+    const spy = vi
+      .spyOn(wrapper.vm, "onStreamTypeChange")
+      .mockResolvedValue(undefined);
+    await wrapper.find(BTN).trigger("click");
+    expect(spy).toHaveBeenCalledWith("logs");
+  });
+});

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :class="store.state.theme == 'dark' ? 'theme-dark' : 'theme-light'"
   >
     <div
-      class="flex items-center gap-1"
+      class="flex items-center gap-2"
       style="max-width: 100%; overflow: hidden"
     >
       <OButton
@@ -28,14 +28,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           searchObj.data.stream.streamType &&
           searchObj.data.stream.streamType !== 'logs'
         "
-        data-test="log-search-index-list-stream-type-badge"
-        variant="ghost"
+        data-test="log-search-index-list-back-to-logs-btn"
+        variant="outline"
         size="icon-sm"
-        class="shrink-0 h-8 w-8 border border-(--o2-border) rounded p-0"
+        class="shrink-0 h-8 w-8 border border-border-default rounded p-0"
         @click="onStreamTypeChange('logs')"
       >
-        <OIcon :name="streamTypeIcon" size="sm" />
-        <OTooltip :content="streamTypeLabel + ' — ' + t('search.switchToLogs')" side="bottom" align="center" />
+        <OIcon name="swap-horiz" size="sm" />
+        <OTooltip :content="t('search.switchToLogs')" side="bottom" align="center" />
       </OButton>
       <div class="flex-1 min-w-0">
         <OSelect
@@ -495,29 +495,6 @@ export default defineComponent({
     const pagination = ref({
       page: 1,
       rowsPerPage: 25,
-    });
-
-    const streamTypes = [
-      { label: t("search.logs"), value: "logs", icon: "search" },
-      { label: t("search.traces"), value: "traces", icon: "account-tree" },
-      { label: t("search.metrics"), value: "metrics", icon: "bar-chart" },
-      {
-        label: t("search.enrichmentTables"),
-        value: "enrichment_tables",
-        icon: "table-view",
-      },
-    ];
-
-    const streamTypeIcon = computed(() => {
-      const current = searchObj.data.stream.streamType;
-      return (
-        streamTypes.find((t) => t.value === current)?.icon ?? "search"
-      );
-    });
-
-    const streamTypeLabel = computed(() => {
-      const current = searchObj.data.stream.streamType;
-      return streamTypes.find((t) => t.value === current)?.label ?? "";
     });
 
     const onStreamTypeChange = async (newType: string) => {
@@ -2037,9 +2014,6 @@ export default defineComponent({
       openFilterCreator,
       addSearchTerm,
       fieldValues,
-      streamTypes,
-      streamTypeIcon,
-      streamTypeLabel,
       onStreamTypeChange,
       "add": "add",
       "visibility-off": "visibility-off",


### PR DESCRIPTION
## Problem

Opening the Streams list → filtering to a non-logs tab (Metrics/Traces/Enrichment) → clicking the explore icon on a row lands the user in the **Logs explorer** with that stream type. The only way back to Logs was an icon-only ghost button in the sidebar that:

- rendered the **current** stream type's icon (e.g. bar-chart for metrics), so it read as a passive *label*, not an action;
- exposed its meaning only via a tooltip;
- did the *opposite* of the icon shown (icon = where you are, click = leave).

Meanwhile the prominent, labeled **Reset** button doesn't reset stream type, so it's a decoy. Result: users get stranded in the Logs explorer showing a non-logs stream (this was hit during DevRel testing).

## Fix

Replace the ambiguous badge with a clear **`swap-horiz` (⇄) switcher icon** button, separated from the stream picker by a gap, with an action-first **"Switch back to Logs"** tooltip.

**Behavior is unchanged** — the control is still gated on `streamType !== 'logs'`, and one click still calls `onStreamTypeChange('logs')`. No routing, service, or store changes.

### Before / After

| | |
|---|---|
| Before | ambiguous type-icon badge, tooltip-only meaning, cramped |
| After | `⇄` switcher icon, gap before the picker, action-first tooltip |

## Housekeeping in the same file
- Migrated the banned legacy `--o2-border` token → `border-default` design token.
- Removed the now-unused `streamTypes` / `streamTypeIcon` / `streamTypeLabel` helpers.

## Tests
- Added focused unit tests in `IndexList.spec.ts`: control hidden when type is logs, shown for non-logs, uses the `swap-horiz` icon, and click still triggers `onStreamTypeChange('logs')`.
- Full `IndexList.spec.ts` suite passes (125 passed).

## Scope
One component (`web/src/plugins/logs/IndexList.vue`) + one i18n key. Pure OSS frontend — no backend / enterprise gating.