### PR TITLE
fix: (metrics) stop y-axis label clipping and scope filter labels to the visible grid

### DIFF
--- a/web/src/composables/metrics/useMetricsExplorerGrid.spec.ts
+++ b/web/src/composables/metrics/useMetricsExplorerGrid.spec.ts
@@ -1474,4 +1474,109 @@ describe("useMetricsExplorerGrid", () => {
       expect(resolved.unit).toBe("celsius"); // ...and so does what the chart uses
     });
   });
+
+  describe("the label picker follows the narrowed grid", () => {
+    // Distinct label sets per metric so a scoped list is DISTINGUISHABLE from the
+    // global one: if scoping worked, only the narrowed metrics' labels appear.
+    const withLabelSchemas = () =>
+      (StreamService.nameList as any).mockResolvedValue({
+        data: {
+          list: STREAMS.map((stream) => {
+            const labels =
+              stream.name === "http_requests_total"
+                ? ["pod", "code", "__name__", "_timestamp"]
+                : stream.name === "idle_metric_total"
+                  ? ["region"]
+                  : stream.name === "cpu_temperature"
+                    ? ["sensor"]
+                    : ["shared"];
+            return { ...stream, schema: labels.map((name) => ({ name, type: "Utf8" })) };
+          }),
+        },
+      });
+
+    it("shows all window labels when nothing is narrowed (global path)", async () => {
+      const grid = await setup();
+      (metricsService.labels as any).mockResolvedValue({
+        data: { data: ["job", "instance", "__name__"] },
+      });
+      (metricsService.labels as any).mockClear();
+
+      await grid.loadLabelNames();
+
+      // The global endpoint was asked, and its internal fields were dropped.
+      expect(metricsService.labels).toHaveBeenCalled();
+      expect(grid.labelNames.value).toEqual(["job", "instance"]);
+    });
+
+    it("scopes labels to the search-matched metrics, from the schema map", async () => {
+      const grid = await setup();
+      withLabelSchemas();
+      (metricsService.labels as any).mockResolvedValue({
+        data: { data: ["should_not_be_used"] },
+      });
+      (metricsService.labels as any).mockClear();
+
+      grid.searchTerm.value = "http_requests_total";
+      await flush();
+      await grid.loadLabelNames();
+
+      // Only http_requests_total's real labels — internal fields excluded, and
+      // the global endpoint was NOT consulted for the narrowed list.
+      expect(grid.labelNames.value).toEqual(["code", "pod"]);
+      expect(metricsService.labels).not.toHaveBeenCalled();
+    });
+
+    it("scopes labels to the selected type facet", async () => {
+      const grid = await setup();
+      withLabelSchemas();
+
+      // Counter bucket = http_requests_total + idle_metric_total (+ the histogram
+      // count/bucket siblings, which carry "shared").
+      grid.selectedTypes.value = new Set(["counter"]);
+      await flush();
+      await grid.loadLabelNames();
+
+      expect(grid.labelNames.value).toContain("pod");
+      expect(grid.labelNames.value).toContain("code");
+      expect(grid.labelNames.value).toContain("region");
+      // A gauge-only label must not leak into the counter-scoped list.
+      expect(grid.labelNames.value).not.toContain("sensor");
+    });
+
+    it("re-derives when the narrowing changes after the first load", async () => {
+      const grid = await setup();
+      withLabelSchemas();
+
+      grid.searchTerm.value = "http_requests_total";
+      await flush();
+      await grid.loadLabelNames();
+      expect(grid.labelNames.value).toEqual(["code", "pod"]);
+
+      // Change the search — the cached list must be invalidated so the next focus
+      // recomputes against the new narrowing.
+      grid.searchTerm.value = "idle_metric_total";
+      await flush();
+      await grid.loadLabelNames();
+      expect(grid.labelNames.value).toEqual(["region"]);
+    });
+
+    it("falls back to the global list when the schema map is empty", async () => {
+      const grid = await setup();
+      // Schema load yields no membership, so scoping is impossible.
+      (StreamService.nameList as any).mockResolvedValue({ data: { list: [] } });
+      (metricsService.labels as any).mockResolvedValue({
+        data: { data: ["job"] },
+      });
+      (metricsService.labels as any).mockClear();
+
+      grid.searchTerm.value = "http_requests_total";
+      await flush();
+      await grid.loadLabelNames();
+
+      // Never leaves the picker empty — the global endpoint answered instead.
+      expect(metricsService.labels).toHaveBeenCalled();
+      expect(grid.labelNames.value).toEqual(["job"]);
+    });
+  });
 });

