### PR TITLE
fix: added warning start filter in synthetics

### DIFF
--- a/web/src/components/reports/CreateReport.vue
+++ b/web/src/components/reports/CreateReport.vue
@@ -411,21 +411,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             class="ml-1 cursor-pointer text-text-muted"
                           >
                             <OTooltip side="right" align="center">
-                              <template #content><span style="font-size: var(--text-sm)">
-                                Pattern: * * * * * * means every second.
-                                <br />
-                                Format: [Second (optional) 0-59] [Minute 0-59]
-                                [Hour 0-23] [Day of Month 1-31, 'L'] [Month
-                                1-12] [Day of Week 0-7 or '1L-7L', 0 and 7 for
-                                Sunday].
-                                <br />
-                                Use '*' to represent any value, 'L' for the last
-                                day/weekday. <br />
-                                Example: 0 0 12 * * ? - Triggers at 12:00 PM
-                                daily. It specifies second, minute, hour, day of
-                                month, month, and day of week,
-                                respectively.</span
-                              ></template>
+                              <template #content>
+                                <span style="font-size: var(--text-sm); white-space: pre-line">
+                                  {{ t('reports.cronFormatTooltip') }}
+                                </span>
+                              </template>
                             </OTooltip>
                           </OIcon>
                         </div>

