### PR TITLE
feat(web): add loongcollector option in custom log ingestion

### DIFF
--- a/web/src/assets/images/ingestion/loongcollector.svg
+++ b/web/src/assets/images/ingestion/loongcollector.svg
@@ -1,0 +1,15 @@
+<svg width="320" height="128" viewBox="0 0 320 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="128" rx="12" fill="#6D7EDC"/>
+  <text
+    x="24"
+    y="76"
+    fill="#EEF2FF"
+    font-family="Inter, Arial, sans-serif"
+    font-size="40"
+    font-weight="700"
+    letter-spacing="0"
+  >
+    LoongCollector
+  </text>
+</svg>
+

--- a/web/src/components/ingestion/Custom.spec.ts
+++ b/web/src/components/ingestion/Custom.spec.ts
@@ -291,6 +291,7 @@ describe("Custom Component", () => {
         "vector",
         "filebeat",
         "gcpLogs",
+        "loongcollector",
       ];
       
       // Test each log route sets correct tab
@@ -691,7 +692,30 @@ describe("Custom Component", () => {
           }
         },
       });
-      
+
+      expect(testWrapper.vm.tabs).toBe("ingestLogs");
+      testWrapper.unmount();
+    });
+
+    it("should handle loongcollector route", () => {
+      mockRouter.currentRoute.value.name = "loongcollector";
+
+      const testWrapper = mount(Custom, {
+        props: { currOrgIdentifier: "test-org" },
+        global: {
+          plugins: [i18n],
+          provide: { store },
+          stubs: {
+            'OSplitter': {
+              template: '<div><slot name="before"></slot><slot name="after"></slot></div>'
+            },
+            'OTabs': true,
+            'ORouteTab': true,
+            'router-view': true
+          }
+        },
+      });
+
       expect(testWrapper.vm.tabs).toBe("ingestLogs");
       testWrapper.unmount();
     });

--- a/web/src/components/ingestion/Custom.vue
+++ b/web/src/components/ingestion/Custom.vue
@@ -108,7 +108,7 @@ export default defineComponent({
     const rumRoutes = ["frontendMonitoring"];
     const logRoutes = [
       "curl", "fluentbit", "fluentd", "kinesisfirehose", "vector",
-      "filebeat", "gcpLogs", "logstash", "syslogNg", "ingestLogsFromOtel",
+      "filebeat", "gcpLogs", "logstash", "syslogNg", "loongcollector", "ingestLogsFromOtel",
     ];
     const tabs = ref(
       logRoutes.includes(router.currentRoute.value.name as string)

--- a/web/src/components/ingestion/logs/Index.spec.ts
+++ b/web/src/components/ingestion/logs/Index.spec.ts
@@ -134,6 +134,7 @@ describe("IngestLogs Component", () => {
         "fluentd",
         "vector",
         "syslogNg",
+        "loongcollector",
       ]);
     });
   });
