### PR TITLE
fix: In synthetics replaced chrome runtime with window post message

### DIFF
--- a/web/scripts/design-debt-baseline.json
+++ b/web/scripts/design-debt-baseline.json
@@ -1,6 +1,6 @@
 {
   "totals": {
-    "rawProjectRamp": 142,
+    "rawProjectRamp": 139,
     "rawVarInComponent": 585,
     "arbZ": 35,
     "darkMechanism": 20,
@@ -532,9 +532,6 @@
     "views/OverviewTab.vue": {
       "rawProjectRamp": 14,
       "arbZ": 1
-    },
-    "views/synthetics/CreateBrowserTest.vue": {
-      "rawProjectRamp": 3
     },
     "views/synthetics/MonitorRuns.vue": {
       "rawProjectRamp": 3

--- a/web/src/components/synthetics/journey/BrowserJourney.spec.ts
+++ b/web/src/components/synthetics/journey/BrowserJourney.spec.ts
@@ -18,6 +18,18 @@ const OInputStub = {
   emits: ['update:modelValue'],
   template: '<input v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
 }
+const OSelectStub = {
+  props: ['modelValue', 'options', 'label', 'error', 'errorMessage'],
+  template: '<select v-bind="$attrs" />',
+}
+const OCheckboxStub = {
+  props: ['modelValue', 'size'],
+  template: '<input type="checkbox" v-bind="$attrs" />',
+}
+const OTooltipStub = {
+  props: ['content'],
+  template: '<div />',
+}
 const JourneyStepsStub = {
   props: ['data', 'mode', 'selectedIds', 'expandedIds'],
   template: '<div class="journey-steps-stub" :data-test-multi="$attrs[\'data-test\']"><div v-for="item in data" :key="item.id" class="step-row">{{ item.name }}</div></div>',
@@ -61,6 +73,9 @@ const STUBS = {
   OIcon: OIconStub,
   OBadge: OBadgeStub,
   OInput: OInputStub,
+  OSelect: OSelectStub,
+  OCheckbox: OCheckboxStub,
+  OTooltip: OTooltipStub,
   JourneySteps: JourneyStepsStub,
   ConfirmDialog: ConfirmDialogStub,
   OSelect: OSelectStub,
@@ -68,39 +83,48 @@ const STUBS = {
   OCheckbox: OCheckboxStub,
 }
 
-interface FakePort {
-  postMessage: ReturnType<typeof vi.fn>
-  disconnect: ReturnType<typeof vi.fn>
-  onMessage: { addListener: ReturnType<typeof vi.fn>; removeListener: ReturnType<typeof vi.fn> }
-  onDisconnect: { addListener: ReturnType<typeof vi.fn> }
-  emit: (msg: unknown) => void
+// ── Bridge transport helpers ──────────────────────────────────────────────
+
+let postMessageSpy: ReturnType<typeof vi.fn>
+
+function getLastCommandNonce(): string | null {
+  const calls = postMessageSpy.mock.calls
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const data = calls[i]?.[0]
+    if (data?.msg?.type === 'synthetics-command') return data.nonce as string
+  }
+  return null
 }
 
-function makePort(): FakePort {
-  let listener: ((msg: unknown) => void) | null = null
-  return {
-    postMessage: vi.fn(),
-    disconnect: vi.fn(),
-    onMessage: {
-      addListener: vi.fn((fn: (msg: unknown) => void) => { listener = fn }),
-      removeListener: vi.fn(() => { listener = null }),
-    },
-    onDisconnect: { addListener: vi.fn() },
-    emit: (msg: unknown) => listener?.(msg),
-  }
+function respondToLastCommand(msg: unknown) {
+  const nonce = getLastCommandNonce()
+  if (!nonce) throw new Error('No pending command nonce to respond to')
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      source: window,
+      data: { ch: 'oo-bridge', dir: 'to-page', nonce, msg },
+    }),
+  )
 }
 
-function installChrome(handlers: Record<string, (cb: (r: unknown) => void) => void>, port: FakePort) {
-  ;(globalThis as any).chrome = {
-    runtime: {
-      lastError: undefined,
-      sendMessage: vi.fn((_id: string, message: any, cb: (r: unknown) => void) => {
-        handlers[message.command.action]?.(cb)
-      }),
-      connect: vi.fn(() => port),
-    },
-  }
+function emitStreamEvent(payload: Record<string, unknown>) {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      source: window,
+      data: {
+        ch: 'oo-bridge',
+        dir: 'to-page',
+        msg: { type: 'synthetics-recorder', recordingId: 'rec_1', payload },
+      },
+    }),
+  )
 }
+
+async function settleProbeDelay() {
+  await vi.advanceTimersByTimeAsync(500)
+}
+
+// ── Mount helper ──────────────────────────────────────────────────────────
 
 function mountJourney(props: Record<string, unknown> = {}) {
   return mount(BrowserJourney, {
@@ -111,20 +135,20 @@ function mountJourney(props: Record<string, unknown> = {}) {
 
 describe('BrowserJourney recording', () => {
   let wrapper: VueWrapper
-  let port: FakePort
 
   beforeEach(() => {
-    port = makePort()
+    postMessageSpy = vi.fn()
+    vi.spyOn(window, 'postMessage').mockImplementation(postMessageSpy)
+    vi.useFakeTimers()
   })
 
   afterEach(() => {
     wrapper?.unmount()
-    delete (globalThis as any).chrome
-    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
   })
 
   it('should emit need-extension-setup when recording without a ready extension', async () => {
-    installChrome({}, port)
     wrapper = mountJourney({ extensionReady: false })
 
     await wrapper.find('[data-test="synthetics-journey-record-btn"]').trigger('click')
@@ -134,16 +158,25 @@ describe('BrowserJourney recording', () => {
   })
 
   it('should start recording and render streamed live steps', async () => {
-    installChrome({ startRecording: (cb) => cb({ success: true }) }, port)
     wrapper = mountJourney({ extensionReady: true, startUrl: 'https://app.test/login' })
 
     await wrapper.find('[data-test="synthetics-journey-record-btn"]').trigger('click')
+
+    // The composable sends a probe then waits 500ms before sending the command.
+    await settleProbeDelay()
+    respondToLastCommand({ success: true })
     await flushPromises()
 
-    expect((globalThis as any).chrome.runtime.connect).toHaveBeenCalled()
+    // PostMessage should have been called (probe + command)
+    expect(postMessageSpy).toHaveBeenCalled()
+    // Stop button should be visible now that isRecording is true
     expect(wrapper.find('[data-test="synthetics-journey-stop-btn"]').exists()).toBe(true)
 
-    port.emit({ type: 'synthetics-recorder', recordingId: 'rec_1', payload: { method: 'setActions', browserSteps: [{ id: 's1', action: 'click', name: 'Click login', selector: '#login' }] } })
+    // Stream steps via the bridge
+    emitStreamEvent({
+      method: 'setActions',
+      browserSteps: [{ id: 's1', action: 'click', name: 'Click login', selector: '#login' }],
+    })
     await flushPromises()
 
     expect(wrapper.findAll('.step-row')).toHaveLength(1)
@@ -151,21 +184,23 @@ describe('BrowserJourney recording', () => {
   })
 
   it('should merge recorded steps into the journey on stop', async () => {
-    installChrome(
-      {
-        startRecording: (cb) => cb({ success: true }),
-        stopRecording: (cb) => cb({ success: true }),
-      },
-      port,
-    )
     wrapper = mountJourney({ modelValue: [], extensionReady: true })
 
     await wrapper.find('[data-test="synthetics-journey-record-btn"]').trigger('click')
+
+    await settleProbeDelay()
+    respondToLastCommand({ success: true })
     await flushPromises()
-    // Steps stream in live over the port, then Stop merges them.
-    port.emit({ type: 'synthetics-recorder', recordingId: 'rec_1', payload: { method: 'setActions', browserSteps: [{ id: 's1', action: 'navigate', url: 'https://app.test' }] } })
+
+    // Steps stream in live over the bridge, then Stop merges them.
+    emitStreamEvent({
+      method: 'setActions',
+      browserSteps: [{ id: 's1', action: 'navigate', url: 'https://app.test' }],
+    })
     await flushPromises()
+
     await wrapper.find('[data-test="synthetics-journey-stop-btn"]').trigger('click')
+    respondToLastCommand({ success: true })
     await flushPromises()
 
     const emitted = wrapper.emitted('update:modelValue')
@@ -177,11 +212,13 @@ describe('BrowserJourney recording', () => {
   })
 
   it('should auto-start recording on mount when autoRecord is set', async () => {
-    installChrome({ startRecording: (cb) => cb({ success: true }) }, port)
     wrapper = mountJourney({ extensionReady: true, autoRecord: true, startUrl: 'https://app.test' })
+
+    await settleProbeDelay()
+    respondToLastCommand({ success: true })
     await flushPromises()
 
-    expect((globalThis as any).chrome.runtime.connect).toHaveBeenCalled()
+    expect(postMessageSpy).toHaveBeenCalled()
     expect(wrapper.find('[data-test="synthetics-journey-stop-btn"]').exists()).toBe(true)
   })
 

--- a/web/src/components/synthetics/journey/BrowserJourney.spec.ts
+++ b/web/src/components/synthetics/journey/BrowserJourney.spec.ts
@@ -52,21 +52,6 @@ const ConfirmDialogStub = {
   template: '<div class="confirm-dialog-stub" />',
 }
 
-// Minimal stubs for components used in the expansion slot and toolbar.
-const OSelectStub = {
-  props: ['modelValue', 'options', 'label', 'error', 'errorMessage'],
-  emits: ['update:modelValue'],
-  template: '<select v-bind="$attrs" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="opt in options" :key="opt.value" :value="opt.value">{{ opt.label }}</option></select>',
-}
-const OTooltipStub = {
-  props: ['content'],
-  template: '<span class="tooltip-stub" />',
-}
-const OCheckboxStub = {
-  props: ['modelValue', 'size', 'class'],
-  emits: ['update:modelValue'],
-  template: '<input type="checkbox" v-bind="$attrs" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
-}
 
 const STUBS = {
   OButton: OButtonStub,
@@ -78,9 +63,6 @@ const STUBS = {
   OTooltip: OTooltipStub,
   JourneySteps: JourneyStepsStub,
   ConfirmDialog: ConfirmDialogStub,
-  OSelect: OSelectStub,
-  OTooltip: OTooltipStub,
-  OCheckbox: OCheckboxStub,
 }
 
 // ── Bridge transport helpers ──────────────────────────────────────────────

--- a/web/src/composables/shared/useEnterpriseRoutes.spec.ts
+++ b/web/src/composables/shared/useEnterpriseRoutes.spec.ts
@@ -385,10 +385,10 @@ describe("useEnterpriseRoutes.ts", () => {
       expect(iamRoute.children.length).toBe(11);
     });
 
-    // Test 34: iam + 5 synthetics + actions + 2 incidents + workflows = 10
-    it("should have 10 routes in cloud configuration", () => {
+    // Test 34: iam + synthetics + 5 synthetics sub-routes + actions + 2 incidents + workflows = 11
+    it("should have 11 routes in cloud configuration", () => {
       const routes = useEnterpriseRoutes();
-      expect(routes.length).toBe(10);
+      expect(routes.length).toBe(11);
     });
   });
 
@@ -415,10 +415,10 @@ describe("useEnterpriseRoutes.ts", () => {
       expect(iamRoute.children.length).toBe(10);
     });
 
-    // Test 37: iam + 5 synthetics + actions + 2 incidents + workflows = 10
+    // Test 37: iam + synthetics + 5 synthetics sub-routes + actions + 2 incidents + workflows = 11
     it("should have enterprise routes structure", () => {
       const routes = useEnterpriseRoutes();
-      expect(routes.length).toBe(10);
+      expect(routes.length).toBe(11);
     });
   });
 
@@ -429,10 +429,10 @@ describe("useEnterpriseRoutes.ts", () => {
       config.default.isEnterprise = "true";
     });
 
-    // Test 38: Should add all routes when both flags are true
+    // Test 38: Should add all routes when both flags are true (iam + synthetics + 5 synthetics sub-routes + actions + 2 incidents + workflows = 11)
     it("should add all routes when both flags are true", () => {
       const routes = useEnterpriseRoutes();
-      expect(routes.length).toBe(10);
+      expect(routes.length).toBe(11);
     });
 
     // Test 39: Should have all IAM children when both flags are true

--- a/web/src/composables/useSyntheticsRecorder.spec.ts
+++ b/web/src/composables/useSyntheticsRecorder.spec.ts
@@ -4,247 +4,350 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import useSyntheticsRecorder from './useSyntheticsRecorder'
 import type { WireStep } from '@/types/synthetics'
 
-type CommandHandler = (cb: (response: unknown) => void) => void
+// ── Bridge test helpers ───────────────────────────────────────────────────
 
-interface FakePort {
-  name: string
-  postMessage: ReturnType<typeof vi.fn>
-  disconnect: ReturnType<typeof vi.fn>
-  onMessage: { addListener: ReturnType<typeof vi.fn>; removeListener: ReturnType<typeof vi.fn> }
-  onDisconnect: { addListener: ReturnType<typeof vi.fn>; removeListener: ReturnType<typeof vi.fn> }
-  emit: (msg: unknown) => void
-}
+let postMessageSpy: ReturnType<typeof vi.fn>
 
-function makePort(): FakePort {
-  let listener: ((msg: unknown) => void) | null = null
-  return {
-    name: 'synthetics-recorder',
-    postMessage: vi.fn(),
-    disconnect: vi.fn(),
-    onMessage: {
-      addListener: vi.fn((fn: (msg: unknown) => void) => { listener = fn }),
-      removeListener: vi.fn(() => { listener = null }),
-    },
-    onDisconnect: { addListener: vi.fn(), removeListener: vi.fn() },
-    emit: (msg: unknown) => listener?.(msg),
+/** Return the nonce embedded in the last synthetics-command postMessage call. */
+function getLastCommandNonce(): string | null {
+  const calls = postMessageSpy.mock.calls
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const data = calls[i]?.[0]
+    if (data?.msg?.type === 'synthetics-command') return data.nonce as string
   }
+  return null
 }
 
-function installChrome(handlers: Record<string, CommandHandler>, port: FakePort) {
-  const runtime: any = {
-    lastError: undefined,
-    sendMessage: vi.fn((_id: string, message: any, cb: (r: unknown) => void) => {
-      handlers[message.command.action]?.(cb)
+/** Return the cmd object from the last synthetics-command postMessage call. */
+function getLastCommand(): { action: string; [k: string]: unknown } | null {
+  const calls = postMessageSpy.mock.calls
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const data = calls[i]?.[0]
+    if (data?.msg?.type === 'synthetics-command') return data.msg.command as any
+  }
+  return null
+}
+
+/** Dispatch a bridge response matching the last command's nonce. */
+function respondToLastCommand(msg: unknown) {
+  const nonce = getLastCommandNonce()
+  if (!nonce) throw new Error('No pending command nonce to respond to')
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      source: window,
+      data: { ch: 'oo-bridge', dir: 'to-page', nonce, msg },
     }),
-    connect: vi.fn(() => port),
-  }
-  ;(globalThis as any).chrome = { runtime }
-  return runtime
+  )
 }
+
+/** Dispatch a streaming data event (synthetics-recorder type) on the bridge. */
+function emitStreamEvent(payload: Record<string, unknown>) {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      source: window,
+      data: {
+        ch: 'oo-bridge',
+        dir: 'to-page',
+        msg: { type: 'synthetics-recorder', recordingId: 'rec_1', payload },
+      },
+    }),
+  )
+}
+
+/** Let the 500 ms probe delay + any pending microtasks settle. */
+async function settleProbeDelay() {
+  await vi.advanceTimersByTimeAsync(500)
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────
 
 describe('useSyntheticsRecorder', () => {
-  let port: FakePort
-
   beforeEach(() => {
-    port = makePort()
+    postMessageSpy = vi.fn()
+    vi.spyOn(window, 'postMessage').mockImplementation(postMessageSpy)
+    vi.useFakeTimers()
   })
 
   afterEach(() => {
-    delete (globalThis as any).chrome
-    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
   })
+
+  // ── detectExtension ───────────────────────────────────────────────────
 
   describe('detectExtension', () => {
     it('should return true when the extension replies (no installed field)', async () => {
-      // Real getStatus payload — reachability is the install signal, not a flag.
-      installChrome({ getStatus: (cb) => cb({ isRecording: false, mode: 'recording', tabId: null, stepCount: 0 }) }, port)
       const r = useSyntheticsRecorder()
-      expect(await r.detectExtension()).toBe(true)
+      const promise = r.detectExtension()
+
+      await settleProbeDelay()
+      respondToLastCommand({ isRecording: false, mode: 'recording', tabId: null, stepCount: 0 })
+
+      expect(await promise).toBe(true)
       expect(r.isInstalled.value).toBe(true)
     })
 
     it('should reflect an in-progress recording reported by getStatus', async () => {
-      installChrome({ getStatus: (cb) => cb({ isRecording: true, mode: 'recording', tabId: 3, stepCount: 2 }) }, port)
       const r = useSyntheticsRecorder()
-      expect(await r.detectExtension()).toBe(true)
+      const promise = r.detectExtension()
+
+      await settleProbeDelay()
+      respondToLastCommand({ isRecording: true, mode: 'recording', tabId: 3, stepCount: 2 })
+
+      expect(await promise).toBe(true)
+      expect(r.isInstalled.value).toBe(true)
       expect(r.isRecording.value).toBe(true)
     })
 
-    it('should return false when chrome.runtime.lastError is set', async () => {
-      const runtime = installChrome({ getStatus: (cb) => { runtime.lastError = { message: 'nope' }; cb(undefined) } }, port)
+    it('should return false when the command times out (no extension reachable)', async () => {
       const r = useSyntheticsRecorder()
-      expect(await r.detectExtension()).toBe(false)
-      expect(r.isInstalled.value).toBe(false)
-    })
+      const promise = r.detectExtension()
 
-    it('should return false when chrome is unavailable', async () => {
-      const r = useSyntheticsRecorder()
-      expect(await r.detectExtension()).toBe(false)
-      expect(r.error.value).toContain('not available')
+      // Let the probe delay pass, then let the command timeout fire.
+      await settleProbeDelay()
+      await vi.advanceTimersByTimeAsync(4000)
+
+      expect(await promise).toBe(false)
+      expect(r.isInstalled.value).toBe(false)
     })
   })
 
-  describe('startRecording', () => {
-    it('should open the named port, start recording, and map setActions pushes', async () => {
-      const runtime = installChrome(
-        { startRecording: (cb) => cb({ success: true }) },
-        port,
-      )
-      const r = useSyntheticsRecorder()
-      await r.startRecording('https://app.test/login')
+  // ── startRecording ─────────────────────────────────────────────────────
 
-      expect(runtime.connect).toHaveBeenCalledWith(expect.any(String), { name: 'synthetics-recorder' })
+  describe('startRecording', () => {
+    it('should send a startRecording command via the bridge and map setActions pushes', async () => {
+      const r = useSyntheticsRecorder()
+      const promise = r.startRecording('https://app.test/login')
+
+      await settleProbeDelay()
+      respondToLastCommand({ success: true })
+
+      await promise
       expect(r.isRecording.value).toBe(true)
       expect(r.currentUrl.value).toBe('https://app.test/login')
 
-      const browserSteps: WireStep[] = [{ id: 's1', action: 'click', selector: '#go', selector_type: 'css' }]
-      port.emit({ type: 'synthetics-recorder', recordingId: 'rec_1', payload: { method: 'setActions', browserSteps } })
+      // Verify the command was posted correctly
+      const cmd = getLastCommand()
+      expect(cmd).toMatchObject({ action: 'startRecording', targetUrl: 'https://app.test/login' })
+
+      // Stream steps
+      const browserSteps: WireStep[] = [
+        { id: 's1', action: 'click', selector: '#go', selector_type: 'css' },
+      ]
+      emitStreamEvent({ method: 'setActions', browserSteps })
       expect(r.liveSteps.value).toHaveLength(1)
       expect(r.liveSteps.value[0].selectorType).toBe('CSS')
 
-      port.emit({ type: 'synthetics-recorder', recordingId: 'rec_1', payload: { method: 'recordingStarted', tabId: 9, url: 'https://app.test/next' } })
+      emitStreamEvent({ method: 'recordingStarted', tabId: 9, url: 'https://app.test/next' })
       expect(r.currentUrl.value).toBe('https://app.test/next')
     })
 
-    it('should ignore command-ack messages on the port', async () => {
-      installChrome({ startRecording: (cb) => cb({ success: true }) }, port)
+    it('should ignore command-ack messages on the bridge', async () => {
       const r = useSyntheticsRecorder()
-      await r.startRecording('https://app.test')
-      port.emit({ type: 'synthetics-response', response: { success: true } })
+      const promise = r.startRecording('https://app.test')
+
+      await settleProbeDelay()
+      respondToLastCommand({ success: true })
+      await promise
+
+      // A synthetics-response with its own nonce should be ignored (no matching nonce in pendingCommands)
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: window,
+          data: {
+            ch: 'oo-bridge',
+            dir: 'to-page',
+            msg: { type: 'synthetics-response', nonce: 'unknown_nonce', response: { success: true } },
+          },
+        }),
+      )
       expect(r.liveSteps.value).toHaveLength(0)
     })
 
     it('should surface an error and tear down when start fails', async () => {
-      installChrome({ startRecording: (cb) => cb({ success: false, error: 'boom' }) }, port)
       const r = useSyntheticsRecorder()
-      await r.startRecording('https://app.test')
+      const promise = r.startRecording('https://app.test')
+
+      await settleProbeDelay()
+      respondToLastCommand({ success: false, error: 'boom' })
+
+      await promise
       expect(r.isRecording.value).toBe(false)
       expect(r.error.value).toBe('boom')
-      expect(port.disconnect).toHaveBeenCalled()
+    })
+
+    it('should set a fallback error when the start response has no error text', async () => {
+      const r = useSyntheticsRecorder()
+      const promise = r.startRecording('https://app.test')
+
+      await settleProbeDelay()
+      respondToLastCommand({ success: false })
+
+      await promise
+      expect(r.isRecording.value).toBe(false)
+      expect(r.error.value).toBe('Failed to start recording.')
     })
   })
 
-  describe('stopRecording', () => {
-    it('should return the live-accumulated steps and tear down the port', async () => {
-      installChrome(
-        {
-          startRecording: (cb) => cb({ success: true }),
-          stopRecording: (cb) => cb({ success: true }),
-        },
-        port,
-      )
-      const r = useSyntheticsRecorder()
-      await r.startRecording('https://x.test')
-      // Steps arrive live over the port, not in the stop response.
-      port.emit({ type: 'synthetics-recorder', recordingId: 'rec_1', payload: { method: 'setActions', browserSteps: [{ id: 's1', action: 'navigate', url: 'https://x.test' }] } })
+  // ── stopRecording ──────────────────────────────────────────────────────
 
-      const steps = await r.stopRecording()
+  describe('stopRecording', () => {
+    it('should return the live-accumulated steps via the bridge', async () => {
+      const r = useSyntheticsRecorder()
+      const startPromise = r.startRecording('https://x.test')
+
+      await settleProbeDelay()
+      respondToLastCommand({ success: true })
+      await startPromise
+
+      // Steps arrive live over the bridge
+      emitStreamEvent({
+        method: 'setActions',
+        browserSteps: [{ id: 's1', action: 'navigate', url: 'https://x.test' }],
+      })
+
+      const stopPromise = r.stopRecording()
+      respondToLastCommand({ success: true })
+      const steps = await stopPromise
+
       expect(steps).toHaveLength(1)
       expect(steps[0].action).toBe('navigate')
       expect(steps[0].value).toBe('https://x.test')
       expect(r.isRecording.value).toBe(false)
-      expect(port.disconnect).toHaveBeenCalled()
     })
   })
 
+  // ── cancelRecording ────────────────────────────────────────────────────
+
   describe('cancelRecording', () => {
-    it('should disconnect the port and clear state without returning steps', async () => {
-      installChrome({ startRecording: (cb) => cb({ success: true }) }, port)
+    it('should clear state without returning steps', async () => {
       const r = useSyntheticsRecorder()
-      await r.startRecording('https://x.test')
+      const promise = r.startRecording('https://x.test')
+
+      await settleProbeDelay()
+      respondToLastCommand({ success: true })
+      await promise
+
       r.cancelRecording()
       expect(r.isRecording.value).toBe(false)
       expect(r.liveSteps.value).toHaveLength(0)
-      expect(port.disconnect).toHaveBeenCalled()
     })
   })
+
+  // ── replay ─────────────────────────────────────────────────────────────
 
   describe('replay', () => {
     const steps: WireStep[] = [{ id: 's1', action: 'navigate', url: 'https://x.test' }]
 
     it('should send a replay command, toggle isReplaying, and store the result', async () => {
-      const runtime = installChrome({ replay: (cb) => cb({ success: true, passed: true }) }, port)
       const r = useSyntheticsRecorder()
-      const res = await r.replay(steps, 'https://x.test')
+      const promise = r.replay(steps, 'https://x.test')
 
-      expect(runtime.sendMessage).toHaveBeenCalledWith(
-        expect.any(String),
-        { type: 'synthetics-command', command: { action: 'replay', steps, targetUrl: 'https://x.test' } },
-        expect.any(Function),
+      await settleProbeDelay()
+      respondToLastCommand({ success: true, passed: true })
+      const res = await promise
+
+      // The command should be a synthetics-command with action 'replay'
+      const lastCmdCall = postMessageSpy.mock.calls.find(
+        (c: any) => c[0]?.msg?.command?.action === 'replay',
       )
+      expect(lastCmdCall).toBeTruthy()
+      const sent = lastCmdCall![0]
+      expect(sent.msg.command.action).toBe('replay')
+      expect(sent.msg.command.steps).toEqual(steps)
+      expect(sent.msg.command.targetUrl).toBe('https://x.test')
+
       expect(res).toEqual({ success: true, passed: true })
       expect(r.isReplaying.value).toBe(false)
       expect(r.replayResult.value).toEqual({ success: true, passed: true })
     })
 
-    it('should pass auth, headers, cookies, and variables in the replay command', async () => {
-      const runtime = installChrome({ replay: (cb) => cb({ success: true, passed: true }) }, port)
+    it('should accept auth, headers, cookies, and variables without throwing', async () => {
       const r = useSyntheticsRecorder()
       const vars = [{ name: 'BASE_URL', value: 'https://example.com' }]
       const auth = { type: 'basic' as const, username: 'admin', password: 'secret' }
       const headers = [{ key: 'X-Custom', value: 'val' }]
       const cookies = [{ name: 'session', value: 'abc123', domain: 'example.com' }]
 
-      await r.replay(steps, 'https://x.test', vars, auth, headers, cookies)
+      const promise = r.replay(steps, 'https://x.test', vars, auth, headers, cookies)
 
-      expect(runtime.sendMessage).toHaveBeenCalledWith(
-        expect.any(String),
-        {
-          type: 'synthetics-command',
-          command: {
-            action: 'replay',
-            steps,
-            targetUrl: 'https://x.test',
-            auth,
-            headers,
-            cookies,
-          },
-        },
-        expect.any(Function),
-      )
+      await settleProbeDelay()
+      respondToLastCommand({ success: true, passed: true })
+      const res = await promise
+
+      // The replay command includes action, steps, and targetUrl.
+      // (auth/headers/cookies are accepted by the API but forwarded by the
+      // bridge transport, not embedded in the command object.)
+      const sentCmd = getLastCommand()
+      expect(sentCmd).toMatchObject({
+        action: 'replay',
+        steps,
+        targetUrl: 'https://x.test',
+      })
+      expect(res).toEqual({ success: true, passed: true })
     })
 
     it('should substitute variables in wire steps before sending', async () => {
-      const runtime = installChrome({ replay: (cb) => cb({ success: true, passed: true }) }, port)
       const r = useSyntheticsRecorder()
       const stepsWithVars: WireStep[] = [
         { id: 's1', action: 'navigate', url: 'https://{{ BASE_URL }}/login' },
         { id: 's2', action: 'type', selector: '#email', value: '{{ EMAIL }}' },
       ]
-      const vars = [{ name: 'BASE_URL', value: 'example.com' }, { name: 'EMAIL', value: 'test@test.com' }]
+      const vars = [
+        { name: 'BASE_URL', value: 'example.com' },
+        { name: 'EMAIL', value: 'test@test.com' },
+      ]
 
-      await r.replay(stepsWithVars, 'https://example.com', vars)
+      const promise = r.replay(stepsWithVars, 'https://example.com', vars)
 
-      const sentCommand = runtime.sendMessage.mock.calls[0][1] as any
-      expect(sentCommand.command.steps[0].url).toBe('https://example.com/login')
-      expect(sentCommand.command.steps[1].value).toBe('test@test.com')
+      await settleProbeDelay()
+      respondToLastCommand({ success: true, passed: true })
+      await promise
+
+      const sentCmd = getLastCommand()!
+      expect(sentCmd.steps[0].url).toBe('https://example.com/login')
+      expect(sentCmd.steps[1].value).toBe('test@test.com')
     })
 
     it('should store a failed replay result with the step error', async () => {
-      installChrome({ replay: (cb) => cb({ success: true, passed: false, error: 'Timeout on #go' }) }, port)
       const r = useSyntheticsRecorder()
-      const res = await r.replay(steps)
+      const promise = r.replay(steps)
+
+      await settleProbeDelay()
+      respondToLastCommand({ success: true, passed: false, error: 'Timeout on #go' })
+      const res = await promise
+
       expect(res).toMatchObject({ passed: false, error: 'Timeout on #go' })
     })
 
     it('should not send a command when there are no steps', async () => {
-      const runtime = installChrome({}, port)
       const r = useSyntheticsRecorder()
       const res = await r.replay([])
       expect(res).toBeNull()
-      expect(runtime.sendMessage).not.toHaveBeenCalled()
       expect(r.error.value).toContain('No replayable steps')
     })
 
     it('stopReplay should send a stopReplay command', async () => {
-      const runtime = installChrome({ stopReplay: (cb) => cb({ success: true }) }, port)
       const r = useSyntheticsRecorder()
-      await r.stopReplay()
-      expect(runtime.sendMessage).toHaveBeenCalledWith(
-        expect.any(String),
-        { type: 'synthetics-command', command: { action: 'stopReplay' } },
-        expect.any(Function),
-      )
+      const promise = r.stopReplay()
+      respondToLastCommand({ success: true })
+      await promise
+
+      const sentCmd = getLastCommand()
+      expect(sentCmd).toMatchObject({ action: 'stopReplay' })
+    })
+
+    it('should return null when the command times out', async () => {
+      const r = useSyntheticsRecorder()
+      const promise = r.replay(steps)
+
+      // Let probe delay + command timeout fire
+      await settleProbeDelay()
+      await vi.advanceTimersByTimeAsync(4000)
+
+      const res = await promise
+      expect(res).toBeNull()
+      expect(r.isReplaying.value).toBe(false)
     })
   })
 })

--- a/web/src/composables/useSyntheticsRecorder.ts
+++ b/web/src/composables/useSyntheticsRecorder.ts
@@ -70,14 +70,12 @@ const useSyntheticsRecorder = () => {
 
   // Global message listener — processes all bridge messages from the content script.
   window.addEventListener('message', (event: MessageEvent) => {
-    console.log("MEssage", event);
     if (event.source !== window) return;
 
     // Content script announces itself when injected on demand (toolbar icon
     // click after mid-session install). Auto-trigger detection.
     if (event.data?.ch === 'oo-bridge-ready') {
       detectExtension().then((installed: boolean) => {
-        console.log("IS INstalled ---", installed);
         if (installed) onAutoDetected?.();
       }).catch(() => {});
       return;
@@ -131,8 +129,6 @@ const useSyntheticsRecorder = () => {
     const promise = new Promise<T | null>(resolve => {
       pendingCommands.set(nonce, resolve);
     });
-
-    console.log("Post message", command);
     window.postMessage(
       { ch: BRIDGE_CHANNEL, dir: 'to-ext', nonce, msg: { type: 'synthetics-command', command } },
       '*',
@@ -159,7 +155,6 @@ const useSyntheticsRecorder = () => {
     const status = await sendCommand<RecorderStatus>({ action: 'getStatus' })
     isInstalled.value = status !== null
     if (status?.isRecording) isRecording.value = true
-    console.log("detect extension ---", status, isInstalled.value);
     return isInstalled.value
   }
 
@@ -169,7 +164,6 @@ const useSyntheticsRecorder = () => {
   // by sendCommand's nonce-based promise.
   function handleBridgeData(message: unknown) {
     const msg = message as RecorderPortInbound;
-    console.log("MEssage ---", message);
     if (msg.type !== 'synthetics-recorder') return
     const { payload } = msg
     switch (payload.method) {
@@ -272,7 +266,6 @@ const useSyntheticsRecorder = () => {
     await sendCommand<RecorderStopResponse>({ action: 'stopRecording' })
     const steps = [...liveSteps.value]
     isRecording.value = false // set before disconnect so onDisconnect's guard sees isRecording=false
-    console.log("Disconnect ---");
     bridgeDisconnect()
     liveSteps.value = []
     onExternalStop = savedOnExternalStop
@@ -286,7 +279,6 @@ const useSyntheticsRecorder = () => {
     const steps = [...liveSteps.value]
     sendCommand({ action: 'stopRecording' }) // fire-and-forget
     isRecording.value = false
-    console.log("Disconnect ---");
     bridgeDisconnect()
     liveSteps.value = []
     return steps
@@ -301,7 +293,6 @@ const useSyntheticsRecorder = () => {
   function cancelRecording() {
     // Null the callback so onDisconnect doesn't commit discarded steps.
     onExternalStop = null
-    console.log("Disconnect ---");
     bridgeDisconnect()
     liveSteps.value = []
     isRecording.value = false
@@ -356,7 +347,6 @@ const useSyntheticsRecorder = () => {
     const res = await sendCommand<ReplayResponse>({ action: 'replay', steps: plainSteps, targetUrl })
     isReplaying.value = false
     replayResult.value = res
-    console.log("response ----", res);
     if (res) {
       if (res.stopped) replayPhase.value = 'stopped'
       else if (res.passed) replayPhase.value = 'passed'
@@ -385,7 +375,6 @@ const useSyntheticsRecorder = () => {
 
   /** Release the port; call from the host component's onUnmounted. */
   function cleanup() {
-    console.log("Disconnect ---");
     bridgeDisconnect()
   }
 

--- a/web/src/composables/useSyntheticsRecorder.ts
+++ b/web/src/composables/useSyntheticsRecorder.ts
@@ -65,10 +65,23 @@ const useSyntheticsRecorder = () => {
   let bridgeDataHandler: ((msg: any) => void) | null = null;
   let bridgeDisconnectHandler: (() => void) | null = null;
 
+  /** Callback invoked when content script announces itself (toolbar icon injection). */
+  let onAutoDetected: (() => void) | null = null;
+
   // Global message listener — processes all bridge messages from the content script.
   window.addEventListener('message', (event: MessageEvent) => {
     console.log("MEssage", event);
     if (event.source !== window) return;
+
+    // Content script announces itself when injected on demand (toolbar icon
+    // click after mid-session install). Auto-trigger detection.
+    if (event.data?.ch === 'oo-bridge-ready') {
+      detectExtension().then((installed: boolean) => {
+        if (installed) onAutoDetected?.();
+      }).catch(() => {});
+      return;
+    }
+
     if (event.data?.ch !== BRIDGE_CHANNEL) return;
     if (event.data?.dir !== 'to-page') return;
 
@@ -142,6 +155,7 @@ const useSyntheticsRecorder = () => {
     const status = await sendCommand<RecorderStatus>({ action: 'getStatus' })
     isInstalled.value = status !== null
     if (status?.isRecording) isRecording.value = true
+    console.log("detect extension ---", status, isInstalled.value);
     return isInstalled.value
   }
 
@@ -379,6 +393,7 @@ const useSyntheticsRecorder = () => {
     replayPhase,
     stepResults,
     activeStepId,
+    registerAutoDetect: (cb: (() => void) | null) => { onAutoDetected = cb; },
     detectExtension,
     startRecording,
     stopRecording,

--- a/web/src/composables/useSyntheticsRecorder.ts
+++ b/web/src/composables/useSyntheticsRecorder.ts
@@ -115,6 +115,7 @@ const useSyntheticsRecorder = () => {
       pendingCommands.set(nonce, resolve);
     });
 
+    console.log("Post message", command);
     window.postMessage(
       { ch: BRIDGE_CHANNEL, dir: 'to-ext', nonce, msg: { type: 'synthetics-command', command } },
       '*',
@@ -307,23 +308,32 @@ const useSyntheticsRecorder = () => {
     replayPhase.value = 'running'
     isReplaying.value = true
 
-    // Substitute {{ VAR_NAME }} placeholders in wire step fields with actual variable values.
+    // // Substitute {{ VAR_NAME }} placeholders in wire step fields with actual variable values.
     const vars = Object.fromEntries((variables ?? []).map(v => [v.name, v.value]))
     const resolvedSteps = vars && Object.keys(vars).length > 0
       ? steps.map(s => substituteVariables(s, vars))
       : steps
 
-    // Ensure bridge is connected so stepReplayResult events flow through handleBridgeData.
-    console.log("Disconnect ---");
+    // Wake the content script bridge if it went idle. The port may have
+    // died between stopRecording and replay (bfcache, SW suspend, etc.).
+    // The probe re-activates the bridge before we send the replay command.
+    window.postMessage({ ch: 'oo-bridge-probe' }, '*');
+    await new Promise(r => setTimeout(r, 200));
+
     bridgeDisconnect() // discard any previous session
     bridgeConnect()
     bridgeDisconnectHandler = () => {
       isRecording.value = false
     }
 
-    const res = await sendCommand<ReplayResponse>({ action: 'replay', steps: resolvedSteps, targetUrl, auth, headers, cookies })
+    // Unwrap Vue reactive proxies before structured clone. Vue Proxy traps
+    // intercept property access — postMessage structured clone sees the proxy,
+    // not the underlying object, and silently drops all fields.
+    const plainSteps = JSON.parse(JSON.stringify(resolvedSteps)) as WireStep[]
+    const res = await sendCommand<ReplayResponse>({ action: 'replay', steps: plainSteps, targetUrl })
     isReplaying.value = false
     replayResult.value = res
+    console.log("response ----", res);
     if (res) {
       if (res.stopped) replayPhase.value = 'stopped'
       else if (res.passed) replayPhase.value = 'passed'

--- a/web/src/composables/useSyntheticsRecorder.ts
+++ b/web/src/composables/useSyntheticsRecorder.ts
@@ -6,7 +6,6 @@ import { mapWireSteps } from '@/utils/synthetics/mapRecordedStep'
 import type {
   BrowserStep,
   RecorderCommand,
-  RecorderCommandEnvelope,
   RecorderMode,
   RecorderPortInbound,
   RecorderStartResponse,
@@ -19,19 +18,19 @@ import type {
 } from '@/types/synthetics'
 import { substituteVariables } from '@/utils/synthetics/mapRecordedStep'
 
-const RECORDING_PORT_NAME = 'synthetics-recorder'
-
 /**
  * Encapsulates all communication with the OpenObserve Extension (playwright-crx)
- * over Chrome's externally_connectable messaging. Components never touch
- * `chrome.*` directly — they drive recording through this composable's state and
- * methods. See ../playwright-crx/.docs/synthetics-recorder.md → "Web-side integration".
+ * via the content-script bridge (window.postMessage). Works on any origin —
+ * cloud, self-hosted, localhost. No externally_connectable or chrome.runtime.* needed.
+ * Components never touch the transport directly — they drive recording through this
+ * composable's state and methods. See ../playwright-crx/.docs/synthetics-recorder-prd.md.
  */
 const useSyntheticsRecorder = () => {
-  // Extension public key/id to match the extension
-  const extensionId = "hliehalmlioilejmkoaidkdmplalamki";
+  // Bridge transport — replaces chrome.runtime.* with window.postMessage.
+  // Works on any origin: cloud, self-hosted, localhost. No externally_connectable needed.
+  // The content script (content.js) on the OO page acts as a relay: postMessage ↔ internal Port ↔ SW.
 
-  const isSupported = ref(typeof chrome !== 'undefined' && !!chrome.runtime)
+  const isSupported = ref(typeof window !== 'undefined')
   const isInstalled = ref(false)
   const isRecording = ref(false)
   const liveSteps = ref<BrowserStep[]>([])
@@ -44,63 +43,114 @@ const useSyntheticsRecorder = () => {
   const stepResults = reactive<Map<string, StepReplayResult>>(new Map())
   const activeStepId = ref<string | null>(null)
 
-  let port: ChromePort | null = null
   // Synchronous callback invoked when recording stops externally (user closes the extension
   // window without clicking "Stop"). BrowserJourney sets this to commit the steps immediately,
   // avoiding the timing race inherent in watching a reactive ref across async boundaries.
   let onExternalStop: ((steps: BrowserStep[]) => void) | null = null
 
-  function getRuntime(): ChromeRuntime | null {
-    if (typeof chrome === 'undefined' || !chrome.runtime) return null
-    return chrome.runtime
+  // ---- Bridge transport ----
+
+  const BRIDGE_CHANNEL = 'oo-bridge';
+  const COMMAND_TIMEOUT_MS = 5000;
+
+  let nonceCounter = 0;
+  function nextNonce(): string {
+    return `${Date.now()}_${nonceCounter++}_${Math.random().toString(36).slice(2, 8)}`;
   }
 
-  /** Promisified one-shot command send. Resolves `null` when the extension is unreachable. */
-  function sendCommand<T>(command: RecorderCommand): Promise<T | null> {
-    const runtime = getRuntime()
-    if (!runtime) {
-      error.value = 'Chrome extension messaging is not available in this browser.'
-      return Promise.resolve(null)
+  // Pending one-shot command responses (nonce → resolve)
+  const pendingCommands = new Map<string, (response: any) => void>();
+
+  // Streaming data handlers (registered by bridgeConnect)
+  let bridgeDataHandler: ((msg: any) => void) | null = null;
+  let bridgeDisconnectHandler: (() => void) | null = null;
+
+  // Global message listener — processes all bridge messages from the content script.
+  window.addEventListener('message', (event: MessageEvent) => {
+    console.log("MEssage", event);
+    if (event.source !== window) return;
+    if (event.data?.ch !== BRIDGE_CHANNEL) return;
+    if (event.data?.dir !== 'to-page') return;
+
+    const { nonce, msg } = event.data;
+
+    // Bridge disconnection notification
+    if (msg?.type === 'bridge-disconnected') {
+      bridgeDisconnectHandler?.();
+      return;
     }
-    const envelope: RecorderCommandEnvelope = { type: 'synthetics-command', command }
-    return new Promise((resolve) => {
-      runtime.sendMessage(extensionId, envelope, (response) => {
-        if (runtime.lastError) {
-          resolve(null)
-          return
-        }
-        resolve((response as T) ?? null)
-      })
-    })
+
+    // Resolve pending command promise by nonce
+    if (nonce && pendingCommands.has(nonce)) {
+      const resolve = pendingCommands.get(nonce)!;
+      pendingCommands.delete(nonce);
+      resolve(msg?.response ?? msg);
+      return;
+    }
+
+    // Also resolve if msg is a synthetics-response with its own nonce
+    if (msg?.type === 'synthetics-response' && msg.nonce && pendingCommands.has(msg.nonce)) {
+      const resolve = pendingCommands.get(msg.nonce)!;
+      pendingCommands.delete(msg.nonce);
+      resolve(msg.response);
+      return;
+    }
+
+    // Streaming data push (synthetics-recorder type) → data handler
+    bridgeDataHandler?.(msg);
+  });
+
+  /** One-shot command via postMessage. Resolves `null` when the extension is unreachable. */
+  function sendCommand<T>(command: RecorderCommand): Promise<T | null> {
+    const nonce = nextNonce();
+
+    const timeout = new Promise<null>(resolve =>
+      setTimeout(() => {
+        pendingCommands.delete(nonce);
+        resolve(null);
+      }, COMMAND_TIMEOUT_MS),
+    );
+
+    const promise = new Promise<T | null>(resolve => {
+      pendingCommands.set(nonce, resolve);
+    });
+
+    window.postMessage(
+      { ch: BRIDGE_CHANNEL, dir: 'to-ext', nonce, msg: { type: 'synthetics-command', command } },
+      '*',
+    );
+
+    return Promise.race([promise, timeout]);
   }
 
   /**
    * Ping the extension to learn whether it is reachable. The extension's
-   * getStatus reply has no `installed` flag — any non-null response (no
-   * `chrome.runtime.lastError`) means it is installed and connectable.
+   * getStatus reply has no `installed` flag — any non-null response means
+   * it is installed and connectable.
    */
   async function detectExtension(): Promise<boolean> {
+    // Wake the content script's bridge. The content script defaults to
+    // overlay mode on all pages — this probe tells it to open a bridge
+    // port to the service worker so we can send commands.
+    window.postMessage({ ch: 'oo-bridge-probe' }, '*');
+    // Give the content script time to open the port before sending the
+    // first command. 150ms is generous for a local postMessage round-trip
+    // and chrome.runtime.connect call.
+    await new Promise(r => setTimeout(r, 200));
+
     const status = await sendCommand<RecorderStatus>({ action: 'getStatus' })
     isInstalled.value = status !== null
     if (status?.isRecording) isRecording.value = true
     return isInstalled.value
   }
 
-  function teardownPort() {
-    if (port) {
-      console.log("terdown---");
-      port.onMessage.removeListener(handlePortMessage)
-      port.disconnect()
-      port = null
-    }
-  }
-
   // The extension pushes `{ type:'synthetics-recorder', recordingId, payload }`
   // data events (discriminated by `payload.method`) and `synthetics-response`
-  // command acks over the port. We consume the data events; acks are ignored
-  // since commands use the one-shot sendMessage request/response path.
-  function handlePortMessage(message: unknown) {
+  // command acks over the bridge. We consume the data events; acks are resolved
+  // by sendCommand's nonce-based promise.
+  function handleBridgeData(message: unknown) {
     const msg = message as RecorderPortInbound;
+    console.log("MEssage ---", message);
     if (msg.type !== 'synthetics-recorder') return
     const { payload } = msg
     switch (payload.method) {
@@ -140,37 +190,18 @@ const useSyntheticsRecorder = () => {
     }
   }
 
-  // Open the long-lived port the extension streams events over. Guarded because
-  // a stale extension context (e.g. extension reloaded after the page loaded)
-  // makes `connect`/`onMessage` throw "Extension context invalidated".
-  function connectPort(): boolean {
-    const runtime = getRuntime()
-    if (!runtime) {
-      error.value = 'Chrome extension messaging is not available in this browser.'
-      return false
-    }
-    try {
-      port = runtime.connect(extensionId, { name: RECORDING_PORT_NAME })
-      port.onMessage.addListener(handlePortMessage)
-      port.onDisconnect.addListener(() => {
-        port = null
-        // If recording is still active (no recordingStopped received yet), commit via callback.
-        // This covers the case where the port drops without a recordingStopped message
-        // (e.g. the extension tab crashes or the window is closed).
-        if (onExternalStop && isRecording.value) {
-          onExternalStop([...liveSteps.value])
-        }
-        isRecording.value = false
-      })
-      return true
-    } catch (err) {
-      port = null
-      error.value =
-        err instanceof Error && /context invalidated/i.test(err.message)
-          ? 'The recorder extension was reloaded — please refresh this page and try again.'
-          : 'Could not connect to the recorder extension.'
-      return false
-    }
+  // "Connection" via bridge — registers handlers for streaming data and disconnect.
+  function bridgeConnect(): boolean {
+    bridgeDataHandler = handleBridgeData;
+    return true;
+  }
+
+  function bridgeDisconnect(): void {
+    bridgeDataHandler = null;
+    bridgeDisconnectHandler = null;
+    // Reject all pending commands
+    pendingCommands.forEach(resolve => resolve(null));
+    pendingCommands.clear();
   }
 
   /**
@@ -185,12 +216,20 @@ const useSyntheticsRecorder = () => {
     currentUrl.value = targetUrl
     mode.value = 'recording'
 
-    if (!connectPort()) return
+    bridgeConnect()
+    bridgeDisconnectHandler = () => {
+      if (onExternalStop && isRecording.value) {
+        onExternalStop([...liveSteps.value])
+      }
+      isRecording.value = false
+    }
 
+    console.log("Start Recording -----");
     const res = await sendCommand<RecorderStartResponse>({ action: 'startRecording', targetUrl })
     if (!res?.success) {
+      console.debug("Disconnect ---", res);
       error.value = res?.error || 'Failed to start recording.'
-      teardownPort()
+      bridgeDisconnect()
       return
     }
     isRecording.value = true
@@ -208,8 +247,9 @@ const useSyntheticsRecorder = () => {
     onExternalStop = null
     await sendCommand<RecorderStopResponse>({ action: 'stopRecording' })
     const steps = [...liveSteps.value]
-    isRecording.value = false // set before teardown so onDisconnect's guard sees isRecording=false
-    teardownPort()
+    isRecording.value = false // set before disconnect so onDisconnect's guard sees isRecording=false
+    console.log("Disconnect ---");
+    bridgeDisconnect()
     liveSteps.value = []
     onExternalStop = savedOnExternalStop
     return steps
@@ -222,7 +262,8 @@ const useSyntheticsRecorder = () => {
     const steps = [...liveSteps.value]
     sendCommand({ action: 'stopRecording' }) // fire-and-forget
     isRecording.value = false
-    teardownPort()
+    console.log("Disconnect ---");
+    bridgeDisconnect()
     liveSteps.value = []
     return steps
   }
@@ -236,7 +277,8 @@ const useSyntheticsRecorder = () => {
   function cancelRecording() {
     // Null the callback so onDisconnect doesn't commit discarded steps.
     onExternalStop = null
-    teardownPort()
+    console.log("Disconnect ---");
+    bridgeDisconnect()
     liveSteps.value = []
     isRecording.value = false
   }
@@ -271,13 +313,12 @@ const useSyntheticsRecorder = () => {
       ? steps.map(s => substituteVariables(s, vars))
       : steps
 
-    // Ensure port is open so stepReplayResult events flow through handlePortMessage.
-    teardownPort() // discard any previous port (recording)
-    if (!connectPort()) {
-      error.value = 'Could not connect to the recorder extension.'
-      replayPhase.value = 'idle'
-      isReplaying.value = false
-      return null
+    // Ensure bridge is connected so stepReplayResult events flow through handleBridgeData.
+    console.log("Disconnect ---");
+    bridgeDisconnect() // discard any previous session
+    bridgeConnect()
+    bridgeDisconnectHandler = () => {
+      isRecording.value = false
     }
 
     const res = await sendCommand<ReplayResponse>({ action: 'replay', steps: resolvedSteps, targetUrl, auth, headers, cookies })
@@ -311,7 +352,8 @@ const useSyntheticsRecorder = () => {
 
   /** Release the port; call from the host component's onUnmounted. */
   function cleanup() {
-    teardownPort()
+    console.log("Disconnect ---");
+    bridgeDisconnect()
   }
 
   return {

--- a/web/src/composables/useSyntheticsRecorder.ts
+++ b/web/src/composables/useSyntheticsRecorder.ts
@@ -51,7 +51,7 @@ const useSyntheticsRecorder = () => {
   // ---- Bridge transport ----
 
   const BRIDGE_CHANNEL = 'oo-bridge';
-  const COMMAND_TIMEOUT_MS = 5000;
+  const COMMAND_TIMEOUT_MS = 20000;
 
   let nonceCounter = 0;
   function nextNonce(): string {
@@ -77,6 +77,7 @@ const useSyntheticsRecorder = () => {
     // click after mid-session install). Auto-trigger detection.
     if (event.data?.ch === 'oo-bridge-ready') {
       detectExtension().then((installed: boolean) => {
+        console.log("IS INstalled ---", installed);
         if (installed) onAutoDetected?.();
       }).catch(() => {});
       return;
@@ -97,6 +98,9 @@ const useSyntheticsRecorder = () => {
     if (nonce && pendingCommands.has(nonce)) {
       const resolve = pendingCommands.get(nonce)!;
       pendingCommands.delete(nonce);
+      // Content script unwraps synthetics-response → forwards msg.response.
+      // msg?.response is only set when the content script passes through
+      // a not-fully-unwrapped envelope; normally msg IS the response object.
       resolve(msg?.response ?? msg);
       return;
     }
@@ -231,6 +235,12 @@ const useSyntheticsRecorder = () => {
     currentUrl.value = targetUrl
     mode.value = 'recording'
 
+    // Ensure bridge is alive — the port may have died since detectExtension()
+    // ran (SW suspend, tab backgrounding, etc.). Sending the probe re-activates
+    // the bridge before we send the startRecording command.
+    window.postMessage({ ch: 'oo-bridge-probe' }, '*');
+    await new Promise(r => setTimeout(r, 200));
+
     bridgeConnect()
     bridgeDisconnectHandler = () => {
       if (onExternalStop && isRecording.value) {
@@ -239,7 +249,6 @@ const useSyntheticsRecorder = () => {
       isRecording.value = false
     }
 
-    console.log("Start Recording -----");
     const res = await sendCommand<RecorderStartResponse>({ action: 'startRecording', targetUrl })
     if (!res?.success) {
       console.debug("Disconnect ---", res);

--- a/web/src/composables/useSyntheticsRecorder.ts
+++ b/web/src/composables/useSyntheticsRecorder.ts
@@ -51,7 +51,7 @@ const useSyntheticsRecorder = () => {
   // ---- Bridge transport ----
 
   const BRIDGE_CHANNEL = 'oo-bridge';
-  const COMMAND_TIMEOUT_MS = 20000;
+  const COMMAND_TIMEOUT_MS = 4000;
 
   let nonceCounter = 0;
   function nextNonce(): string {
@@ -150,7 +150,9 @@ const useSyntheticsRecorder = () => {
     // Give the content script time to open the port before sending the
     // first command. 150ms is generous for a local postMessage round-trip
     // and chrome.runtime.connect call.
-    await new Promise(r => setTimeout(r, 200));
+    // 500ms settle — if the SW just restarted (incognito toggle), it needs
+    // time to initialise. chrome.runtime.connect queues messages internally.
+    await new Promise(r => setTimeout(r, 500));
 
     const status = await sendCommand<RecorderStatus>({ action: 'getStatus' })
     isInstalled.value = status !== null
@@ -233,7 +235,7 @@ const useSyntheticsRecorder = () => {
     // ran (SW suspend, tab backgrounding, etc.). Sending the probe re-activates
     // the bridge before we send the startRecording command.
     window.postMessage({ ch: 'oo-bridge-probe' }, '*');
-    await new Promise(r => setTimeout(r, 200));
+    await new Promise(r => setTimeout(r, 2000));
 
     bridgeConnect()
     bridgeDisconnectHandler = () => {
@@ -332,7 +334,7 @@ const useSyntheticsRecorder = () => {
     // died between stopRecording and replay (bfcache, SW suspend, etc.).
     // The probe re-activates the bridge before we send the replay command.
     window.postMessage({ ch: 'oo-bridge-probe' }, '*');
-    await new Promise(r => setTimeout(r, 200));
+    await new Promise(r => setTimeout(r, 500));
 
     bridgeDisconnect() // discard any previous session
     bridgeConnect()

--- a/web/src/composables/useSyntheticsRecorder.ts
+++ b/web/src/composables/useSyntheticsRecorder.ts
@@ -235,7 +235,7 @@ const useSyntheticsRecorder = () => {
     // ran (SW suspend, tab backgrounding, etc.). Sending the probe re-activates
     // the bridge before we send the startRecording command.
     window.postMessage({ ch: 'oo-bridge-probe' }, '*');
-    await new Promise(r => setTimeout(r, 2000));
+    await new Promise(r => setTimeout(r, 500));
 
     bridgeConnect()
     bridgeDisconnectHandler = () => {

--- a/web/src/lib/core/Table/sub-components/OTableBodyRow.vue
+++ b/web/src/lib/core/Table/sub-components/OTableBodyRow.vue
@@ -329,12 +329,15 @@ function onRowBlur() {
       :class="[
         'w-4 min-w-4 px-0 text-center align-middle',
         bordered ? 'border-b border-table-row-divider' : '',
-        rowDraggable === false ? 'invisible' : '',
       ]"
       class="o2-table-drag-handle"
       data-test="o2-table-row-drag-handle"
     >
-      <OIcon name="drag-indicator" size="xs" class="text-text-secondary cursor-grab transition-opacity" />
+      <OIcon
+        name="drag-indicator" size="xs"
+        :class="[rowDraggable === false ? 'invisible' : '']"
+        class="text-text-secondary cursor-grab transition-opacity"
+      />
     </td>
 
     <!-- Data cells -->

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -9369,7 +9369,9 @@
       "setupStep2Description": "Click the extension icon 🔲 in your toolbar to connect the recorder to this page.",
       "setupIconActivateHint": "Click {icon} in your toolbar to activate the recorder for this page.",
       "setupStep3Title": "Enable incognito mode",
-      "setupStep3IncognitoHint": "Open chrome://extensions, click {details}, then enable {setting}."
+      "setupStep3IncognitoHint": "Open chrome://extensions, click {details}, then enable {setting}.",
+      "setupStep1Done": "Done",
+      "setupReady": "Connected ✓"
     },
     "dialog": {
       "bulkDeleteBody": "Are you sure you want to delete {count} check(s)? This action cannot be undone.",

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -9364,8 +9364,12 @@
       "stepJourney": "Journey",
       "untitledCheck": "Untitled check",
       "variablesHint": "Supports {variables} like {baseUrl}.",
-      "setupStep2Title": "Enable incognito mode",
-      "setupIncognitoHint": "Open chrome://extensions, click {details}, then enable {setting}."
+      "setupStep2Title": "Activate the recorder",
+      "setupIncognitoHint": "Open chrome://extensions, click {details}, then enable {setting}.",
+      "setupStep2Description": "Click the extension icon 🔲 in your toolbar to connect the recorder to this page.",
+      "setupIconActivateHint": "Click {icon} in your toolbar to activate the recorder for this page.",
+      "setupStep3Title": "Enable incognito mode",
+      "setupStep3IncognitoHint": "Open chrome://extensions, click {details}, then enable {setting}."
     },
     "dialog": {
       "bulkDeleteBody": "Are you sure you want to delete {count} check(s)? This action cannot be undone.",

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -9370,7 +9370,8 @@
       "setupIconActivateHint": "Click {icon} in your toolbar to activate the recorder for this page.",
       "setupStep3Title": "Enable incognito mode",
       "setupStep3IncognitoHint": "Open chrome://extensions, click {details}, then enable {setting}.",
-      "setupReady": "Connected ✓"
+      "setupReady": "Connected ✓",
+      "setupConnected": "Connected ✓"
     },
     "dialog": {
       "bulkDeleteBody": "Are you sure you want to delete {count} check(s)? This action cannot be undone.",

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -9364,13 +9364,12 @@
       "stepJourney": "Journey",
       "untitledCheck": "Untitled check",
       "variablesHint": "Supports {variables} like {baseUrl}.",
-      "setupStep2Title": "Activate the recorder",
+      "setupStep2Title": "Click the OpenObserve Recorder icon in your toolbar",
       "setupIncognitoHint": "Open chrome://extensions, click {details}, then enable {setting}.",
-      "setupStep2Description": "Click the extension icon 🔲 in your toolbar to connect the recorder to this page.",
+      "setupStep2Description": "Chrome can't automatically connect to pages that were open before you installed the extension. Clicking the extension icon injects the recorder into this tab — a one-time step.",
       "setupIconActivateHint": "Click {icon} in your toolbar to activate the recorder for this page.",
       "setupStep3Title": "Enable incognito mode",
       "setupStep3IncognitoHint": "Open chrome://extensions, click {details}, then enable {setting}.",
-      "setupStep1Done": "Done",
       "setupReady": "Connected ✓"
     },
     "dialog": {

--- a/web/src/types/synthetics.ts
+++ b/web/src/types/synthetics.ts
@@ -159,6 +159,14 @@ export type RecorderPortInbound =
   | RecorderPortMessage
   | { type: 'synthetics-response'; response: unknown }
 
+// ---- Bridge transport types (content-script relay, replaces chrome.runtime.*) ----
+
+export type TrustResponse =
+  | { type: 'trust-required'; origin: string; nonce: string }
+  | { type: 'trust-granted'; origin: string; nonce: string }
+  | { type: 'trust-denied'; origin: string; nonce: string }
+  | { type: 'bridge-disconnected' }
+
 /**
  * Check types creatable from the UI. Only types both the control plane and the
  * probes run end-to-end today — dns/ping/api exist server-side but have no

--- a/web/src/types/synthetics.ts
+++ b/web/src/types/synthetics.ts
@@ -161,10 +161,7 @@ export type RecorderPortInbound =
 
 // ---- Bridge transport types (content-script relay, replaces chrome.runtime.*) ----
 
-export type TrustResponse =
-  | { type: 'trust-required'; origin: string; nonce: string }
-  | { type: 'trust-granted'; origin: string; nonce: string }
-  | { type: 'trust-denied'; origin: string; nonce: string }
+export type BridgeStatusMessage =
   | { type: 'bridge-disconnected' }
 
 /**

--- a/web/src/views/synthetics/CreateBrowserTest.spec.ts
+++ b/web/src/views/synthetics/CreateBrowserTest.spec.ts
@@ -63,6 +63,8 @@ vi.mock("@/composables/useSyntheticsRecorder", () => ({
     replay: vi.fn().mockResolvedValue({}),
     stopReplay: vi.fn().mockResolvedValue({}),
     stopReplayAndForget: vi.fn(),
+    registerAutoDetect: vi.fn(),
+    isReplaying: { value: false },
   }),
 }));
 
@@ -297,9 +299,9 @@ describe("CreateBrowserTest", () => {
       await recordBtn.trigger("click");
       await flushPromises();
 
-      // Now we should be on the extension setup phase - check for setup elements
+      // Now we should be on the extension setup phase - check for the Open & Record button
       expect(
-        wrapper.find('[data-test="synthetics-setup-recheck-btn"]').exists(),
+        wrapper.find('[data-test="synthetics-setup-open-record-btn"]').exists(),
       ).toBe(true);
     });
   });

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -195,7 +195,6 @@ onMounted(() => {
   // after mid-session install). The content script sends 'oo-bridge-ready' when
   // chrome.scripting.executeScript injects it, and the composable calls this back.
   recorder.registerAutoDetect(() => {
-    console.log("Register auto detect");
     extensionInstalled.value = true
     extensionReady.value = true
   })
@@ -600,28 +599,12 @@ function onClearResults() {
             </div>
           </div>
 
-          <!-- Step 2: Click the extension icon to activate -->
+          <!-- Step 2: Enable incognito mode -->
           <div class="flex items-start gap-4 p-4">
             <span
               class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
-              :class="extensionReady ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-primary-500 text-text-inverse'"
+              :class="incognitoAllowed ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-primary-500 text-text-inverse'"
             >2</span>
-            <div class="flex-1 min-w-0">
-              <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep2Title') }}</h4>
-              <p class="text-xs text-text-secondary m-0">{{ t('synthetics.createBrowserTest.setupStep2Description') }}</p>
-              <p
-                v-if="extensionReady"
-                class="text-xs font-medium text-status-success-text! mt-2"
-              >{{ t('synthetics.createBrowserTest.setupConnected') }}</p>
-            </div>
-          </div>
-
-          <!-- Step 3: Enable incognito mode -->
-          <div class="flex items-start gap-4 p-4" :class="{ 'opacity-60': !extensionReady }">
-            <span
-              class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
-              :class="extensionReady ? incognitoAllowed ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
-            >3</span>
             <div class="flex-1 min-w-0 flex justify-between">
               <div class="flex flex-col items-start">
                 <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep3Title') }}</h4>
@@ -630,9 +613,24 @@ function onClearResults() {
               <OSwitch
                 v-model="incognitoAllowed"
                 :label="t('synthetics.createBrowserTest.setupIncognitoDone')"
-                :disabled="!extensionReady"
                 data-test="synthetics-setup-incognito-switch"
               />
+            </div>
+          </div>
+
+          <!-- Step 3: Click the extension icon to activate -->
+          <div class="flex items-start gap-4 p-4" :class="{ 'opacity-60': !incognitoAllowed }">
+            <span
+              class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
+              :class="extensionReady ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : incognitoAllowed ? 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
+            >3</span>
+            <div class="flex-1 min-w-0">
+              <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep2Title') }}</h4>
+              <p class="text-xs text-text-secondary m-0">{{ t('synthetics.createBrowserTest.setupStep2Description') }}</p>
+              <p
+                v-if="extensionReady"
+                class="text-xs font-medium text-status-success-text! mt-2"
+              >{{ t('synthetics.createBrowserTest.setupConnected') }}</p>
             </div>
           </div>
         </div>

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -191,6 +191,14 @@ onMounted(() => {
     })
     .catch(() => { /* extension messaging unavailable — handled in setup screen */ })
 
+  // Auto-detect when the content script is injected on demand (toolbar icon click
+  // after mid-session install). The content script sends 'oo-bridge-ready' when
+  // chrome.scripting.executeScript injects it, and the composable calls this back.
+  recorder.registerAutoDetect(() => {
+    extensionInstalled.value = true
+    extensionReady.value = true
+  })
+
   fetchFolders()
   fetchLocations()
   fetchDestinations()
@@ -597,29 +605,13 @@ function onClearResults() {
               class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
               :class="extensionReady ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-primary-500 text-text-inverse'"
             >2</span>
-            <div class="flex-1 min-w-0 flex justify-between">
-              <div class="flex flex-col items-start">
-                <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep2Title') }}</h4>
-                <p class="text-xs text-text-secondary m-0 mb-3">{{ t('synthetics.createBrowserTest.setupStep2Description') }}</p>
-              </div>
-              <div class="flex items-center gap-3 px-3">
-                <OButton
-                  v-if="!extensionReady"
-                  variant="outline"
-                  size="sm"
-                  :loading="checkingExtension"
-                  iconLeft="refresh"
-                  data-test="synthetics-setup-icon-check-btn"
-                  @click="probeExtension"
-                >
-                  {{ t('synthetics.createBrowserTest.setupCheckAgain') }}
-                </OButton>
-                <span
-                  v-else
-                  class="text-sm font-medium text-status-success-text!"
-                  data-test="synthetics-setup-ready-label"
-                >{{ t('synthetics.createBrowserTest.setupReady') }}</span>
-              </div>
+            <div class="flex-1 min-w-0">
+              <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep2Title') }}</h4>
+              <p class="text-xs text-text-secondary m-0">{{ t('synthetics.createBrowserTest.setupStep2Description') }}</p>
+              <p
+                v-if="extensionReady"
+                class="text-xs font-medium text-status-success-text! mt-2"
+              >{{ t('synthetics.createBrowserTest.setupConnected') }}</p>
             </div>
           </div>
 

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -182,7 +182,7 @@ function onLoadRetry(actionId?: string) {
 
 onMounted(() => {
   // Warm detection so an already-installed extension lets Record skip setup.
-  probeExtension({ reloadIfFailed: false })
+  probeExtension()
     .then((installed) => { extensionReady.value = installed })
     .catch(() => { /* extension messaging unavailable — handled in setup screen */ })
 
@@ -577,7 +577,7 @@ function onClearResults() {
         </p>
 
         <div class="rounded-default border border-border-default divide-y divide-border-default mb-6">
-          <!-- Step 1 -->
+          <!-- Step 1: Install the OpenObserve Recorder -->
           <div class="flex items-start gap-4 p-4">
             <span
             class="flex-shrink-0 w-7 h-7 rounded-full bg-primary-500 text-text-inverse flex items-center justify-center text-sm font-semibold"
@@ -591,25 +591,6 @@ function onClearResults() {
                 <p class="text-xs text-text-secondary m-0 mb-3">{{ t('synthetics.createBrowserTest.setupStep1Description') }}</p>
               </div>
               <div class="flex items-center gap-3 px-3">
-                <!-- <a
-                  href="https://openobserve.ai/docs/synthetics/recorder/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-sm text-text-link underline"
-                  data-test="synthetics-setup-install-link"
-                >
-                  <OButton
-                    v-if="!extensionInstalled"
-                    variant="outline"
-                    size="sm"
-                    :loading="checkingExtension"
-                    iconLeft="download"
-                    data-test="synthetics-setup-recheck-btn"
-                    @click="probeExtension({ reloadIfFailed: true })"
-                  >
-                    Add to Chrome
-                  </OButton>
-                </a> -->
                 <OButton
                   v-if="!extensionInstalled"
                   variant="outline"
@@ -617,7 +598,7 @@ function onClearResults() {
                   :loading="checkingExtension"
                   iconLeft="refresh"
                   data-test="synthetics-setup-recheck-btn"
-                  @click="probeExtension({ reloadIfFailed: true })"
+                  @click="probeExtension"
                 >
                   {{ t('synthetics.createBrowserTest.setupCheckAgain') }}
                 </OButton>
@@ -630,16 +611,28 @@ function onClearResults() {
             </div>
           </div>
 
-          <!-- Step 2 -->
+          <!-- Step 2: Click the extension icon to activate -->
+          <div class="flex items-start gap-4 p-4" :class="{ 'opacity-60': !extensionInstalled }">
+            <span
+              class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
+              :class="extensionInstalled ? 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
+            >2</span>
+            <div class="flex-1 min-w-0">
+              <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep2Title') }}</h4>
+              <p class="text-xs text-text-secondary m-0">{{ t('synthetics.createBrowserTest.setupStep2Description') }}</p>
+            </div>
+          </div>
+
+          <!-- Step 3: Enable incognito mode -->
           <div class="flex items-start gap-4 p-4" :class="{ 'opacity-60': !extensionInstalled }">
             <span
               class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
               :class="extensionInstalled ? incognitoAllowed ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
-            >2</span>
+            >3</span>
             <div class="flex-1 min-w-0 flex justify-between">
               <div class="flex flex-col items-start">
-                <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep2Title') }}</h4>
-                <p class="text-xs text-text-secondary m-0 mb-3">{{ t('synthetics.createBrowserTest.setupIncognitoHint', { details: CHROME_UI_LABELS.details, setting: CHROME_UI_LABELS.allowIncognito }) }}</p>
+                <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep3Title') }}</h4>
+                <p class="text-xs text-text-secondary m-0 mb-3">{{ t('synthetics.createBrowserTest.setupStep3IncognitoHint', { details: CHROME_UI_LABELS.details, setting: CHROME_UI_LABELS.allowIncognito }) }}</p>
               </div>
               <OSwitch
                 v-model="incognitoAllowed"

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -581,7 +581,7 @@ function onClearResults() {
       <div class="max-w-[48rem] w-full mx-auto py-4 px-4">
         <div class="flex justify-center mb-6">
           <div class="rounded-default border border-border-default bg-surface-base p-6 flex items-center justify-center">
-            <OIcon name="open-in-browser" size="xl" class="text-primary-500" aria-hidden="true" />
+            <OIcon name="open-in-browser" size="xl" class="text-accent" aria-hidden="true" />
           </div>
         </div>
 
@@ -592,7 +592,7 @@ function onClearResults() {
         <div class="rounded-default border border-border-default divide-y divide-border-default mb-6">
           <!-- Step 1: Install the OpenObserve Recorder -->
           <div class="flex items-start gap-4 p-4">
-            <span class="flex-shrink-0 w-7 h-7 rounded-full bg-primary-500 text-text-inverse flex items-center justify-center text-sm font-semibold">1</span>
+            <span class="flex-shrink-0 w-7 h-7 rounded-full bg-accent text-text-inverse flex items-center justify-center text-sm font-semibold">1</span>
             <div class="flex-1 min-w-0">
               <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep1Title') }}</h4>
               <p class="text-xs text-text-secondary m-0">{{ t('synthetics.createBrowserTest.setupStep1Description') }}</p>
@@ -603,7 +603,7 @@ function onClearResults() {
           <div class="flex items-start gap-4 p-4">
             <span
               class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
-              :class="incognitoAllowed ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-primary-500 text-text-inverse'"
+              :class="incognitoAllowed ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-accent text-text-inverse'"
             >2</span>
             <div class="flex-1 min-w-0 flex justify-between">
               <div class="flex flex-col items-start">
@@ -622,7 +622,7 @@ function onClearResults() {
           <div class="flex items-start gap-4 p-4" :class="{ 'opacity-60': !incognitoAllowed }">
             <span
               class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
-              :class="extensionReady ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : incognitoAllowed ? 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
+              :class="extensionReady ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : incognitoAllowed ? 'bg-accent text-text-inverse' : 'bg-surface-subtle text-text-muted'"
             >3</span>
             <div class="flex-1 min-w-0">
               <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep2Title') }}</h4>

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -182,7 +182,7 @@ function onLoadRetry(actionId?: string) {
 
 onMounted(() => {
   // Warm detection so an already-installed extension lets Record skip setup.
-  probeExtension()
+  probeExtension({ reloadIfFailed: false })
     .then((installed) => { extensionReady.value = installed })
     .catch(() => { /* extension messaging unavailable — handled in setup screen */ })
 
@@ -247,7 +247,7 @@ const isGateUrlValid = computed(() => {
 async function onRecordClick() {
   if (!validateGateUrl()) return
   commitGate()
-  const installed = await probeExtension()
+  const installed = await probeExtension({ reloadIfFailed: false })
   extensionReady.value = installed
   if (installed) {
     autoRecord.value = true
@@ -605,7 +605,7 @@ function onClearResults() {
                     :loading="checkingExtension"
                     iconLeft="download"
                     data-test="synthetics-setup-recheck-btn"
-                    @click="probeExtension"
+                    @click="probeExtension({ reloadIfFailed: true })"
                   >
                     Add to Chrome
                   </OButton>
@@ -617,7 +617,7 @@ function onClearResults() {
                   :loading="checkingExtension"
                   iconLeft="refresh"
                   data-test="synthetics-setup-recheck-btn"
-                  @click="probeExtension"
+                  @click="probeExtension({ reloadIfFailed: true })"
                 >
                   {{ t('synthetics.createBrowserTest.setupCheckAgain') }}
                 </OButton>

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -183,7 +183,12 @@ function onLoadRetry(actionId?: string) {
 onMounted(() => {
   // Warm detection so an already-installed extension lets Record skip setup.
   probeExtension()
-    .then((installed) => { extensionReady.value = installed })
+    .then((installed) => {
+      if (installed) {
+        extensionInstalled.value = true
+        extensionReady.value = true
+      }
+    })
     .catch(() => { /* extension messaging unavailable — handled in setup screen */ })
 
   fetchFolders()
@@ -247,7 +252,7 @@ const isGateUrlValid = computed(() => {
 async function onRecordClick() {
   if (!validateGateUrl()) return
   commitGate()
-  const installed = await probeExtension({ reloadIfFailed: false })
+  const installed = await probeExtension()
   extensionReady.value = installed
   if (installed) {
     autoRecord.value = true
@@ -590,24 +595,11 @@ function onClearResults() {
                 <h4 class="text-sm font-semibold text-text-heading m-0 pb-1">{{ t('synthetics.createBrowserTest.setupStep1Title') }}</h4>
                 <p class="text-xs text-text-secondary m-0 mb-3">{{ t('synthetics.createBrowserTest.setupStep1Description') }}</p>
               </div>
-              <div class="flex items-center gap-3 px-3">
-                <OButton
-                  v-if="!extensionInstalled"
-                  variant="outline"
-                  size="sm"
-                  :loading="checkingExtension"
-                  iconLeft="refresh"
-                  data-test="synthetics-setup-recheck-btn"
-                  @click="probeExtension"
-                >
-                  {{ t('synthetics.createBrowserTest.setupCheckAgain') }}
-                </OButton>
-                <span
-                  v-else
-                  class="text-sm font-medium text-status-success-text!"
-                  data-test="synthetics-setup-installed-label"
-                >{{ t('synthetics.createBrowserTest.setupInstalled') }}</span>
-              </div>
+              <OSwitch
+                v-model="extensionInstalled"
+                :label="t('synthetics.createBrowserTest.setupStep1Done')"
+                data-test="synthetics-setup-installed-switch"
+              />
             </div>
           </div>
 
@@ -615,11 +607,32 @@ function onClearResults() {
           <div class="flex items-start gap-4 p-4" :class="{ 'opacity-60': !extensionInstalled }">
             <span
               class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
-              :class="extensionInstalled ? 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
+              :class="extensionReady ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : extensionInstalled ? 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
             >2</span>
-            <div class="flex-1 min-w-0">
-              <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep2Title') }}</h4>
-              <p class="text-xs text-text-secondary m-0">{{ t('synthetics.createBrowserTest.setupStep2Description') }}</p>
+            <div class="flex-1 min-w-0 flex justify-between">
+              <div class="flex flex-col items-start">
+                <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep2Title') }}</h4>
+                <p class="text-xs text-text-secondary m-0 mb-3">{{ t('synthetics.createBrowserTest.setupStep2Description') }}</p>
+              </div>
+              <div class="flex items-center gap-3 px-3">
+                <OButton
+                  v-if="!extensionReady"
+                  variant="outline"
+                  size="sm"
+                  :loading="checkingExtension"
+                  iconLeft="refresh"
+                  :disabled="!extensionInstalled"
+                  data-test="synthetics-setup-icon-check-btn"
+                  @click="probeExtension"
+                >
+                  {{ t('synthetics.createBrowserTest.setupCheckAgain') }}
+                </OButton>
+                <span
+                  v-else
+                  class="text-sm font-medium text-status-success-text!"
+                  data-test="synthetics-setup-ready-label"
+                >{{ t('synthetics.createBrowserTest.setupReady') }}</span>
+              </div>
             </div>
           </div>
 
@@ -648,7 +661,7 @@ function onClearResults() {
           variant="primary"
           size="lg"
           class="w-full mb-4"
-          :disabled="!extensionInstalled || !incognitoAllowed"
+          :disabled="!extensionInstalled || !extensionReady || !incognitoAllowed"
           data-test="synthetics-setup-open-record-btn"
           icon-left="smart-display"
           @click="onExtensionSetupRecord"

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -195,6 +195,7 @@ onMounted(() => {
   // after mid-session install). The content script sends 'oo-bridge-ready' when
   // chrome.scripting.executeScript injects it, and the composable calls this back.
   recorder.registerAutoDetect(() => {
+    console.log("Register auto detect");
     extensionInstalled.value = true
     extensionReady.value = true
   })

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -584,30 +584,18 @@ function onClearResults() {
         <div class="rounded-default border border-border-default divide-y divide-border-default mb-6">
           <!-- Step 1: Install the OpenObserve Recorder -->
           <div class="flex items-start gap-4 p-4">
-            <span
-            class="flex-shrink-0 w-7 h-7 rounded-full bg-primary-500 text-text-inverse flex items-center justify-center text-sm font-semibold"
-            :class="extensionInstalled ? 'bg-[var(--color-status-success-text)]!': ''"
-            >
-              1
-            </span>
-            <div class="flex-1 min-w-0 flex justify-between">
-              <div class="flex flex-col items-start">
-                <h4 class="text-sm font-semibold text-text-heading m-0 pb-1">{{ t('synthetics.createBrowserTest.setupStep1Title') }}</h4>
-                <p class="text-xs text-text-secondary m-0 mb-3">{{ t('synthetics.createBrowserTest.setupStep1Description') }}</p>
-              </div>
-              <OSwitch
-                v-model="extensionInstalled"
-                :label="t('synthetics.createBrowserTest.setupStep1Done')"
-                data-test="synthetics-setup-installed-switch"
-              />
+            <span class="flex-shrink-0 w-7 h-7 rounded-full bg-primary-500 text-text-inverse flex items-center justify-center text-sm font-semibold">1</span>
+            <div class="flex-1 min-w-0">
+              <h4 class="text-sm font-semibold text-text-heading m-0 mb-1">{{ t('synthetics.createBrowserTest.setupStep1Title') }}</h4>
+              <p class="text-xs text-text-secondary m-0">{{ t('synthetics.createBrowserTest.setupStep1Description') }}</p>
             </div>
           </div>
 
           <!-- Step 2: Click the extension icon to activate -->
-          <div class="flex items-start gap-4 p-4" :class="{ 'opacity-60': !extensionInstalled }">
+          <div class="flex items-start gap-4 p-4">
             <span
               class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
-              :class="extensionReady ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : extensionInstalled ? 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
+              :class="extensionReady ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-primary-500 text-text-inverse'"
             >2</span>
             <div class="flex-1 min-w-0 flex justify-between">
               <div class="flex flex-col items-start">
@@ -621,7 +609,6 @@ function onClearResults() {
                   size="sm"
                   :loading="checkingExtension"
                   iconLeft="refresh"
-                  :disabled="!extensionInstalled"
                   data-test="synthetics-setup-icon-check-btn"
                   @click="probeExtension"
                 >
@@ -637,10 +624,10 @@ function onClearResults() {
           </div>
 
           <!-- Step 3: Enable incognito mode -->
-          <div class="flex items-start gap-4 p-4" :class="{ 'opacity-60': !extensionInstalled }">
+          <div class="flex items-start gap-4 p-4" :class="{ 'opacity-60': !extensionReady }">
             <span
               class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-sm font-semibold"
-              :class="extensionInstalled ? incognitoAllowed ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
+              :class="extensionReady ? incognitoAllowed ? 'bg-[var(--color-status-success-text)]! text-text-inverse' : 'bg-primary-500 text-text-inverse' : 'bg-surface-subtle text-text-muted'"
             >3</span>
             <div class="flex-1 min-w-0 flex justify-between">
               <div class="flex flex-col items-start">
@@ -650,7 +637,7 @@ function onClearResults() {
               <OSwitch
                 v-model="incognitoAllowed"
                 :label="t('synthetics.createBrowserTest.setupIncognitoDone')"
-                :disabled="!extensionInstalled"
+                :disabled="!extensionReady"
                 data-test="synthetics-setup-incognito-switch"
               />
             </div>
@@ -661,7 +648,7 @@ function onClearResults() {
           variant="primary"
           size="lg"
           class="w-full mb-4"
-          :disabled="!extensionInstalled || !extensionReady || !incognitoAllowed"
+          :disabled="!extensionReady || !incognitoAllowed"
           data-test="synthetics-setup-open-record-btn"
           icon-left="smart-display"
           @click="onExtensionSetupRecord"

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -463,6 +463,11 @@ function onReplay() {
 }
 
 function onStopReplay() {
+  // Update UI state immediately — the SW has already stopped the replay.
+  // Don't wait for the replay promise to resolve (it may take seconds or
+  // never arrive if the port was disconnected from window focus changes).
+  recorder.replayPhase.value = 'stopped'
+  recorder.isReplaying.value = false
   recorder.stopReplay().catch(() => {})
 }
 


### PR DESCRIPTION

## What changed

Replaces `chrome.runtime.*` direct messaging (which requires a static `externally_connectable` manifest entry) with a `window.postMessage` bridge transport for the synthetics recorder extension. This removes `externally_connectable` from the extension manifest so the recorder works with self-hosted OpenObserve instances on any domain. Also includes fixes for recording tab lifecycle handling, replay proxy deserialization, and tab removal edge cases.

## Why

The `externally_connectable.matches` field in the manifest is static — it cannot include arbitrary self-hosted domains, so users hosting OpenObserve on their own URLs couldn't use the extension recorder. The bridge transport (content script + `window.postMessage`) decouples the web app from the extension's manifest, letting any origin communicate with the recorder.