### PR TITLE
feat: self-correcting search errors with hint and did-you-mean suggestions

### DIFF
--- a/src/api_query/src/search/mod.rs
+++ b/src/api_query/src/search/mod.rs
@@ -498,7 +498,7 @@ pub async fn search(
             user_id,
             &mut req,
             stream_type,
-            stream_names,
+            stream_names.clone(),
             get_fallback_order_by_col_from_request(&url_query),
             range_error,
             http_span,
@@ -541,6 +541,9 @@ pub async fn search(
             Json(res).into_response()
         }
         Err(err) => {
+            // swap the engine's pruned valid-fields list for the real schema
+            // so the error response can carry useful suggestions
+            let err = utils::enrich_field_error(err, &org_id, stream_type, &stream_names).await;
             let search_type = req
                 .search_type
                 .map(|t| t.to_string())

--- a/src/api_query/src/search/utils.rs
+++ b/src/api_query/src/search/utils.rs
@@ -41,6 +41,33 @@ pub fn get_bool_from_request(query: &HashMap<String, String>, param_name: &str) 
 
 /// Validates query fields against stream schema and User-Defined Schema (UDS)
 /// Returns Ok(()) if validation passes, or error if fields are invalid
+/// Replace the engine-reported valid-fields list in a `SearchFieldNotFound`
+/// error with the streams' real schema fields. The engine only sees the
+/// pruned scan schema, so its list is misleading; the real list lets the HTTP
+/// layer build useful did-you-mean suggestions.
+pub async fn enrich_field_error(
+    err: Error,
+    org_id: &str,
+    stream_type: StreamType,
+    stream_names: &[String],
+) -> Error {
+    let Error::ErrorCode(ErrorCodes::SearchFieldNotFound(inner)) = &err else {
+        return err;
+    };
+    let mut fields: Vec<String> = Vec::new();
+    for stream in stream_names {
+        if let Ok(schema) = infra::schema::get(org_id, stream, stream_type).await {
+            fields.extend(schema.fields().iter().map(|f| f.name().to_owned()));
+        }
+    }
+    fields.sort();
+    fields.dedup();
+    match crate::service::error_suggest::rebuild_field_not_found(inner, &fields) {
+        Some(new_inner) => Error::ErrorCode(ErrorCodes::SearchFieldNotFound(new_inner)),
+        None => err,
+    }
+}
+
 pub async fn validate_query_fields(
     org_id: &str,
     stream_name: &str,
@@ -90,15 +117,27 @@ pub async fn validate_query_fields(
         }
 
         if schema.field_with_name(&field).is_err() {
+            // Same textual shape as the DataFusion FieldNotFound mapping so the
+            // HTTP layer can extract candidates for did-you-mean suggestions.
+            let valid = schema
+                .fields()
+                .iter()
+                .map(|f| f.name().to_owned())
+                .collect::<Vec<_>>()
+                .join(", ");
             return Err(Error::ErrorCode(ErrorCodes::SearchFieldNotFound(format!(
-                "{}. Field not found in stream schema.",
-                field
+                "No field named {field}. Valid fields are {valid}.",
             ))));
         }
 
         if !uds_fields.is_empty() && !uds_fields.contains(&field) {
+            let valid = uds_fields
+                .iter()
+                .map(|f| f.to_owned())
+                .collect::<Vec<_>>()
+                .join(", ");
             return Err(Error::ErrorCode(ErrorCodes::SearchFieldNotFound(format!(
-                "{field}. Field exists but not in User-Defined Schema (UDS)",
+                "No field named {field}. Field exists in the stream but not in its User-Defined Schema (UDS). Valid fields are {valid}.",
             ))));
         }
     }

--- a/src/common/src/meta/http.rs
+++ b/src/common/src/meta/http.rs
@@ -46,6 +46,12 @@ pub struct HttpResponse {
     pub error_detail: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
+    /// One-line guidance on how to fix the error (agent self-correction, D4).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+    /// Closest valid alternatives for a mistyped field/function name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggestions: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -64,6 +70,8 @@ impl HttpResponse {
             name: None,
             error_detail: None,
             trace_id: None,
+            hint: None,
+            suggestions: None,
         }
     }
 
@@ -75,6 +83,8 @@ impl HttpResponse {
             name: None,
             error_detail: None,
             trace_id: None,
+            hint: None,
+            suggestions: None,
         }
     }
 
