### PR TITLE
test(workflows): de-flake K9 canary — log Save-intercept, don't hard-assert it

### DIFF
--- a/tests/ui-testing/pages/workflowsPages/workflowsPage.js
+++ b/tests/ui-testing/pages/workflowsPages/workflowsPage.js
@@ -171,9 +171,13 @@ class WorkflowsPage {
   }
 
   /**
-   * K9: attempt a PLAIN Playwright click on Save (no JS bypass). Returns true if it was
-   * intercepted (Save is covered by the tooltip overlay so the click never lands). Documents the
-   * K9 bug and acts as a regression marker — if K9 is fixed this returns false and the test fails.
+   * K9 canary probe — attempts a PLAIN Playwright click on Save (no JS bypass) and returns
+   * true if it was intercepted (the click never landed). This is NON-deterministic in headless
+   * CI: Save has no tooltip of its own (WorkflowEditor.vue), so the overlay that intercepts it
+   * is a transient/adjacent tooltip that often never appears on a programmatic hover.
+   * Callers MUST treat the result as informational only, not a hard assertion — see the CT-19
+   * K9 spec. A consistent `false` would be the signal that K9 is fixed and the clickSave()
+   * JS-bypass workaround can be dropped.
    */
   async normalSaveClickIsIntercepted(timeoutMs = 4000) {
     await this.page.locator(this.saveBtn).hover().catch(() => {});

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-negative.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-negative.spec.js
@@ -191,18 +191,24 @@ test.describe(
       }
     );
 
-    // K9 — a NORMAL Playwright .click() on Save is intercepted (Save is covered by the tooltip
-    // overlay), which is why the page object saves via a JS .click(). This asserts the bug still
-    // reproduces AND that the JS-click workaround reaches the app. If K9 is ever fixed, the first
-    // assertion flips and this fails — the signal to drop the workaround from the page object.
+    // K9 — the page object saves via a JS .click() because a stray tooltip overlay can cover
+    // Save and swallow a normal Playwright .click(). Save has no tooltip of its own
+    // (WorkflowEditor.vue), so that intercepting overlay is transient/adjacent and does NOT
+    // reproduce deterministically in headless CI — a hard assert on interception flakes (it
+    // passed on slow runs, failed on fast ones). So the interception is logged as an
+    // informational canary, and the real assertion is the stable one: the JS-click save
+    // still reaches the app. If K9 is ever fixed the canary log shows `intercepted:false`
+    // consistently — the signal to drop the workaround from the page object.
     test(
-      'CT-19 K9: a normal .click() on Save is intercepted by the tooltip overlay',
+      'CT-19 K9: JS-click Save workaround reaches the app (tooltip-overlay canary)',
       { tag: ['@workflowsNegative'] },
       async () => {
         await pm.workflowsPage.goToAdd();
         await pm.workflowsPage.setName(`wf_auto_neg_${uniq()}`);
-        // A plain click cannot land on Save (overlay owns the point).
-        expect(await pm.workflowsPage.normalSaveClickIsIntercepted(4000)).toBe(true);
+        // Informational only — the intercepting overlay is non-deterministic in CI, so this
+        // is logged, not asserted (see comment above).
+        const intercepted = await pm.workflowsPage.normalSaveClickIsIntercepted(4000);
+        testLogger.info('K9 canary: normal Save click intercepted by overlay?', { intercepted });
         // The JS-click workaround still reaches the app (validation toast comes back).
         const msg = await pm.workflowsPage.saveAndCaptureResult();
         expect(msg.length).toBeGreaterThan(0);


### PR DESCRIPTION
## How this was found

The **Playwright E2E Crosscheck** bot (the ENT gate that runs enterprise-only specs against OSS PRs) flagged a failing spec on an unrelated logs PR ([#13414 comment](https://github.com/openobserve/openobserve/pull/13414#issuecomment-5058151842)):

> `Workflows/workflows-negative.spec.js` — *"enterprise-only e2e spec failed against this PR … wouldn't show up in OSS CI."*

Digging showed it wasn't caused by that PR — the same test was **also failing on #13413 and #13315**. It's a pre-existing **flake** in the ENT gate, so this PR fixes it at the source.

## Evidence it's a flake, not a real break

The **same branch** produced both outcomes:

| ENT crosscheck run | PR | K9 test |
|---|---|---|
| 30005431754 | #13414 | ✅ passed (~50s, slow path) |
| 30008606974 | #13414 | ❌ failed |
| 30006996158 | #13315 | ❌ failed |
| 30006419247 | #13413 | ❌ failed |

## Root cause

`CT-19 K9` hard-asserted that a normal `.click()` on Save is intercepted by a tooltip overlay:
```js
expect(await pm.workflowsPage.normalSaveClickIsIntercepted(4000)).toBe(true);
```
But the Save button has **no tooltip of its own** (`WorkflowEditor.vue`) — the overlay that intercepts it is a **transient/adjacent tooltip** that often never appears on a programmatic hover in headless CI. The probe therefore conflates *"blocked by overlay"* with *"click landed"*, and the assertion flips run to run. (A first attempt — waiting for the overlay before probing — didn't help: the overlay simply isn't reliably summoned.)

## Fix (test-only, no product/Vue changes)

- Treat interception as an **informational canary** — `testLogger.info(...)` instead of a hard assert.
- Keep the **stable** assertion: the JS-click Save workaround still reaches the app (`msg.length > 0`) — the adjacent trigger-only-save test already exercises that same path and passes consistently.
- If K9 is ever genuinely fixed, the canary log shows `intercepted:false` consistently — the signal to drop the JS-click workaround.

This removes the flaky gate without losing meaningful coverage. Changes are limited to the spec and its page object.

## Verification

`Workflows/*` are enterprise-only (skipped on OSS CI), so verified via the **ENT gate against this OSS branch** (`e2e` label). The removed assertion was the only flaky part; the retained assertion matches an already-stable adjacent test.