### PR TITLE
fix: In traces 'status' field was getting added as 'Span Status' in spans mode

### DIFF
--- a/web/src/components/TenstackTable.vue
+++ b/web/src/components/TenstackTable.vue
@@ -185,7 +185,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               v-for="header in headerGroup.headers"
               :key="header.id"
               :id="header.id"
-              class="px-2 relative table-head text-ellipsis!"
+              class="px-2 relative table-head text-ellipsis! group"
               :class="[
                 (header.column.columnDef.meta as any)?.align === 'center'
                   ? 'text-center!'
@@ -391,7 +391,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </template>
                 <div
                   :data-test="`o2-table-add-data-from-column-${header.column.columnDef.header}`"
-                  class="invisible items-center absolute right-2 top-0 px-2 column-actions h-full flex"
+                  class="invisible items-center absolute right-2 top-0 px-2 column-actions h-full flex group-hover:visible bg-[var(--color-table-header-bg)]"
+                  :class="
+                    store.state.theme === 'dark' ? 'field_overlay_dark' : ''
+                  "
                   v-if="
                     (header.column.columnDef.meta as any)?.closable ||
                     (header.column.columnDef.meta as any)?.showWrap
@@ -400,11 +403,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   <OIcon
                     v-if="(header.column.columnDef.meta as any).closable"
                     :data-test="`o2-table-th-remove-${header.column.columnDef.header}-btn`"
-                    name="cancel"
                     class="m-0 close-icon cursor-pointer text-icon-color"
+                    name="close"
                     :title="t('common.close')"
                     size="sm"
-                    @click="closeColumn(header.column.columnDef)"
+                    @click.stop="closeColumn(header.column.columnDef)"
                    />
                 </div>
               </div>

--- a/web/src/components/TenstackTable.vue
+++ b/web/src/components/TenstackTable.vue
@@ -392,9 +392,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <div
                   :data-test="`o2-table-add-data-from-column-${header.column.columnDef.header}`"
                   class="invisible items-center absolute right-2 top-0 px-2 column-actions h-full flex group-hover:visible bg-[var(--color-table-header-bg)]"
-                  :class="
-                    store.state.theme === 'dark' ? 'field_overlay_dark' : ''
-                  "
                   v-if="
                     (header.column.columnDef.meta as any)?.closable ||
                     (header.column.columnDef.meta as any)?.showWrap

--- a/web/src/composables/useTraces.spec.ts
+++ b/web/src/composables/useTraces.spec.ts
@@ -1125,7 +1125,7 @@ describe("useTraces", () => {
       expect(DEFAULT_TRACE_COLUMNS.traces).not.toContain("extra_field");
     });
 
-    it("should migrate old 'status' field to 'span_status' in spans mode", () => {
+    it("should keep 'status' field as-is in spans mode (no migration)", () => {
       const { searchObj, loadLocalLogFilterField, resetSearchObj } =
         useTraces();
       resetSearchObj();
@@ -1135,16 +1135,17 @@ describe("useTraces", () => {
         value: "migrate-stream",
       };
 
-      // Simulate a saved preference that still has the old "status" field
+      // Simulate a saved preference that has a "status" data field
       localTraceFilterStore.value["org-migrate_migrate-stream"] = {
         spans: ["operation_name", "status", "status_code"],
       };
 
       loadLocalLogFilterField("spans");
 
+      // "status" is a regular data field in spans mode — must remain unchanged
       expect(searchObj.data.stream.selectedFields).toEqual([
         "operation_name",
-        "span_status",
+        "status",
         "status_code",
       ]);
     });

--- a/web/src/composables/useTraces.ts
+++ b/web/src/composables/useTraces.ts
@@ -277,18 +277,11 @@ const useTraces = () => {
     const key = `${identifier}_${searchObj.data.stream.selectedStream.value}`;
     const saved = useLocalTraceFilterField()?.value?.[key];
 
-    let fields = [];
-    fields = saved?.[searchMode]?.length
-      ? saved?.[searchMode]
-      : [...DEFAULT_TRACE_COLUMNS[searchMode]];
+    const fields =
+      saved?.[searchMode]?.length
+        ? saved?.[searchMode]
+        : [...DEFAULT_TRACE_COLUMNS[searchMode]];
 
-    fields = fields.map((field) => {
-      if (field === "status" && searchMode === "spans") {
-        return "span_status";
-      } else {
-        return field;
-      }
-    });
     searchObj.data.stream.selectedFields = fields;
   };
 

--- a/web/src/plugins/traces/composables/useTracesTableColumns.ts
+++ b/web/src/plugins/traces/composables/useTracesTableColumns.ts
@@ -130,9 +130,13 @@ const KNOWN_COLUMN_META: Record<
   },
 };
 
-function toColumnDef(fieldName: string): ColumnDef<Record<string, any>> {
+function toColumnDef(
+  fieldName: string,
+  searchMode?: "traces" | "spans",
+): ColumnDef<Record<string, any>> {
   const known = KNOWN_COLUMN_META[fieldName];
-  if (known) {
+  // "status" is a traces-mode special column; in spans mode treat it as generic
+  if (known && !(fieldName === "status" && searchMode === "spans")) {
     return {
       id: fieldName,
       header: known.header,
@@ -170,7 +174,7 @@ export function useTracesTableColumns() {
     selectedFields: string[],
   ): ColumnDef<Record<string, any>>[] => {
     const cols: ColumnDef<Record<string, any>>[] = selectedFields.map((field) =>
-      toColumnDef(field),
+      toColumnDef(field, searchMode),
     );
 
     const timestampCol =
@@ -196,13 +200,13 @@ export function useTracesTableColumns() {
       const llm: ColumnDef<Record<string, any>>[] = [];
 
       if (!selectedFields.includes("input_tokens")) {
-        llm.push(toColumnDef("input_tokens"));
+        llm.push(toColumnDef("input_tokens", searchMode));
       }
       if (!selectedFields.includes("output_tokens")) {
-        llm.push(toColumnDef("output_tokens"));
+        llm.push(toColumnDef("output_tokens", searchMode));
       }
       if (!selectedFields.includes("cost")) {
-        llm.push(toColumnDef("cost"));
+        llm.push(toColumnDef("cost", searchMode));
       }
 
       if (tailIdx !== -1) {


### PR DESCRIPTION
## What changed

Removes the automatic migration of the `status` field to `span_status` in spans search mode, and passes the current `searchMode` to column definition generation so `status` is treated as a generic data column in spans mode instead of getting traces-mode special column rendering. Alongside this, the TenstackTable header actions area gets a hover-visibility fix and the old `.logs-table` CSS block for column actions is deleted in favour of the generic `group-hover:visible` approach.

## Why

The previous code was conflating the `status` data field (a legitimate user-configurable column in spans mode) with the "Span Status" column definition that is meaningful only in traces mode. This meant any user who had `status` saved in their spans column preferences would have it silently renamed to `span_status`, which either broke the column or showed incorrect data.