### PR TITLE
fix(pipelines): make Pipeline Destinations search null-safe

### DIFF
--- a/web/src/components/alerts/PipelinesDestinationList.spec.ts
+++ b/web/src/components/alerts/PipelinesDestinationList.spec.ts
@@ -308,6 +308,37 @@ describe("PipelinesDestinationList", () => {
       (wrapper!.vm as any).filterQuery = "zzz-no-match";
       expect((wrapper!.vm as any).visibleRows).toHaveLength(0);
     });
+
+    it("filters without crashing when a non-matching row has null type/url/method", async () => {
+      // Destinations without a type render "—" in the UI; those fields are
+      // null. A non-matching search term must still iterate past such a row,
+      // which used to throw in filterData and silently disable search
+      // (the whole list stayed visible regardless of the query).
+      (destinationService.list as any).mockResolvedValue({
+        data: [
+          makeDestination(1),
+          makeDestination(2, {
+            name: "no-type-dest",
+            destination_type_name: null,
+            url: null,
+            method: null,
+            output_format: null,
+          }),
+        ],
+      });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      // Random string that matches nothing — must return [] without throwing.
+      (wrapper!.vm as any).filterQuery = "zzz-no-match";
+      expect((wrapper!.vm as any).visibleRows).toHaveLength(0);
+
+      // And a term matching only the fully-populated row still works.
+      (wrapper!.vm as any).filterQuery = "destination-1";
+      const rows = (wrapper!.vm as any).visibleRows;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].name).toBe("destination-1");
+    });
   });
 
   // ── editor toggle ──────────────────────────────────────────────────────────

--- a/web/src/components/alerts/PipelinesDestinationList.vue
+++ b/web/src/components/alerts/PipelinesDestinationList.vue
@@ -515,10 +515,10 @@ export default defineComponent({
         }
 
         if (
-          rows[i]["name"].toLowerCase().includes(terms) ||
-          rows[i]["destination_type_name"].toLowerCase().includes(terms) ||
-          rows[i]["url"].toLowerCase().includes(terms) ||
-          rows[i]["method"].toLowerCase().includes(terms) ||
+          (rows[i]["name"] || "").toLowerCase().includes(terms) ||
+          (rows[i]["destination_type_name"] || "").toLowerCase().includes(terms) ||
+          (rows[i]["url"] || "").toLowerCase().includes(terms) ||
+          (rows[i]["method"] || "").toLowerCase().includes(terms) ||
           outputFormatStr.includes(terms)
         ) {
           filtered.push(rows[i]);


### PR DESCRIPTION
## What
Fixes broken search on the **Pipeline Destinations** page (Management > Pipeline Destinations — "External targets for pipeline output"). Typing any query left the full list visible; search filtered nothing.

## Root cause
Destinations without a type/URL/method render as **"—"** in the list and have those fields as `null`. `filterData()` called `.toLowerCase()` on them directly:

```js
rows[i]["destination_type_name"].toLowerCase()  // null → TypeError
```

Any search term that didn't match such a row's name reached this line mid-iteration and threw a `TypeError`. The exception aborted the `visibleRows` computed, which then kept its last value — the **full unfiltered list** — so search appeared to do nothing regardless of the query. A random non-matching string (the common case) triggers it every time, since it forces evaluation past every null-type row.

## Fix
Guard each field with a `|| ""` fallback before `toLowerCase()` in `filterData()`.

## Test
Added a regression test covering a **non-matching** query over a row with null `type`/`url`/`method` (this is what reproduces the crash — a matching-name term short-circuits the `||` before touching the null field). Verified it **fails without the source fix** and **passes with it**. Full spec: 36/36 passing.

Fixes openobserve/o2-enterprise#2234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
