### PR TITLE
fix: added header-level tab navigation (Checks / Private Locations) to the Synthetic Monitoring page

### DIFF
--- a/web/src/components/synthetics/results/ProtocolRunSummary.vue
+++ b/web/src/components/synthetics/results/ProtocolRunSummary.vue
@@ -172,7 +172,7 @@ const showAssertions = computed(
       :subtitle="run ? fmtTs(run.timestamp) : ''"
       :back="{
         label: t('synthetics.results.monitors'),
-        to: { name: 'synthetics-monitor-results', params: { id: monitorId } },
+        to: { name: 'synthetic-monitor-results', params: { id: monitorId } },
         dataTest: 'synthetics-protocol-run-back-btn',
       }"
     >

--- a/web/src/composables/shared/useEnterpriseRoutes.ts
+++ b/web/src/composables/shared/useEnterpriseRoutes.ts
@@ -209,7 +209,7 @@ const useEnterpriseRoutes = () => {
         },
       },
       {
-        path: "synthetic/:id/results",
+        path: "synthetics/:id/results",
         name: "synthetic-monitor-results",
         component: () => import("@/views/synthetics/MonitorResults.vue"),
         meta: { title: "Monitor Results" },

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -9897,6 +9897,7 @@
     "tabs": {
       "all": "All",
       "browser": "Browser",
+      "checks": "Checks",
       "http": "HTTP",
       "ssh": "SSH",
       "tcp": "TCP",

--- a/web/src/views/SyntheticMonitoring.spec.ts
+++ b/web/src/views/SyntheticMonitoring.spec.ts
@@ -34,6 +34,7 @@ const {
   mockServiceGet,
   mockServiceCreate,
   mockServiceGetLocations,
+  mockServiceGetAgentSetup,
   mockRouterPush,
 } = vi.hoisted(() => ({
   mockServiceList: vi.fn().mockResolvedValue({ data: { monitors: [] } }),
@@ -44,6 +45,7 @@ const {
   mockServiceGet: vi.fn().mockResolvedValue({ data: {} }),
   mockServiceCreate: vi.fn().mockResolvedValue({ data: { id: "new-1" } }),
   mockServiceGetLocations: vi.fn().mockResolvedValue({ data: { locations: [] } }),
+  mockServiceGetAgentSetup: vi.fn().mockResolvedValue({ data: { install: "curl ...", token: "abc123" } }),
   mockRouterPush: vi.fn(),
 }));
 
@@ -74,6 +76,7 @@ vi.mock("@/services/synthetics", () => ({
     bulkDelete: mockServiceBulkDelete,
     run: mockServiceRun,
     getLocations: mockServiceGetLocations,
+    getAgentSetup: mockServiceGetAgentSetup,
   },
 }));
 
@@ -178,7 +181,31 @@ const baseStubs = {
     props: ["value", "size", "iconLeft"],
     inheritAttrs: true,
   },
-
+  // ── Stubs for tabs-below header tabs (Reka-UI backed, must be stubbed) ──
+  OTabs: {
+    template: '<div data-test="synthetic-monitoring-header-tabs"><slot /></div>',
+    props: ["modelValue", "align", "dense", "bordered", "orientation", "reorderable"],
+    emits: ["change", "update:modelValue", "reorder"],
+  },
+  OTab: {
+    template: '<div data-test="synthetic-monitoring-header-tab"><slot /></div>',
+    props: ["value", "name", "label", "icon", "disable", "tooltip"],
+  },
+  OText: {
+    template: '<span><slot /></span>',
+    props: ["variant"],
+  },
+  // ── Stubs for Private Locations functionality ────────────────────────
+  PrivateLocations: {
+    template: '<div data-test="synthetic-monitoring-private-locations-stub" />',
+    props: ["locations", "loading"],
+    emits: ["refresh", "copy-setup", "delete"],
+  },
+  AgentSetupDrawer: {
+    template: '<div data-test="synthetic-monitoring-agent-setup-drawer-stub" />',
+    props: ["open", "install", "locationName", "locationId", "token", "org", "o2Url", "scriptUrl"],
+    emits: ["update:open"],
+  },
 };
 
 function mountPage() {
@@ -297,6 +324,199 @@ describe("SyntheticMonitoring", () => {
       await nextTick();
 
       expect(mt.props("hasFilters")).toBe(false);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Header tabs (tabs-below pattern: OTabs in the OPageLayout #header-tabs slot)
+  // ═══════════════════════════════════════════════════════════════════════
+  describe("header tabs", () => {
+    it("renders both tab options (Checks and Private Locations) in the header", () => {
+      wrapper = mountPage();
+      const tabsWrapper = wrapper.find('[data-test="synthetic-monitoring-header-tabs"]');
+      expect(tabsWrapper.exists()).toBe(true);
+
+      const tabElements = wrapper.findAll('[data-test="synthetic-monitoring-header-tab"]');
+      expect(tabElements).toHaveLength(2);
+    });
+
+    it("defaults activeSection to 'checks'", () => {
+      wrapper = mountPage();
+      expect((wrapper.vm as any).activeSection).toBe("checks");
+    });
+
+    it("allows switching activeSection to 'private'", async () => {
+      wrapper = mountPage();
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+      expect((wrapper.vm as any).activeSection).toBe("private");
+    });
+
+    it("can switch activeSection back from 'private' to 'checks'", async () => {
+      wrapper = mountPage();
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+      (wrapper.vm as any).activeSection = "checks";
+      await nextTick();
+      expect((wrapper.vm as any).activeSection).toBe("checks");
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Conditional #actions slot: New Check vs Setup an agent
+  // ═══════════════════════════════════════════════════════════════════════
+  describe("conditional header action button", () => {
+    it("shows New Check button when on Checks tab and hides Setup agent button", () => {
+      wrapper = mountPage();
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-new-check-btn"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-setup-agent-btn"]').exists(),
+      ).toBe(false);
+    });
+
+    it("shows Setup an agent button when on Private tab and hides New Check button", async () => {
+      wrapper = mountPage();
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-new-check-btn"]').exists(),
+      ).toBe(false);
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-setup-agent-btn"]').exists(),
+      ).toBe(true);
+    });
+
+    it("clicking New Check button sets showTypePicker to true", async () => {
+      wrapper = mountPage();
+      expect((wrapper.vm as any).showTypePicker).toBe(false);
+
+      await wrapper
+        .find('[data-test="synthetic-monitoring-new-check-btn"]')
+        .trigger("click");
+
+      expect((wrapper.vm as any).showTypePicker).toBe(true);
+    });
+
+    it("clicking Setup an agent button sets showSetupDrawer to true", async () => {
+      wrapper = mountPage();
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+
+      await wrapper
+        .find('[data-test="synthetic-monitoring-setup-agent-btn"]')
+        .trigger("click");
+
+      // openSetupDrawer sets showSetupDrawer synchronously before any async call
+      expect((wrapper.vm as any).showSetupDrawer).toBe(true);
+      // Confirm getAgentSetup was called as part of openSetupDrawer
+      expect(mockServiceGetAgentSetup).toHaveBeenCalled();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Sidebar, main content, and PrivateLocations visibility per activeSection
+  // ═══════════════════════════════════════════════════════════════════════
+  describe("sidebar and main content visibility", () => {
+    it("shows sidebar folder list only on Checks tab", async () => {
+      wrapper = mountPage();
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-folder-list"]').exists(),
+      ).toBe(true);
+
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-folder-list"]').exists(),
+      ).toBe(false);
+    });
+
+    it("shows MonitorTable only on Checks tab", async () => {
+      wrapper = mountPage();
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-monitors-table"]').exists(),
+      ).toBe(true);
+
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-monitors-table"]').exists(),
+      ).toBe(false);
+    });
+
+    it("renders PrivateLocations on Private Locations tab", async () => {
+      wrapper = mountPage();
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-private-locations-stub"]').exists(),
+      ).toBe(false);
+
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-private-locations-stub"]').exists(),
+      ).toBe(true);
+    });
+
+    it("shows sidebar and MonitorTable again after switching back to Checks", async () => {
+      wrapper = mountPage();
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+      (wrapper.vm as any).activeSection = "checks";
+      await nextTick();
+
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-folder-list"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-monitors-table"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-test="synthetic-monitoring-private-locations-stub"]').exists(),
+      ).toBe(false);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // PrivateLocations: old @setup listener removed, replaced by @copy-setup
+  // ═══════════════════════════════════════════════════════════════════════
+  describe("PrivateLocations no longer emits setup", () => {
+    it("uses @copy-setup instead of the old @setup to open the setup drawer", async () => {
+      wrapper = mountPage();
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+
+      const plWrapper = wrapper.findComponent(
+        '[data-test="synthetic-monitoring-private-locations-stub"]',
+      );
+      expect(plWrapper.exists()).toBe(true);
+
+      // Emit copy-setup (the replacement for the old @setup listener).
+      plWrapper.vm.$emit("copy-setup", { id: "loc1", name: "Test Location" });
+
+      // @copy-setup calls openSetupDrawer which sets showSetupDrawer = true
+      expect((wrapper.vm as any).showSetupDrawer).toBe(true);
+    });
+
+    it("does not respond to a 'setup' emit on PrivateLocations", async () => {
+      wrapper = mountPage();
+      (wrapper.vm as any).activeSection = "private";
+      await nextTick();
+
+      const plWrapper = wrapper.findComponent(
+        '[data-test="synthetic-monitoring-private-locations-stub"]',
+      );
+      expect((wrapper.vm as any).showSetupDrawer).toBe(false);
+
+      // Emitting the old "setup" event should have no effect — it is unbound.
+      plWrapper.vm.$emit("setup", { id: "loc1", name: "Test Location" });
+      await nextTick();
+
+      expect((wrapper.vm as any).showSetupDrawer).toBe(false);
     });
   });
 });

--- a/web/src/views/SyntheticMonitoring.vue
+++ b/web/src/views/SyntheticMonitoring.vue
@@ -34,11 +34,11 @@
           align="left"
           @change="activeSection = ($event as 'checks' | 'private')"
         >
-          <OTab value="checks">
+          <OTab name="checks">
             <OIcon name="radar" size="sm" />
             <span>{{ t('synthetics.tabs.checks') }}</span>
           </OTab>
-          <OTab value="private">
+          <OTab name="private">
             <OIcon name="location-on" size="sm" />
             <span>{{ t('synthetics.tabs.private') }}</span>
           </OTab>

--- a/web/src/views/SyntheticMonitoring.vue
+++ b/web/src/views/SyntheticMonitoring.vue
@@ -5,9 +5,11 @@
     :subtitle="t('synthetics.pageSubtitle')"
     icon="radar"
     bleed
+    tabs-below
   >
       <template #actions>
         <OButton
+          v-if="activeSection === 'checks'"
           size="sm"
           variant="primary"
           data-test="synthetic-monitoring-new-check-btn"
@@ -15,11 +17,37 @@
         >
           {{ t('synthetics.newCheck.button') }}
         </OButton>
+        <OButton
+          v-else
+          size="sm"
+          variant="primary"
+          data-test="synthetic-monitoring-setup-agent-btn"
+          @click="openSetupDrawer()"
+        >
+          {{ t('synthetics.privateLocations.setupAgent') }}
+        </OButton>
+      </template>
+
+      <template #header-tabs>
+        <OTabs
+          :model-value="activeSection"
+          align="left"
+          @change="activeSection = ($event as 'checks' | 'private')"
+        >
+          <OTab value="checks">
+            <OIcon name="radar" size="sm" />
+            <span>{{ t('synthetics.tabs.checks') }}</span>
+          </OTab>
+          <OTab value="private">
+            <OIcon name="location-on" size="sm" />
+            <span>{{ t('synthetics.tabs.private') }}</span>
+          </OTab>
+        </OTabs>
       </template>
     <!-- CONTENT AREA: sidebar + main -->
     <div class="flex flex-1 overflow-hidden">
       <!-- LEFT SIDEBAR: folder navigation (locations are org-level, no folders) -->
-      <div v-if="activeTab !== 'private'" class="w-rail shrink-0 overflow-y-auto">
+      <div v-if="activeSection === 'checks'" class="w-rail shrink-0 overflow-y-auto">
         <FolderList
           type="synthetics"
           data-test="synthetic-monitoring-folder-list"
@@ -29,28 +57,16 @@
 
       <!-- ── PRIVATE LOCATIONS TAB ── -->
       <PrivateLocations
-        v-if="activeTab === 'private'"
+        v-if="activeSection === 'private'"
         :locations="privateLocations"
         :loading="locationsLoading"
         @refresh="loadPrivateLocations"
-        @setup="openSetupDrawer()"
         @copy-setup="openSetupDrawer"
         @delete="confirmDeleteLocation"
-      >
-        <template #tabs>
-          <OToggleGroup
-            :model-value="activeTab"
-            @update:model-value="onTabChange"
-          >
-            <OToggleGroupItem v-for="tab in typeTabs" :key="tab.key" :value="tab.key" size="sm">
-              {{ tab.label }}
-            </OToggleGroupItem>
-          </OToggleGroup>
-        </template>
-      </PrivateLocations>
+      />
 
       <!-- RIGHT MAIN: filter bar + table -->
-      <div v-else class="flex-1 flex flex-col overflow-hidden min-w-0">
+      <div v-if="activeSection === 'checks'" class="flex-1 flex flex-col overflow-hidden min-w-0">
 
         <!-- ── CHECKS TABLE ── -->
         <MonitorTable
@@ -268,6 +284,8 @@ import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OButton from "@/lib/core/Button/OButton.vue";
 import OSelect from "@/lib/forms/Select/OSelect.vue";
 import OInput from "@/lib/forms/Input/OInput.vue";
+import OTabs from "@/lib/navigation/Tabs/OTabs.vue";
+import OTab from "@/lib/navigation/Tabs/OTab.vue";
 import OToggleGroup from "@/lib/core/ToggleGroup/OToggleGroup.vue";
 import OToggleGroupItem from "@/lib/core/ToggleGroup/OToggleGroupItem.vue";
 import ODialog from "@/lib/overlay/Dialog/ODialog.vue";
@@ -431,6 +449,7 @@ onMounted(() => {
   initPage()
 })
 
+const activeSection   = ref<'checks' | 'private'>('checks');
 const activeTab      = ref("all");
 const monitorTableMode = computed(() => activeTab.value === 'browser' ? 'browser' : 'all');
 const statusFilter   = ref("all");
@@ -546,16 +565,11 @@ const typeTabs = computed(() => [
     label: t(`synthetics.tabs.${ct}`),
     icon: CHECK_TYPE_CARDS.find(c => c.type === ct)?.icon,
   })),
-  { key: 'private', label: t('synthetics.tabs.private') },
 ]);
 
 const onTabChange = (v: unknown) => {
   const tab = v as string;
   activeTab.value = tab;
-  if (tab === 'private') {
-    loadPrivateLocations();
-    return;
-  }
   typeFilter.value = tab === 'all' ? 'all' : tab.toUpperCase();
 };
 

