### PR TITLE
fix(traces): apply sensitive-data redaction (SDR) patterns to traces

### DIFF
--- a/src/core/src/traces/mod.rs
+++ b/src/core/src/traces/mod.rs
@@ -873,6 +873,33 @@ pub async fn handle_otlp_request(
         return format_response(partial_success, req_type);
     }
 
+    // Apply sensitive-data redaction (SDR) regex patterns to trace records before writing.
+    // Span attributes are flattened to top-level string fields (see
+    // finalize_and_buffer_trace_span), so the same field-level pattern engine used for logs
+    // applies directly here.
+    #[cfg(feature = "vectorscan")]
+    {
+        match o2_enterprise::enterprise::re_patterns::get_pattern_manager().await {
+            Ok(pattern_manager) => {
+                for (stream, data) in json_data_by_stream.iter_mut() {
+                    if let Err(e) = pattern_manager.process_at_ingestion(
+                        org_id,
+                        StreamType::Traces,
+                        stream,
+                        &mut data.0,
+                    ) {
+                        log::error!(
+                            "[TRACES] error applying SDR patterns for stream {stream}: {e}"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                log::error!("[TRACES] failed to get pattern manager for SDR redaction: {e}");
+            }
+        }
+    }
+
     if let Err(e) = write_traces_by_stream(
         org_id,
         (started_at, &start),
@@ -1166,6 +1193,33 @@ pub async fn ingest_json(
     // if no data, fast return
     if json_data_by_stream.is_empty() {
         return format_response(partial_success, req_type);
+    }
+
+    // Apply sensitive-data redaction (SDR) regex patterns to trace records before writing.
+    // Span attributes are flattened to top-level string fields (see
+    // finalize_and_buffer_trace_span), so the same field-level pattern engine used for logs
+    // applies directly here.
+    #[cfg(feature = "vectorscan")]
+    {
+        match o2_enterprise::enterprise::re_patterns::get_pattern_manager().await {
+            Ok(pattern_manager) => {
+                for (stream, data) in json_data_by_stream.iter_mut() {
+                    if let Err(e) = pattern_manager.process_at_ingestion(
+                        org_id,
+                        StreamType::Traces,
+                        stream,
+                        &mut data.0,
+                    ) {
+                        log::error!(
+                            "[TRACES] error applying SDR patterns for stream {stream}: {e}"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                log::error!("[TRACES] failed to get pattern manager for SDR redaction: {e}");
+            }
+        }
     }
 
     if let Err(e) = write_traces_by_stream(

--- a/src/search_service/src/cache/mod.rs
+++ b/src/search_service/src/cache/mod.rs
@@ -1224,7 +1224,7 @@ pub async fn apply_regex_to_response(
 
     let ret = match pattern_manager.process_at_search(
         org_id,
-        StreamType::Logs,
+        stream_type,
         &mut res.hits,
         projections,
     ) {


### PR DESCRIPTION
Regex-based SDR patterns were only ever applied to logs; traces were never redacted, for two reasons:

- The trace ingestion pipeline never invoked the pattern engine, so sensitive span attributes were written to storage unredacted.
- The query-time redactor passed a hardcoded StreamType::Logs to process_at_search, so pattern associations on a traces stream (keyed org/traces/<stream>) were never matched.

The o2_enterprise redaction engine already supports StreamType::Traces and is reused unchanged. Fixes are at the call sites in core:

- traces: run process_at_ingestion with StreamType::Traces over json_data_by_stream before write, at both the OTLP (handle_otlp_request) and raw-JSON (ingest_json) entry points. Span attributes are flattened to top-level string fields, so the existing field-level engine applies directly.
- search_service: pass the real stream_type instead of a hardcoded StreamType::Logs in apply_regex_to_response.