### PR TITLE
fix(agent-graph): decouple from Service Graph, gate on resolved agent stream

### DIFF
--- a/web/src/enterprise/views/AIObservability/AgentGraphPage.spec.ts
+++ b/web/src/enterprise/views/AIObservability/AgentGraphPage.spec.ts
@@ -1,0 +1,267 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// @vitest-environment jsdom
+//
+// Regression tests for the Agent Graph page's stream-gating logic.
+//
+// The bug: in "agent" mode the page fell back to the `default` trace stream
+// whenever no agent was selected (e.g. no agents in the time window, or before
+// loadAgents() resolved). ServiceGraph loads on mount, so it queried `default`
+// and rendered that whole stream's service topology instead of an agent graph —
+// the wrong graph that "only a refresh fixed". These tests pin the corrected
+// behavior: ServiceGraph mounts ONLY once a real agent stream is resolved, and a
+// "no agents" empty state renders otherwise — never the default-stream graph.
+
+// ---------------------------------------------------------------------------
+// vi.mock() calls MUST be hoisted above imports.
+// ---------------------------------------------------------------------------
+import { reactive } from "vue";
+
+const mockListAgents = vi.fn();
+
+// Module-scoped traces store singleton (mirrors useTraces()).
+const mockSearchObj = reactive({
+  data: {
+    datetime: {
+      type: "relative",
+      relativeTimePeriod: "15m",
+      startTime: 0,
+      endTime: 0,
+    },
+    stream: { selectedStream: { value: "" } },
+  },
+  meta: {
+    serviceGraphVisualizationType: "tree",
+    serviceGraphLayoutType: "horizontal",
+  },
+});
+
+vi.mock("@/services/gen-ai-agent-mapping.service", () => ({
+  default: {
+    listAgents: (...args: any[]) => mockListAgents(...args),
+  },
+}));
+
+
+vi.mock("@/composables/useTraces", () => ({
+  default: vi.fn(() => ({ searchObj: mockSearchObj })),
+}));
+
+vi.mock("vuex", () => ({
+  useStore: vi.fn(() => ({
+    state: { selectedOrganization: { identifier: "test-org" } },
+  })),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: vi.fn(() => ({
+    t: (key: string) => key,
+  })),
+}));
+
+// Only relative-time resolution is exercised; return a fixed window.
+vi.mock("@/utils/date", () => ({
+  getConsumableRelativeTime: vi.fn(() => ({ startTime: 100, endTime: 200 })),
+}));
+
+// ServiceGraph is loaded via defineAsyncComponent(() => import(...)). Under
+// jsdom that async wrapper doesn't resolve into the DOM when gated behind a
+// v-if that flips true only after mount (which is exactly our case). Replace
+// defineAsyncComponent with a synchronous stub so we can assert (a) whether the
+// graph mounted at all and (b) which stream/viz/layout it was handed.
+vi.mock("vue", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    defineAsyncComponent: () =>
+      actual.defineComponent({
+        name: "ServiceGraphStub",
+        props: [
+          "streamFilter",
+          "vizType",
+          "layoutType",
+          "hideStreamSelector",
+          "agentHighlight",
+        ],
+        template: `<div data-test="service-graph-stub" :data-stream="streamFilter" :data-viz="vizType" :data-layout="layoutType" />`,
+      }),
+  };
+});
+
+// Design-system stubs — reduced to just the contract these tests read.
+vi.mock("@/lib/core/PageLayout/OPageLayout.vue", () => ({
+  default: {
+    name: "OPageLayout",
+    template: `<div class="o-page-layout"><slot name="actions" /><slot name="subnav" /><slot /></div>`,
+  },
+}));
+
+vi.mock("@/components/DateTime.vue", () => ({
+  default: { name: "DateTime", template: `<div class="date-time" />` },
+}));
+
+vi.mock("@/lib/forms/Select/OSelect.vue", () => ({
+  default: {
+    name: "OSelect",
+    props: ["modelValue", "options", "label"],
+    emits: ["update:model-value"],
+    // Expose each option's value so tests can inspect what a select offers.
+    template: `<div class="o-select" :data-label="label" :data-value="modelValue">
+      <span
+        v-for="o in (options || [])"
+        :key="o.value ?? o"
+        class="o-select-option"
+        :data-option="o.value ?? o"
+      >{{ o.label ?? o }}</span>
+    </div>`,
+  },
+}));
+
+vi.mock("@/lib/core/ToggleGroup/OToggleGroup.vue", () => ({
+  default: {
+    name: "OToggleGroup",
+    props: ["modelValue"],
+    emits: ["update:model-value"],
+    template: `<div class="o-toggle-group" :data-value="modelValue"><slot /></div>`,
+  },
+}));
+
+vi.mock("@/lib/core/ToggleGroup/OToggleGroupItem.vue", () => ({
+  default: {
+    name: "OToggleGroupItem",
+    template: `<button class="o-toggle-item"><slot /></button>`,
+  },
+}));
+
+vi.mock("@/lib/core/Icon/OIcon.vue", () => ({
+  default: { name: "OIcon", template: `<i class="o-icon" />` },
+}));
+
+vi.mock("@/lib/core/RefreshButton/ORefreshButton.vue", () => ({
+  default: { name: "ORefreshButton", template: `<button class="o-refresh" />` },
+}));
+
+vi.mock("@/lib/feedback/Spinner/OSpinner.vue", () => ({
+  default: { name: "OSpinner", template: `<div class="o-spinner" />` },
+}));
+
+vi.mock("@/lib/core/EmptyState/OEmptyState.vue", () => ({
+  default: {
+    name: "OEmptyState",
+    props: ["title", "description", "illustration", "size"],
+    template: `<div class="o-empty-state" :data-title="title" />`,
+  },
+}));
+
+vi.mock("@/components/shared/SkeletonBox.vue", () => ({
+  default: { name: "SkeletonBox", template: `<div class="skeleton-box" />` },
+}));
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import AgentGraphPage from "./AgentGraphPage.vue";
+
+const AGENT = {
+  name: "sre_agent",
+  id: null,
+  source_stream: "sre_agent_traces_production",
+  source_stream_type: "traces",
+};
+
+async function mountPage() {
+  const wrapper = mount(AgentGraphPage);
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("AgentGraphPage — agent-mode stream gating", () => {
+  it("mounts ServiceGraph with the SELECTED agent's source_stream (not 'default')", async () => {
+    mockListAgents.mockResolvedValue({ agents: [AGENT] });
+
+    const wrapper = await mountPage();
+
+    const sg = wrapper.find('[data-test="service-graph-stub"]');
+    expect(sg.exists()).toBe(true);
+    expect(sg.attributes("data-stream")).toBe("sre_agent_traces_production");
+    // Must never fall back to the default stream.
+    expect(sg.attributes("data-stream")).not.toBe("default");
+  });
+
+  it("shows the 'no agents' empty state — NOT the default service graph — when no agents are discovered", async () => {
+    mockListAgents.mockResolvedValue({ agents: [] });
+
+    const wrapper = await mountPage();
+
+    // The regression: ServiceGraph must NOT render (it would have queried the
+    // fallback `default` stream and drawn the wrong graph).
+    expect(wrapper.find('[data-test="service-graph-stub"]').exists()).toBe(false);
+    // The empty state is shown instead.
+    expect(wrapper.find('[data-test="agent-graph-no-agents"]').exists()).toBe(true);
+  });
+
+  it("does not render ServiceGraph while agents are still loading", async () => {
+    // Never-resolving listAgents keeps agentsLoaded=false.
+    mockListAgents.mockReturnValue(new Promise(() => {}));
+
+    const wrapper = mount(AgentGraphPage);
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="service-graph-stub"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="agent-graph-no-agents"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="agent-graph-loading"]').exists()).toBe(true);
+  });
+
+  it("passes the page's own vizType/layoutType (independent of the traces store) to ServiceGraph", async () => {
+    localStorage.setItem("agentGraph_visualizationType", "graph");
+    localStorage.setItem("agentGraph_layoutType", "force");
+    // Traces store is on tree/horizontal — must NOT leak through.
+    mockSearchObj.meta.serviceGraphVisualizationType = "tree";
+    mockSearchObj.meta.serviceGraphLayoutType = "horizontal";
+    mockListAgents.mockResolvedValue({ agents: [AGENT] });
+
+    const wrapper = await mountPage();
+
+    const sg = wrapper.find('[data-test="service-graph-stub"]');
+    expect(sg.attributes("data-viz")).toBe("graph");
+    expect(sg.attributes("data-layout")).toBe("force");
+  });
+
+  it("Stream picker offers ONLY the distinct source_streams of discovered agents (not agentless streams)", async () => {
+    // Two agents across two streams; one stream (streamB) appears twice.
+    mockListAgents.mockResolvedValue({
+      agents: [
+        { name: "a1", id: null, source_stream: "streamA", source_stream_type: "traces" },
+        { name: "a2", id: null, source_stream: "streamB", source_stream_type: "traces" },
+        { name: "a3", id: null, source_stream: "streamB", source_stream_type: "traces" },
+      ],
+    });
+
+    const wrapper = await mountPage();
+    // Switch to Stream mode so the stream selector renders.
+    (wrapper.vm as any).filterMode = "stream";
+    await flushPromises();
+
+    const streamSelect = wrapper
+      .findAll(".o-select")
+      .find((s) => s.attributes("data-label") === "aiObservability.agentGraph.stream");
+    expect(streamSelect).toBeTruthy();
+
+    const opts = streamSelect!.findAll(".o-select-option");
+    const values = opts.map((o) => o.attributes("data-option")).sort();
+    // Exactly the agent-bearing streams, de-duplicated. No `default`, no
+    // agentless stream like `introspection`.
+    expect(values).toEqual(["streamA", "streamB"]);
+
+    // Each label is annotated with the agent count for that stream.
+    const labelByValue = Object.fromEntries(
+      opts.map((o) => [o.attributes("data-option"), o.text()]),
+    );
+    expect(labelByValue["streamA"]).toContain("(1 aiObservability.agentGraph.agentCountSingular)");
+    expect(labelByValue["streamB"]).toContain("(2 aiObservability.agentGraph.agentCountPlural)");
+  });
+});

