### PR TITLE
fix(agent-graph): correct stream gating, independent selector, and agent→model/tool edge attribution

### DIFF
--- a/src/core/src/traces/service_graph/processor.rs
+++ b/src/core/src/traces/service_graph/processor.rs
@@ -187,14 +187,25 @@ pub async fn process_service_graph() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Build the `COALESCE(child.agent, p1.agent, …, pN.agent, service_name)`
+/// Build the
+/// `COALESCE(child.agent, p1.agent, …, pN.agent, [trace_agent,] service_name)`
 /// nearest-ancestor-agent expression for the tool/model edge `from`. `depth` is
 /// the number of ancestor levels to climb (N). When `has_agent_id`, each level
 /// prefers `agent_id` then `agent_name`. This is what lets a tool/LLM span whose
 /// agent name lives several levels up the parent chain (real Google ADK:
 /// generate_content→chat→execute_tool) still attribute to the owning agent.
+///
+/// When `with_trace_agent`, a per-trace agent level (`ta.agent_name`, joined by
+/// `trace_id`) is inserted just before the `service_name` fallback. This is the
+/// last resort for a span whose direct parent chain is BROKEN — e.g. the
+/// intermediate `generate_content` span was dropped/sampled and never ingested,
+/// so climbing `reference_parent_span_id` hits a missing row and finds no agent
+/// within `depth` hops. Without it those spans mis-attribute to the host
+/// service, drawing a spurious `service → model`/`service → tool` edge instead
+/// of `agent → model`/`agent → tool`. Real agentic traces are single-agent (the
+/// CTE takes MAX per trace_id), so this cannot merge two agents' calls.
 #[cfg(feature = "enterprise")]