@@ -250,6 +251,18 @@ describe("IngestLogs Component", () => {
       const tw = mount(IngestLogs, buildMountOptions());
       expect(mockRouter.push).toHaveBeenCalledWith({
         name: "syslogNg",
+        query: {
+          org_identifier: store.state.selectedOrganization.identifier,
+        },
+      });
+      tw.unmount();
+    });
+
+    it("should push with org_identifier query when route is 'loongcollector'", () => {
+      mockRouter.currentRoute.value.name = "loongcollector";
+      const tw = mount(IngestLogs, buildMountOptions());
+      expect(mockRouter.push).toHaveBeenCalledWith({
+        name: "loongcollector",
         query: {
           org_identifier: store.state.selectedOrganization.identifier,
         },

--- a/web/src/components/ingestion/logs/Index.vue
+++ b/web/src/components/ingestion/logs/Index.vue
@@ -113,6 +113,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               icon="plagiarism"
               label="Syslog-ng"
             />
+            <ORouteTab
+              name="loongcollector"
+              data-test="ingestion-logs-tab-loongcollector"
+              :to="{
+                name: 'loongcollector',
+                query: {
+                  org_identifier: store.state.selectedOrganization.identifier,
+                },
+              }"
+              :icon="'img:' + getImageURL('images/ingestion/loongcollector.svg')"
+              label="LoongCollector"
+            />
     </template>
 
       <div class="w-full h-full">
@@ -168,6 +180,7 @@ export default defineComponent({
       "fluentd",
       "vector",
       "syslogNg",
+      "loongcollector",
     ];
 
     onBeforeMount(() => {

--- a/web/src/components/ingestion/logs/LoongCollector.spec.ts
+++ b/web/src/components/ingestion/logs/LoongCollector.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createStore } from "vuex";
+import LoongCollector from "./LoongCollector.vue";
+
+vi.mock("../../../utils/zincutils", () => ({
+  getEndPoint: vi.fn(() => ({
+    url: "https://test.example.com:5080",
+    host: "test.example.com",
+    port: "5080",
+    protocol: "https",
+    tls: true,
+  })),
+  getIngestionURL: vi.fn(() => "https://test.example.com:5080"),
+  getImageURL: vi.fn(() => "mock-image-url"),
+}));
+
+vi.mock("@/components/CopyContent.vue", () => ({
+  default: {
+    name: "CopyContent",
+    props: ["content"],
+    template: "<div class='copy-content'>{{ content }}</div>",
+  },
+}));
+
+describe("LoongCollector.vue", () => {
+  let wrapper: any;
+  let store: any;
+
+  beforeEach(() => {
+    store = createStore({
+      state: {
+        selectedOrganization: {
+          identifier: "test-org",
+        },
+      },
+    });
+
+    wrapper = mount(LoongCollector, {
+      global: {
+        plugins: [store],
+      },
+      props: {
+        currOrgIdentifier: "test-org",
+        currUserEmail: "test@example.com",
+      },
+    });
+  });
+
+  it("renders LoongCollector docs text", () => {
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.text()).toContain("LoongCollector configuration");
+  });
+
+  it("generates OpenObserve logs ingestion RemoteURL", () => {
+    expect(wrapper.vm.content).toContain(
+      "RemoteURL: https://test.example.com:5080/api/test-org/default/_json",
+    );
+  });
+
+  it("uses flusher_http style output", () => {
+    expect(wrapper.vm.content).toContain("Type: flusher_http");
+    expect(wrapper.vm.content).toContain("Method: POST");
+    expect(wrapper.vm.content).toContain("Authorization: Basic [BASIC_PASSCODE]");
+  });
+});
+

--- a/web/src/components/ingestion/logs/LoongCollector.vue
+++ b/web/src/components/ingestion/logs/LoongCollector.vue
@@ -1,0 +1,80 @@
+<!-- Copyright 2026 OpenObserve Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+  <IngestionContent>
+    <CopyContent class="copy-content-container-cls" :content="content" />
+    <IngestionDocLink href="https://github.com/alibaba/loongcollector">
+      to learn more about LoongCollector configuration.
+    </IngestionDocLink>
+  </IngestionContent>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import { useStore } from "vuex";
+import { getEndPoint, getIngestionURL } from "@/utils/zincutils";
+import CopyContent from "@/components/CopyContent.vue";
+import IngestionContent from "@/components/ingestion/IngestionContent.vue";
+import IngestionDocLink from "@/components/ingestion/IngestionDocLink.vue";
+
+export default defineComponent({
+  name: "LoongCollector",
+  props: {
+    currOrgIdentifier: {
+      type: String,
+    },
+    currUserEmail: {
+      type: String,
+    },
+  },
+  components: { CopyContent, IngestionContent, IngestionDocLink },
+  setup() {
+    const store = useStore();
+    const endpoint: any = ref({
+      url: "",
+      host: "",
+      port: "",
+      protocol: "",
+      tls: "",
+    });
+
+    const ingestionURL = getIngestionURL();
+    endpoint.value = getEndPoint(ingestionURL);
+
+    const content = `enable: true
+inputs:
+  - Type: input_file
+    FilePaths:
+      - /var/log/*.log
+processors:
+  - Type: processor_json
+    SourceKey: content
+flushers:
+  - Type: flusher_http
+    RemoteURL: ${endpoint.value.url}/api/${store.state.selectedOrganization.identifier}/default/_json
+    Method: POST
+    Headers:
+      Authorization: Basic [BASIC_PASSCODE]
+    Compress: gzip`;
+
+    return {
+      content,
+    };
+  },
+});
+</script>
+

--- a/web/src/components/ingestion/logs/ingestionIndex.spec.ts
+++ b/web/src/components/ingestion/logs/ingestionIndex.spec.ts
@@ -113,6 +113,7 @@ describe("IngestLogs Index Component", () => {
         "fluentd",
         "vector",
         "syslogNg",
+        "loongcollector",
       ];
       expect(wrapper.vm.ingestRoutes).toEqual(expectedRoutes);
     });
@@ -300,7 +301,8 @@ describe("IngestLogs Index Component", () => {
         "fluentbit", 
         "fluentd",
         "vector",
-        "syslogNg"
+        "syslogNg",
+        "loongcollector"
       ];
       
       expect(wrapper.vm.ingestRoutes).toEqual(expectedRoutes);

--- a/web/src/composables/shared/useIngestionRoutes.spec.ts
+++ b/web/src/composables/shared/useIngestionRoutes.spec.ts
@@ -27,6 +27,7 @@ vi.mock("@/utils/zincutils", () => ({
 }));
 
 vi.mock("@/components/ingestion/logs/SyslogNg.vue", () => ({ default: {} }));
+vi.mock("@/components/ingestion/logs/LoongCollector.vue", () => ({ default: {} }));
 vi.mock("@/views/Ingestion.vue", () => ({ default: {} }));
 vi.mock("@/components/ingestion/logs/FluentBit.vue", () => ({ default: {} }));
 vi.mock("@/components/ingestion/logs/Fluentd.vue", () => ({ default: {} }));
@@ -197,6 +198,7 @@ describe("useIngestionRoutes", () => {
       expect(logRouteNames).toContain("ingestLogsFromOtel");
       expect(logRouteNames).toContain("logstash");
       expect(logRouteNames).toContain("syslogNg");
+      expect(logRouteNames).toContain("loongcollector");
     });
 
     it("should have metrics routes under custom", () => {

--- a/web/src/composables/shared/useIngestionRoutes.ts
+++ b/web/src/composables/shared/useIngestionRoutes.ts
@@ -16,6 +16,7 @@
 import config from "@/aws-exports";
 import { routeGuard } from "@/utils/zincutils";
 import SyslogNg from "@/components/ingestion/logs/SyslogNg.vue";
+import LoongCollector from "@/components/ingestion/logs/LoongCollector.vue";
 import Ingestion from "@/views/Ingestion.vue";
 import FluentBit from "@/components/ingestion/logs/FluentBit.vue";
 import Fluentd from "@/components/ingestion/logs/Fluentd.vue";
@@ -219,6 +220,14 @@ const useIngestionRoutes = () => {
                   path: "syslogng",
                   name: "syslogNg",
                   component: SyslogNg,
+                  beforeEnter(to: any, from: any, next: any) {
+                    routeGuard(to, from, next);
+                  },
+                },
+                {
+                  path: "loongcollector",
+                  name: "loongcollector",
+                  component: LoongCollector,
                   beforeEnter(to: any, from: any, next: any) {
                     routeGuard(to, from, next);
                   },

--- a/web/src/utils/routeTabMaps.spec.ts
+++ b/web/src/utils/routeTabMaps.spec.ts
@@ -323,6 +323,12 @@ describe("resolveTab", () => {
       expect(resolveTab("ingestLogs", "syslogNg", "curl")).toBe("syslogNg");
     });
 
+    it("ingestLogs – loongcollector", () => {
+      expect(resolveTab("ingestLogs", "loongcollector", "curl")).toBe(
+        "loongcollector"
+      );
+    });
+
     it("billings – usage", () => {
       expect(resolveTab("billings", "usage", "usage")).toBe("usage");
     });
@@ -532,8 +538,8 @@ describe("ROUTE_TAB_MAPS", () => {
       expect(Object.keys(ROUTE_TAB_MAPS.ingestMetrics)).toHaveLength(6);
     });
 
-    it("ingestLogs has 8 entries", () => {
-      expect(Object.keys(ROUTE_TAB_MAPS.ingestLogs)).toHaveLength(8);
+    it("ingestLogs has 9 entries", () => {
+      expect(Object.keys(ROUTE_TAB_MAPS.ingestLogs)).toHaveLength(9);
     });
 
     it("billings has 4 entries", () => {

--- a/web/src/utils/routeTabMaps.ts
+++ b/web/src/utils/routeTabMaps.ts
@@ -120,6 +120,7 @@ const ROUTE_TAB_MAPS: Record<string, Record<string, string>> = {
     ingestLogsFromOtel: "ingestLogsFromOtel",
     logstash: "logstash",
     syslogNg: "syslogNg",
+    loongcollector: "loongcollector",
   },
 
   /** enterprise/components/billings/Billing.vue */


### PR DESCRIPTION
This PR adds LoongCollector, **Alibaba’s self-developed log collector**, as a explicit custom log ingestion choice in the user interface.

The LoongCollector log collection configuration as follows：
ilucky@ubuntu:/.../loongcollector-3.3.5$ cat conf/continuous_pipeline_config/local/collector.yaml 

> enable: true
inputs:
  &nbsp;&nbsp;\- Type: input_file
  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;FilePaths:
      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- /tmp/*.log
processors:
  &nbsp;&nbsp;\- Type: processor_json
  &nbsp;&nbsp;&nbsp;&nbsp; SourceKey: content
flushers:
  &nbsp;&nbsp; \- Type: flusher_http
    &nbsp;&nbsp; &nbsp;&nbsp; RemoteURL: http://192.168.139.3:5080/api/default/default/_json
    &nbsp;&nbsp; &nbsp;&nbsp; Method: POST
    &nbsp;&nbsp; &nbsp;&nbsp; Headers:
      &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; Authorization: Basic cm9vdEBleGFtcGxlLmNvbTpvMm9pX1hVcHBBeUdVd0J4VHZHbmpYY2c1eWJGblZFNFduak9D
    Compress: gzip

<img width="2926" height="1194" alt="image" src="https://github.com/user-attachments/assets/ae2a5af6-ea03-4a41-833a-c53e7f692f9d" />
<img width="2932" height="990" alt="image" src="https://github.com/user-attachments/assets/1bed13bb-ec40-4200-a71a-1229a6884af6" />
<img width="2932" height="1196" alt="image" src="https://github.com/user-attachments/assets/79e54f4c-1c67-46c5-8fac-97506907da5e" />