--- a/web/src/enterprise/views/AIObservability/AgentGraphPage.vue
+++ b/web/src/enterprise/views/AIObservability/AgentGraphPage.vue
@@ -78,22 +78,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div
         v-if="filterMode === 'stream'"
         data-test="agent-graph-stream-selector"
-        class="w-56 shrink-0"
+        class="w-80 shrink-0"
       >
         <OSelect
           v-model="activeStream"
           :label="t('aiObservability.agentGraph.stream')"
           label-position="inside"
-          :options="availableStreams.map((s) => ({ label: s, value: s }))"
+          :options="streamSelectOptions"
           labelKey="label"
           valueKey="value"
+          option-tooltip
           class="w-full rounded-default"
         />
       </div>
       <div
         v-else
         data-test="agent-graph-agent-selector"
-        class="w-56 shrink-0"
+        class="w-80 shrink-0"
       >
         <SkeletonBox
           v-if="!agentsLoaded"
@@ -112,16 +113,83 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           class="w-full rounded-default"
         />
       </div>
+
+      <!-- Agent Graph's OWN visualization + layout selection. Kept fully
+           independent of the Traces Service Graph tab (its own state + distinct
+           localStorage keys), so the two surfaces don't share a type. Same
+           control shape as the Traces SearchBar toolbar for consistency. -->
+      <div class="ml-auto flex items-center gap-2 shrink-0">
+        <OToggleGroup
+          :model-value="vizType"
+          type="single"
+          data-test="agent-graph-viz-type"
+          @update:model-value="onVizTypeChange"
+        >
+          <OToggleGroupItem value="tree" size="sm">
+            <template #icon-left>
+              <OIcon name="git-branch" size="sm" />
+            </template>
+            {{ t("traces.treeView") }}
+          </OToggleGroupItem>
+          <OToggleGroupItem value="graph" size="sm">
+            <template #icon-left>
+              <OIcon name="share" size="sm" class="shrink-0" />
+            </template>
+            {{ t("traces.graphView") }}
+          </OToggleGroupItem>
+        </OToggleGroup>
+        <OSelect
+          v-model="layoutType"
+          :options="layoutOptions"
+          :searchable="false"
+          data-test="agent-graph-layout-type"
+          class="w-[7.5rem] min-h-8! h-8!"
+          :disabled="vizType === 'graph'"
+          @update:model-value="onLayoutTypeChange"
+        />
+      </div>
     </div>
     </template>
 
