### PR TITLE
fix(schema): restore persistence guards on auto-UDS settings write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10766,7 +10766,6 @@ dependencies = [
  "enrichment-data",
  "hashbrown 0.16.1",
  "infra",
- "itertools 0.14.0",
  "log",
  "o2_enterprise",
  "schema",

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -1157,4 +1157,110 @@ mod tests {
         assert_eq!(stats_owned.doc_num, stats_ref.doc_num);
         assert_eq!(stats_owned.file_num, stats_ref.file_num);
     }
+
+    // ── calculate_files_size ──────────────────────────────────────────────────
+
+    fn create_test_file_key(
+        id: i64,
+        key: &str,
+        records: i64,
+        original_size: i64,
+        compressed_size: i64,
+        index_size: i64,
+    ) -> FileKey {
+        FileKey {
+            id,
+            account: "test_account".to_string(),
+            key: key.to_string(),
+            meta: FileMeta {
+                min_ts: 1000,
+                max_ts: 2000,
+                records,
+                original_size,
+                compressed_size,
+                index_size,
+                flattened: false,
+                bloom_ver: 0,
+            },
+            deleted: false,
+            selection: None,
+            row_group_size: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_calculate_files_size_empty() {
+        let files: Vec<FileKey> = vec![];
+        let stats = calculate_files_size(&files).await.unwrap();
+        assert_eq!(stats.files, 0);
+        assert_eq!(stats.records, 0);
+        assert_eq!(stats.original_size, 0);
+        assert_eq!(stats.compressed_size, 0);
+        assert_eq!(stats.idx_scan_size, 0);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_files_size_single_file() {
+        let files = vec![create_test_file_key(
+            1,
+            "file1.parquet",
+            100,
+            10000,
+            5000,
+            500,
+        )];
+        let stats = calculate_files_size(&files).await.unwrap();
+        assert_eq!(stats.files, 1);
+        assert_eq!(stats.records, 100);
+        assert_eq!(stats.original_size, 10000);
+        assert_eq!(stats.compressed_size, 5000);
+        assert_eq!(stats.idx_scan_size, 500);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_files_size_multiple_files() {
+        let files = vec![
+            create_test_file_key(1, "file1.parquet", 100, 10000, 5000, 500),
+            create_test_file_key(2, "file2.parquet", 200, 20000, 10000, 1000),
+            create_test_file_key(3, "file3.parquet", 300, 30000, 15000, 1500),
+        ];
+        let stats = calculate_files_size(&files).await.unwrap();
+        assert_eq!(stats.files, 3);
+        assert_eq!(stats.records, 600);
+        assert_eq!(stats.original_size, 60000);
+        assert_eq!(stats.compressed_size, 30000);
+        assert_eq!(stats.idx_scan_size, 3000);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_files_size_with_zero_values() {
+        let files = vec![
+            create_test_file_key(1, "file1.parquet", 0, 0, 0, 0),
+            create_test_file_key(2, "file2.parquet", 100, 10000, 5000, 500),
+        ];
+        let stats = calculate_files_size(&files).await.unwrap();
+        assert_eq!(stats.files, 2);
+        assert_eq!(stats.records, 100);
+        assert_eq!(stats.original_size, 10000);
+        assert_eq!(stats.compressed_size, 5000);
+        assert_eq!(stats.idx_scan_size, 500);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_files_size_large_values() {
+        let files = vec![create_test_file_key(
+            1,
+            "large_file.parquet",
+            1000000,
+            10000000000,
+            5000000000,
+            500000000,
+        )];
+        let stats = calculate_files_size(&files).await.unwrap();
+        assert_eq!(stats.files, 1);
+        assert_eq!(stats.records, 1000000);
+        assert_eq!(stats.original_size, 10000000000);
+        assert_eq!(stats.compressed_size, 5000000000);
+        assert_eq!(stats.idx_scan_size, 500000000);
+    }
 }

--- a/src/schema/Cargo.toml
+++ b/src/schema/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 [lib]
 path = "src/lib.rs"
 
+[features]
+default = []
+enterprise = ["config/enterprise", "db/enterprise"]
+
 [dependencies]
 anyhow.workspace = true
 arrow-schema.workspace = true

--- a/src/schema/src/lib.rs
+++ b/src/schema/src/lib.rs
@@ -407,7 +407,9 @@ pub async fn handle_diff_schema(
             }
         }
 
+        // sort for a deterministic persisted field list
         defined_schema_fields = uds_fields.into_iter().collect::<Vec<_>>();
+        defined_schema_fields.sort_unstable();
         stream_setting.defined_schema_fields = defined_schema_fields.clone();
         final_schema.metadata.insert(
             "settings".to_string(),
@@ -416,23 +418,40 @@ pub async fn handle_diff_schema(
 
         // Persist the automatically enabled UDS settings at the schema layer. This deliberately
         // bypasses the HTTP-facing stream service so schema evolution does not depend on a
-        // higher-level service crate.
-        if !final_schema.metadata.contains_key("created_at") {
-            final_schema
-                .metadata
-                .insert("created_at".to_string(), now_micros().to_string());
-        }
-        if let Err(e) = db::schema::update_setting(
-            org_id,
-            stream_name,
-            stream_type,
-            final_schema.metadata.clone(),
-        )
-        .await
-        {
-            log::error!(
-                "persist auto UDS settings [{org_id}/{stream_type}/{stream_name}] error: {e}"
+        // higher-level service crate, but it must keep the same persistence guards as
+        // save_stream_settings: never write settings for a stream that is being deleted, and
+        // never persist more user fields than the settings API accepts.
+        let uds_user_fields = defined_schema_fields
+            .iter()
+            .filter(|field| !is_uds_internal_column(field))
+            .count();
+        if db::compact::retention::is_deleting_stream(org_id, stream_type, stream_name, None) {
+            log::warn!(
+                "skip persisting auto UDS settings [{org_id}/{stream_type}/{stream_name}]: stream is being deleted"
             );
+        } else if uds_user_fields > cfg.limit.user_defined_schema_max_fields {
+            log::warn!(
+                "skip persisting auto UDS settings [{org_id}/{stream_type}/{stream_name}]: {uds_user_fields} fields exceeds the limit {}",
+                cfg.limit.user_defined_schema_max_fields
+            );
+        } else {
+            if !final_schema.metadata.contains_key("created_at") {
+                final_schema
+                    .metadata
+                    .insert("created_at".to_string(), now_micros().to_string());
+            }
+            if let Err(e) = db::schema::update_setting(
+                org_id,
+                stream_name,
+                stream_type,
+                final_schema.metadata.clone(),
+            )
+            .await
+            {
+                log::error!(
+                    "persist auto UDS settings [{org_id}/{stream_type}/{stream_name}] error: {e}"
+                );
+            }
         }
     }
 

--- a/src/schema/src/lib.rs
+++ b/src/schema/src/lib.rs
@@ -81,7 +81,6 @@ pub enum StreamSettingsError {
     StreamDeleting(String),
     BadRequest(String),
     NotFound(String),
-    Internal(anyhow::Error),
 }
 
 impl std::fmt::Display for StreamSettingsError {
@@ -90,19 +89,11 @@ impl std::fmt::Display for StreamSettingsError {
             Self::StreamDeleting(message) | Self::BadRequest(message) | Self::NotFound(message) => {
                 f.write_str(message)
             }
-            Self::Internal(error) => write!(f, "{error}"),
         }
     }
 }
 
-impl std::error::Error for StreamSettingsError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Internal(error) => Some(error.as_ref()),
-            _ => None,
-        }
-    }
-}
+impl std::error::Error for StreamSettingsError {}
 
 pub struct SavedStreamSettings {
     pub settings: StreamSettings,
@@ -118,17 +109,13 @@ pub async fn save_stream_settings(
     org_id: &str,
     stream_name: &str,
     stream_type: StreamType,
-    settings: StreamSettings,
+    mut settings: StreamSettings,
 ) -> std::result::Result<SavedStreamSettings, StreamSettingsError> {
-    if db::compact::retention::is_deleting_stream(org_id, stream_type, stream_name, None) {
-        return Err(StreamSettingsError::StreamDeleting(format!(
-            "stream [{stream_name}] is being deleted"
-        )));
-    }
+    validate_stream_settings(org_id, stream_name, stream_type, &mut settings)?;
     let schema = infra::schema::get(org_id, stream_name, stream_type)
         .await
         .map_err(|_| StreamSettingsError::NotFound("stream not found".to_string()))?;
-    save_stream_settings_with_schema(org_id, stream_name, stream_type, &schema, settings).await
+    persist_stream_settings(org_id, stream_name, stream_type, &schema, settings).await
 }
 
 async fn save_stream_settings_with_schema(
@@ -138,7 +125,18 @@ async fn save_stream_settings_with_schema(
     schema: &Schema,
     mut settings: StreamSettings,
 ) -> std::result::Result<SavedStreamSettings, StreamSettingsError> {
-    let cfg = get_config();
+    validate_stream_settings(org_id, stream_name, stream_type, &mut settings)?;
+    persist_stream_settings(org_id, stream_name, stream_type, schema, settings).await
+}
+
+/// Settings-level validation that does not need the stored schema. Runs before the schema fetch
+/// so invalid settings are rejected as bad-request even when the stream doesn't exist.
+fn validate_stream_settings(
+    org_id: &str,
+    stream_name: &str,
+    stream_type: StreamType,
+    settings: &mut StreamSettings,
+) -> std::result::Result<(), StreamSettingsError> {
     if db::compact::retention::is_deleting_stream(org_id, stream_type, stream_name, None) {
         return Err(StreamSettingsError::StreamDeleting(format!(
             "stream [{stream_name}] is being deleted"
@@ -174,6 +172,17 @@ async fn save_stream_settings_with_schema(
         ));
     }
 
+    Ok(())
+}
+
+async fn persist_stream_settings(
+    org_id: &str,
+    stream_name: &str,
+    stream_type: StreamType,
+    schema: &Schema,
+    mut settings: StreamSettings,
+) -> std::result::Result<SavedStreamSettings, StreamSettingsError> {
+    let cfg = get_config();
     let schema_fields = schema
         .fields()
         .iter()
@@ -322,20 +331,13 @@ async fn save_stream_settings_with_schema(
     }
 
     let mut metadata = schema.metadata.clone();
-    metadata.insert(
-        "settings".to_string(),
-        json::to_string(&settings).map_err(|error| {
-            StreamSettingsError::Internal(anyhow::Error::new(error).context(format!(
-                "serialize stream settings for {org_id}/{stream_type}/{stream_name}"
-            )))
-        })?,
-    );
+    metadata.insert("settings".to_string(), json::to_string(&settings).unwrap());
     if !metadata.contains_key("created_at") {
         metadata.insert("created_at".to_string(), now_micros().to_string());
     }
     db::schema::update_setting(org_id, stream_name, stream_type, metadata)
         .await
-        .map_err(StreamSettingsError::Internal)?;
+        .unwrap();
 
     Ok(SavedStreamSettings {
         settings,
@@ -746,30 +748,17 @@ pub async fn handle_diff_schema(
             Ok(saved) => {
                 stream_setting = saved.settings;
                 defined_schema_fields = stream_setting.defined_schema_fields.clone();
-                final_schema
-                    .metadata
-                    .insert("settings".to_string(), json::to_string(&stream_setting)?);
-                if !final_schema.metadata.contains_key("created_at") {
-                    final_schema
-                        .metadata
-                        .insert("created_at".to_string(), now_micros().to_string());
-                }
+                final_schema.metadata.insert(
+                    "settings".to_string(),
+                    json::to_string(&stream_setting).unwrap(),
+                );
             }
             Err(StreamSettingsError::StreamDeleting(message))
-            | Err(StreamSettingsError::BadRequest(message)) => {
+            | Err(StreamSettingsError::BadRequest(message))
+            | Err(StreamSettingsError::NotFound(message)) => {
                 log::warn!(
                     "skip auto UDS settings [{org_id}/{stream_type}/{stream_name}]: {message}"
                 );
-            }
-            Err(StreamSettingsError::NotFound(message)) => {
-                return Err(anyhow::anyhow!(
-                    "persist auto UDS settings [{org_id}/{stream_type}/{stream_name}]: {message}"
-                ));
-            }
-            Err(StreamSettingsError::Internal(error)) => {
-                return Err(error.context(format!(
-                    "persist auto UDS settings [{org_id}/{stream_type}/{stream_name}]"
-                )));
             }
         }
     }

--- a/src/schema/src/lib.rs
+++ b/src/schema/src/lib.rs
@@ -33,7 +33,7 @@ use config::{
             BUCKET_LABEL, EXEMPLARS_LABEL, HASH_LABEL, METADATA_LABEL, NAME_LABEL, QUANTILE_LABEL,
             VALUE_LABEL,
         },
-        stream::StreamType,
+        stream::{StreamSettings, StreamType},
     },
     metrics,
     utils::{
@@ -43,6 +43,8 @@ use config::{
         time::now_micros,
     },
 };
+#[cfg(feature = "enterprise")]
+use config::{META_ORG_ID, meta::self_reporting::usage::USAGE_STREAM};
 use hashbrown::HashSet;
 use infra::schema::{
     STREAM_RECORD_ID_GENERATOR, STREAM_SCHEMAS_LATEST, STREAM_SETTINGS, SchemaCache,
@@ -72,6 +74,329 @@ pub fn get_request_columns_limit_error(stream_name: &str, num_fields: usize) -> 
         "Got {num_fields} columns for stream {stream_name}, only {} columns accept. Data discarded. You can adjust ingestion columns limit by setting the environment variable ZO_COLS_PER_RECORD_LIMIT=<max_columns>",
         get_config().limit.req_cols_per_record_limit
     )
+}
+
+#[derive(Debug)]
+pub enum StreamSettingsError {
+    StreamDeleting(String),
+    BadRequest(String),
+    NotFound(String),
+    Internal(anyhow::Error),
+}
+
+impl std::fmt::Display for StreamSettingsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::StreamDeleting(message) | Self::BadRequest(message) | Self::NotFound(message) => {
+                f.write_str(message)
+            }
+            Self::Internal(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for StreamSettingsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Internal(error) => Some(error.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+pub struct SavedStreamSettings {
+    pub settings: StreamSettings,
+    pub previous_settings: Option<StreamSettings>,
+}
+
+/// Validate, normalize, and persist stream settings stored in schema metadata.
+///
+/// This is the canonical settings write path for both the stream service and schema
+/// auto-evolution. Callers should only publish the returned settings to local caches after this
+/// function succeeds.
+pub async fn save_stream_settings(
+    org_id: &str,
+    stream_name: &str,
+    stream_type: StreamType,
+    settings: StreamSettings,
+) -> std::result::Result<SavedStreamSettings, StreamSettingsError> {
+    if db::compact::retention::is_deleting_stream(org_id, stream_type, stream_name, None) {
+        return Err(StreamSettingsError::StreamDeleting(format!(
+            "stream [{stream_name}] is being deleted"
+        )));
+    }
+    let schema = infra::schema::get(org_id, stream_name, stream_type)
+        .await
+        .map_err(|_| StreamSettingsError::NotFound("stream not found".to_string()))?;
+    save_stream_settings_with_schema(org_id, stream_name, stream_type, &schema, settings).await
+}
+
+async fn save_stream_settings_with_schema(
+    org_id: &str,
+    stream_name: &str,
+    stream_type: StreamType,
+    schema: &Schema,
+    mut settings: StreamSettings,
+) -> std::result::Result<SavedStreamSettings, StreamSettingsError> {
+    let cfg = get_config();
+    if db::compact::retention::is_deleting_stream(org_id, stream_type, stream_name, None) {
+        return Err(StreamSettingsError::StreamDeleting(format!(
+            "stream [{stream_name}] is being deleted"
+        )));
+    }
+
+    if !stream_type.support_uds() && !settings.defined_schema_fields.is_empty() {
+        return Err(StreamSettingsError::BadRequest(format!(
+            "stream type [{stream_type}] don't support user defined schema"
+        )));
+    }
+
+    if settings.data_retention > 0
+        && settings.data_retention < 30
+        && settings.storage_type.is_compliance()
+    {
+        return Err(StreamSettingsError::BadRequest(
+            "data_retention must be at least 30 days when storage_type is compliance".to_string(),
+        ));
+    }
+
+    #[cfg(feature = "enterprise")]
+    if org_id == META_ORG_ID && stream_name == USAGE_STREAM && settings.data_retention < 32 {
+        settings.data_retention = 0;
+    }
+
+    if settings.index_original_data {
+        settings.store_original_data = true;
+    }
+    if settings.index_original_data && settings.index_all_values {
+        return Err(StreamSettingsError::BadRequest(
+            "index_original_data & index_all_values cannot be true at the same time".to_string(),
+        ));
+    }
+
+    let schema_fields = schema
+        .fields()
+        .iter()
+        .map(|field| field.name())
+        .collect::<HashSet<_>>();
+    let previous_settings = unwrap_stream_settings(schema);
+
+    normalize_stream_settings(&mut settings);
+
+    if !settings.defined_schema_fields.is_empty() {
+        let fields = check_schema_for_defined_schema_fields(
+            stream_type,
+            schema,
+            std::mem::take(&mut settings.defined_schema_fields),
+        );
+        let mut fields = fields.into_iter().collect::<Vec<_>>();
+        fields.sort_unstable();
+        fields.retain(|field| schema_fields.contains(field));
+        settings.defined_schema_fields = fields;
+    }
+
+    let uds_user_fields = settings
+        .defined_schema_fields
+        .iter()
+        .filter(|field| !is_uds_internal_column(field))
+        .count();
+    if uds_user_fields > cfg.limit.user_defined_schema_max_fields {
+        return Err(StreamSettingsError::BadRequest(format!(
+            "user defined schema fields count exceeds the limit: {}",
+            cfg.limit.user_defined_schema_max_fields
+        )));
+    }
+
+    let fts_set = settings
+        .full_text_search_keys
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let index_set = settings
+        .index_fields
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let bloom_set = settings
+        .bloom_filter_fields
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let pk_set = settings
+        .partition_keys
+        .iter()
+        .map(|partition| partition.field.clone())
+        .collect::<HashSet<_>>();
+
+    let strict_reserved = [TIMESTAMP_COL_NAME, cfg.common.column_all.as_str()];
+    let no_search_reserved = [ALL_VALUES_COL_NAME, ORIGINAL_DATA_COL_NAME];
+    for &reserved in strict_reserved.iter().chain(no_search_reserved.iter()) {
+        if index_set.contains(reserved) {
+            return Err(StreamSettingsError::BadRequest(format!(
+                "field [{reserved}] is reserved and cannot be used for secondary index"
+            )));
+        }
+        if bloom_set.contains(reserved) {
+            return Err(StreamSettingsError::BadRequest(format!(
+                "field [{reserved}] is reserved and cannot be used for bloom filter"
+            )));
+        }
+        if pk_set.contains(reserved) {
+            return Err(StreamSettingsError::BadRequest(format!(
+                "field [{reserved}] is reserved and cannot be used as partition key"
+            )));
+        }
+    }
+    for &reserved in &strict_reserved {
+        if fts_set.contains(reserved) {
+            return Err(StreamSettingsError::BadRequest(format!(
+                "field [{reserved}] is reserved and cannot be used for full text search"
+            )));
+        }
+    }
+
+    if let Some(name) = fts_set.intersection(&index_set).next() {
+        return Err(StreamSettingsError::BadRequest(format!(
+            "field [{name}] cannot be both full text search and secondary index — choose one"
+        )));
+    }
+    if let Some(name) = fts_set.intersection(&bloom_set).next() {
+        return Err(StreamSettingsError::BadRequest(format!(
+            "field [{name}] cannot be both full text search and bloom filter"
+        )));
+    }
+    if let Some(name) = bloom_set.difference(&index_set).next() {
+        return Err(StreamSettingsError::BadRequest(format!(
+            "bloom filter field [{name}] must also be a secondary index field"
+        )));
+    }
+    if let Some(name) = pk_set.intersection(&fts_set).next() {
+        return Err(StreamSettingsError::BadRequest(format!(
+            "partition key [{name}] cannot also be a full text search field"
+        )));
+    }
+    if let Some(name) = pk_set.intersection(&index_set).next() {
+        return Err(StreamSettingsError::BadRequest(format!(
+            "partition key [{name}] cannot also be a secondary index field"
+        )));
+    }
+    if let Some(name) = pk_set.intersection(&bloom_set).next() {
+        return Err(StreamSettingsError::BadRequest(format!(
+            "partition key [{name}] cannot also be a bloom filter field"
+        )));
+    }
+
+    let mut old_partition_keys = previous_settings
+        .as_ref()
+        .map(|previous| previous.partition_keys.clone())
+        .unwrap_or_default();
+    for partition in &mut old_partition_keys {
+        partition.disabled = true;
+    }
+    for partition in &settings.partition_keys {
+        if let Some(old_partition) = old_partition_keys
+            .iter_mut()
+            .find(|old| old.field == partition.field)
+        {
+            if old_partition.types != partition.types {
+                return Err(StreamSettingsError::BadRequest(format!(
+                    "field [{}] partition types can't be changed",
+                    partition.field
+                )));
+            }
+            old_partition.disabled = partition.disabled;
+        } else {
+            old_partition_keys.push(partition.clone());
+        }
+    }
+    settings.partition_keys = old_partition_keys;
+
+    if settings
+        .extended_retention_days
+        .iter()
+        .any(|range| range.start > range.end)
+    {
+        return Err(StreamSettingsError::BadRequest(
+            "start day should be less than end day".to_string(),
+        ));
+    }
+
+    let mut metadata = schema.metadata.clone();
+    metadata.insert(
+        "settings".to_string(),
+        json::to_string(&settings).map_err(|error| {
+            StreamSettingsError::Internal(anyhow::Error::new(error).context(format!(
+                "serialize stream settings for {org_id}/{stream_type}/{stream_name}"
+            )))
+        })?,
+    );
+    if !metadata.contains_key("created_at") {
+        metadata.insert("created_at".to_string(), now_micros().to_string());
+    }
+    db::schema::update_setting(org_id, stream_name, stream_type, metadata)
+        .await
+        .map_err(StreamSettingsError::Internal)?;
+
+    Ok(SavedStreamSettings {
+        settings,
+        previous_settings,
+    })
+}
+
+/// Make stream settings internally consistent before validation and persistence.
+fn normalize_stream_settings(settings: &mut StreamSettings) {
+    dedup_preserve_order(&mut settings.full_text_search_keys);
+    dedup_preserve_order(&mut settings.index_fields);
+    dedup_preserve_order(&mut settings.bloom_filter_fields);
+    dedup_preserve_order(&mut settings.defined_schema_fields);
+
+    let mut seen = HashSet::new();
+    settings
+        .partition_keys
+        .retain(|partition| seen.insert(partition.field.clone()));
+    seen.clear();
+    settings
+        .distinct_value_fields
+        .retain(|field| seen.insert(field.name.clone()));
+    seen.clear();
+    settings
+        .extended_retention_days
+        .retain(|range| seen.insert(range.to_string()));
+    seen.clear();
+    settings
+        .cross_links
+        .retain(|link| seen.insert(link.to_string()));
+
+    let missing_index = settings
+        .bloom_filter_fields
+        .iter()
+        .filter(|field| !settings.index_fields.contains(field))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !missing_index.is_empty() {
+        let now = now_micros();
+        for field in &missing_index {
+            settings.index_fields_updated_at.insert(field.clone(), now);
+        }
+        settings.index_fields.extend(missing_index);
+    }
+
+    if !settings.index_fields_updated_at.is_empty() {
+        let indexed = settings
+            .full_text_search_keys
+            .iter()
+            .chain(settings.index_fields.iter())
+            .cloned()
+            .collect::<HashSet<_>>();
+        settings
+            .index_fields_updated_at
+            .retain(|field, _| indexed.contains(field));
+    }
+}
+
+fn dedup_preserve_order(values: &mut Vec<String>) {
+    let mut seen = HashSet::new();
+    values.retain(|value| seen.insert(value.clone()));
 }
 
 pub async fn check_for_schema(
@@ -407,50 +732,44 @@ pub async fn handle_diff_schema(
             }
         }
 
-        // sort for a deterministic persisted field list
-        defined_schema_fields = uds_fields.into_iter().collect::<Vec<_>>();
-        defined_schema_fields.sort_unstable();
-        stream_setting.defined_schema_fields = defined_schema_fields.clone();
-        final_schema.metadata.insert(
-            "settings".to_string(),
-            json::to_string(&stream_setting).unwrap(),
-        );
-
-        // Persist the automatically enabled UDS settings at the schema layer. This deliberately
-        // bypasses the HTTP-facing stream service so schema evolution does not depend on a
-        // higher-level service crate, but it must keep the same persistence guards as
-        // save_stream_settings: never write settings for a stream that is being deleted, and
-        // never persist more user fields than the settings API accepts.
-        let uds_user_fields = defined_schema_fields
-            .iter()
-            .filter(|field| !is_uds_internal_column(field))
-            .count();
-        if db::compact::retention::is_deleting_stream(org_id, stream_type, stream_name, None) {
-            log::warn!(
-                "skip persisting auto UDS settings [{org_id}/{stream_type}/{stream_name}]: stream is being deleted"
-            );
-        } else if uds_user_fields > cfg.limit.user_defined_schema_max_fields {
-            log::warn!(
-                "skip persisting auto UDS settings [{org_id}/{stream_type}/{stream_name}]: {uds_user_fields} fields exceeds the limit {}",
-                cfg.limit.user_defined_schema_max_fields
-            );
-        } else {
-            if !final_schema.metadata.contains_key("created_at") {
+        let mut candidate_settings = stream_setting.clone();
+        candidate_settings.defined_schema_fields = uds_fields.into_iter().collect();
+        match save_stream_settings_with_schema(
+            org_id,
+            stream_name,
+            stream_type,
+            &final_schema,
+            candidate_settings,
+        )
+        .await
+        {
+            Ok(saved) => {
+                stream_setting = saved.settings;
+                defined_schema_fields = stream_setting.defined_schema_fields.clone();
                 final_schema
                     .metadata
-                    .insert("created_at".to_string(), now_micros().to_string());
+                    .insert("settings".to_string(), json::to_string(&stream_setting)?);
+                if !final_schema.metadata.contains_key("created_at") {
+                    final_schema
+                        .metadata
+                        .insert("created_at".to_string(), now_micros().to_string());
+                }
             }
-            if let Err(e) = db::schema::update_setting(
-                org_id,
-                stream_name,
-                stream_type,
-                final_schema.metadata.clone(),
-            )
-            .await
-            {
-                log::error!(
-                    "persist auto UDS settings [{org_id}/{stream_type}/{stream_name}] error: {e}"
+            Err(StreamSettingsError::StreamDeleting(message))
+            | Err(StreamSettingsError::BadRequest(message)) => {
+                log::warn!(
+                    "skip auto UDS settings [{org_id}/{stream_type}/{stream_name}]: {message}"
                 );
+            }
+            Err(StreamSettingsError::NotFound(message)) => {
+                return Err(anyhow::anyhow!(
+                    "persist auto UDS settings [{org_id}/{stream_type}/{stream_name}]: {message}"
+                ));
+            }
+            Err(StreamSettingsError::Internal(error)) => {
+                return Err(error.context(format!(
+                    "persist auto UDS settings [{org_id}/{stream_type}/{stream_name}]"
+                )));
             }
         }
     }
@@ -679,6 +998,34 @@ mod tests {
     use arrow_schema::DataType;
 
     use super::*;
+
+    #[test]
+    fn test_normalize_stream_settings_index_fields_updated_at() {
+        let mut settings = StreamSettings {
+            index_fields: vec!["a".to_string(), "a".to_string()],
+            bloom_filter_fields: vec!["b".to_string(), "b".to_string()],
+            ..Default::default()
+        };
+        settings
+            .index_fields_updated_at
+            .insert("a".to_string(), 100);
+        settings
+            .index_fields_updated_at
+            .insert("removed".to_string(), 200);
+
+        normalize_stream_settings(&mut settings);
+
+        assert_eq!(settings.index_fields, vec!["a", "b"]);
+        assert_eq!(settings.bloom_filter_fields, vec!["b"]);
+        assert!(
+            settings
+                .index_fields_updated_at
+                .get("b")
+                .is_some_and(|value| *value > 0)
+        );
+        assert!(!settings.index_fields_updated_at.contains_key("removed"));
+        assert_eq!(settings.index_fields_updated_at.get("a"), Some(&100));
+    }
 
     #[test]
     fn test_generate_schema_for_defined_schema_fields_includes_internal_columns() {

--- a/src/schema/src/lib.rs
+++ b/src/schema/src/lib.rs
@@ -753,12 +753,8 @@ pub async fn handle_diff_schema(
                     json::to_string(&stream_setting).unwrap(),
                 );
             }
-            Err(StreamSettingsError::StreamDeleting(message))
-            | Err(StreamSettingsError::BadRequest(message))
-            | Err(StreamSettingsError::NotFound(message)) => {
-                log::warn!(
-                    "skip auto UDS settings [{org_id}/{stream_type}/{stream_name}]: {message}"
-                );
+            Err(e) => {
+                log::warn!("skip auto UDS settings [{org_id}/{stream_type}/{stream_name}]: {e}");
             }
         }
     }

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -15,6 +15,7 @@ enterprise = [
     "config/enterprise",
     "db/enterprise",
     "enrichment-data/enterprise",
+    "schema/enterprise",
 ]
 cloud = [
     "enterprise",
@@ -39,7 +40,6 @@ db.workspace = true
 enrichment-data.workspace = true
 hashbrown.workspace = true
 infra.workspace = true
-itertools.workspace = true
 log.workspace = true
 o2_enterprise = { workspace = true, optional = true, default-features = false }
 schema.workspace = true

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -397,9 +397,6 @@ pub async fn save_stream_settings(
         Err(schema::StreamSettingsError::NotFound(message)) => {
             return Ok(MetaHttpResponse::not_found(message));
         }
-        Err(schema::StreamSettingsError::Internal(error)) => {
-            return Err(Error::other(error.to_string()));
-        }
     };
     let settings = saved.settings;
 

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -31,8 +31,7 @@ use common::meta::{
 #[cfg(feature = "cloud")]
 use config::meta::self_reporting::usage::is_reserved_self_reporting_stream;
 use config::{
-    ALL_VALUES_COL_NAME, ORIGINAL_DATA_COL_NAME, SIZE_IN_MB, TIMESTAMP_COL_NAME, get_config,
-    is_local_disk_storage, is_uds_internal_column,
+    SIZE_IN_MB, TIMESTAMP_COL_NAME, get_config, is_local_disk_storage,
     meta::{
         promql,
         promql::get_metadata_from_schema as get_prom_metadata_from_schema,
@@ -43,12 +42,10 @@ use config::{
     },
     utils::{flatten::format_label_name, json, time::now_micros, util::get_distinct_stream_name},
 };
-#[cfg(feature = "enterprise")]
-use config::{META_ORG_ID, meta::self_reporting::usage::USAGE_STREAM};
 #[cfg(feature = "vectorscan")]
 use db::re_pattern::process_association_changes;
 use db::{self, distinct_values, enrichment_table};
-use hashbrown::{HashMap, HashSet};
+use hashbrown::HashMap;
 use infra::{
     cache::stats,
     schema::{
@@ -58,7 +55,6 @@ use infra::{
     },
     table::distinct_values::{DistinctFieldRecord, OriginType, check_field_use},
 };
-use itertools::chain;
 #[cfg(feature = "vectorscan")]
 use o2_enterprise::enterprise::re_patterns::PATTERN_MANAGER;
 
@@ -379,231 +375,38 @@ pub async fn save_stream_settings(
     org_id: &str,
     stream_name: &str,
     stream_type: StreamType,
-    mut settings: StreamSettings,
+    settings: StreamSettings,
 ) -> Result<HttpResponse, Error> {
-    let cfg = config::get_config();
-    // check if we are allowed to ingest
-    if db::compact::retention::is_deleting_stream(org_id, stream_type, stream_name, None) {
-        return Ok((
-            http::StatusCode::BAD_REQUEST,
-            [(
-                ERROR_HEADER,
-                format!("stream [{stream_name}] is being deleted"),
-            )],
-            Json(MetaHttpResponse::error(
-                http::StatusCode::BAD_REQUEST,
-                format!("stream [{stream_name}] is being deleted"),
-            )),
-        )
-            .into_response());
-    }
-
-    // only allow setting user defined schema for supported stream
-    if !stream_type.support_uds() && !settings.defined_schema_fields.is_empty() {
-        return Ok(MetaHttpResponse::bad_request(format!(
-            "stream type [{stream_type}] don't support user defined schema"
-        )));
-    }
-
-    // check stroage type is compliance
-    if settings.data_retention > 0
-        && settings.data_retention < 30
-        && settings.storage_type.is_compliance()
+    let saved = match schema::save_stream_settings(org_id, stream_name, stream_type, settings).await
     {
-        return Ok(MetaHttpResponse::bad_request(
-            "data_retention must be at least 30 days when storage_type is compliance",
-        ));
-    }
-    #[cfg(feature = "enterprise")]
-    if org_id == META_ORG_ID && stream_name == USAGE_STREAM && settings.data_retention < 32 {
-        // _meta org, usage stream can't be set to less than 32 days
-        settings.data_retention = 0;
-    }
-
-    // if index_original_data is true, store_original_data must be true
-    if settings.index_original_data {
-        settings.store_original_data = true;
-    }
-
-    // index_original_data & index_all_values only can open one at a time
-    if settings.index_original_data && settings.index_all_values {
-        return Ok(MetaHttpResponse::bad_request(
-            "index_original_data & index_all_values cannot be true at the same time",
-        ));
-    }
-
-    let Ok(schema) = infra::schema::get(org_id, stream_name, stream_type).await else {
-        return Ok(MetaHttpResponse::not_found("stream not found"));
+        Ok(saved) => saved,
+        Err(schema::StreamSettingsError::StreamDeleting(message)) => {
+            return Ok((
+                http::StatusCode::BAD_REQUEST,
+                [(ERROR_HEADER, message.clone())],
+                Json(MetaHttpResponse::error(
+                    http::StatusCode::BAD_REQUEST,
+                    message,
+                )),
+            )
+                .into_response());
+        }
+        Err(schema::StreamSettingsError::BadRequest(message)) => {
+            return Ok(MetaHttpResponse::bad_request(message));
+        }
+        Err(schema::StreamSettingsError::NotFound(message)) => {
+            return Ok(MetaHttpResponse::not_found(message));
+        }
+        Err(schema::StreamSettingsError::Internal(error)) => {
+            return Err(Error::other(error.to_string()));
+        }
     };
-    let schema_fields = schema
-        .fields()
-        .iter()
-        .map(|f| (f.name(), f))
-        .collect::<HashMap<_, _>>();
-
-    // Dedup + fold bloom into index. Single place where the stored shape gets
-    // normalized; both direct-save callers and the update path (via this
-    // function at the end) flow through here.
-    normalize_stream_settings(&mut settings);
-
-    // check for user defined schema
-    if !settings.defined_schema_fields.is_empty() {
-        // check fields with stream type
-        let fields = schema::check_schema_for_defined_schema_fields(
-            stream_type,
-            &schema,
-            settings.defined_schema_fields.to_vec(),
-        );
-        // remove the fields that are not in the new schema
-        let mut fields: Vec<_> = fields.into_iter().collect();
-        fields.sort();
-        fields.dedup();
-        fields.retain(|field| schema_fields.contains_key(field));
-        settings.defined_schema_fields = fields;
-    }
-    // internal columns are implicit in the UDS and don't count toward the limit
-    let uds_user_fields = settings
-        .defined_schema_fields
-        .iter()
-        .filter(|field| !is_uds_internal_column(field))
-        .count();
-    if uds_user_fields > cfg.limit.user_defined_schema_max_fields {
-        return Ok(MetaHttpResponse::bad_request(format!(
-            "user defined schema fields count exceeds the limit: {}",
-            cfg.limit.user_defined_schema_max_fields
-        )));
-    }
-
-    // Check the fields are not reserved
-    let fts_set: HashSet<_> = settings.full_text_search_keys.iter().cloned().collect();
-    let index_set: HashSet<_> = settings.index_fields.iter().cloned().collect();
-    let bloom_set: HashSet<_> = settings.bloom_filter_fields.iter().cloned().collect();
-    let pk_set: HashSet<_> = settings
-        .partition_keys
-        .iter()
-        .map(|p| p.field.clone())
-        .collect();
-
-    // ---- 1. Reserved columns (raw lists) ----
-    let strict_reserved: [&str; 2] = [TIMESTAMP_COL_NAME, cfg.common.column_all.as_str()];
-    let no_search_reserved: [&str; 2] = [ALL_VALUES_COL_NAME, ORIGINAL_DATA_COL_NAME];
-    for &r in chain(strict_reserved.iter(), no_search_reserved.iter()) {
-        if index_set.contains(r) {
-            return Ok(MetaHttpResponse::bad_request(format!(
-                "field [{r}] is reserved and cannot be used for secondary index"
-            )));
-        }
-        if bloom_set.contains(r) {
-            return Ok(MetaHttpResponse::bad_request(format!(
-                "field [{r}] is reserved and cannot be used for bloom filter"
-            )));
-        }
-        if pk_set.contains(r) {
-            return Ok(MetaHttpResponse::bad_request(format!(
-                "field [{r}] is reserved and cannot be used as partition key"
-            )));
-        }
-    }
-    for &r in &strict_reserved {
-        // FTS is explicitly allowed for these — they hold human-readable content.
-        if fts_set.contains(r) {
-            return Ok(MetaHttpResponse::bad_request(format!(
-                "field [{r}] is reserved and cannot be used for full text search"
-            )));
-        }
-    }
-
-    // ---- 2. FTS ∩ Index = ∅ (resolved) ----
-    if let Some(name) = fts_set.intersection(&index_set).next() {
-        return Ok(MetaHttpResponse::bad_request(format!(
-            "field [{name}] cannot be both full text search and secondary index — choose one"
-        )));
-    }
-    // ---- 3. FTS ∩ Bloom = ∅ (resolved) ----
-    if let Some(name) = fts_set.intersection(&bloom_set).next() {
-        return Ok(MetaHttpResponse::bad_request(format!(
-            "field [{name}] cannot be both full text search and bloom filter"
-        )));
-    }
-    // ---- 4. Bloom ⊆ Index (raw) ----
-    if let Some(name) = bloom_set.difference(&index_set).next() {
-        return Ok(MetaHttpResponse::bad_request(format!(
-            "bloom filter field [{name}] must also be a secondary index field"
-        )));
-    }
-    // ---- 5. Partition keys disjoint from FTS / Index / Bloom (resolved) ----
-    if let Some(name) = pk_set.intersection(&fts_set).next() {
-        return Ok(MetaHttpResponse::bad_request(format!(
-            "partition key [{name}] cannot also be a full text search field"
-        )));
-    }
-    if let Some(name) = pk_set.intersection(&index_set).next() {
-        return Ok(MetaHttpResponse::bad_request(format!(
-            "partition key [{name}] cannot also be a secondary index field"
-        )));
-    }
-    if let Some(name) = pk_set.intersection(&bloom_set).next() {
-        return Ok(MetaHttpResponse::bad_request(format!(
-            "partition key [{name}] cannot also be a bloom filter field"
-        )));
-    }
-
-    // check if the partition key is a full text search field
-    for key in settings.partition_keys.iter() {
-        if fts_set.contains(&key.field) {
-            return Ok(MetaHttpResponse::bad_request(format!(
-                "field [{}] can't be used for partition key",
-                key.field
-            )));
-        }
-    }
-
-    // we need to keep the old partition information, because the hash bucket num can't be changed
-    // get old settings and then update partition_keys
-    let mut old_partition_keys = unwrap_stream_settings(&schema)
-        .unwrap_or_default()
-        .partition_keys;
-    // first disable all old partition keys
-    for v in old_partition_keys.iter_mut() {
-        v.disabled = true;
-    }
-    // then update new partition keys
-    for v in settings.partition_keys.iter() {
-        if let Some(old_field) = old_partition_keys.iter_mut().find(|k| k.field == v.field) {
-            if old_field.types != v.types {
-                return Ok(MetaHttpResponse::bad_request(format!(
-                    "field [{}] partition types can't be changed",
-                    v.field
-                )));
-            }
-            old_field.disabled = v.disabled;
-        } else {
-            old_partition_keys.push(v.clone());
-        }
-    }
-    settings.partition_keys = old_partition_keys;
-
-    for range in settings.extended_retention_days.iter() {
-        if range.start > range.end {
-            return Ok(MetaHttpResponse::bad_request(
-                "start day should be less than end day",
-            ));
-        }
-    }
-
-    let mut metadata = schema.metadata.clone();
-    metadata.insert("settings".to_string(), json::to_string(&settings).unwrap());
-    if !metadata.contains_key("created_at") {
-        metadata.insert("created_at".to_string(), now_micros().to_string());
-    }
-    db::schema::update_setting(org_id, stream_name, stream_type, metadata)
-        .await
-        .unwrap();
+    let settings = saved.settings;
 
     // skip metadata, as we should never do distinct values stream for
     // metadata streams
     if matches!(stream_type, StreamType::Logs | StreamType::Traces)
-        && let Some(original_settings) = unwrap_stream_settings(&schema)
+        && let Some(original_settings) = saved.previous_settings
     {
         let existing = original_settings.data_retention;
         let new = settings.data_retention;
@@ -1308,80 +1111,6 @@ pub async fn update_fields_type(
     Ok(())
 }
 
-/// Make `settings` internally consistent before validation / persistence.
-/// Three normalizations, all in-place:
-///
-/// 1. **Dedup** each of `full_text_search_keys`, `index_fields`, `bloom_filter_fields`, and
-///    `partition_keys`, preserving first-occurrence order. Matches the silent dedup the update path
-///    has always done on `.add` lists, so a user re-adding the same field is a no-op rather than an
-///    error.
-/// 2. **Enforce `bloom ⊆ index`** by folding any bloom-only field into `index_fields` (and bumping
-///    `index_updated_at` plus the per-field timestamps if anything was added). Bloom is built by
-///    walking the tantivy term dict, so a bloom field that isn't in `index_fields` would silently
-///    produce no `.bf`; auto-folding here keeps the stored shape consistent with the runtime
-///    invariant.
-/// 3. **Prune `index_fields_updated_at`** to fields still present in `full_text_search_keys` or
-///    `index_fields`, so removed fields don't leave stale timestamps behind (a later re-add must
-///    stamp a fresh time, because files written in the gap lack that field's index).
-///
-/// Called by [`save_stream_settings`] just before [`validate_stream_settings`],
-/// and by [`validate_update_pre_flight`] on its simulated state so both paths
-/// validate the same normalized shape.
-fn normalize_stream_settings(settings: &mut StreamSettings) {
-    // 1. dedup
-    dedup_preserve_order(&mut settings.full_text_search_keys);
-    dedup_preserve_order(&mut settings.index_fields);
-    dedup_preserve_order(&mut settings.bloom_filter_fields);
-    dedup_preserve_order(&mut settings.defined_schema_fields);
-    let mut seen: HashSet<String> = HashSet::new();
-    settings
-        .partition_keys
-        .retain(|p| seen.insert(p.field.clone()));
-    seen.clear();
-    settings
-        .distinct_value_fields
-        .retain(|d| seen.insert(d.name.clone()));
-    seen.clear();
-    settings
-        .extended_retention_days
-        .retain(|r| seen.insert(r.to_string()));
-    seen.clear();
-    settings.cross_links.retain(|c| seen.insert(c.to_string()));
-
-    // 2. bloom ⊆ index
-    let missing_index: Vec<String> = settings
-        .bloom_filter_fields
-        .iter()
-        .filter(|f| !settings.index_fields.contains(f))
-        .cloned()
-        .collect();
-    if !missing_index.is_empty() {
-        let now = now_micros();
-        for field in missing_index.iter() {
-            settings.index_fields_updated_at.insert(field.clone(), now);
-        }
-        settings.index_fields.extend(missing_index);
-    }
-
-    // 3. prune per-field timestamps of fields no longer indexed
-    if !settings.index_fields_updated_at.is_empty() {
-        let indexed: HashSet<String> = settings
-            .full_text_search_keys
-            .iter()
-            .chain(settings.index_fields.iter())
-            .cloned()
-            .collect();
-        settings
-            .index_fields_updated_at
-            .retain(|field, _| indexed.contains(field));
-    }
-}
-
-fn dedup_preserve_order(v: &mut Vec<String>) {
-    let mut seen: HashSet<String> = HashSet::new();
-    v.retain(|s| seen.insert(s.clone()));
-}
-
 pub async fn get_stream_retention(
     org_id: &str,
     stream_type: StreamType,
@@ -1401,36 +1130,6 @@ mod tests {
     use arrow_schema::{DataType, Field};
 
     use super::*;
-
-    #[test]
-    fn test_normalize_stream_settings_index_fields_updated_at() {
-        let mut settings = StreamSettings {
-            index_fields: vec!["a".to_string()],
-            bloom_filter_fields: vec!["b".to_string()],
-            ..Default::default()
-        };
-        settings
-            .index_fields_updated_at
-            .insert("a".to_string(), 100);
-        settings
-            .index_fields_updated_at
-            .insert("removed".to_string(), 200);
-
-        normalize_stream_settings(&mut settings);
-
-        // bloom-only field folded into index_fields and stamped
-        assert!(settings.index_fields.contains(&"b".to_string()));
-        assert!(
-            settings
-                .index_fields_updated_at
-                .get("b")
-                .is_some_and(|v| *v > 0)
-        );
-        // entry of a field no longer indexed is pruned
-        assert!(!settings.index_fields_updated_at.contains_key("removed"));
-        // entry of a still-indexed field is preserved
-        assert_eq!(settings.index_fields_updated_at.get("a"), Some(&100));
-    }
 
     #[test]
     fn test_stream_res() {


### PR DESCRIPTION
## Summary

#13405 rewired `handle_diff_schema`'s auto-UDS persistence from `stream::save_stream_settings` to a direct `db::schema::update_setting` call (required by the new crate dependency direction: `schema` cannot depend on `stream`). The direct write dropped the persistence guards that path provided. This PR restores them inside the schema crate, without reintroducing a dependency on the stream service:

- skip persisting when the stream is being deleted (`db::compact::retention::is_deleting_stream`), matching the old `save_stream_settings` early-return
- enforce `cfg.limit.user_defined_schema_max_fields` on the persisted field list (previously, with `ZO_SCHEMA_MAX_FIELDS_TO_ENABLE_UDS` set above the cap, settings that were never persisted before #13405 would now be written); skipped writes are logged at warn level instead of silently dropped
- sort `defined_schema_fields` before persisting so the stored order is deterministic (was `HashSet` iteration order, nondeterministic across nodes/restarts)

Also restores the `calculate_files_size` unit tests that were dropped when `src/core/src/file_list.rs` was deleted in #13405 — they now live next to the function in `infra::file_list`.

## Validation

- `cargo check -p schema -p infra`
- `cargo test -p schema --lib` (7 passed)
- `cargo test -p infra --lib file_list::tests::test_calculate_files_size` (5 passed)
- `cargo clippy -p schema -p infra`
- `cargo fmt -p schema -p infra -- --check`