### PR TITLE
fix: use cluster_coordinator instead of queue_store in nats register check

### DIFF
--- a/src/common/src/infra/cluster/nats.rs
+++ b/src/common/src/infra/cluster/nats.rs
@@ -31,10 +31,11 @@ use tokio::task;
 
 /// Register and keep alive the node to cluster
 pub(crate) async fn register_and_keep_alive() -> Result<()> {
-    // if local node is single node or meta store is not nats, return ok
+    // if local node is single node or cluster coordinator is not nats, return ok
     let cfg = get_config();
-    let meta_store: config::meta::meta_store::MetaStore = cfg.common.queue_store.as_str().into();
-    if cfg.common.local_mode || meta_store != config::meta::meta_store::MetaStore::Nats {
+    let coordinator: config::meta::meta_store::MetaStore =
+        cfg.common.cluster_coordinator.as_str().into();
+    if cfg.common.local_mode || coordinator != config::meta::meta_store::MetaStore::Nats {
         return Ok(());
     }
 


### PR DESCRIPTION
## Problem

`nats::register_and_keep_alive()` gates node registration on `cfg.common.queue_store`:

```rust
let meta_store: config::meta::meta_store::MetaStore = cfg.common.queue_store.as_str().into();
if cfg.common.local_mode || meta_store != config::meta::meta_store::MetaStore::Nats {
    return Ok(());
}
```

This is the wrong config knob. Whether a node registers to the cluster is decided by the **cluster coordinator** backend, not the queue backend — the dispatcher in `cluster/mod.rs` already routes here based on `cfg.common.cluster_coordinator`. With this check on `queue_store`, setting `ZO_QUEUE_STORE` to a non-NATS backend while the cluster coordinator is still NATS makes the node silently skip cluster registration.

## Fix

Check `cfg.common.cluster_coordinator` instead of `cfg.common.queue_store`, matching the dispatch logic in `cluster/mod.rs`.