+    <!-- Gate the graph until the effective stream is genuinely resolved.
+         ServiceGraph loads unconditionally in its own onMounted, so mounting it
+         before loadAgents() resolves would fire an initial query against the
+         fallback ("default") stream — rendering the wrong, non-agent graph that
+         only a manual refresh replaced. Rendering only once `graphReady` is true
+         mounts ServiceGraph exactly once, with the correct stream. Later agent
+         switches keep it mounted and go through the streamFilter watcher. -->
     <ServiceGraph
+      v-if="graphReady"
       ref="graphRef"
       :stream-filter="effectiveStream"
+      :viz-type="vizType"
+      :layout-type="layoutType"
       hide-stream-selector
       agent-highlight
       class="flex-1 min-h-0"
     />
+    <!-- No agents discovered in the current org / time window — show an empty
+         state, NOT the fallback `default` service graph (the original bug). -->
+    <div
+      v-else-if="hasNoAgents"
+      data-test="agent-graph-no-agents"
+      class="flex-1 min-h-0 flex items-center justify-center"
+    >
+      <OEmptyState
+        size="block"
+        illustration="service-graph"
+        :title="t('aiObservability.agentGraph.noAgentsTitle')"
+        :description="t('aiObservability.agentGraph.noAgentsDescription')"
+      />
+    </div>
+    <!-- Agents / stream still resolving. -->
+    <div
+      v-else
+      data-test="agent-graph-loading"
+      class="flex-1 min-h-0 flex items-center justify-center"
+    >
+      <OSpinner />
+    </div>
   </OPageLayout>
 </template>
 