--- a/web/src/views/SyntheticMonitoring.vue
+++ b/web/src/views/SyntheticMonitoring.vue
@@ -552,7 +552,7 @@ const openDetail = (monitor: any) => {
   const query: Record<string, string> = { name: monitor.name, folder: monitor.folder_name }
   if (monitor.lastTriggeredAt > 0) query.last_triggered_at = String(monitor.lastTriggeredAt)
   router.push({
-    name: 'synthetics-monitor-results',
+    name: 'synthetic-monitor-results',
     params: { id: String(monitor.id) },
     query,
   });

--- a/web/src/views/synthetics/PrivateLocations.spec.ts
+++ b/web/src/views/synthetics/PrivateLocations.spec.ts
@@ -1,0 +1,587 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, VueWrapper } from "@vue/test-utils";
+import type { SyntheticLocation } from "@/types/synthetics";
+
+// ── Mocks (hoisted by Vitest) ──────────────────────────────────────────────
+
+vi.mock("vue-i18n", () => ({
+  useI18n: vi.fn(() => ({ t: (key: string) => key })),
+}));
+
+// Hoisted so the vi.mock factory below can reference it (vi.mock is hoisted
+// to the top of the file, so top-level const declarations are in TDZ when the
+// factory runs).
+const { mockRouterPush } = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+}));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
+
+vi.mock("@/utils/synthetics/format", () => ({
+  formatTimeAgoUs: vi.fn((us: number) => `formatted-${us}`),
+}));
+
+// ── Component under test ───────────────────────────────────────────────────
+
+import PrivateLocations from "./PrivateLocations.vue";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeLocation(overrides: Partial<SyntheticLocation> = {}): SyntheticLocation {
+  return {
+    id: "loc-1",
+    name: "US East",
+    region: "us-east-1",
+    provider: "aws",
+    kind: "private",
+    pool: "default",
+    enabled: true,
+    types: ["http", "browser"],
+    live_agents: 3,
+    agent_names: ["agent-a", "agent-b", "agent-c"],
+    agents_total: 5,
+    status: "online",
+    version: "2.0.0",
+    last_seen_at: Date.now() * 1000,
+    monitors_count: 0,
+    checks_per_min: 10,
+    ...overrides,
+  };
+}
+
+const OTableStub = {
+  template: `
+    <div :data-test="$attrs['data-test']">
+      <div class="otable-toolbar"><slot name="toolbar" /></div>
+      <div class="otable-toolbar-trailing"><slot name="toolbar-trailing" /></div>
+      <table>
+        <tbody>
+          <tr
+            v-for="(row, index) in (data || [])"
+            :key="row[rowKey]"
+            class="otable-row"
+            @click="$emit('row-click', row)"
+          >
+            <td class="otable-cell-status"><slot name="cell-status" :row="row" /></td>
+            <td class="otable-cell-name"><slot name="cell-name" :row="row" /></td>
+            <td class="otable-cell-agents"><slot name="cell-agents" :row="row" /></td>
+            <td class="otable-cell-types"><slot name="cell-types" :row="row" /></td>
+            <td class="otable-cell-lastSeen"><slot name="cell-lastSeen" :row="row" /></td>
+            <td class="otable-cell-actions"><slot name="cell-actions" :row="row" /></td>
+          </tr>
+        </tbody>
+      </table>
+      <div v-if="!data || data.length === 0" class="otable-empty"><slot name="empty" /></div>
+    </div>
+  `,
+  props: [
+    "data",
+    "columns",
+    "rowKey",
+    "loading",
+    "pagination",
+    "pageSize",
+    "pageSizeOptions",
+    "showGlobalFilter",
+    "persistColumns",
+    "tableId",
+    "enableColumnResize",
+  ],
+  emits: ["row-click"],
+};
+
+const OButtonStub = {
+  template: '<button @click="$emit(\'click\')"><slot /></button>',
+  props: ["variant", "size", "iconLeft", "loading", "title"],
+  emits: ["click"],
+};
+
+const OInputStub = {
+  template:
+    '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  props: ["modelValue", "placeholder"],
+  emits: ["update:modelValue"],
+};
+
+const OBadgeStub = {
+  template: '<span class="obadge-stub"><slot /></span>',
+  props: ["variant", "dot", "size"],
+};
+
+const OTagStub = {
+  template: '<span class="otag-stub"><slot /></span>',
+  props: ["size", "shape", "variant"],
+};
+
+const OEmptyStateStub = {
+  template: '<div :data-test="$attrs[\'data-test\']" class="oemptystate-stub" />',
+  props: ["size", "illustration", "filtered", "title", "description"],
+};
+
+function makeWrapper(props: { locations?: SyntheticLocation[]; loading?: boolean } = {}) {
+  return mount(PrivateLocations, {
+    props: {
+      locations: props.locations ?? [],
+      loading: props.loading ?? false,
+    },
+    global: {
+      stubs: {
+        OTable: OTableStub,
+        OButton: OButtonStub,
+        OInput: OInputStub,
+        OBadge: OBadgeStub,
+        OTag: OTagStub,
+        OEmptyState: OEmptyStateStub,
+      },
+    },
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("PrivateLocations", () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRouterPush.mockReset();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  describe("rendering", () => {
+    it("renders the table with the correct data-test attribute", () => {
+      wrapper = makeWrapper({ locations: [makeLocation()] });
+
+      expect(
+        wrapper.find('[data-test="synthetics-private-locations-table"]').exists(),
+      ).toBe(true);
+    });
+
+    it("renders the search input in the toolbar", () => {
+      wrapper = makeWrapper({ locations: [makeLocation()] });
+
+      const input = wrapper.find(
+        '[data-test="synthetics-private-locations-search-input"]',
+      );
+      expect(input.exists()).toBe(true);
+    });
+
+    it("renders the refresh button in the toolbar-trailing", () => {
+      wrapper = makeWrapper({ locations: [makeLocation()] });
+
+      const refreshBtn = wrapper.find(
+        '[data-test="synthetics-private-locations-refresh-btn"]',
+      );
+      expect(refreshBtn.exists()).toBe(true);
+    });
+
+    it("renders location rows in the table", () => {
+      const locations = [
+        makeLocation({ id: "loc-1", name: "US East" }),
+        makeLocation({ id: "loc-2", name: "EU West" }),
+      ];
+      wrapper = makeWrapper({ locations });
+
+      const rows = wrapper.findAll(".otable-row");
+      expect(rows).toHaveLength(2);
+    });
+
+    it("renders the location name and pool in the name cell", () => {
+      wrapper = makeWrapper({
+        locations: [makeLocation({ name: "US East", pool: "prod" })],
+      });
+
+      const nameCell = wrapper.find(".otable-cell-name");
+      expect(nameCell.text()).toContain("US East");
+      expect(nameCell.text()).toContain("prod");
+    });
+
+    it("renders agents count and version in the agents cell", () => {
+      wrapper = makeWrapper({
+        locations: [makeLocation({ live_agents: 3, agents_total: 5, version: "2.0.0" })],
+      });
+
+      const agentsCell = wrapper.find(".otable-cell-agents");
+      expect(agentsCell.text()).toContain("3/5");
+      expect(agentsCell.text()).toContain("v2.0.0");
+    });
+
+    it("renders type chips for each type", () => {
+      wrapper = makeWrapper({
+        locations: [makeLocation({ types: ["http", "browser", "tcp"] })],
+      });
+
+      const chips = wrapper.findAll(".otable-cell-types .otag-stub");
+      expect(chips).toHaveLength(3);
+      expect(chips[0].text()).toBe("HTTP");
+      expect(chips[1].text()).toBe("BROWSER");
+      expect(chips[2].text()).toBe("TCP");
+    });
+
+    it("renders a dash when types array is empty", () => {
+      wrapper = makeWrapper({ locations: [makeLocation({ types: [] })] });
+
+      const typesCell = wrapper.find(".otable-cell-types");
+      expect(typesCell.text()).toBe("—");
+    });
+
+    it("renders the last seen formatted time", () => {
+      const ts = 1700000000000000;
+      wrapper = makeWrapper({ locations: [makeLocation({ last_seen_at: ts })] });
+
+      const lastSeenCell = wrapper.find(".otable-cell-lastSeen");
+      expect(lastSeenCell.text()).toContain(`formatted-${ts}`);
+    });
+
+    it("renders a dash when last_seen_at is missing", () => {
+      wrapper = makeWrapper({
+        locations: [makeLocation({ last_seen_at: undefined as any })],
+      });
+
+      const lastSeenCell = wrapper.find(".otable-cell-lastSeen");
+      expect(lastSeenCell.text()).toBe("—");
+    });
+
+    it("renders copy and delete action buttons for each row", () => {
+      wrapper = makeWrapper({
+        locations: [
+          makeLocation({ id: "loc-a" }),
+          makeLocation({ id: "loc-b" }),
+        ],
+      });
+
+      expect(
+        wrapper.find('[data-test="synthetics-private-locations-copy-btn-loc-a"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-test="synthetics-private-locations-delete-btn-loc-a"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-test="synthetics-private-locations-copy-btn-loc-b"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-test="synthetics-private-locations-delete-btn-loc-b"]').exists(),
+      ).toBe(true);
+    });
+
+    it("renders OBadge with success variant for online status", () => {
+      wrapper = makeWrapper({ locations: [makeLocation({ status: "online" })] });
+
+      const badge = wrapper.find(".obadge-stub");
+      expect(badge.exists()).toBe(true);
+      const statusCell = wrapper.find(".otable-cell-status");
+      expect(statusCell.text()).toContain("synthetics.privateLocations.status.online");
+    });
+  });
+
+  describe("loading prop", () => {
+    it("passes loading true to OTable", () => {
+      wrapper = makeWrapper({ loading: true, locations: [] });
+      // The OTable stub is rendered; verify the empty slot doesn't
+      // show OEmptyState when loading is true (v-if="!loading")
+      expect(
+        wrapper.find('[data-test="synthetics-private-locations-empty-state"]').exists(),
+      ).toBe(false);
+    });
+
+    it("passes loading false to OTable", () => {
+      wrapper = makeWrapper({ loading: false });
+      // With loading false and no data, the empty state should appear
+      // This is tested in the empty state section
+      expect(
+        wrapper.find('[data-test="synthetics-private-locations-table"]').exists(),
+      ).toBe(true);
+    });
+  });
+
+  describe("search/filter", () => {
+    it("shows all locations when search is empty", () => {
+      const locations = [
+        makeLocation({ id: "loc-1", name: "US East" }),
+        makeLocation({ id: "loc-2", name: "EU West" }),
+        makeLocation({ id: "loc-3", name: "Asia Pacific" }),
+      ];
+      wrapper = makeWrapper({ locations });
+
+      const rows = wrapper.findAll(".otable-row");
+      expect(rows).toHaveLength(3);
+    });
+
+    it("filters locations by name (case-insensitive)", async () => {
+      // Use regions that don't contain "east" so only name matches drive the result.
+      const locations = [
+        makeLocation({ id: "loc-1", name: "US East", region: "r-1", pool: "p-1" }),
+        makeLocation({ id: "loc-2", name: "EU West", region: "r-2", pool: "p-2" }),
+        makeLocation({ id: "loc-3", name: "Asia Pacific", region: "r-3", pool: "p-3" }),
+      ];
+      wrapper = makeWrapper({ locations });
+
+      const input = wrapper.find("input");
+      await input.setValue("east");
+
+      const rows = wrapper.findAll(".otable-row");
+      expect(rows).toHaveLength(1);
+      const nameCell = wrapper.find(".otable-cell-name");
+      expect(nameCell.text()).toContain("US East");
+    });
+
+    it("filters locations by region (case-insensitive)", async () => {
+      const locations = [
+        makeLocation({ id: "loc-1", name: "Prod", region: "us-east-1" }),
+        makeLocation({ id: "loc-2", name: "Staging", region: "eu-west-1" }),
+      ];
+      wrapper = makeWrapper({ locations });
+
+      const input = wrapper.find("input");
+      await input.setValue("west");
+
+      const rows = wrapper.findAll(".otable-row");
+      expect(rows).toHaveLength(1);
+      const nameCell = wrapper.find(".otable-cell-name");
+      expect(nameCell.text()).toContain("Staging");
+    });
+
+    it("filters locations by pool (case-insensitive)", async () => {
+      const locations = [
+        makeLocation({ id: "loc-1", name: "A", pool: "alpha" }),
+        makeLocation({ id: "loc-2", name: "B", pool: "beta" }),
+        makeLocation({ id: "loc-3", name: "C", pool: "alpha-backup" }),
+      ];
+      wrapper = makeWrapper({ locations });
+
+      const input = wrapper.find("input");
+      await input.setValue("ALPHA");
+
+      const rows = wrapper.findAll(".otable-row");
+      expect(rows).toHaveLength(2);
+    });
+
+    it("shows no rows when search matches nothing", async () => {
+      const locations = [
+        makeLocation({ id: "loc-1", name: "US East" }),
+      ];
+      wrapper = makeWrapper({ locations });
+
+      const input = wrapper.find("input");
+      await input.setValue("zzz-nonexistent");
+
+      const rows = wrapper.findAll(".otable-row");
+      expect(rows).toHaveLength(0);
+    });
+
+    it("restores all rows when search is cleared", async () => {
+      // Use unique regions/pools so "east" only matches the name field.
+      const locations = [
+        makeLocation({ id: "loc-1", name: "US East", region: "r-a", pool: "p-a" }),
+        makeLocation({ id: "loc-2", name: "EU West", region: "r-b", pool: "p-b" }),
+      ];
+      wrapper = makeWrapper({ locations });
+
+      const input = wrapper.find("input");
+      await input.setValue("east");
+      expect(wrapper.findAll(".otable-row")).toHaveLength(1);
+
+      await input.setValue("");
+      expect(wrapper.findAll(".otable-row")).toHaveLength(2);
+    });
+  });
+
+  describe("events", () => {
+    it('emits "refresh" when refresh button is clicked', async () => {
+      wrapper = makeWrapper({ locations: [makeLocation()] });
+
+      const refreshBtn = wrapper.find(
+        '[data-test="synthetics-private-locations-refresh-btn"]',
+      );
+      await refreshBtn.trigger("click");
+
+      expect(wrapper.emitted("refresh")).toBeTruthy();
+      expect(wrapper.emitted("refresh")).toHaveLength(1);
+    });
+
+    it('emits "copy-setup" with row data when copy button is clicked', async () => {
+      const loc = makeLocation({ id: "loc-abc", name: "Test Location" });
+      wrapper = makeWrapper({ locations: [loc] });
+
+      const copyBtn = wrapper.find(
+        '[data-test="synthetics-private-locations-copy-btn-loc-abc"]',
+      );
+      await copyBtn.trigger("click");
+
+      expect(wrapper.emitted("copy-setup")).toBeTruthy();
+      expect(wrapper.emitted("copy-setup")).toHaveLength(1);
+      expect(wrapper.emitted("copy-setup")![0][0]).toEqual(loc);
+    });
+
+    it('emits "delete" with row data when delete button is clicked', async () => {
+      const loc = makeLocation({ id: "loc-xyz", monitors_count: 0 });
+      wrapper = makeWrapper({ locations: [loc] });
+
+      const deleteBtn = wrapper.find(
+        '[data-test="synthetics-private-locations-delete-btn-loc-xyz"]',
+      );
+      await deleteBtn.trigger("click");
+
+      expect(wrapper.emitted("delete")).toBeTruthy();
+      expect(wrapper.emitted("delete")).toHaveLength(1);
+      expect(wrapper.emitted("delete")![0][0]).toEqual(loc);
+    });
+
+    it("does not emit delete when button is clicked but monitors_count > 0 (disabled)", async () => {
+      const loc = makeLocation({ id: "loc-busy", monitors_count: 5 });
+      wrapper = makeWrapper({ locations: [loc] });
+
+      // Native disabled button blocks the click event from firing.
+      const deleteBtn = wrapper.find(
+        '[data-test="synthetics-private-locations-delete-btn-loc-busy"]',
+      );
+      await deleteBtn.trigger("click");
+
+      expect(wrapper.emitted("delete")).toBeFalsy();
+    });
+  });
+
+  describe("delete button disabled state", () => {
+    it("delete button is enabled when monitors_count is 0", () => {
+      wrapper = makeWrapper({
+        locations: [makeLocation({ id: "loc-free", monitors_count: 0 })],
+      });
+
+      const deleteBtn = wrapper.find(
+        '[data-test="synthetics-private-locations-delete-btn-loc-free"]',
+      );
+      expect(deleteBtn.attributes("disabled")).toBeUndefined();
+    });
+
+    it("delete button is disabled when monitors_count > 0", () => {
+      wrapper = makeWrapper({
+        locations: [makeLocation({ id: "loc-busy", monitors_count: 3 })],
+      });
+
+      const deleteBtn = wrapper.find(
+        '[data-test="synthetics-private-locations-delete-btn-loc-busy"]',
+      );
+      expect(deleteBtn.attributes("disabled")).toBeDefined();
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows OEmptyState when locations is empty and not loading", () => {
+      wrapper = makeWrapper({ locations: [], loading: false });
+
+      const emptyState = wrapper.find(
+        '[data-test="synthetics-private-locations-empty-state"]',
+      );
+      expect(emptyState.exists()).toBe(true);
+    });
+
+    it("does not show OEmptyState when loading is true (even with empty locations)", () => {
+      wrapper = makeWrapper({ locations: [], loading: true });
+
+      const emptyState = wrapper.find(
+        '[data-test="synthetics-private-locations-empty-state"]',
+      );
+      expect(emptyState.exists()).toBe(false);
+    });
+
+    it("does not show OEmptyState when locations has items", () => {
+      wrapper = makeWrapper({ locations: [makeLocation()], loading: false });
+
+      const emptyState = wrapper.find(
+        '[data-test="synthetics-private-locations-empty-state"]',
+      );
+      expect(emptyState.exists()).toBe(false);
+    });
+  });
+
+  describe("row click navigation", () => {
+    it("navigates to private location detail on row click", async () => {
+      const loc = makeLocation({ id: "loc-detail" });
+      wrapper = makeWrapper({ locations: [loc] });
+
+      const row = wrapper.find(".otable-row");
+      await row.trigger("click");
+
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        name: "synthetic-private-location",
+        params: { id: "loc-detail" },
+      });
+    });
+  });
+
+  describe("status variant mapping", () => {
+    it("uses success variant for online status", () => {
+      wrapper = makeWrapper({ locations: [makeLocation({ id: "loc-1", status: "online" })] });
+
+      const badge = wrapper.find(".obadge-stub");
+      expect(badge.exists()).toBe(true);
+      // Text still renders because the stub renders the slot
+      const statusCell = wrapper.find(".otable-cell-status");
+      expect(statusCell.text()).toContain("synthetics.privateLocations.status.online");
+    });
+
+    it("uses error variant for offline status", () => {
+      wrapper = makeWrapper({ locations: [makeLocation({ id: "loc-2", status: "offline" })] });
+
+      const statusCell = wrapper.find(".otable-cell-status");
+      expect(statusCell.text()).toContain("synthetics.privateLocations.status.offline");
+    });
+
+    it("uses default variant for unknown status", () => {
+      wrapper = makeWrapper({
+        locations: [makeLocation({ id: "loc-3", status: "pending" as any })],
+      });
+
+      const statusCell = wrapper.find(".otable-cell-status");
+      expect(statusCell.text()).toContain("synthetics.privateLocations.status.pending");
+    });
+  });
+
+  describe("no setup agent button", () => {
+    it("does NOT render a 'Setup an agent' button in the toolbar", () => {
+      wrapper = makeWrapper({ locations: [makeLocation()] });
+
+      const toolbar = wrapper.find(".otable-toolbar");
+      const toolbarText = toolbar.text();
+      // The toolbar only contains the search input; there should be no
+      // setup-related button text
+      expect(toolbarText).not.toContain("Setup");
+      expect(toolbarText).not.toContain("Agent");
+      expect(toolbarText).not.toContain("agent");
+    });
+
+    it("does NOT render any button other than refresh in the toolbar-trailing", async () => {
+      wrapper = makeWrapper({ locations: [makeLocation()] });
+
+      const trailing = wrapper.find(".otable-toolbar-trailing");
+      const buttons = trailing.findAll("button");
+      // Only the refresh button should exist in toolbar-trailing
+      expect(buttons).toHaveLength(1);
+      expect(
+        buttons[0]?.attributes("data-test"),
+      ).toBe("synthetics-private-locations-refresh-btn");
+    });
+  });
+});

