### PR TITLE
fix: When receiving metric, stream deletion check does not function properly

### DIFF
--- a/src/core/src/metrics/json.rs
+++ b/src/core/src/metrics/json.rs
@@ -91,7 +91,7 @@ pub async fn ingest(
     user: ingestion_common::IngestUser,
 ) -> Result<IngestionResponse> {
     // check system resource
-    if let Err(e) = check_ingestion_allowed(org_id, StreamType::Metrics, stream_name).await {
+    if let Err(e) = check_ingestion_allowed(org_id, StreamType::Metrics, None).await {
         // we do not want to log trial period expired errors
         if matches!(e, infra::errors::Error::TrialPeriodExpired) {
             return Ok(IngestionResponse {
@@ -134,6 +134,10 @@ pub async fn ingest(
     // records buffer
     let mut json_data_by_stream: HashMap<String, Vec<_>> = HashMap::new();
 
+    // check if stream is deleting from cache
+    let mut stream_delete_status = std::collections::HashMap::new();
+    let mut skipped_records: u32 = 0;
+
     let reader: Vec<json::Value> = json::from_slice(&body)?;
     for record in reader.into_iter() {
         // JSON Flattening
@@ -149,6 +153,27 @@ pub async fn ingest(
                 }
             },
         };
+
+        // check stream if it is deleting
+        let is_deleting = match stream_delete_status.get(&stream_name) {
+            Some(v) => *v,
+            None => {
+                let flag = db::compact::retention::is_deleting_stream(
+                    org_id,
+                    StreamType::Metrics,
+                    &stream_name,
+                    None,
+                );
+                stream_delete_status.insert(stream_name.clone(), flag);
+                flag
+            }
+        };
+
+        if is_deleting {
+            skipped_records += 1;
+            continue;
+        }
+
         let metrics_type = record
             .get(TYPE_LABEL)
             .and_then(|v| v.as_str())
@@ -258,6 +283,11 @@ pub async fn ingest(
                 .or_default()
                 .push((local_val, metrics_type));
         }
+    }
+
+    // warn if any records were skipped due to streams being deleted
+    if skipped_records > 0 {
+        log::warn!("[METRICS:JSON] Skipped {skipped_records} records due to streams being deleted");
     }
 
     // process records buffered for pipeline processing

--- a/src/core/src/metrics/otlp.rs
+++ b/src/core/src/metrics/otlp.rs
@@ -180,6 +180,10 @@ pub async fn handle_otlp_request(
     // records buffer
     let mut json_data_by_stream: HashMap<String, Vec<_>> = HashMap::new();
 
+    // check if stream is deleting from cache
+    let mut stream_delete_status: HashMap<String, bool> = HashMap::new();
+    let mut skipped_records: u32 = 0;
+
     for resource_metric in &request.resource_metrics {
         if resource_metric.scope_metrics.is_empty() {
             continue;
@@ -187,6 +191,26 @@ pub async fn handle_otlp_request(
         for scope_metric in &resource_metric.scope_metrics {
             for metric in &scope_metric.metrics {
                 let metric_name = format_stream_name(metric.name.to_string());
+
+                // check stream if it is deleting
+                let is_deleting = match stream_delete_status.get(&metric_name) {
+                    Some(v) => *v,
+                    None => {
+                        let flag = db::compact::retention::is_deleting_stream(
+                            org_id,
+                            StreamType::Metrics,
+                            &metric_name,
+                            None,
+                        );
+                        stream_delete_status.insert(metric_name.clone(), flag);
+                        flag
+                    }
+                };
+
+                if is_deleting {
+                    skipped_records += 1;
+                    continue;
+                }
 
                 let mut rec = json::json!({});
                 if let Some(res) = &resource_metric.resource {
@@ -402,6 +426,11 @@ pub async fn handle_otlp_request(
                 }
             }
         }
+    }
+
+    // warn if any records were skipped due to streams being deleted
+    if skipped_records > 0 {
+        log::warn!("[METRICS:OTLP] Skipped {skipped_records} records due to streams being deleted");
     }
 
     // process records buffered for pipeline processing

--- a/src/core/src/metrics/prom.rs
+++ b/src/core/src/metrics/prom.rs
@@ -110,6 +110,10 @@ pub async fn remote_write(
     // records buffer
     let mut json_data_by_stream: HashMap<String, Vec<_>> = HashMap::new();
 
+    // check if stream is deleting from cache
+    let mut stream_delete_status: HashMap<String, bool> = HashMap::new();
+    let mut skipped_records: u32 = 0;
+
     // parse metadata
     for item in request.metadata {
         let metric_name = format_stream_name(item.metric_family_name.to_string());
@@ -295,6 +299,26 @@ pub async fn remote_write(
             None => continue,
         };
 
+        // check stream if it is deleting
+        let is_deleting = match stream_delete_status.get(&metric_name) {
+            Some(v) => *v,
+            None => {
+                let flag = db::compact::retention::is_deleting_stream(
+                    org_id,
+                    StreamType::Metrics,
+                    &metric_name,
+                    None,
+                );
+                stream_delete_status.insert(metric_name.clone(), flag);
+                flag
+            }
+        };
+
+        if is_deleting {
+            skipped_records += 1;
+            continue;
+        }
+
         // Note: All configurations (pipeline, UDS, schema, partition, alerts) are now pre-loaded
         // before the loop to avoid repeated async queries
 
@@ -408,6 +432,12 @@ pub async fn remote_write(
         }
         sample_processing_time += sample_start.elapsed().as_micros();
     }
+
+    // warn if any records were skipped due to streams being deleted
+    if skipped_records > 0 {
+        log::warn!("[METRICS:PROM] Skipped {skipped_records} records due to streams being deleted");
+    }
+
     let parse_timeseries_ms = step_start.elapsed().as_millis();
 
     // Detailed performance logging


### PR DESCRIPTION
Issue: When receiving metric data via the Curl, Prometheus, and OTLP receivers, the stream deletion check does not function properly, Relevant code is shown below（stream param is None）:
```text
    check_ingestion_allowed(org_id, StreamType::Metrics, None).await?;
    ......
    if let Some(stream_name) = stream_name
        && db::compact::retention::is_deleting_stream(org_id, stream_type, stream_name, None)
    {
        return Err(Error::IngestionError(format!(
            "stream [{stream_name}] is being deleted"
        )));
    }
```
<img width="1828" height="1044" alt="761dc86986a3c1027167094c991b7237" src="https://github.com/user-attachments/assets/e813f303-3aad-49de-8ab0-c7583c7d7bd6" />
<img width="1898" height="1296" alt="f7cd4ce0ee87c985e156e55745095bfc" src="https://github.com/user-attachments/assets/9e37efca-71ff-4846-91dd-9d1c44910001" />


Fix：
When iterating over the metric list,  after we get the stream_name, we skip metrics which it's stream is deleting...at the same time we record the count of the skipped metrics.

Test：
1. First, execute the following command to ingest the metric `custom_metric6` into OpenObserve; the `custom_metric6` stream will be created automatically
```text
curl -u root@example.com:o2oi_dMJ0RsB50MzVt2CVPCripths0WaGE832 \
  -k http://localhost:5080/api/default/ingest/metrics/_json \
  -H "Content-Type: application/json" \
  -d '[
    {
      "__name__": "custom_metric6",
      "__type__": "gauge",
      "job": "test_job",
      "instance": "localhost:9090",
      "_timestamp": 1784538553535,
      "value": 42.5
    }
  ]'
```

2.we delete the `custom_metric6` stream on page, if metrics are ingested immediately, the corresponding logs will be printed. Once the stream deletion completes successfully, reposting metrics will recreate the stream automatically.
<img width="3254" height="716" alt="image" src="https://github.com/user-attachments/assets/23817b08-7f76-4fdd-8400-c719b8f734b6" />