@@ -133,12 +201,15 @@ import { useStore } from "vuex";
 import DateTime from "@/components/DateTime.vue";
 import OPageLayout from "@/lib/core/PageLayout/OPageLayout.vue";
 import OSelect from "@/lib/forms/Select/OSelect.vue";
+import type { SelectModelValue } from "@/lib/forms/Select/OSelect.types";
 import OToggleGroup from "@/lib/core/ToggleGroup/OToggleGroup.vue";
 import OToggleGroupItem from "@/lib/core/ToggleGroup/OToggleGroupItem.vue";
+import OIcon from "@/lib/core/Icon/OIcon.vue";
 import ORefreshButton from "@/lib/core/RefreshButton/ORefreshButton.vue";
+import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
+import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
 import SkeletonBox from "@/components/shared/SkeletonBox.vue";
 import useTraces from "@/composables/useTraces";
-import useStreams from "@/composables/useStreams";
 import { getConsumableRelativeTime } from "@/utils/date";
 import genAiAgentMappingService, {
   type GenAiAgentListItem,
@@ -149,7 +220,6 @@ defineOptions({ name: "AIAgentGraphPage" });
 const { t } = useI18n();
 const store = useStore();
 const { searchObj } = useTraces();
-const { getStreams } = useStreams();
 
 const ServiceGraph = defineAsyncComponent(
   () => import("@/plugins/traces/ServiceGraph.vue"),
@@ -160,8 +230,50 @@ const DEFAULT_RELATIVE = "15m";
 // Default scope is "agent" — the AI module is agent-centric (agents load on
 // mount, so the default is ready on first paint).
 const filterMode = ref<"stream" | "agent">("agent");
-const availableStreams = ref<string[]>([]);
-const activeStream = ref<string>("default");
+const activeStream = ref<string>("");
+
+// Agent Graph's OWN visualization + layout selection — deliberately NOT the
+// shared traces store (`searchObj.meta.serviceGraph*Type`) that the Traces
+// Service Graph tab uses. Kept independent so the Agent Graph type doesn't bleed
+// in from that tab, and so a remount can't render the stale shared type. Its
+// own localStorage keys persist the choice across visits. Passed down to
+// ServiceGraph via `viz-type` / `layout-type` props, which override the store.
+const vizType = ref<"tree" | "graph">(
+  (localStorage.getItem("agentGraph_visualizationType") as
+    | "tree"
+    | "graph") || "tree",
+);
+const layoutType = ref<string>(
+  localStorage.getItem("agentGraph_layoutType") || "horizontal",
+);
+
+const layoutOptions = computed(() =>
+  vizType.value === "graph"
+    ? [{ label: t("traces.layoutForce"), value: "force" }]
+    : [
+        { label: t("traces.layoutHorizontal"), value: "horizontal" },
+        { label: t("traces.layoutVertical"), value: "vertical" },
+      ],
+);
+
+function onVizTypeChange(
+  value: boolean | AcceptableValue | AcceptableValue[],
+) {
+  if (value !== "tree" && value !== "graph") return;
+  vizType.value = value;
+  localStorage.setItem("agentGraph_visualizationType", value);
+  // Mirror the SearchBar toolbar: each view has a sensible default layout.
+  const nextLayout = value === "tree" ? "horizontal" : "force";
+  layoutType.value = nextLayout;
+  localStorage.setItem("agentGraph_layoutType", nextLayout);
+}
+
+function onLayoutTypeChange(value: SelectModelValue) {
+  // Layout options are always plain string values (horizontal/vertical/force);
+  // v-model already assigned layoutType — this handler only persists it.
+  if (typeof value !== "string") return;
+  localStorage.setItem("agentGraph_layoutType", value);
+}
 
 // Graph child ref + header refresh state. ServiceGraph exposes
 // { refresh, loading, lastRunAt }.
@@ -211,17 +323,69 @@ const agentSelectOptions = computed(() =>
   })),
 );
 
