### PR TITLE
test: heal dark-mode detection and logs scroll-container selectors after design-token migration

### DIFF
--- a/tests/ui-testing/pages/generalPages/homePage.js
+++ b/tests/ui-testing/pages/generalPages/homePage.js
@@ -503,9 +503,11 @@ export class HomePage {
      * @returns {Promise<boolean>} - True if dark mode is active
      */
     async isDarkMode() {
-        // Read the body class via page.evaluate (the dark-theme class lives on
-        // document.body and is not addressable via a data-test attribute).
-        return await this.page.evaluate(() => document.body.classList.contains('body--dark'));
+        // The dark-mode signal is the `.dark` class on <html>
+        // (document.documentElement) — set by utils/theme.ts. The legacy Quasar
+        // `body--dark` class on <body> was retired in the design-token
+        // migration (#13173).
+        return await this.page.evaluate(() => document.documentElement.classList.contains('dark'));
     }
 
     /**

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -10584,33 +10584,51 @@ export class LogsPage {
     /**
      * Get the scroll position (scrollTop) of the main results scroll container.
      * Call waitForResultsLoaded() first to ensure the container exists.
-     * Navigates from pagination -> .search-list -> child with overflow-y-auto.
+     * Post design-token migration (#13173) the `.search-list` wrapper is gone:
+     * the scroller is the combined scroll area (`ref="scrollContainerRef"` in
+     * logs/SearchResult.vue), a scrollable sibling below the pagination header.
+     * Walk up from the pagination until an ancestor has a scrollable child
+     * that is not the header itself (matched by computed overflow-y, so class
+     * renames don't break it).
      * @returns {Promise<number>}
      */
     async getScrollContainerPosition() {
         return await this.page.evaluate(() => {
             const pagination = document.querySelector('[data-test="logs-search-result-pagination"]');
             if (!pagination) return -1;
-            const searchList = pagination.closest('.search-list');
-            if (!searchList) return -1;
-            const container = searchList.querySelector('[class*="overflow-y-auto"]');
-            return container ? container.scrollTop : -1;
+            let el = pagination.parentElement;
+            while (el && el !== document.body) {
+                const container = Array.from(el.children).find(
+                    (child) => !child.contains(pagination) &&
+                        /(auto|scroll)/.test(getComputedStyle(child).overflowY)
+                );
+                if (container) return container.scrollTop;
+                el = el.parentElement;
+            }
+            return -1;
         });
     }
 
     /**
      * Scroll the main results container to the bottom.
      * Call waitForResultsLoaded() first to ensure the container exists.
+     * Uses the same container discovery as getScrollContainerPosition().
      */
     async scrollToResultsBottom() {
         await this.page.evaluate(() => {
             const pagination = document.querySelector('[data-test="logs-search-result-pagination"]');
             if (!pagination) return;
-            const searchList = pagination.closest('.search-list');
-            if (!searchList) return;
-            const container = searchList.querySelector('[class*="overflow-y-auto"]');
-            if (container) {
-                container.scrollTop = container.scrollHeight;
+            let el = pagination.parentElement;
+            while (el && el !== document.body) {
+                const container = Array.from(el.children).find(
+                    (child) => !child.contains(pagination) &&
+                        /(auto|scroll)/.test(getComputedStyle(child).overflowY)
+                );
+                if (container) {
+                    container.scrollTop = container.scrollHeight;
+                    return;
+                }
+                el = el.parentElement;
             }
         });
         await this.page.waitForTimeout(500);


### PR DESCRIPTION
## Why

The 2026-07-21 scheduled Playwright Regression runs failed on **both** OSS ([run 29801668855](https://github.com/openobserve/openobserve/actions/runs/29801668855)) and ENT ([run 29801639539](https://github.com/openobserve/o2-enterprise/actions/runs/29801639539)) — same 4 tests, same shards (Traces-Regression, Logs-Regression).

Root cause: the design-token migration (#13173, `f15e27e5fd`, merged 2026-07-20 evening — the only code change between the last green scheduled run and the failing one) removed Quasar entirely, breaking two page-object seams:

| Failing test | Broken seam |
|---|---|
| `traces-bugs.spec.js` › trace values should be visible on hover in dark mode (@bug-4151) | `homePage.isDarkMode()` read the retired Quasar `body--dark` class on `<body>`. Dark mode is now the `.dark` class on `<html>` (set by `utils/theme.ts`). `themePage.js` was already migrated inside #13173 — `homePage.js` was missed. |
| `logs-9044-7354.spec.js` › all 3 scroll-retention tests (#9044) | `getScrollContainerPosition()` / `scrollToResultsBottom()` navigated `pagination → .search-list → [class*="overflow-y-auto"]` — both hooks are gone. The results scroller is now the combined scroll area (`ref="scrollContainerRef"` in `logs/SearchResult.vue`). Helpers returned the `-1` "not found" sentinel, so `expect(scroll).toBeGreaterThan(10)` failed. |

## What

Test-side only (no `web/` changes):
- `homePage.isDarkMode()` → checks `document.documentElement.classList.contains('dark')`.
- Logs scroll helpers → walk up from the `logs-search-result-pagination` anchor and pick the sibling child whose **computed** `overflow-y` is `auto`/`scroll`, so future utility-class renames don't break it again.

Pagination helpers (`-page-N`, `-next`, `aria-current="page"`) already matched the new OPagination markup and needed no change.

## ENT

ENT overrides none of these files — its regression workflow checks out OSS tests (`cp -r o2-enterprise/tests/* openobserve/tests/` overlays only ENT-owned files). The ENT scheduled run heals automatically once this merges; verified pre-merge by dispatching ENT `playwright_regression.yml` with `oss_branch: test/heal-dark-mode-scroll-selectors`.

## Verification

All 4 previously-failing tests pass locally against a post-migration build (`main` @ `c523d0034c`, enterprise features):
- `logs-9044-7354.spec.js` — 3 passed (49s)
- `traces-bugs.spec.js -g "trace values should be visible on hover in dark mode"` — 1 passed (18s)

OSS + ENT regression runs seeded against this branch (links in comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)