### PR TITLE
test(pipelines): fix addPipeline mount-wait flake (isVisible timeout is a no-op)

### DIFF
--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -420,10 +420,20 @@ export class PipelinesPage {
         // DESTRUCTIVE — no page.reload() (a reload trips the editor's
         // onBeforeRouteLeave unsaved-changes guard and stalls downstream tests).
         const railToggle = this.page.locator('[data-test="pipeline-node-sidebar-collapse-btn"]');
+        // Poll for the mount signal across 3 attempts. Each attempt must ACTUALLY wait, so use
+        // waitFor (which blocks up to `timeout`) — locator.isVisible({timeout}) does NOT wait,
+        // it returns the current state immediately, which collapsed the intended ~45s of
+        // resilience down to the final 15s and flaked under concurrent cloud load (VueFlow
+        // mount lags). If an attempt times out and we're still on the list page (the add click
+        // was dropped before navigation), re-click; otherwise keep waiting on the next attempt.
         for (let attempt = 1; attempt <= 3; attempt++) {
-            if (await railToggle.isVisible({ timeout: 15000 }).catch(() => false)) break;
-            if (await this.addPipelineButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-                await this.addPipelineButton.click().catch(() => {});
+            try {
+                await railToggle.waitFor({ state: 'visible', timeout: 15000 });
+                break;
+            } catch {
+                if (await this.addPipelineButton.isVisible().catch(() => false)) {
+                    await this.addPipelineButton.click().catch(() => {});
+                }
             }
         }
         await railToggle.waitFor({ state: 'visible', timeout: 15000 });


### PR DESCRIPTION
## What flaked

`Pipelines-Regression` → *"should validate scheduled pipeline SQL query with metrics stream type"* (`pipeline-regression.spec.js:73`) timed out in the ENT gate waiting for the editor mount signal `[data-test="pipeline-node-sidebar-collapse-btn"]` (15s, all retries).

It's a **load-timing flake, not a real break**: OSS CI ([run 30005672782](https://github.com/openobserve/openobserve/actions/runs/30005672782)) and the ENT `main` baseline ([run 30005554375](https://github.com/openobserve/o2-enterprise/actions/runs/30005554375)) both pass this same test.

## Root cause

`addPipeline()` meant to poll for the mount signal across 3 attempts of 15s (re-clicking the add button non-destructively if the click was dropped before navigation):
```js
for (let attempt = 1; attempt <= 3; attempt++) {
    if (await railToggle.isVisible({ timeout: 15000 }).catch(() => false)) break;
    ...
}
await railToggle.waitFor({ state: 'visible', timeout: 15000 });
```
But **`locator.isVisible({ timeout })` does not wait** — it returns the current state immediately and ignores `timeout` (Playwright 1.50). So the loop spun through instantly and the editor effectively got only the **final 15s** `waitFor` to mount. Under concurrent cloud load VueFlow's mount lags past 15s → timeout.

## Fix (page-object only)

Make each poll attempt actually block using `waitFor({ state: 'visible' })` inside the loop (try/catch, re-click on the list page between attempts), restoring the intended **~45s** of resilience before the final assert.

## Verification

Local verification is currently blocked by a stale local build (the selector was added in #13397 and isn't in the local `web/dist`), so this is gated on a fresh CI regression run against the branch. The change only lengthens the effective mount wait; it can't regress the happy path (which already passes on fresh builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)