+// Streams offered in the Stream picker are ONLY those that actually carry agent
+// data — i.e. the distinct source_streams of discovered agents. A trace stream
+// with services but no agents (e.g. `introspection`) has nothing agent-related
+// to show here, so it must not appear. Derived from the agents list rather than
+// from all trace streams for exactly this reason.
+const availableStreams = computed(() => [
+  ...new Set(agents.value.map((a) => a.source_stream)),
+]);
+
+// Stream picker options: the stream name annotated with how many agents it
+// contains, e.g. "sre_agent_traces_production (2 agents)". The count makes it
+// clear a stream holds multiple agents and disambiguates otherwise similar (or
+// truncated) stream names. `value` stays the bare stream name. The full stream
+// name is kept in `title` so a truncated label still reveals itself on hover.
+const streamSelectOptions = computed(() => {
+  const counts = new Map<string, number>();
+  for (const a of agents.value) {
+    counts.set(a.source_stream, (counts.get(a.source_stream) ?? 0) + 1);
+  }
+  return availableStreams.value.map((s) => {
+    const n = counts.get(s) ?? 0;
+    return {
+      label: `${s} (${n} ${
+        n === 1
+          ? t("aiObservability.agentGraph.agentCountSingular")
+          : t("aiObservability.agentGraph.agentCountPlural")
+      })`,
+      value: s,
+    };
+  });
+});
+
 const selectedAgent = computed<GenAiAgentListItem | null>(
   () => agents.value.find((a) => agentKey(a) === activeAgentKey.value) ?? null,
 );
 
