### PR TITLE
test: harden org-selector switch flows against virtualized dropdown (changeOrg + logoManagement)

### DIFF
--- a/tests/ui-testing/pages/generalPages/homePage.js
+++ b/tests/ui-testing/pages/generalPages/homePage.js
@@ -208,8 +208,49 @@ export class HomePage {
     async clickOrgRow(row, { timeout = 20000 } = {}) {
         await row.waitFor({ state: 'visible', timeout: 10000 });
         await expect(async () => {
-            await row.click({ timeout: 5000 });
+            // Virtualized rows carry a `transform: translateY(...)` that keeps
+            // shifting while the popper animates in and the list settles. Under
+            // CI load those frames stretch out, so Playwright's actionability
+            // "element is stable" check can burn the whole 5s click budget and
+            // time out even though the row is present and visible. Nudge it into
+            // view and force the click past the stability/hit-test gates — the
+            // row is already confirmed visible, so this clicks a real target.
+            await row.scrollIntoViewIfNeeded({ timeout: 2000 }).catch(() => {});
+            await row.click({ force: true, timeout: 5000 });
+            // select() closes the menu. If the click landed mid-reflow and
+            // missed, the popover stays open — gate on it hiding so toPass retries
+            // instead of leaving an un-selected menu for the next step.
+            await this.orgMenuList.waitFor({ state: 'hidden', timeout: 3000 });
         }).toPass({ timeout });
+    }
+
+    /**
+     * Switch to a specific org by identifier, verified by the URL.
+     *
+     * A force-click on a virtualized row that is still re-positioning can land
+     * on a neighbouring row (often "default") — the menu still closes, so a
+     * "menu hidden" check alone can't tell a right selection from a wrong one.
+     * The only authoritative success signal is the URL carrying the target
+     * identifier, so retry the whole open → search → click until it does,
+     * re-opening the menu when a prior miss closed it.
+     */
+    async selectOrgByIdentifier(orgName, orgIdentifier) {
+        const targetRow = this.getOrgMenuItemByIdentifier(orgIdentifier);
+        await expect(async () => {
+            if (!(await this.orgMenuList.isVisible())) {
+                await this.orgSelector.click();
+                await this.orgMenuList.waitFor({ state: 'visible', timeout: 5000 });
+            }
+            // Filter is name/identifier-matched; the name can be shared across
+            // several orgs, so we still target the unique identifier row.
+            await this.orgSearchInput.fill(orgName, { force: true });
+            await targetRow.waitFor({ state: 'visible', timeout: 5000 });
+            await targetRow.scrollIntoViewIfNeeded({ timeout: 2000 }).catch(() => {});
+            await targetRow.click({ force: true, timeout: 5000 });
+            await this.page.waitForURL(new RegExp(`org_identifier=${orgIdentifier}`), {
+                timeout: 5000,
+            });
+        }).toPass({ timeout: 30000 });
     }
 
     async selectOrganization(orgName) {
@@ -251,26 +292,20 @@ export class HomePage {
     async homePageOrg(orgName, orgIdentifier) {
         await this.page.reload();
         await this.orgSelector.waitFor({ state: 'visible', timeout: 10000 });
-        await this.orgSelector.click();
-        await this.orgMenuList.waitFor({ state: 'visible', timeout: 10000 });
 
-        // Search for the organization
-        await this.orgSearchInput.fill(orgName);
-
-        // When a specific identifier is available, target that row directly so
-        // we don't race against the OInput debounce / OTable filter and end up
-        // clicking the previously-first row (often "default").
+        // When a specific identifier is available, use the URL-verified switch
+        // so we can't silently settle on the wrong row (the name may be shared
+        // across several orgs). It opens the menu itself.
         if (orgIdentifier) {
-            await this.clickOrgRow(this.getOrgMenuItemByIdentifier(orgIdentifier));
-            // Wait for the router push to land — the URL should now carry the
-            // new org identifier.
-            await this.page.waitForURL(new RegExp(`org_identifier=${orgIdentifier}`), {
-                timeout: 10000,
-            }).catch(() => {});
+            await this.selectOrgByIdentifier(orgName, orgIdentifier);
             return;
         }
 
-        // Click the organization from search results
+        await this.orgSelector.click();
+        await this.orgMenuList.waitFor({ state: 'visible', timeout: 10000 });
+
+        // Search for the organization, then click the first match.
+        await this.orgSearchInput.fill(orgName);
         await this.clickOrgRow(this.orgMenuItemLabel.first());
     }
 

--- a/tests/ui-testing/pages/generalPages/logoManagementPage.js
+++ b/tests/ui-testing/pages/generalPages/logoManagementPage.js
@@ -19,6 +19,7 @@ export
         this.saveButtonLight = page.locator('[data-test="settings_ent_logo_custom_light_save_btn"]');
         this.enterpriseFeature = page.locator('#enterpriseFeature');
         this.organizationSearchInput = page.locator('[data-test="organization-search-input-field"]');
+        this.organizationMenuList = page.locator('[data-test="organization-menu-list"]');
         this.organizationMenuItem = page.locator('[data-test="organization-menu-item-label-item-label"]');
         this.navbarOrganizationsSelect = page.locator('[data-test="navbar-organizations-select"]');
 
@@ -48,15 +49,34 @@ export
     async managementOrg(orgName) {
         await this.page.waitForTimeout(2000);
         await this.page.reload();
-        await this.navbarOrganizationsSelect.click();
-        await this.page.waitForTimeout(2000);
 
-        // Search for the organization
-        await this.organizationSearchInput.fill(orgName);
-        await this.page.waitForTimeout(2000);
+        // Open the org dropdown and confirm the popover actually rendered before
+        // typing. The menu is a virtualized reka-ui popper that animates in, so a
+        // blind waitForTimeout can race ahead of the open and leave the search
+        // input un-rendered (the CI failure mode). Retry the open until the menu
+        // list is visible instead.
+        await expect(async () => {
+            await this.navbarOrganizationsSelect.click();
+            await this.organizationMenuList.waitFor({ state: 'visible', timeout: 3000 });
+        }).toPass({ timeout: 15000 });
 
-        // Click the organization from search results
-        await this.organizationMenuItem.first().click();
+        // Search for the organization. The OInput wrapper's outer node is a
+        // <div>; fill the inner native input via the -field suffix.
+        await this.organizationSearchInput.waitFor({ state: 'attached', timeout: 10000 });
+        await this.organizationSearchInput.fill(orgName, { force: true });
+
+        // Click the matching row, tolerating the virtualized list re-positioning
+        // underneath — the translateY transforms defeat Playwright's stability
+        // check, so scroll into view and force the click past it.
+        const row = this.organizationMenuItem.first();
+        await row.waitFor({ state: 'visible', timeout: 10000 });
+        await expect(async () => {
+            await row.scrollIntoViewIfNeeded({ timeout: 2000 }).catch(() => {});
+            await row.click({ force: true, timeout: 5000 });
+            // Selecting a row closes the menu; if the click missed mid-reflow the
+            // popover stays open, so gate on it hiding and let toPass retry.
+            await this.organizationMenuList.waitFor({ state: 'hidden', timeout: 3000 });
+        }).toPass({ timeout: 20000 });
     }
 
     async managementPageURLValidation() {


### PR DESCRIPTION
## What

Heals the two `GeneralTests` specs that flake on the redesigned **`OrganizationSelector.vue`** (reka-ui `ODropdown` + `@tanstack/vue-virtual` virtualized list, from the design-token migration): `changeOrg.spec.js` and `logoManagement.spec.js`. Test-only — no product/frontend change.

## Why it flakes (CI parallel load only — passes single-worker locally)

- **changeOrg** — virtual rows carry a `transform: translateY(...)` that keeps shifting while the popper animates in and the list settles, so Playwright's actionability *stability* check burns the click budget and times out. A force-click on a still-moving row can also land on a **neighbouring row** (often `default`) — the menu still closes, so the wrong org is selected and the swallowed `waitForURL(...).catch(()=>{})` hid it until a later assertion failed.
- **logoManagement** — `managementOrg` had no "menu opened" gate; a blind `waitForTimeout` raced ahead of the popper open, so `organization-search-input-field` never rendered and `fill()` timed out (45s).

This is **not a regression from any single PR** — it reproduces on every branch's ENT `GeneralTests` run (the org-selector redesign was never hardened for the virtualized dropdown).

## Fix

- `homePage.js` `clickOrgRow`: `scrollIntoViewIfNeeded` + `force` click + gate on the menu **hiding**, so a missed click retries instead of leaving an un-selected menu.
- `homePage.js` `selectOrgByIdentifier` (new): retry open → search → click until the **URL** carries the target identifier — the only authoritative signal that the right row was selected. `homePageOrg`'s identifier branch uses it.
- `logoManagementPage.js` `managementOrg`: retry the open until the menu list is visible, fill the `-field` input with `force`, hardened row click with the same menu-hidden verification. Added `organizationMenuList` locator.

## Verification (local enterprise build v0.92.0-rc1)

| Test set | Workers | Result |
|----------|---------|--------|
| changeOrg "change organisation validation" (14) ×3 | 4 | 14/14 pass each (was 1-failed pre-fix) |
| changeOrg full spec | 4 | 28 pass, 0 fail (no regressions) |
| logoManagement ×2 | 1 | pass |

## Enterprise coverage

Carries the `e2e` label so the **ENT e2e gate** dispatches the enterprise suite against this branch (built against ENT main) and mirrors the result here — validating the `@enterprise` logoManagement spec and ENT GeneralTests without a separate ENT PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)