### PR TITLE
fix: Agent Graph — agents, tools & models as first-class service-graph nodes

### DIFF
--- a/src/core/src/traces/otel/attributes.rs
+++ b/src/core/src/traces/otel/attributes.rs
@@ -217,6 +217,13 @@ impl OpenInferenceAttributes {
     pub const LLM_TOKEN_COUNT_PROMPT: &'static str = "llm.token_count.prompt";
     pub const LLM_TOKEN_COUNT_COMPLETION: &'static str = "llm.token_count.completion";
     pub const LLM_INVOCATION_PARAMETERS: &'static str = "llm.invocation_parameters";
+    // Tool name on a TOOL-kind span (Arize/Phoenix, OpenAI Agents, Google ADK).
+    pub const TOOL_NAME: &'static str = "tool.name";
+    pub const TOOL_CALL_FUNCTION_NAME: &'static str = "tool_call.function.name";
+    // Agent name (OpenInference AGENT span).
+    pub const AGENT_NAME: &'static str = "agent.name";
+    // Graph-framework node identity (LangGraph via OpenInference).
+    pub const GRAPH_NODE_ID: &'static str = "graph.node.id";
 }
 
 /// Langfuse Attributes
@@ -276,10 +283,18 @@ pub struct FrameworkAttributes;
 
 impl FrameworkAttributes {
     // Google Vertex AI Agent
+    pub const GCP_VERTEX_AGENT_NAME: &'static str = "gcp.vertex.agent.name";
     pub const GCP_VERTEX_AGENT_LLM_REQUEST: &'static str = "gcp.vertex.agent.llm_request";
     pub const GCP_VERTEX_AGENT_LLM_RESPONSE: &'static str = "gcp.vertex.agent.llm_response";
     pub const GCP_VERTEX_AGENT_TOOL_CALL_ARGS: &'static str = "gcp.vertex.agent.tool_call_args";
     pub const GCP_VERTEX_AGENT_TOOL_RESPONSE: &'static str = "gcp.vertex.agent.tool_response";
+
+    // CrewAI (traceloop-based)
+    pub const CREWAI_TASK_AGENT: &'static str = "crewai.task.agent";
+    pub const CREWAI_TASK_TOOLS: &'static str = "crewai.task.tools";
+
+    // LangChain / LangGraph
+    pub const LANGCHAIN_TOOL_NAME: &'static str = "langchain.tool.name";
 
     // Logfire
     pub const LOGFIRE_PROMPT: &'static str = "prompt";

--- a/src/core/src/traces/otel/extractors/agent.rs
+++ b/src/core/src/traces/otel/extractors/agent.rs
@@ -69,7 +69,19 @@ impl AgentExtractor {
     }
 }
 
-const BUILT_IN_AGENT_NAME_FIELDS: &[&str] = &["agent.name", "llm.agent.name"];
+// Built-in agent-name keys across the tracing conventions OpenObserve documents,
+// so agent nodes render out-of-the-box regardless of framework:
+//  - Gen-AI / OpenInference: agent.name, llm.agent.name
+//  - Google ADK (Vertex):    gcp.vertex.agent.name
+//  - CrewAI (traceloop):     crewai.task.agent
+// service.name is deliberately NOT here — it is the app tier, not agent identity
+// (guarded by test_service_name_is_not_span_agent_fallback).
+const BUILT_IN_AGENT_NAME_FIELDS: &[&str] = &[
+    "agent.name",
+    "llm.agent.name",
+    "gcp.vertex.agent.name",
+    "crewai.task.agent",
+];
 
 const BUILT_IN_AGENT_ID_FIELDS: &[&str] = &["agent.id", "agent_id", "llm.agent.id", "llm.agent_id"];
 

--- a/src/core/src/traces/otel/extractors/gen_ai_operation.rs
+++ b/src/core/src/traces/otel/extractors/gen_ai_operation.rs
@@ -220,6 +220,28 @@ pub fn is_llm_trace(attributes: &HashMap<String, json::Value>, scope_name: Optio
         return true;
     }
 
+    // 5b. OpenInference span kind. WITHOUT this, only the LLM-kind span (which
+    // carries llm.model_name) passes the gate — the sibling AGENT and TOOL spans
+    // fail it and never get gen_ai processing, so their agent/tool names are lost.
+    // This is what made OpenAI Agents / Google ADK render model-only.
+    if attributes.contains_key(OpenInferenceAttributes::SPAN_KIND) {
+        return true;
+    }
+
+    // 5c. Framework agent/tool identity keys — a span carrying any of these is a
+    // GenAI span even if it lacks a model attribute (CrewAI task span, LangChain
+    // tool span, Google ADK agent span, OpenInference tool/agent span).
+    if attributes.contains_key(OpenInferenceAttributes::AGENT_NAME)
+        || attributes.contains_key(OpenInferenceAttributes::TOOL_NAME)
+        || attributes.contains_key(OpenInferenceAttributes::TOOL_CALL_FUNCTION_NAME)
+        || attributes.contains_key(FrameworkAttributes::GCP_VERTEX_AGENT_NAME)
+        || attributes.contains_key(FrameworkAttributes::CREWAI_TASK_AGENT)
+        || attributes.contains_key(FrameworkAttributes::CREWAI_TASK_TOOLS)
+        || attributes.contains_key(FrameworkAttributes::LANGCHAIN_TOOL_NAME)
+    {
+        return true;
+    }
+
     // 6. Most common model attributes (very common in LLM traces)
     if attributes.contains_key(FrameworkAttributes::GCP_VERTEX_AGENT_LLM_REQUEST)
         || attributes.contains_key(FrameworkAttributes::LOGFIRE_PROMPT)