--- a/web/src/views/synthetics/PrivateLocations.vue
+++ b/web/src/views/synthetics/PrivateLocations.vue
@@ -18,7 +18,6 @@
     >
       <template #toolbar>
         <div class="flex items-center gap-2 flex-1 min-w-0">
-          <slot name="tabs" />
           <div class="flex-1 min-w-0">
             <OInput
               v-model="search"
@@ -31,15 +30,6 @@
       </template>
 
       <template #toolbar-trailing>
-        <OButton
-          variant="outline"
-          size="sm"
-          icon-left="code"
-          data-test="synthetics-private-locations-setup-btn"
-          @click="emit('setup')"
-        >
-          {{ t("synthetics.privateLocations.setupAgent") }}
-        </OButton>
         <OButton
           variant="outline"
           size="icon-sm"
@@ -134,9 +124,7 @@
           :filtered="!!search"
           :title="t('synthetics.privateLocations.empty.title')"
           :description="t('synthetics.privateLocations.empty.description')"
-          :action-label="t('synthetics.privateLocations.empty.action')"
           data-test="synthetics-private-locations-empty-state"
-          @action="onEmptyAction"
         />
       </template>
     </OTable>
@@ -163,7 +151,6 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   (e: "refresh"): void;
-  (e: "setup"): void;
   (e: "copy-setup", row: SyntheticLocation): void;
   (e: "delete", row: SyntheticLocation): void;
 }>();