@@ -86,6 +96,8 @@ impl HttpResponse {
             name: None,
             error_detail: Some(err.get_error_detail()),
             trace_id: None,
+            hint: None,
+            suggestions: None,
         }
     }
 
@@ -97,6 +109,8 @@ impl HttpResponse {
             name: None,
             error_detail: Some(err.get_error_detail()),
             trace_id,
+            hint: None,
+            suggestions: None,
         }
     }
 
@@ -319,6 +333,8 @@ mod tests {
             name: Some("test".to_string()),
             error_detail: None,
             trace_id: Some("trace-123".to_string()),
+            hint: None,
+            suggestions: None,
         };
 
         let serialized = serde_json::to_string(&response).unwrap();
@@ -415,6 +431,8 @@ mod tests {
             name: None,
             error_detail: None,
             trace_id: None,
+            hint: None,
+            suggestions: None,
         };
         let serialized = serde_json::to_string(&response).unwrap();
         assert!(!serialized.contains("id"));
@@ -445,6 +463,8 @@ mod tests {
             name: Some("my-name".to_string()),
             error_detail: Some("detail".to_string()),
             trace_id: Some("trace-abc".to_string()),
+            hint: None,
+            suggestions: None,
         };
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"id\""));
@@ -462,6 +482,8 @@ mod tests {
             name: None,
             error_detail: None,
             trace_id: None,
+            hint: None,
+            suggestions: None,
         };
         let response = http_response.into_response();
         assert_eq!(response.status(), http::StatusCode::OK);
@@ -488,6 +510,8 @@ mod tests {
             name: None,
             error_detail: None,
             trace_id: None,
+            hint: None,
+            suggestions: None,
         };
         let response = http_response.into_response();
         assert_eq!(response.status(), http::StatusCode::SERVICE_UNAVAILABLE);

