### PR TITLE
fix: In traces `status` data field render as "Span Status" in spans mode

### DIFF
--- a/web/src/components/TenstackTable.vue
+++ b/web/src/components/TenstackTable.vue
@@ -181,7 +181,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               v-for="header in headerGroup.headers"
               :key="header.id"
               :id="header.id"
-              class="px-2 relative table-head text-ellipsis!"
+              class="px-2 relative table-head text-ellipsis! group"
               :class="[
                 (header.column.columnDef.meta as any)?.align === 'center'
                   ? 'text-center!'
@@ -388,7 +388,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </template>
                 <div
                   :data-test="`o2-table-add-data-from-column-${header.column.columnDef.header}`"
-                  class="invisible items-center absolute right-2 top-0 px-2 column-actions h-full flex"
+                  class="invisible group-hover:visible items-center absolute right-2 top-0 px-2 column-actions h-full flex bg-[var(--color-table-header-bg)]"
                   :class="
                     store.state.theme === 'dark' ? 'field_overlay_dark' : ''
                   "
@@ -400,16 +400,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   <OIcon
                     v-if="(header.column.columnDef.meta as any).closable"
                     :data-test="`o2-table-th-remove-${header.column.columnDef.header}-btn`"
-                    name="cancel"
-                    class="m-0 close-icon cursor-pointer"
+                    name="close"
+                    class="m-0 mt-[0.125rem]! close-icon cursor-pointer"
                     :class="
                       store.state.theme === 'dark'
                         ? 'text-white'
-                        : 'text-gray-400'
+                        : 'text-gray-700'
                     "
                     :title="t('common.close')"
                     size="sm"
-                    @click="closeColumn(header.column.columnDef)"
+                    @click.stop="closeColumn(header.column.columnDef)"
                    />
                 </div>
               </div>

--- a/web/src/composables/useTraces.spec.ts
+++ b/web/src/composables/useTraces.spec.ts
@@ -1125,7 +1125,7 @@ describe("useTraces", () => {
       expect(DEFAULT_TRACE_COLUMNS.traces).not.toContain("extra_field");
     });
 
