### PR TITLE
fix: initialize agent options in enterprise searches

### DIFF
--- a/src/core/src/anomaly_detection.rs
+++ b/src/core/src/anomaly_detection.rs
@@ -1498,6 +1498,7 @@ pub async fn execute_anomaly_query(
         use_cache: false,
         clear_cache: false,
         local_mode: None,
+        agent_options: None,
     };
 
     let parsed_stream_type = StreamType::from(stream_type);

--- a/src/core/src/traces/agent_signals/api.rs
+++ b/src/core/src/traces/agent_signals/api.rs
@@ -109,6 +109,7 @@ pub async fn get_agent_signals(
         use_cache: false,
         clear_cache: false,
         local_mode: Some(false),
+        agent_options: None,
     };
 
     let trace_id = config::ider::generate();

--- a/src/core/src/traces/service_graph/api.rs
+++ b/src/core/src/traces/service_graph/api.rs
@@ -283,6 +283,7 @@ pub async fn query_edges_from_stream_internal(
         use_cache: false,
         clear_cache: false,
         local_mode: Some(false),
+        agent_options: None,
     };
 
     // Check if stream exists (using Logs type since we write as logs stream)
@@ -421,6 +422,7 @@ pub async fn get_edge_history(
         use_cache: false,
         clear_cache: false,
         local_mode: Some(false),
+        agent_options: None,
     };
 
     // Return empty if stream doesn't exist yet

--- a/src/core/src/traces/service_graph/processor.rs
+++ b/src/core/src/traces/service_graph/processor.rs
@@ -654,6 +654,7 @@ pub(crate) async fn run_graph_search(
         use_cache: false,
         clear_cache: false,
         local_mode: Some(false),
+        agent_options: None,
     };
 
     let trace_id = config::ider::generate();


### PR DESCRIPTION
## What

Initialize `agent_options: None` in the five Enterprise-only `config::meta::search::Request` literals used by:

- anomaly detection
- agent signals
- service graph queries

## Why

PR #13343 added `agent_options` to the shared search `Request` type, but these Enterprise-gated initializers were not compiled by the normal OSS build. The Enterprise build then failed with `E0063: missing field agent_options` in [run 29891005192](https://github.com/openobserve/o2-enterprise/actions/runs/29891005192).

Using `None` preserves the existing behavior for these internal searches while satisfying the updated request type.

## Impact

Restores Enterprise compilation without changing request or response behavior.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Enterprise combined workspace: `cargo check --all-targets` using `o2-enterprise/Cargo.toml.openobserve` (passed)
