### PR TITLE
test: add DashboardFavorites page object and associated tests for fav…

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -304,6 +304,7 @@ jobs:
                 "dashboard-multi-sql.spec.js",
                 "crossLinkMultiStream.spec.js",
                 "dashboards-form-validation.spec.js",
+                "dashboard-favorites.spec.js",
               ]
           - testfolder: "Dashboards-Settings"
             browser: "chrome"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -304,15 +304,8 @@ jobs:
                 "dashboard-multi-sql.spec.js",
                 "crossLinkMultiStream.spec.js",
                 "dashboards-form-validation.spec.js",
-              ]
-          # Isolated in its own shard (own fresh OpenObserve instance) because
-          # its tests favorite dashboards on the shared test account while
-          # running — while active, that redirects any other test in the same
-          # shard that lands on Dashboards with no explicit ?folder= to the
-          # Favorites view instead of "default" (dashboard-import.spec.js,
-          # maxquery.spec.js). End-of-test cleanup alone can't prevent this
-          # since the collision happens mid-run, not from leftover state.
-          - testfolder: "Dashboards-Favorites"
+              ]         
+          - testfolder: "Dashboards-Isolated"
             browser: "chrome"
             run_files: ["dashboard-favorites.spec.js"]
           - testfolder: "Dashboards-Settings"
@@ -622,7 +615,7 @@ jobs:
               "Logs-Builder-Basic"|"Logs-Builder-Advanced"|"Logs-Core"|"Logs-Features")
                 ACTUAL_FOLDER="Logs"
                 ;;
-              "Dashboards-Core"|"Dashboards-Settings"|"Dashboards-Charts"|"Dashboards-Streaming"|"Dashboards-Variables"|"Dashboard-Table-Pagination"|"Dashboard-Pivot-Table"|"Dashboards-Panel-Level-DateTime-Config"|"Dashboard-Config-Settings"|"Dashboards-Favorites")
+              "Dashboards-Core"|"Dashboards-Settings"|"Dashboards-Charts"|"Dashboards-Streaming"|"Dashboards-Variables"|"Dashboard-Table-Pagination"|"Dashboard-Pivot-Table"|"Dashboards-Panel-Level-DateTime-Config"|"Dashboard-Config-Settings"|"Dashboards-Isolated")
                 ACTUAL_FOLDER="Dashboards"
                 ;;
               "RUM-Token")

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -304,8 +304,17 @@ jobs:
                 "dashboard-multi-sql.spec.js",
                 "crossLinkMultiStream.spec.js",
                 "dashboards-form-validation.spec.js",
-                "dashboard-favorites.spec.js",
               ]
+          # Isolated in its own shard (own fresh OpenObserve instance) because
+          # its tests favorite dashboards on the shared test account while
+          # running — while active, that redirects any other test in the same
+          # shard that lands on Dashboards with no explicit ?folder= to the
+          # Favorites view instead of "default" (dashboard-import.spec.js,
+          # maxquery.spec.js). End-of-test cleanup alone can't prevent this
+          # since the collision happens mid-run, not from leftover state.
+          - testfolder: "Dashboards-Favorites"
+            browser: "chrome"
+            run_files: ["dashboard-favorites.spec.js"]
           - testfolder: "Dashboards-Settings"
             browser: "chrome"
             run_files:
@@ -613,7 +622,7 @@ jobs:
               "Logs-Builder-Basic"|"Logs-Builder-Advanced"|"Logs-Core"|"Logs-Features")
                 ACTUAL_FOLDER="Logs"
                 ;;
-              "Dashboards-Core"|"Dashboards-Settings"|"Dashboards-Charts"|"Dashboards-Streaming"|"Dashboards-Variables"|"Dashboard-Table-Pagination"|"Dashboard-Pivot-Table"|"Dashboards-Panel-Level-DateTime-Config"|"Dashboard-Config-Settings")
+              "Dashboards-Core"|"Dashboards-Settings"|"Dashboards-Charts"|"Dashboards-Streaming"|"Dashboards-Variables"|"Dashboard-Table-Pagination"|"Dashboard-Pivot-Table"|"Dashboards-Panel-Level-DateTime-Config"|"Dashboard-Config-Settings"|"Dashboards-Favorites")
                 ACTUAL_FOLDER="Dashboards"
                 ;;
               "RUM-Token")