--- a/web/src/composables/metrics/useMetricsExplorerGrid.ts
+++ b/web/src/composables/metrics/useMetricsExplorerGrid.ts
@@ -1770,11 +1770,64 @@ export function useMetricsExplorerGrid() {
    */
   let labelNamesGeneration = 0;
 
+  const isLabelField = (l: string) =>
+    !!l && !l.startsWith("__") && !INTERNAL_LABEL_FIELDS.has(l);
+
+  /**
+   * True when the user has narrowed the grid with a facet (prefix/suffix/type) or
+   * a metric-name search. In that case the picker offers only the labels of the
+   * metrics that survive the narrowing — NOT every label in the window. With
+   * nothing selected it stays `false` and the picker shows all labels (the
+   * global `metricsService.labels()` path).
+   */
+  const isLabelPickerNarrowed = () =>
+    selectedPrefixes.value.size +
+      selectedSuffixes.value.size +
+      selectedTypes.value.size >
+      0 || searchTerm.value.trim().length > 0;
+
+  /**
+   * The labels of the metrics the user has narrowed to, unioned from the schema
+   * map. Scoped to `sortedCandidates` (facets + search + favourites) — the
+   * no-data hiding filter is deliberately excluded, so a label from a metric
+   * that is merely empty in the current window is still offered.
+   *
+   * Returns null (not an empty list) to mean "cannot scope — fall back to the
+   * global list": the schema map failed to load, or genuinely produced no
+   * labels. An empty picker would be worse than a broad one.
+   */
+  const scopedLabelNames = (): string[] | null => {
+    const byStream = labelsByStream.value;
+    if (!Object.keys(byStream).length) return null;
+    const names = new Set<string>();
+    for (const card of sortedCandidates.value) {
+      for (const label of byStream[card.name] ?? []) {
+        if (isLabelField(label)) names.add(label);
+      }
+    }
+    if (!names.size) return null;
+    return [...names].sort();
+  };
+
   const loadLabelNames = async () => {
     if (labelNames.value.length || labelNamesLoading.value) return;
     const generation = labelNamesGeneration;
     labelNamesLoading.value = true;
     try {
+      // Narrowed picker: derive from the already-loaded schema map instead of
+      // asking the backend for every label in the window. No new network call —
+      // `ensureSchemas` populates `labelsByStream`, the same map value
+      // suggestions use. Falls through to the global path if scoping is not
+      // possible (schema load failed, or no labels on the narrowed set).
+      if (isLabelPickerNarrowed()) {
+        await ensureSchemas();
+        if (generation !== labelNamesGeneration) return;
+        const scoped = scopedLabelNames();
+        if (scoped) {
+          labelNames.value = scoped;
+          return;
+        }
+      }
       const { start_time, end_time } = timeRange.value;
       const DAY_US = 24 * 3600 * 1_000_000;
       // Walked only while the answer is empty; a rung that ERRORS is walked
@@ -1800,10 +1853,7 @@ export function useMetricsExplorerGrid() {
           // internal columns (`aggregation_temporality`, `_timestamp`, `value`, …).
           // Those are not labels and filtering on them is meaningless, so they are
           // kept out of the picker.
-          names = (response?.data?.data ?? []).filter(
-            (l: string) =>
-              l && !l.startsWith("__") && !INTERNAL_LABEL_FIELDS.has(l),
-          );
+          names = (response?.data?.data ?? []).filter(isLabelField);
         } catch {
           if (generation !== labelNamesGeneration) return;
         }
@@ -1816,6 +1866,23 @@ export function useMetricsExplorerGrid() {
       if (generation === labelNamesGeneration) labelNamesLoading.value = false;
     }
   };
+
+  /**
+   * The narrowed picker's list is a function of the facet selection and the
+   * search term, so it goes stale the moment either changes. Drop the cached
+   * list (and cancel any in-flight load) so the next `@focus-picker` recomputes
+   * against the current narrowing — reverting to the global list once nothing is
+   * selected. Mirrors the window/org invalidation above.
+   */
+  watch(
+    [selectedPrefixes, selectedSuffixes, selectedTypes, searchTerm],
+    () => {
+      labelNamesGeneration++;
+      labelNames.value = [];
+      labelNamesLoading.value = false;
+    },
+    { deep: true },
+  );
 
   /**
    * Suggested values per label, for the CURRENT org and window.

--- a/web/src/plugins/metrics/explorer/MetricCardChart.spec.ts
+++ b/web/src/plugins/metrics/explorer/MetricCardChart.spec.ts
@@ -105,3 +105,39 @@ describe("MetricCardChart re-renders when anything it DRAWS WITH changes", () =>
     expect(schema.queries[0].query).toBe("sum(rate(up[5m]))");
   });
 });
+
+describe("the y-axis labels get breathing room from the card's left edge", () => {
+  beforeEach(() => convertPromQLData.mockReset());
+
+  // The ChartRenderer stub records the options the card actually hands off.
+  const optionsHandedToRenderer = (wrapper: any) =>
+    wrapper.findComponent({ name: "ChartRenderer" }).props("data")?.options;
+
+  it("adds a left inset for line cards so the widest label is not clipped", async () => {
+    // containLabel under-reserves by a few px; the card widens grid.left to
+    // absorb it. The converter's default left (5) must be overridden to 8.
+    convertPromQLData.mockResolvedValue({
+      options: { series: [{ type: "line" }], grid: { left: 5, containLabel: true } },
+    });
+
+    const wrapper = mountChart({ chartType: "line" });
+    await nextTick();
+    await nextTick();
+
+    expect(optionsHandedToRenderer(wrapper).grid.left).toBe(8);
+  });
+
+  it("leaves the heatmap grid alone (it manages its own axis layout)", async () => {
+    // A heatmap sets its own axisLabel width/truncation; the line-card inset must
+    // not touch its grid.left.
+    convertPromQLData.mockResolvedValue({
+      options: { series: [{ type: "heatmap" }], grid: { left: 5 } },
+    });
+
+    const wrapper = mountChart({ chartType: "heatmap" });
+    await nextTick();
+    await nextTick();
+
+    expect(optionsHandedToRenderer(wrapper).grid.left).toBe(5);
+  });
+});

--- a/web/src/plugins/metrics/explorer/MetricCardChart.vue
+++ b/web/src/plugins/metrics/explorer/MetricCardChart.vue
@@ -52,6 +52,14 @@ import { toZonedTime } from "date-fns-tz";
 import ChartRenderer from "@/components/dashboards/panels/ChartRenderer.vue";
 import { convertPromQLData } from "@/utils/dashboard/convertPromQLData";
 
+/**
+ * Extra left inset (px) for the y-axis label strip on a metric card, added
+ * OUTSIDE ECharts' `containLabel` reservation. containLabel sizes the strip from
+ * a text-width estimate that under-measures the rendered width by a few pixels,
+ * pushing the widest labels past the card's left edge; this inset absorbs that.
+ */
+const Y_AXIS_LABEL_LEFT_INSET = 8;
+
 export default defineComponent({
   name: "MetricCardChart",
   components: { ChartRenderer },
@@ -234,6 +242,26 @@ export default defineComponent({
           };
 
           pinTimeAxis(options);
+
+          if (props.chartType !== "heatmap") {
+            // ECharts `containLabel` reserves the y-axis label strip from its own
+            // text-width ESTIMATE, which under-measures the actually-rendered
+            // width by a few pixels. On these small cards that shortfall pushes
+            // the widest labels ~3px past the left edge, clipping their first
+            // character (measured: "700.00c/s" rendered at x=-2). A small extra
+            // left inset absorbs the estimate error so labels never touch the
+            // edge. Applied only to the metric cards, not the shared converter,
+            // so dashboards keep their existing layout.
+            const grid = Array.isArray(options.grid)
+              ? options.grid[0]
+              : options.grid;
+            if (grid) {
+              // `left` is added OUTSIDE the containLabel reservation, so this is
+              // pure breathing room. 8 clears the measured ~3px overhang with
+              // margin to spare, without visibly shrinking the plot.
+              grid.left = Y_AXIS_LABEL_LEFT_INSET;
+            }
+          }
 
           if (props.chartType === "heatmap") {
             // Keep the colour bar — without it the cells are just colours with

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.spec.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.spec.ts
@@ -207,6 +207,29 @@ describe("Dashboard Data Conversion Utils", () => {
       });
     });
 
+    it("compacts large custom-unit values with an SI suffix so axis labels fit", () => {
+      // A counter card uses unit "custom" with "c/s". Without SI scaling the raw
+      // "160000.00c/s" is too wide and clips on small metric panels. The numeric
+      // part carries the SI letter; the custom unit is preserved after it.
+      expect(getUnitValue(160000, "custom", "c/s")).toEqual({
+        value: "160.00K",
+        unit: "c/s",
+      });
+      expect(getUnitValue(2_500_000, "custom", "c/s")).toEqual({
+        value: "2.50M",
+        unit: "c/s",
+      });
+    });
+
+    it("leaves small custom-unit values unscaled (no SI suffix below 1000)", () => {
+      // Below 1000 the SI suffix is empty, so the existing "100.00"/"items"
+      // contract is unchanged.
+      expect(getUnitValue(100, "custom", "items")).toEqual({
+        value: "100.00",
+        unit: "items",
+      });
+    });
+
     it("should handle zero values", () => {
       expect(getUnitValue(0, "bytes")).toEqual({
         value: "0.00",

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -171,9 +171,24 @@ export const getUnitValue = (
       return { value: finalValue, unit: finalUnit };
     }
     case "custom": {
+      // Compact large magnitudes with an SI suffix (K/M/B/T/Q) the same way the
+      // "numbers" unit does. Without it a value like 160000 renders as the full
+      // "160000.00", which — with a custom suffix like "c/s" — is too wide for a
+      // small panel's y-axis label and clips on the left edge. The SI letter
+      // rides on the value; the custom unit stays after it ("160.00K" + "c/s").
+      const numeric = parseFloat(value);
+      if (!Number.isFinite(numeric)) {
+        return { value: `${value}`, unit: `${customUnit ?? ""}` };
+      }
+      const table = units.numbers;
+      let unitIndex = table.length - 1;
+      while (unitIndex > 0 && Math.abs(numeric) < table[unitIndex].divisor) {
+        unitIndex--;
+      }
+      const scaled = (numeric / table[unitIndex].divisor).toFixed(decimals);
       // console.timeEnd("getUnitValue:");
       return {
-        value: `${parseFloat(value)?.toFixed(decimals) ?? 0}`,
+        value: `${scaled}${table[unitIndex].unit}`,
         unit: `${customUnit ?? ""}`,
       };
     }


### PR DESCRIPTION
## What

Two independent fixes on the **Metrics explorer** grid.

### 1. Y-axis labels no longer clip
Wide y-axis labels on the small metric panels (e.g. `160000.00c/s`) were sliced off at the card's left edge — rendering as `0000.00c/s`. Two root causes, both fixed:

- **Un-scaled custom units.** The `"custom"` unit formatter (used by counter cards: `unit: "custom"`, `unitCustom: "c/s"`) emitted full-magnitude numbers with no SI scaling, unlike the `numbers`/`bytes` units. It now compacts them: `160000.00c/s` → `160.00Kc/s`, reusing the existing K/M/B/T/Q table.
- **`containLabel` under-reservation.** ECharts sizes the y-axis label strip from a text-width *estimate* that under-measures the rendered width by ~3px (confirmed by measuring the rendered SVG `<text>` nodes at x = −2/−3). `MetricCardChart` now adds an 8px left inset for non-heatmap cards to absorb the shortfall. Scoped to the metric cards — the shared `convertPromQLData` (used by dashboards) is **untouched**.

### 2. `+ Filter` label dropdown follows the narrowed grid
The label dropdown listed **every** label in the time window, ignoring the active narrowing. Now, when a prefix/suffix/type facet **or** the metric-name search is active, the label list is derived from the schema map scoped to the visible metrics (`sortedCandidates`). With nothing narrowed it keeps today's global list. Invalidates on facet/search change; fails open to the global list if the schema map is empty. No new backend calls — reuses the schema map value-suggestions already load.

## How it was found
The y-axis clip took systematic debugging: the first hypotheses (grid `containLabel`/`left`) were wrong — browser diagnostics showed the option reaching ECharts was already correct and the container was wide enough. Switching the cards to the SVG renderer and measuring the actual `<text>` node positions (labels at x = −2/−3) pinned the two real causes above.

## Tests
- `convertDataIntoUnitValue.spec.ts` — SI compaction for custom units (+ small-value unchanged). 228 pass.
- `MetricCardChart.spec.ts` — left inset applied for line cards, skipped for heatmap (red-green verified). 5 pass.
- `useMetricsExplorerGrid.spec.ts` — label scoping by facet/search, fallback, invalidation. 55 pass.
- **288 tests pass total.** Type-check clean, ESLint clean on all changed files.

## Scope / risk
- Frontend only (`web/`). No backend, no o2-enterprise, no migrations.
- The y-axis inset is metric-card-only; dashboards are not affected.
- Both changes are contained to the Metrics explorer.