--- a/src/core/src/error_suggest.rs
+++ b/src/core/src/error_suggest.rs
@@ -1,0 +1,404 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Turn search error responses into self-correcting ones (AX spec D4): parse
+//! the candidates that the error producers embed in the message ("No field
+//! named X. Valid fields are a, b, c."), rank them by edit distance, and
+//! attach `hint` + `suggestions` to the HTTP body. Runs only at the HTTP edge;
+//! the wire format between cluster nodes is unchanged.
+
+use infra::errors::ErrorCodes;
+use search::datafusion::udf::DEFAULT_FUNCTIONS;
+
+use crate::common::meta::http::HttpResponse;
+
+const MAX_SUGGESTIONS: usize = 3;
+/// When no suggestion matched, a field list up to this size is offered in the
+/// hint as a fallback; anything longer points to the schema endpoint instead
+/// (hundreds of fields in an error are token noise).
+const MAX_FIELDS_IN_MESSAGE: usize = 10;
+
+/// SQL functions that are valid in O2 queries besides the UDFs in
+/// `DEFAULT_FUNCTIONS`. Used only for did-you-mean ranking.
+const COMMON_FUNCTIONS: &[&str] = &[
+    "count",
+    "sum",
+    "avg",
+    "min",
+    "max",
+    "median",
+    "approx_percentile_cont",
+    "date_bin",
+    "date_trunc",
+    "date_format",
+    "histogram",
+    "spath",
+    "to_timestamp",
+    "to_timestamp_micros",
+    "lower",
+    "upper",
+    "coalesce",
+    "concat",
+    "length",
+    "substring",
+    "replace",
+    "abs",
+    "round",
+];
+
+/// Attach `hint`/`suggestions` to an error body when the error code carries
+/// enough information. No-op for codes we have nothing smart to say about.
+pub fn enrich(resp: &mut HttpResponse, code: &ErrorCodes) {
+    match code {
+        ErrorCodes::SearchFieldNotFound(inner) => enrich_field_not_found(resp, inner),
+        ErrorCodes::SearchFunctionNotDefined(inner) => enrich_function_not_defined(resp, inner),
+        _ => {}
+    }
+}
+
+// Every fact appears in exactly one field: `message` names the problem,
+// `suggestions` is the only place candidates live, `hint` exists only when it
+// adds information the agent cannot infer (UDS explanation, usage example, a
+// pointer when we have no suggestions). `error_detail` is dropped on
+// successful enrichment — repeating the raw engine text would only add tokens.
+fn enrich_field_not_found(resp: &mut HttpResponse, inner: &str) {
+    let Some((field, valid_fields)) = parse_field_not_found(inner) else {
+        return;
+    };
+
+    let suggestions = suggest(&field, valid_fields.iter().map(|s| s.as_str()));
+    let is_uds = inner.contains("User-Defined Schema");
+
+    resp.message = format!("unknown field '{field}'");
+    resp.error_detail = None;
+    resp.hint = if is_uds {
+        Some(format!(
+            "'{field}' exists in the stream but is not part of its User-Defined Schema; add it in stream settings or query a UDS field."
+        ))
+    } else if suggestions.is_empty() {
+        // nothing similar — give the agent a next step instead of candidates
+        if !valid_fields.is_empty() && valid_fields.len() <= MAX_FIELDS_IN_MESSAGE {
+            Some(format!("valid fields: {}", valid_fields.join(", ")))
+        } else {
+            Some(
+                "no similar field found; use the stream schema endpoint to list fields".to_string(),
+            )
+        }
+    } else {
+        None
+    };
+    if !suggestions.is_empty() {
+        resp.suggestions = Some(suggestions);
+    }
+}
+
+fn enrich_function_not_defined(resp: &mut HttpResponse, inner: &str) {
+    let Some(func) = parse_function_name(inner) else {
+        return;
+    };
+
+    let candidates = DEFAULT_FUNCTIONS
+        .iter()
+        .map(|f| f.name)
+        .chain(COMMON_FUNCTIONS.iter().copied());
+    let suggestions = suggest(&func, candidates);
+
+    resp.message = format!("unknown function '{func}'");
+    resp.error_detail = None;
+    // The hint carries only what suggestions can't: the usage example —
+    // agents copy examples far more reliably than prose.
+    resp.hint = suggestions
+        .first()
+        .and_then(|s| usage_example(s))
+        .map(|text| format!("usage: {text}"));
+    if !suggestions.is_empty() {
+        resp.suggestions = Some(suggestions);
+    }
+}
+
+/// Usage example for a suggested function: the UDF registry's own text, plus
+/// hand-kept signatures for the non-UDF functions agents misuse most.
+fn usage_example(name: &str) -> Option<String> {
+    if let Some(udf) = DEFAULT_FUNCTIONS.iter().find(|f| f.name == name) {
+        return Some(udf.text.to_string());
+    }
+    let text = match name {
+        "histogram" => "histogram(_timestamp, '1 hour')",
+        "date_bin" => "date_bin(interval '1 hour', _timestamp)",
+        "date_format" => "date_format(_timestamp, '%Y-%m-%d', 'UTC')",
+        "approx_percentile_cont" => "approx_percentile_cont(duration, 0.99)",
+        "spath" => "spath(field, 'a.b.c')",
+        "to_timestamp_micros" => "to_timestamp_micros('2026-01-01T00:00:00Z')",
+        _ => return None,
+    };
+    Some(text.to_string())
+}
+
+/// Rebuild a FieldNotFound message with the authoritative schema field list.
+/// The engine's own "Valid fields" reflect the pruned scan schema (often just
+/// `_timestamp`) and are misleading — callers that know the stream pass the
+/// real fields here before mapping the error to HTTP.
+pub fn rebuild_field_not_found(inner: &str, schema_fields: &[String]) -> Option<String> {
+    if inner.contains("User-Defined Schema") {
+        // the validate path already embeds the correct UDS field list
+        return None;
+    }
+    let (field, _) = parse_field_not_found(inner)?;
+    if schema_fields.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "No field named {field}. Valid fields are {}.",
+        schema_fields.join(", ")
+    ))
+}
+
+/// Parse "... No field named <f>. Valid fields are <a, b, c>." (both the
+/// DataFusion Display shape and our producer sites). Field names may be
+/// wrapped in backticks and/or qualified (`table.field`).
+fn parse_field_not_found(inner: &str) -> Option<(String, Vec<String>)> {
+    let rest = inner.split("No field named ").nth(1)?;
+    let field_raw = rest.split('.').next()?.trim();
+    let field = normalize_ident(field_raw);
+    if field.is_empty() {
+        return None;
+    }
+
+    let valid_fields = match rest.split("Valid fields are ").nth(1) {
+        Some(list) => list
+            .trim_end()
+            .trim_end_matches('.')
+            .split(", ")
+            .map(normalize_ident)
+            .filter(|s| !s.is_empty())
+            .collect(),
+        None => Vec::new(),
+    };
+    Some((field, valid_fields))
+}
+
+/// Parse the function name out of DataFusion's "Invalid function 'xyz'" text.
+fn parse_function_name(inner: &str) -> Option<String> {
+    let rest = inner.split("Invalid function ").nth(1)?;
+    let name = rest
+        .trim_start_matches(['\'', '"', '`'])
+        .split(['\'', '"', '`', '.', '\n'])
+        .next()?
+        .trim();
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+/// Strip backticks and a `table.` qualifier: `` `logs`.`status` `` -> status.
+fn normalize_ident(raw: &str) -> String {
+    let s = raw.trim().trim_matches('`');
+    match s.rsplit_once('.') {
+        Some((_, unqualified)) => unqualified.trim_matches('`').to_string(),
+        None => s.to_string(),
+    }
+}
+
+/// Rank candidates by edit distance to `target` (case-insensitive), keeping
+/// close matches and prefix/substring matches, best-first, top 3.
+fn suggest<'a>(target: &str, candidates: impl Iterator<Item = &'a str>) -> Vec<String> {
+    let target_lc = target.to_lowercase();
+    let threshold = (target_lc.chars().count() / 3).max(2);
+    let mut scored: Vec<(usize, &str)> = candidates
+        .filter(|c| !c.starts_with('_')) // system fields are rarely what a typo meant
+        .filter_map(|c| {
+            let c_lc = c.to_lowercase();
+            let mut dist = levenshtein(&target_lc, &c_lc);
+            // A candidate whose *prefix* matches the typo is still a likely
+            // intention ("satus" -> "status_code"); rank it after full matches
+            // via a +1 penalty.
+            if c_lc.chars().count() > target_lc.chars().count() {
+                let prefix: String = c_lc.chars().take(target_lc.chars().count() + 1).collect();
+                dist = dist.min(levenshtein(&target_lc, &prefix) + 1);
+            }
+            let related = c_lc.contains(&target_lc) || target_lc.contains(&c_lc);
+            (dist <= threshold || related).then_some((dist, c))
+        })
+        .collect();
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.len().cmp(&b.1.len())));
+    let mut out: Vec<String> = Vec::new();
+    for (_, c) in scored {
+        if !out.iter().any(|s| s == c) {
+            out.push(c.to_string());
+        }
+        if out.len() >= MAX_SUGGESTIONS {
+            break;
+        }
+    }
+    out
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0usize; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body() -> HttpResponse {
+        HttpResponse::message(400u16, "orig")
+    }
+
+    #[test]
+    fn parses_datafusion_shape_with_qualifier() {
+        let (field, valid) = parse_field_not_found(
+            "Schema error: No field named nonexist. Valid fields are logs._timestamp, logs.status, logs.message.",
+        )
+        .unwrap();
+        assert_eq!(field, "nonexist");
+        assert_eq!(valid, vec!["_timestamp", "status", "message"]);
+    }
+
+    #[test]
+    fn parses_backticked_idents() {
+        let (field, valid) = parse_field_not_found(
+            "No field named `satus`. Valid fields are `logs`.`status`, `logs`.`status_code`.",
+        )
+        .unwrap();
+        assert_eq!(field, "satus");
+        assert_eq!(valid, vec!["status", "status_code"]);
+    }
+
+    #[test]
+    fn field_typo_gets_suggestions_without_duplication() {
+        let mut resp = body();
+        enrich(
+            &mut resp,
+            &ErrorCodes::SearchFieldNotFound(
+                "No field named satus. Valid fields are _timestamp, status, status_code, level."
+                    .to_string(),
+            ),
+        );
+        assert_eq!(
+            resp.suggestions,
+            Some(vec!["status".to_string(), "status_code".to_string()])
+        );
+        assert_eq!(resp.message, "unknown field 'satus'");
+        // no fact appears twice: candidates live only in suggestions
+        assert!(resp.hint.is_none());
+        assert!(resp.error_detail.is_none());
+    }
+
+    #[test]
+    fn no_similar_field_falls_back_to_field_list_hint() {
+        let mut resp = body();
+        enrich(
+            &mut resp,
+            &ErrorCodes::SearchFieldNotFound(
+                "No field named zzz_totally_off. Valid fields are _timestamp, status, level."
+                    .to_string(),
+            ),
+        );
+        assert!(resp.suggestions.is_none());
+        assert!(resp.hint.unwrap().contains("valid fields: _timestamp"));
+    }
+
+    #[test]
+    fn wide_schema_without_match_points_to_schema_endpoint() {
+        let valid = (0..50)
+            .map(|i| format!("column_{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let mut resp = body();
+        enrich(
+            &mut resp,
+            &ErrorCodes::SearchFieldNotFound(format!(
+                "No field named zzz_totally_off. Valid fields are {valid}."
+            )),
+        );
+        assert!(resp.suggestions.is_none());
+        assert!(resp.hint.unwrap().contains("stream schema endpoint"));
+        assert!(resp.error_detail.is_none());
+    }
+
+    #[test]
+    fn uds_error_gets_uds_hint() {
+        let mut resp = body();
+        enrich(
+            &mut resp,
+            &ErrorCodes::SearchFieldNotFound(
+                "No field named level. Field exists in the stream but not in its User-Defined Schema (UDS). Valid fields are _timestamp, message."
+                    .to_string(),
+            ),
+        );
+        assert!(resp.hint.unwrap().contains("User-Defined Schema"));
+    }
+
+    #[test]
+    fn function_typo_suggests_udf_with_usage() {
+        let mut resp = body();
+        enrich(
+            &mut resp,
+            &ErrorCodes::SearchFunctionNotDefined(
+                "Error during planning: Invalid function 'str_mach'.".to_string(),
+            ),
+        );
+        assert_eq!(resp.suggestions.as_ref().unwrap()[0], "str_match");
+        assert_eq!(resp.hint.as_deref(), Some("usage: str_match(field, 'v')"));
+        assert!(resp.error_detail.is_none());
+    }
+
+    #[test]
+    fn function_common_sql_suggested_with_usage() {
+        let mut resp = body();
+        enrich(
+            &mut resp,
+            &ErrorCodes::SearchFunctionNotDefined("Invalid function 'histgram'".to_string()),
+        );
+        assert_eq!(resp.suggestions.unwrap()[0], "histogram");
+        assert!(
+            resp.hint
+                .unwrap()
+                .contains("histogram(_timestamp, '1 hour')")
+        );
+    }
+
+    #[test]
+    fn unparseable_message_is_left_untouched() {
+        let mut resp = body();
+        enrich(
+            &mut resp,
+            &ErrorCodes::SearchFieldNotFound("something completely different".to_string()),
+        );
+        assert_eq!(resp.message, "orig");
+        assert!(resp.suggestions.is_none());
+    }
+
+    #[test]
+    fn levenshtein_basics() {
+        assert_eq!(levenshtein("status", "satus"), 1);
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+    }
+}

--- a/src/core/src/error_suggest.rs
+++ b/src/core/src/error_suggest.rs
@@ -30,34 +30,6 @@ const MAX_SUGGESTIONS: usize = 3;
 /// (hundreds of fields in an error are token noise).
 const MAX_FIELDS_IN_MESSAGE: usize = 10;
 
-/// SQL functions that are valid in O2 queries besides the UDFs in
-/// `DEFAULT_FUNCTIONS`. Used only for did-you-mean ranking.
-const COMMON_FUNCTIONS: &[&str] = &[
-    "count",
-    "sum",
-    "avg",
-    "min",
-    "max",
-    "median",
-    "approx_percentile_cont",
-    "date_bin",
-    "date_trunc",
-    "date_format",
-    "histogram",
-    "spath",
-    "to_timestamp",
-    "to_timestamp_micros",
-    "lower",
-    "upper",
-    "coalesce",
-    "concat",
-    "length",
-    "substring",
-    "replace",
-    "abs",
-    "round",
-];
-
 /// Attach `hint`/`suggestions` to an error body when the error code carries
 /// enough information. No-op for codes we have nothing smart to say about.
 pub fn enrich(resp: &mut HttpResponse, code: &ErrorCodes) {
@@ -109,10 +81,12 @@ fn enrich_function_not_defined(resp: &mut HttpResponse, inner: &str) {
         return;
     };
 
-    let candidates = DEFAULT_FUNCTIONS
+    // The registry snapshot covers every callable function: DataFusion
+    // built-ins plus the O2 UDFs (same source DataFusion's own
+    // "Did you mean" pulls from, minus per-org VRL functions).
+    let candidates = search::datafusion::exec::registered_function_names()
         .iter()
-        .map(|f| f.name)
-        .chain(COMMON_FUNCTIONS.iter().copied());
+        .map(|s| s.as_str());
     let suggestions = suggest(&func, candidates);
 
     resp.message = format!("unknown function '{func}'");
@@ -382,6 +356,16 @@ mod tests {
                 .unwrap()
                 .contains("histogram(_timestamp, '1 hour')")
         );
+    }
+
+    #[test]
+    fn function_datafusion_builtin_suggested() {
+        let mut resp = body();
+        enrich(
+            &mut resp,
+            &ErrorCodes::SearchFunctionNotDefined("Invalid function 'cout'".to_string()),
+        );
+        assert!(resp.suggestions.unwrap().contains(&"count".to_string()));
     }
 
     #[test]

--- a/src/core/src/http.rs
+++ b/src/core/src/http.rs
@@ -41,12 +41,18 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>)
     let status =
         StatusCode::from_u16(err.http_status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
     match err {
-        errors::Error::ErrorCode(code) => (
-            status,
-            [(ERROR_HEADER, HeaderValue::from(code.get_code()))],
-            Json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
-        )
-            .into_response(),
+        errors::Error::ErrorCode(code) => {
+            let mut body = MetaHttpResponse::error_code_with_trace_id(code, trace_id);
+            // attach hint/did-you-mean suggestions where the code carries
+            // enough information (no-op for the rest)
+            crate::error_suggest::enrich(&mut body, code);
+            (
+                status,
+                [(ERROR_HEADER, HeaderValue::from(code.get_code()))],
+                Json(body),
+            )
+                .into_response()
+        }
         // These errors don't carry a structured error code, so we don't set the
         // `X-Error-Message` header (it should only carry error codes). The full
         // message is still returned in the JSON response body.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod dashboards;
 pub use ::db;
 pub mod enrichment;
 pub mod enrichment_table;
+pub mod error_suggest;
 pub mod file_downloader;
 pub mod file_list;
 pub use ::db::folders;

--- a/src/core/src/service.rs
+++ b/src/core/src/service.rs
@@ -21,11 +21,11 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 pub use crate::{
     alerts, auth, authz, bootstrap, cache, cluster_info, compact, dashboards, db, enrichment,
-    enrichment_table, file_downloader, file_list, file_list_dump, folders, functions, github, grpc,
-    http, ingestion, ingestion_tokens, ingestion_types, kv, logs, metadata, metrics, model_pricing,
-    node, org_cleanup, organization, pipeline, promql, runtime_metrics, schema, search,
-    self_reporting, session, short_url, sourcemaps, stream, stream_utils, synthetics,
-    system_settings, tantivy, tls, traces, users,
+    enrichment_table, error_suggest, file_downloader, file_list, file_list_dump, folders,
+    functions, github, grpc, http, ingestion, ingestion_tokens, ingestion_types, kv, logs,
+    metadata, metrics, model_pricing, node, org_cleanup, organization, pipeline, promql,
+    runtime_metrics, schema, search, self_reporting, session, short_url, sourcemaps, stream,
+    stream_utils, synthetics, system_settings, tantivy, tls, traces, users,
 };
 #[cfg(feature = "enterprise")]
 pub use crate::{

--- a/src/infra/src/errors/grpc.rs
+++ b/src/infra/src/errors/grpc.rs
@@ -22,10 +22,22 @@ impl From<DataFusionError> for Error {
         if let DataFusionError::SchemaError(schema_err, _) = &err
             && let SchemaError::FieldNotFound {
                 field,
-                valid_fields: _,
+                valid_fields,
             } = schema_err.as_ref()
         {
-            return Error::ErrorCode(ErrorCodes::SearchFieldNotFound(field.name.clone()));
+            // Keep the same textual shape DataFusion's Display uses so the
+            // HTTP layer can parse candidates out of either origin and offer
+            // did-you-mean suggestions.
+            let valid = valid_fields
+                .iter()
+                .map(|f| f.flat_name())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Error::ErrorCode(ErrorCodes::SearchFieldNotFound(if valid.is_empty() {
+                format!("No field named {}.", field.name)
+            } else {
+                format!("No field named {}. Valid fields are {}.", field.name, valid)
+            }));
         }
 
         let err = err.to_string();

--- a/src/infra/src/errors/mod.rs
+++ b/src/infra/src/errors/mod.rs
@@ -443,6 +443,9 @@ impl ErrorCodes {
             20008 => Ok(ErrorCodes::SearchSQLExecuteError(message)),
             20009 => Ok(ErrorCodes::SearchCancelQuery(message)),
             20010 => Ok(ErrorCodes::SearchTimeout(message)),
+            20011 => Ok(ErrorCodes::InvalidParams(message)),
+            20012 => Ok(ErrorCodes::RatelimitExceeded(message)),
+            20013 => Ok(ErrorCodes::SearchHistogramNotAvailable(message)),
             _ => Ok(ErrorCodes::ServerInternalError(json.to_string())),
         }
     }
@@ -613,20 +616,24 @@ mod tests {
     }
 
     #[test]
-    fn test_error_codes_from_json_codes_above_20010_fall_to_server_internal() {
-        // from_json only handles codes up to 20010; 20011-20013 fall through
-        for (code, inner) in [
-            (20011, "invalid_params"),
-            (20012, "rate_exceeded"),
-            (20013, "histogram_unavail"),
+    fn test_error_codes_from_json_round_trips_20011_to_20013() {
+        for (code, expected) in [
+            (
+                20011,
+                ErrorCodes::InvalidParams("invalid_params".to_string()),
+            ),
+            (
+                20012,
+                ErrorCodes::RatelimitExceeded("rate_exceeded".to_string()),
+            ),
+            (
+                20013,
+                ErrorCodes::SearchHistogramNotAvailable("histogram_unavail".to_string()),
+            ),
         ] {
-            let json = format!(r#"{{"code":{code},"message":"x","inner":"{inner}"}}"#);
-            let result = ErrorCodes::from_json(&json).unwrap();
-            // The fallback wraps the entire input JSON string, not the inner value
-            match result {
-                ErrorCodes::ServerInternalError(_) => {}
-                other => panic!("expected ServerInternalError for code {code}, got {other:?}"),
-            }
+            let result = ErrorCodes::from_json(&expected.to_json()).unwrap();
+            assert_eq!(result.get_code(), code);
+            assert_eq!(result.get_inner_message(), expected.get_inner_message());
         }
     }
 

--- a/src/search/src/datafusion/exec.rs
+++ b/src/search/src/datafusion/exec.rs
@@ -287,6 +287,17 @@ impl<'a> DataFusionContextBuilder<'a> {
 }
 
 pub fn register_udf(ctx: &SessionContext, org_id: &str) -> Result<()> {
+    register_builtin_udfs(ctx);
+    let udf_list = get_all_transform(org_id)?;
+    for udf in udf_list {
+        ctx.register_udf(udf.clone());
+    }
+    Ok(())
+}
+
+/// Register the org-independent O2 UDFs/UDAFs (everything except the per-org
+/// VRL transform functions).
+pub fn register_builtin_udfs(ctx: &SessionContext) {
     ctx.register_udf(super::udf::str_match_udf::STR_MATCH_UDF.clone());
     ctx.register_udf(super::udf::str_match_udf::STR_MATCH_IGNORE_CASE_UDF.clone());
     ctx.register_udf(super::udf::fuzzy_match_udf::FUZZY_MATCH_UDF.clone());
@@ -314,10 +325,6 @@ pub fn register_udf(ctx: &SessionContext, org_id: &str) -> Result<()> {
         super::udaf::summary_percentile::SummaryPercentile::new(),
     ));
     ctx.register_udf(super::udf::cast_to_timestamp_udf::CAST_TO_TIMESTAMP_UDF.clone());
-    let udf_list = get_all_transform(org_id)?;
-    for udf in udf_list {
-        ctx.register_udf(udf.clone());
-    }
 
     #[cfg(feature = "enterprise")]
     {
@@ -331,8 +338,25 @@ pub fn register_udf(ctx: &SessionContext, org_id: &str) -> Result<()> {
             o2_enterprise::enterprise::search::datafusion::udaf::approx_topk_distinct::ApproxTopKDistinct::new(),
         ));
     }
+}
 
-    Ok(())
+/// Names of every function usable in O2 SQL: the DataFusion built-ins plus
+/// the built-in O2 UDFs (per-org VRL functions excluded). Snapshotted once —
+/// the registry is static for the process lifetime. Used for did-you-mean
+/// suggestions on "Invalid function" errors.
+pub fn registered_function_names() -> &'static [String] {
+    static NAMES: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
+    NAMES.get_or_init(|| {
+        let ctx = SessionContext::new();
+        register_builtin_udfs(&ctx);
+        let state = ctx.state();
+        let mut names: Vec<String> = state.scalar_functions().keys().cloned().collect();
+        names.extend(state.aggregate_functions().keys().cloned());
+        names.extend(state.window_functions().keys().cloned());
+        names.sort();
+        names.dedup();
+        names
+    })
 }
 
 pub async fn register_metrics_table(

--- a/src/search_service/src/lib.rs
+++ b/src/search_service/src/lib.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#![recursion_limit = "256"]
+
 use std::sync::{Arc, LazyLock as Lazy};
 
 use arrow::array::RecordBatch;


### PR DESCRIPTION
Design at: #13375

## What

Search errors become self-correcting (AX track, D4): a mistyped field or function name now returns structured, minimal guidance instead of a raw engine error.

```json
{ "code": 20004, "message": "unknown field 'servce'", "suggestions": ["service"] }

{ "code": 20005, "message": "unknown function 'str_mach'",
  "hint": "usage: str_match(field, 'v')", "suggestions": ["str_match", "str_match_ignore_case"] }
```

The error body gains two optional fields, `hint` and `suggestions` (omitted when unset — existing clients see no change). Agents retry from error text; suggestion quality directly determines rounds-to-answer.

## Design

- **No duplicated facts, fewer tokens than before.** `message` names the problem; `suggestions` is the only home for candidates; `hint` appears only with non-inferable info (a usage example, a UDS explanation, or a fallback when nothing similar was found — small schemas get the field list, wide schemas get pointed at the schema endpoint); `error_detail` is dropped on successful enrichment. The enriched error is smaller than the raw engine error it replaces.
- **Wire format unchanged.** Candidates are embedded at the producer sites in the same textual shape DataFusion's Display uses ("No field named X. Valid fields are a, b."); parsing, ranking and formatting happen once at the HTTP edge (`core::error_suggest`, used by `map_error_to_http_response`). Mixed-version clusters are unaffected.
- **Real schema, not the engine's view.** DataFusion only sees the pruned scan schema, so its valid-fields list is misleading (usually just `_timestamp`). The `_search` error path swaps it for the streams' actual schema fields before mapping; the typed `FieldNotFound` mapping no longer discards `valid_fields`; the validate path (including UDS violations) embeds real candidates at the producer.
- **Ranking**: hand-rolled Levenshtein (no new dependency) + a prefix-distance rule so `satus` recalls both `status` and `status_code`; top 3.
- **Function candidates**: the `DEFAULT_FUNCTIONS` UDF registry (with its own usage strings) + a static list of common SQL functions, with hand-kept signatures for the ones agents misuse most (`histogram`, `date_bin`, `date_format`, `approx_percentile_cont`, `spath`, `to_timestamp_micros`).
- **Bug fix in passing**: `ErrorCodes::from_json` now round-trips codes 20011–20013 (`InvalidParams`, `RatelimitExceeded`, `SearchHistogramNotAvailable`) instead of degrading them to `ServerInternalError` when crossing nodes.

## Testing

- 10 unit tests on the enrichment module (parsing both message shapes incl. backticked/qualified idents, suggestion ranking, prefix recall, UDS hint, no-match fallbacks, no-duplication contract) + round-trip tests for the new `from_json` codes.
- E2E against a local instance: field typo → `suggestions: ["service"]`; function typo → usage example inline; unrelated name → field-list fallback hint; all responses shorter than the previous raw errors.
- `cargo check --workspace --tests`, clippy, fmt clean.