--- a/web/src/components/synthetics/configure/CheckAlerts.vue
+++ b/web/src/components/synthetics/configure/CheckAlerts.vue
@@ -123,7 +123,7 @@ const silenceMinutes = computed({
       <!-- ── Cooldown Period ────────────────────────────────────────────── -->
       <div class="flex items-center gap-2">
         <label class="w-32 text-sm font-medium text-text-body flex items-center">
-          {{ t('synthetics.scheduleAlert.cooldownPeriod') }} *
+          {{ t('synthetics.scheduleAlert.cooldownPeriod') }}
         </label>
         <div class="flex items-center">
           <div class="w-21.75">

--- a/web/src/components/synthetics/configure/CheckSchedule.vue
+++ b/web/src/components/synthetics/configure/CheckSchedule.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 // Copyright 2026 OpenObserve Inc.
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { BrowserCheck, BrowserCheckSchedule } from '@/types/synthetics'
+import { getCronIntervalDifferenceInSeconds } from '@/utils/queryUtils'
 import OInput from '@/lib/forms/Input/OInput.vue'
 import OSelect from '@/lib/forms/Select/OSelect.vue'
 import OToggleGroup from '@/lib/core/ToggleGroup/OToggleGroup.vue'
@@ -95,6 +96,34 @@ const cron = computed({
   get: () => props.check.schedule.cron ?? '',
   set: (v: string) => updateSchedule({ cron: v }),
 })
+
+const cronError = ref('')
+
+watch(
+  () => [props.check.schedule.cron, props.check.schedule.type] as const,
+  ([cronVal, type]) => {
+    if (type !== 'cron') {
+      cronError.value = ''
+      return
+    }
+    const trimmed = (cronVal ?? '').trim()
+    if (!trimmed) {
+      cronError.value = t('reports.validation.invalidCron')
+      return
+    }
+    // Single-space split matches the 6-field check in CreateReport.schema.ts
+    if (trimmed.split(' ').length !== 6) {
+      cronError.value = t('reports.validation.cronSixFields')
+      return
+    }
+    try {
+      getCronIntervalDifferenceInSeconds(trimmed)
+      cronError.value = ''
+    } catch {
+      cronError.value = t('reports.validation.invalidCron')
+    }
+  },
+)
 
 function buildTimezoneOptions(): { label: string; value: string }[] {
   try {
@@ -233,13 +262,33 @@ const startTime = computed({
 
       <!-- Cron inputs -->
       <div v-if="check.schedule.type === 'cron'" class="flex items-start gap-3 flex-wrap">
-        <OInput
-          v-model="cron"
-          :label="t('synthetics.scheduleAlert.cronExpression')"
-          placeholder="*/5 * * * *"
-          class="w-83!"
-          data-test="synthetics-check-schedule-cron-input"
-        />
+        <div>
+          <div class="mb-1 font-bold text-text-secondary">
+            {{ t('synthetics.scheduleAlert.cronExpression') }}
+            <OIcon name="info" size="sm" class="ml-1 cursor-pointer text-text-muted">
+              <OTooltip side="right" align="center">
+                <template #content>
+                  <span style="font-size: var(--text-sm); white-space: pre-line">
+                    {{ t('reports.cronFormatTooltip') }}
+                  </span>
+                </template>
+              </OTooltip>
+            </OIcon>
+          </div>
+          <OInput
+            v-model="cron"
+            placeholder="0 */5 * * * *"
+            class="w-83!"
+            data-test="synthetics-check-schedule-cron-input"
+          />
+          <p
+            v-if="cronError"
+            class="text-xs text-status-error-text mt-1"
+            data-test="synthetics-check-schedule-cron-error"
+          >
+            {{ cronError }}
+          </p>
+        </div>
         <OSelect
           v-model="timezone"
           :label="t('synthetics.scheduleAlert.timezone')"

--- a/web/src/composables/synthetics/syntheticResultsSchema.spec.ts
+++ b/web/src/composables/synthetics/syntheticResultsSchema.spec.ts
@@ -39,7 +39,13 @@ describe("syntheticResultsSchema query builders", () => {
       `FILTER (WHERE ${SYNTHETIC_FIELDS.status} = '${STATUS_VALUES.passed}')`,
     );
     expect(sql).toContain(
-      `FILTER (WHERE ${SYNTHETIC_FIELDS.status} != '${STATUS_VALUES.passed}')`,
+      `FILTER (WHERE ${SYNTHETIC_FIELDS.status} = '${STATUS_VALUES.warning}')`,
+    );
+    expect(sql).toContain(
+      `FILTER (WHERE ${SYNTHETIC_FIELDS.status} = '${STATUS_VALUES.failed}')`,
+    );
+    expect(sql).toContain(
+      `FILTER (WHERE ${SYNTHETIC_FIELDS.status} = '${STATUS_VALUES.error}')`,
     );
     expect(sql).toContain(`approx_percentile_cont(${SYNTHETIC_FIELDS.duration}, 0.95)`);
   });

--- a/web/src/composables/synthetics/syntheticResultsSchema.ts
+++ b/web/src/composables/synthetics/syntheticResultsSchema.ts
@@ -87,7 +87,11 @@ export type RunStatus = "passed" | "warning" | "failed" | "error";
 export interface SyntheticKpi {
   uptimePct: number;
   p95Ms: number;
+  passedRuns: number;
+  warningRuns: number;
+  /** Count of runs with status = 'failed' (actual failures, not warnings or errors). */
   failedRuns: number;
+  errorRuns: number;
   totalRuns: number;
   /** Count of runs that had at least one retry (attempts > 1). */
   retriedRuns: number;
@@ -240,7 +244,10 @@ export interface SyntheticBucket {
   avgMs: number;
   p95Ms: number;
   uptimePct: number;
+  warningRuns: number;
+  /** Count of runs with status = 'failed' (actual failures, not warnings or errors). */
   failedRuns: number;
+  errorRuns: number;
 }
 
 // ── Step analysis types (used by aggregateStepStats) ──────────────────────
@@ -431,7 +438,9 @@ export function buildKpiSql(
   return `SELECT
   COUNT(*) as total_runs,
   COUNT(*) FILTER (WHERE ${F.status} = '${STATUS_VALUES.passed}') as passed_runs,
-  COUNT(*) FILTER (WHERE ${F.status} != '${STATUS_VALUES.passed}') as failed_runs,${retriedClause}
+  COUNT(*) FILTER (WHERE ${F.status} = '${STATUS_VALUES.warning}') as warning_runs,
+  COUNT(*) FILTER (WHERE ${F.status} = '${STATUS_VALUES.failed}') as failed_runs,
+  COUNT(*) FILTER (WHERE ${F.status} = '${STATUS_VALUES.error}') as error_runs,${retriedClause}
   COALESCE(approx_percentile_cont(${F.duration}, 0.95), 0) as p95_duration
 FROM ${TABLE}
 WHERE ${F.monitorId} = '${id}'`;
@@ -454,7 +463,9 @@ export function buildHistogramSql(monitorId: string, interval: string): string {
   COALESCE(approx_percentile_cont(${F.duration}, 0.95), 0) as p95_duration,
   COUNT(*) as total_runs,
   COUNT(*) FILTER (WHERE ${F.status} = '${STATUS_VALUES.passed}') as passed_runs,
-  COUNT(*) FILTER (WHERE ${F.status} != '${STATUS_VALUES.passed}') as failed_runs
+  COUNT(*) FILTER (WHERE ${F.status} = '${STATUS_VALUES.warning}') as warning_runs,
+  COUNT(*) FILTER (WHERE ${F.status} = '${STATUS_VALUES.failed}') as failed_runs,
+  COUNT(*) FILTER (WHERE ${F.status} = '${STATUS_VALUES.error}') as error_runs
 FROM ${TABLE}
 WHERE ${F.monitorId} = '${id}'
 GROUP BY ts
@@ -607,13 +618,18 @@ export function mapKpi(
 ): SyntheticKpi {
   const totalRuns = num(rawKpiRow?.total_runs);
   const passedRuns = num(rawKpiRow?.passed_runs);
+  const warningRuns = num(rawKpiRow?.warning_runs);
   const failedRuns = num(rawKpiRow?.failed_runs);
+  const errorRuns = num(rawKpiRow?.error_runs);
   const retriedRuns = num(rawKpiRow?.retried_runs);
   const lastRunTsRaw = rawLastRun ? num(rawLastRun.ts) : 0;
   return {
-    uptimePct: totalRuns > 0 ? (passedRuns / totalRuns) * 100 : 0,
+    uptimePct: totalRuns > 0 ? ((passedRuns + warningRuns) / totalRuns) * 100 : 0,
     p95Ms: num(rawKpiRow?.p95_duration),
+    passedRuns,
+    warningRuns,
     failedRuns,
+    errorRuns,
     totalRuns,
     retriedRuns,
     lastRunStatus: rawLastRun ? toRunStatus(rawLastRun.status) : null,
@@ -771,7 +787,9 @@ export function mapHistogram(
       avgMs: 0,
       p95Ms: 0,
       uptimePct: 100,
+      warningRuns: 0,
       failedRuns: 0,
+      errorRuns: 0,
     });
   }
 
@@ -780,12 +798,15 @@ export function mapHistogram(
     const tsMs = new Date(`${key}Z`).getTime();
     const total = num(hit.total_runs);
     const passed = num(hit.passed_runs);
+    const warning = num(hit.warning_runs);
     buckets.set(key, {
       tsMs: Number.isFinite(tsMs) ? tsMs : 0,
       avgMs: num(hit.avg_duration),
       p95Ms: num(hit.p95_duration),
-      uptimePct: total > 0 ? (passed / total) * 100 : 100,
+      uptimePct: total > 0 ? ((passed + warning) / total) * 100 : 100,
+      warningRuns: num(hit.warning_runs),
       failedRuns: num(hit.failed_runs),
+      errorRuns: num(hit.error_runs),
     });
   }
 

--- a/web/src/composables/useSyntheticResults.ts
+++ b/web/src/composables/useSyntheticResults.ts
@@ -44,7 +44,10 @@ import useStreams from "@/composables/useStreams";
 const EMPTY_KPI: SyntheticKpi = {
   uptimePct: 0,
   p95Ms: 0,
+  passedRuns: 0,
+  warningRuns: 0,
   failedRuns: 0,
+  errorRuns: 0,
   totalRuns: 0,
   retriedRuns: 0,
   lastRunStatus: null,

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -6352,6 +6352,7 @@
     "description": "Description",
     "cron": "Cron Job",
     "cronExpression": "Cron expression",
+    "cronFormatTooltip": "Pattern: * * * * * * means every second.\nFormat: [Second (optional) 0-59] [Minute 0-59] [Hour 0-23] [Day of Month 1-31, 'L'] [Month 1-12] [Day of Week 0-7 or '1L-7L', 0 and 7 for Sunday].\nUse '*' to represent any value, 'L' for the last day/weekday.\nExample: 0 0 12 * * ? - Triggers at 12:00 PM daily.",
     "timeRange": "Time Range",
     "frequency": "Frequency",
     "lastTriggeredAt": "Last Triggered At",

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -9406,7 +9406,6 @@
       "failed": "Failed",
       "passed": "Passed",
       "unknown": "Unknown",
-      "warning": "Warning",
       "warning": "Warning"
     },
     "footer": {

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -9406,6 +9406,7 @@
       "failed": "Failed",
       "passed": "Passed",
       "unknown": "Unknown",
+      "warning": "Warning",
       "warning": "Warning"
     },
     "footer": {
@@ -9830,10 +9831,13 @@
       "tabSteps": "Steps",
       "timelineAllFailed": "All {count} failed",
       "timelineAllPassed": "All {count} passed",
+      "timelineAllWarning": "All {count} warning",
       "timelineMixed": "{passed} passed, {failed} failed of {total}",
       "timelineNow": "Now",
       "triggerManual": "Manual",
       "triggerSchedule": "Schedule",
+      "warning": "Warning",
+      "warningRuns": "Warning Runs",
       "window24h": "Last 24 hours",
       "window1h": "Last 1 hour",
       "windowDays": "Last {days} days",

--- a/web/src/views/SyntheticMonitoring.vue
+++ b/web/src/views/SyntheticMonitoring.vue
@@ -697,6 +697,7 @@ const statusTabs = computed(() => {
   const tabs = [
     { filter: 'all',      label: t('synthetics.filters.allStatuses'),      count: ms.length },
     { filter: 'passed',   label: t('synthetics.filters.passed'),   count: ms.filter(m => m.status === 'passed').length },
+    { filter: 'warning',  label: t('synthetics.filters.warning'),  count: ms.filter(m => m.status === 'warning').length },
     { filter: 'failed',   label: t('synthetics.filters.failed'),   count: ms.filter(m => m.status === 'failed').length },
   ]
   const unknownCount = ms.filter(m => m.status === 'unknown').length

--- a/web/src/views/synthetics/MonitorRuns.spec.ts
+++ b/web/src/views/synthetics/MonitorRuns.spec.ts
@@ -252,7 +252,7 @@ const baseStubs = {
   },
   MonitorStatusTimeline: {
     template: '<div data-test="monitor-status-timeline" />',
-    props: ["segments", "failCount", "passCount", "mixedCount", "startLabel", "endLabel"],
+    props: ["segments", "failCount", "passCount", "mixedCount", "startLabel", "endLabel", "isBrowser"],
   },
   ChartRenderer: {
     template: '<div data-test="chart-renderer" />',

--- a/web/src/views/synthetics/MonitorRuns.spec.ts
+++ b/web/src/views/synthetics/MonitorRuns.spec.ts
@@ -41,15 +41,18 @@ vi.mock("@/composables/useSyntheticResults", () => {
       kpi: ref({
         uptimePct: 99.65,
         p95Ms: 2940,
+        passedRuns: 285,
+        warningRuns: 2,
         failedRuns: 1,
+        errorRuns: 0,
         totalRuns: 288,
         retriedRuns: 2,
         lastRunStatus: "passed",
         lastRunAt: Date.now() - 120_000,
       }),
       buckets: ref([
-        { tsMs: 1_700_000_000_000, avgMs: 1500, p95Ms: 2000, uptimePct: 100, failedRuns: 0 },
-        { tsMs: 1_700_003_600_000, avgMs: 1600, p95Ms: 2100, uptimePct: 99, failedRuns: 1 },
+        { tsMs: 1_700_000_000_000, avgMs: 1500, p95Ms: 2000, uptimePct: 100, warningRuns: 0, failedRuns: 0, errorRuns: 0 },
+        { tsMs: 1_700_003_600_000, avgMs: 1600, p95Ms: 2100, uptimePct: 99, warningRuns: 0, failedRuns: 1, errorRuns: 0 },
       ]),
       runs: ref([
         {

--- a/web/src/views/synthetics/MonitorRuns.vue
+++ b/web/src/views/synthetics/MonitorRuns.vue
@@ -129,9 +129,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <!-- KPI Cards — gated on KPI + last-run queries -->
             <template v-if="kpiLoading || !kpiHasLoadedOnce">
               <div class="px-page-edge">
-                <div class="grid grid-cols-5 gap-2.5">
+                <div class="grid grid-cols-6 gap-2.5">
                   <div
-                    v-for="n in 5"
+                    v-for="n in 6"
                     :key="n"
                     class="card-container rounded-default flex flex-col px-3.5 pt-2.5 pb-2.5 gap-2 bg-surface-base border border-border-default"
                   >
@@ -143,7 +143,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </template>
             <template v-else>
               <div class="px-page-edge">
-              <div class="grid grid-cols-5 gap-2.5">
+              <div class="grid grid-cols-6 gap-2.5">
                 <div
                   v-for="card in kpiCards"
                   :key="card.key"
@@ -1265,6 +1265,12 @@ const actionOptions: SelectOption[] = [
 function toMockRun(r: SyntheticRun, idx: number): MockRun {
   const eng = r.browserEngine;
   const browser = eng ? eng.charAt(0).toUpperCase() + eng.slice(1) : eng;
+  const mappedStatus = (
+    r.status === "passed" ? "pass"
+    : r.status === "warning" ? "warning"
+    : r.status === "error" ? "error"
+    : "fail"
+  ) as MockRun["status"];
   return {
     id: idx + 1,
     runId: r.runId || "unknown-" + idx,
@@ -1273,7 +1279,7 @@ function toMockRun(r: SyntheticRun, idx: number): MockRun {
     timestamp: r.timestamp,
     triggerType: r.triggerType,
     duration: r.durationMs,
-    status: r.status === "passed" ? ("pass" as const) : ("fail" as const),
+    status: mappedStatus,
     location: r.location,
     browser,
     device: r.device,
@@ -1368,14 +1374,22 @@ const kpiCards = computed<KpiCard[]>(() => {
         key: "last-run",
         label: t('synthetics.results.lastRun'),
         value: k.lastRunStatus
-          ? k.lastRunStatus === "failed"
-            ? t('synthetics.results.failed')
-            : t('synthetics.results.passed')
+          ? k.lastRunStatus === "passed"
+            ? t('synthetics.results.passed')
+            : k.lastRunStatus === "warning"
+              ? t('synthetics.protocolRun.warning')
+              : k.lastRunStatus === "error"
+                ? t('synthetics.results.error')
+                : t('synthetics.results.failed')
           : "—",
         valueClass:
-          k.lastRunStatus === "failed"
-            ? "text-status-error-text!"
-            : "text-status-success-text!",
+          k.lastRunStatus === "passed"
+            ? "text-status-success-text!"
+            : k.lastRunStatus === "warning"
+              ? "text-status-warning-text!"
+              : k.lastRunStatus
+                ? "text-status-error-text!"
+                : undefined,
       },
       {
         key: "pass-rate",
@@ -1397,6 +1411,12 @@ const kpiCards = computed<KpiCard[]>(() => {
         valueClass: k.retriedRuns > 0 ? "text-text-body!" : undefined,
       },
       {
+        key: "warning-runs",
+        label: t('synthetics.runs.warningRuns'),
+        value: String(k.warningRuns),
+        valueClass: k.warningRuns > 0 ? "text-status-warning-text!" : undefined,
+      },
+      {
         key: "failed-runs",
         label: t('synthetics.results.failedRuns'),
         value: String(k.failedRuns),
@@ -1408,29 +1428,44 @@ const kpiCards = computed<KpiCard[]>(() => {
   const fallbackPassPct =
     allRuns.value.length > 0
       ? (
-          (allRuns.value.filter((r) => r.status === "pass").length /
+          (allRuns.value.filter((r) => r.status === "pass" || r.status === "warning").length /
             allRuns.value.length) *
           100
         ).toFixed(1) + "%"
       : "100%";
   const lastRun = allRuns.value[0];
   return [
+    {
+      key: "last-run",
+      label: t('synthetics.results.lastRun'),
+      value: lastRun
+        ? lastRun.status === "pass"
+          ? t('synthetics.results.passed')
+          : lastRun.status === "warning"
+            ? t('synthetics.protocolRun.warning')
+            : t('synthetics.results.failed')
+        : "—",
+      valueClass:
+        lastRun?.status === "pass"
+          ? "text-status-success-text!"
+          : lastRun?.status === "warning"
+            ? "text-status-warning-text!"
+            : lastRun
+              ? "text-status-error-text!"
+              : undefined,
+    },
     { key: "pass-rate", label: t('synthetics.runs.passRate'), value: fallbackPassPct },
     { key: "p95-duration", label: t('synthetics.results.p95Duration'), value: "—" },
     { key: "retry-rate", label: t('synthetics.runs.retryRate'), value: "0.0%" },
     {
+      key: "warning-runs",
+      label: t('synthetics.runs.warningRuns'),
+      value: String(allRuns.value.filter((r) => r.status === "warning").length),
+    },
+    {
       key: "failed-runs",
       label: t('synthetics.results.failedRuns'),
       value: String(totalFails.value),
-    },
-    {
-      key: "last-run",
-      label: t('synthetics.results.lastRun'),
-      value: lastRun?.status === "fail" ? t('synthetics.results.failed') : t('synthetics.results.passed'),
-      valueClass:
-        lastRun?.status === "fail"
-          ? "text-status-error-text!"
-          : "text-status-success-text!",
     },
   ];
 });
@@ -1440,14 +1475,14 @@ interface TimelineExecution {
   location: string;
   browserEngine: string;
   device: string;
-  status: "pass" | "fail";
+  status: "pass" | "warning" | "fail" | "error";
   statusIcon: string;
   errorSnippet: string | null;
 }
 
 interface TimelineSegment {
   runId: string;
-  status: "all-pass" | "mixed" | "all-fail";
+  status: "all-pass" | "all-warning" | "mixed" | "all-fail";
   color: string;
   title: string;
   /** Epoch ms of the first execution in this logical run. */
@@ -1476,10 +1511,17 @@ const timelineSegments = computed<TimelineSegment[]>(() => {
 
   return groupOrder.map((runId) => {
     const executions = groupMap.get(runId)!;
-    const allPass = executions.every((e) => e.status === "pass");
-    const allFail = executions.every((e) => e.status === "fail");
+    const allPass = executions.every(
+      (e) => e.status === "pass" || e.status === "warning",
+    );
+    const allFail = executions.every(
+      (e) => e.status === "fail" || e.status === "error",
+    );
+    const allWarning = executions.every((e) => e.status === "warning");
     const status: TimelineSegment["status"] = allPass
-      ? "all-pass"
+      ? allWarning
+        ? "all-warning"
+        : "all-pass"
       : allFail
         ? "all-fail"
         : "mixed";
@@ -1487,25 +1529,39 @@ const timelineSegments = computed<TimelineSegment[]>(() => {
     const color =
       status === "all-pass"
         ? "bg-badge-success-solid-bg/80"
-        : status === "all-fail"
-          ? "bg-badge-error-solid-bg/80"
-          : "bg-badge-orange-solid-bg/80";
+        : status === "all-warning"
+          ? "bg-badge-warning-solid-bg/80"
+          : status === "all-fail"
+            ? "bg-badge-error-solid-bg/80"
+            : "bg-badge-orange-solid-bg/80";
 
-    const passCount = executions.filter((e) => e.status === "pass").length;
+    const passCount = executions.filter(
+      (e) => e.status === "pass" || e.status === "warning",
+    ).length;
     const failCount = executions.length - passCount;
     const title =
       status === "all-pass"
         ? t('synthetics.runs.timelineAllPassed', { count: executions.length })
-        : status === "all-fail"
-          ? t('synthetics.runs.timelineAllFailed', { count: executions.length })
-          : t('synthetics.runs.timelineMixed', { passed: passCount, failed: failCount, total: executions.length });
+        : status === "all-warning"
+          ? t('synthetics.runs.timelineAllWarning', { count: executions.length })
+          : status === "all-fail"
+            ? t('synthetics.runs.timelineAllFailed', { count: executions.length })
+            : t('synthetics.runs.timelineMixed', { passed: passCount, failed: failCount, total: executions.length });
 
     const execDetails: TimelineExecution[] = executions.map((e) => ({
       location: e.location,
       browserEngine: e.browser,
       device: e.device,
-      status: e.status === "pass" ? "pass" : "fail",
-      statusIcon: e.status === "pass" ? "check_circle" : "cancel",
+      status: e.status === "pass"
+        ? "pass"
+        : e.status === "warning"
+          ? "warning"
+          : e.status === "error"
+            ? "error"
+            : "fail",
+      statusIcon: e.status === "pass" || e.status === "warning"
+        ? "check_circle"
+        : "cancel",
       errorSnippet: e.errorPattern
         ? e.errorPattern.split(":")[0].substring(0, 50)
         : null,
@@ -1526,7 +1582,11 @@ const timelineFailCount = computed(() =>
   String(timelineSegments.value.filter((s) => s.status === "all-fail").length),
 );
 const timelinePassCount = computed(() =>
-  String(timelineSegments.value.filter((s) => s.status === "all-pass").length),
+  String(
+    timelineSegments.value.filter(
+      (s) => s.status === "all-pass" || s.status === "all-warning",
+    ).length,
+  ),
 );
 const timelineMixedCount = computed(() =>
   String(timelineSegments.value.filter((s) => s.status === "mixed").length),
@@ -1591,7 +1651,7 @@ const browserBreakdown = computed<BreakdownItem[]>(() => {
     const key = run.browser || "Unknown";
     const g = groups.get(key) ?? { pass: 0, total: 0 };
     g.total++;
-    if (run.status === "pass") g.pass++;
+    if (run.status === "pass" || run.status === "warning") g.pass++;
     groups.set(key, g);
   }
   const browserIconMap: Record<string, string> = {
@@ -1617,7 +1677,7 @@ const locationBreakdown = computed<BreakdownItem[]>(() => {
     const key = run.location || "Unknown";
     const g = groups.get(key) ?? { pass: 0, total: 0 };
     g.total++;
-    if (run.status === "pass") g.pass++;
+    if (run.status === "pass" || run.status === "warning") g.pass++;
     groups.set(key, g);
   }
 
@@ -1654,7 +1714,7 @@ const deviceBreakdown = computed<BreakdownItem[]>(() => {
     const key = run.device || "Unknown";
     const g = groups.get(key) ?? { pass: 0, total: 0 };
     g.total++;
-    if (run.status === "pass") g.pass++;
+    if (run.status === "pass" || run.status === "warning") g.pass++;
     groups.set(key, g);
   }
   return Array.from(groups.entries()).map(([id, g]) => {
@@ -1708,6 +1768,7 @@ const locationDurationBreakdown = computed<BreakdownItem[]>(() => {
 const statusOptions = [
   { key: "all", label: t('synthetics.filters.all'), dot: "var(--color-text-secondary)" },
   { key: "pass", label: t('synthetics.results.passed'), dot: "var(--color-status-success-text)" },
+  { key: "warning", label: t('synthetics.runs.warning'), dot: "var(--color-status-warning-text)" },
   { key: "fail", label: t('synthetics.results.failed'), dot: "var(--color-status-error-text)" },
 ];
 
@@ -1751,7 +1812,7 @@ function fmtAge(min: number): string {
 }
 interface MockRun {
   id: number; runId: string; ageMin: number; scheduledTs: number;
-  timestamp: number; duration: number; status: "pass" | "fail";
+  timestamp: number; duration: number; status: "pass" | "warning" | "fail" | "error";
   location: string; browser: string; device: string; triggerType: string;
   failedStep: string | null; locator: string | null; action: string | null;
   errorPattern: string | null;
@@ -1776,7 +1837,13 @@ function generateRuns(timeRange?: { startTimeMs: number; endTimeMs: number }): M
     const intervalFraction = logicalRunIdx / NUM_LOGICAL_RUNS;
     const scheduledBase = baseTime - Math.round(intervalFraction * timeSpan);
     for (let execIdx = 0; execIdx < numExecutions; execIdx++) {
-      const isFail = r() < 0.22;
+      const rand = r();
+      const status: MockRun["status"] =
+        rand < 0.05 ? "warning"
+        : rand < 0.22 ? "fail"
+        : rand < 0.24 ? "error"
+        : "pass";
+      const isFail = status === "fail" || status === "error";
       const dur = isFail ? Math.round(20000 + r() * 15000) : Math.round(1800 + r() * 3200);
       const errIdx = Math.floor(r() * errs.length);
       const failedStep = isFail ? steps[8 + Math.floor(r() * 4)] : null;
@@ -1785,7 +1852,7 @@ function generateRuns(timeRange?: { startTimeMs: number; endTimeMs: number }): M
         id: idCounter++, runId,
         ageMin: Math.round((baseTime - scheduledBase) / 60000),
         scheduledTs: scheduledBase, timestamp: scheduledBase + Math.round(r() * 30000),
-        triggerType: "schedule", duration: dur, status: isFail ? "fail" : "pass",
+        triggerType: "schedule", duration: dur, status,
         location: locations[Math.floor(r() * locations.length)],
         browser: browsers[Math.floor(r() * browsers.length)],
         device: devices[r() < 0.7 ? 0 : r() < 0.85 ? 1 : 2],
@@ -1843,12 +1910,24 @@ interface VisibleRun {
 
 const visibleRuns = computed<VisibleRun[]>(() => {
   return filteredRuns.value.map((run) => {
-    const isFail = run.status === "fail";
+    const isPass = run.status === "pass";
+    const isWarning = run.status === "warning";
+    const isError = run.status === "error";
     return {
       id: run.id,
-      statusBadgeVariant: isFail ? "error-soft" : "success-soft",
-      statusIcon: isFail ? "cancel" : "check_circle",
-      statusLabel: isFail ? t('synthetics.results.failed') : t('synthetics.results.passed'),
+      statusBadgeVariant: isPass
+        ? "success-soft"
+        : isWarning
+          ? "warning-soft"
+          : "error-soft",
+      statusIcon: isPass || isWarning ? "check_circle" : "cancel",
+      statusLabel: isPass
+        ? t('synthetics.results.passed')
+        : isWarning
+          ? t('synthetics.protocolRun.warning')
+          : isError
+            ? t('synthetics.results.error')
+            : t('synthetics.results.failed'),
       scheduledTs: run.scheduledTs,
       lastRunTs: run.timestamp,
       triggerType: run.triggerType === "manual" ? t('synthetics.runs.triggerManual') : t('synthetics.runs.triggerSchedule'),

--- a/web/src/views/synthetics/MonitorRuns.vue
+++ b/web/src/views/synthetics/MonitorRuns.vue
@@ -117,6 +117,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <div class="px-page-edge">
               <MonitorStatusTimeline
                 :segments="timelineSegments"
+                :is-browser="isBrowser"
                 :fail-count="timelineFailCount"
                 :pass-count="timelinePassCount"
                 :mixed-count="timelineMixedCount"
@@ -1583,13 +1584,15 @@ const timelineFailCount = computed(() =>
 );
 const timelinePassCount = computed(() =>
   String(
-    timelineSegments.value.filter(
-      (s) => s.status === "all-pass" || s.status === "all-warning",
-    ).length,
+    timelineSegments.value.filter((s) => s.status === "all-pass").length,
   ),
 );
 const timelineMixedCount = computed(() =>
-  String(timelineSegments.value.filter((s) => s.status === "mixed").length),
+  String(
+    timelineSegments.value.filter(
+      (s) => s.status === "mixed" || s.status === "all-warning",
+    ).length,
+  ),
 );
 
 function formatTimelineDate(ms: number): string {

--- a/web/src/views/synthetics/MonitorStatusTimeline.spec.ts
+++ b/web/src/views/synthetics/MonitorStatusTimeline.spec.ts
@@ -24,13 +24,13 @@ interface TimelineExecution {
   location: string;
   browserEngine: string;
   device: string;
-  status: "pass" | "fail";
+  status: "pass" | "warning" | "fail" | "error";
   errorSnippet: string | null;
 }
 
 interface TimelineSegment {
   runId: string;
-  status: "all-pass" | "mixed" | "all-fail";
+  status: "all-pass" | "all-warning" | "mixed" | "all-fail";
   color: string;
   title: string;
   timestampMs: number;

--- a/web/src/views/synthetics/MonitorStatusTimeline.spec.ts
+++ b/web/src/views/synthetics/MonitorStatusTimeline.spec.ts
@@ -80,6 +80,7 @@ const defaultProps = {
   mixedCount: "0",
   startLabel: "Start",
   endLabel: "End",
+  isBrowser: true,
 };
 
 // ── Mount factory ──────────────────────────────────────────────────────────
@@ -254,6 +255,45 @@ describe("MonitorStatusTimeline", () => {
       const text = tooltip.text();
       expect(text).toContain("2 passed");
       expect(text).toContain("1 failed");
+    });
+  });
+
+  describe("isBrowser prop", () => {
+    it("should render per-execution details with device text when isBrowser is true", () => {
+      const executions: TimelineExecution[] = [
+        makePassExec({ location: "us-east-1", browserEngine: "Chromium", device: "laptop" }),
+        makeFailExec({ location: "us-east-1", browserEngine: "Firefox", device: "tablet" }),
+      ];
+      wrapper = makeWrapper({
+        segments: [makeSegment({ executions })],
+        isBrowser: true,
+      });
+
+      const tooltip = wrapper.find(".otooltip-stub");
+      const text = tooltip.text();
+      // Per-execution device labels should be visible
+      expect(text).toContain("laptop");
+      expect(text).toContain("tablet");
+    });
+
+    it("should NOT render per-execution detail rows when isBrowser is false", () => {
+      const executions: TimelineExecution[] = [
+        makePassExec({ location: "us-east-1", browserEngine: "Chromium", device: "laptop" }),
+        makeFailExec({ location: "eu-west-1", browserEngine: "Firefox", device: "tablet" }),
+      ];
+      wrapper = makeWrapper({
+        segments: [makeSegment({ executions })],
+        isBrowser: false,
+      });
+
+      const tooltip = wrapper.find(".otooltip-stub");
+      const text = tooltip.text();
+      // Location group headers should still be shown
+      expect(text).toContain("us-east-1");
+      expect(text).toContain("eu-west-1");
+      // But per-execution device labels should NOT be shown
+      expect(text).not.toContain("laptop");
+      expect(text).not.toContain("tablet");
     });
   });
 

--- a/web/src/views/synthetics/MonitorStatusTimeline.vue
+++ b/web/src/views/synthetics/MonitorStatusTimeline.vue
@@ -109,11 +109,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       <span
                         class="w-2 h-2 rounded-full shrink-0"
                         :class="{
-                          'bg-badge-success-solid-bg':
+                          'bg-[var(--color-badge-success-solid-bg)]':
                             group.status === 'all-pass',
-                          'bg-color-badge-orange-solid-bg':
+                          'bg-[var(--color-badge-warning-solid-bg)]':
                             group.status === 'mixed' || group.status === 'all-warning',
-                          'bg-color-badge-error-solid-bg':
+                          'bg-[var(--color-badge-error-solid-bg)]':
                             group.status === 'all-fail',
                         }"
                       />
@@ -121,32 +121,40 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         {{ group.location }}
                       </span>
                     </div>
-                    <div
-                      v-for="(exec, eIdx) in group.executions"
-                      :key="eIdx"
-                      class="flex items-center gap-1.5 py-0.5 pl-4"
-                    >
-                      <span
-                        class="w-2 h-2 rounded-full shrink-0"
-                        :class="{
-                          'bg-[var(--color-badge-success-solid-bg)]':
-                            exec.status === 'pass',
-                          'bg-[var(--color-badge-warning-solid-bg)]':
-                            exec.status === 'warning',
-                          'bg-[var(--color-badge-error-solid-bg)]':
-                            exec.status === 'fail' || exec.status === 'error',
-                        }"
-                      />
-                      <img
-                        v-if="browserIconUrl(exec.browserEngine)"
-                        :src="browserIconUrl(exec.browserEngine)"
-                        class="w-3.5 h-3.5"
-                        alt=""
-                      />
-                      <span class="text-text-secondary text-xs">{{
-                        exec.device
-                      }}</span>
-                    </div>
+                    <!--
+                      Per-execution detail rows: only rendered for browser monitors
+                      where each execution carries a browser engine + device.
+                      Non-browser monitors only have locations — the group header
+                      above (dot + location name) is the full summary.
+                    -->
+                    <template v-if="isBrowser">
+                      <div
+                        v-for="(exec, eIdx) in group.executions"
+                        :key="eIdx"
+                        class="flex items-center gap-1.5 py-0.5 pl-4"
+                      >
+                        <span
+                          class="w-2 h-2 rounded-full shrink-0"
+                          :class="{
+                            'bg-[var(--color-badge-success-solid-bg)]':
+                              exec.status === 'pass',
+                            'bg-[var(--color-badge-warning-solid-bg)]':
+                              exec.status === 'warning',
+                            'bg-[var(--color-badge-error-solid-bg)]':
+                              exec.status === 'fail' || exec.status === 'error',
+                          }"
+                        />
+                        <img
+                          v-if="browserIconUrl(exec.browserEngine)"
+                          :src="browserIconUrl(exec.browserEngine)"
+                          class="w-3.5 h-3.5"
+                          alt=""
+                        />
+                        <span class="text-text-secondary text-xs">{{
+                          exec.device
+                        }}</span>
+                      </div>
+                    </template>
                   </template>
                 </div>
               </template>
@@ -223,8 +231,11 @@ interface Props {
   mixedCount: string;
   startLabel: string;
   endLabel: string;
+  isBrowser?: boolean;
 }
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  isBrowser: true,
+});
 
 const browserIconUrl = (name: string): string => {
   switch (name) {
@@ -260,9 +271,20 @@ function groupedByLocation(execs: TimelineExecution[]): ExecGroup[] {
     else map.set(exec.location, [exec]);
   }
   return Array.from(map, ([location, executions]) => {
-    const allPass = executions.every((e) => e.status === "pass");
-    const allFail = executions.every((e) => e.status === "fail");
-    const status = allPass ? "all-pass" : allFail ? "all-fail" : "mixed";
+    const allPass = executions.every(
+      (e) => e.status === "pass" || e.status === "warning",
+    );
+    const allFail = executions.every(
+      (e) => e.status === "fail" || e.status === "error",
+    );
+    const allWarning = executions.every((e) => e.status === "warning");
+    const status = allPass
+      ? allWarning
+        ? "all-warning"
+        : "all-pass"
+      : allFail
+        ? "all-fail"
+        : "mixed";
     return { location, status, executions };
   });
 }

--- a/web/src/views/synthetics/MonitorStatusTimeline.vue
+++ b/web/src/views/synthetics/MonitorStatusTimeline.vue
@@ -112,7 +112,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           'bg-badge-success-solid-bg':
                             group.status === 'all-pass',
                           'bg-color-badge-orange-solid-bg':
-                            group.status === 'mixed',
+                            group.status === 'mixed' || group.status === 'all-warning',
                           'bg-color-badge-error-solid-bg':
                             group.status === 'all-fail',
                         }"
@@ -128,11 +128,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     >
                       <span
                         class="w-2 h-2 rounded-full shrink-0"
-                        :class="
-                          exec.status === 'pass'
-                            ? 'bg-[var(--color-badge-success-solid-bg)]'
-                            : 'bg-[var(--color-badge-error-solid-bg)]'
-                        "
+                        :class="{
+                          'bg-[var(--color-badge-success-solid-bg)]':
+                            exec.status === 'pass',
+                          'bg-[var(--color-badge-warning-solid-bg)]':
+                            exec.status === 'warning',
+                          'bg-[var(--color-badge-error-solid-bg)]':
+                            exec.status === 'fail' || exec.status === 'error',
+                        }"
                       />
                       <img
                         v-if="browserIconUrl(exec.browserEngine)"
@@ -199,13 +202,13 @@ interface TimelineExecution {
   location: string;
   browserEngine: string;
   device: string;
-  status: "pass" | "fail";
+  status: "pass" | "warning" | "fail" | "error";
   errorSnippet: string | null;
 }
 
 interface TimelineSegment {
   runId: string;
-  status: "all-pass" | "mixed" | "all-fail";
+  status: "all-pass" | "all-warning" | "mixed" | "all-fail";
   color: string;
   title: string;
   /** Epoch ms of the first execution in this logical run. */
@@ -238,12 +241,12 @@ const browserIconUrl = (name: string): string => {
 
 interface ExecGroup {
   location: string;
-  status: "all-pass" | "mixed" | "all-fail";
+  status: "all-pass" | "all-warning" | "mixed" | "all-fail";
   executions: TimelineExecution[];
 }
 
 function passCountLocal(execs: TimelineExecution[]): number {
-  return execs.filter((e) => e.status === "pass").length;
+  return execs.filter((e) => e.status === "pass" || e.status === "warning").length;
 }
 function failCountLocal(execs: TimelineExecution[]): number {
   return execs.filter((e) => e.status === "fail").length;


### PR DESCRIPTION
## What changed

- **Warning status consistency**: The backend returns 4 run statuses (`passed`, `warning`, `failed`, `error`) but the frontend only handled `passed`/`failed` consistently. Across `MonitorRuns.vue`, `SyntheticMonitoring.vue`, `syntheticResultsSchema.ts`, and `useSyntheticResults.ts`, all 4 statuses are now properly mapped to their own badge variants, filter options, KPI cards, timeline segments, and breakdowns.
- **Cooldown period label**: Removed the `*` required indicator from the cooldown period label in `CheckAlerts.vue` since the field is optional.

## Why

The TLS certificate-expiring-soon check returns `warning` status, which appeared inconsistently: green "passed" in some views, red "failed" in others, or entirely missing from filter dropdowns. The fixes ensure SREs can distinguish "slightly flaky check" from "service is crashing" at a glance.