@@ -274,11 +261,4 @@ const openDetail = (row: SyntheticLocation) => {
   router.push({ name: "synthetic-private-location", params: { id: row.id } });
 };
 
-const onEmptyAction = (id?: string) => {
-  if (id === "clear-filters") {
-    search.value = "";
-    return;
-  }
-  emit("setup");
-};
 </script>

--- a/web/src/views/synthetics/RunDetail.vue
+++ b/web/src/views/synthetics/RunDetail.vue
@@ -48,7 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :subtitle="currentRun.timestamp"
       :back="{
         label: t('synthetics.results.monitors'),
-        to: { name: 'synthetics-monitor-results', params: { id: monitorId } },
+        to: { name: 'synthetic-monitor-results', params: { id: monitorId } },
         dataTest: 'synthetics-run-detail-back-btn',
       }"
     >


### PR DESCRIPTION
## What changed

- Added header-level tab navigation (Checks / Private Locations) to the Synthetic Monitoring page using `OPageLayout`'s `#header-tabs` slot with `tabs-below`, rendering tabs on a dedicated second row.
- Made the header action button conditional: "New Check" on the Checks tab, "Setup an agent" on the Private Locations tab.
- Removed the `@setup` emit and "Setup an agent" button from the `PrivateLocations` table toolbar — that action now lives in the page header.
- Removed the `#tabs` slot (type toggle group) and `onEmptyAction` handler from `PrivateLocations`.
- Added 14 new tests for `SyntheticMonitoring` (25 total) and created a new `PrivateLocations.spec.ts` with 35 tests.

## Why

The user reported that `header-tabs` was not rendering on a second row — investigation revealed the `tabsBelow` prop was missing. Separately, the "Setup an agent" action needed to appear contextually in the page header when viewing Private Locations rather than as a persistent button in the table toolbar.