-fn build_agent_or_service(has_agent_id: bool, depth: usize) -> String {
+fn build_agent_or_service(has_agent_id: bool, depth: usize, with_trace_agent: bool) -> String {
     let level = |alias: &str| -> String {
         if has_agent_id {
             format!("{alias}.gen_ai_agent_id, {alias}.gen_ai_agent_name")
@@ -206,8 +217,41 @@ fn build_agent_or_service(has_agent_id: bool, depth: usize) -> String {
     for k in 1..=depth {
         parts.push(level(&format!("p{k}")));
     }
+    if with_trace_agent {
+        // The per-trace CTE only carries agent name/id columns (aliased `ta`).
+        parts.push(if has_agent_id {
+            "ta.gen_ai_agent_id, ta.gen_ai_agent_name".to_string()
+        } else {
+            "ta.gen_ai_agent_name".to_string()
+        });
+    }
     parts.push("c.service_name".to_string());
     format!("COALESCE({})", parts.join(", "))
+}
+
+/// The per-trace agent CTE + its `LEFT JOIN`, used as the broken-parent-chain
+/// fallback in `build_agent_or_service` (see there). Returns the `WITH …` CTE
+/// clause (empty string if no agent-id column) and the join clause to splice
+/// into the tool/model queries. One agent per trace is assumed (single-agent
+/// agentic traces); `MAX` gives a deterministic pick if that ever fails to hold.
+#[cfg(feature = "enterprise")]
+fn build_trace_agent_cte(stream_name: &str, has_agent_id: bool, start_time: i64, end_time: i64) -> (String, String) {
+    let id_col = if has_agent_id {
+        ", MAX(gen_ai_agent_id) AS gen_ai_agent_id"
+    } else {
+        ""
+    };
+    let cte = format!(
+        r#"WITH trace_agent AS (
+            SELECT trace_id, MAX(gen_ai_agent_name) AS gen_ai_agent_name{id_col}
+            FROM "{stream_name}"
+            WHERE _timestamp >= {start_time} AND _timestamp < {end_time}
+                AND gen_ai_agent_name IS NOT NULL AND gen_ai_agent_name != ''
+            GROUP BY trace_id
+        )"#,
+    );
+    let join = "LEFT JOIN trace_agent AS ta ON c.trace_id = ta.trace_id".to_string();
+    (cte, join)
 }
 
 /// Build the chained ancestor `LEFT JOIN`s (p1 on child `c`, p2 on p1, …, pN on
@@ -452,19 +496,29 @@ async fn compute_stream_edges(
             .map(|s| s.field_with_name("reference_parent_span_id").is_ok())
             .unwrap_or(false);
         // The nearest-ancestor-agent-or-service `from` for tool/model. With the
-        // parent-link column present, COALESCE walks child → p1 → … → pN → service;
-        // otherwise it is the flat child-or-service form (no join possible).
+        // parent-link column present, COALESCE walks child → p1 → … → pN →
+        // per-trace agent → service; otherwise it is the flat child-or-service
+        // form (no join possible). The per-trace agent level recovers the owning
+        // agent when the direct parent chain is broken (a dropped intermediate
+        // span), which otherwise mis-attributes the span to the host service.
         let agent_or_service = if has_parent_link {
-            build_agent_or_service(has_agent_id, AGENT_INHERIT_DEPTH)
+            build_agent_or_service(has_agent_id, AGENT_INHERIT_DEPTH, true)
         } else {
             format!("COALESCE({agent_ident}, service_name)")
         };
-        // The chained ancestor LEFT JOINs (p1 on child, p2 on p1, …), shared by
-        // the tool and model queries. Empty when the stream has no parent link.
-        let ancestor_joins = if has_parent_link {
-            build_ancestor_joins(stream_name, AGENT_INHERIT_DEPTH)
+        // The chained ancestor LEFT JOINs (p1 on child, p2 on p1, …) plus the
+        // per-trace agent join, shared by the tool and model queries. Empty when
+        // the stream has no parent link.
+        let (trace_agent_cte, ancestor_joins) = if has_parent_link {
+            let (cte, ta_join) =
+                build_trace_agent_cte(stream_name, has_agent_id, start_time, end_time);
+            let joins = format!(
+                "{}\n                    {ta_join}",
+                build_ancestor_joins(stream_name, AGENT_INHERIT_DEPTH),
+            );
+            (cte, joins)
         } else {
-            String::new()
+            (String::new(), String::new())
         };
 
         // Model identity: prefer request.model, fall back to response.model. Some
@@ -529,7 +583,8 @@ async fn compute_stream_edges(
         let (tool_sql, model_sql) = if has_parent_link {
             (
                 format!(
-                    r#"SELECT {tool_from} AS client, c.gen_ai_tool_name AS server,
+                    r#"{trace_agent_cte}
+                    SELECT {tool_from} AS client, c.gen_ai_tool_name AS server,
                         'tool' AS connection_type, {mc}
                     FROM "{stream_name}" AS c
                     {ancestor_joins}
@@ -540,7 +595,8 @@ async fn compute_stream_edges(
                     GROUP BY {tool_from}, c.gen_ai_tool_name"#,
                 ),
                 format!(
-                    r#"SELECT {model_from} AS client, {model_expr_c} AS server,
+                    r#"{trace_agent_cte}
+                    SELECT {model_from} AS client, {model_expr_c} AS server,
                         'model' AS connection_type, {mc}
                     FROM "{stream_name}" AS c
                     {ancestor_joins}
@@ -702,7 +758,7 @@ mod test {
     // silently collapsing back to a single parent level.
     #[test]
     fn test_agent_or_service_climbs_all_levels() {
-        let expr = super::build_agent_or_service(false, 4);
+        let expr = super::build_agent_or_service(false, 4, false);
         assert_eq!(
             expr,
             "COALESCE(c.gen_ai_agent_name, p1.gen_ai_agent_name, \
@@ -718,13 +774,65 @@ mod test {
 
     #[test]
     fn test_agent_or_service_prefers_agent_id_when_present() {
-        let expr = super::build_agent_or_service(true, 2);
+        let expr = super::build_agent_or_service(true, 2, false);
         assert_eq!(
             expr,
             "COALESCE(c.gen_ai_agent_id, c.gen_ai_agent_name, \
              p1.gen_ai_agent_id, p1.gen_ai_agent_name, \
              p2.gen_ai_agent_id, p2.gen_ai_agent_name, c.service_name)"
         );
+    }
+
+    // Broken-parent-chain fallback: when a tool/model span's intermediate parent
+    // span was dropped/never ingested, climbing p1..pN finds no agent, so a
+    // per-trace agent level (`ta.*`) must sit just before the service_name
+    // fallback — attributing the span to the trace's agent instead of the host
+    // service. Regression guard for the `service → model`/`service → tool` bug.
+    #[test]
+    fn test_agent_or_service_includes_trace_agent_before_service() {
+        let expr = super::build_agent_or_service(false, 2, true);
+        assert_eq!(
+            expr,
+            "COALESCE(c.gen_ai_agent_name, p1.gen_ai_agent_name, \
+             p2.gen_ai_agent_name, ta.gen_ai_agent_name, c.service_name)"
+        );
+        // trace-agent sits AFTER the last ancestor and BEFORE service.
+        let ta = expr.find("ta.gen_ai_agent_name").unwrap();
+        let p2 = expr.find("p2.gen_ai_agent_name").unwrap();
+        let svc = expr.find("c.service_name").unwrap();
+        assert!(p2 < ta && ta < svc);
+    }
+
+    #[test]
+    fn test_agent_or_service_trace_agent_with_agent_id() {
+        let expr = super::build_agent_or_service(true, 1, true);
+        assert_eq!(
+            expr,
+            "COALESCE(c.gen_ai_agent_id, c.gen_ai_agent_name, \
+             p1.gen_ai_agent_id, p1.gen_ai_agent_name, \
+             ta.gen_ai_agent_id, ta.gen_ai_agent_name, c.service_name)"
+        );
+    }
+
+    #[test]
+    fn test_trace_agent_cte_groups_by_trace() {
+        let (cte, join) = super::build_trace_agent_cte("mystream", false, 100, 200);
+        // CTE picks one agent per trace within the window.
+        assert!(cte.contains("WITH trace_agent AS"));
+        assert!(cte.contains("MAX(gen_ai_agent_name) AS gen_ai_agent_name"));
+        assert!(cte.contains("GROUP BY trace_id"));
+        assert!(cte.contains("_timestamp >= 100 AND _timestamp < 200"));
+        // No agent-id column requested → not selected.
+        assert!(!cte.contains("gen_ai_agent_id"));
+        // Join is by trace_id onto the child alias `c`.
+        assert_eq!(
+            join,
+            "LEFT JOIN trace_agent AS ta ON c.trace_id = ta.trace_id"
+        );
+
+        // With agent-id, the CTE also carries it.
+        let (cte_id, _) = super::build_trace_agent_cte("mystream", true, 100, 200);
+        assert!(cte_id.contains("MAX(gen_ai_agent_id) AS gen_ai_agent_id"));
     }
 
     #[test]

--- a/src/core/src/traces/service_graph/processor.rs
+++ b/src/core/src/traces/service_graph/processor.rs
@@ -235,7 +235,12 @@ fn build_agent_or_service(has_agent_id: bool, depth: usize, with_trace_agent: bo
 /// into the tool/model queries. One agent per trace is assumed (single-agent
 /// agentic traces); `MAX` gives a deterministic pick if that ever fails to hold.
 #[cfg(feature = "enterprise")]
-fn build_trace_agent_cte(stream_name: &str, has_agent_id: bool, start_time: i64, end_time: i64) -> (String, String) {
+fn build_trace_agent_cte(
+    stream_name: &str,
+    has_agent_id: bool,
+    start_time: i64,
+    end_time: i64,
+) -> (String, String) {
     let id_col = if has_agent_id {
         ", MAX(gen_ai_agent_id) AS gen_ai_agent_id"
     } else {

--- a/web/src/enterprise/views/AIObservability/AgentGraphPage.spec.ts
+++ b/web/src/enterprise/views/AIObservability/AgentGraphPage.spec.ts
@@ -1,0 +1,267 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// @vitest-environment jsdom
+//
+// Regression tests for the Agent Graph page's stream-gating logic.
+//
+// The bug: in "agent" mode the page fell back to the `default` trace stream
+// whenever no agent was selected (e.g. no agents in the time window, or before
+// loadAgents() resolved). ServiceGraph loads on mount, so it queried `default`
+// and rendered that whole stream's service topology instead of an agent graph —
+// the wrong graph that "only a refresh fixed". These tests pin the corrected
+// behavior: ServiceGraph mounts ONLY once a real agent stream is resolved, and a
+// "no agents" empty state renders otherwise — never the default-stream graph.
+
+// ---------------------------------------------------------------------------
+// vi.mock() calls MUST be hoisted above imports.
+// ---------------------------------------------------------------------------
+import { reactive } from "vue";
+
+const mockListAgents = vi.fn();
+
+// Module-scoped traces store singleton (mirrors useTraces()).
+const mockSearchObj = reactive({
+  data: {
+    datetime: {
+      type: "relative",
+      relativeTimePeriod: "15m",
+      startTime: 0,
+      endTime: 0,
+    },
+    stream: { selectedStream: { value: "" } },
+  },
+  meta: {
+    serviceGraphVisualizationType: "tree",
+    serviceGraphLayoutType: "horizontal",
+  },
+});
+
+vi.mock("@/services/gen-ai-agent-mapping.service", () => ({
+  default: {
+    listAgents: (...args: any[]) => mockListAgents(...args),
+  },
+}));
+
+
+vi.mock("@/composables/useTraces", () => ({
+  default: vi.fn(() => ({ searchObj: mockSearchObj })),
+}));
+
+vi.mock("vuex", () => ({
+  useStore: vi.fn(() => ({
+    state: { selectedOrganization: { identifier: "test-org" } },
+  })),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: vi.fn(() => ({
+    t: (key: string) => key,
+  })),
+}));
+
+// Only relative-time resolution is exercised; return a fixed window.
+vi.mock("@/utils/date", () => ({
+  getConsumableRelativeTime: vi.fn(() => ({ startTime: 100, endTime: 200 })),
+}));
+
+// ServiceGraph is loaded via defineAsyncComponent(() => import(...)). Under
+// jsdom that async wrapper doesn't resolve into the DOM when gated behind a
+// v-if that flips true only after mount (which is exactly our case). Replace
+// defineAsyncComponent with a synchronous stub so we can assert (a) whether the
+// graph mounted at all and (b) which stream/viz/layout it was handed.
+vi.mock("vue", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    defineAsyncComponent: () =>
+      actual.defineComponent({
+        name: "ServiceGraphStub",
+        props: [
+          "streamFilter",
+          "vizType",
+          "layoutType",
+          "hideStreamSelector",
+          "agentHighlight",
+        ],
+        template: `<div data-test="service-graph-stub" :data-stream="streamFilter" :data-viz="vizType" :data-layout="layoutType" />`,
+      }),
+  };
+});
+
+// Design-system stubs — reduced to just the contract these tests read.
+vi.mock("@/lib/core/PageLayout/OPageLayout.vue", () => ({
+  default: {
+    name: "OPageLayout",
+    template: `<div class="o-page-layout"><slot name="actions" /><slot name="subnav" /><slot /></div>`,
+  },
+}));
+
+vi.mock("@/components/DateTime.vue", () => ({
+  default: { name: "DateTime", template: `<div class="date-time" />` },
+}));
+
+vi.mock("@/lib/forms/Select/OSelect.vue", () => ({
+  default: {
+    name: "OSelect",
+    props: ["modelValue", "options", "label"],
+    emits: ["update:model-value"],
+    // Expose each option's value so tests can inspect what a select offers.
+    template: `<div class="o-select" :data-label="label" :data-value="modelValue">
+      <span
+        v-for="o in (options || [])"
+        :key="o.value ?? o"
+        class="o-select-option"
+        :data-option="o.value ?? o"
+      >{{ o.label ?? o }}</span>
+    </div>`,
+  },
+}));
+
+vi.mock("@/lib/core/ToggleGroup/OToggleGroup.vue", () => ({
+  default: {
+    name: "OToggleGroup",
+    props: ["modelValue"],
+    emits: ["update:model-value"],
+    template: `<div class="o-toggle-group" :data-value="modelValue"><slot /></div>`,
+  },
+}));
+
+vi.mock("@/lib/core/ToggleGroup/OToggleGroupItem.vue", () => ({
+  default: {
+    name: "OToggleGroupItem",
+    template: `<button class="o-toggle-item"><slot /></button>`,
+  },
+}));
+
+vi.mock("@/lib/core/Icon/OIcon.vue", () => ({
+  default: { name: "OIcon", template: `<i class="o-icon" />` },
+}));
+
+vi.mock("@/lib/core/RefreshButton/ORefreshButton.vue", () => ({
+  default: { name: "ORefreshButton", template: `<button class="o-refresh" />` },
+}));
+
+vi.mock("@/lib/feedback/Spinner/OSpinner.vue", () => ({
+  default: { name: "OSpinner", template: `<div class="o-spinner" />` },
+}));
+
+vi.mock("@/lib/core/EmptyState/OEmptyState.vue", () => ({
+  default: {
+    name: "OEmptyState",
+    props: ["title", "description", "illustration", "size"],
+    template: `<div class="o-empty-state" :data-title="title" />`,
+  },
+}));
+
+vi.mock("@/components/shared/SkeletonBox.vue", () => ({
+  default: { name: "SkeletonBox", template: `<div class="skeleton-box" />` },
+}));
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import AgentGraphPage from "./AgentGraphPage.vue";
+
+const AGENT = {
+  name: "sre_agent",
+  id: null,
+  source_stream: "sre_agent_traces_production",
+  source_stream_type: "traces",
+};
+
+async function mountPage() {
+  const wrapper = mount(AgentGraphPage);
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("AgentGraphPage — agent-mode stream gating", () => {
+  it("mounts ServiceGraph with the SELECTED agent's source_stream (not 'default')", async () => {
+    mockListAgents.mockResolvedValue({ agents: [AGENT] });
+
+    const wrapper = await mountPage();
+
+    const sg = wrapper.find('[data-test="service-graph-stub"]');
+    expect(sg.exists()).toBe(true);
+    expect(sg.attributes("data-stream")).toBe("sre_agent_traces_production");
+    // Must never fall back to the default stream.
+    expect(sg.attributes("data-stream")).not.toBe("default");
+  });
+
+  it("shows the 'no agents' empty state — NOT the default service graph — when no agents are discovered", async () => {
+    mockListAgents.mockResolvedValue({ agents: [] });
+
+    const wrapper = await mountPage();
+
+    // The regression: ServiceGraph must NOT render (it would have queried the
+    // fallback `default` stream and drawn the wrong graph).
+    expect(wrapper.find('[data-test="service-graph-stub"]').exists()).toBe(false);
+    // The empty state is shown instead.
+    expect(wrapper.find('[data-test="agent-graph-no-agents"]').exists()).toBe(true);
+  });
+
+  it("does not render ServiceGraph while agents are still loading", async () => {
+    // Never-resolving listAgents keeps agentsLoaded=false.
+    mockListAgents.mockReturnValue(new Promise(() => {}));
+
+    const wrapper = mount(AgentGraphPage);
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="service-graph-stub"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="agent-graph-no-agents"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="agent-graph-loading"]').exists()).toBe(true);
+  });
+
+  it("passes the page's own vizType/layoutType (independent of the traces store) to ServiceGraph", async () => {
+    localStorage.setItem("agentGraph_visualizationType", "graph");
+    localStorage.setItem("agentGraph_layoutType", "force");
+    // Traces store is on tree/horizontal — must NOT leak through.
+    mockSearchObj.meta.serviceGraphVisualizationType = "tree";
+    mockSearchObj.meta.serviceGraphLayoutType = "horizontal";
+    mockListAgents.mockResolvedValue({ agents: [AGENT] });
+
+    const wrapper = await mountPage();
+
+    const sg = wrapper.find('[data-test="service-graph-stub"]');
+    expect(sg.attributes("data-viz")).toBe("graph");
+    expect(sg.attributes("data-layout")).toBe("force");
+  });
+
+  it("Stream picker offers ONLY the distinct source_streams of discovered agents (not agentless streams)", async () => {
+    // Two agents across two streams; one stream (streamB) appears twice.
+    mockListAgents.mockResolvedValue({
+      agents: [
+        { name: "a1", id: null, source_stream: "streamA", source_stream_type: "traces" },
+        { name: "a2", id: null, source_stream: "streamB", source_stream_type: "traces" },
+        { name: "a3", id: null, source_stream: "streamB", source_stream_type: "traces" },
+      ],
+    });
+
+    const wrapper = await mountPage();
+    // Switch to Stream mode so the stream selector renders.
+    (wrapper.vm as any).filterMode = "stream";
+    await flushPromises();
+
+    const streamSelect = wrapper
+      .findAll(".o-select")
+      .find((s) => s.attributes("data-label") === "aiObservability.agentGraph.stream");
+    expect(streamSelect).toBeTruthy();
+
+    const opts = streamSelect!.findAll(".o-select-option");
+    const values = opts.map((o) => o.attributes("data-option")).sort();
+    // Exactly the agent-bearing streams, de-duplicated. No `default`, no
+    // agentless stream like `introspection`.
+    expect(values).toEqual(["streamA", "streamB"]);
+
+    // Each label is annotated with the agent count for that stream.
+    const labelByValue = Object.fromEntries(
+      opts.map((o) => [o.attributes("data-option"), o.text()]),
+    );
+    expect(labelByValue["streamA"]).toContain("(1 aiObservability.agentGraph.agentCountSingular)");
+    expect(labelByValue["streamB"]).toContain("(2 aiObservability.agentGraph.agentCountPlural)");
+  });
+});

--- a/web/src/enterprise/views/AIObservability/AgentGraphPage.vue
+++ b/web/src/enterprise/views/AIObservability/AgentGraphPage.vue
@@ -78,22 +78,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div
         v-if="filterMode === 'stream'"
         data-test="agent-graph-stream-selector"
-        class="w-56 shrink-0"
+        class="w-80 shrink-0"
       >
         <OSelect
           v-model="activeStream"
           :label="t('aiObservability.agentGraph.stream')"
           label-position="inside"
-          :options="availableStreams.map((s) => ({ label: s, value: s }))"
+          :options="streamSelectOptions"
           labelKey="label"
           valueKey="value"
+          option-tooltip
           class="w-full rounded-default"
         />
       </div>
       <div
         v-else
         data-test="agent-graph-agent-selector"
-        class="w-56 shrink-0"
+        class="w-80 shrink-0"
       >
         <SkeletonBox
           v-if="!agentsLoaded"
@@ -112,16 +113,83 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           class="w-full rounded-default"
         />
       </div>
+
+      <!-- Agent Graph's OWN visualization + layout selection. Kept fully
+           independent of the Traces Service Graph tab (its own state + distinct
+           localStorage keys), so the two surfaces don't share a type. Same
+           control shape as the Traces SearchBar toolbar for consistency. -->
+      <div class="ml-auto flex items-center gap-2 shrink-0">
+        <OToggleGroup
+          :model-value="vizType"
+          type="single"
+          data-test="agent-graph-viz-type"
+          @update:model-value="onVizTypeChange"
+        >
+          <OToggleGroupItem value="tree" size="sm">
+            <template #icon-left>
+              <OIcon name="git-branch" size="sm" />
+            </template>
+            {{ t("traces.treeView") }}
+          </OToggleGroupItem>
+          <OToggleGroupItem value="graph" size="sm">
+            <template #icon-left>
+              <OIcon name="share" size="sm" class="shrink-0" />
+            </template>
+            {{ t("traces.graphView") }}
+          </OToggleGroupItem>
+        </OToggleGroup>
+        <OSelect
+          v-model="layoutType"
+          :options="layoutOptions"
+          :searchable="false"
+          data-test="agent-graph-layout-type"
+          class="w-[7.5rem] min-h-8! h-8!"
+          :disabled="vizType === 'graph'"
+          @update:model-value="onLayoutTypeChange"
+        />
+      </div>
     </div>
     </template>
 
+    <!-- Gate the graph until the effective stream is genuinely resolved.
+         ServiceGraph loads unconditionally in its own onMounted, so mounting it
+         before loadAgents() resolves would fire an initial query against the
+         fallback ("default") stream — rendering the wrong, non-agent graph that
+         only a manual refresh replaced. Rendering only once `graphReady` is true
+         mounts ServiceGraph exactly once, with the correct stream. Later agent
+         switches keep it mounted and go through the streamFilter watcher. -->
     <ServiceGraph
+      v-if="graphReady"
       ref="graphRef"
       :stream-filter="effectiveStream"
+      :viz-type="vizType"
+      :layout-type="layoutType"
       hide-stream-selector
       agent-highlight
       class="flex-1 min-h-0"
     />
+    <!-- No agents discovered in the current org / time window — show an empty
+         state, NOT the fallback `default` service graph (the original bug). -->
+    <div
+      v-else-if="hasNoAgents"
+      data-test="agent-graph-no-agents"
+      class="flex-1 min-h-0 flex items-center justify-center"
+    >
+      <OEmptyState
+        size="block"
+        illustration="service-graph"
+        :title="t('aiObservability.agentGraph.noAgentsTitle')"
+        :description="t('aiObservability.agentGraph.noAgentsDescription')"
+      />
+    </div>
+    <!-- Agents / stream still resolving. -->
+    <div
+      v-else
+      data-test="agent-graph-loading"
+      class="flex-1 min-h-0 flex items-center justify-center"
+    >
+      <OSpinner />
+    </div>
   </OPageLayout>
 </template>
 
@@ -133,12 +201,15 @@ import { useStore } from "vuex";
 import DateTime from "@/components/DateTime.vue";
 import OPageLayout from "@/lib/core/PageLayout/OPageLayout.vue";
 import OSelect from "@/lib/forms/Select/OSelect.vue";
+import type { SelectModelValue } from "@/lib/forms/Select/OSelect.types";
 import OToggleGroup from "@/lib/core/ToggleGroup/OToggleGroup.vue";
 import OToggleGroupItem from "@/lib/core/ToggleGroup/OToggleGroupItem.vue";
+import OIcon from "@/lib/core/Icon/OIcon.vue";
 import ORefreshButton from "@/lib/core/RefreshButton/ORefreshButton.vue";
+import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
+import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
 import SkeletonBox from "@/components/shared/SkeletonBox.vue";
 import useTraces from "@/composables/useTraces";
-import useStreams from "@/composables/useStreams";
 import { getConsumableRelativeTime } from "@/utils/date";
 import genAiAgentMappingService, {
   type GenAiAgentListItem,
@@ -149,7 +220,6 @@ defineOptions({ name: "AIAgentGraphPage" });
 const { t } = useI18n();
 const store = useStore();
 const { searchObj } = useTraces();
-const { getStreams } = useStreams();
 
 const ServiceGraph = defineAsyncComponent(
   () => import("@/plugins/traces/ServiceGraph.vue"),
@@ -160,8 +230,50 @@ const DEFAULT_RELATIVE = "15m";
 // Default scope is "agent" — the AI module is agent-centric (agents load on
 // mount, so the default is ready on first paint).
 const filterMode = ref<"stream" | "agent">("agent");
-const availableStreams = ref<string[]>([]);
-const activeStream = ref<string>("default");
+const activeStream = ref<string>("");
+
+// Agent Graph's OWN visualization + layout selection — deliberately NOT the
+// shared traces store (`searchObj.meta.serviceGraph*Type`) that the Traces
+// Service Graph tab uses. Kept independent so the Agent Graph type doesn't bleed
+// in from that tab, and so a remount can't render the stale shared type. Its
+// own localStorage keys persist the choice across visits. Passed down to
+// ServiceGraph via `viz-type` / `layout-type` props, which override the store.
+const vizType = ref<"tree" | "graph">(
+  (localStorage.getItem("agentGraph_visualizationType") as
+    | "tree"
+    | "graph") || "tree",
+);
+const layoutType = ref<string>(
+  localStorage.getItem("agentGraph_layoutType") || "horizontal",
+);
+
+const layoutOptions = computed(() =>
+  vizType.value === "graph"
+    ? [{ label: t("traces.layoutForce"), value: "force" }]
+    : [
+        { label: t("traces.layoutHorizontal"), value: "horizontal" },
+        { label: t("traces.layoutVertical"), value: "vertical" },
+      ],
+);
+
+function onVizTypeChange(
+  value: boolean | AcceptableValue | AcceptableValue[],
+) {
+  if (value !== "tree" && value !== "graph") return;
+  vizType.value = value;
+  localStorage.setItem("agentGraph_visualizationType", value);
+  // Mirror the SearchBar toolbar: each view has a sensible default layout.
+  const nextLayout = value === "tree" ? "horizontal" : "force";
+  layoutType.value = nextLayout;
+  localStorage.setItem("agentGraph_layoutType", nextLayout);
+}
+
+function onLayoutTypeChange(value: SelectModelValue) {
+  // Layout options are always plain string values (horizontal/vertical/force);
+  // v-model already assigned layoutType — this handler only persists it.
+  if (typeof value !== "string") return;
+  localStorage.setItem("agentGraph_layoutType", value);
+}
 
 // Graph child ref + header refresh state. ServiceGraph exposes
 // { refresh, loading, lastRunAt }.
@@ -211,17 +323,69 @@ const agentSelectOptions = computed(() =>
   })),
 );
 
+// Streams offered in the Stream picker are ONLY those that actually carry agent
+// data — i.e. the distinct source_streams of discovered agents. A trace stream
+// with services but no agents (e.g. `introspection`) has nothing agent-related
+// to show here, so it must not appear. Derived from the agents list rather than
+// from all trace streams for exactly this reason.
+const availableStreams = computed(() => [
+  ...new Set(agents.value.map((a) => a.source_stream)),
+]);
+
+// Stream picker options: the stream name annotated with how many agents it
+// contains, e.g. "sre_agent_traces_production (2 agents)". The count makes it
+// clear a stream holds multiple agents and disambiguates otherwise similar (or
+// truncated) stream names. `value` stays the bare stream name. The full stream
+// name is kept in `title` so a truncated label still reveals itself on hover.
+const streamSelectOptions = computed(() => {
+  const counts = new Map<string, number>();
+  for (const a of agents.value) {
+    counts.set(a.source_stream, (counts.get(a.source_stream) ?? 0) + 1);
+  }
+  return availableStreams.value.map((s) => {
+    const n = counts.get(s) ?? 0;
+    return {
+      label: `${s} (${n} ${
+        n === 1
+          ? t("aiObservability.agentGraph.agentCountSingular")
+          : t("aiObservability.agentGraph.agentCountPlural")
+      })`,
+      value: s,
+    };
+  });
+});
+
 const selectedAgent = computed<GenAiAgentListItem | null>(
   () => agents.value.find((a) => agentKey(a) === activeAgentKey.value) ?? null,
 );
 
-// The stream the graph queries: the picked stream, or the selected agent's
-// source_stream. Deriving the stream from the agent is the whole point — the
-// user picks an agent, not a stream.
+// The stream the graph queries: the picked stream, or the SELECTED agent's
+// source_stream. In agent mode with no agent selected there is NO valid stream —
+// it must be empty, NOT `activeStream` ("default"). Falling back to "default"
+// here was the bug: with no agent selected (e.g. no agents in the window) the
+// graph rendered the whole `default` trace stream's service topology instead of
+// an agent-scoped graph.
 const effectiveStream = computed(() =>
   filterMode.value === "agent"
-    ? (selectedAgent.value?.source_stream ?? activeStream.value)
+    ? (selectedAgent.value?.source_stream ?? "")
     : activeStream.value,
+);
+
+// Whether there is simply nothing agent-related to graph in the current org /
+// time window. There are no agents at all → both modes have nothing to show
+// (the Stream picker is itself derived from agent-bearing streams).
+const hasNoAgents = computed(
+  () => agentsLoaded.value && !agents.value.length,
+);
+
+// The graph may only mount once it has a real stream to query. In agent mode
+// that requires an actually-selected agent (whose source_stream is the stream);
+// in stream mode, a chosen agent-bearing stream. This prevents ServiceGraph's
+// mount-time load from ever firing against a fallback/agentless stream.
+const graphReady = computed(() =>
+  filterMode.value === "agent"
+    ? !!selectedAgent.value && !!effectiveStream.value
+    : !!activeStream.value,
 );
 
 function onFilterModeChange(
@@ -239,31 +403,6 @@ function effectiveWindow() {
   return { startTime: dt.startTime, endTime: dt.endTime };
 }
 
-async function loadStreams() {
-  try {
-    const res = (await getStreams("traces", false, false)) as {
-      list?: { name: string; settings?: { is_llm_stream?: boolean } }[];
-    };
-    // Only LLM trace streams belong in the Agent Graph picker — a plain
-    // service/HTTP trace stream has no agents or gen_ai edges to graph, so
-    // offering it would just resolve to an empty graph. `is_llm_stream` is the
-    // backend-maintained flag (auto-detected at ingest from gen_ai_* columns).
-    // Exclude only streams explicitly flagged non-LLM, matching the same filter
-    // used by LLM Insights and Sessions.
-    availableStreams.value = (res?.list ?? [])
-      .filter((s) => s.settings?.is_llm_stream !== false)
-      .map((s) => s.name);
-    if (
-      availableStreams.value.length &&
-      !availableStreams.value.includes(activeStream.value)
-    ) {
-      activeStream.value = availableStreams.value[0];
-    }
-  } catch {
-    availableStreams.value = [];
-  }
-}
-
 async function loadAgents() {
   try {
     const org = store.state.selectedOrganization.identifier;
@@ -274,11 +413,31 @@ async function loadAgents() {
       endTime,
     );
     agents.value = res.agents ?? [];
+    // Reconcile the selection against the fresh list. Reloading (e.g. after a
+    // time-range change) can return a different or empty set, which would
+    // otherwise leave `activeAgentKey` pointing at an agent no longer present —
+    // the dropdown then shows a stale name while the graph has no agent. Clear a
+    // now-invalid key, and auto-select the first agent when none is selected.
+    const keys = new Set(agents.value.map((a) => agentKey(a)));
+    if (activeAgentKey.value && !keys.has(activeAgentKey.value)) {
+      activeAgentKey.value = "";
+    }
     if (!activeAgentKey.value && agents.value.length) {
       activeAgentKey.value = agentKey(agents.value[0]);
     }
+    // Same reconciliation for the Stream picker, whose options are the distinct
+    // agent-bearing source_streams (availableStreams). Clear a now-absent
+    // stream, and default to the first agent-bearing stream.
+    if (activeStream.value && !availableStreams.value.includes(activeStream.value)) {
+      activeStream.value = "";
+    }
+    if (!activeStream.value && availableStreams.value.length) {
+      activeStream.value = availableStreams.value[0];
+    }
   } catch {
     agents.value = [];
+    activeAgentKey.value = "";
+    activeStream.value = "";
   } finally {
     agentsLoaded.value = true;
   }
@@ -318,7 +477,6 @@ onMounted(() => {
       searchObj.data.datetime.relativeTimePeriod || DEFAULT_RELATIVE,
     );
   }
-  loadStreams();
   loadAgents();
 });
 </script>

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -7729,7 +7729,11 @@
     "agentGraph": {
       "allAgents": "All agents",
       "stream": "Stream",
-      "agent": "Agent"
+      "agent": "Agent",
+      "noAgentsTitle": "No agents found",
+      "noAgentsDescription": "No agents were discovered in this time range. Try widening the time range, or check that your traces include gen_ai agent attributes.",
+      "agentCountSingular": "agent",
+      "agentCountPlural": "agents"
     },
     "kpi": {
       "totalCost": "Total Cost",

--- a/web/src/plugins/traces/ServiceGraph.vue
+++ b/web/src/plugins/traces/ServiceGraph.vue
@@ -188,11 +188,11 @@
         </ODropdown>
         <OSeparator
           vertical
-          v-if="searchObj.meta.serviceGraphVisualizationType === 'graph'"
+          v-if="resolvedVizType === 'graph'"
           class="self-stretch mx-1"
         />
         <div
-          v-if="searchObj.meta.serviceGraphVisualizationType === 'graph'"
+          v-if="resolvedVizType === 'graph'"
           data-test="sg-node-size-info"
           class="flex flex-row items-center gap-2 min-w-0"
         >
@@ -367,6 +367,7 @@ import {
   computed,
   watch,
   nextTick,
+  type PropType,
 } from "vue";
 import { useStore } from "vuex";
 import useTheme from "@/composables/useTheme";
@@ -458,6 +459,21 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    // Optional external control of visualization + layout type. When set (the
+    // Agent Graph page owns its own Tree/Graph + layout selection), these win
+    // over the shared traces store `searchObj.meta.serviceGraph*Type`. This
+    // keeps the Agent Graph fully decoupled from the Traces Service Graph tab:
+    // its type no longer bleeds in from that tab, and a remount can't paint the
+    // stale shared state. Undefined = fall back to the shared store (the Traces
+    // Service Graph tab, which is driven by the SearchBar toolbar).
+    vizType: {
+      type: String as PropType<"tree" | "graph" | undefined>,
+      default: undefined,
+    },
+    layoutType: {
+      type: String,
+      default: undefined,
+    },
   },
   emits: ["view-traces", "request:stream-change", "jump-to-stream-data"],
   setup(props, { emit, expose }) {
@@ -467,6 +483,19 @@ export default defineComponent({
     const { t } = useI18n();
     const { getStreams } = useStreams();
     const { searchObj } = useTraces();
+
+    // Resolved visualization + layout type. A parent that owns its own type
+    // selection (the Agent Graph page) passes `vizType`/`layoutType` props;
+    // those win. Otherwise fall back to the shared traces store, which the
+    // Traces Service Graph tab drives via the SearchBar toolbar. All reads below
+    // go through these — never `searchObj.meta.serviceGraph*Type` directly — so
+    // the two surfaces stay decoupled.
+    const resolvedVizType = computed<"tree" | "graph">(
+      () => props.vizType ?? searchObj.meta.serviceGraphVisualizationType,
+    );
+    const resolvedLayoutType = computed<string>(
+      () => props.layoutType ?? searchObj.meta.serviceGraphLayoutType,
+    );
 
     const loading = ref(false);
     // Stamped when a graph load settles — lets a parent page show a
@@ -705,8 +734,8 @@ export default defineComponent({
         return { options: {}, notMerge: true };
       }
 
-      const vizType = searchObj.meta.serviceGraphVisualizationType;
-      const layoutType = searchObj.meta.serviceGraphLayoutType;
+      const vizType = resolvedVizType.value;
+      const layoutType = resolvedLayoutType.value;
 
       // Don't use cache if filters are active (search filter)
       const hasActiveFilters = searchFilter.value?.trim();
@@ -881,7 +910,7 @@ export default defineComponent({
 
       // Tree view: emphasis.focus:'relative' in the series config handles dimming natively.
       // No manual dispatch needed — ECharts triggers it on mouseover automatically.
-      if (searchObj.meta.serviceGraphVisualizationType !== "graph") return;
+      if (resolvedVizType.value !== "graph") return;
 
       const rawEdges: any[] = filteredGraphData.value.edges || [];
 
@@ -1450,7 +1479,7 @@ export default defineComponent({
     // but the series type swaps via setOption. Re-register tooltip handlers so both
     // ZRender (tree) and ECharts edge events (graph) work correctly after the swap.
     watch(
-      () => searchObj.meta.serviceGraphVisualizationType,
+      () => resolvedVizType.value,
       async () => {
         if (edgeTooltipCleanup) {
           edgeTooltipCleanup();
@@ -1656,9 +1685,10 @@ export default defineComponent({
       );
     };
 
-    // Watch composable viz/layout state changes from SearchBar toolbar
+    // Watch resolved viz/layout state changes (SearchBar toolbar for the Traces
+    // Service Graph tab, or the Agent Graph page's own selector via props).
     watch(
-      () => searchObj.meta.serviceGraphVisualizationType,
+      () => resolvedVizType.value,
       () => {
         // Only clear the cache — do NOT bump chartKey (that would recreate the
         // ChartRenderer and replay the tree expand animation). The clean series
@@ -1670,7 +1700,7 @@ export default defineComponent({
     );
 
     watch(
-      () => searchObj.meta.serviceGraphLayoutType,
+      () => resolvedLayoutType.value,
       () => {
         chartKey.value++;
       },
@@ -1814,6 +1844,7 @@ export default defineComponent({
       chartRendererRef,
       graphContainerRef,
       searchObj,
+      resolvedVizType,
       loadServiceGraph,
       formatNumber,
       applyFilters,


### PR DESCRIPTION
Fixes the Agent Graph end-to-end — UI (openobserve/web) + service-graph backend (openobserve/core). Root causes were found and validated against live trace data.

---

## 1. UI: wrong graph until refresh + no independent graph-type selector

The Agent Graph page embeds Traces' `ServiceGraph`, which read its viz/layout type from the shared `searchObj.meta` singleton and auto-loads on mount.

- **Wrong graph on return (from Agent Behavior):** the effective stream fell back to the literal `default` trace stream before `loadAgents()` resolved, so ServiceGraph rendered that whole stream's service topology instead of the agent graph. Fixed: no `default` fallback in agent mode; render is gated behind `graphReady` (a resolved agent stream), with a spinner / "no agents" empty state otherwise; stale agent/stream selections reconciled on reload.
- **No graph-type selector / inherited the Traces tab's type:** added `vizType`/`layoutType` prop overrides on `ServiceGraph` (computeds prefer props, else the shared store — Traces behavior unchanged), and gave the Agent Graph page its own Tree/Graph + layout selector with its own state and `agentGraph_*` localStorage keys.
- **Stream picker** now lists only the distinct `source_stream`s of discovered agents (not agentless streams), annotated with per-stream agent counts, with an option tooltip and wider control.

New `AgentGraphPage.spec.ts` (5 tests): gating, empty state, viz/layout independence, stream-picker scoping. `vue-tsc` app + vitest typecheck clean.

## 2. Backend: agent→model/tool edges mis-attributed to the service

Model/tool spans (`chat`, `execute_tool`) don't carry `gen_ai.agent.name` — it lives on an ancestor `invoke_agent` span (confirmed as the norm across the OTel GenAI spec, Google ADK, OpenAI Agents SDK, OpenInference, CrewAI, LangGraph). The edge builder climbs ≤4 parent hops to find it, else falls back to `service_name`. When an intermediate span is missing (the spec permits omitting `invoke_agent`; inconsistent sampling / async context loss produce orphan LLM spans), the climb fails and the span mis-attributes to the service — a spurious `service → model` / `service → tool` edge.

Fix: add a per-trace agent CTE (`MAX(gen_ai_agent_name) GROUP BY trace_id`) as a fallback level in the COALESCE, between the ancestor climb and the `service_name` fallback, for both edge queries. This matches the industry-recommended fallback (group by trace when the chain breaks).

### Validation (live introspect data, 2 streams, 7-day window)

| stream | before | after |
|---|---|---|
| `sre_agent_traces_production` | `service → model` (47+3 reqs) | eliminated → o2_ai_agent (247) / sre_rca_agent (29) |
| `sre_agent_traces_production_us2` | `service → model` (20 reqs) | eliminated → o2_ai_agent (279) |

- No cross-agent contamination in the multi-agent stream (traces are single-agent). No tool-edge regression.
- Non-agent traces: CTE returns nothing → NULL join → falls to `service_name` exactly as before (no behavior change).
- Perf: single-column `GROUP BY trace_id` aggregate, ~+25% wallclock on the batch edge query; runs in the hourly job, not a hot path.

Unit tests cover the COALESCE position and CTE builder.

## Not included / follow-up
- **env/version in the agent dropdown** requires backend extractor + DB migration + API changes. Tracked separately.

## Note
Full enterprise `cargo build` isn't runnable in the dev environment (the `o2_enterprise` crate is a resolution stub); the SQL-builder logic is verified via standalone rustc and the runtime behavior via the live dry-run above. CI runs the real enterprise build.