### PR TITLE
fix: skip caching files below record threshold

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1490,6 +1490,8 @@ pub struct Limit {
     pub query_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_THREAD_NUM", default = 0)]
     pub file_download_thread_num: usize,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_MIN_RECORDS", default = 100)]
+    pub file_download_min_records: i64,
     #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_THREAD_NUM", default = 0)]
     pub file_download_priority_queue_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_WINDOW_SECS", default = 3600)]

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -64,12 +64,12 @@ impl Event for Eventer {
 
             // Collect files to download
             for item in put_items.iter() {
-                if !crate::service::file_downloader::should_download(item.meta.records) {
+                if !crate::job::should_download(item.meta.records) {
                     continue;
                 }
                 // files with data older than the cache max age should not be
                 // cached, e.g. merged files from compaction of old partitions
-                if crate::service::file_downloader::exceeds_cache_max_age(
+                if crate::job::exceeds_cache_max_age(
                     item.meta.max_ts,
                     CacheType::Disk,
                 ) {

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -64,6 +64,9 @@ impl Event for Eventer {
 
             // Collect files to download
             for item in put_items.iter() {
+                if !crate::job::should_download(item.meta.records) {
+                    continue;
+                }
                 // cache parquet
                 if cfg.cache_latest_files.cache_parquet {
                     files_to_download.push((

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -69,10 +69,7 @@ impl Event for Eventer {
                 }
                 // files with data older than the cache max age should not be
                 // cached, e.g. merged files from compaction of old partitions
-                if crate::job::exceeds_cache_max_age(
-                    item.meta.max_ts,
-                    CacheType::Disk,
-                ) {
+                if crate::job::exceeds_cache_max_age(item.meta.max_ts, CacheType::Disk) {
                     continue;
                 }
                 // cache parquet

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -553,6 +553,16 @@ pub async fn queue_download(
     Ok(())
 }
 
+/// Returns true when a file contains enough records to be worth downloading
+/// into the cache.
+pub fn should_download(records: i64) -> bool {
+    has_minimum_records(records, get_config().limit.file_download_min_records)
+}
+
+fn has_minimum_records(records: i64, min_records: i64) -> bool {
+    records >= min_records
+}
+
 // if the file timestamp is in the past window, it should be prioritized
 fn should_prioritize_file(ts: i64, window_secs: i64) -> bool {
     let window_micros = window_secs * 1_000_000;
@@ -562,7 +572,18 @@ fn should_prioritize_file(ts: i64, window_secs: i64) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{FileInfo, PriorityDownloadQueue, file_data, processing_files, queued_files};
+    use super::{
+        FileInfo, PriorityDownloadQueue, file_data, has_minimum_records, processing_files,
+        queued_files,
+    };
+
+    #[test]
+    fn test_has_minimum_records() {
+        assert!(!has_minimum_records(99, 100));
+        assert!(has_minimum_records(100, 100));
+        assert!(has_minimum_records(101, 100));
+        assert!(has_minimum_records(0, 0));
+    }
 
     #[test]
     fn test_is_processing_false_initially() {

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -556,13 +556,9 @@ pub async fn queue_download(
 /// Returns true when the record count is unknown or the file contains enough
 /// records to be worth downloading into the cache.
 pub fn should_download(records: i64) -> bool {
-    should_download_with_min_records(records, get_config().limit.file_download_min_records)
-}
-
-fn should_download_with_min_records(records: i64, min_records: i64) -> bool {
     // A zero value can mean the record count was not populated by an older
     // gRPC sender. Treat it as unknown rather than as an undersized file.
-    records == 0 || records >= min_records
+    records == 0 || records >= get_config().limit.file_download_min_records
 }
 
 // if the file timestamp is in the past window, it should be prioritized
@@ -575,17 +571,15 @@ fn should_prioritize_file(ts: i64, window_secs: i64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        FileInfo, PriorityDownloadQueue, file_data, processing_files, queued_files,
-        should_download_with_min_records,
+        FileInfo, PriorityDownloadQueue, file_data, processing_files, queued_files, should_download,
     };
 
     #[test]
-    fn test_should_download_with_min_records() {
-        assert!(should_download_with_min_records(0, 100));
-        assert!(!should_download_with_min_records(99, 100));
-        assert!(should_download_with_min_records(100, 100));
-        assert!(should_download_with_min_records(101, 100));
-        assert!(should_download_with_min_records(0, 0));
+    fn test_should_download() {
+        assert!(should_download(0));
+        assert!(!should_download(99));
+        assert!(should_download(100));
+        assert!(should_download(101));
     }
 
     #[test]

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -553,14 +553,16 @@ pub async fn queue_download(
     Ok(())
 }
 
-/// Returns true when a file contains enough records to be worth downloading
-/// into the cache.
+/// Returns true when the record count is unknown or the file contains enough
+/// records to be worth downloading into the cache.
 pub fn should_download(records: i64) -> bool {
-    has_minimum_records(records, get_config().limit.file_download_min_records)
+    should_download_with_min_records(records, get_config().limit.file_download_min_records)
 }
 
-fn has_minimum_records(records: i64, min_records: i64) -> bool {
-    records >= min_records
+fn should_download_with_min_records(records: i64, min_records: i64) -> bool {
+    // A zero value can mean the record count was not populated by an older
+    // gRPC sender. Treat it as unknown rather than as an undersized file.
+    records == 0 || records >= min_records
 }
 
 // if the file timestamp is in the past window, it should be prioritized
@@ -573,16 +575,17 @@ fn should_prioritize_file(ts: i64, window_secs: i64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        FileInfo, PriorityDownloadQueue, file_data, has_minimum_records, processing_files,
-        queued_files,
+        FileInfo, PriorityDownloadQueue, file_data, processing_files, queued_files,
+        should_download_with_min_records,
     };
 
     #[test]
-    fn test_has_minimum_records() {
-        assert!(!has_minimum_records(99, 100));
-        assert!(has_minimum_records(100, 100));
-        assert!(has_minimum_records(101, 100));
-        assert!(has_minimum_records(0, 0));
+    fn test_should_download_with_min_records() {
+        assert!(should_download_with_min_records(0, 100));
+        assert!(!should_download_with_min_records(99, 100));
+        assert!(should_download_with_min_records(100, 100));
+        assert!(should_download_with_min_records(101, 100));
+        assert!(should_download_with_min_records(0, 0));
     }
 
     #[test]

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -56,7 +56,9 @@ mod service_graph;
 mod session_cleanup;
 mod stats;
 
-pub use file_downloader::{download_from_node, exceeds_cache_max_age, queue_download, should_download};
+pub use file_downloader::{
+    download_from_node, exceeds_cache_max_age, queue_download, should_download,
+};
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 #[cfg(feature = "enterprise")]

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -56,7 +56,7 @@ mod service_graph;
 mod session_cleanup;
 mod stats;
 
-pub use file_downloader::{download_from_node, queue_download};
+pub use file_downloader::{download_from_node, queue_download, should_download};
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 #[cfg(feature = "enterprise")]

--- a/src/service/file_list_dump.rs
+++ b/src/service/file_list_dump.rs
@@ -187,6 +187,7 @@ pub async fn exec(
                     &f.key,
                     f.meta.compressed_size,
                     f.meta.max_ts,
+                    f.meta.records,
                 )
             })
             .collect_vec(),

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -156,6 +156,7 @@ pub(crate) async fn create_context(
                     &f.key,
                     f.meta.compressed_size,
                     f.meta.max_ts,
+                    f.meta.records,
                 )
             })
             .collect_vec(),

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -175,6 +175,7 @@ pub async fn search(
                     &f.key,
                     f.meta.compressed_size,
                     f.meta.max_ts,
+                    f.meta.records,
                 )
             })
             .collect_vec(),
@@ -288,7 +289,7 @@ pub async fn search(
 #[tracing::instrument(name = "service:search:grpc:storage:cache_files", skip_all)]
 pub async fn cache_files(
     trace_id: &str,
-    files: &[(i64, &String, &String, i64, i64)],
+    files: &[(i64, &String, &String, i64, i64, i64)],
     scan_stats: &mut ScanStats,
     file_type: &str,
 ) -> (file_data::CacheType, u64, u64) {
@@ -297,7 +298,7 @@ pub async fn cache_files(
     let (mut cache_hits, mut cache_misses) = (0, 0);
 
     let start = std::time::Instant::now();
-    for (_id, _account, file, _size, max_ts) in files.iter() {
+    for (_id, _account, file, _size, max_ts, _records) in files.iter() {
         if file_data::memory::exist(file).await {
             scan_stats.querier_memory_cached_files += 1;
             cached_files.insert(file);
@@ -371,8 +372,8 @@ pub async fn cache_files(
     let trace_id = trace_id.to_string();
     let files = files
         .iter()
-        .filter_map(|(id, account, file, size, ts)| {
-            if cached_files.contains(&file) {
+        .filter_map(|(id, account, file, size, ts, records)| {
+            if cached_files.contains(file) || !crate::job::should_download(*records) {
                 None
             } else {
                 Some((*id, account.to_string(), file.to_string(), *size, *ts))
@@ -453,7 +454,16 @@ pub async fn tantivy_search(
         &query.trace_id,
         &index_file_names
             .iter()
-            .map(|(ttv_file, f)| (f.id, &f.account, ttv_file, f.meta.index_size, f.meta.max_ts))
+            .map(|(ttv_file, f)| {
+                (
+                    f.id,
+                    &f.account,
+                    ttv_file,
+                    f.meta.index_size,
+                    f.meta.max_ts,
+                    f.meta.records,
+                )
+            })
             .collect_vec(),
         &mut scan_stats,
         "index",


### PR DESCRIPTION
## Summary

Backport the download-queue minimum-record threshold to `branch-v0.80.0`.

- add `ZO_FILE_DOWNLOAD_MIN_RECORDS` with a default of 100 records
- skip undersized files before latest-file batch downloads and background queue insertion
- apply the threshold consistently to Parquet and index files
- preserve caching when `records == 0`, which can represent missing metadata from older gRPC senders

## Why

Downloading and caching very small files consumes queue capacity and cache space without providing enough reuse benefit.

## Impact

Files with a known positive record count below the configured threshold are read from object storage without being added to the download cache. A zero count is treated as unknown and remains cache-eligible; files at or above the threshold keep the existing behavior.

## Validation

- `cargo fmt --all -- --check`
- focused minimum-record boundary test
- `git diff --check`

Backport for #13288