--- a/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
@@ -69,9 +69,12 @@ export default class DashboardFavorites {
 
   // The row checkbox is keyed by row id (the dashboard id, per row-key="id"),
   // which tests don't know — resolve it by prefix inside the row instead.
+  // Must be scoped to the <label> (OTableSelectCheckbox), not the enclosing
+  // <td data-test="o2-table-select-cell">, whose own data-test also matches
+  // the "o2-table-select-" prefix and would trip strict mode.
   getRowCheckbox(dashboardName) {
     return this.getRow(dashboardName).locator(
-      '[data-test^="o2-table-select-"]'
+      'label[data-test^="o2-table-select-"]'
     );
   }
 
@@ -115,7 +118,19 @@ export default class DashboardFavorites {
     const toggle = this.getFavoriteToggle(dashboardName);
     await toggle.waitFor({ state: "visible", timeout: 15000 });
     await toggle.click();
-    await this.verifyIsNotFavorite(dashboardName);
+    // Unfavoriting drops the row entirely when viewed from the Favorites
+    // pseudo-folder, but only flips the icon class when viewed from the
+    // dashboard's real folder — the toggle element itself disappears in
+    // the former case, so assert whichever the row actually did. Callers
+    // assert the specific outcome right after.
+    await expect(async () => {
+      // count() checks the DOM once with no actionability wait, unlike
+      // getAttribute() — which blocks retrying for the element to attach
+      // and would hang past toPass's own budget once the row is gone.
+      if ((await toggle.count()) === 0) return;
+      const classAttr = (await toggle.getAttribute("class")) ?? "";
+      expect(classAttr).not.toMatch(/text-favorite/);
+    }).toPass({ timeout: 15000 });
   }
 
   // Favorited rows render the filled `favorite` icon and carry the rose

--- a/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
@@ -155,6 +155,12 @@ export default class DashboardFavorites {
     await this.getRowDeleteBtn(dashboardName).click();
     await this.deleteConfirmBtn.waitFor({ state: "visible", timeout: 15000 });
     await this.deleteConfirmBtn.click();
+    // Wait for the dialog to actually close before the caller asserts on
+    // the resulting list state, instead of racing the close animation.
+    await this.page
+      .locator('[data-test="dashboard-confirm-dialog"]')
+      .waitFor({ state: "detached", timeout: 10000 })
+      .catch(() => {});
   }
 
   async selectDashboard(dashboardName) {

--- a/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
@@ -1,0 +1,185 @@
+// Methods: toggle favorite, open the Favorites rail entry, assert favorite
+// state, bulk-select and bulk-delete rows, assert toast outcomes.
+//
+// Backs dashboard-favorites.spec.js. Favorites are a per-user setting rendered
+// through a `__favorites__` pseudo-folder in the folder rail — it is not a real
+// backend folder, which is what made delete-from-Favorites regress before.
+
+import { expect } from "@playwright/test";
+
+// Mirrors FAVORITES_FOLDER_ID in web/src/composables/useFavoriteDashboards.ts.
+const FAVORITES_FOLDER_ID = "__favorites__";
+
+export default class DashboardFavorites {
+  constructor(page) {
+    this.page = page;
+
+    // Folder rail — the Favorites entry is keyed by the pseudo-folder id.
+    this.favoritesFolderTab = page.locator(
+      `[data-test="dashboard-folder-tab-${FAVORITES_FOLDER_ID}"]`
+    );
+
+    // Dashboard list surface.
+    this.dashboardTable = page.locator('[data-test="dashboard-table"]');
+    this.searchInput = page.locator('[data-test="dashboard-search-field"]');
+    this.refreshBtn = page.locator('[data-test="dashboard-list-refresh"]');
+
+    // Bulk action bar (only rendered once at least one row is selected).
+    this.bulkDeleteBtn = page.locator(
+      '[data-test="dashboard-list-delete-dashboards-btn"]'
+    );
+    this.bulkDeleteConfirmBtn = page.locator(
+      '[data-test="dashboard-confirm-bulk-delete-dialog"] [data-test="o-dialog-primary-btn"]'
+    );
+
+    // Single-row delete confirmation.
+    this.deleteConfirmBtn = page.locator(
+      '[data-test="dashboard-confirm-dialog"] [data-test="o-dialog-primary-btn"]'
+    );
+
+    // OToast stamps the variant on the root, so success and error are
+    // distinguishable without reading message text.
+    this.errorToast = page.locator('[data-test-variant="error"]');
+    this.successToast = page.locator('[data-test-variant="success"]');
+  }
+
+  // ── Per-row factories ──────────────────────────────────────────────────
+  // Name cells and heart toggles are keyed by the dashboard's display name.
+
+  getNameCell(dashboardName) {
+    return this.page.locator(
+      `[data-test="dashboard-name-cell-${dashboardName}"]`
+    );
+  }
+
+  getFavoriteToggle(dashboardName) {
+    return this.page.locator(
+      `[data-test="dashboard-favorite-toggle-${dashboardName}"]`
+    );
+  }
+
+  // Walk from the name cell up to the enclosing OTable row so row-scoped
+  // controls (checkbox, delete) resolve against the right dashboard. Same
+  // ancestor-axis pattern used by dashboard-list.js.
+  getRow(dashboardName) {
+    return this.getNameCell(dashboardName).locator(
+      "xpath=ancestor::*[starts-with(@data-test,'o2-table-row-')]"
+    );
+  }
+
+  // The row checkbox is keyed by row id (the dashboard id, per row-key="id"),
+  // which tests don't know — resolve it by prefix inside the row instead.
+  getRowCheckbox(dashboardName) {
+    return this.getRow(dashboardName).locator(
+      '[data-test^="o2-table-select-"]'
+    );
+  }
+
+  getRowDeleteBtn(dashboardName) {
+    return this.getRow(dashboardName).locator('[data-test="dashboard-delete"]');
+  }
+
+  // ── Navigation ─────────────────────────────────────────────────────────
+
+  async openFavoritesFolder() {
+    await this.favoritesFolderTab.waitFor({ state: "visible", timeout: 15000 });
+    await this.favoritesFolderTab.click();
+    // The rail pushes ?folder=__favorites__ once the view switches.
+    await this.page
+      .waitForURL(new RegExp(`folder=${FAVORITES_FOLDER_ID}`), {
+        timeout: 15000,
+      })
+      .catch(() => {});
+  }
+
+  // Narrow the paginated list to a single row. The list is 20-per-page with no
+  // newest-first sort, so a freshly created dashboard can land on page 2+.
+  async searchDashboard(dashboardName) {
+    await this.searchInput.waitFor({ state: "visible", timeout: 15000 });
+    await this.searchInput.fill(dashboardName);
+    await this.getNameCell(dashboardName)
+      .waitFor({ state: "visible", timeout: 15000 })
+      .catch(() => {});
+  }
+
+  // ── Favorite toggling ──────────────────────────────────────────────────
+
+  async addToFavorites(dashboardName) {
+    const toggle = this.getFavoriteToggle(dashboardName);
+    await toggle.waitFor({ state: "visible", timeout: 15000 });
+    await toggle.click();
+    await this.verifyIsFavorite(dashboardName);
+  }
+
+  async removeFromFavorites(dashboardName) {
+    const toggle = this.getFavoriteToggle(dashboardName);
+    await toggle.waitFor({ state: "visible", timeout: 15000 });
+    await toggle.click();
+    await this.verifyIsNotFavorite(dashboardName);
+  }
+
+  // Favorited rows render the filled `favorite` icon and carry the rose
+  // `text-favorite` class; unfavorited ones use the `favorite-border` outline.
+  // Asserting on the class keeps this independent of icon-name internals.
+  async verifyIsFavorite(dashboardName) {
+    await expect(this.getFavoriteToggle(dashboardName)).toHaveClass(
+      /text-favorite/,
+      { timeout: 15000 }
+    );
+  }
+
+  async verifyIsNotFavorite(dashboardName) {
+    await expect(this.getFavoriteToggle(dashboardName)).not.toHaveClass(
+      /text-favorite/,
+      { timeout: 15000 }
+    );
+  }
+
+  // ── Presence assertions ────────────────────────────────────────────────
+
+  async verifyDashboardVisible(dashboardName) {
+    await expect(this.getNameCell(dashboardName)).toBeVisible({
+      timeout: 15000,
+    });
+  }
+
+  async verifyDashboardNotPresent(dashboardName) {
+    await expect(this.getNameCell(dashboardName)).toHaveCount(0, {
+      timeout: 15000,
+    });
+  }
+
+  // ── Deletion ───────────────────────────────────────────────────────────
+
+  async deleteDashboardFromRow(dashboardName) {
+    await this.getRowDeleteBtn(dashboardName).click();
+    await this.deleteConfirmBtn.waitFor({ state: "visible", timeout: 15000 });
+    await this.deleteConfirmBtn.click();
+  }
+
+  async selectDashboard(dashboardName) {
+    const checkbox = this.getRowCheckbox(dashboardName);
+    await checkbox.waitFor({ state: "visible", timeout: 15000 });
+    await checkbox.click();
+  }
+
+  async bulkDeleteSelected() {
+    await this.bulkDeleteBtn.waitFor({ state: "visible", timeout: 15000 });
+    await this.bulkDeleteBtn.click();
+    await this.bulkDeleteConfirmBtn.waitFor({
+      state: "visible",
+      timeout: 15000,
+    });
+    await this.bulkDeleteConfirmBtn.click();
+  }
+
+  // Regression guard: bulk delete used to send `__favorites__` as the ?folder=
+  // query param, which the backend rejects with a 404.
+  async verifyNoErrorToast() {
+    await expect(this.errorToast).toHaveCount(0, { timeout: 10000 });
+  }
+
+  async verifySuccessToast() {
+    await expect(this.successToast.first()).toBeVisible({ timeout: 15000 });
+  }
+}

--- a/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
@@ -107,17 +107,34 @@ export default class DashboardFavorites {
 
   // ── Favorite toggling ──────────────────────────────────────────────────
 
+  // Toggling a favorite updates the UI optimistically, then fires a
+  // fire-and-forget POST to persist it (useFavoriteDashboards.ts). A test that
+  // reloads right after addToFavorites() can otherwise race the page teardown
+  // against that still-in-flight request and lose the favorite server-side
+  // while the DOM already looked correct. Wait for the response so callers
+  // get a genuinely persisted state, not just the optimistic one.
+  async waitForFavoritesPersisted(action) {
+    await Promise.all([
+      this.page.waitForResponse(
+        (response) =>
+          /\/settings\/v2\/user\//.test(response.url()) &&
+          response.status() === 200
+      ),
+      action(),
+    ]);
+  }
+
   async addToFavorites(dashboardName) {
     const toggle = this.getFavoriteToggle(dashboardName);
     await toggle.waitFor({ state: "visible", timeout: 15000 });
-    await toggle.click();
+    await this.waitForFavoritesPersisted(() => toggle.click());
     await this.verifyIsFavorite(dashboardName);
   }
 
   async removeFromFavorites(dashboardName) {
     const toggle = this.getFavoriteToggle(dashboardName);
     await toggle.waitFor({ state: "visible", timeout: 15000 });
-    await toggle.click();
+    await this.waitForFavoritesPersisted(() => toggle.click());
     // Unfavoriting drops the row entirely when viewed from the Favorites
     // pseudo-folder, but only flips the icon class when viewed from the
     // dashboard's real folder — the toggle element itself disappears in

--- a/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
@@ -150,6 +150,21 @@ export default class DashboardFavorites {
     );
   }
 
+  // Teardown helper: un-favorite if (and only if) still favorited, without
+  // throwing if the dashboard is already gone. Deleting a folder does not
+  // prune favorites for the dashboards inside it (a real app bug, tracked
+  // separately) — every test that favorites a dashboard but doesn't itself
+  // delete it would otherwise leave a ghost favorite behind forever on the
+  // shared test account. Call this before deleteFolder in afterEach.
+  async unfavoriteIfFavorited(dashboardName) {
+    const toggle = this.getFavoriteToggle(dashboardName);
+    if ((await toggle.count()) === 0) return;
+    const classAttr = (await toggle.getAttribute("class")) ?? "";
+    if (/text-favorite/.test(classAttr)) {
+      await toggle.click();
+    }
+  }
+
   // ── Presence assertions ────────────────────────────────────────────────
 
   async verifyDashboardVisible(dashboardName) {

--- a/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
@@ -113,13 +113,22 @@ export default class DashboardFavorites {
   // against that still-in-flight request and lose the favorite server-side
   // while the DOM already looked correct. Wait for the response so callers
   // get a genuinely persisted state, not just the optimistic one.
+  //
+  // The settings/v2/user/{userId} endpoint is keyed only by user, not by
+  // which setting is being saved — setting_key travels in the POST body, not
+  // the URL. Matching on URL alone can resolve on an unrelated user-setting
+  // save (e.g. home_dashboard) that happens to land in the same window,
+  // letting a caller proceed before the favorites save actually completed.
+  // Check the request body's setting_key so this only resolves on the right
+  // save.
   async waitForFavoritesPersisted(action) {
     await Promise.all([
-      this.page.waitForResponse(
-        (response) =>
-          /\/settings\/v2\/user\//.test(response.url()) &&
-          response.status() === 200
-      ),
+      this.page.waitForResponse((response) => {
+        if (!/\/settings\/v2\/user\//.test(response.url())) return false;
+        if (response.status() !== 200) return false;
+        const body = response.request().postDataJSON();
+        return body?.setting_key === "favorite_dashboards";
+      }),
       action(),
     ]);
   }

--- a/tests/ui-testing/pages/dashboardPages/dashboard-folder.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-folder.js
@@ -119,6 +119,14 @@ export default class DashboardFolder {
     // Click delete icon and confirm via class-member locators.
     await this.deleteFolderIcon.click();
     await this.confirmDeleteFolderBtn.click();
+    // Wait for the confirm dialog to actually close before returning, same
+    // as createFolder — otherwise callers (afterEach cleanup in particular)
+    // can race ahead while the delete is still in flight, leaving the
+    // folder undeleted with no error surfaced.
+    await this.page
+      .locator('[data-test="o-dialog-overlay"]')
+      .waitFor({ state: "detached", timeout: 10000 })
+      .catch(() => {});
   }
 
   // Edit folder name

--- a/tests/ui-testing/pages/page-manager.js
+++ b/tests/ui-testing/pages/page-manager.js
@@ -2,6 +2,7 @@
 import DashboardCreate from "./dashboardPages/dashboard-create";
 import DashboardListPage from "./dashboardPages/dashboard-list";
 import DashboardFolder from "./dashboardPages/dashboard-folder";
+import DashboardFavorites from "./dashboardPages/dashboard-favorites";
 import DashboardactionPage from "./dashboardPages/dashboard-panel-actions";
 import DashboardPanelConfigs from "./dashboardPages/dashboard-panel-configs";
 import DashboardPanel from "./dashboardPages/dashboard-panel-edit";
@@ -118,6 +119,7 @@ class PageManager {
     this.dashboardCreate = new DashboardCreate(page);
     this.dashboardList = new DashboardListPage(page);
     this.dashboardFolder = new DashboardFolder(page);
+    this.dashboardFavorites = new DashboardFavorites(page);
     this.dashboardPanelActions = new DashboardactionPage(page);
     this.dashboardPanelConfigs = new DashboardPanelConfigs(page);
     this.dashboardPanelEdit = new DashboardPanel(page);

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
@@ -1,0 +1,165 @@
+import { test as base, expect } from "../baseFixtures.js";
+import logData from "../../fixtures/log.json";
+import { login } from "./utils/dashLogin.js";
+import { ingestion } from "./utils/dashIngestion.js";
+import { waitForDashboardPage } from "./utils/dashCreation.js";
+import PageManager from "../../pages/page-manager";
+const testLogger = require("../utils/test-logger.js");
+
+export const test = base;
+
+test.describe.configure({ mode: "parallel" });
+
+// Favorites are a per-user setting surfaced through a `__favorites__`
+// pseudo-folder in the rail — not a real backend folder. These tests cover the
+// add/remove round trip plus the three regressions that came out of it:
+//   1. bulk delete sent `__favorites__` as ?folder=, which the backend 404s on
+//   2. deleting a dashboard left a ghost row behind in Favorites
+//   3. bulk-deleting from Favorites left a ghost row in the source folder
+//      (folder navigation is cache-first)
+test.describe("dashboard favorites testcases", () => {
+  // Each test seeds its own folder + dashboard so shards can run in parallel
+  // without contending over shared favorites state (favorites are per-user,
+  // and the suite logs in as the same user).
+  let pm;
+  let folderName;
+  let dashboardName;
+
+  test.beforeEach(async ({ page }) => {
+    testLogger.debug("Test setup - beforeEach hook executing");
+    await login(page);
+    await page.waitForTimeout(1000);
+    await ingestion(page);
+    await page.waitForTimeout(2000);
+
+    await page.goto(
+      `${logData.logsUrl}?org_identifier=${process.env["ORGNAME"]}`
+    );
+
+    pm = new PageManager(page);
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+
+    folderName = pm.dashboardFolder.generateUniqueFolderName("fav");
+    dashboardName = "Dash_" + Date.now();
+
+    await pm.dashboardFolder.createFolder(folderName);
+    await pm.dashboardFolder.searchFolder(folderName);
+    await pm.dashboardFolder.openFolderByName(folderName);
+    await page.waitForTimeout(1000);
+
+    await pm.dashboardCreate.createDashboard(dashboardName);
+    await pm.dashboardCreate.backToDashboardList();
+    await waitForDashboardPage(page);
+  });
+
+  test("should add a dashboard to favorites and show it in the Favorites folder", async ({
+    page,
+  }) => {
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.addToFavorites(dashboardName);
+
+    // The favorited dashboard is reachable from the rail's Favorites entry
+    // regardless of which folder it actually lives in.
+    await pm.dashboardFavorites.openFavoritesFolder();
+    await pm.dashboardFavorites.verifyDashboardVisible(dashboardName);
+    await pm.dashboardFavorites.verifyIsFavorite(dashboardName);
+  });
+
+  test("should remove a dashboard from favorites and drop it from the Favorites folder", async ({
+    page,
+  }) => {
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.addToFavorites(dashboardName);
+
+    await pm.dashboardFavorites.openFavoritesFolder();
+    await pm.dashboardFavorites.verifyDashboardVisible(dashboardName);
+
+    // Unfavoriting from inside the Favorites view removes the row from it...
+    await pm.dashboardFavorites.removeFromFavorites(dashboardName);
+    await pm.dashboardFavorites.verifyDashboardNotPresent(dashboardName);
+
+    // ...but must not delete the dashboard itself.
+    await pm.dashboardFolder.searchFolder(folderName);
+    await pm.dashboardFolder.openFolderByName(folderName);
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.verifyDashboardVisible(dashboardName);
+    await pm.dashboardFavorites.verifyIsNotFavorite(dashboardName);
+  });
+
+  test("should persist the favorite across a page reload", async ({ page }) => {
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.addToFavorites(dashboardName);
+
+    // Favorites live in a user setting, not local component state.
+    await page.reload();
+    await waitForDashboardPage(page);
+
+    await pm.dashboardFavorites.openFavoritesFolder();
+    await pm.dashboardFavorites.verifyDashboardVisible(dashboardName);
+  });
+
+  // Regression: the bulk delete request used activeFolderId as ?folder=, which
+  // in the Favorites view is the `__favorites__` pseudo-folder id. The backend
+  // has no such folder, so every bulk delete from Favorites 404'd.
+  test("should bulk delete a favorited dashboard from the Favorites folder without a 404", async ({
+    page,
+  }) => {
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.addToFavorites(dashboardName);
+
+    await pm.dashboardFavorites.openFavoritesFolder();
+    await pm.dashboardFavorites.verifyDashboardVisible(dashboardName);
+
+    await pm.dashboardFavorites.selectDashboard(dashboardName);
+    await pm.dashboardFavorites.bulkDeleteSelected();
+
+    await pm.dashboardFavorites.verifyNoErrorToast();
+    await pm.dashboardFavorites.verifyDashboardNotPresent(dashboardName);
+  });
+
+  // Regression: nothing pruned the favorites setting on delete, so the row kept
+  // rendering from its stored label and any action on it hit a dead id.
+  test("should drop a deleted dashboard from Favorites automatically", async ({
+    page,
+  }) => {
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.addToFavorites(dashboardName);
+
+    // Delete it from the folder it actually lives in.
+    await pm.dashboardFavorites.deleteDashboardFromRow(dashboardName);
+    await pm.dashboardFavorites.verifyDashboardNotPresent(dashboardName);
+
+    // Favorites must not keep a ghost row for it.
+    await pm.dashboardFavorites.openFavoritesFolder();
+    await pm.dashboardFavorites.verifyDashboardNotPresent(dashboardName);
+  });
+
+  // Regression: bulk delete never updated the cached folder lists, and folder
+  // navigation is cache-first, so the deleted dashboard reappeared in its
+  // source folder until a manual refresh.
+  test("should not leave a deleted dashboard in its source folder after a bulk delete from Favorites", async ({
+    page,
+  }) => {
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.addToFavorites(dashboardName);
+
+    await pm.dashboardFavorites.openFavoritesFolder();
+    await pm.dashboardFavorites.selectDashboard(dashboardName);
+    await pm.dashboardFavorites.bulkDeleteSelected();
+    await pm.dashboardFavorites.verifyNoErrorToast();
+
+    // Navigate back to the source folder WITHOUT reloading — a reload would
+    // refetch and mask the stale-cache bug this test exists to catch.
+    await pm.dashboardFolder.searchFolder(folderName);
+    await pm.dashboardFolder.openFolderByName(folderName);
+    await pm.dashboardFavorites.verifyDashboardNotPresent(dashboardName);
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Best-effort cleanup: the folder may already be gone if the test deleted
+    // its dashboard, and a failing test should surface its own error rather
+    // than a teardown error.
+    await pm.dashboardFolder.deleteFolder(folderName).catch(() => {});
+  });
+});

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
@@ -1,7 +1,6 @@
 import { test as base, expect } from "../baseFixtures.js";
 import logData from "../../fixtures/log.json";
 import { login } from "./utils/dashLogin.js";
-import { ingestion } from "./utils/dashIngestion.js";
 import { waitForDashboardPage } from "./utils/dashCreation.js";
 import PageManager from "../../pages/page-manager";
 const testLogger = require("../utils/test-logger.js");
@@ -29,10 +28,8 @@ test.describe("dashboard favorites testcases", () => {
     testLogger.debug("Test setup - beforeEach hook executing");
     await login(page);
     await page.waitForTimeout(1000);
-    // Favorites tests never query the ingested stream (no panels/search
-    // involved), so there's no need to wait out log-indexing lag here —
-    // ingestion() itself already awaits the POST response.
-    await ingestion(page);
+    // No ingestion here: favorites tests never touch the ingested stream
+    // (no panels/search involved), so seeding one is pure setup cost.
 
     await page.goto(
       `${logData.logsUrl}?org_identifier=${process.env["ORGNAME"]}`

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
@@ -29,8 +29,10 @@ test.describe("dashboard favorites testcases", () => {
     testLogger.debug("Test setup - beforeEach hook executing");
     await login(page);
     await page.waitForTimeout(1000);
+    // Favorites tests never query the ingested stream (no panels/search
+    // involved), so there's no need to wait out log-indexing lag here —
+    // ingestion() itself already awaits the POST response.
     await ingestion(page);
-    await page.waitForTimeout(2000);
 
     await page.goto(
       `${logData.logsUrl}?org_identifier=${process.env["ORGNAME"]}`
@@ -46,7 +48,8 @@ test.describe("dashboard favorites testcases", () => {
     await pm.dashboardFolder.createFolder(folderName);
     await pm.dashboardFolder.searchFolder(folderName);
     await pm.dashboardFolder.openFolderByName(folderName);
-    await page.waitForTimeout(1000);
+    // No fixed settle wait needed — createDashboard() below already waits
+    // for the "New Dashboard" button to be visible before acting.
 
     await pm.dashboardCreate.createDashboard(dashboardName);
     await pm.dashboardCreate.backToDashboardList();
@@ -114,6 +117,9 @@ test.describe("dashboard favorites testcases", () => {
     await pm.dashboardFavorites.selectDashboard(dashboardName);
     await pm.dashboardFavorites.bulkDeleteSelected();
 
+    // Positive check: the delete actually succeeded server-side, not just
+    // that the row disappeared from an optimistic UI update.
+    await pm.dashboardFavorites.verifySuccessToast();
     await pm.dashboardFavorites.verifyNoErrorToast();
     await pm.dashboardFavorites.verifyDashboardNotPresent(dashboardName);
   });
@@ -128,6 +134,7 @@ test.describe("dashboard favorites testcases", () => {
 
     // Delete it from the folder it actually lives in.
     await pm.dashboardFavorites.deleteDashboardFromRow(dashboardName);
+    await pm.dashboardFavorites.verifySuccessToast();
     await pm.dashboardFavorites.verifyDashboardNotPresent(dashboardName);
 
     // Favorites must not keep a ghost row for it.
@@ -147,6 +154,7 @@ test.describe("dashboard favorites testcases", () => {
     await pm.dashboardFavorites.openFavoritesFolder();
     await pm.dashboardFavorites.selectDashboard(dashboardName);
     await pm.dashboardFavorites.bulkDeleteSelected();
+    await pm.dashboardFavorites.verifySuccessToast();
     await pm.dashboardFavorites.verifyNoErrorToast();
 
     // Navigate back to the source folder WITHOUT reloading — a reload would

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
@@ -162,6 +162,17 @@ test.describe("dashboard favorites testcases", () => {
   });
 
   test.afterEach(async ({ page }) => {
+    // Un-favorite before deleting the folder. Deleting a folder does not
+    // prune favorites for the dashboards inside it, so without this, tests
+    // that favorite a dashboard but don't themselves delete it (add /
+    // persist-across-reload) leave a ghost favorite on the shared test
+    // account forever — best-effort since the dashboard/folder may already
+    // be gone if the test deleted it itself.
+    await pm.dashboardFolder.searchFolder(folderName).catch(() => {});
+    await pm.dashboardFolder.openFolderByName(folderName).catch(() => {});
+    await pm.dashboardFavorites.searchDashboard(dashboardName).catch(() => {});
+    await pm.dashboardFavorites.unfavoriteIfFavorited(dashboardName).catch(() => {});
+
     // Best-effort cleanup: the folder may already be gone if the test deleted
     // its dashboard, and a failing test should surface its own error rather
     // than a teardown error.


### PR DESCRIPTION
## Summary

Adds a Playwright E2E test suite covering the dashboard Favorites feature — favoriting/unfavoriting a dashboard, the `Favorites` pseudo-folder view, and its interaction with single and bulk delete flows.

## What's covered

New `dashboard-favorites.spec.js` (6 tests) + `DashboardFavorites` page object:

- Add a dashboard to favorites and verify it appears in the Favorites view
- Remove a dashboard from favorites — confirms it drops from the Favorites view while the dashboard itself remains untouched
- Favorite state persists across a page reload
- Bulk-delete a favorited dashboard from the Favorites view completes successfully with no error
- Deleting a dashboard directly also removes it from Favorites automatically
- Bulk-deleting a dashboard from the Favorites view doesn't leave a stale copy behind in its original folder

## CI

`dashboard-favorites.spec.js` runs in its own dedicated `Dashboards-Isolated` shard with a fresh backend instance, keeping it independent from the rest of the dashboard test suite.
