### PR TITLE
test(traces): heal bug #11531 spec for flame-graph-default trace detail

### DIFF
--- a/tests/ui-testing/playwright-tests/RegressionSet/Traces/traces-bugs.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Traces/traces-bugs.spec.js
@@ -329,6 +329,12 @@ test.describe("Traces Regression Bugs — Batch 1", () => {
       await firstResult.click();
       await page.waitForTimeout(2000);
 
+      // The span tree and span blocks read below live in the waterfall view.
+      // Since #13347 the trace detail opens on the flame graph by default (and
+      // the last active tab is persisted per-browser), so select waterfall
+      // explicitly before asserting the tree is visible.
+      await pm.tracesPage.openTraceDetailsTab('waterfall');
+
       await pm.tracesPage.expectTraceDetailsVisible();
       testLogger.info('Trace details visible');
 


### PR DESCRIPTION
## What

Heals the **Traces-Regression** failure on `main` (scheduled run [29935986660](https://github.com/openobserve/openobserve/actions/runs/29935986660/job/88982390601)).

The Bug #11531 test in `traces-bugs.spec.js` (`traces spans tab should not reference non-existent method field`) clicks a trace result and immediately asserts the span tree via `expectTraceDetailsVisible()`, which waits for `[data-test="trace-details-tree"]`.

## Why it started failing

PR 13347 (`fix: traces page default flame graph and drag-drop option added`) changed the trace detail view to **open on the flame graph by default** (`DEFAULT_TRACE_TAB = "flame-graph"`) instead of the waterfall. The span tree lives inside `v-if="activeTab === 'waterfall'"`, so it no longer renders on open — the assertion timed out (15s) and the job exited 1.

This is **not a product bug** — it's an intentional product change. 13347 added a `openTraceDetailsTab()` helper and updated the other traces specs, but this Bug #11531 test was missed.

## Fix

Select the waterfall tab explicitly before reading the tree, matching the pattern 13347 already applied elsewhere:

```js
// Since 13347 the trace detail opens on the flame graph by default.
await pm.tracesPage.openTraceDetailsTab('waterfall');
await pm.tracesPage.expectTraceDetailsVisible();
```

Test-only change; no product code touched.

## Verification (local, hosted O2 @ localhost:5080, `default` traces stream w/ data)

| State | Result |
|-------|--------|
| Before fix (unpatched) | ❌ `expectTraceDetailsVisible` times out at `tracesPage.js:310` |
| After fix (patched) | ✅ `1 passed (22.3s)` — "Trace details visible" logged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)