### PR TITLE
fix: stream dropdown shows no data on metrics page

### DIFF
--- a/web/src/components/dashboards/addPanel/PanelFieldList.spec.ts
+++ b/web/src/components/dashboards/addPanel/PanelFieldList.spec.ts
@@ -929,6 +929,19 @@ describe("FieldList", () => {
   describe("edit mode loads the stream list for an ALREADY-set stream", () => {
     const currentQuery = () => mockReturn.dashboardPanelData.data.queries[0];
 
+    it("fetches immediately in metrics edit mode even when stream is blank", async () => {
+      currentQuery().fields.stream = "";
+      currentQuery().fields.stream_type = "metrics";
+
+      wrapper = mountComponent({
+        pageKey: "metrics",
+        props: { editMode: true },
+      });
+      await flushPromises();
+
+      expect(mockGetStreams).toHaveBeenCalledWith("metrics", false);
+    });
+
     it("fetches when the stream is set before mount (the seeded-parent case)", async () => {
       // The parent seeded this before the field list ever mounted.
       currentQuery().fields.stream = "envoy_cluster_assignment_stale";

--- a/web/src/components/dashboards/addPanel/PanelFieldList.vue
+++ b/web/src/components/dashboards/addPanel/PanelFieldList.vue
@@ -626,7 +626,10 @@ if (isEditPanel) {
     let loaded = false;
     let stopEditInitialLoad: (() => void) | undefined;
     const onStream = (streamName: string) => {
-      if (!streamName || loaded) return;
+      if (loaded) return;
+      // Metrics visualize starts blank by design; load the metric stream list
+      // immediately so the stream dropdown is selectable without a preseeded stream.
+      if (!streamName && dashboardPanelDataPageKey !== "metrics") return;
       loaded = true;
       // Undefined on the immediate pass — `watch` has not returned yet, so the
       // handle does not exist. `loaded` is what stops a second run; this is only


### PR DESCRIPTION
fix: stream dropdown shows no data on metrics page

before fix:
<img width="1722" height="1018" alt="image" src="https://github.com/user-attachments/assets/66c99bcf-55b5-4e06-9fc9-22ea58c8c0a4" />

after fix:
<img width="2194" height="1234" alt="image" src="https://github.com/user-attachments/assets/cc1987f6-5b88-4976-8b9a-0c5e988cb61c" />