-// The stream the graph queries: the picked stream, or the selected agent's
-// source_stream. Deriving the stream from the agent is the whole point — the
-// user picks an agent, not a stream.
+// The stream the graph queries: the picked stream, or the SELECTED agent's
+// source_stream. In agent mode with no agent selected there is NO valid stream —
+// it must be empty, NOT `activeStream` ("default"). Falling back to "default"
+// here was the bug: with no agent selected (e.g. no agents in the window) the
+// graph rendered the whole `default` trace stream's service topology instead of
+// an agent-scoped graph.
 const effectiveStream = computed(() =>
   filterMode.value === "agent"
-    ? (selectedAgent.value?.source_stream ?? activeStream.value)
+    ? (selectedAgent.value?.source_stream ?? "")
     : activeStream.value,
+);
+
+// Whether there is simply nothing agent-related to graph in the current org /
+// time window. There are no agents at all → both modes have nothing to show
+// (the Stream picker is itself derived from agent-bearing streams).
+const hasNoAgents = computed(
+  () => agentsLoaded.value && !agents.value.length,
+);
+
+// The graph may only mount once it has a real stream to query. In agent mode
+// that requires an actually-selected agent (whose source_stream is the stream);
+// in stream mode, a chosen agent-bearing stream. This prevents ServiceGraph's
+// mount-time load from ever firing against a fallback/agentless stream.
+const graphReady = computed(() =>
+  filterMode.value === "agent"
+    ? !!selectedAgent.value && !!effectiveStream.value
+    : !!activeStream.value,
 );
 
 function onFilterModeChange(
@@ -239,31 +403,6 @@ function effectiveWindow() {
   return { startTime: dt.startTime, endTime: dt.endTime };
 }
 
-async function loadStreams() {
-  try {
-    const res = (await getStreams("traces", false, false)) as {
-      list?: { name: string; settings?: { is_llm_stream?: boolean } }[];
-    };
-    // Only LLM trace streams belong in the Agent Graph picker — a plain
-    // service/HTTP trace stream has no agents or gen_ai edges to graph, so
-    // offering it would just resolve to an empty graph. `is_llm_stream` is the
-    // backend-maintained flag (auto-detected at ingest from gen_ai_* columns).
-    // Exclude only streams explicitly flagged non-LLM, matching the same filter
-    // used by LLM Insights and Sessions.
-    availableStreams.value = (res?.list ?? [])
-      .filter((s) => s.settings?.is_llm_stream !== false)
-      .map((s) => s.name);
-    if (
-      availableStreams.value.length &&
-      !availableStreams.value.includes(activeStream.value)
-    ) {
-      activeStream.value = availableStreams.value[0];
-    }
-  } catch {
-    availableStreams.value = [];
-  }
-}
-
 async function loadAgents() {
   try {
     const org = store.state.selectedOrganization.identifier;
@@ -274,11 +413,31 @@ async function loadAgents() {
       endTime,
     );
     agents.value = res.agents ?? [];
+    // Reconcile the selection against the fresh list. Reloading (e.g. after a
+    // time-range change) can return a different or empty set, which would
+    // otherwise leave `activeAgentKey` pointing at an agent no longer present —
+    // the dropdown then shows a stale name while the graph has no agent. Clear a
+    // now-invalid key, and auto-select the first agent when none is selected.
+    const keys = new Set(agents.value.map((a) => agentKey(a)));
+    if (activeAgentKey.value && !keys.has(activeAgentKey.value)) {
+      activeAgentKey.value = "";
+    }
     if (!activeAgentKey.value && agents.value.length) {
       activeAgentKey.value = agentKey(agents.value[0]);
     }
+    // Same reconciliation for the Stream picker, whose options are the distinct
+    // agent-bearing source_streams (availableStreams). Clear a now-absent
+    // stream, and default to the first agent-bearing stream.
+    if (activeStream.value && !availableStreams.value.includes(activeStream.value)) {
+      activeStream.value = "";
+    }
+    if (!activeStream.value && availableStreams.value.length) {
+      activeStream.value = availableStreams.value[0];
+    }
   } catch {
     agents.value = [];
+    activeAgentKey.value = "";
+    activeStream.value = "";
   } finally {
     agentsLoaded.value = true;
   }
@@ -318,7 +477,6 @@ onMounted(() => {
       searchObj.data.datetime.relativeTimePeriod || DEFAULT_RELATIVE,
     );
   }
-  loadStreams();
   loadAgents();
 });
 </script>

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -7726,7 +7726,11 @@
     "agentGraph": {
       "allAgents": "All agents",
       "stream": "Stream",
-      "agent": "Agent"
+      "agent": "Agent",
+      "noAgentsTitle": "No agents found",
+      "noAgentsDescription": "No agents were discovered in this time range. Try widening the time range, or check that your traces include gen_ai agent attributes.",
+      "agentCountSingular": "agent",
+      "agentCountPlural": "agents"
     },
     "kpi": {
       "totalCost": "Total Cost",

--- a/web/src/plugins/traces/ServiceGraph.vue
+++ b/web/src/plugins/traces/ServiceGraph.vue
@@ -188,11 +188,11 @@
         </ODropdown>
         <OSeparator
           vertical
-          v-if="searchObj.meta.serviceGraphVisualizationType === 'graph'"
+          v-if="resolvedVizType === 'graph'"
           class="self-stretch mx-1"
         />
         <div
-          v-if="searchObj.meta.serviceGraphVisualizationType === 'graph'"
+          v-if="resolvedVizType === 'graph'"
           data-test="sg-node-size-info"
           class="flex flex-row items-center gap-2 min-w-0"
         >
@@ -367,6 +367,7 @@ import {
   computed,
   watch,
   nextTick,
+  type PropType,
 } from "vue";
 import { useStore } from "vuex";
 import useTheme from "@/composables/useTheme";
@@ -458,6 +459,21 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    // Optional external control of visualization + layout type. When set (the
+    // Agent Graph page owns its own Tree/Graph + layout selection), these win
+    // over the shared traces store `searchObj.meta.serviceGraph*Type`. This
+    // keeps the Agent Graph fully decoupled from the Traces Service Graph tab:
+    // its type no longer bleeds in from that tab, and a remount can't paint the
+    // stale shared state. Undefined = fall back to the shared store (the Traces
+    // Service Graph tab, which is driven by the SearchBar toolbar).
+    vizType: {
+      type: String as PropType<"tree" | "graph" | undefined>,
+      default: undefined,
+    },
+    layoutType: {
+      type: String,
+      default: undefined,
+    },
   },
   emits: ["view-traces", "request:stream-change", "jump-to-stream-data"],
   setup(props, { emit, expose }) {
@@ -467,6 +483,19 @@ export default defineComponent({
     const { t } = useI18n();
     const { getStreams } = useStreams();
     const { searchObj } = useTraces();
+
+    // Resolved visualization + layout type. A parent that owns its own type
+    // selection (the Agent Graph page) passes `vizType`/`layoutType` props;
+    // those win. Otherwise fall back to the shared traces store, which the
+    // Traces Service Graph tab drives via the SearchBar toolbar. All reads below
+    // go through these — never `searchObj.meta.serviceGraph*Type` directly — so
+    // the two surfaces stay decoupled.
+    const resolvedVizType = computed<"tree" | "graph">(
+      () => props.vizType ?? searchObj.meta.serviceGraphVisualizationType,
+    );
+    const resolvedLayoutType = computed<string>(
+      () => props.layoutType ?? searchObj.meta.serviceGraphLayoutType,
+    );
 
     const loading = ref(false);
     // Stamped when a graph load settles — lets a parent page show a
@@ -705,8 +734,8 @@ export default defineComponent({
         return { options: {}, notMerge: true };
       }
 
-      const vizType = searchObj.meta.serviceGraphVisualizationType;
-      const layoutType = searchObj.meta.serviceGraphLayoutType;
+      const vizType = resolvedVizType.value;
+      const layoutType = resolvedLayoutType.value;
 
       // Don't use cache if filters are active (search filter)
       const hasActiveFilters = searchFilter.value?.trim();
@@ -881,7 +910,7 @@ export default defineComponent({
 
       // Tree view: emphasis.focus:'relative' in the series config handles dimming natively.
       // No manual dispatch needed — ECharts triggers it on mouseover automatically.
-      if (searchObj.meta.serviceGraphVisualizationType !== "graph") return;
+      if (resolvedVizType.value !== "graph") return;
 
       const rawEdges: any[] = filteredGraphData.value.edges || [];
 
@@ -1450,7 +1479,7 @@ export default defineComponent({
     // but the series type swaps via setOption. Re-register tooltip handlers so both
     // ZRender (tree) and ECharts edge events (graph) work correctly after the swap.
     watch(
-      () => searchObj.meta.serviceGraphVisualizationType,
+      () => resolvedVizType.value,
       async () => {
         if (edgeTooltipCleanup) {
           edgeTooltipCleanup();
@@ -1656,9 +1685,10 @@ export default defineComponent({
       );
     };
 
-    // Watch composable viz/layout state changes from SearchBar toolbar
+    // Watch resolved viz/layout state changes (SearchBar toolbar for the Traces
+    // Service Graph tab, or the Agent Graph page's own selector via props).
     watch(
-      () => searchObj.meta.serviceGraphVisualizationType,
+      () => resolvedVizType.value,
       () => {
         // Only clear the cache — do NOT bump chartKey (that would recreate the
         // ChartRenderer and replay the tree expand animation). The clean series
@@ -1670,7 +1700,7 @@ export default defineComponent({
     );
 
     watch(
-      () => searchObj.meta.serviceGraphLayoutType,
+      () => resolvedLayoutType.value,
       () => {
         chartKey.value++;
       },
@@ -1814,6 +1844,7 @@ export default defineComponent({
       chartRendererRef,
       graphContainerRef,
       searchObj,
+      resolvedVizType,
       loadServiceGraph,
       formatNumber,
       applyFilters,


### PR DESCRIPTION
## Summary

Fixes three Agent Graph issues, all rooted in the page embedding Traces' `ServiceGraph` (which reads viz/layout type from the shared `searchObj.meta` singleton and auto-loads on mount).

### 1. Wrong graph until refresh (returning from Agent Behavior)
On mount, the effective stream fell back to the literal `default` trace stream before `loadAgents()` resolved, so ServiceGraph rendered the whole `default` stream's service topology instead of the agent graph. Manual refresh masked it.
- `effectiveStream` no longer falls back to `default` in agent mode (empty without a selected agent)
- ServiceGraph render is gated behind `graphReady` (a genuinely resolved agent stream); spinner / "no agents" empty state otherwise
- stale agent/stream selections are reconciled on reload

### 2. No graph-type selector; inherited the Traces tab's type
- Added `vizType`/`layoutType` prop overrides on `ServiceGraph` (resolved via computeds that prefer props, else the shared store — Traces behavior unchanged)
- Agent Graph page gets its own Tree/Graph + layout selector, backed by its own state and distinct `agentGraph_*` localStorage keys

### 3. Stream picker listed agentless streams
- Now lists only the distinct `source_stream`s of discovered agents, annotated with per-stream agent counts (e.g. `sre_agent_traces_production (2 agents)`), with an option tooltip and a wider control for long names

## Tests
- New `AgentGraphPage.spec.ts` (5 tests): stream gating, no-agents empty state, viz/layout independence from the Traces store, stream-picker scoping + counts
- `vue-tsc` app + vitest typecheck clean

## Not included / follow-up
- **agent→model edge attribution** (agent node shows tool edges but model edges attach to the service root) is a **backend** topology gap in `src/core/src/traces/service_graph/processor.rs` (`build_agent_or_service` COALESCE falls back to `service_name` past `AGENT_INHERIT_DEPTH=4` hops or when no ancestor carries `gen_ai_agent_name`). Tracked separately.
- **env/version in the agent dropdown** requires backend extractor + DB migration + API changes. Tracked separately.