### PR TITLE
fix: synthetics UI issues

### DIFF
--- a/web/src/components/synthetics/configure/CheckAlerts.spec.ts
+++ b/web/src/components/synthetics/configure/CheckAlerts.spec.ts
@@ -2,7 +2,6 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, VueWrapper } from "@vue/test-utils";
-import { nextTick } from "vue";
 import type { BrowserCheck } from "@/types/synthetics";
 import { mockMonitorHttp } from "@/test/unit/mockData/synthetics";
 
@@ -120,31 +119,6 @@ describe("CheckAlerts", () => {
       expect(wrapper.find("h3").text()).toBe("synthetics.scheduleAlert.alerts");
     });
 
-    it("should display retry count from check data", () => {
-      wrapper = mountCheckAlerts(mockMonitorHttp, ["dest-1"]);
-
-      const retriesInput = wrapper.find(
-        '[data-test="synthetics-check-alerts-retries-input"]',
-      );
-      expect(retriesInput.exists()).toBe(true);
-      expect(retriesInput.attributes("value")).toBe(
-        String(mockMonitorHttp.retries),
-      );
-    });
-
-    it("should display retry delay from check data", () => {
-      wrapper = mountCheckAlerts(
-        { waitBeforeRetrySecs: 10 },
-        ["dest-1"],
-      );
-
-      const delayInput = wrapper.find(
-        '[data-test="synthetics-check-alerts-retry-delay-input"]',
-      );
-      expect(delayInput.exists()).toBe(true);
-      expect(delayInput.attributes("value")).toBe("10");
-    });
-
     it("should display failure threshold from check data", () => {
       wrapper = mountCheckAlerts(
         { alertIfFails: 3 },
@@ -152,7 +126,7 @@ describe("CheckAlerts", () => {
       );
 
       const thresholdInput = wrapper.find(
-        '[data-test="synthetics-check-alerts-failure-threshold-input"]',
+        '[data-test="synthetics-check-alerts-threshold-input"]',
       );
       expect(thresholdInput.exists()).toBe(true);
       expect(thresholdInput.attributes("value")).toBe("3");
@@ -169,42 +143,6 @@ describe("CheckAlerts", () => {
       );
       expect(cooldownInput.exists()).toBe(true);
       expect(cooldownInput.attributes("value")).toBe("5");
-    });
-
-    it("should render default values when check fields are undefined", () => {
-      // Spread includes undefined keys which override the defaults from mockMonitorHttp
-      const sparse = {
-        retries: undefined,
-        waitBeforeRetrySecs: undefined,
-        alertIfFails: undefined,
-        cooldownMins: undefined,
-      };
-
-      wrapper = mountCheckAlerts(sparse, ["dest-1"]);
-
-      expect(
-        wrapper
-          .find('[data-test="synthetics-check-alerts-retries-input"]')
-          .attributes("value"),
-      ).toBe("0");
-
-      expect(
-        wrapper
-          .find('[data-test="synthetics-check-alerts-retry-delay-input"]')
-          .attributes("value"),
-      ).toBe("0");
-
-      expect(
-        wrapper
-          .find('[data-test="synthetics-check-alerts-failure-threshold-input"]')
-          .attributes("value"),
-      ).toBe("1");
-
-      expect(
-        wrapper
-          .find('[data-test="synthetics-check-alerts-cooldown-input"]')
-          .attributes("value"),
-      ).toBe("5");
     });
 
     it("should select destinations from check.notifications.destinations", () => {
@@ -240,41 +178,6 @@ describe("CheckAlerts", () => {
 
   // ── Interactions ─────────────────────────────────────────────────────────
 
-  describe("retry count input", () => {
-    it("should emit update:check with updated retries when input changes", async () => {
-      wrapper = mountCheckAlerts({ retries: 2 }, ["dest-1"]);
-
-      const retriesInput = wrapper.find(
-        '[data-test="synthetics-check-alerts-retries-input"]',
-      );
-      await retriesInput.setValue("5");
-
-      const emitted = wrapper.emitted("update:check");
-      expect(emitted).toBeTruthy();
-      const lastEmit = emitted![emitted!.length - 1][0] as BrowserCheck;
-      expect(lastEmit.retries).toBe(5);
-    });
-  });
-
-  describe("retry delay input", () => {
-    it("should emit update:check with updated waitBeforeRetrySecs when input changes", async () => {
-      wrapper = mountCheckAlerts(
-        { waitBeforeRetrySecs: 10 },
-        ["dest-1"],
-      );
-
-      const delayInput = wrapper.find(
-        '[data-test="synthetics-check-alerts-retry-delay-input"]',
-      );
-      await delayInput.setValue("30");
-
-      const emitted = wrapper.emitted("update:check");
-      expect(emitted).toBeTruthy();
-      const lastEmit = emitted![emitted!.length - 1][0] as BrowserCheck;
-      expect(lastEmit.waitBeforeRetrySecs).toBe(30);
-    });
-  });
-
   describe("failure threshold input", () => {
     it("should emit update:check with updated alertIfFails when input changes", async () => {
       wrapper = mountCheckAlerts(
@@ -283,7 +186,7 @@ describe("CheckAlerts", () => {
       );
 
       const thresholdInput = wrapper.find(
-        '[data-test="synthetics-check-alerts-failure-threshold-input"]',
+        '[data-test="synthetics-check-alerts-threshold-input"]',
       );
       await thresholdInput.setValue("2");
 
@@ -326,27 +229,6 @@ describe("CheckAlerts", () => {
       expect(emitted).toBeTruthy();
       const lastEmit = emitted![emitted!.length - 1][0] as BrowserCheck;
       expect(lastEmit.notifications.destinations).toEqual(["dest-1", "dest-3"]);
-    });
-
-    it("should show error when all destinations are deselected", async () => {
-      wrapper = mountCheckAlerts(
-        { notifications: { destinations: ["dest-1"] } },
-        ["dest-1", "dest-2"],
-      );
-
-      // Find the OSelect stub component via its root element's data-test
-      const selectComp = wrapper.findComponent(
-        '[data-test="synthetics-check-alerts-destinations-select"]',
-      );
-      expect(selectComp.exists()).toBe(true);
-
-      // Emit an empty selection to simulate user deselecting all destinations
-      selectComp.vm.$emit("update:modelValue", []);
-      await nextTick();
-
-      expect(wrapper.text()).toContain(
-        "synthetics.scheduleAlert.destinationRequired",
-      );
     });
   });
 
@@ -427,22 +309,4 @@ describe("CheckAlerts", () => {
     });
   });
 
-  describe("v-model preservation", () => {
-    it("should preserve other check fields when updating retries", async () => {
-      wrapper = mountCheckAlerts(mockMonitorHttp, ["dest-1"]);
-
-      const retriesInput = wrapper.find(
-        '[data-test="synthetics-check-alerts-retries-input"]',
-      );
-      await retriesInput.setValue("4");
-
-      const emitted = wrapper.emitted("update:check");
-      const lastEmit = emitted![emitted!.length - 1][0] as BrowserCheck;
-
-      expect(lastEmit.name).toBe(mockMonitorHttp.name);
-      expect(lastEmit.url).toBe(mockMonitorHttp.url);
-      expect(lastEmit.retries).toBe(4);
-      expect(lastEmit.alertIfFails).toBe(mockMonitorHttp.alertIfFails);
-    });
-  });
 });

--- a/web/src/components/synthetics/configure/CheckAlerts.vue
+++ b/web/src/components/synthetics/configure/CheckAlerts.vue
@@ -33,6 +33,13 @@ const localDestinations = computed({
     emit('update:check', { ...props.check, notifications: { destinations: v } }),
 })
 
+// ─── failure threshold ────────────────────────────────────────────────────────
+
+const failureThreshold = computed({
+  get: () => props.check.alertIfFails ?? 1,
+  set: (v: string | number) => emit('update:check', { ...props.check, alertIfFails: Number(v) }),
+})
+
 function routeToCreateDestination() {
   const url = router.resolve({
     name: 'alertDestinations',
@@ -98,6 +105,19 @@ const silenceMinutes = computed({
             {{ t('synthetics.scheduleAlert.addNewDestination') }}
           </OButton>
         </div>
+      </div>
+
+      <!-- ── Alert threshold ──────────────────────────────────────────── -->
+      <div class="flex items-center gap-2 flex-nowrap">
+        <label class="text-sm font-medium text-text-body whitespace-nowrap w-32">{{ t('synthetics.scheduleAlert.alertedIfFails') }}</label>
+        <OInput
+          v-model="failureThreshold"
+          type="number"
+          class="w-25!"
+          placeholder="1"
+          data-test="synthetics-check-alerts-threshold-input"
+        />
+        <span class="text-sm text-text-body whitespace-nowrap">{{ t('synthetics.scheduleAlert.alertedIfFailsSuffix') }}</span>
       </div>
 
       <!-- ── Cooldown Period ────────────────────────────────────────────── -->

--- a/web/src/components/synthetics/configure/CheckAlerts.vue
+++ b/web/src/components/synthetics/configure/CheckAlerts.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 // Copyright 2026 OpenObserve Inc.
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
 import type { BrowserCheck } from '@/types/synthetics'
 import OInput from '@/lib/forms/Input/OInput.vue'
 import OSelect from '@/lib/forms/Select/OSelect.vue'
-import type { SelectModelValue } from '@/lib/forms/Select/OSelect.types'
 import OIcon from '@/lib/core/Icon/OIcon.vue'
 import OButton from '@/lib/core/Button/OButton.vue'
 
@@ -26,44 +25,13 @@ const { t } = useI18n()
 const store = useStore()
 const router = useRouter()
 
-// ─── retries ──────────────────────────────────────────────────────────────────
-
-const retries = computed({
-  get: () => props.check.retries ?? 0,
-  set: (v: string | number) => emit('update:check', { ...props.check, retries: Number(v) }),
-})
-
-const retryDelayMs = computed({
-  get: () => props.check.waitBeforeRetrySecs ?? 0,
-  set: (v: string | number) => emit('update:check', { ...props.check, waitBeforeRetrySecs: Number(v) }),
-})
-
-// ─── alert threshold ──────────────────────────────────────────────────────────
-
-const failureThreshold = computed({
-  get: () => props.check.alertIfFails ?? 1,
-  set: (v: string | number) => emit('update:check', { ...props.check, alertIfFails: Number(v) }),
-})
-
 // ─── destinations ─────────────────────────────────────────────────────────────
 
 const localDestinations = computed({
   get: () => props.check.notifications.destinations,
-  set: (v: string[]) => {
-    destinationError.value = v.length === 0
-    emit('update:check', { ...props.check, notifications: { destinations: v } })
-  },
+  set: (v: string[]) =>
+    emit('update:check', { ...props.check, notifications: { destinations: v } }),
 })
-
-const destinationError = ref(false)
-
-function onDestinationsChange(value: SelectModelValue) {
-  const v = (Array.isArray(value) ? value : []).filter(
-    (d): d is string => typeof d === 'string',
-  )
-  destinationError.value = v.length === 0
-  emit('update:check', { ...props.check, notifications: { destinations: v } })
-}
 
 function routeToCreateDestination() {
   const url = router.resolve({
@@ -85,7 +53,10 @@ const silenceMinutes = computed({
 </script>
 
 <template>
-  <div class="rounded-default border border-border-default mb-4">
+  <div
+    class="rounded-default border border-border-default mb-4"
+    data-test="synthetics-check-alerts"
+  >
     <div class="flex items-center border-b border-border-default py-2.5 px-3">
       <div class="w-[0.1875rem] h-4 rounded-default mr-2 shrink-0 bg-primary-600" />
       <h3 class="text-base font-semibold text-text-heading">
@@ -94,59 +65,18 @@ const silenceMinutes = computed({
     </div>
     <div class="px-3 py-2 flex flex-col gap-4">
 
-      <!-- ── Retries ────────────────────────────────────────────────────── -->
-      <div class="flex flex-col gap-2">
-        <div class="flex items-center gap-2 flex-nowrap">
-          <label class="text-sm font-medium text-text-body whitespace-nowrap w-32">{{ t('synthetics.scheduleAlert.retriesOnFailure') }}</label>
-          <OInput
-            v-model="retries"
-            type="number"
-            class="w-25!"
-            placeholder="0"
-            data-test="synthetics-check-alerts-retries-input"
-          />
-          <span class="text-sm text-text-body whitespace-nowrap">{{ t('synthetics.scheduleAlert.retriesOnFailureSuffix') }}</span>
-        </div>
-        <div class="flex items-center gap-2 flex-nowrap">
-          <label class="text-sm font-medium text-text-body whitespace-nowrap w-32">{{ t('synthetics.scheduleAlert.retryDelay') }}</label>
-          <OInput
-            v-model="retryDelayMs"
-            type="number"
-            class="w-25!"
-            placeholder="0"
-            data-test="synthetics-check-alerts-retry-delay-input"
-          />
-          <span class="text-sm text-text-body whitespace-nowrap">{{ t('synthetics.scheduleAlert.retryDelaySuffix') }}</span>
-        </div>
-
-        <!-- ── Failure threshold ────────────────────────────────────────── -->
-        <div class="flex items-center gap-2 flex-nowrap">
-          <label class="text-sm font-medium text-text-body whitespace-nowrap w-32">{{ t('synthetics.scheduleAlert.alertedIfFails') }}</label>
-          <OInput
-            v-model="failureThreshold"
-            type="number"
-            class="w-25!"
-            placeholder="1"
-            data-test="synthetics-check-alerts-failure-threshold-input"
-          />
-          <span class="text-sm text-text-body whitespace-nowrap">{{ t('synthetics.scheduleAlert.alertedIfFailsSuffix') }}</span>
-        </div>
-      </div>
-
-      <!-- ── Destinations ───────────────────────────────────────────────── -->
+      <!-- ── Destinations (optional) ────────────────────────────────────── -->
       <div>
         <div class="flex items-center gap-2">
           <label class="text-sm font-medium text-text-body mb-1 block w-32">
-            {{ t('synthetics.scheduleAlert.destinations') }} *
+            {{ t('synthetics.scheduleAlert.destinations') }}
           </label>
           <OSelect
             v-model="localDestinations"
             :options="destinations"
             multiple
-            :error="destinationError"
             class="min-w-45 max-w-75"
             data-test="synthetics-check-alerts-destinations-select"
-            @update:model-value="onDestinationsChange"
           >
             <template #empty>{{ t('synthetics.scheduleAlert.noDestinations') }}</template>
           </OSelect>
@@ -168,9 +98,6 @@ const silenceMinutes = computed({
             {{ t('synthetics.scheduleAlert.addNewDestination') }}
           </OButton>
         </div>
-        <p v-if="destinationError" class="mt-1 text-xs text-status-error-text">
-          {{ t('synthetics.scheduleAlert.destinationRequired') }}
-        </p>
       </div>
 
       <!-- ── Cooldown Period ────────────────────────────────────────────── -->

--- a/web/src/components/synthetics/configure/CheckAlerts.vue
+++ b/web/src/components/synthetics/configure/CheckAlerts.vue
@@ -14,6 +14,7 @@ import OButton from '@/lib/core/Button/OButton.vue'
 const props = defineProps<{
   check: BrowserCheck
   destinations: string[]
+  validationErrors?: Record<string, string>
 }>()
 
 const emit = defineEmits<{
@@ -193,6 +194,15 @@ const silenceMinutes = computed({
           </div>
         </div>
       </div>
+
+      <!-- Validation error -->
+      <p
+        v-if="props.validationErrors?.alerts"
+        class="text-xs text-status-error-text"
+        data-test="synthetics-check-alerts-error"
+      >
+        {{ props.validationErrors.alerts }}
+      </p>
 
     </div>
   </div>

--- a/web/src/components/synthetics/configure/CheckBrowserDevices.vue
+++ b/web/src/components/synthetics/configure/CheckBrowserDevices.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   check: BrowserCheck
   browsers?: string[]
   devices?: SyntheticsDevice[]
+  validationErrors?: Record<string, string>
 }>()
 const emit = defineEmits<{ 'update:check': [value: BrowserCheck] }>()
 
@@ -128,6 +129,15 @@ function toggle(browserId: string, deviceId: string) {
           />
         </div>
       </div>
+
+      <!-- Validation error -->
+      <p
+        v-if="props.validationErrors?.browserDevices"
+        class="text-xs text-status-error-text"
+        data-test="synthetics-check-browser-devices-error"
+      >
+        {{ props.validationErrors.browserDevices }}
+      </p>
     </div>
   </div>
 </template>

--- a/web/src/components/synthetics/configure/CheckConfigure.vue
+++ b/web/src/components/synthetics/configure/CheckConfigure.vue
@@ -76,12 +76,14 @@ function handleUpdate(value: BrowserCheck) {
       />
       <CheckSchedule
         :check="check"
+        :validation-errors="props.validationErrors ?? {}"
         data-test="synthetics-check-configure-schedule"
         @update:check="handleUpdate"
       />
       <CheckAlerts
         :check="check"
         :destinations="destinations ?? []"
+        :validation-errors="props.validationErrors ?? {}"
         data-test="synthetics-check-configure-alerts"
         @update:check="handleUpdate"
         @refresh:destinations="emit('refresh:destinations')"
@@ -90,6 +92,7 @@ function handleUpdate(value: BrowserCheck) {
         :check="check"
         :locations="locations ?? []"
         :allow-private="allowPrivateLocations"
+        :validation-errors="props.validationErrors ?? {}"
         data-test="synthetics-check-configure-locations"
         @update:check="handleUpdate"
         @setup-agent="emit('setup-agent')"
@@ -99,6 +102,7 @@ function handleUpdate(value: BrowserCheck) {
         :check="check"
         :browsers="browsers"
         :devices="devices"
+        :validation-errors="props.validationErrors ?? {}"
         data-test="synthetics-check-configure-browser-devices"
         @update:check="handleUpdate"
       />

--- a/web/src/components/synthetics/configure/CheckConfigure.vue
+++ b/web/src/components/synthetics/configure/CheckConfigure.vue
@@ -6,6 +6,7 @@ import type { BrowserCheck, SyntheticCheckType, SyntheticsLocation, SyntheticsFo
 import CheckDetails from './CheckDetails.vue'
 import CheckAuthNetwork from './CheckAuthNetwork.vue'
 import CheckSchedule from './CheckSchedule.vue'
+import CheckRetries from './CheckRetries.vue'
 import CheckAlerts from './CheckAlerts.vue'
 import CheckLocations from './CheckLocations.vue'
 import CheckBrowserDevices from './CheckBrowserDevices.vue'
@@ -78,6 +79,12 @@ function handleUpdate(value: BrowserCheck) {
         :check="check"
         :validation-errors="props.validationErrors ?? {}"
         data-test="synthetics-check-configure-schedule"
+        @update:check="handleUpdate"
+      />
+      <CheckRetries
+        :check="check"
+        :validation-errors="props.validationErrors ?? {}"
+        data-test="synthetics-check-configure-retries"
         @update:check="handleUpdate"
       />
       <CheckAlerts

--- a/web/src/components/synthetics/configure/CheckLocations.vue
+++ b/web/src/components/synthetics/configure/CheckLocations.vue
@@ -17,7 +17,8 @@ const props = defineProps<{
   locations: SyntheticsLocation[]
   /** Shows the private-locations subsection + setup CTA (protocol checks only —
    *  browser tests are Lambda-only and pass the public list without this). */
-  allowPrivate?: boolean
+  allowPrivate?: boolean,
+  validationErrors?: Record<string, string>;
 }>()
 const emit = defineEmits<{
   'update:check': [value: BrowserCheck]
@@ -187,6 +188,13 @@ function agentSubtext(location: SyntheticsLocation): string {
       >
         {{ t('synthetics.locations.empty') }}
       </div>
+      <p
+      v-if="props.validationErrors?.locations"
+      class="mt-2 text-xs text-status-error-text"
+      data-test="synthetics-check-locations-error"
+      >
+          {{ props.validationErrors.locations }}
+      </p>
     </div>
   </div>
 </template>

--- a/web/src/components/synthetics/configure/CheckRetries.spec.ts
+++ b/web/src/components/synthetics/configure/CheckRetries.spec.ts
@@ -1,0 +1,154 @@
+// Copyright 2026 OpenObserve Inc.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mount, VueWrapper } from "@vue/test-utils";
+import type { BrowserCheck } from "@/types/synthetics";
+import { mockMonitorHttp } from "@/test/unit/mockData/synthetics";
+
+// ── Stubs ────────────────────────────────────────────────────────────────────
+
+const OInputStub = {
+  props: ["modelValue", "type", "placeholder", "class"],
+  emits: ["update:modelValue"],
+  template: `<input v-bind="$attrs" :value="modelValue" :type="type" @input="$emit('update:modelValue', $event.target.value)" />`,
+};
+
+const STUBS = {
+  OInput: OInputStub,
+};
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("vue-i18n", () => ({
+  useI18n: vi.fn(() => ({ t: (key: string) => key })),
+}));
+
+// ── SUT import (after mocks) ────────────────────────────────────────────────
+
+import CheckRetries from "./CheckRetries.vue";
+
+// ── Mount factory ────────────────────────────────────────────────────────────
+
+function mountCheckRetries(
+  checkOverrides: Partial<BrowserCheck> = {},
+  validationErrors?: Record<string, string>,
+) {
+  const check = { ...mockMonitorHttp, ...checkOverrides } as BrowserCheck;
+  return mount(CheckRetries, {
+    props: { check, validationErrors },
+    global: {
+      stubs: STUBS,
+    },
+  }) as VueWrapper;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("CheckRetries", () => {
+  let wrapper: VueWrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe("initial render", () => {
+    it("renders the retries section heading using i18n key", () => {
+      wrapper = mountCheckRetries(mockMonitorHttp);
+
+      expect(wrapper.find("h3").text()).toBe("synthetics.scheduleAlert.retries");
+    });
+
+    it("renders the retries input with value from check.retries", () => {
+      wrapper = mountCheckRetries({ retries: 3 });
+
+      const input = wrapper.find(
+        '[data-test="synthetics-check-retries-count-input"]',
+      );
+      expect(input.exists()).toBe(true);
+      expect(input.attributes("value")).toBe("3");
+    });
+
+    it("renders the retry delay input with value from check.waitBeforeRetrySecs", () => {
+      wrapper = mountCheckRetries({ waitBeforeRetrySecs: 15 });
+
+      const input = wrapper.find(
+        '[data-test="synthetics-check-retries-delay-input"]',
+      );
+      expect(input.exists()).toBe(true);
+      expect(input.attributes("value")).toBe("15");
+    });
+
+    it("renders default values (0) when check fields are undefined", () => {
+      wrapper = mountCheckRetries({
+        retries: undefined,
+        waitBeforeRetrySecs: undefined,
+      } as Partial<BrowserCheck> as any);
+
+      const retriesInput = wrapper.find(
+        '[data-test="synthetics-check-retries-count-input"]',
+      );
+      const delayInput = wrapper.find(
+        '[data-test="synthetics-check-retries-delay-input"]',
+      );
+
+      expect(retriesInput.attributes("value")).toBe("0");
+      expect(delayInput.attributes("value")).toBe("0");
+    });
+
+    it("does not render the validation error element when validationErrors.retries is not set", () => {
+      wrapper = mountCheckRetries(mockMonitorHttp);
+
+      const error = wrapper.find(
+        '[data-test="synthetics-check-retries-error"]',
+      );
+      expect(error.exists()).toBe(false);
+    });
+  });
+
+  describe("retries input", () => {
+    it("emits update:check with updated retries when retries input changes", async () => {
+      wrapper = mountCheckRetries({ retries: 2 });
+
+      const input = wrapper.find(
+        '[data-test="synthetics-check-retries-count-input"]',
+      );
+      await input.setValue("5");
+
+      const emitted = wrapper.emitted("update:check");
+      expect(emitted).toBeTruthy();
+      const lastEmit = emitted![emitted!.length - 1][0] as BrowserCheck;
+      expect(lastEmit.retries).toBe(5);
+    });
+  });
+
+  describe("retry delay input", () => {
+    it("emits update:check with updated waitBeforeRetrySecs when delay input changes", async () => {
+      wrapper = mountCheckRetries({ waitBeforeRetrySecs: 10 });
+
+      const input = wrapper.find(
+        '[data-test="synthetics-check-retries-delay-input"]',
+      );
+      await input.setValue("30");
+
+      const emitted = wrapper.emitted("update:check");
+      expect(emitted).toBeTruthy();
+      const lastEmit = emitted![emitted!.length - 1][0] as BrowserCheck;
+      expect(lastEmit.waitBeforeRetrySecs).toBe(30);
+    });
+  });
+
+  describe("validation error", () => {
+    it("shows the validation error message when validationErrors.retries is set", () => {
+      wrapper = mountCheckRetries(mockMonitorHttp, {
+        retries: "Retries must be between 0 and 10",
+      });
+
+      const error = wrapper.find(
+        '[data-test="synthetics-check-retries-error"]',
+      );
+      expect(error.exists()).toBe(true);
+      expect(error.text()).toBe("Retries must be between 0 and 10");
+    });
+  });
+});

--- a/web/src/components/synthetics/configure/CheckRetries.vue
+++ b/web/src/components/synthetics/configure/CheckRetries.vue
@@ -22,11 +22,6 @@ const retryDelayMs = computed({
   get: () => props.check.waitBeforeRetrySecs ?? 0,
   set: (v: string | number) => emit('update:check', { ...props.check, waitBeforeRetrySecs: Number(v) }),
 })
-
-const failureThreshold = computed({
-  get: () => props.check.alertIfFails ?? 1,
-  set: (v: string | number) => emit('update:check', { ...props.check, alertIfFails: Number(v) }),
-})
 </script>
 
 <template>
@@ -63,18 +58,6 @@ const failureThreshold = computed({
         />
         <span class="text-sm text-text-body whitespace-nowrap">{{ t('synthetics.scheduleAlert.retryDelaySuffix') }}</span>
       </div>
-      <div class="flex items-center gap-2 flex-nowrap">
-        <label class="text-sm font-medium text-text-body whitespace-nowrap w-32">{{ t('synthetics.scheduleAlert.alertedIfFails') }}</label>
-        <OInput
-          v-model="failureThreshold"
-          type="number"
-          class="w-25!"
-          placeholder="1"
-          data-test="synthetics-check-retries-threshold-input"
-        />
-        <span class="text-sm text-text-body whitespace-nowrap">{{ t('synthetics.scheduleAlert.alertedIfFailsSuffix') }}</span>
-      </div>
-
       <!-- Validation error -->
       <p
         v-if="props.validationErrors?.retries"

--- a/web/src/components/synthetics/configure/CheckRetries.vue
+++ b/web/src/components/synthetics/configure/CheckRetries.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+// Copyright 2026 OpenObserve Inc.
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { BrowserCheck } from '@/types/synthetics'
+import OInput from '@/lib/forms/Input/OInput.vue'
+
+const props = defineProps<{
+  check: BrowserCheck
+  validationErrors?: Record<string, string>
+}>()
+const emit = defineEmits<{ 'update:check': [value: BrowserCheck] }>()
+
+const { t } = useI18n()
+
+const retries = computed({
+  get: () => props.check.retries ?? 0,
+  set: (v: string | number) => emit('update:check', { ...props.check, retries: Number(v) }),
+})
+
+const retryDelayMs = computed({
+  get: () => props.check.waitBeforeRetrySecs ?? 0,
+  set: (v: string | number) => emit('update:check', { ...props.check, waitBeforeRetrySecs: Number(v) }),
+})
+
+const failureThreshold = computed({
+  get: () => props.check.alertIfFails ?? 1,
+  set: (v: string | number) => emit('update:check', { ...props.check, alertIfFails: Number(v) }),
+})
+</script>
+
+<template>
+  <div
+    class="rounded-default border border-border-default mb-4"
+    data-test="synthetics-check-retries"
+  >
+    <div class="flex items-center border-b border-border-default py-2.5 px-3">
+      <div class="w-[0.1875rem] h-4 rounded-default mr-2 shrink-0 bg-primary-600" />
+      <h3 class="text-base font-semibold text-text-heading">
+        {{ t('synthetics.scheduleAlert.retries') }}
+      </h3>
+    </div>
+    <div class="px-3 py-2 flex flex-col gap-3">
+      <div class="flex items-center gap-2 flex-nowrap">
+        <label class="text-sm font-medium text-text-body whitespace-nowrap w-32">{{ t('synthetics.scheduleAlert.retriesOnFailure') }}</label>
+        <OInput
+          v-model="retries"
+          type="number"
+          class="w-25!"
+          placeholder="0"
+          data-test="synthetics-check-retries-count-input"
+        />
+        <span class="text-sm text-text-body whitespace-nowrap">{{ t('synthetics.scheduleAlert.retriesOnFailureSuffix') }}</span>
+      </div>
+      <div class="flex items-center gap-2 flex-nowrap">
+        <label class="text-sm font-medium text-text-body whitespace-nowrap w-32">{{ t('synthetics.scheduleAlert.retryDelay') }}</label>
+        <OInput
+          v-model="retryDelayMs"
+          type="number"
+          class="w-25!"
+          placeholder="0"
+          data-test="synthetics-check-retries-delay-input"
+        />
+        <span class="text-sm text-text-body whitespace-nowrap">{{ t('synthetics.scheduleAlert.retryDelaySuffix') }}</span>
+      </div>
+      <div class="flex items-center gap-2 flex-nowrap">
+        <label class="text-sm font-medium text-text-body whitespace-nowrap w-32">{{ t('synthetics.scheduleAlert.alertedIfFails') }}</label>
+        <OInput
+          v-model="failureThreshold"
+          type="number"
+          class="w-25!"
+          placeholder="1"
+          data-test="synthetics-check-retries-threshold-input"
+        />
+        <span class="text-sm text-text-body whitespace-nowrap">{{ t('synthetics.scheduleAlert.alertedIfFailsSuffix') }}</span>
+      </div>
+
+      <!-- Validation error -->
+      <p
+        v-if="props.validationErrors?.retries"
+        class="text-xs text-status-error-text"
+        data-test="synthetics-check-retries-error"
+      >
+        {{ props.validationErrors.retries }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/web/src/components/synthetics/configure/CheckRetries.vue
+++ b/web/src/components/synthetics/configure/CheckRetries.vue
@@ -30,7 +30,7 @@ const retryDelayMs = computed({
     data-test="synthetics-check-retries"
   >
     <div class="flex items-center border-b border-border-default py-2.5 px-3">
-      <div class="w-[0.1875rem] h-4 rounded-default mr-2 shrink-0 bg-primary-600" />
+      <div class="w-0.75 h-4 rounded-default mr-2 shrink-0 bg-accent" />
       <h3 class="text-base font-semibold text-text-heading">
         {{ t('synthetics.scheduleAlert.retries') }}
       </h3>

--- a/web/src/components/synthetics/configure/CheckSchedule.vue
+++ b/web/src/components/synthetics/configure/CheckSchedule.vue
@@ -12,7 +12,10 @@ import OTooltip from '@/lib/overlay/Tooltip/OTooltip.vue'
 import ODate from '@/lib/forms/Date/ODate.vue'
 import OTime from '@/lib/forms/Time/OTime.vue'
 
-const props = defineProps<{ check: BrowserCheck }>()
+const props = defineProps<{
+  check: BrowserCheck;
+  validationErrors?: Record<string, string>;
+}>();
 const emit = defineEmits<{ 'update:check': [value: BrowserCheck] }>()
 
 const { t } = useI18n()
@@ -264,6 +267,15 @@ const startTime = computed({
           data-test="synthetics-check-schedule-custom-interval-unit-select"
         />
       </div>
+
+      <!-- Validation error -->
+      <p
+        v-if="props.validationErrors?.schedule"
+        class="text-xs text-status-error-text"
+        data-test="synthetics-check-schedule-error"
+      >
+        {{ props.validationErrors.schedule }}
+      </p>
 
       <!-- Schedule Later date/time pickers -->
       <div v-if="startType === 'later' && check.schedule.type !== 'cron'" class="flex items-start gap-3 flex-wrap">

--- a/web/src/components/synthetics/journey/BrowserJourney.spec.ts
+++ b/web/src/components/synthetics/journey/BrowserJourney.spec.ts
@@ -15,6 +15,7 @@ const OIconStub = { template: '<i />' }
 const OBadgeStub = { template: '<span><slot /></span>' }
 const OInputStub = {
   props: ['modelValue'],
+  emits: ['update:modelValue'],
   template: '<input v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
 }
 const JourneyStepsStub = {
@@ -22,8 +23,37 @@ const JourneyStepsStub = {
   template: '<div class="journey-steps-stub" :data-test-multi="$attrs[\'data-test\']"><div v-for="item in data" :key="item.id" class="step-row">{{ item.name }}</div></div>',
 }
 
+// Stub that renders the expansion slot so inline-editor interactions (selector,
+// value, timeout inputs) can be tested through the DOM.
+const JourneyStepsStubWithExpansion = {
+  props: ['data', 'mode', 'selectedIds', 'expandedIds', 'selectionEnabled', 'locked', 'readonly'],
+  template: `
+    <div class="journey-steps-stub" :data-test-multi="$attrs['data-test']">
+      <div v-for="item in data" :key="item.id" class="step-row">
+        {{ item.name }}
+        <slot name="expansion" :row="item" />
+      </div>
+    </div>`,
+}
+
 const ConfirmDialogStub = {
   template: '<div class="confirm-dialog-stub" />',
+}
+
+// Minimal stubs for components used in the expansion slot and toolbar.
+const OSelectStub = {
+  props: ['modelValue', 'options', 'label', 'error', 'errorMessage'],
+  emits: ['update:modelValue'],
+  template: '<select v-bind="$attrs" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="opt in options" :key="opt.value" :value="opt.value">{{ opt.label }}</option></select>',
+}
+const OTooltipStub = {
+  props: ['content'],
+  template: '<span class="tooltip-stub" />',
+}
+const OCheckboxStub = {
+  props: ['modelValue', 'size', 'class'],
+  emits: ['update:modelValue'],
+  template: '<input type="checkbox" v-bind="$attrs" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
 }
 
 const STUBS = {
@@ -33,6 +63,9 @@ const STUBS = {
   OInput: OInputStub,
   JourneySteps: JourneyStepsStub,
   ConfirmDialog: ConfirmDialogStub,
+  OSelect: OSelectStub,
+  OTooltip: OTooltipStub,
+  OCheckbox: OCheckboxStub,
 }
 
 interface FakePort {
@@ -150,5 +183,40 @@ describe('BrowserJourney recording', () => {
 
     expect((globalThis as any).chrome.runtime.connect).toHaveBeenCalled()
     expect(wrapper.find('[data-test="synthetics-journey-stop-btn"]').exists()).toBe(true)
+  })
+
+  it('should sync selector edit into step.wire when handleStepUpdate fires', async () => {
+    const wire = { id: 'w1', action: 'click', selector: '#old', name: 'Old Click', selector_type: 'css' }
+    const step = { id: 's1', action: 'click', name: 'Old Click', selector: '#old', timeout: 30000, code: '', wire }
+
+    wrapper = mount(BrowserJourney, {
+      props: { modelValue: [step] },
+      global: {
+        stubs: { ...STUBS, JourneySteps: JourneyStepsStubWithExpansion },
+      },
+    })
+
+    // The expansion slot renders an OInput for the selector with
+    // data-test="synthetics-journey-step-selector-input". Update its value.
+    const selectorInput = wrapper.find('[data-test="synthetics-journey-step-selector-input"]')
+    await selectorInput.setValue('#new')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    const updatedSteps = emitted![emitted!.length - 1][0] as any[]
+    expect(updatedSteps[0].selector).toBe('#new')
+    expect(updatedSteps[0].wire.selector).toBe('#new')
+  })
+
+  it('should emit clear-results when modelValue becomes empty', async () => {
+    wrapper = mountJourney({
+      modelValue: [{ id: 's1', action: 'click', name: 'Step 1', code: '' }],
+    })
+
+    // Clearing all steps should trigger the length watcher to emit clear-results
+    // so the replay pass/fail banner does not persist.
+    await wrapper.setProps({ modelValue: [] })
+
+    expect(wrapper.emitted('clear-results')).toBeTruthy()
   })
 })

--- a/web/src/components/synthetics/journey/BrowserJourney.vue
+++ b/web/src/components/synthetics/journey/BrowserJourney.vue
@@ -2,7 +2,7 @@
 // Copyright 2026 OpenObserve Inc.
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { BrowserStep, ReplayPhase, StepReplayResult } from '@/types/synthetics'
+import type { BrowserStep, ReplayPhase, StepReplayResult, WireStep } from '@/types/synthetics'
 import type { StepDotState } from './JourneySteps.vue'
 import useSyntheticsRecorder from '@/composables/useSyntheticsRecorder'
 import { getUUIDv7 } from '@/utils/zincutils'
@@ -431,7 +431,21 @@ function handleStepUpdate(row: BrowserStep, patch: Partial<BrowserStep>) {
   const idx = findIndex(row)
   if (idx < 0) return
   const next = [...props.modelValue]
-  next[idx] = { ...next[idx], ...patch }
+
+  // Sync edits into the recorded wire step so the API receives the updated
+  // values. journeyToWireSteps prefers wire over UI fields, so without this
+  // sync, edits to recorded steps are silently discarded on save.
+  let wire = next[idx].wire ? { ...next[idx].wire } : undefined
+  if (wire) {
+    if (patch.name !== undefined) wire.name = patch.name
+    if (patch.selector !== undefined) wire.selector = patch.selector
+    if (patch.selectorType !== undefined) wire.selector_type = patch.selectorType.toLowerCase() as WireStep['selector_type']
+    if (patch.value !== undefined) wire.value = patch.value
+    if (patch.timeout !== undefined) wire.timeout_ms = patch.timeout
+    if (patch.action !== undefined) wire = undefined // action changed → wire metadata is no longer accurate
+  }
+
+  next[idx] = { ...next[idx], wire, ...patch }
   emit('update:modelValue', next)
 }
 

--- a/web/src/components/synthetics/journey/BrowserJourney.vue
+++ b/web/src/components/synthetics/journey/BrowserJourney.vue
@@ -137,8 +137,13 @@ function deleteSelectedSteps() {
   selectedStepIds.value = []
 }
 
-// Clear selection when the step list changes, filter changes, or replay starts
-watch(() => props.modelValue.length, () => { selectedStepIds.value = [] })
+// Clear selection when the step list changes, filter changes, or replay starts.
+// Also clear replay banner when all steps are deleted so stale pass/fail banners
+// don't linger after the user removes every step.
+watch(() => props.modelValue.length, (newLen) => {
+  selectedStepIds.value = []
+  if (newLen === 0) emit('clear-results')
+})
 watch(filterQuery, () => { selectedStepIds.value = [] })
 watch(() => props.replayPhase, (phase) => {
   if (phase === 'running') {

--- a/web/src/components/synthetics/results/ProtocolRunSummary.vue
+++ b/web/src/components/synthetics/results/ProtocolRunSummary.vue
@@ -172,7 +172,7 @@ const showAssertions = computed(
       :subtitle="run ? fmtTs(run.timestamp) : ''"
       :back="{
         label: t('synthetics.results.monitors'),
-        to: { name: 'synthetic-monitor-results', params: { id: monitorId } },
+        to: { name: 'synthetics-monitor-results', params: { id: monitorId } },
         dataTest: 'synthetics-protocol-run-back-btn',
       }"
     >

--- a/web/src/composables/shared/useEnterpriseRoutes.spec.ts
+++ b/web/src/composables/shared/useEnterpriseRoutes.spec.ts
@@ -385,7 +385,7 @@ describe("useEnterpriseRoutes.ts", () => {
       expect(iamRoute.children.length).toBe(11);
     });
 
-    // Test 34: Should have 10 routes in cloud configuration (iam + synthetic + 4 synthetic sub-routes + 2 incident routes + actions + workflows)
+    // Test 34: iam + 5 synthetics + actions + 2 incidents + workflows = 10
     it("should have 10 routes in cloud configuration", () => {
       const routes = useEnterpriseRoutes();
       expect(routes.length).toBe(10);
@@ -415,7 +415,7 @@ describe("useEnterpriseRoutes.ts", () => {
       expect(iamRoute.children.length).toBe(10);
     });
 
-    // Test 37: Should have 10 routes in enterprise configuration
+    // Test 37: iam + 5 synthetics + actions + 2 incidents + workflows = 10
     it("should have enterprise routes structure", () => {
       const routes = useEnterpriseRoutes();
       expect(routes.length).toBe(10);

--- a/web/src/composables/shared/useEnterpriseRoutes.ts
+++ b/web/src/composables/shared/useEnterpriseRoutes.ts
@@ -182,10 +182,19 @@ const useEnterpriseRoutes = () => {
 
     routes.push(
       {
-        path: "synthetics/new",
-        name: "synthetics-new",
+        path: "synthetics/add",
+        name: "synthetics-add",
         component: () => import("@/views/synthetics/CreateCheck.vue"),
-        meta: { title: "New Check" },
+        meta: { title: "Add Check" },
+        beforeEnter(to: any, from: any, next: any) {
+          syntheticsRouteGuard(to, from, next);
+        },
+      },
+      {
+        path: "synthetics/edit/:id",
+        name: "synthetics-edit",
+        component: () => import("@/views/synthetics/CreateCheck.vue"),
+        meta: { title: "Edit Check" },
         beforeEnter(to: any, from: any, next: any) {
           syntheticsRouteGuard(to, from, next);
         },

--- a/web/src/composables/shared/useEnterpriseRoutes.ts
+++ b/web/src/composables/shared/useEnterpriseRoutes.ts
@@ -174,7 +174,7 @@ const useEnterpriseRoutes = () => {
       path: "synthetic",
       name: "synthetic",
       component: () => import("@/views/SyntheticMonitoring.vue"),
-      meta: { title: "Synthetic Monitoring" },
+      meta: { title: "Synthetics" },
       beforeEnter(to: any, from: any, next: any) {
         syntheticsRouteGuard(to, from, next);
       },

--- a/web/src/composables/shared/useEnterpriseRoutes.ts
+++ b/web/src/composables/shared/useEnterpriseRoutes.ts
@@ -171,8 +171,8 @@ const useEnterpriseRoutes = () => {
     });
 
     routes.push({
-      path: "synthetic",
-      name: "synthetic",
+      path: "synthetics",
+      name: "synthetics",
       component: () => import("@/views/SyntheticMonitoring.vue"),
       meta: { title: "Synthetics" },
       beforeEnter(to: any, from: any, next: any) {
@@ -182,8 +182,8 @@ const useEnterpriseRoutes = () => {
 
     routes.push(
       {
-        path: "synthetic/new",
-        name: "synthetic-new",
+        path: "synthetics/new",
+        name: "synthetics-new",
         component: () => import("@/views/synthetics/CreateCheck.vue"),
         meta: { title: "New Check" },
         beforeEnter(to: any, from: any, next: any) {
@@ -209,8 +209,8 @@ const useEnterpriseRoutes = () => {
         },
       },
       {
-        path: "synthetic/:id/results/run/:runId/:executionId",
-        name: "synthetic-run-detail",
+        path: "synthetics/:id/results/run/:runId/:executionId",
+        name: "synthetics-run-detail",
         component: () => import("@/views/synthetics/RunDetail.vue"),
         meta: { title: "Run Detail" },
         beforeEnter(to: any, from: any, next: any) {

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -711,7 +711,7 @@ export default defineComponent({
 
     const updateSyntheticMenu = () => {
       const existingIndex = linksList.value.findIndex(
-        (l: any) => l.name === "synthetic",
+        (l: any) => l.name === "synthetics",
       );
 
       if (!isSyntheticsEnabled.value) {
@@ -736,8 +736,8 @@ export default defineComponent({
       linksList.value.splice(insertAt, 0, {
         title: t("menu.synthetic"),
         icon: "radar",
-        link: "/synthetic",
-        name: "synthetic",
+        link: "/synthetics",
+        name: "synthetics",
       });
     };
 

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -900,7 +900,7 @@
     "language": "Language",
     "actions": "Actions",
     "keyboardShortcuts": "Keyboard Shortcuts",
-    "synthetic": "Synthetic"
+    "synthetic": "Synthetics"
   },
   "rum": {
     "title": "Real User Monitoring",
@@ -9517,7 +9517,7 @@
       "willBeCreatedIn": "Will be created in"
     },
     "pageSubtitle": "Proactively monitor uptime, performance, and user journeys from global locations",
-    "pageTitle": "Synthetic Checks",
+    "pageTitle": "Synthetics",
     "protocolConfig": {
       "http": {
         "addAssertion": "Add assertion",

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -10009,7 +10009,9 @@
         "checkName": "Name",
         "noChecks": "No checks are assigned to this location yet.",
         "notFound": "Location not found"
-      }
+      },
+      "urlRequired": "Starting URL is required",
+      "fixHighlightedFields": "Fix the highlighted fields before saving"
     }
   },
   "shortcuts": {

--- a/web/src/utils/synthetics/mapRecordedStep.spec.ts
+++ b/web/src/utils/synthetics/mapRecordedStep.spec.ts
@@ -76,19 +76,24 @@ describe('mapRecordedStep', () => {
       expect(buildWireFromStep(lean({ action: 'assert', selector: '.h', value: 'Welcome' }))).toMatchObject({ action: 'assert', text: 'Welcome' })
     })
 
-    it.each(['hover', 'scroll', 'wait', 'screenshot'] as const)('should return null for unsupported action %s', (action) => {
-      expect(buildWireFromStep(lean({ action }))).toBeNull()
+    it.each(['hover', 'scroll', 'wait', 'screenshot'] as const)('should return a valid wire for action %s (previously null)', (action) => {
+      const wire = buildWireFromStep(lean({ action }))
+      expect(wire).not.toBeNull()
+      expect(wire!.action).toBe(action)
     })
   })
 
-  it('should prefer the recorded wire and reverse-map manual steps in journeyToWireSteps', () => {
+  it('should include all steps via journeyToWireSteps (including previously filtered actions)', () => {
     const recorded = mapWireStep({ id: 's1', action: 'navigate', url: 'https://x.test' })
     const manual: BrowserStep = { id: 'm1', action: 'click', selector: '#go', timeout: 30000, code: '' }
-    const unsupported: BrowserStep = { id: 'm2', action: 'wait', timeout: 30000, code: '' }
+    const waitStep: BrowserStep = { id: 'm2', action: 'wait', timeout: 30000, code: '' }
+    const hoverStep: BrowserStep = { id: 'm3', action: 'hover', selector: '.el', timeout: 30000, code: '' }
 
-    const wires = journeyToWireSteps([recorded, manual, unsupported])
-    expect(wires).toHaveLength(2) // recorded + manual click; wait dropped
+    const wires = journeyToWireSteps([recorded, manual, waitStep, hoverStep])
+    expect(wires).toHaveLength(4) // all steps included — no drop on buildWireFromStep
     expect(wires[0]).toBe(recorded.wire) // recorded preserved verbatim
+    expect(wires[2]).toMatchObject({ action: 'wait' })
+    expect(wires[3]).toMatchObject({ action: 'hover', selector: '.el' })
     expect(wires[1]).toMatchObject({ action: 'click', selector: '#go' })
   })
 

--- a/web/src/utils/synthetics/mapRecordedStep.ts
+++ b/web/src/utils/synthetics/mapRecordedStep.ts
@@ -127,9 +127,18 @@ export function buildWireFromStep(step: BrowserStep): WireStep | null {
       return step.value !== undefined && step.value !== ''
         ? { ...base, text: step.value }
         : base
+    case 'hover':
+      return base
+    case 'scroll':
+      return { ...base, value: step.value }
+    case 'wait':
+      return { ...base, value: step.value }
+    case 'screenshot':
+      return base
     default:
-      // hover / scroll / wait / screenshot — not supported by the player.
-      return null
+      // Should never reach here — StepAction is a closed union.
+      console.warn(`[synthetics] unknown action "${step.action}", defaulting to click`)
+      return { ...base, action: 'click' }
   }
 }
 

--- a/web/src/views/SyntheticMonitoring.vue
+++ b/web/src/views/SyntheticMonitoring.vue
@@ -539,7 +539,7 @@ const openDetail = (monitor: any) => {
   const query: Record<string, string> = { name: monitor.name, folder: monitor.folder_name }
   if (monitor.lastTriggeredAt > 0) query.last_triggered_at = String(monitor.lastTriggeredAt)
   router.push({
-    name: 'synthetic-monitor-results',
+    name: 'synthetics-monitor-results',
     params: { id: String(monitor.id) },
     query,
   });
@@ -799,7 +799,7 @@ const onEmptyAction = (actionId: string) => {
 }
 
 const openCreate = (type: SyntheticCheckType = 'browser') =>
-  router.push({ name: 'synthetic-new', query: { folder: activeFolderId.value, type } })
+  router.push({ name: 'synthetics-new', query: { folder: activeFolderId.value, type } })
 
 const onTypeSelected = (type: SyntheticCheckType) => {
   showTypePicker.value = false
@@ -808,7 +808,7 @@ const onTypeSelected = (type: SyntheticCheckType) => {
 
 const openEdit = (m: any) => {
   router.push({
-    name: 'synthetic-new',
+    name: 'synthetics-new',
     query: { edit: String(m.id), folder: activeFolderId.value },
   })
 }

--- a/web/src/views/SyntheticMonitoring.vue
+++ b/web/src/views/SyntheticMonitoring.vue
@@ -425,12 +425,6 @@ async function initPage() {
 
   // Load locations after monitors — not critical for initial render.
   loadLocations()
-
-  const editId = route.query.edit
-  if (typeof editId === 'string' && editId) {
-    const monitor = monitors.value.find((m) => String(m.id) === editId)
-    if (monitor) openEdit(monitor)
-  }
 }
 
 onMounted(() => {
@@ -799,7 +793,7 @@ const onEmptyAction = (actionId: string) => {
 }
 
 const openCreate = (type: SyntheticCheckType = 'browser') =>
-  router.push({ name: 'synthetics-new', query: { folder: activeFolderId.value, type } })
+  router.push({ name: 'synthetics-add', query: { folder: activeFolderId.value, type } })
 
 const onTypeSelected = (type: SyntheticCheckType) => {
   showTypePicker.value = false
@@ -808,8 +802,9 @@ const onTypeSelected = (type: SyntheticCheckType) => {
 
 const openEdit = (m: any) => {
   router.push({
-    name: 'synthetics-new',
-    query: { edit: String(m.id), folder: activeFolderId.value },
+    name: 'synthetics-edit',
+    params: { id: String(m.id) },
+    query: { folder: activeFolderId.value },
   })
 }
 

--- a/web/src/views/synthetics/CreateBrowserTest.spec.ts
+++ b/web/src/views/synthetics/CreateBrowserTest.spec.ts
@@ -28,6 +28,7 @@ const {
   mockServiceUpdate,
   mockServiceGet,
   mockRouterPush,
+  mockToast,
 } = vi.hoisted(() => ({
   mockServiceGetLocations: vi.fn().mockResolvedValue({
     data: { locations: [], browsers: [], devices: [] },
@@ -36,6 +37,7 @@ const {
   mockServiceUpdate: vi.fn().mockResolvedValue({}),
   mockServiceGet: vi.fn().mockResolvedValue({ data: {} }),
   mockRouterPush: vi.fn(),
+  mockToast: vi.fn(() => vi.fn()),
 }));
 
 vi.mock("vue-router", () => ({
@@ -84,7 +86,7 @@ vi.mock("@/utils/commons", () => ({
 }));
 
 vi.mock("@/lib/feedback/Toast/useToast", () => ({
-  toast: vi.fn(() => vi.fn()),
+  toast: mockToast,
 }));
 
 vi.mock("@/utils/synthetics/buildPayload", () => ({
@@ -108,7 +110,7 @@ vi.mock(
         }),
       makeBrowserCheckSaveSchema: (t: any) =>
         z.object({
-          name: z.string().optional(),
+          name: z.string().min(1, "Name is required"),
           url: z.string().optional(),
           locations: z.array(z.any()).optional(),
           journey: z.array(z.any()).optional(),
@@ -206,12 +208,21 @@ const baseStubs = {
   },
 };
 
-function mountPage() {
+// ── Missing component stubs required by OPageLayout ──────────────────────
+const pageLayoutStubs = {
+  OPageLayout: {
+    template: '<div><slot /></div>',
+    props: ["title", "subtitle", "back", "class", "bleed"],
+  },
+};
+
+function mountPage(props: Record<string, unknown> = {}) {
   return mount(CreateBrowserTest, {
     global: {
       plugins: [i18n, store],
-      stubs: baseStubs,
+      stubs: { ...baseStubs, ...pageLayoutStubs },
     },
+    props,
   });
 }
 
@@ -290,6 +301,104 @@ describe("CreateBrowserTest", () => {
       expect(
         wrapper.find('[data-test="synthetics-setup-recheck-btn"]').exists(),
       ).toBe(true);
+    });
+  });
+
+  describe("edit mode", () => {
+    it("should call syntheticsService.get when editId prop is provided", async () => {
+      wrapper = mountPage({ editId: "check-123" });
+      await flushPromises();
+
+      expect(mockServiceGet).toHaveBeenCalledWith("default", "check-123");
+    });
+
+    it("should NOT call syntheticsService.get when editId prop is not provided", async () => {
+      wrapper = mountPage();
+      await flushPromises();
+
+      expect(mockServiceGet).not.toHaveBeenCalled();
+    });
+
+    it("should render 'Update Check' button in Journey step footer when editId is set", async () => {
+      mockServiceGet.mockResolvedValue({
+        data: { name: "Test Check", url: "https://example.com", journey: [] },
+      });
+
+      wrapper = mountPage({ editId: "check-123" });
+      await flushPromises();
+
+      expect(
+        wrapper.find('[data-test="synthetics-create-save-from-journey-btn"]').exists(),
+      ).toBe(true);
+    });
+
+    it("should NOT render 'Update Check' button when editId is not set, even in editor phase", async () => {
+      wrapper = mountPage();
+      await flushPromises();
+
+      // Navigate to editor phase via Build Manually
+      const urlInput = wrapper.find('[data-test="synthetics-create-url-input"]');
+      await urlInput.setValue("https://example.com");
+
+      const buildBtn = wrapper.find('[data-test="synthetics-create-build-btn"]');
+      await buildBtn.trigger("click");
+      await flushPromises();
+
+      // We are now in the editor phase on step 1 — verify footer buttons
+      // Continue and Cancel should be present
+      expect(
+        wrapper.find('[data-test="synthetics-create-continue-btn"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-test="synthetics-create-cancel-btn"]').exists(),
+      ).toBe(true);
+      // Update Check button should NOT appear (no editId)
+      expect(
+        wrapper.find('[data-test="synthetics-create-save-from-journey-btn"]').exists(),
+      ).toBe(false);
+    });
+  });
+
+  describe("validation", () => {
+    it("should show error toast when saving with an empty name", async () => {
+      // Mount in edit mode so the Journey footer save button is rendered.
+      // The save schema requires name to be non-empty — the check starts
+      // with an empty name, so the first save attempt must fail validation.
+      mockServiceGet.mockResolvedValue({
+        data: { name: "", url: "https://example.com", journey: [] },
+      });
+
+      wrapper = mountPage({ editId: "check-123" });
+      await flushPromises();
+
+      const saveBtn = wrapper.find('[data-test="synthetics-create-save-from-journey-btn"]');
+      expect(saveBtn.exists()).toBe(true);
+
+      await saveBtn.trigger("click");
+      await flushPromises();
+
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "error",
+        }),
+      );
+    });
+
+    it("should NOT call create or update services when validation fails", async () => {
+      mockServiceGet.mockResolvedValue({
+        data: { name: "", url: "https://example.com", journey: [] },
+      });
+
+      wrapper = mountPage({ editId: "check-123" });
+      await flushPromises();
+
+      const saveBtn = wrapper.find('[data-test="synthetics-create-save-from-journey-btn"]');
+      await saveBtn.trigger("click");
+      await flushPromises();
+
+      // Validation should fail before any API call
+      expect(mockServiceCreate).not.toHaveBeenCalled();
+      expect(mockServiceUpdate).not.toHaveBeenCalled();
     });
   });
 });

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -395,14 +395,14 @@ async function saveCheck() {
       dismiss()
       toast({ variant: 'success', message: t('synthetics.newCheck.updated') })
       isDirty.value = false
-      router.push({ name: 'synthetic', query: { folder: check.value.folder } })
+      router.push({ name: 'synthetics', query: { folder: check.value.folder } })
     } else {
       const res = await syntheticsService.create(org, apiPayload.value, check.value.folder)
       const savedId = res.data?.id ?? crypto.randomUUID()
       dismiss()
       toast({ variant: 'success', message: t('synthetics.newCheck.saved') })
       isDirty.value = false
-      router.push({ name: 'synthetic', query: { folder: check.value.folder } })
+      router.push({ name: 'synthetics', query: { folder: check.value.folder } })
     }
   } catch (err: any) {
     dismiss()
@@ -482,7 +482,7 @@ function onClearResults() {
     class="bg-surface-base"
     :title="headerTitle"
     :subtitle="folderName"
-    :back="{ label: t('synthetics.newCheck.back'), to: { name: 'synthetic' }, dataTest: 'synthetics-create-back-btn' }"
+    :back="{ label: t('synthetics.newCheck.back'), to: { name: 'synthetics' }, dataTest: 'synthetics-create-back-btn' }"
     bleed
   >
 
@@ -758,7 +758,7 @@ function onClearResults() {
           </template>
           <span class="flex-1" aria-hidden="true" />
 
-          <OButton variant="ghost" size="sm" data-test="synthetics-create-cancel-btn" @click="router.push({ name: 'synthetic' })">
+          <OButton variant="ghost" size="sm" data-test="synthetics-create-cancel-btn" @click="router.push({ name: 'synthetics' })">
             {{ t('common.cancel') }}
           </OButton>
           <OButton variant="outline" size="sm" data-test="synthetics-create-continue-btn" @click="onContinueToConfigure">
@@ -781,7 +781,7 @@ function onClearResults() {
         <!-- Configure step: Cancel | Back + Save -->
         <template v-else-if="currentStep === 2">
           <span class="flex-1" aria-hidden="true" />
-          <OButton variant="ghost" size="sm" data-test="synthetics-create-cancel-btn" @click="router.push({ name: 'synthetic' })">
+          <OButton variant="ghost" size="sm" data-test="synthetics-create-cancel-btn" @click="router.push({ name: 'synthetics' })">
             {{ t('common.cancel') }}
           </OButton>
           <OButton variant="outline" size="sm" data-test="synthetics-create-back-to-journey-btn" @click="currentStep = 1">

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -378,6 +378,10 @@ async function saveCheck() {
       currentStep.value = 1
       journeyRef.value?.validateStepSelectors?.()
     }
+    toast({
+      variant: 'error',
+      message: t('synthetics.validation.fixHighlightedFields'),
+    })
     return
   }
 

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -757,9 +757,20 @@ function onClearResults() {
           <OButton variant="ghost" size="sm" data-test="synthetics-create-cancel-btn" @click="router.push({ name: 'synthetic' })">
             {{ t('common.cancel') }}
           </OButton>
-          <OButton variant="primary" size="sm" data-test="synthetics-create-continue-btn" @click="onContinueToConfigure">
+          <OButton variant="outline" size="sm" data-test="synthetics-create-continue-btn" @click="onContinueToConfigure">
             {{ t('synthetics.createBrowserTest.continue') }}
             <template #suffix><OIcon name="chevron-right" size="sm" /></template>
+          </OButton>
+          <OButton
+            v-if="editId"
+            variant="primary"
+            size="sm"
+            :loading="isSaving"
+            data-test="synthetics-create-save-from-journey-btn"
+            @click="saveCheck"
+          >
+            {{ t('synthetics.newCheck.updateCheck') }}
+            <template #suffix><OIcon name="save" size="sm" /></template>
           </OButton>
         </template>
 

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -68,7 +68,7 @@ const currentStep = ref(1)
 const journeyStepDone = ref(false)
 const checkName = ref('')
 const startUrl = ref('')
-const editId = ref<string | null>(null)
+const props = defineProps<{ editId?: string | null }>()
 const isLoadingEdit = ref(false)
 const loadError = ref(false)
 const urlError = ref('')
@@ -149,7 +149,6 @@ async function fetchDestinations() {
 async function loadForEdit(id: string) {
   isLoadingEdit.value = true
   loadError.value = false
-  editId.value = id
   phase.value = 'editor'
   try {
     const org = store.state.selectedOrganization.identifier
@@ -176,8 +175,8 @@ async function loadForEdit(id: string) {
 
 function onLoadRetry(actionId?: string) {
   if (!actionId) return;
-  if (actionId === 'retry' && editId.value) {
-    loadForEdit(editId.value)
+  if (actionId === 'retry' && props.editId) {
+    loadForEdit(props.editId)
   }
 }
 
@@ -191,9 +190,8 @@ onMounted(() => {
   fetchLocations()
   fetchDestinations()
 
-  const editQueryId = route.query.edit
-  if (typeof editQueryId === 'string' && editQueryId) {
-    loadForEdit(editQueryId).catch(console.error)
+  if (props.editId) {
+    loadForEdit(props.editId).catch(console.error)
   } else {
     // Preselect the folder the user came from (New Monitor within a folder).
     const folderQuery = route.query.folder
@@ -390,8 +388,8 @@ async function saveCheck() {
   const dismiss = toast({ variant: 'loading', message: t('synthetics.newCheck.saving'), timeout: 0 })
   try {
     const org = store.state.selectedOrganization.identifier
-    if (editId.value) {
-      await syntheticsService.update(org, editId.value, apiPayload.value, check.value.folder)
+    if (props.editId) {
+      await syntheticsService.update(org, props.editId, apiPayload.value, check.value.folder)
       dismiss()
       toast({ variant: 'success', message: t('synthetics.newCheck.updated') })
       isDirty.value = false
@@ -766,7 +764,7 @@ function onClearResults() {
             <template #suffix><OIcon name="chevron-right" size="sm" /></template>
           </OButton>
           <OButton
-            v-if="editId"
+            v-if="props.editId"
             variant="primary"
             size="sm"
             :loading="isSaving"
@@ -789,7 +787,7 @@ function onClearResults() {
             {{ t('common.goBack') }}
           </OButton>
           <OButton variant="primary" size="sm" :loading="isSaving" data-test="synthetics-create-save-btn" @click="saveCheck">
-            {{ editId ? t('synthetics.newCheck.updateCheck') : t('synthetics.newCheck.saveCheck') }}
+            {{ props.editId ? t('synthetics.newCheck.updateCheck') : t('synthetics.newCheck.saveCheck') }}
             <template #suffix><OIcon name="save" size="sm" /></template>
           </OButton>
         </template>

--- a/web/src/views/synthetics/CreateCheck.spec.ts
+++ b/web/src/views/synthetics/CreateCheck.spec.ts
@@ -21,9 +21,10 @@ import i18n from "@/locales";
 
 const mockPush = vi.fn();
 const mockRouteQuery: Record<string, string | string[] | undefined> = {};
+const mockRouteParams: Record<string, string | string[] | undefined> = {};
 
 vi.mock("vue-router", () => ({
-  useRoute: () => ({ query: mockRouteQuery }),
+  useRoute: () => ({ query: mockRouteQuery, params: mockRouteParams }),
   useRouter: () => ({ push: mockPush }),
   RouterLink: { name: "RouterLinkStub", template: "<a><slot /></a>" },
 }));
@@ -92,8 +93,9 @@ describe("CreateCheck", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset route query
+    // Reset route state
     Object.keys(mockRouteQuery).forEach((k) => delete mockRouteQuery[k]);
+    Object.keys(mockRouteParams).forEach((k) => delete mockRouteParams[k]);
   });
 
   afterEach(() => {
@@ -193,7 +195,7 @@ describe("CreateCheck", () => {
 
   describe("edit mode", () => {
     it("should show skeleton while resolving the type (before service responds)", () => {
-      mockRouteQuery.edit = "mon-http-1";
+      mockRouteParams.id = "mon-http-1";
       // Don't await — check the immediate render before the promise resolves
       wrapper = makeWrapper();
 
@@ -203,7 +205,7 @@ describe("CreateCheck", () => {
     });
 
     it("should render CreateProtocolCheck after resolving edit monitor type from API", async () => {
-      mockRouteQuery.edit = "mon-tcp-1";
+      mockRouteParams.id = "mon-tcp-1";
       vi.mocked(mockedService.get).mockResolvedValueOnce({
         data: { type: "tcp", name: "TCP Monitor", id: "mon-tcp-1" },
       });
@@ -225,7 +227,7 @@ describe("CreateCheck", () => {
     });
 
     it("should default to CreateBrowserTest when edit monitor has an unknown type", async () => {
-      mockRouteQuery.edit = "mon-unknown-1";
+      mockRouteParams.id = "mon-unknown-1";
       vi.mocked(mockedService.get).mockResolvedValueOnce({
         data: { type: "bizarre-type", name: "Unknown Monitor", id: "mon-unknown-1" },
       });
@@ -239,7 +241,7 @@ describe("CreateCheck", () => {
     });
 
     it("should default to CreateBrowserTest when the API call fails", async () => {
-      mockRouteQuery.edit = "mon-non-existent";
+      mockRouteParams.id = "mon-non-existent";
       vi.mocked(mockedService.get).mockRejectedValueOnce(new Error("Not found"));
 
       wrapper = makeWrapper();
@@ -252,7 +254,7 @@ describe("CreateCheck", () => {
     });
 
     it("should pass edit-id to CreateProtocolCheck when resolving a protocol monitor", async () => {
-      mockRouteQuery.edit = "proto-http-1";
+      mockRouteParams.id = "proto-http-1";
       vi.mocked(mockedService.get).mockResolvedValueOnce({
         data: { type: "http", name: "HTTP Monitor", id: "proto-http-1" },
       });

--- a/web/src/views/synthetics/CreateCheck.vue
+++ b/web/src/views/synthetics/CreateCheck.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 // Copyright 2026 OpenObserve Inc.
 //
-// Router view for `synthetic-new`. Dispatches on `?type=` (create) or the
-// fetched monitor's type (`?edit=`) — the browser flow keeps its dedicated
-// journey/configure view; protocol checks (http/tcp/tls/ssh) share the
+// Router view for `synthetics-add` and `synthetics-edit/:id`. Dispatches on
+// `?type=` (create) or the route param `:id` (edit) — the browser flow keeps
+// its dedicated journey/configure view; protocol checks share the
 // configure-only page.
 import { computed, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
@@ -18,7 +18,7 @@ const route = useRoute()
 const store = useStore()
 
 const editId = computed(() =>
-  typeof route.query.edit === 'string' && route.query.edit ? route.query.edit : undefined,
+  typeof route.params.id === 'string' && route.params.id ? route.params.id : undefined,
 )
 
 // Create: type comes from the query. Edit: type comes from the stored monitor,
@@ -47,7 +47,7 @@ onMounted(async () => {
 
 <template>
   <CreateBrowserTestSkeleton v-if="resolvedType === null" :rows="10" />
-  <CreateBrowserTest v-else-if="resolvedType === 'browser'" />
+  <CreateBrowserTest v-else-if="resolvedType === 'browser'" :edit-id="editId" />
   <CreateProtocolCheck
     v-else
     :key="resolvedType"

--- a/web/src/views/synthetics/CreateProtocolCheck.vue
+++ b/web/src/views/synthetics/CreateProtocolCheck.vue
@@ -226,7 +226,7 @@ async function saveCheck() {
       toast({ variant: 'success', message: t('synthetics.newCheck.saved') })
     }
     isDirty.value = false
-    router.push({ name: 'synthetic', query: { folder: check.value.folder } })
+    router.push({ name: 'synthetics', query: { folder: check.value.folder } })
   } catch (err: any) {
     dismiss()
     toast({
@@ -243,7 +243,7 @@ async function saveCheck() {
 <template>
   <OPageLayout
     :title="headerTitle"
-    :back="{ label: t('synthetics.newCheck.back'), to: { name: 'synthetic' }, dataTest: 'synthetics-create-back-btn' }"
+    :back="{ label: t('synthetics.newCheck.back'), to: { name: 'synthetics' }, dataTest: 'synthetics-create-back-btn' }"
     bleed
   >
 
@@ -275,7 +275,7 @@ async function saveCheck() {
       <!-- Sticky footer -->
       <div class="flex items-center px-3 py-2.5 gap-2 border-t border-border-default shrink-0 bg-surface-base">
         <span class="flex-1" aria-hidden="true" />
-        <OButton variant="ghost" size="sm" data-test="synthetics-create-cancel-btn" @click="router.push({ name: 'synthetic' })">
+        <OButton variant="ghost" size="sm" data-test="synthetics-create-cancel-btn" @click="router.push({ name: 'synthetics' })">
           {{ t('common.cancel') }}
         </OButton>
         <OButton variant="primary" size="sm" :loading="isSaving" data-test="synthetics-create-save-btn" @click="saveCheck">

--- a/web/src/views/synthetics/MonitorResults.spec.ts
+++ b/web/src/views/synthetics/MonitorResults.spec.ts
@@ -203,7 +203,7 @@ describe("MonitorResults", () => {
       expect(editBtn.exists()).toBe(true);
     });
 
-    it("should navigate to synthetic-new with edit query on click", async () => {
+    it("should navigate to synthetics-edit with id param on click", async () => {
       wrapper = makeWrapper();
       await flushPromises();
 

--- a/web/src/views/synthetics/MonitorResults.spec.ts
+++ b/web/src/views/synthetics/MonitorResults.spec.ts
@@ -213,7 +213,7 @@ describe("MonitorResults", () => {
       await editBtn.trigger("click");
 
       expect(mockRouterPush).toHaveBeenCalledWith({
-        name: "synthetic-new",
+        name: "synthetics-new",
         query: { edit: "mon-1" },
       });
     });
@@ -308,7 +308,7 @@ describe("MonitorResults", () => {
       await editBtn.trigger("click");
 
       expect(mockRouterPush).toHaveBeenCalledWith({
-        name: "synthetic-new",
+        name: "synthetics-new",
         query: { edit: "mon-1" },
       });
     });

--- a/web/src/views/synthetics/MonitorResults.spec.ts
+++ b/web/src/views/synthetics/MonitorResults.spec.ts
@@ -213,8 +213,8 @@ describe("MonitorResults", () => {
       await editBtn.trigger("click");
 
       expect(mockRouterPush).toHaveBeenCalledWith({
-        name: "synthetics-new",
-        query: { edit: "mon-1" },
+        name: "synthetics-edit",
+        params: { id: "mon-1" },
       });
     });
   });
@@ -308,8 +308,8 @@ describe("MonitorResults", () => {
       await editBtn.trigger("click");
 
       expect(mockRouterPush).toHaveBeenCalledWith({
-        name: "synthetics-new",
-        query: { edit: "mon-1" },
+        name: "synthetics-edit",
+        params: { id: "mon-1" },
       });
     });
 

--- a/web/src/views/synthetics/MonitorResults.vue
+++ b/web/src/views/synthetics/MonitorResults.vue
@@ -336,7 +336,7 @@ function onJumpToWindow(startTime: number, endTime: number) {
 }
 
 function editMonitor() {
-  router.push({ name: "synthetics-new", query: { edit: monitorId.value } });
+  router.push({ name: "synthetics-edit", params: { id: monitorId.value } });
 }
 
 function openRunDetail(runId: string, executionId: string) {

--- a/web/src/views/synthetics/MonitorResults.vue
+++ b/web/src/views/synthetics/MonitorResults.vue
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :subtitle="folderName"
     :back="{
       label: t('synthetics.results.monitors'),
-      to: { name: 'synthetic' },
+      to: { name: 'synthetics' },
     }"
     bleed
   >
@@ -336,7 +336,7 @@ function onJumpToWindow(startTime: number, endTime: number) {
 }
 
 function editMonitor() {
-  router.push({ name: "synthetic-new", query: { edit: monitorId.value } });
+  router.push({ name: "synthetics-new", query: { edit: monitorId.value } });
 }
 
 function openRunDetail(runId: string, executionId: string) {

--- a/web/src/views/synthetics/RunDetail.vue
+++ b/web/src/views/synthetics/RunDetail.vue
@@ -48,7 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :subtitle="currentRun.timestamp"
       :back="{
         label: t('synthetics.results.monitors'),
-        to: { name: 'synthetic-monitor-results', params: { id: monitorId } },
+        to: { name: 'synthetics-monitor-results', params: { id: monitorId } },
         dataTest: 'synthetics-run-detail-back-btn',
       }"
     >

--- a/web/src/views/synthetics/RunDetail.vue
+++ b/web/src/views/synthetics/RunDetail.vue
@@ -384,7 +384,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.runDetail.detailSelector') }}</dt>
                             <dd class="text-text-secondary">{{ row.detail }}</dd>
                             <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.runDetail.detailUrl') }}</dt>
-                            <dd class="truncate text-text-secondary">{{ row.detail }}</dd>
+                            <dd class="truncate text-text-secondary">{{ row.url || currentRun.url }}</dd>
                             <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.results.duration') }}</dt>
                             <dd class="text-text-secondary">{{ row.durStr }}</dd>
                           </dl>
@@ -700,6 +700,7 @@ interface StepRow {
   action: string;
   name: string;
   detail: string;
+  url: string;
   duration: number;
   status: "pass" | "fail";
   icon: string;
@@ -734,6 +735,7 @@ function buildSteps(detail: SyntheticRunDetail | null): StepRow[] {
         recorded?.url ||
         ex.step_id.slice(0, 8),
       detail: recorded?.selector ?? recorded?.url ?? ex.step_id,
+      url: recorded?.url ?? "",
       duration: ex.duration_ms,
       status: isFail ? ("fail" as const) : ("pass" as const),
       icon: recorded ? actionIcon(recorded.action) : "radio_button_checked",


### PR DESCRIPTION
## What changed

Fixes UI issues in OpenObserve's Synthetics monitoring section: label corrections ("Synthetic" → "Synthetics"), validation feedback (toast + OForm thread-through), step editing data-loss bugs (wire sync, buildWireFromStep), replay banner cleanup, retries extraction into its own component, and URL display in RunDetail step expansion.

## Why

Each fix addresses a specific user-reported or observed defect — steps that silently dropped edits on save, validation errors that gave no visual feedback, a banner that persisted after deleting all steps, and incorrect label/URL display in sidebar, headers, and run detail views.