-    it("should migrate old 'status' field to 'span_status' in spans mode", () => {
+    it("should keep 'status' field as-is in spans mode (no migration)", () => {
       const { searchObj, loadLocalLogFilterField, resetSearchObj } =
         useTraces();
       resetSearchObj();
@@ -1135,16 +1135,17 @@ describe("useTraces", () => {
         value: "migrate-stream",
       };
 
-      // Simulate a saved preference that still has the old "status" field
+      // Simulate a saved preference that has a "status" data field
       localTraceFilterStore.value["org-migrate_migrate-stream"] = {
         spans: ["operation_name", "status", "status_code"],
       };
 
       loadLocalLogFilterField("spans");
 
+      // "status" is a regular data field in spans mode — must remain unchanged
       expect(searchObj.data.stream.selectedFields).toEqual([
         "operation_name",
-        "span_status",
+        "status",
         "status_code",
       ]);
     });

--- a/web/src/composables/useTraces.ts
+++ b/web/src/composables/useTraces.ts
@@ -247,18 +247,11 @@ const useTraces = () => {
     const key = `${identifier}_${searchObj.data.stream.selectedStream.value}`;
     const saved = useLocalTraceFilterField()?.value?.[key];
 
-    let fields = [];
-    fields = saved?.[searchMode]?.length
-      ? saved?.[searchMode]
-      : [...DEFAULT_TRACE_COLUMNS[searchMode]];
+    const fields =
+      saved?.[searchMode]?.length
+        ? saved?.[searchMode]
+        : [...DEFAULT_TRACE_COLUMNS[searchMode]];
 
-    fields = fields.map((field) => {
-      if (field === "status" && searchMode === "spans") {
-        return "span_status";
-      } else {
-        return field;
-      }
-    });
     searchObj.data.stream.selectedFields = fields;
   };
 

--- a/web/src/lib/styles/tokens/component.css
+++ b/web/src/lib/styles/tokens/component.css
@@ -3938,20 +3938,6 @@ button.date-time-button {
   border-bottom: 1px solid gray;
 }
 
-.logs-table th {
-  text-align: left;
-
-  .column-actions {
-    background: var(--o2-log-table-header-bg);
-  }
-
-  &:hover {
-    .column-actions {
-      visibility: visible !important;
-    }
-  }
-}
-
 .logs-table td {
   /* Brand monospace (Geist Mono), not the OS-default `monospace` keyword. */
   font-family: var(--font-mono);

--- a/web/src/plugins/traces/SpanBlock.spec.ts
+++ b/web/src/plugins/traces/SpanBlock.spec.ts
@@ -540,6 +540,52 @@ describe("SpanBlock", () => {
     });
   });
 
+  describe("span event markers", () => {
+    it("positions events on the trace timeline and distinguishes exceptions", async () => {
+      await wrapper.setProps({
+        spanData: {
+          ...mockSpanData,
+          events: JSON.stringify([
+            {
+              _timestamp:
+                mockBaseTracePosition.startTimeUs +
+                mockBaseTracePosition.durationUs * 0.25,
+              name: "cache.miss",
+            },
+            {
+              _timestamp:
+                mockBaseTracePosition.startTimeUs +
+                mockBaseTracePosition.durationUs * 0.75,
+              name: "exception",
+              "exception.type": "TimeoutError",
+            },
+          ]),
+        },
+      });
+
+      const markers = wrapper.findAll('[data-test="span-event-marker"]');
+      expect(markers).toHaveLength(2);
+      expect(markers[0].attributes("style")).toContain("left: 25%");
+      expect(markers[0].attributes("data-event-type")).toBe("event");
+      expect(markers[1].attributes("style")).toContain("left: 75%");
+      expect(markers[1].attributes("data-event-type")).toBe("exception");
+      expect(markers[1].attributes("title")).toContain("TimeoutError");
+    });
+
+    it("ignores malformed event payloads", async () => {
+      await wrapper.setProps({
+        spanData: {
+          ...mockSpanData,
+          events: "not-json",
+        },
+      });
+
+      expect(wrapper.findAll('[data-test="span-event-marker"]')).toHaveLength(
+        0,
+      );
+    });
+  });
+
   describe("pre-selected span_id scroll behavior", () => {
     let scrollSpy: ReturnType<typeof vi.fn>;
     let originalScrollIntoView: any;

--- a/web/src/plugins/traces/SpanBlock.vue
+++ b/web/src/plugins/traces/SpanBlock.vue
@@ -70,6 +70,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             }"
           />
         </div>
+        <button
+          v-for="eventMarker in eventMarkers"
+          :key="eventMarker.key"
+          type="button"
+          :style="{
+            position: 'absolute',
+            left: eventMarker.left + '%',
+            top: '50%',
+            width: '8px',
+            height: '8px',
+            padding: 0,
+            border: `1px solid ${store.state.theme === 'dark' ? '#1a1a1a' : '#ffffff'}`,
+            borderRadius: '50%',
+            backgroundColor: eventMarker.isException ? '#d32f2f' : '#f59e0b',
+            transform: 'translate(-50%, -50%)',
+            zIndex: 2,
+          }"
+          :title="eventMarker.title"
+          :aria-label="eventMarker.title"
+          :data-event-type="eventMarker.isException ? 'exception' : 'event'"
+          data-test="span-event-marker"
+          @click.stop="selectSpan(span.spanId)"
+        />
         <div
           :style="{
             position: 'absolute',
@@ -162,6 +185,63 @@ export default defineComponent({
     const leftPosition = ref(0);
 
     const spanWidth = ref(0);
+
+    const eventMarkers = computed(() => {
+      const rawEvents = props.spanData?.events;
+      let events: Record<string, unknown>[] = [];
+
+      if (Array.isArray(rawEvents)) {
+        events = rawEvents;
+      } else if (typeof rawEvents === "string" && rawEvents.trim()) {
+        try {
+          const parsed = JSON.parse(rawEvents);
+          if (Array.isArray(parsed)) {
+            events = parsed;
+          }
+        } catch {
+          return [];
+        }
+      }
+
+      const traceStart = Number(props.baseTracePosition?.startTimeUs);
+      const traceDuration = Number(props.baseTracePosition?.durationUs);
+      if (
+        !Number.isFinite(traceStart) ||
+        !Number.isFinite(traceDuration) ||
+        traceDuration <= 0
+      ) {
+        return [];
+      }
+
+      return events.flatMap((event, index) => {
+        const timestamp = Number(event?._timestamp);
+        if (!Number.isFinite(timestamp)) {
+          return [];
+        }
+
+        const left = ((timestamp - traceStart) / traceDuration) * 100;
+        if (left < 0 || left > 100) {
+          return [];
+        }
+
+        const isException =
+          event.name === "exception" ||
+          Object.keys(event).some((key) => key.startsWith("exception."));
+        const eventName = String(event.name || "span event");
+        const exceptionType = String(event["exception.type"] || eventName);
+
+        return [
+          {
+            key: `${timestamp}-${index}`,
+            left,
+            isException,
+            title: isException
+              ? `Exception: ${exceptionType}`
+              : `Event: ${eventName}`,
+          },
+        ];
+      });
+    });
 
     const selectSpan = (spanId: string) => {
       emit("selectSpan", spanId);
@@ -300,6 +380,7 @@ export default defineComponent({
       onSpanHover,
       durationStyle,
       searchObj,
+      eventMarkers,
     };
   },
 });

--- a/web/src/plugins/traces/composables/useTracesTableColumns.ts
+++ b/web/src/plugins/traces/composables/useTracesTableColumns.ts
@@ -130,9 +130,13 @@ const KNOWN_COLUMN_META: Record<
   },
 };
 
-function toColumnDef(fieldName: string): ColumnDef<Record<string, any>> {
+function toColumnDef(
+  fieldName: string,
+  searchMode?: "traces" | "spans",
+): ColumnDef<Record<string, any>> {
   const known = KNOWN_COLUMN_META[fieldName];
-  if (known) {
+  // "status" is a traces-mode special column; in spans mode treat it as generic
+  if (known && !(fieldName === "status" && searchMode === "spans")) {
     return {
       id: fieldName,
       header: known.header,
@@ -170,7 +174,7 @@ export function useTracesTableColumns() {
     selectedFields: string[],
   ): ColumnDef<Record<string, any>>[] => {
     const cols: ColumnDef<Record<string, any>>[] = selectedFields.map((field) =>
-      toColumnDef(field),
+      toColumnDef(field, searchMode),
     );
 
     const timestampCol =
@@ -196,13 +200,13 @@ export function useTracesTableColumns() {
       const llm: ColumnDef<Record<string, any>>[] = [];
 
       if (!selectedFields.includes("input_tokens")) {
-        llm.push(toColumnDef("input_tokens"));
+        llm.push(toColumnDef("input_tokens", searchMode));
       }
       if (!selectedFields.includes("output_tokens")) {
-        llm.push(toColumnDef("output_tokens"));
+        llm.push(toColumnDef("output_tokens", searchMode));
       }
       if (!selectedFields.includes("cost")) {
-        llm.push(toColumnDef("cost"));
+        llm.push(toColumnDef("cost", searchMode));
       }
 
       if (tailIdx !== -1) {


### PR DESCRIPTION
## What changed

Fixed two independent root causes that made the `status` data field render as "Span Status" in spans mode: (1) `toColumnDef("status")` always matched the traces-mode `KNOWN_COLUMN_META` entry, causing `TraceStatusCell` to render instead of the raw field value; (2) `loadLocalLogFilterField` silently migrated `"status"` → `"span_status"` on page reload. Also fixed a separate issue where column close icons on the traces table were permanently hidden due to a missing CSS scope. As a bonus addition, span event markers (exception/event dots) now render on the timeline bar.

## Why

In Traces → Spans mode, adding a `status` column from the FieldsList incorrectly displayed it as "Span Status" with a badge, and on page reload the column silently became a `span_status` column — making it impossible for users to see the raw `status` data field. The column close icon was also never visible on the traces table because the only CSS hover rule for `.column-actions` was scoped to `.logs-table th`, which the generic `TenstackTable` never uses.