### PR TITLE
feat(traces): default trace detail view to Waterfall

### DIFF
--- a/web/src/plugins/traces/TraceDetails.spec.ts
+++ b/web/src/plugins/traces/TraceDetails.spec.ts
@@ -413,8 +413,8 @@ describe("TraceDetails", () => {
     });
 
     it("should show search navigation buttons when there are results", async () => {
-      // Search is a waterfall-view affordance — it is hidden on the flame-graph
-      // (the default view), map and thread tabs.
+      // Search is a waterfall-view affordance — it is hidden on the flame-graph,
+      // map and thread tabs.
       wrapper.vm.activeTab = "waterfall";
       wrapper.vm.searchResults = 5;
       wrapper.vm.currentIndex = 2;
@@ -3035,8 +3035,8 @@ describe("TraceDetails", () => {
 
     // The fixture trace has no LLM spans, so the dag and thread tabs are
     // filtered out of traceTabs regardless of the stored order.
-    it("defaults to the flame graph when nothing is persisted", () => {
-      expect(wrapper.vm.activeTab).toBe("flame-graph");
+    it("defaults to the waterfall when nothing is persisted", () => {
+      expect(wrapper.vm.activeTab).toBe("waterfall");
     });
 
     it("restores the persisted active tab on mount", async () => {
@@ -3059,14 +3059,14 @@ describe("TraceDetails", () => {
       await remount();
 
       expect(tabValues()).not.toContain("thread");
-      expect(wrapper.vm.activeTab).toBe("flame-graph");
+      expect(wrapper.vm.activeTab).toBe("waterfall");
     });
 
     it("ignores a persisted tab that is no longer a known tab", async () => {
       localStorage.setItem(ACTIVE_KEY, "some-removed-tab");
       await remount();
 
-      expect(wrapper.vm.activeTab).toBe("flame-graph");
+      expect(wrapper.vm.activeTab).toBe("waterfall");
     });
 
     it("renders tabs in the persisted order", async () => {
@@ -3095,18 +3095,18 @@ describe("TraceDetails", () => {
       localStorage.setItem(ORDER_KEY, "{not json");
       await remount();
 
-      expect(tabValues()).toEqual(["flame-graph", "waterfall", "map"]);
+      expect(tabValues()).toEqual(["waterfall", "flame-graph", "map"]);
     });
 
     it("moves a tab before the drop target and persists the new order", async () => {
       wrapper.vm.onTabReorder({ from: "map", to: "flame-graph", before: true });
       await wrapper.vm.$nextTick();
 
-      expect(tabValues()).toEqual(["map", "flame-graph", "waterfall"]);
+      expect(tabValues()).toEqual(["waterfall", "map", "flame-graph"]);
       expect(storedOrder()).toEqual([
+        "waterfall",
         "map",
         "flame-graph",
-        "waterfall",
         "dag",
         "thread",
       ]);
@@ -3114,13 +3114,13 @@ describe("TraceDetails", () => {
 
     it("moves a tab after the drop target", async () => {
       wrapper.vm.onTabReorder({
-        from: "flame-graph",
+        from: "waterfall",
         to: "map",
         before: false,
       });
       await wrapper.vm.$nextTick();
 
-      expect(tabValues()).toEqual(["waterfall", "map", "flame-graph"]);
+      expect(tabValues()).toEqual(["flame-graph", "map", "waterfall"]);
     });
 
     it("keeps hidden tabs in the persisted order so the arrangement survives", async () => {

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -1001,7 +1001,7 @@ const ThreadView = defineAsyncComponent(() => import("./ThreadView.vue"));
 
 /**
  * Tab definitions for the trace detail views. The order here is the *default*
- * order — Flame Graph leads because it is the default landing view. Users can
+ * order — Waterfall leads because it is the default landing view. Users can
  * drag tabs to reorder them (same interaction as the Home page tab bar) and
  * that order is persisted per-browser under LS_TRACE_TAB_ORDER_KEY.
  *
@@ -1009,8 +1009,8 @@ const ThreadView = defineAsyncComponent(() => import("./ThreadView.vue"));
  * others at the same nominal size.
  */
 const TRACE_TAB_DEFS = [
-  { value: "flame-graph", labelKey: "traces.flameGraph", icon: "flame", iconSize: "sm" },
   { value: "waterfall", labelKey: "traces.waterfall", icon: "align-left", iconSize: "sm" },
+  { value: "flame-graph", labelKey: "traces.flameGraph", icon: "flame", iconSize: "sm" },
   { value: "map", labelKey: "traces.traceGraph", icon: "account-tree", iconSize: "sm" },
   { value: "dag", labelKey: "traces.dag", icon: "git-branch", iconSize: "sm" },
   { value: "thread", labelKey: "traces.thread", icon: "chat", iconSize: "xs" },
@@ -1019,7 +1019,7 @@ const TRACE_TAB_DEFS = [
 type TraceTabValue = (typeof TRACE_TAB_DEFS)[number]["value"];
 
 /** The view a trace opens on when the user has no persisted preference. */
-const DEFAULT_TRACE_TAB: TraceTabValue = "flame-graph";
+const DEFAULT_TRACE_TAB: TraceTabValue = "waterfall";
 
 const LS_TRACE_TAB_ORDER_KEY = "o2_trace_tab_order";
 const LS_TRACE_ACTIVE_TAB_KEY = "o2_trace_active_tab";


### PR DESCRIPTION
## What

On the traces detail page, make **Waterfall** the first tab and the default landing view (previously Flame Graph).

## Why

Waterfall is the more universally useful default for inspecting a trace's span timeline; users landing on Flame Graph first had an extra click to get to it.

## Changes

- `TraceDetails.vue`: reorder `TRACE_TAB_DEFS` so `waterfall` leads `flame-graph`, and set `DEFAULT_TRACE_TAB` to `"waterfall"`. The fallback watcher and reorder/persistence logic reference these, so they follow automatically.
- `TraceDetails.spec.ts`: updated tab-order / default / fallback / reorder assertions for the new default order.

## Behavior note

Tab order and the active tab are persisted per-browser in `localStorage` (`o2_trace_tab_order` / `o2_trace_active_tab`). Users who have already opened a trace keep their saved preference — the new Waterfall default applies to browsers with no stored preference.

## Testing

`TraceDetails.spec.ts` + `TraceDetails.missing-span-kind.spec.ts` — 199 passed / 3 skipped.