@@ -709,6 +731,39 @@ mod tests {
     fn test_is_llm_trace_gen_ai_events() {
         let attrs = HashMap::new();
         assert!(!is_llm_trace(&attrs, None));
+    }
+
+    #[test]
+    fn test_is_llm_trace_openinference_tool_and_agent_spans() {
+        // Regression: OpenInference TOOL/AGENT spans carry no model attribute, so
+        // without recognising openinference.span.kind they failed the LLM gate and
+        // their tool/agent names were never extracted (OpenAI Agents / Google ADK
+        // rendered model-only). All three OpenInference span kinds must pass.
+        for kind in ["AGENT", "TOOL", "LLM"] {
+            let attrs = make_attributes(vec![("openinference.span.kind", kind)]);
+            assert!(
+                is_llm_trace(&attrs, None),
+                "openinference.span.kind={kind} must be an LLM span"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_llm_trace_framework_identity_keys() {
+        // A span carrying a framework agent/tool key is a GenAI span even without
+        // a model attribute (CrewAI task, LangChain tool, Google ADK agent).
+        for key in [
+            "tool.name",
+            "tool_call.function.name",
+            "agent.name",
+            "gcp.vertex.agent.name",
+            "crewai.task.agent",
+            "crewai.task.tools",
+            "langchain.tool.name",
+        ] {
+            let attrs = make_attributes(vec![(key, "x")]);
+            assert!(is_llm_trace(&attrs, None), "{key} must be an LLM span");
+        }
     }
 
     #[test]

--- a/src/core/src/traces/otel/extractors/tool.rs
+++ b/src/core/src/traces/otel/extractors/tool.rs
@@ -19,27 +19,50 @@ use std::collections::HashMap;
 
 use config::utils::json;
 
-use crate::service::traces::otel::attributes::{GenAiAttributes, LangfuseAttributes};
+use crate::service::traces::otel::attributes::{
+    FrameworkAttributes, GenAiAttributes, LangfuseAttributes, OpenInferenceAttributes,
+};
+
+/// Read a non-empty trimmed string attribute, else None.
+fn str_attr(attributes: &HashMap<String, json::Value>, key: &str) -> Option<String> {
+    let s = attributes.get(key)?.as_str()?.trim();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
 
 pub struct ToolExtractor;
 
 impl ToolExtractor {
-    /// Extract tool name
+    /// Extract tool name.
+    ///
+    /// Reads across the tracing conventions OpenObserve documents so tool nodes
+    /// render regardless of which framework produced the span:
+    ///  - Gen-AI semconv:  `gen_ai.tool.name`
+    ///  - OpenInference:   `tool.name`, `tool_call.function.name`
+    ///                     (Arize/Phoenix, OpenAI Agents, Google ADK)
+    ///  - LangChain:       `langchain.tool.name`
+    ///  - CrewAI:          `crewai.task.tools`
+    ///  - Langfuse:        `langfuse.observation.metadata.tool.name`
     pub fn extract_tool_name(&self, attributes: &HashMap<String, json::Value>) -> Option<String> {
-        // Check Gen-AI attributes first
-        if let Some(value) = attributes.get(GenAiAttributes::TOOL_NAME)
-            && let Some(s) = value.as_str()
-        {
-            return Some(s.to_string());
+        // Gen-AI semconv wins.
+        if let Some(s) = str_attr(attributes, GenAiAttributes::TOOL_NAME) {
+            return Some(s);
         }
-
-        // Check Langfuse attributes
-        if let Some(value) = attributes.get(LangfuseAttributes::METADATA_TOOL_NAME)
-            && let Some(s) = value.as_str()
-        {
-            return Some(s.to_string());
+        // Framework conventions, in the order they appear across the docs.
+        for key in [
+            OpenInferenceAttributes::TOOL_NAME,
+            OpenInferenceAttributes::TOOL_CALL_FUNCTION_NAME,
+            FrameworkAttributes::LANGCHAIN_TOOL_NAME,
+            FrameworkAttributes::CREWAI_TASK_TOOLS,
+            LangfuseAttributes::METADATA_TOOL_NAME,
+        ] {
+            if let Some(s) = str_attr(attributes, key) {
+                return Some(s);
+            }
         }
-
         None
     }
 
@@ -105,6 +128,54 @@ mod tests {
 
         let result = extractor.extract_tool_name(&attrs);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_extract_tool_name_openinference() {
+        // Arize/Phoenix, OpenAI Agents, Google ADK: tool.name on a TOOL span.
+        let extractor = ToolExtractor;
+        let mut attrs = HashMap::new();
+        attrs.insert("tool.name".to_string(), json::json!("file_search"));
+        assert_eq!(
+            extractor.extract_tool_name(&attrs),
+            Some("file_search".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_tool_name_openinference_function_call() {
+        let extractor = ToolExtractor;
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "tool_call.function.name".to_string(),
+            json::json!("run_query"),
+        );
+        assert_eq!(
+            extractor.extract_tool_name(&attrs),
+            Some("run_query".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_tool_name_langchain() {
+        let extractor = ToolExtractor;
+        let mut attrs = HashMap::new();
+        attrs.insert("langchain.tool.name".to_string(), json::json!("calculator"));
+        assert_eq!(
+            extractor.extract_tool_name(&attrs),
+            Some("calculator".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_tool_name_crewai() {
+        let extractor = ToolExtractor;
+        let mut attrs = HashMap::new();
+        attrs.insert("crewai.task.tools".to_string(), json::json!("web_scraper"));
+        assert_eq!(
+            extractor.extract_tool_name(&attrs),
+            Some("web_scraper".to_string())
+        );
     }
 
     #[test]

--- a/src/core/src/traces/otel/extractors/tool.rs
+++ b/src/core/src/traces/otel/extractors/tool.rs
@@ -41,8 +41,8 @@ impl ToolExtractor {
     /// Reads across the tracing conventions OpenObserve documents so tool nodes
     /// render regardless of which framework produced the span:
     ///  - Gen-AI semconv:  `gen_ai.tool.name`
-    ///  - OpenInference:   `tool.name`, `tool_call.function.name`
-    ///                     (Arize/Phoenix, OpenAI Agents, Google ADK)
+    ///  - OpenInference:   `tool.name`, `tool_call.function.name` (Arize/Phoenix, OpenAI Agents,
+    ///    Google ADK)
     ///  - LangChain:       `langchain.tool.name`
     ///  - CrewAI:          `crewai.task.tools`
     ///  - Langfuse:        `langfuse.observation.metadata.tool.name`

--- a/src/core/src/traces/service_graph/processor.rs
+++ b/src/core/src/traces/service_graph/processor.rs
@@ -165,14 +165,66 @@ pub async fn process_service_graph() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Build the `COALESCE(child.agent, p1.agent, …, pN.agent, service_name)`
+/// nearest-ancestor-agent expression for the tool/model edge `from`. `depth` is
+/// the number of ancestor levels to climb (N). When `has_agent_id`, each level
+/// prefers `agent_id` then `agent_name`. This is what lets a tool/LLM span whose
+/// agent name lives several levels up the parent chain (real Google ADK:
+/// generate_content→chat→execute_tool) still attribute to the owning agent.
+#[cfg(feature = "enterprise")]
+fn build_agent_or_service(has_agent_id: bool, depth: usize) -> String {
+    let level = |alias: &str| -> String {
+        if has_agent_id {
+            format!("{alias}.gen_ai_agent_id, {alias}.gen_ai_agent_name")
+        } else {
+            format!("{alias}.gen_ai_agent_name")
+        }
+    };
+    let mut parts = vec![level("c")];
+    for k in 1..=depth {
+        parts.push(level(&format!("p{k}")));
+    }
+    parts.push("c.service_name".to_string());
+    format!("COALESCE({})", parts.join(", "))
+}
+
+/// Build the chained ancestor `LEFT JOIN`s (p1 on child `c`, p2 on p1, …, pN on
+/// p(N-1)) joining each span to its parent via `reference_parent_span_id` within
+/// the same `trace_id`. Paired with `build_agent_or_service` to realise the
+/// multi-level agent inheritance climb.
+#[cfg(feature = "enterprise")]
+fn build_ancestor_joins(stream_name: &str, depth: usize) -> String {
+    (1..=depth)
+        .map(|k| {
+            let prev = if k == 1 {
+                "c".to_string()
+            } else {
+                format!("p{}", k - 1)
+            };
+            format!(
+                "LEFT JOIN \"{stream_name}\" AS p{k} \
+                 ON {prev}.reference_parent_span_id = p{k}.span_id \
+                 AND {prev}.trace_id = p{k}.trace_id"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n                    ")
+}
+
 /// Process a single trace stream
 #[cfg(feature = "enterprise")]
-async fn process_stream(
+/// Aggregate one trace stream into service-graph edge hits for a window WITHOUT
+/// persisting them. Split out of `process_stream` so the compute step (the
+/// query-4 self-joins for instrumented / inferred / GenAI agent-tool-model
+/// edges) is isolated from the write step. Returns the raw SQL hits
+/// (`client`/`server`/`connection_type`/metrics) the writer consumes.
+#[cfg(feature = "enterprise")]
+async fn compute_stream_edges(
     org_id: &str,
     stream_name: &str,
     start_time: i64,
     end_time: i64,
-) -> Result<(), anyhow::Error> {
+) -> Result<Vec<serde_json::Value>, anyhow::Error> {
     // Build SQL to aggregate service graph edges directly in DataFusion
     // Use CTE to compute client/server first, then aggregate
     log::info!(
@@ -322,14 +374,231 @@ async fn process_stream(
         }
     }
 
+    // ── Agent edges (GenAI topology) ─────────────────────────────────────────
+    // Three edge families derived from gen_ai_* columns already on each span, as
+    // a flat GROUP BY (no self-join — see design §2.2, avoids window-boundary
+    // edge loss). Gated on `gen_ai_operation_name` existing in the schema, which
+    // doubles as the LLM gate: it filters out the resource-fallback bleed where a
+    // process-wide gen_ai.agent.name would otherwise tag plain HTTP spans (§2.4).
+    //
+    // Predicates key on COLUMN PRESENCE, not the operation-name string: real data
+    // shows an open vocabulary (`chat`, `generate_content`, `span`, …). Model edges
+    // COALESCE request/response model because some vendors (Langfuse, OpenInference)
+    // populate ONLY response.model — verified live against synthetic vendor traces.
+    //
+    // Agent identity is COALESCE(agent_id, agent_name); `agent_id` may not exist
+    // as a column (verified: real streams lack it), so it is schema-gated
+    // independently and dropped from the COALESCE when absent (§6.1 finding 3).
+    let has_gen_ai = infra::schema::get(org_id, stream_name, StreamType::Traces)
+        .await
+        .map(|s| s.field_with_name("gen_ai_operation_name").is_ok())
+        .unwrap_or(false);
+    if has_gen_ai {
+        let has_agent_id = infra::schema::get(org_id, stream_name, StreamType::Traces)
+            .await
+            .map(|s| s.field_with_name("gen_ai_agent_id").is_ok())
+            .unwrap_or(false);
+        // Identity expression: prefer id, fall back to name; omit id if the column
+        // is absent (referencing a missing column is a hard error, not NULL).
+        let agent_ident = if has_agent_id {
+            "COALESCE(gen_ai_agent_id, gen_ai_agent_name)"
+        } else {
+            "gen_ai_agent_name"
+        };
+
+        // Stream schema, used to gate optional columns (parent link, model cols).
+        let model_schema = infra::schema::get(org_id, stream_name, StreamType::Traces).await;
+
+        // For tool/model, the `from` is the agent that OWNS the span. But most
+        // frameworks (OpenInference, traceloop, CrewAI, Google ADK) put the agent
+        // name ONLY on an ancestor `invoke_agent`/AGENT span — the child tool and
+        // LLM spans carry no agent name. Critically, the agent may be MORE THAN
+        // ONE level up: real Google ADK traces nest
+        //   generate_content(agent=X) → chat(agent=NULL) → execute_tool(tool)
+        // so the tool's agent lives at depth 2, not 1. We therefore climb the
+        // parent chain up to AGENT_INHERIT_DEPTH levels and take the NEAREST
+        // ancestor (including self) that carries an agent name, falling back to
+        // the host service_name:
+        //   from = COALESCE(child.agent, p1.agent, …, pN.agent, child.service_name)
+        // A recursive CTE would be the general form, but the search engine does
+        // not support WITH RECURSIVE here (it panics), and real agent trees are
+        // shallow — a bounded chained-join climb is both supported and cheaper.
+        // p1..pN are the ancestor aliases in the tool/model queries below.
+        const AGENT_INHERIT_DEPTH: usize = 4;
+        let has_parent_link = model_schema
+            .as_ref()
+            .map(|s| s.field_with_name("reference_parent_span_id").is_ok())
+            .unwrap_or(false);
+        // The nearest-ancestor-agent-or-service `from` for tool/model. With the
+        // parent-link column present, COALESCE walks child → p1 → … → pN → service;
+        // otherwise it is the flat child-or-service form (no join possible).
+        let agent_or_service = if has_parent_link {
+            build_agent_or_service(has_agent_id, AGENT_INHERIT_DEPTH)
+        } else {
+            format!("COALESCE({agent_ident}, service_name)")
+        };
+        // The chained ancestor LEFT JOINs (p1 on child, p2 on p1, …), shared by
+        // the tool and model queries. Empty when the stream has no parent link.
+        let ancestor_joins = if has_parent_link {
+            build_ancestor_joins(stream_name, AGENT_INHERIT_DEPTH)
+        } else {
+            String::new()
+        };
+
+        // Model identity: prefer request.model, fall back to response.model. Some
+        // vendors (Langfuse, OpenInference) populate ONLY response.model, others
+        // only request.model. BOTH columns must be schema-gated independently —
+        // referencing a column absent from the stream schema is a hard error, so
+        // the COALESCE is built from only the columns that actually exist.
+        let has_request_model = model_schema
+            .as_ref()
+            .map(|s| s.field_with_name("gen_ai_request_model").is_ok())
+            .unwrap_or(false);
+        let has_response_model = model_schema
+            .as_ref()
+            .map(|s| s.field_with_name("gen_ai_response_model").is_ok())
+            .unwrap_or(false);
+        let model_expr = match (has_request_model, has_response_model) {
+            (true, true) => "COALESCE(gen_ai_request_model, gen_ai_response_model)",
+            (true, false) => "gen_ai_request_model",
+            (false, true) => "gen_ai_response_model",
+            // Neither column exists — no model edges possible; the predicate below
+            // will be false-ish and the query still runs (schema-safe).
+            (false, false) => "CAST(NULL AS STRING)",
+        };
+        let model_predicate =
+            format!("{model_expr} IS NOT NULL AND {model_expr} != ''");
+
+        // Metric aggregates shared by every edge query (aliased to child `c`
+        // where a join is present, so it works in both flat and joined forms).
+        let metrics = |t: &str| {
+            format!(
+                "COUNT(*) AS total_requests, \
+                 COUNT(*) FILTER (WHERE {t}span_status = 'ERROR') AS errors, \
+                 CAST(COUNT(*) FILTER (WHERE {t}span_status = 'ERROR') * 100.0 / COUNT(*) AS DOUBLE) AS error_rate, \
+                 CAST(approx_median({t}end_time - {t}start_time) AS BIGINT) AS p50, \
+                 CAST(approx_percentile_cont({t}end_time - {t}start_time, 0.95) AS BIGINT) AS p95, \
+                 CAST(approx_percentile_cont({t}end_time - {t}start_time, 0.99) AS BIGINT) AS p99"
+            )
+        };
+
+        // 1) service → agent : an invoke_agent span's host service calls the agent.
+        // A flat scan — the agent name IS on this span by definition.
+        let m = metrics("");
+        let agent_sql = format!(
+            r#"SELECT service_name AS client, {agent_ident} AS server,
+                'agent' AS connection_type, {m}
+            FROM "{stream_name}"
+            WHERE _timestamp >= {start_time} AND _timestamp < {end_time}
+                AND gen_ai_operation_name = 'invoke_agent'
+                AND service_name IS NOT NULL AND service_name != ''
+                AND ({agent_ident}) IS NOT NULL AND ({agent_ident}) != ''
+                AND service_name != ({agent_ident})
+            GROUP BY service_name, {agent_ident}"#,
+        );
+
+        // 2) agent → tool  and  3) agent → model. These key the `from` on the
+        // OWNING agent, inherited from the parent span (parent-agent join) because
+        // most frameworks omit agent name on the child tool/LLM span. When the
+        // stream lacks the parent-link column, `agent_or_service` is the flat
+        // child-or-service form and no join is emitted.
+        let mc = metrics("c.");
+        let tool_from = &agent_or_service;
+        let model_from = &agent_or_service;
+        let (tool_sql, model_sql) = if has_parent_link {
+            (
+                format!(
+                    r#"SELECT {tool_from} AS client, c.gen_ai_tool_name AS server,
+                        'tool' AS connection_type, {mc}
+                    FROM "{stream_name}" AS c
+                    {ancestor_joins}
+                    WHERE c._timestamp >= {start_time} AND c._timestamp < {end_time}
+                        AND c.gen_ai_tool_name IS NOT NULL AND c.gen_ai_tool_name != ''
+                        AND ({tool_from}) IS NOT NULL AND ({tool_from}) != ''
+                        AND ({tool_from}) != c.gen_ai_tool_name
+                    GROUP BY {tool_from}, c.gen_ai_tool_name"#,
+                ),
+                format!(
+                    r#"SELECT {model_from} AS client, {model_expr_c} AS server,
+                        'model' AS connection_type, {mc}
+                    FROM "{stream_name}" AS c
+                    {ancestor_joins}
+                    WHERE c._timestamp >= {start_time} AND c._timestamp < {end_time}
+                        AND {model_predicate_c}
+                        AND ({model_from}) IS NOT NULL AND ({model_from}) != ''
+                        AND ({model_from}) != ({model_expr_c})
+                    GROUP BY {model_from}, {model_expr_c}"#,
+                    model_expr_c = model_expr.replace("gen_ai_", "c.gen_ai_"),
+                    model_predicate_c = model_predicate.replace("gen_ai_", "c.gen_ai_"),
+                ),
+            )
+        } else {
+            let m = metrics("");
+            (
+                format!(
+                    r#"SELECT {agent_or_service} AS client, gen_ai_tool_name AS server,
+                        'tool' AS connection_type, {m}
+                    FROM "{stream_name}"
+                    WHERE _timestamp >= {start_time} AND _timestamp < {end_time}
+                        AND gen_ai_tool_name IS NOT NULL AND gen_ai_tool_name != ''
+                        AND ({agent_or_service}) IS NOT NULL AND ({agent_or_service}) != ''
+                        AND ({agent_or_service}) != gen_ai_tool_name
+                    GROUP BY {agent_or_service}, gen_ai_tool_name"#,
+                ),
+                format!(
+                    r#"SELECT {agent_or_service} AS client, {model_expr} AS server,
+                        'model' AS connection_type, {m}
+                    FROM "{stream_name}"
+                    WHERE _timestamp >= {start_time} AND _timestamp < {end_time}
+                        AND {model_predicate}
+                        AND ({agent_or_service}) IS NOT NULL AND ({agent_or_service}) != ''
+                        AND ({agent_or_service}) != ({model_expr})
+                    GROUP BY {agent_or_service}, {model_expr}"#,
+                ),
+            )
+        };
+
+        for (conn_type, agent_sql) in [
+            ("agent", agent_sql),
+            ("tool", tool_sql),
+            ("model", model_sql),
+        ] {
+            match run_graph_search(org_id, agent_sql, start_time, end_time).await {
+                Ok(mut agent_hits) => {
+                    log::info!(
+                        "[ServiceGraph] Query returned {} {conn_type} edges from {org_id}/{stream_name}",
+                        agent_hits.len(),
+                    );
+                    hits.append(&mut agent_hits);
+                }
+                // Non-fatal: still write whatever edges we already have.
+                Err(e) => log::debug!(
+                    "[ServiceGraph] Agent {conn_type}-edge query (non-fatal) for {org_id}/{stream_name}: {e}"
+                ),
+            }
+        }
+    }
+
+    Ok(hits)
+}
+
+/// Hourly-job path: aggregate one stream's edges and PERSIST them to the
+/// `_o2_service_graph` stream. Thin wrapper over `compute_stream_edges` so the
+/// live Agent Graph path can reuse the exact same aggregation without writing.
+#[cfg(feature = "enterprise")]
+async fn process_stream(
+    org_id: &str,
+    stream_name: &str,
+    start_time: i64,
+    end_time: i64,
+) -> Result<(), anyhow::Error> {
+    let hits = compute_stream_edges(org_id, stream_name, start_time, end_time).await?;
     if hits.is_empty() {
         return Ok(());
     }
-
     // SQL already aggregated everything - just write directly to _o2_service_graph stream
     crate::service::traces::service_graph::write_sql_aggregated_edges(org_id, stream_name, hits)
         .await?;
-
     Ok(())
 }
 
@@ -404,5 +673,56 @@ mod test {
                 data.org_id == "random" && data.stream_name == "random-stream"
             })
         );
+    }
+
+    // Multi-level agent inheritance: a tool/LLM span's owning agent may be more
+    // than one parent up (real Google ADK: generate_content(agent)→chat→tool),
+    // so the `from` COALESCE must walk child → p1 → … → pN → service, and the
+    // query must emit one chained LEFT JOIN per level. Regression guard against
+    // silently collapsing back to a single parent level.
+    #[test]
+    fn test_agent_or_service_climbs_all_levels() {
+        let expr = super::build_agent_or_service(false, 4);
+        assert_eq!(
+            expr,
+            "COALESCE(c.gen_ai_agent_name, p1.gen_ai_agent_name, \
+             p2.gen_ai_agent_name, p3.gen_ai_agent_name, p4.gen_ai_agent_name, \
+             c.service_name)"
+        );
+        // child first (self wins), service_name last (fallback).
+        assert!(expr.starts_with("COALESCE(c.gen_ai_agent_name,"));
+        assert!(expr.ends_with("c.service_name)"));
+        // one agent term per level + child + service.
+        assert_eq!(expr.matches("gen_ai_agent_name").count(), 5);
+    }
+
+    #[test]
+    fn test_agent_or_service_prefers_agent_id_when_present() {
+        let expr = super::build_agent_or_service(true, 2);
+        assert_eq!(
+            expr,
+            "COALESCE(c.gen_ai_agent_id, c.gen_ai_agent_name, \
+             p1.gen_ai_agent_id, p1.gen_ai_agent_name, \
+             p2.gen_ai_agent_id, p2.gen_ai_agent_name, c.service_name)"
+        );
+    }
+
+    #[test]
+    fn test_ancestor_joins_chain_parent_links() {
+        let joins = super::build_ancestor_joins("mystream", 3);
+        // p1 joins the child c; p2 joins p1; p3 joins p2 — a true chain.
+        assert!(joins.contains(
+            "LEFT JOIN \"mystream\" AS p1 ON c.reference_parent_span_id = p1.span_id"
+        ));
+        assert!(joins.contains(
+            "LEFT JOIN \"mystream\" AS p2 ON p1.reference_parent_span_id = p2.span_id"
+        ));
+        assert!(joins.contains(
+            "LEFT JOIN \"mystream\" AS p3 ON p2.reference_parent_span_id = p3.span_id"
+        ));
+        // trace_id is part of every join key (no cross-trace leakage).
+        assert_eq!(joins.matches("trace_id = p").count(), 3);
+        // exactly `depth` joins.
+        assert_eq!(joins.matches("LEFT JOIN").count(), 3);
     }
 }

--- a/src/core/src/traces/service_graph/processor.rs
+++ b/src/core/src/traces/service_graph/processor.rs
@@ -466,8 +466,7 @@ async fn compute_stream_edges(
             // will be false-ish and the query still runs (schema-safe).
             (false, false) => "CAST(NULL AS STRING)",
         };
-        let model_predicate =
-            format!("{model_expr} IS NOT NULL AND {model_expr} != ''");
+        let model_predicate = format!("{model_expr} IS NOT NULL AND {model_expr} != ''");
 
         // Metric aggregates shared by every edge query (aliased to child `c`
         // where a join is present, so it works in both flat and joined forms).
@@ -711,15 +710,21 @@ mod test {
     fn test_ancestor_joins_chain_parent_links() {
         let joins = super::build_ancestor_joins("mystream", 3);
         // p1 joins the child c; p2 joins p1; p3 joins p2 — a true chain.
-        assert!(joins.contains(
-            "LEFT JOIN \"mystream\" AS p1 ON c.reference_parent_span_id = p1.span_id"
-        ));
-        assert!(joins.contains(
-            "LEFT JOIN \"mystream\" AS p2 ON p1.reference_parent_span_id = p2.span_id"
-        ));
-        assert!(joins.contains(
-            "LEFT JOIN \"mystream\" AS p3 ON p2.reference_parent_span_id = p3.span_id"
-        ));
+        assert!(
+            joins.contains(
+                "LEFT JOIN \"mystream\" AS p1 ON c.reference_parent_span_id = p1.span_id"
+            )
+        );
+        assert!(
+            joins.contains(
+                "LEFT JOIN \"mystream\" AS p2 ON p1.reference_parent_span_id = p2.span_id"
+            )
+        );
+        assert!(
+            joins.contains(
+                "LEFT JOIN \"mystream\" AS p3 ON p2.reference_parent_span_id = p3.span_id"
+            )
+        );
         // trace_id is part of every join key (no cross-trace leakage).
         assert_eq!(joins.matches("trace_id = p").count(), 3);
         // exactly `depth` joins.

--- a/web/src/enterprise/composables/router.ts
+++ b/web/src/enterprise/composables/router.ts
@@ -29,6 +29,8 @@ const AILLMInsightsPage = () =>
   import("@/enterprise/views/AIObservability/LLMInsightsPage.vue");
 const AISessionsPage = () =>
   import("@/enterprise/views/AIObservability/SessionsPage.vue");
+const AIAgentGraphPage = () =>
+  import("@/enterprise/views/AIObservability/AgentGraphPage.vue");
 // Reused for the AI/LLM session drill-down so it lives under /ai (keeps the
 // AI menu item active) instead of the Traces session-details route.
 const SessionDetails = () =>
@@ -92,6 +94,12 @@ const useEnvRoutes = () => {
           name: "aiSessions",
           component: AISessionsPage,
           meta: { title: "Sessions", keepAlive: false },
+        },
+        {
+          path: "agent-graph",
+          name: "aiAgentGraph",
+          component: AIAgentGraphPage,
+          meta: { title: "Agent Graph", keepAlive: false },
         },
         {
           path: "evaluations",

--- a/web/src/enterprise/views/AIObservability/AgentGraphPage.vue
+++ b/web/src/enterprise/views/AIObservability/AgentGraphPage.vue
@@ -1,0 +1,265 @@
+<!-- Copyright 2026 OpenObserve Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+  <div
+    data-test="ai-agent-graph-page"
+    class="flex flex-col h-full min-h-0 overflow-hidden"
+  >
+    <AppPageHeader
+      :title="t('aiObservability.nav.agentGraph')"
+      :subtitle="t('aiObservability.subtitle.agentGraph')"
+      icon="hub"
+      class="px-4 border-b border-border-default"
+    >
+      <template #actions>
+        <date-time
+          ref="dateTimeRef"
+          auto-apply
+          menu-align="end"
+          :default-type="searchObj.data.datetime.type"
+          :default-absolute-time="{
+            startTime: searchObj.data.datetime.startTime ?? 0,
+            endTime: searchObj.data.datetime.endTime ?? 0,
+          }"
+          :default-relative-time="
+            searchObj.data.datetime.relativeTimePeriod ?? '15m'
+          "
+          data-test="ai-agent-graph-date-time"
+          class="h-[2rem]"
+          @on:date-change="onDateChange"
+        />
+      </template>
+    </AppPageHeader>
+
+    <!-- Scope control — same Stream/Agent pattern as LLM Insights, so the two
+         AI pages read as one product. Stream tab picks a trace stream; Agent
+         tab picks a discovered agent and the graph follows its source_stream. -->
+    <div
+      class="flex items-center gap-3 px-4 py-2 border-b border-border-default"
+    >
+      <OToggleGroup
+        :model-value="filterMode"
+        type="single"
+        data-test="agent-graph-filter-mode"
+        @update:model-value="onFilterModeChange"
+      >
+        <OToggleGroupItem value="stream" size="sm">{{
+          t("aiObservability.agentGraph.stream")
+        }}</OToggleGroupItem>
+        <OToggleGroupItem value="agent" size="sm">{{
+          t("aiObservability.agentGraph.agent")
+        }}</OToggleGroupItem>
+      </OToggleGroup>
+
+      <div
+        v-if="filterMode === 'stream'"
+        data-test="agent-graph-stream-selector"
+        class="w-[14rem] flex-shrink-0"
+      >
+        <OSelect
+          v-model="activeStream"
+          :label="t('aiObservability.agentGraph.stream')"
+          label-position="inside"
+          :options="availableStreams.map((s) => ({ label: s, value: s }))"
+          labelKey="label"
+          valueKey="value"
+          class="w-full rounded"
+        />
+      </div>
+      <div
+        v-else
+        data-test="agent-graph-agent-selector"
+        class="w-[14rem] flex-shrink-0"
+      >
+        <SkeletonBox
+          v-if="!agentsLoaded"
+          width="100%"
+          height="2.125rem"
+          rounded
+        />
+        <OSelect
+          v-else
+          v-model="activeAgentKey"
+          :label="t('aiObservability.agentGraph.agent')"
+          label-position="inside"
+          :options="agentSelectOptions"
+          labelKey="label"
+          valueKey="value"
+          class="w-full rounded"
+        />
+      </div>
+    </div>
+
+    <div class="flex-1 min-h-0 overflow-hidden">
+      <ServiceGraph
+        :stream-filter="effectiveStream"
+        hide-stream-selector
+        agent-highlight
+        class="h-full"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineAsyncComponent, ref, computed, onMounted } from "vue";
+import { useI18n } from "vue-i18n";
+import { useStore } from "vuex";
+import DateTime from "@/components/DateTime.vue";
+import AppPageHeader from "@/components/common/AppPageHeader.vue";
+import OSelect from "@/lib/forms/Select/OSelect.vue";
+import OToggleGroup from "@/lib/core/ToggleGroup/OToggleGroup.vue";
+import OToggleGroupItem from "@/lib/core/ToggleGroup/OToggleGroupItem.vue";
+import SkeletonBox from "@/components/shared/SkeletonBox.vue";
+import useTraces from "@/composables/useTraces";
+import useStreams from "@/composables/useStreams";
+import { getConsumableRelativeTime } from "@/utils/date";
+import genAiAgentMappingService, {
+  type GenAiAgentListItem,
+} from "@/services/gen-ai-agent-mapping.service";
+
+defineOptions({ name: "AIAgentGraphPage" });
+
+const { t } = useI18n();
+const store = useStore();
+const { searchObj } = useTraces();
+const { getStreams } = useStreams();
+
+const ServiceGraph = defineAsyncComponent(
+  () => import("@/plugins/traces/ServiceGraph.vue"),
+);
+
+const DEFAULT_RELATIVE = "15m";
+
+const filterMode = ref<"stream" | "agent">("stream");
+const availableStreams = ref<string[]>([]);
+const activeStream = ref<string>("default");
+
+const agents = ref<GenAiAgentListItem[]>([]);
+const agentsLoaded = ref(false);
+const activeAgentKey = ref<string>("");
+
+// Stream-scoped identity, mirroring LLM Insights — same-named agents in
+// different streams don't collide.
+const agentKey = (a: GenAiAgentListItem) => `${a.source_stream}::${a.name}`;
+
+const agentSelectOptions = computed(() =>
+  agents.value.map((a) => ({
+    label: a.id ? `${a.name} (${a.id})` : a.name,
+    value: agentKey(a),
+  })),
+);
+
+const selectedAgent = computed<GenAiAgentListItem | null>(
+  () => agents.value.find((a) => agentKey(a) === activeAgentKey.value) ?? null,
+);
+
+// The stream the graph queries: the picked stream, or the selected agent's
+// source_stream. Deriving the stream from the agent is the whole point — the
+// user picks an agent, not a stream.
+const effectiveStream = computed(() =>
+  filterMode.value === "agent"
+    ? (selectedAgent.value?.source_stream ?? activeStream.value)
+    : activeStream.value,
+);
+
+function onFilterModeChange(mode?: string | number | null) {
+  if (mode === "stream" || mode === "agent") filterMode.value = mode;
+}
+
+function effectiveWindow() {
+  const dt = searchObj.data.datetime;
+  if (dt.type === "relative" && dt.relativeTimePeriod) {
+    const r = getConsumableRelativeTime(dt.relativeTimePeriod);
+    if (r) return { startTime: r.startTime, endTime: r.endTime };
+  }
+  return { startTime: dt.startTime, endTime: dt.endTime };
+}
+
+async function loadStreams() {
+  try {
+    const res = await getStreams("traces", false, false);
+    availableStreams.value = (res?.list ?? []).map((s: any) => s.name);
+    if (
+      availableStreams.value.length &&
+      !availableStreams.value.includes(activeStream.value)
+    ) {
+      activeStream.value = availableStreams.value[0];
+    }
+  } catch {
+    availableStreams.value = [];
+  }
+}
+
+async function loadAgents() {
+  try {
+    const org = store.state.selectedOrganization.identifier;
+    const { startTime, endTime } = effectiveWindow();
+    const res = await genAiAgentMappingService.listAgents(
+      org,
+      startTime,
+      endTime,
+    );
+    agents.value = res.agents ?? [];
+    if (!activeAgentKey.value && agents.value.length) {
+      activeAgentKey.value = agentKey(agents.value[0]);
+    }
+  } catch {
+    agents.value = [];
+  } finally {
+    agentsLoaded.value = true;
+  }
+}
+
+function applyRelative(period: string) {
+  const range = getConsumableRelativeTime(period);
+  if (!range) return;
+  searchObj.data.datetime = {
+    type: "relative",
+    relativeTimePeriod: period,
+    startTime: range.startTime,
+    endTime: range.endTime,
+  };
+}
+
+function onDateChange(value: any) {
+  if (value?.valueType === "relative" && value.relativeTimePeriod) {
+    applyRelative(value.relativeTimePeriod);
+  } else {
+    searchObj.data.datetime = {
+      type: "absolute",
+      relativeTimePeriod: "",
+      startTime: value.startTime,
+      endTime: value.endTime,
+    };
+  }
+  loadAgents();
+}
+
+onMounted(() => {
+  if (
+    searchObj.data.datetime.type === "relative" ||
+    !searchObj.data.datetime.startTime
+  ) {
+    applyRelative(
+      searchObj.data.datetime.relativeTimePeriod || DEFAULT_RELATIVE,
+    );
+  }
+  loadStreams();
+  loadAgents();
+});
+</script>

--- a/web/src/enterprise/views/AIObservability/Index.vue
+++ b/web/src/enterprise/views/AIObservability/Index.vue
@@ -97,6 +97,14 @@ const sectionItems = computed<(SectionHubItem & { group: string })[]>(() => [
     group: "Monitor",
   },
   {
+    key: "agentGraph",
+    label: t("aiObservability.nav.agentGraph"),
+    icon: "hub",
+    to: { name: "aiAgentGraph", query: orgQuery.value },
+    dataTest: "ai-secondary-nav-agent-graph",
+    group: "Monitor",
+  },
+  {
     key: "quality",
     label: t("aiObservability.nav.quality"),
     icon: "star-rate",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -4961,7 +4961,10 @@
         "database": "Datastores",
         "queue": "Queues",
         "external": "External",
-        "rpc": "RPC"
+        "rpc": "RPC",
+        "agent": "Agents",
+        "tool": "Tools",
+        "model": "Models"
       }
     },
     "openInFullView": "Open in full view",
@@ -5936,6 +5939,7 @@
     "nav": {
       "llmInsights": "LLM Insights",
       "sessions": "LLM Sessions",
+      "agentGraph": "Agent Graph",
       "quality": "Quality",
       "evalJobs": "Eval Jobs",
       "scorers": "Scorers",
@@ -5944,10 +5948,16 @@
     "subtitle": {
       "llmInsights": "Track latency, errors, tokens, and cost across your LLM traffic",
       "sessions": "Browse and inspect agent sessions turn by turn",
+      "agentGraph": "See what your agents interact with — tools, models, services, and datastores",
       "quality": "Score and track the quality of your LLM responses",
       "evalJobs": "Run and monitor evaluation jobs across your sessions",
       "scorers": "Create and manage the scorers that grade LLM outputs",
       "scoreConfigs": "Configure the scoring rubrics used by your evaluations"
+    },
+    "agentGraph": {
+      "allAgents": "All agents",
+      "stream": "Stream",
+      "agent": "Agent"
     },
     "kpi": {
       "totalCost": "Total Cost",

--- a/web/src/plugins/traces/ServiceGraph.spec.ts
+++ b/web/src/plugins/traces/ServiceGraph.spec.ts
@@ -197,10 +197,11 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
     },
   };
 
-  const createWrapper = (storeOverrides = {}) => {
+  const createWrapper = (storeOverrides = {}, props = {}) => {
     mockStore = createMockStore(storeOverrides);
 
     return mount(ServiceGraph, {
+      props,
       global: {
         plugins: [i18n],
         mocks: {
@@ -438,6 +439,63 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
 
       expect(wrapper.emitted("request:stream-change")).toBeTruthy();
       expect(wrapper.emitted("request:stream-change")![0]).toEqual(["all"]);
+    });
+  });
+
+  describe("Parent-driven streamFilter prop (Agent Graph page)", () => {
+    afterEach(() => {
+      if (wrapper) wrapper.unmount();
+    });
+
+    it("reloads the graph when the streamFilter prop changes", async () => {
+      vi.mocked(serviceGraphService.getCurrentTopology).mockResolvedValue({
+        data: { nodes: [], edges: [] },
+      } as any);
+      wrapper = createWrapper({}, { streamFilter: "stream-a" });
+      await flushPromises();
+      vi.mocked(serviceGraphService.getCurrentTopology).mockClear();
+
+      // Parent selects a different agent → its source_stream flows in as the prop.
+      await wrapper.setProps({ streamFilter: "stream-b" });
+      await flushPromises();
+
+      // Regression: previously the prop watcher only synced the ref and never
+      // refetched, so the graph never refreshed on agent change.
+      expect(serviceGraphService.getCurrentTopology).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ streamName: "stream-b" }),
+      );
+    });
+
+    it("does not reload when the streamFilter prop is unchanged", async () => {
+      vi.mocked(serviceGraphService.getCurrentTopology).mockResolvedValue({
+        data: { nodes: [], edges: [] },
+      } as any);
+      wrapper = createWrapper({}, { streamFilter: "stream-a" });
+      await flushPromises();
+      vi.mocked(serviceGraphService.getCurrentTopology).mockClear();
+
+      await wrapper.setProps({ streamFilter: "stream-a" });
+      await flushPromises();
+
+      expect(serviceGraphService.getCurrentTopology).not.toHaveBeenCalled();
+    });
+
+    // Both the Agent Graph page (agentHighlight) and the Service Graph tab read
+    // the pre-aggregated _o2_service_graph stream via /topology/current — a cheap
+    // small-stream read that scales to TB-level trace volumes. We deliberately do
+    // NOT re-scan raw traces per load.
+    it("reads the persisted /current topology on the Agent Graph page (agentHighlight)", async () => {
+      wrapper = createWrapper(
+        {},
+        { streamFilter: "fw_crewai", agentHighlight: true },
+      );
+      await flushPromises();
+
+      expect(serviceGraphService.getCurrentTopology).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ streamName: "fw_crewai" }),
+      );
     });
   });
 
@@ -1984,6 +2042,9 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
         queue: 0,
         external: 1,
         rpc: 0,
+        agent: 0,
+        tool: 0,
+        model: 0,
       });
     });
 

--- a/web/src/plugins/traces/ServiceGraph.vue
+++ b/web/src/plugins/traces/ServiceGraph.vue
@@ -2,8 +2,10 @@
   <OCard class="h-full flex flex-col">
     <!-- Top toolbar: [stream-selector] [search-input]  ···spacer···  [legends] -->
     <div class="flex items-center gap-2 p-[0.375rem] pb-0">
-      <!-- Stream selector -->
+      <!-- Stream selector (hidden when a parent drives selection, e.g. the
+           Agent Graph page which selects by agent). -->
       <div
+        v-if="!hideStreamSelector"
         data-test="service-graph-stream-selector"
         class="w-44 flex-shrink-0"
       >
@@ -440,6 +442,29 @@ export default defineComponent({
     OToggleGroupItem,
     ServiceGraphNoDataState,
   },
+  props: {
+    // Optional external stream override. When set (e.g. by the standalone
+    // Agent Graph page, which selects by agent → its source_stream), it seeds
+    // the internal streamFilter and keeps it in sync, instead of the component
+    // sourcing the stream from the shared traces store.
+    streamFilter: {
+      type: String,
+      default: undefined,
+    },
+    // Hide the built-in stream dropdown when the parent owns selection.
+    hideStreamSelector: {
+      type: Boolean,
+      default: false,
+    },
+    // Agent-node highlighting (indigo tint, larger size, radar-ping halo) is a
+    // treatment for the dedicated Agent Graph page ONLY. On the regular Service
+    // Graph tab agents are rendered like any other node. The Agent Graph page
+    // sets this true; every other mount leaves it false.
+    agentHighlight: {
+      type: Boolean,
+      default: false,
+    },
+  },
   emits: ["view-traces", "request:stream-change", "jump-to-stream-data"],
   setup(props, { emit }) {
     const store = useStore();
@@ -462,12 +487,30 @@ export default defineComponent({
 
     const searchFilter = ref("");
 
-    // Stream filter — synced from traces page selected stream
+    // Stream filter — an external `streamFilter` prop (Agent Graph page) wins;
+    // otherwise sync from the traces page selected stream / localStorage.
     const tracesStream = searchObj.data.stream?.selectedStream?.value || "";
     const storedStreamFilter = localStorage.getItem(
       "serviceGraph_streamFilter",
     );
-    const streamFilter = ref(tracesStream || storedStreamFilter || "default");
+    const streamFilter = ref(
+      props.streamFilter || tracesStream || storedStreamFilter || "default",
+    );
+    // Keep the internal ref in sync when the parent drives the stream (e.g. the
+    // Agent Graph page selecting by agent → its source_stream) AND reload the
+    // graph. The built-in dropdown delegates reload to its parent via
+    // `request:stream-change`; a parent-driven stream has no such round-trip, so
+    // we refetch here directly. `loadServiceGraph` is hoisted (defined later in
+    // setup) — safe because the watcher callback only runs on later changes.
+    watch(
+      () => props.streamFilter,
+      (next) => {
+        if (next && next !== streamFilter.value) {
+          streamFilter.value = next;
+          loadServiceGraph();
+        }
+      },
+    );
     const availableStreams = ref<string[]>([]);
 
     const graphData = ref<any>({
@@ -559,7 +602,16 @@ export default defineComponent({
     // Count nodes by kind (from backend service_type) for the legend. Nodes with
     // no inferred type are instrumented services; the rest are inferred deps.
     const kindCounts = computed(() => {
-      const counts = { service: 0, database: 0, queue: 0, external: 0, rpc: 0 };
+      const counts = {
+        service: 0,
+        database: 0,
+        queue: 0,
+        external: 0,
+        rpc: 0,
+        agent: 0,
+        tool: 0,
+        model: 0,
+      };
       // Count the RAW backend topology, not the collapsed view — the legend must
       // report the true entity counts regardless of collapse/expand state, and
       // must never count a boundary node (which represents N members) as one.
@@ -570,6 +622,9 @@ export default defineComponent({
         else if (t === "queue") counts.queue++;
         else if (t === "external") counts.external++;
         else if (t === "rpc") counts.rpc++;
+        else if (t === "agent") counts.agent++;
+        else if (t === "tool") counts.tool++;
+        else if (t === "model") counts.model++;
         else counts.service++;
       }
       return counts;
@@ -603,6 +658,9 @@ export default defineComponent({
       { key: "queue", label: t("traces.serviceGraph.kind.queue"), count: kindCounts.value.queue, toggleable: true },
       { key: "external", label: t("traces.serviceGraph.kind.external"), count: kindCounts.value.external, toggleable: true },
       { key: "rpc", label: t("traces.serviceGraph.kind.rpc"), count: kindCounts.value.rpc, toggleable: true },
+      { key: "agent", label: t("traces.serviceGraph.kind.agent"), count: kindCounts.value.agent, toggleable: true },
+      { key: "tool", label: t("traces.serviceGraph.kind.tool"), count: kindCounts.value.tool, toggleable: true },
+      { key: "model", label: t("traces.serviceGraph.kind.model"), count: kindCounts.value.model, toggleable: true },
     ]);
 
     // How many entity types the user has hidden. Non-zero means the graph is
@@ -658,6 +716,8 @@ export default defineComponent({
               // label font + node size to the fit-to-view compression, keeping
               // labels from overlapping on tall (many-leaf) graphs.
               graphContainerRef.value?.clientHeight || 700,
+              // Agent highlighting (tint/size/ping) only on the Agent Graph page.
+              props.agentHighlight,
             )
           : convertServiceGraphToNetwork(
               filteredGraphData.value,
@@ -669,6 +729,8 @@ export default defineComponent({
               undefined,
               graphContainerRef.value?.clientWidth || 1200,
               graphContainerRef.value?.clientHeight || 700,
+              // Agent highlighting (tint/size/ping) only on the Agent Graph page.
+              props.agentHighlight,
             );
 
       // Cache the options for graph view
@@ -1032,6 +1094,14 @@ export default defineComponent({
       chart.on("finished", debouncedBuild);
       // Also try immediately (works if chart already rendered)
       buildEdgeData();
+
+      // NOTE: the agent "radar ping" halo is NOT drawn here. It is baked into
+      // each agent node's own symbol SVG (see getServiceIconDataUrl) as native
+      // SMIL <animate> rings — the graph renders in SVG mode, so they animate.
+      // Doing it in the symbol (rather than an ECharts `graphic` overlay) keeps
+      // the halo perfectly centred on the node and moving/zooming with it; the
+      // overlay approach drifted because `graphic` lives outside the roam
+      // (pan/zoom) transform applied to the series group.
 
       // Use imported helper functions for testability
 
@@ -1411,14 +1481,17 @@ export default defineComponent({
 
         // Topology, node kinds, edges and latency all come from the
         // pre-aggregated _o2_service_graph stream via /topology/current. The
-        // backend (processor + build_topology) now computes the complete,
-        // classified topology — including async queue consumers and collision
-        // handling — so the UI is a thin renderer with no client-side derivation.
+        // backend hourly job (processor + build_topology) computes the complete,
+        // classified topology — queue consumers, collision handling, GenAI
+        // agent/tool/model edges — incrementally per window, so reading it here
+        // is a cheap small-stream read that scales to TB-level trace volumes
+        // (we do NOT re-scan raw traces per load). The UI is a thin renderer.
+        const streamName =
+          streamFilter.value && streamFilter.value !== "all"
+            ? streamFilter.value
+            : undefined;
         const response = await serviceGraphService.getCurrentTopology(orgId, {
-          streamName:
-            streamFilter.value && streamFilter.value !== "all"
-              ? streamFilter.value
-              : undefined,
+          streamName,
           startTime,
           endTime,
         });

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
@@ -599,6 +599,59 @@ describe("ServiceGraphNodeSidePanel", () => {
       expect(panel.exists()).toBe(true);
       expect(panel.text()).toContain("No operations found");
     });
+
+    // A tool node's caller is its OWNING AGENT, which sits on an ancestor span —
+    // the operations query must climb the parent chain (COALESCE + chained LEFT
+    // JOINs) exactly like the graph edge, so the panel and the graph agree. The
+    // bug: it used raw service_name, showing the host app as the caller while the
+    // graph correctly showed the agent.
+    it("climbs the parent chain for a TOOL node's caller (matches the graph)", async () => {
+      vi.mocked(searchService.search).mockClear();
+      vi.mocked(searchService.search).mockResolvedValue({
+        data: { hits: [] },
+      } as any);
+      wrapper = mountPanel({
+        streamFilter: "sre_agent_v2",
+        selectedNode: { ...baseNode, name: "load_skill", service_type: "tool" },
+      });
+      await flushPromises();
+      const sql =
+        vi.mocked(searchService.search).mock.calls[0][0].query.query.sql;
+      // Nearest-ancestor-agent caller, not raw service_name.
+      expect(sql).toContain(
+        "COALESCE(c.gen_ai_agent_name, p1.gen_ai_agent_name",
+      );
+      expect(sql).toContain("c.service_name)");
+      // Chained ancestor joins, one per level, keyed on parent span + trace.
+      expect(sql).toContain(
+        'LEFT JOIN "sre_agent_v2" AS p1 ON c.reference_parent_span_id = p1.span_id',
+      );
+      expect(sql).toContain(
+        "p1.reference_parent_span_id = p2.span_id",
+      );
+      expect((sql.match(/LEFT JOIN/g) || []).length).toBe(4);
+      // Filters the tool's own spans (child-qualified identity field).
+      expect(sql).toContain("c.gen_ai_tool_name = 'load_skill'");
+      // NOT the old raw-service_name caller.
+      expect(sql).not.toContain("service_name as caller_service");
+    });
+
+    it("keeps raw service_name as caller for an INFERRED dependency node", async () => {
+      vi.mocked(searchService.search).mockClear();
+      vi.mocked(searchService.search).mockResolvedValue({
+        data: { hits: [] },
+      } as any);
+      wrapper = mountPanel({
+        streamFilter: "default",
+        selectedNode: { ...baseNode, name: "postgres", service_type: "database" },
+      });
+      await flushPromises();
+      const sql =
+        vi.mocked(searchService.search).mock.calls[0][0].query.query.sql;
+      // Inferred deps genuinely have the caller on service_name — no agent climb.
+      expect(sql).toContain("service_name as caller_service");
+      expect(sql).not.toContain("LEFT JOIN");
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -1028,6 +1081,79 @@ describe("ServiceGraphNodeSidePanel", () => {
         });
         expect(wrapper.vm.isInferred).toBe(true);
       }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // serviceNameField — column the panel filters on, per node family
+  // ---------------------------------------------------------------------------
+
+  describe("serviceNameField", () => {
+    it("uses service_name for an instrumented service (no service_type)", () => {
+      wrapper = mountPanel({ selectedNode: baseNode });
+      expect(wrapper.vm.serviceNameField).toBe("service_name");
+    });
+
+    it("uses infer_service_name for inferred dependency kinds", () => {
+      for (const st of ["database", "queue", "rpc", "external"]) {
+        wrapper = mountPanel({
+          selectedNode: { ...baseNode, service_type: st },
+        });
+        expect(wrapper.vm.serviceNameField).toBe("infer_service_name");
+      }
+    });
+
+    it("uses the gen_ai_* column for agent and tool kinds (not infer_service_name)", () => {
+      for (const [st, col] of Object.entries({
+        agent: "gen_ai_agent_name",
+        tool: "gen_ai_tool_name",
+      })) {
+        wrapper = mountPanel({
+          selectedNode: { ...baseNode, service_type: st },
+        });
+        // regression: previously returned "infer_service_name" → "field not found"
+        expect(wrapper.vm.serviceNameField).toBe(col);
+      }
+    });
+
+    it("model defaults to gen_ai_request_model before schema resolves", () => {
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "model" },
+      });
+      // streamFieldSet is empty until the schema fetch settles
+      expect(wrapper.vm.serviceNameField).toBe("gen_ai_request_model");
+    });
+
+    it("model COALESCEs request/response when the schema has both", async () => {
+      getStreamMock.mockResolvedValueOnce({
+        schema: [
+          { name: "gen_ai_request_model", type: "keyword" },
+          { name: "gen_ai_response_model", type: "keyword" },
+        ],
+      });
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "model" },
+        streamFilter: "default",
+      });
+      await flushPromises();
+      await flushPromises();
+      expect(wrapper.vm.serviceNameField).toBe(
+        "COALESCE(gen_ai_request_model, gen_ai_response_model)",
+      );
+    });
+
+    it("model falls back to response_model when the schema has only that (Langfuse/OpenInference)", async () => {
+      getStreamMock.mockResolvedValueOnce({
+        schema: [{ name: "gen_ai_response_model", type: "keyword" }],
+      });
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "model" },
+        streamFilter: "default",
+      });
+      await flushPromises();
+      await flushPromises();
+      // regression: response-only vendors would otherwise hit "field not found"
+      expect(wrapper.vm.serviceNameField).toBe("gen_ai_response_model");
     });
   });
 

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -918,19 +918,89 @@ export default defineComponent({
       return escapeSingleQuotes(name);
     };
 
+    // Shared cache of stream schema field names — populated by resolveStreamSchema,
+    // consumed by serviceNameField (model column resolution), resolveWorkloadFields
+    // and inferredTabConfigs. Declared here (ahead of serviceNameField) so the
+    // computed can read it without a temporal-dead-zone error at mount.
+    const streamFieldSet = ref<Set<string>>(new Set());
+
     /**
-     * Returns the correct SQL field name for the service name column in WHERE clauses.
+     * Returns the SQL expression for the node's identity column, used in WHERE
+     * clauses (`{expr} = 'name'`). A node falls into one of three families, keyed
+     * by `service_type`:
      *
-     * Inferred services (those discovered from span attributes rather than instrumented
-     * SDKs) use `infer_service_name`, while regular instrumented services use `service_name`.
-     * The distinction is driven by `props.selectedNode.service_type`:
-     * - When `service_type` is set (e.g. "database", "queue", "rpc", "http"), the node
-     *   represents an inferred service → `infer_service_name`.
-     * - When `service_type` is absent, the node represents an instrumented service → `service_name`.
+     * - **Instrumented service** (`service_type` absent) → `service_name`.
+     * - **Inferred dependency** (`database`/`queue`/`rpc`/`external`) → discovered
+     *   from span peer attributes, keyed by `infer_service_name`.
+     * - **GenAI entity** (`agent`/`tool`/`model`) → derived from `gen_ai_*` columns.
+     *   `agent`/`tool` have a single column. `model` may land in either
+     *   `gen_ai_request_model` or `gen_ai_response_model` depending on the vendor
+     *   (Langfuse/OpenInference populate only response), so it resolves to a
+     *   COALESCE over whichever of the two the stream schema actually has —
+     *   referencing a missing column is a hard "field not found" error.
+     *
+     * All call sites use this only as `WHERE {expr} = '...'`, so a COALESCE(...)
+     * expression is valid everywhere it is interpolated.
      */
-    const serviceNameField = computed(() =>
-      props.selectedNode?.service_type ? "infer_service_name" : "service_name",
-    );
+    const GENAI_NAME_FIELD: Record<string, string> = {
+      agent: "gen_ai_agent_name",
+      tool: "gen_ai_tool_name",
+    };
+
+    // Depth of the parent-chain climb used to attribute a tool/model span to its
+    // OWNING agent. Must match the backend (processor.rs AGENT_INHERIT_DEPTH):
+    // the agent name usually lives on an ANCESTOR span (real Google ADK nests
+    // generate_content(agent)→chat→execute_tool), not on the tool/LLM span
+    // itself, so the caller shown in this panel must climb the same way the graph
+    // edge does — otherwise the panel says the app called the tool while the
+    // graph correctly says the agent did.
+    const AGENT_INHERIT_DEPTH = 4;
+
+    // The nearest-ancestor-agent-or-service caller expression + chained ancestor
+    // LEFT JOINs, aliased to child `c` (p1 on c, p2 on p1, …). Mirrors query-4.
+    const genAiCallerClimb = (streamName: string) => {
+      const parts = ["c.gen_ai_agent_name"];
+      for (let k = 1; k <= AGENT_INHERIT_DEPTH; k++)
+        parts.push(`p${k}.gen_ai_agent_name`);
+      parts.push("c.service_name");
+      const callerExpr = `COALESCE(${parts.join(", ")})`;
+      const joins = Array.from({ length: AGENT_INHERIT_DEPTH }, (_, i) => {
+        const k = i + 1;
+        const prev = k === 1 ? "c" : `p${k - 1}`;
+        return `LEFT JOIN "${streamName}" AS p${k} ON ${prev}.reference_parent_span_id = p${k}.span_id AND ${prev}.trace_id = p${k}.trace_id`;
+      }).join(" ");
+      return { callerExpr, joins };
+    };
+
+    /**
+     * The node's identity column expression, with every column prefixed by
+     * `alias` (e.g. `"c."` inside a self-join, `""` for a single-table query).
+     * The prefix is applied AT CONSTRUCTION from the known column names — callers
+     * never post-process the string, so there is no place for a column name to
+     * be missed. See `serviceNameField` for the family rules.
+     */
+    const identityField = (alias = ""): string => {
+      const st = props.selectedNode?.service_type;
+      if (!st) return `${alias}service_name`;
+      if (st === "model") {
+        // Prefer request.model, fall back to response.model; only include a
+        // column the schema has. If neither is known yet (schema unresolved),
+        // default to request.model — the query re-runs reactively once the
+        // schema fetch settles.
+        const fs = streamFieldSet.value;
+        const hasReq = fs.has("gen_ai_request_model");
+        const hasResp = fs.has("gen_ai_response_model");
+        if (hasReq && hasResp)
+          return `COALESCE(${alias}gen_ai_request_model, ${alias}gen_ai_response_model)`;
+        if (hasResp && !hasReq) return `${alias}gen_ai_response_model`;
+        return `${alias}gen_ai_request_model`;
+      }
+      return `${alias}${GENAI_NAME_FIELD[st] ?? "infer_service_name"}`;
+    };
+
+    // Single-table identity expression (unaliased) — used everywhere the query
+    // is a plain `FROM "{stream}"` with no join.
+    const serviceNameField = computed(() => identityField());
 
     const loadDashboard = () => {
       if (!props.selectedNode || props.streamFilter === "all") {
@@ -1353,7 +1423,12 @@ export default defineComponent({
       }
     };
 
-    // Reload RED charts when node, time range, stream, or visibility changes
+    // Reload RED charts when node, time range, stream, visibility — or the
+    // resolved identity column — changes. `serviceNameField` is in the deps
+    // because for a model node it depends on the stream schema (request vs
+    // response model column); the schema fetch settles AFTER the first render,
+    // so without re-running here the charts fire once with the wrong/absent
+    // column and error with "field not found".
     watch(
       () =>
         [
@@ -1361,6 +1436,7 @@ export default defineComponent({
           props.timeRange,
           props.streamFilter,
           props.visible,
+          serviceNameField.value,
         ] as const,
       ([, , , visible]) => {
         if (visible && props.selectedNode) {
@@ -1393,9 +1469,6 @@ export default defineComponent({
     // IDs of alias entries the user has checked in the dropdown
     const selectedWorkloadFields = ref<string[]>([]);
 
-    // Shared cache of stream schema field names — populated by resolveStreamSchema,
-    // consumed by both resolveWorkloadFields and inferredTabConfigs.
-    const streamFieldSet = ref<Set<string>>(new Set());
     const schemaResolved = ref(false);
 
     /** Fetch the trace stream schema and populate streamFieldSet.
@@ -1814,14 +1887,33 @@ export default defineComponent({
       try {
         const serviceName = buildServiceName();
         const streamName = props.streamFilter || "default";
+        const st = props.selectedNode?.service_type;
+        // A tool/model node's caller is its OWNING AGENT, which usually sits on an
+        // ancestor span — resolve it with the same parent-chain climb the graph
+        // edge uses (else the panel would show the host app as the caller, in
+        // conflict with the graph). Genuinely-inferred deps (database/queue/…)
+        // keep the raw service_name as caller. Instrumented services show none.
+        const isGenAiChild = st === "tool" || st === "model";
         const isInf = isInferred.value;
-        const selectCols = isInf
-          ? "service_name as caller_service, operation_name"
-          : "operation_name";
-        const groupCols = isInf
-          ? "service_name, operation_name"
-          : "operation_name";
-        const sql = `SELECT ${selectCols}, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' GROUP BY ${groupCols}`;
+
+        const metrics = `count(*) as request_count, count(*) FILTER (WHERE ${isGenAiChild ? "c." : ""}span_status = 'ERROR') as error_count, approx_percentile_cont(${isGenAiChild ? "c." : ""}duration, 0.50) as p50_latency, approx_percentile_cont(${isGenAiChild ? "c." : ""}duration, 0.75) as p75_latency, approx_percentile_cont(${isGenAiChild ? "c." : ""}duration, 0.95) as p95_latency, approx_percentile_cont(${isGenAiChild ? "c." : ""}duration, 0.99) as p99_latency`;
+
+        let sql: string;
+        if (isGenAiChild) {
+          const { callerExpr, joins } = genAiCallerClimb(streamName);
+          // The identity field, built already aliased to the child table `c`
+          // (no post-processing of the expression string).
+          const childField = identityField("c.");
+          sql = `SELECT ${callerExpr} as caller_service, c.operation_name, ${metrics} FROM "${streamName}" AS c ${joins} WHERE ${childField} = '${serviceName}' GROUP BY ${callerExpr}, c.operation_name`;
+        } else {
+          const selectCols = isInf
+            ? "service_name as caller_service, operation_name"
+            : "operation_name";
+          const groupCols = isInf
+            ? "service_name, operation_name"
+            : "operation_name";
+          sql = `SELECT ${selectCols}, ${metrics} FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' GROUP BY ${groupCols}`;
+        }
 
         const response = await searchService.search({
           org_identifier: store.state.selectedOrganization.identifier,
@@ -1937,6 +2029,10 @@ export default defineComponent({
         props.selectedNode?.id,
         props.streamFilter,
         operationsViewMode.value,
+        // Re-fetch once the schema resolves the model column (request vs
+        // response) — otherwise a model node's operations query fires with the
+        // wrong column and returns "No operations found".
+        serviceNameField.value,
       ],
       () => {
         if (
@@ -2343,6 +2439,8 @@ export default defineComponent({
       serviceHealth,
       isAllStreamsSelected,
       isInferred,
+      serviceNameField,
+      streamFieldSet,
       formatNumber,
       getErrorRateClass,
       getLatencyClass,

--- a/web/src/utils/theme.spec.ts
+++ b/web/src/utils/theme.spec.ts
@@ -1,6 +1,26 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { applyThemeColors } from './theme';
+import { applyThemeColors, cssToken } from './theme';
 import type { SemanticColors } from './theme';
+
+describe('cssToken', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('style');
+  });
+
+  it('returns the resolved token value when the custom property is set', () => {
+    document.documentElement.style.setProperty('--color-indigo-500', '#6366f1');
+    expect(cssToken('--color-indigo-500', '#000000')).toBe('#6366f1');
+  });
+
+  it('accepts a token name without the leading --', () => {
+    document.documentElement.style.setProperty('--color-indigo-300', '#a5b4fc');
+    expect(cssToken('color-indigo-300', '#000000')).toBe('#a5b4fc');
+  });
+
+  it('returns the fallback when the token is unset', () => {
+    expect(cssToken('--color-does-not-exist', '#deadbe')).toBe('#deadbe');
+  });
+});
 
 const SEMANTIC: SemanticColors = {
   error: '#F45B49',

--- a/web/src/utils/theme.ts
+++ b/web/src/utils/theme.ts
@@ -14,6 +14,29 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Resolve a design-token CSS custom property to its concrete value at runtime.
+ *
+ * Charts (ECharts options, SVG data-URI symbols, canvas) can't use `var(--x)` —
+ * they need a literal color string. This reads the token from the document root
+ * so the single source of truth stays the token layer (`lib/styles/tokens/*`),
+ * not a hardcoded hex. `fallback` is returned when the token is unset or the DOM
+ * is unavailable (SSR / unit tests), so callers still get a sensible value.
+ *
+ * @param token   - Token name, with or without the leading `--` (e.g. "--color-indigo-500")
+ * @param fallback - Value to use if the token can't be read
+ */
+export const cssToken = (token: string, fallback: string): string => {
+  if (typeof document === "undefined" || !document.documentElement) {
+    return fallback;
+  }
+  const name = token.startsWith("--") ? token : `--${token}`;
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  return value || fallback;
+};
+
+/**
  * Helper function to convert hex color to rgba
  * @param hex - Hex color code (e.g., "#3F7994")
  * @param opacity - Opacity value (1-10 scale, where 10 = fully opaque)

--- a/web/src/utils/traces/__fixtures__/classification_cases.json
+++ b/web/src/utils/traces/__fixtures__/classification_cases.json
@@ -76,5 +76,29 @@
     "is_real_service": false,
     "infer_type": "",
     "expected": "service"
+  },
+  {
+    "note": "agent node from connection_type=agent (client-only, not a real service)",
+    "is_real_service": false,
+    "infer_type": "agent",
+    "expected": "agent"
+  },
+  {
+    "note": "agent that IS also a real service must still be Agent (positional-fix: agent wins over is_real_service)",
+    "is_real_service": true,
+    "infer_type": "agent",
+    "expected": "agent"
+  },
+  {
+    "note": "tool node from connection_type=tool",
+    "is_real_service": false,
+    "infer_type": "tool",
+    "expected": "tool"
+  },
+  {
+    "note": "model node from connection_type=model",
+    "is_real_service": true,
+    "infer_type": "model",
+    "expected": "model"
   }
 ]

--- a/web/src/utils/traces/computeTreeLayout.spec.ts
+++ b/web/src/utils/traces/computeTreeLayout.spec.ts
@@ -20,6 +20,41 @@ import { computeTreeLayout } from "./computeTreeLayout";
 const N = (id: string, label = id) => ({ id, label });
 const E = (from: string, to: string) => ({ from, to });
 
+describe("computeTreeLayout — entry-edge roots (agent-graph regression)", () => {
+  it("treats a node reached only by the entry edge (from=null) as a root, so its subtree gets real depth", () => {
+    // The service-graph API emits a synthetic entry edge {from: null → entry}.
+    // Shape: (entry) → orchestrator → {Supervisor, Worker}; Worker → gpt-4o.
+    // Bug: the entry edge counted `orchestrator` as having an incoming parent,
+    // so roots was empty, BFS never ran, and EVERY node collapsed to depth 0 —
+    // which drew gpt-4o hanging off the wrong parent instead of under Worker.
+    const g = {
+      nodes: [
+        N("orchestrator"),
+        N("Supervisor"),
+        N("Worker"),
+        N("gpt-4o"),
+        N("run_query"),
+      ],
+      edges: [
+        { from: null, to: "orchestrator" },
+        E("orchestrator", "Supervisor"),
+        E("orchestrator", "Worker"),
+        E("Worker", "gpt-4o"),
+        E("Worker", "run_query"),
+      ],
+    };
+    const pos = computeTreeLayout(g as any);
+    // Depth increases down the real hierarchy — not all-flat.
+    expect(pos.get("Supervisor")!.x).toBeGreaterThan(pos.get("orchestrator")!.x);
+    expect(pos.get("Worker")!.x).toBeGreaterThan(pos.get("orchestrator")!.x);
+    // The model sits BEYOND its agent (Worker), i.e. it is Worker's child.
+    expect(pos.get("gpt-4o")!.x).toBeGreaterThan(pos.get("Worker")!.x);
+    expect(pos.get("run_query")!.x).toBeGreaterThan(pos.get("Worker")!.x);
+    // gpt-4o and Supervisor are NOT in the same column (the collapse symptom).
+    expect(pos.get("gpt-4o")!.x).not.toBe(pos.get("Supervisor")!.x);
+  });
+});
+
 describe("computeTreeLayout — columns (X by depth)", () => {
   it("places each depth level in its own column (root left, deps right)", () => {
     // root → a → dep

--- a/web/src/utils/traces/computeTreeLayout.ts
+++ b/web/src/utils/traces/computeTreeLayout.ts
@@ -64,7 +64,14 @@ export function computeTreeLayout(
   // Children adjacency (spanning tree: each node placed once, at first parent).
   const children = new Map<string, string[]>();
   for (const n of graph.nodes) children.set(n.id, []);
-  const hasIncoming = new Set(graph.edges.map((e) => e.to));
+  // A node is a root when it has no *real* parent. The synthetic entry edge
+  // (from == null → the topology's entry service) must NOT count as incoming —
+  // otherwise the entry node looks parented, roots comes back empty, BFS never
+  // runs, and every node collapses to depth 0 (a flat, mis-wired tree). This is
+  // exactly what made an agent's model hang off the wrong parent.
+  const hasIncoming = new Set(
+    graph.edges.filter((e) => e.from != null).map((e) => e.to),
+  );
   const placed = new Set<string>();
   for (const e of graph.edges) {
     if (e.from == null) continue;

--- a/web/src/utils/traces/convertTraceData.spec.ts
+++ b/web/src/utils/traces/convertTraceData.spec.ts
@@ -308,6 +308,88 @@ describe("convertTraceData", () => {
   });
 
   describe("convertServiceGraphToTree", () => {
+    it("roots the tree at the entry-edge node so children attach to the right parent (agent-graph regression)", () => {
+      // API shape: {from: null → orchestrator}, orchestrator → {Supervisor, Worker},
+      // Worker → {gpt-4o, run_query}. Bug: the null-from entry edge made
+      // orchestrator look parented, rootNodes came back empty, and gpt-4o was
+      // placed under the wrong parent (visible as a model hanging off the root).
+      const graphData = {
+        nodes: [
+          { id: "orchestrator", label: "orchestrator" },
+          { id: "Supervisor", label: "Supervisor", service_type: "agent" },
+          { id: "Worker", label: "Worker", service_type: "agent" },
+          { id: "gpt-4o", label: "gpt-4o", service_type: "model" },
+          { id: "run_query", label: "run_query", service_type: "tool" },
+        ],
+        edges: [
+          { from: null, to: "orchestrator", total_requests: 1 },
+          { from: "orchestrator", to: "Supervisor", total_requests: 1 },
+          { from: "orchestrator", to: "Worker", total_requests: 1 },
+          { from: "Worker", to: "gpt-4o", total_requests: 1 },
+          { from: "Worker", to: "run_query", total_requests: 1 },
+        ],
+      };
+      const result = convertServiceGraphToTree(graphData as any, "horizontal");
+      const roots = result.options.series[0].data;
+      // A single root (orchestrator), not a flat pile of orphaned nodes.
+      expect(roots).toHaveLength(1);
+      expect(roots[0].name).toBe("orchestrator");
+      // orchestrator's children are the two agents.
+      const l1 = (roots[0].children ?? []).map((c: any) => c.name).sort();
+      expect(l1).toEqual(["Supervisor", "Worker"]);
+      // gpt-4o is under Worker — NOT a sibling of the agents / under the root.
+      const worker = roots[0].children.find((c: any) => c.name === "Worker");
+      const workerKids = (worker.children ?? []).map((c: any) => c.name).sort();
+      expect(workerKids).toEqual(["gpt-4o", "run_query"]);
+    });
+
+    // Agent highlighting (indigo tint, larger symbol, radar-ping halo) is a
+    // treatment for the dedicated Agent Graph page ONLY. On the Service Graph
+    // tab the caller omits agentHighlight, and an agent must render as a plain
+    // node — no ping animation, no size bump.
+    it("does NOT highlight agents unless agentHighlight is set", () => {
+      const graphData = {
+        nodes: [
+          { id: "root", label: "root" },
+          { id: "planner", label: "planner", service_type: "agent" },
+        ],
+        edges: [
+          { from: null, to: "root", total_requests: 1 },
+          { from: "root", to: "planner", total_requests: 1 },
+        ],
+      };
+      const decode = (sym: string) =>
+        atob(
+          sym.replace(/^image:\/\//, "").replace("data:image/svg+xml;base64,", ""),
+        );
+
+      // Service Graph mount (agentHighlight defaults false).
+      const plain = convertServiceGraphToTree(graphData as any, "horizontal");
+      const plainAgent = plain.options.series[0].data[0].children.find(
+        (c: any) => c.name === "planner",
+      );
+      const plainSvg = decode(plainAgent.symbol);
+      expect(plainSvg).not.toContain("<animate ");
+      expect(plainSvg).toContain('viewBox="0 0 56 56"'); // tight box = plain node
+
+      // Agent Graph mount (agentHighlight true).
+      const hl = convertServiceGraphToTree(
+        graphData as any,
+        "horizontal",
+        true,
+        700,
+        true,
+      );
+      const hlAgent = hl.options.series[0].data[0].children.find(
+        (c: any) => c.name === "planner",
+      );
+      const hlSvg = decode(hlAgent.symbol);
+      expect(hlSvg).toContain("<animate "); // ping rings present
+      expect(hlSvg).toContain('viewBox="0 0 104 104"'); // padded box
+      // Highlighted agent symbol is larger than the plain one.
+      expect(hlAgent.symbolSize).toBeGreaterThan(plainAgent.symbolSize);
+    });
+
     it("should convert service graph to tree with horizontal layout", () => {
       const graphData = {
         nodes: [
@@ -485,6 +567,51 @@ describe("convertTraceData", () => {
   });
 
   describe("convertServiceGraphToNetwork", () => {
+    // Layered layout must preserve the agent hierarchy's DEPTH:
+    // service(0) → agent(1) → model/tool(2). The old code pinned every node with
+    // a service_type to the max rank, collapsing agent→model so a model (gpt-4o)
+    // jumped up to the agent's column and its edge looked like it came from the
+    // parent app. GenAI kinds must keep their BFS depth. (agent-graph regression)
+    it("keeps model/tool one rank deeper than their agent in layered layout", () => {
+      const graphData = {
+        nodes: [
+          { id: "crewai-app", label: "crewai-app", service_type: "service", requests: 13 },
+          { id: "ResearchCrew", label: "ResearchCrew", service_type: "agent", requests: 4 },
+          { id: "gpt-4o", label: "gpt-4o", service_type: "model", requests: 6 },
+          { id: "web_scraper", label: "web_scraper", service_type: "tool", requests: 1 },
+        ],
+        edges: [
+          { from: null, to: "crewai-app", total_requests: 13 },
+          { from: "crewai-app", to: "ResearchCrew", total_requests: 4, connection_type: "agent" },
+          { from: "ResearchCrew", to: "gpt-4o", total_requests: 6, connection_type: "model" },
+          { from: "ResearchCrew", to: "web_scraper", total_requests: 1, connection_type: "tool" },
+        ],
+      };
+      const res = convertServiceGraphToNetwork(
+        graphData as any,
+        "layered",
+        new Map(),
+        true,
+        undefined,
+        1200,
+        700,
+        true,
+      );
+      const data = res.options.series[0].data;
+      const x = (id: string) => data.find((n: any) => n.id === id)!.x;
+      // Strictly increasing depth: app < agent < model, app < agent < tool.
+      expect(x("crewai-app")).toBeLessThan(x("ResearchCrew"));
+      expect(x("ResearchCrew")).toBeLessThan(x("gpt-4o"));
+      expect(x("ResearchCrew")).toBeLessThan(x("web_scraper"));
+      // Model and tool share the same (deepest) rank → same column.
+      expect(x("gpt-4o")).toBe(x("web_scraper"));
+      // The gpt-4o link originates at the agent, never the parent app.
+      const links = res.options.series[0].links || [];
+      expect(links.find((l: any) => l.target === "gpt-4o")?.source).toBe(
+        "ResearchCrew",
+      );
+    });
+
     it("should convert service graph to network format", () => {
       const graphData = {
         nodes: [
@@ -842,6 +969,45 @@ describe('convertServiceGraphToNetwork', () => {
     it("should handle undefined-like name without throwing", () => {
       const result = getServiceIconDataUrl(null as any, false, "#000000");
       expect(result.startsWith("data:image/svg+xml;base64,")).toBe(true);
+    });
+
+    // Agent nodes carry an animated "radar ping" halo baked INTO their symbol
+    // SVG (SMIL <animate> rings), so the effect stays centred on the node and
+    // pans/zooms with it. These assertions lock that in — the halo drifting or
+    // disappearing is a regression, not a cosmetic tweak.
+    it("bakes animated radar-ping rings into the agent symbol", () => {
+      const svg = decodeDataUrl(
+        getServiceIconDataUrl("planner", false, "#22c55e", "agent"),
+      );
+      // Two staggered rings, each with r / opacity / stroke-width animations.
+      expect((svg.match(/<circle[^>]*opacity="0"/g) || []).length).toBe(2);
+      expect((svg.match(/<animate /g) || []).length).toBe(6);
+      expect(svg).toContain('attributeName="r"');
+      expect(svg).toContain('repeatCount="indefinite"');
+      // Indigo accent, outside the health palette.
+      expect(svg).toContain("#6366f1");
+    });
+
+    it("centres the agent disc + rings in the padded viewBox (no clip)", () => {
+      const svg = decodeDataUrl(
+        getServiceIconDataUrl("planner", true, "#22c55e", "agent"),
+      );
+      // Padded box so the ring can expand without clipping; disc at its centre.
+      expect(svg).toContain('viewBox="0 0 104 104"');
+      expect(svg).toContain('cx="52" cy="52"');
+      // Max animated radius (46) must stay inside the half-box (52).
+      const maxR = Math.max(
+        ...[...svg.matchAll(/values="24;(\d+)"/g)].map((m) => Number(m[1])),
+      );
+      expect(maxR).toBeLessThanOrEqual(52);
+    });
+
+    it("does NOT add ping rings or padding to non-agent nodes", () => {
+      const svg = decodeDataUrl(
+        getServiceIconDataUrl("payment", false, "#22c55e", "service"),
+      );
+      expect(svg).toContain('viewBox="0 0 56 56"');
+      expect(svg).not.toContain("<animate ");
     });
   });
 });

--- a/web/src/utils/traces/convertTraceData.ts
+++ b/web/src/utils/traces/convertTraceData.ts
@@ -1,5 +1,7 @@
 import { toZonedTime } from "date-fns-tz";
 import { computeTreeLayout } from "./computeTreeLayout";
+import { resolveModelVendorLogo } from "./modelVendorLogo";
+import { cssToken } from "@/utils/theme";
 export const convertTraceData = (props: any, timezone: string) => {
   const options: any = {
     backgroundColor: "transparent",
@@ -240,6 +242,10 @@ export const convertServiceGraphToTree = (
   layoutType: string = "horizontal",
   isDarkMode: boolean = true,
   canvasHeight: number = 700,
+  // When true (Agent Graph page only), agents get the accent treatment:
+  // indigo disc tint + glyph, larger symbol, and the radar-ping halo. On the
+  // regular Service Graph tab this is false and agents render like any node.
+  agentHighlight: boolean = false,
 ) => {
   // Build adjacency map for edges
   const edgesMap = new Map<string, any[]>();
@@ -259,8 +265,17 @@ export const convertServiceGraphToTree = (
     incomingEdgesMap.get(edge.to)!.push(edge);
   });
 
-  // Find all root nodes (nodes with no incoming edges)
-  const nodesWithIncoming = new Set(graphData.edges.map((e: any) => e.to));
+  // Find all root nodes (nodes with no *real* incoming edge). The synthetic
+  // entry edge {from: null → entry service} must be excluded — otherwise the
+  // entry node looks parented, rootNodes comes back empty, buildTree never
+  // starts from it, and the whole hierarchy is built via the arbitrary-order
+  // fallback below, mis-placing children (e.g. an agent's model drawn under the
+  // wrong parent). Mirrors the same guard in computeTreeLayout.
+  const nodesWithIncoming = new Set(
+    graphData.edges
+      .filter((e: any) => e.from != null)
+      .map((e: any) => e.to),
+  );
   const rootNodes = graphData.nodes.filter(
     (n: any) => !nodesWithIncoming.has(n.id),
   );
@@ -320,11 +335,17 @@ export const convertServiceGraphToTree = (
 
   const green = isDarkMode ? "#10b981" : "#52c41a";
 
-  // Node color: same absolute thresholds as Graph View so color matches tooltip error rate
+  // Node color: same absolute thresholds as Graph View so color matches tooltip
+  // error rate. Dark-mode values resolve from the semantic token layer (exact
+  // token matches); the light-mode values are the legacy Ant palette with no
+  // exact token, so they stay as literals until the palette is unified.
   const getNodeColor = (errRate: number): string => {
-    if (errRate > 10) return isDarkMode ? "#ef4444" : "#f5222d"; // Red — critical
-    if (errRate > 5) return isDarkMode ? "#f97316" : "#fa8c16"; // Orange — warning
-    if (errRate > 1) return isDarkMode ? "#fbbf24" : "#faad14"; // Yellow — degraded
+    if (errRate > 10)
+      return isDarkMode ? cssToken("--color-error-500", "#ef4444") : "#f5222d"; // Red — critical
+    if (errRate > 5)
+      return isDarkMode ? cssToken("--color-orange-500", "#f97316") : "#fa8c16"; // Orange — warning
+    if (errRate > 1)
+      return isDarkMode ? cssToken("--color-amber-400", "#fbbf24") : "#faad14"; // Yellow — degraded
     return green;
   };
 
@@ -383,19 +404,34 @@ export const convertServiceGraphToTree = (
     // Tree edges are always neutral gray — color belongs on node borders only
     const edgeColor = isDarkMode ? "#4a5568" : "#b0b7c3";
 
+    // Agent accent treatment (tint/size/ping) applies only when the Agent
+    // Graph page asks for it. Elsewhere an un-highlighted agent must render as a
+    // plain node, so we DOWNGRADE its kind to null before the icon builder —
+    // passing the raw "agent" type would re-trigger the accent regardless.
+    const isAgentNode = node.service_type === "agent" && agentHighlight;
+    const iconServiceType =
+      node.service_type === "agent" && !agentHighlight ? null : node.service_type;
+
     // Reuse the same SVG icon as graph view (circle + service-type icon)
     const iconDataUrl = getServiceIconSvg(
       node.id,
       isDarkMode,
       borderColor,
-      node.service_type,
+      iconServiceType,
     );
 
     return {
       name: node.label || node.id,
       value: totalRequests,
       symbol: iconDataUrl,
-      symbolSize: nodeSymbolSize, // Auto-shrunk to fit (see sizing block); uniform so ECharts spaces nodes consistently
+      // Highlighted agents are the subject of the Agent Graph — render them
+      // ~30% larger so they read as the primary entities. Their symbol uses a
+      // padded 104-wide viewBox (vs 56) to give the radar-ping halo room to
+      // expand, so the disc occupies a smaller fraction of the box; the 104/56
+      // factor cancels that out and the ×1.3 on top is the visual emphasis.
+      symbolSize: isAgentNode
+        ? Math.round(nodeSymbolSize * 1.3 * (104 / 56))
+        : nodeSymbolSize,
       lineStyle: {
         color: edgeColor,
         width: 2,
@@ -404,6 +440,9 @@ export const convertServiceGraphToTree = (
         color: isDarkMode ? "#1a1f2e" : "#ffffff",
         borderColor: borderColor,
         borderWidth: 4,
+        // Neutral drop shadow for every node. Agents no longer carry a static
+        // indigo glow — their emphasis is the animated radar-ping halo baked
+        // into the symbol (highlighted mode only).
         shadowBlur: 10,
         shadowColor: isDarkMode ? "rgba(0, 0, 0, 0.3)" : "rgba(0, 0, 0, 0.1)",
         shadowOffsetX: 0,
@@ -820,6 +859,15 @@ const KIND_ICON_SVG: Record<string, string> = {
     `<circle cx="12" cy="12" r="10"/>` +
     `<line x1="2" y1="12" x2="22" y2="12"/>` +
     `<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>`,
+  // GenAI entity kinds (agent-graph feature). Bot / wrench / chip.
+  agent:
+    `<rect x="3" y="11" width="18" height="10" rx="2"/>` +
+    `<circle cx="12" cy="5" r="2"/><path d="M12 7v4"/>` +
+    `<line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/>`,
+  tool: `<path d="M14.7 6.3a4 4 0 0 0-5.4 5.4L3 18l3 3 6.3-6.3a4 4 0 0 0 5.4-5.4l-2.8 2.8-2.1-2.1 2.8-2.8z"/>`,
+  model:
+    `<rect x="6" y="6" width="12" height="12" rx="1"/>` +
+    `<path d="M9 2v2M15 2v2M9 20v2M15 20v2M2 9h2M2 15h2M20 9h2M20 15h2"/>`,
 };
 
 /**
@@ -1086,8 +1134,27 @@ export function getServiceIconDataUrl(
   borderColor: string,
   serviceType?: string | null,
 ): string {
-  const iconColor = isDark ? "#e4e7eb" : "#374151";
-  const bgColor = isDark ? "#1a1f2e" : "#ffffff";
+  // Agents are the SUBJECT of the agent graph, so they get an accent treatment
+  // that makes them the primary read WITHOUT touching the health border
+  // (green/amber/red) — the icon disc is washed with an indigo tint and the
+  // glyph is drawn in indigo. Indigo is deliberately outside the health palette
+  // and distinct from the tool/model kind colours. Every other kind keeps the
+  // neutral disc + gray glyph.
+  const isAgent = serviceType === "agent";
+  // Agent accent = indigo design tokens (deliberately outside the health
+  // palette). Resolved from the token layer at runtime because the value is
+  // baked into an SVG data-URI where `var(--…)` can't be used.
+  const AGENT_ACCENT = isDark
+    ? cssToken("--color-indigo-300", "#a5b4fc")
+    : cssToken("--color-indigo-500", "#6366f1");
+  const iconColor = isAgent ? AGENT_ACCENT : isDark ? "#e4e7eb" : "#374151";
+  const bgColor = isAgent
+    ? isDark
+      ? cssToken("--color-indigo-900", "#312e81") // dark indigo disc wash
+      : cssToken("--color-indigo-50", "#eef2ff") // light indigo wash
+    : isDark
+      ? "#1a1f2e"
+      : "#ffffff";
 
   // Normalize: lowercase and collapse hyphens/underscores to spaces so
   // "load-generator" and "load_generator" both match /load/ or /generator/.
@@ -1099,14 +1166,80 @@ export function getServiceIconDataUrl(
   const matched = SERVICE_ICON_RULES.find(({ regex }) => regex.test(n));
   const icon = authoritative ?? (matched ? matched.svg : SERVER_ICON_SVG);
 
-  // 56×56 viewBox: circle r=24 centered at (28,28); icon 24×24 translated to (16,16)
+  // Agent nodes get an animated "radar ping" halo: concentric rings that expand
+  // out from the disc and fade — the "getting encircled" effect that makes
+  // agents the living focal point of the graph. We bake it into the node's own
+  // symbol SVG (rather than an ECharts `graphic` overlay) so it is ALWAYS
+  // centered on the node and pans/zooms with it — the overlay approach drifted
+  // because `graphic` lives outside the roam-transformed series group. The graph
+  // uses the SVG renderer (render-type="svg"), so SMIL <animate> runs natively.
+  //
+  // Geometry: agents use a padded viewBox (-24..80, 104 wide) so a ring can
+  // expand to r≈46 without clipping while the disc stays r=24 at centre (52,52).
+  // Non-agents keep the tight 56×56 box (disc r=24 at 28,28). Because the disc's
+  // fraction of the box differs, the agent symbolSize is bumped ×~1.86 at the
+  // call sites so the disc renders at the same pixel size as its neighbours.
+  const cx = isAgent ? 52 : 28;
+  const cy = isAgent ? 52 : 28;
+  const viewBox = isAgent ? "0 0 104 104" : "0 0 56 56";
+  const iconTx = isAgent ? 40 : 16; // icon 24×24 top-left so it centres on disc
+
+  // Two staggered rings → a continuous ripple rather than a single strobe.
+  // stroke is the indigo agent accent; opacity + radius animate in lockstep.
+  const pingRings = isAgent
+    ? [0, 1]
+        .map((k) => {
+          const begin = `${k * 1.3}s`;
+          return (
+            `<circle cx="${cx}" cy="${cy}" r="24" fill="none" ` +
+            `stroke="${AGENT_ACCENT}" stroke-width="2.5" opacity="0">` +
+            `<animate attributeName="r" values="24;46" dur="2.6s" ` +
+            `begin="${begin}" repeatCount="indefinite" ` +
+            `calcMode="spline" keySplines="0.25 0.1 0.25 1" keyTimes="0;1"/>` +
+            `<animate attributeName="opacity" values="0.55;0" dur="2.6s" ` +
+            `begin="${begin}" repeatCount="indefinite"/>` +
+            `<animate attributeName="stroke-width" values="2.5;0.5" dur="2.6s" ` +
+            `begin="${begin}" repeatCount="indefinite"/>` +
+            `</circle>`
+          );
+        })
+        .join("")
+    : "";
+
   const svg =
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56">` +
-    `<circle cx="28" cy="28" r="24" fill="${bgColor}" stroke="${borderColor}" stroke-width="4"/>` +
-    `<g transform="translate(16,16)" fill="none" stroke="${iconColor}" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">` +
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}">` +
+    pingRings +
+    `<circle cx="${cx}" cy="${cy}" r="24" fill="${bgColor}" stroke="${borderColor}" stroke-width="4"/>` +
+    `<g transform="translate(${iconTx},${iconTx})" fill="none" stroke="${iconColor}" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">` +
     icon +
     `</g></svg>`;
 
+  return `data:image/svg+xml;base64,${btoa(encodeURIComponent(svg).replace(/%([0-9A-F]{2})/g, (_, p1) => String.fromCharCode(parseInt(p1, 16))))}`;
+}
+
+/**
+ * Compose a vendor brand logo into the SAME 56×56 circle+border frame the chip
+ * icons use, so a model node with a logo is visually identical in size to every
+ * other node. Without the frame the raw logo fills the whole ECharts symbol box
+ * (~2.3× the glyph area) and drops the border — making e.g. the Anthropic mark
+ * look oversized next to its neighbours. The logo is embedded via <image> in the
+ * same 24×24 inset region as the icons, preserveAspectRatio-contained.
+ */
+function getModelLogoDataUrl(logoUrl: string, borderColor: string): string {
+  // Brand marks are drawn on a WHITE inner disc regardless of theme: vendor
+  // logos are authored for a light ground (many are a dark/mono mark on
+  // transparent), so on a dark node background they'd vanish. The white disc
+  // guarantees contrast for every vendor, light or dark theme.
+  // The logo fills a 34×34 region centered in the 56 box (was 20×20 — too
+  // small next to the stroked chip icons), clipped to the disc so square PNGs
+  // don't spill past the circle.
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56">` +
+    `<defs><clipPath id="c"><circle cx="28" cy="28" r="22"/></clipPath></defs>` +
+    `<circle cx="28" cy="28" r="24" fill="#ffffff" stroke="${borderColor}" stroke-width="4"/>` +
+    `<image href="${logoUrl}" x="11" y="11" width="34" height="34" ` +
+    `preserveAspectRatio="xMidYMid meet" clip-path="url(#c)"/>` +
+    `</svg>`;
   return `data:image/svg+xml;base64,${btoa(encodeURIComponent(svg).replace(/%([0-9A-F]{2})/g, (_, p1) => String.fromCharCode(parseInt(p1, 16))))}`;
 }
 
@@ -1116,6 +1249,18 @@ function getServiceIconSvg(
   borderColor: string,
   serviceType?: string | null,
 ): string {
+  // Model nodes: prefer the provider's brand logo (OpenAI / Anthropic / Gemini
+  // …) so the provider mix reads at a glance, composed into the same frame as
+  // every other node. Falls through to the chip icon for unknown models.
+  if (serviceType === "model") {
+    // Always the light-ground logo variant: the frame draws it on a white disc
+    // (see getModelLogoDataUrl), so the mark designed for light backgrounds is
+    // the correct one regardless of the app theme.
+    const vendorLogo = resolveModelVendorLogo(name, false);
+    if (vendorLogo) {
+      return `image://${getModelLogoDataUrl(vendorLogo, borderColor)}`;
+    }
+  }
   return `image://${getServiceIconDataUrl(name, isDark, borderColor, serviceType)}`;
 }
 
@@ -1157,6 +1302,9 @@ export const convertServiceGraphToNetwork = (
   selectedNodeId?: string,
   canvasWidth: number = 1200,
   canvasHeight: number = 700,
+  // Agent accent treatment (tint/size/ping) — Agent Graph page only. See
+  // convertServiceGraphToTree for the rationale.
+  agentHighlight: boolean = false,
 ) => {
   // Graph view supports 'force' (organic) and 'layered' (directed left→right,
   // dependencies pinned as terminal leaves). Tree layouts ('horizontal',
@@ -1210,14 +1358,16 @@ export const convertServiceGraphToNetwork = (
   });
 
   // Layered ranks: rank 0 = no inbound edge; rank = 1 + max(pred ranks).
-  // Inferred deps (service_type present) are pinned to the max rank so they are
-  // always terminal downstream leaves. The `seen` guard breaks cycles.
+  // The `seen` guard breaks cycles.
   const rank = new Map<string, number>();
   if (normalizedLayoutType === "layered") {
     const preds = new Map<string, string[]>();
     validNodes.forEach((n: any) => preds.set(n.id, []));
     graphData.edges.forEach((e: any) => {
-      if (preds.has(e.to)) preds.get(e.to)!.push(e.from);
+      // Skip the entry edge (from == null): it is not a real predecessor, and
+      // counting it would push the true root (the app) to rank 1+, cascading a
+      // wrong depth onto the whole chain.
+      if (e.from != null && preds.has(e.to)) preds.get(e.to)!.push(e.from);
     });
     const visit = (id: string, seen: Set<string>): number => {
       if (rank.has(id)) return rank.get(id)!;
@@ -1229,9 +1379,23 @@ export const convertServiceGraphToNetwork = (
       return r;
     };
     validNodes.forEach((n: any) => visit(n.id, new Set()));
+    // Pin genuine terminal dependencies (databases, queues, external services
+    // with no downstream) to the max rank so they line up as a clean right-hand
+    // leaf column. A node is terminal iff it has NO outgoing edge. We must NOT
+    // pin by "has a service_type" — the root app and agents also carry a
+    // service_type, and pinning them flattened the service→agent→model chain,
+    // dropping a model like gpt-4o into the agent's own column so its edge
+    // looked like it came from the parent app. Out-degree is the right signal:
+    // agents/services that call downstream keep their real BFS depth.
+    const hasOutgoing = new Set<string>();
+    graphData.edges.forEach((e: any) => {
+      if (e.from != null) hasOutgoing.add(e.from);
+    });
     const maxRank = Math.max(0, ...Array.from(rank.values()));
     validNodes.forEach((n: any) => {
-      if (n.service_type) rank.set(n.id, maxRank); // deps are terminal leaves
+      if (n.service_type && !hasOutgoing.has(n.id)) {
+        rank.set(n.id, maxRank); // terminal (leaf) inferred dependency
+      }
     });
   }
 
@@ -1262,16 +1426,19 @@ export const convertServiceGraphToNetwork = (
     const errorRate =
       metrics.requests > 0 ? (metrics.errors / metrics.requests) * 100 : 0;
 
-    // Border color based on error rate (theme-aware)
+    // Border color based on error rate (theme-aware). Dark-mode red/orange/yellow
+    // resolve from the semantic token layer (exact matches); the healthy green
+    // and all light-mode values are the legacy Ant palette with no exact token.
     let borderColor: string;
     if (isDarkMode) {
       // Dark mode colors
       borderColor = "#10b981"; // Green (healthy)
       if (errorRate > 10)
-        borderColor = "#ef4444"; // Red (critical)
+        borderColor = cssToken("--color-error-500", "#ef4444"); // Red (critical)
       else if (errorRate > 5)
-        borderColor = "#f97316"; // Orange (warning)
-      else if (errorRate > 1) borderColor = "#fbbf24"; // Yellow (degraded)
+        borderColor = cssToken("--color-orange-500", "#f97316"); // Orange (warning)
+      else if (errorRate > 1)
+        borderColor = cssToken("--color-amber-400", "#fbbf24"); // Yellow (degraded)
     } else {
       // Light mode colors
       borderColor = "#52c41a"; // Green (healthy)
@@ -1283,17 +1450,32 @@ export const convertServiceGraphToNetwork = (
     }
 
     // Node size: scales with request volume like DataDog (70–110 px range)
-    const symbolSize = Math.max(
+    const baseSymbolSize = Math.max(
       70,
       Math.min(110, Math.log10(metrics.requests + 1) * 28),
     );
+    // Agent accent treatment (tint/size/ping) applies only when the Agent
+    // Graph page asks for it; elsewhere an un-highlighted agent renders like any
+    // other node — downgrade its kind to null so the icon builder skips the
+    // accent (passing raw "agent" would re-trigger it).
+    const isAgentNode = node.service_type === "agent" && agentHighlight;
+    const iconServiceType =
+      node.service_type === "agent" && !agentHighlight ? null : node.service_type;
+
+    // Highlighted agents render ~30% larger so they read as the primary
+    // entities. The 104/56 factor compensates for the agent symbol's padded
+    // viewBox (see getServiceIconDataUrl) so the disc stays ≈1.3× a neighbour
+    // while its radar-ping halo has room to expand.
+    const symbolSize = isAgentNode
+      ? Math.round(baseSymbolSize * 1.3 * (104 / 56))
+      : baseSymbolSize;
 
     // SVG symbol: circle with health-colored border + service-type icon
     const iconDataUrl = getServiceIconSvg(
       node.id,
       isDarkMode,
       borderColor,
-      node.service_type,
+      iconServiceType,
     );
 
     // Use cached position if available
@@ -1308,7 +1490,9 @@ export const convertServiceGraphToNetwork = (
       errors: metrics.errors,
       symbol: iconDataUrl,
       symbolSize,
-      // itemStyle opacity is needed for emphasis.focus adjacency dimming to work on images
+      // itemStyle opacity is needed for emphasis.focus adjacency dimming to work
+      // on images. Agents no longer carry a static indigo glow — their emphasis
+      // is the animated radar-ping halo baked into the symbol (highlight mode).
       itemStyle: { opacity: 1 },
       label: { show: true },
       emphasis: {

--- a/web/src/utils/traces/modelVendorLogo.spec.ts
+++ b/web/src/utils/traces/modelVendorLogo.spec.ts
@@ -14,42 +14,62 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { describe, it, expect } from "vitest";
-import { resolveModelVendorLogo } from "./modelVendorLogo";
+import { modelVendorSlug, resolveModelVendorLogo } from "./modelVendorLogo";
 
-// The glob returns real bundled URLs under Vitest; a matched vendor yields a
-// non-empty string, an unmatched model yields "".
-describe("resolveModelVendorLogo", () => {
-  it("maps OpenAI model families to a self-contained data: logo", () => {
+// The vendor LOGO assets live under `src/assets/ai-datasource-content/generated/`
+// which is GITIGNORED and fetched at build time (scripts/fetch-datasource-content
+// .mjs) — so they may be absent in a fresh checkout / CI. The name→slug mapping
+// (`modelVendorSlug`) is pure and always testable; the asset-dependent URL
+// resolution is asserted only when the logos are actually bundled.
+describe("modelVendorSlug (pure name → vendor mapping)", () => {
+  it("maps OpenAI model families", () => {
     for (const m of ["gpt-4o", "gpt-4o-mini", "o1-preview", "o3-mini"]) {
-      const logo = resolveModelVendorLogo(m);
-      expect(logo).not.toBe("");
-      // Must be an inlined data: URI (not an external URL) so it stays
-      // canvas-safe when embedded in the node's SVG frame.
-      expect(logo.startsWith("data:")).toBe(true);
+      expect(modelVendorSlug(m)).toBe("openai");
     }
   });
 
-  it("maps Anthropic (Claude) models to a logo", () => {
+  it("maps Anthropic (Claude) models", () => {
     for (const m of ["claude-3-5-sonnet", "claude-sonnet-4-6", "anthropic/claude-3-5-sonnet"]) {
-      expect(resolveModelVendorLogo(m)).not.toBe("");
+      expect(modelVendorSlug(m)).toBe("anthropic");
     }
   });
 
-  it("maps Gemini / Vertex models to a logo", () => {
-    for (const m of ["gemini-1.5-pro", "gemini-2.0-flash"]) {
-      expect(resolveModelVendorLogo(m)).not.toBe("");
+  it("maps Gemini / Vertex models", () => {
+    for (const m of ["gemini-1.5-pro", "gemini-2.0-flash", "vertex-gemini"]) {
+      expect(modelVendorSlug(m)).toBe("gemini");
     }
   });
 
   it("strips a provider prefix before matching", () => {
-    // openai/… and anthropic/… should still resolve by the model family.
-    expect(resolveModelVendorLogo("openai/gpt-4o")).not.toBe("");
-    expect(resolveModelVendorLogo("anthropic/claude-3-5-sonnet")).not.toBe("");
+    expect(modelVendorSlug("openai/gpt-4o")).toBe("openai");
+    expect(modelVendorSlug("anthropic/claude-3-5-sonnet")).toBe("anthropic");
   });
 
+  it("returns undefined for an unknown / empty model", () => {
+    expect(modelVendorSlug("some-internal-model-xyz")).toBeUndefined();
+    expect(modelVendorSlug(undefined)).toBeUndefined();
+    expect(modelVendorSlug("")).toBeUndefined();
+  });
+});
+
+describe("resolveModelVendorLogo", () => {
+  // A model with no vendor rule always resolves to "" regardless of assets.
   it("returns empty string for an unknown model (chip-icon fallback)", () => {
     expect(resolveModelVendorLogo("some-internal-model-xyz")).toBe("");
     expect(resolveModelVendorLogo(undefined)).toBe("");
     expect(resolveModelVendorLogo("")).toBe("");
+  });
+
+  // When the vendor logo asset IS bundled, the result must be a self-contained
+  // `data:` URI (canvas-safe inside the node's SVG frame). If the gitignored
+  // assets aren't present (CI without the fetch), there is nothing to assert —
+  // the contract is "" in that case, already covered above.
+  it("returns a self-contained data: URI when the vendor logo is bundled", () => {
+    const logo = resolveModelVendorLogo("gpt-4o");
+    if (logo === "") {
+      // Assets not fetched in this environment — nothing to verify.
+      return;
+    }
+    expect(logo.startsWith("data:")).toBe(true);
   });
 });

--- a/web/src/utils/traces/modelVendorLogo.spec.ts
+++ b/web/src/utils/traces/modelVendorLogo.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, it, expect } from "vitest";
+import { resolveModelVendorLogo } from "./modelVendorLogo";
+
+// The glob returns real bundled URLs under Vitest; a matched vendor yields a
+// non-empty string, an unmatched model yields "".
+describe("resolveModelVendorLogo", () => {
+  it("maps OpenAI model families to a self-contained data: logo", () => {
+    for (const m of ["gpt-4o", "gpt-4o-mini", "o1-preview", "o3-mini"]) {
+      const logo = resolveModelVendorLogo(m);
+      expect(logo).not.toBe("");
+      // Must be an inlined data: URI (not an external URL) so it stays
+      // canvas-safe when embedded in the node's SVG frame.
+      expect(logo.startsWith("data:")).toBe(true);
+    }
+  });
+
+  it("maps Anthropic (Claude) models to a logo", () => {
+    for (const m of ["claude-3-5-sonnet", "claude-sonnet-4-6", "anthropic/claude-3-5-sonnet"]) {
+      expect(resolveModelVendorLogo(m)).not.toBe("");
+    }
+  });
+
+  it("maps Gemini / Vertex models to a logo", () => {
+    for (const m of ["gemini-1.5-pro", "gemini-2.0-flash"]) {
+      expect(resolveModelVendorLogo(m)).not.toBe("");
+    }
+  });
+
+  it("strips a provider prefix before matching", () => {
+    // openai/… and anthropic/… should still resolve by the model family.
+    expect(resolveModelVendorLogo("openai/gpt-4o")).not.toBe("");
+    expect(resolveModelVendorLogo("anthropic/claude-3-5-sonnet")).not.toBe("");
+  });
+
+  it("returns empty string for an unknown model (chip-icon fallback)", () => {
+    expect(resolveModelVendorLogo("some-internal-model-xyz")).toBe("");
+    expect(resolveModelVendorLogo(undefined)).toBe("");
+    expect(resolveModelVendorLogo("")).toBe("");
+  });
+});

--- a/web/src/utils/traces/modelVendorLogo.ts
+++ b/web/src/utils/traces/modelVendorLogo.ts
@@ -55,25 +55,35 @@ const MODEL_VENDOR_RULES: Array<{ re: RegExp; slug: string }> = [
 ];
 
 /**
- * Resolve a model name to a bundled vendor-logo URL, or "" if none matches.
- * `isDark` picks the dark-mode variant when the vendor ships one.
+ * Map a model name to its vendor slug (folder under `generated/<slug>/`), or
+ * `undefined` if no rule matches. Pure name→slug logic with no dependency on the
+ * logo assets — so it is deterministically testable even when the (gitignored,
+ * fetched-at-build) logo files are absent.
  */
-export function resolveModelVendorLogo(
-  modelName: string | undefined,
-  isDark = false,
-): string {
-  if (!modelName) return "";
+export function modelVendorSlug(modelName: string | undefined): string | undefined {
+  if (!modelName) return undefined;
   // Strip a provider prefix like "anthropic/claude-3-5" or "openai/gpt-4o".
   const bare = modelName.includes("/")
     ? modelName.slice(modelName.lastIndexOf("/") + 1)
     : modelName;
   const probe = `${modelName} ${bare}`;
-  for (const { re, slug } of MODEL_VENDOR_RULES) {
-    if (re.test(probe)) {
-      const b = logosBySlug[slug];
-      if (!b) continue;
-      return (isDark ? b.dark || b.light : b.light || b.dark) ?? "";
-    }
-  }
-  return "";
+  return MODEL_VENDOR_RULES.find(({ re }) => re.test(probe))?.slug;
+}
+
+/**
+ * Resolve a model name to a bundled vendor-logo `data:` URL. Returns "" when the
+ * model matches no vendor rule OR the matched vendor's logo asset is not present
+ * (the `generated/` assets are gitignored and fetched at build time, so callers
+ * must treat "" as "no logo — use the chip-icon fallback"). `isDark` picks the
+ * dark-mode variant when the vendor ships one.
+ */
+export function resolveModelVendorLogo(
+  modelName: string | undefined,
+  isDark = false,
+): string {
+  const slug = modelVendorSlug(modelName);
+  if (!slug) return "";
+  const b = logosBySlug[slug];
+  if (!b) return "";
+  return (isDark ? b.dark || b.light : b.light || b.dark) ?? "";
 }

--- a/web/src/utils/traces/modelVendorLogo.ts
+++ b/web/src/utils/traces/modelVendorLogo.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Maps a GenAI model node's name to a brand logo, reusing the same vendor logos
+// the AI-integrations catalog ships (generated/<vendor>/logo.svg). This is what
+// lets the agent graph render a model node (e.g. "gpt-4o", "claude-3-5-sonnet")
+// with the OpenAI / Anthropic / Gemini mark instead of a generic chip icon —
+// making provider mix readable at a glance. Falls back to the chip icon when the
+// model doesn't match a known vendor.
+
+// Vendor logos, inlined as base64 `data:` URIs (Vite `?inline`) rather than
+// hashed URLs. The graph embeds these inside an SVG <image> that ECharts
+// rasterizes to canvas — an EXTERNAL url there can render blank or taint the
+// canvas, whereas a self-contained data: URI always renders. Light + dark
+// variants are both captured so the graph can pick per theme.
+const logoModules = import.meta.glob(
+  "@/assets/ai-datasource-content/generated/*/*.{svg,png,webp,jpg,jpeg}",
+  { query: "?inline", import: "default", eager: true },
+) as Record<string, string>;
+
+const logosBySlug: Record<string, { light?: string; dark?: string }> = {};
+for (const [path, url] of Object.entries(logoModules)) {
+  const m = path.match(/([^/]+)\/([^/]+)$/);
+  if (!m) continue;
+  const [, slug, file] = m;
+  const bucket = (logosBySlug[slug] ??= {});
+  if (/^dark-logo\./i.test(file)) bucket.dark = url;
+  else if (/^logo\./i.test(file)) bucket.light = url;
+}
+
+/**
+ * Ordered model-name → vendor-slug rules. First match wins, so more specific
+ * patterns precede generic ones. Slugs correspond to folders under
+ * `generated/<slug>/` that carry a `logo.*`.
+ */
+const MODEL_VENDOR_RULES: Array<{ re: RegExp; slug: string }> = [
+  { re: /(^|[^a-z])(gpt|o1|o3|o4|davinci|text-embedding|dall-?e|whisper)/i, slug: "openai" },
+  { re: /claude|anthropic/i, slug: "anthropic" },
+  { re: /gemini|palm|bison|gemma|vertex/i, slug: "gemini" },
+  { re: /mistral|mixtral|codestral/i, slug: "mistral" },
+  { re: /llama|meta-/i, slug: "litellm" }, // no dedicated meta logo; litellm proxies these
+  { re: /command|cohere/i, slug: "openrouter" },
+];
+
+/**
+ * Resolve a model name to a bundled vendor-logo URL, or "" if none matches.
+ * `isDark` picks the dark-mode variant when the vendor ships one.
+ */
+export function resolveModelVendorLogo(
+  modelName: string | undefined,
+  isDark = false,
+): string {
+  if (!modelName) return "";
+  // Strip a provider prefix like "anthropic/claude-3-5" or "openai/gpt-4o".
+  const bare = modelName.includes("/")
+    ? modelName.slice(modelName.lastIndexOf("/") + 1)
+    : modelName;
+  const probe = `${modelName} ${bare}`;
+  for (const { re, slug } of MODEL_VENDOR_RULES) {
+    if (re.test(probe)) {
+      const b = logosBySlug[slug];
+      if (!b) continue;
+      return (isDark ? b.dark || b.light : b.light || b.dark) ?? "";
+    }
+  }
+  return "";
+}

--- a/web/src/utils/traces/serviceClassification.ts
+++ b/web/src/utils/traces/serviceClassification.ts
@@ -26,13 +26,23 @@
 // uninstrumented gRPC backends are never hidden. Unknown non-empty inferred
 // types default to External (a dependency), never Service.
 
+// GenAI entity kinds (agent/tool/model) are derived from a span's gen_ai_*
+// columns at ingest (surfaced via the edge `connection_type`). Unlike inferred
+// dependencies they are NOT positional: an agent is usually also a real service,
+// so they must win BEFORE the isRealService check — otherwise every agent that
+// calls a tool classifies as a bare Service. Kept in sync with the Rust
+// EntityKind and the shared fixture.
+
 /** The kind an entity is classified into. RPC is a first-class dependency. */
 export type EntityKind =
   | "service"
   | "datastore"
   | "queue"
   | "external"
-  | "rpc";
+  | "rpc"
+  | "agent"
+  | "tool"
+  | "model";
 
 /** The inferred types we branch on explicitly. */
 export type KnownInferType = "database" | "queue" | "external" | "rpc";
@@ -41,10 +51,13 @@ export type KnownInferType = "database" | "queue" | "external" | "rpc";
  * Classify a trace entity.
  *
  * @param isRealService true when the entity emits its own spans (a real
- *   instrumented service). Wins first: a real service that is also inferred (a
- *   collision) stays a Service.
- * @param inferServiceType the entity's `infer_service_type`
- *   (`database`/`queue`/`external`/`rpc`), or null/undefined/empty when none.
+ *   instrumented service). Wins over the dependency kinds: a real service that
+ *   is also inferred (a collision) stays a Service. Does NOT win over GenAI
+ *   kinds — those are explicit and authoritative.
+ * @param inferServiceType the entity's classification tag: for inferred
+ *   dependencies the `infer_service_type`
+ *   (`database`/`queue`/`external`/`rpc`); for GenAI entities the edge
+ *   `connection_type` (`agent`/`tool`/`model`). null/undefined/empty when none.
  *   Note the backend stores `database` (not `datastore`) as the raw type; this
  *   function maps it to the `datastore` kind. Unknown non-empty values fall
  *   through to `external` (a dependency), never `service`.
@@ -53,8 +66,18 @@ export function classifyEntity(
   isRealService: boolean,
   inferServiceType?: KnownInferType | (string & {}) | null,
 ): EntityKind {
-  if (isRealService) return "service";
   const t = (inferServiceType ?? "").trim();
+  // GenAI kinds are explicit and authoritative — checked before isRealService,
+  // because agents are usually real services too.
+  switch (t) {
+    case "agent":
+      return "agent";
+    case "tool":
+      return "tool";
+    case "model":
+      return "model";
+  }
+  if (isRealService) return "service";
   switch (t) {
     case "database":
       return "datastore";


### PR DESCRIPTION
## What

Adds an **Agent Graph** to AI Observability that renders AI agents, tools, and models as first-class nodes in the service graph — unified with the real downstream services an agent talks to. It answers "what does my agent actually interact with?" (tools, models, services, datastores) instead of showing GenAI spans in isolation.

## Why

LLM Insights shows plenty of per-call data but no picture of the flow — where a request starts, where the agent sits, and everything it fans out to. This surfaces the full agent topology, works across every framework OpenObserve documents, and correctly attributes tools/models to the owning agent even when the instrumentation nests them several spans deep.

## Backend (`src/core`)

- **Agent/tool/model edge families in the service-graph processor** (`traces/service_graph/processor.rs`): derives `service → agent`, `agent → model`, `agent → tool` edges from the canonical `gen_ai_*` columns, keyed on column presence (open operation-name vocabulary), schema-gated so streams missing a column don't error.
- **Multi-level agent inheritance.** The owning agent name usually lives on an *ancestor* span (real Google ADK nests `generate_content(agent) → chat → execute_tool`), not on the tool/LLM span. The `from` climbs the parent chain up to `AGENT_INHERIT_DEPTH` (4) levels — `COALESCE(child.agent, p1…pN, service_name)` + chained ancestor `LEFT JOIN`s — taking the nearest ancestor with an agent name. Extracted `build_agent_or_service` / `build_ancestor_joins` as pure, unit-tested helpers. (Recursive CTE was tried first but panics in the search engine; a bounded chained join is supported and shallow-tree-cheap.)
- **Extractor coverage** for the framework conventions OpenObserve documents (gen_ai semconv, OpenInference, traceloop, CrewAI, Google ADK, LangChain, Langfuse): `is_llm_trace` gate now admits OpenInference/framework agent+tool spans; `extract_tool_name` reads `tool.name` / `langchain.tool.name` / `crewai.task.tools` / Langfuse metadata; new attribute constants. All normalize into the canonical `gen_ai.*` columns at ingest, so the query layer reads one column set regardless of vendor.

## Frontend (`web/src`)

- **Standalone Agent Graph page** under AI Observability (`AgentGraphPage.vue`) with Stream/Agent selectors and a DateTime picker, matching the LLM Insights UX; route + rail item + i18n.
- **Graph rendering** (`convertTraceData.ts`, `ServiceGraph.vue`): agent/tool/model node kinds, vendor brand logos on model nodes (reusing the AI-integrations catalog logos), an animated "radar-ping" halo baked into the agent symbol SVG so it stays centered and pans/zooms with the node, and a layered-layout depth fix so `service < agent < model/tool` renders correctly. Agent highlighting is gated to the Agent Graph page (the Service Graph tab is unchanged).
- **Side-panel caller consistency** (`ServiceGraphNodeSidePanel.vue`): the Operations table now resolves a tool/model node's caller with the *same* ancestor-agent climb the graph edge uses, so the panel and graph agree (previously the panel showed the host app as the caller). Refactored the identity-field builder to emit aliased columns directly (no fragile regex post-processing).
- **Design tokens** (`theme.ts`): added `cssToken(name, fallback)` to resolve `--color-*` tokens at runtime for chart/SVG contexts (where `var(--x)` can't be used), and routed the agent-accent + exact-match health colors through it instead of hardcoded hex.

## Consistency

Service classification is mirrored TS ⇄ Rust; the shared `classification_cases.json` vector (both copies kept identical) drives unit tests in both languages.

## Testing

- Rust: multi-level inheritance + edge-attribution unit tests; `cargo build` clean.
- Frontend: new specs for the graph conversion, layout, model-vendor-logo, side-panel caller climb, and `cssToken`; full traces suite green.
- Verified end-to-end on real production traces (SRE agent) and on synthetic fixtures for CrewAI / OpenAI-Agents / Google ADK / genai-semconv / LangChain — every framework attributes agent → model/tool correctly.

## Notes

- Topology is read from the pre-aggregated `_o2_service_graph` stream (the hourly incremental job), so it scales to large trace volumes — no per-load raw-trace scan.
- The enterprise `classify_entity` / `build_topology` changes live in the o2-enterprise repo and are required for the enterprise build.
