### PR TITLE
fix: fixed protocol check breakdown cards

### DIFF
--- a/web/src/components/synthetic-monitoring/MonitorTable.spec.ts
+++ b/web/src/components/synthetic-monitoring/MonitorTable.spec.ts
@@ -121,7 +121,8 @@ const ODropdownSeparatorStub = {
 
 const OTooltipStub = {
   name: "OTooltipStub",
-  template: '<div class="otooltip-stub" :data-content="content" :data-content-class="contentClass"><slot /></div>',
+  template:
+    '<div class="otooltip-stub" :data-content="content" :data-content-class="contentClass"><slot /></div>',
   props: ["content", "side", "contentClass", "delay"],
 };
 
@@ -790,9 +791,7 @@ describe("MonitorTable", () => {
         // Row 2 has ["us-east-1", "eu-west-1", "ap-southeast-1"]
         // Only us-east-1 is mapped; eu-west-1 and ap-southeast-1 fall back to raw IDs
         const row2LocTooltip = tooltips[16];
-        expect(row2LocTooltip.props("content")).toBe(
-          "US East\neu-west-1\nap-southeast-1",
-        );
+        expect(row2LocTooltip.props("content")).toBe("US East\neu-west-1\nap-southeast-1");
       });
     });
   });

--- a/web/src/components/synthetic-monitoring/MonitorTable.spec.ts
+++ b/web/src/components/synthetic-monitoring/MonitorTable.spec.ts
@@ -121,8 +121,8 @@ const ODropdownSeparatorStub = {
 
 const OTooltipStub = {
   name: "OTooltipStub",
-  template: '<div class="otooltip-stub" />',
-  props: ["content", "side", "contentClass"],
+  template: '<div class="otooltip-stub" :data-content="content" :data-content-class="contentClass"><slot /></div>',
+  props: ["content", "side", "contentClass", "delay"],
 };
 
 const OEmptyStateStub = {
@@ -630,6 +630,170 @@ describe("MonitorTable", () => {
       expect(duplicateBtn.exists()).toBe(true);
       const moreBtn = wrapper.find('[data-test="monitor-table-more-btn"]');
       expect(moreBtn.exists()).toBe(true);
+    });
+  });
+
+  // ── Cell tooltips (OTooltip wrapping) ──────────────────────────────────
+
+  describe("cell tooltips", () => {
+    // ── Name cell ──────────────────────────────────────────────────────
+
+    describe("name cell", () => {
+      it("renders OTooltip wrapping the name with cursor-help when name is present", () => {
+        wrapper = mountMonitorTable();
+        // Per row: name=idx+0, url=idx+1, locations=idx+2, then 4 action OTooltips.
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        expect(tooltips.length).toBeGreaterThanOrEqual(3);
+        const nameTooltip = tooltips[0];
+        expect(nameTooltip.props("content")).toBe("HTTP Health Check");
+        expect(nameTooltip.find("span.cursor-help").exists()).toBe(true);
+      });
+
+      it("renders em-dash fallback span without OTooltip when name is absent", () => {
+        wrapper = mountMonitorTable({
+          data: [{ ...mockMonitorList[0], name: undefined as any, id: "test-no-name" }],
+        });
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        // Only URL + locations + 4 actions = 6 OTooltips (name cell skipped)
+        expect(tooltips.length).toBe(6);
+        // The em-dash fallback should appear in the DOM
+        expect(wrapper.text()).toContain("—");
+      });
+    });
+
+    // ── URL cell ───────────────────────────────────────────────────────
+
+    describe("url cell", () => {
+      it("renders OTooltip wrapping the URL with cursor-help when URL is present", () => {
+        wrapper = mountMonitorTable();
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        const urlTooltip = tooltips[1];
+        expect(urlTooltip.props("content")).toBe("https://example.com/health");
+        expect(urlTooltip.find("span.cursor-help").exists()).toBe(true);
+      });
+
+      it("renders em-dash fallback span without OTooltip when URL is absent", () => {
+        wrapper = mountMonitorTable({
+          data: [{ ...mockMonitorList[0], url: undefined as any, id: "test-no-url" }],
+        });
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        // Name + locations + 4 actions = 6 OTooltips (URL cell skipped)
+        expect(tooltips.length).toBe(6);
+        // URL tooltip at index 1 is now the locations tooltip (shifted)
+        expect(tooltips[1].props("content")).toContain("us-east-1");
+        expect(wrapper.text()).toContain("—");
+      });
+    });
+
+    // ── Locations cell ─────────────────────────────────────────────────
+
+    describe("locations cell", () => {
+      it("renders OTooltip with formatted location list using locationNames", () => {
+        wrapper = mountMonitorTable({
+          locationNames: {
+            "us-east-1": "US East (N. Virginia)",
+            "eu-west-1": "EU (Ireland)",
+          },
+        });
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        const locTooltip = tooltips[2];
+        expect(locTooltip.props("content")).toBe("US East (N. Virginia)\nEU (Ireland)");
+        expect(locTooltip.props("contentClass")).toContain("whitespace-pre-wrap");
+      });
+
+      it("falls back to raw location IDs when locationNames is empty", () => {
+        wrapper = mountMonitorTable();
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        const locTooltip = tooltips[2];
+        expect(locTooltip.props("content")).toBe("us-east-1\neu-west-1");
+      });
+
+      it("falls back to raw IDs for locations not in the locationNames map", () => {
+        wrapper = mountMonitorTable({
+          locationNames: { "us-east-1": "US East" },
+        });
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        const locTooltip = tooltips[2];
+        // eu-west-1 is not mapped, so it falls back to the raw id
+        expect(locTooltip.props("content")).toBe("US East\neu-west-1");
+      });
+
+      it("shows first location label and cursor-help class", () => {
+        wrapper = mountMonitorTable();
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        const locTooltip = tooltips[2];
+        expect(locTooltip.text()).toContain("us-east-1");
+        expect(locTooltip.find(".cursor-help").exists()).toBe(true);
+      });
+
+      it("shows +N badge when more than one location", () => {
+        wrapper = mountMonitorTable();
+        // Row 0 (mockMonitorHttp): 2 locations => "+1"
+        // Row 2 (mockMonitorBrowser): 3 locations => "+2"
+        const text = wrapper.text();
+        expect(text).toContain("+1");
+        expect(text).toContain("+2");
+      });
+
+      it("does not show count badge when only one location", () => {
+        wrapper = mountMonitorTable();
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        // Row 1 (mockMonitorTcp) has 1 location. Its locations OTooltip is at index 9.
+        const row1LocTooltip = tooltips[9];
+        const row1LocText = row1LocTooltip.text();
+        expect(row1LocText).toContain("us-east-1");
+        expect(row1LocText).not.toContain("+");
+      });
+
+      it("renders em-dash fallback without OTooltip when locations are empty", () => {
+        wrapper = mountMonitorTable({
+          data: [{ ...mockMonitorList[0], locations: [] as any, id: "test-no-loc" }],
+        });
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        // Name + URL + 4 actions = 6 OTooltips (locations cell skipped)
+        expect(tooltips.length).toBe(6);
+        expect(wrapper.text()).toContain("—");
+      });
+
+      it("has delay=0 for instant tooltip appearance", () => {
+        wrapper = mountMonitorTable();
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        const locTooltip = tooltips[2];
+        expect(locTooltip.props("delay")).toBe(0);
+      });
+    });
+
+    // ── formatLocationsList helper ──────────────────────────────────────
+
+    describe("formatLocationsList", () => {
+      it("joins location labels with newlines when all IDs are in the map", () => {
+        wrapper = mountMonitorTable({
+          locationNames: {
+            "us-east-1": "US East (N. Virginia)",
+            "eu-west-1": "EU (Ireland)",
+            "ap-southeast-1": "Asia Pacific (Singapore)",
+          },
+        });
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        // Row 2 (mockMonitorBrowser) has 3 locations, its loc OTooltip is at index 16
+        const row2LocTooltip = tooltips[16];
+        expect(row2LocTooltip.props("content")).toBe(
+          "US East (N. Virginia)\nEU (Ireland)\nAsia Pacific (Singapore)",
+        );
+      });
+
+      it("handles location IDs not in the map by returning the raw ID", () => {
+        wrapper = mountMonitorTable({
+          locationNames: { "us-east-1": "US East" },
+        });
+        const tooltips = wrapper.findAllComponents({ name: "OTooltipStub" });
+        // Row 2 has ["us-east-1", "eu-west-1", "ap-southeast-1"]
+        // Only us-east-1 is mapped; eu-west-1 and ap-southeast-1 fall back to raw IDs
+        const row2LocTooltip = tooltips[16];
+        expect(row2LocTooltip.props("content")).toBe(
+          "US East\neu-west-1\nap-southeast-1",
+        );
+      });
     });
   });
 });

--- a/web/src/components/synthetic-monitoring/MonitorTable.vue
+++ b/web/src/components/synthetic-monitoring/MonitorTable.vue
@@ -31,30 +31,35 @@
 
     <!-- Status badge -->
     <template #cell-status="{ row }">
-      <OBadge
-        :variant="resolveBadge('serviceStatus', (row as any).status).variant"
-        :dot="true"
-        size="sm"
-      >
-        {{ resolveBadge("serviceStatus", (row as any).status).label }}
+      <OBadge :variant="resolveBadge('serviceStatus', (row as any).status).variant" :dot="true" size="sm">
+        {{ resolveBadge('serviceStatus', (row as any).status).label }}
       </OBadge>
     </template>
 
     <!-- Monitor name -->
     <template #cell-name="{ row }">
-      <div class="flex min-w-0 items-center gap-1.5 overflow-hidden">
-        <span class="truncate">{{ (row as any).name || "—" }}</span>
-      </div>
       <OTooltip
         v-if="(row as any).name"
         :content="(row as any).name"
         content-class="max-w-[25rem] whitespace-normal break-words text-xs"
-      />
+      >
+        <div class="flex items-center gap-1.5 min-w-0 overflow-hidden">
+          <span class="truncate cursor-help">{{ (row as any).name || '—' }}</span>
+        </div>
+      </OTooltip>
+      <span v-else class="truncate">—</span>
     </template>
 
     <!-- URL / Endpoint -->
     <template #cell-url="{ row }">
-      <span class="truncate">{{ (row as any).url || "—" }}</span>
+      <OTooltip
+        v-if="(row as any).url"
+        :content="(row as any).url"
+        content-class="max-w-[25rem] whitespace-normal break-words text-xs"
+      >
+        <span class="truncate cursor-help">{{ (row as any).url }}</span>
+      </OTooltip>
+      <span v-else class="truncate">—</span>
     </template>
 
     <!-- HTTP Method badge (API mode) -->
@@ -66,31 +71,28 @@
 
     <!-- Steps count (Browser mode) -->
     <template #cell-steps="{ row }">
-      <span class="truncate">{{
-        (row as any).steps ? `${(row as any).steps} ${t("synthetics.table.stepsSuffix")}` : "—"
-      }}</span>
+      <span class="truncate">{{ (row as any).steps ? `${(row as any).steps} ${t('synthetics.table.stepsSuffix')}` : '—' }}</span>
     </template>
 
     <!-- Assertions count (API mode) -->
     <template #cell-assertions="{ row }">
-      <span class="truncate">{{
-        (row as any).assertions
-          ? `${(row as any).assertions} ${t("synthetics.table.checksSuffix")}`
-          : "—"
-      }}</span>
+      <span class="truncate">{{ (row as any).assertions ? `${(row as any).assertions} ${t('synthetics.table.checksSuffix')}` : '—' }}</span>
     </template>
 
     <!-- Folder name (cross-folder search mode) — click navigates sidebar to that folder -->
     <template #cell-folder_name="{ row }">
-      <div class="cursor-pointer" @click.stop="emit('navigate-to-folder', (row as any).folderId)">
-        {{ (row as any).folder_name || "—" }}
+      <div
+        class="cursor-pointer"
+        @click.stop="emit('navigate-to-folder', (row as any).folderId)"
+      >
+        {{ (row as any).folder_name || '—' }}
       </div>
     </template>
 
     <!-- Type badge (monitors mode) -->
     <template #cell-type="{ row }">
       <OBadge :variant="resolveBadge('syntheticType', (row as any).type).variant" size="sm">
-        {{ resolveBadge("syntheticType", (row as any).type).label }}
+        {{ resolveBadge('syntheticType', (row as any).type).label }}
       </OBadge>
     </template>
 
@@ -101,13 +103,7 @@
           v-for="(tick, i) in (row as any).history"
           :key="i"
           class="spark-bar"
-          :class="
-            tick.status === 'up'
-              ? 'bg-[var(--color-success-500)]'
-              : tick.status === 'down'
-                ? 'bg-[var(--color-error-500)]'
-                : 'bg-[var(--color-warning-500)]'
-          "
+          :class="tick.status === 'up' ? 'bg-[var(--color-success-500)]' : tick.status === 'down' ? 'bg-[var(--color-error-500)]' : 'bg-[var(--color-warning-500)]'"
           @mouseenter="showSparkTip($event, tick)"
           @mouseleave="hideSparkTip"
         />
@@ -119,15 +115,8 @@
       <span
         v-if="(row as any).responseTime"
         class="font-mono text-sm font-semibold"
-        :class="
-          parseFloat((row as any).responseTime) < 300
-            ? 'text-[var(--color-success-600)]'
-            : parseFloat((row as any).responseTime) < 1000
-              ? 'text-[var(--color-warning-600)]'
-              : 'text-[var(--color-error-600)]'
-        "
-        >{{ (row as any).responseTime }}</span
-      >
+        :class="parseFloat((row as any).responseTime) < 300 ? 'text-[var(--color-success-600)]' : parseFloat((row as any).responseTime) < 1000 ? 'text-[var(--color-warning-600)]' : 'text-[var(--color-error-600)]'"
+      >{{ (row as any).responseTime }}</span>
       <span v-else class="text-sm">—</span>
     </template>
 
@@ -137,58 +126,43 @@
         <div class="flex items-center justify-end gap-2">
           <OProgressBar
             :value="(row as any).uptime / 100"
-            :variant="
-              (row as any).uptime >= 99
-                ? 'default'
-                : (row as any).uptime >= 95
-                  ? 'warning'
-                  : 'danger'
-            "
+            :variant="(row as any).uptime >= 99 ? 'default' : (row as any).uptime >= 95 ? 'warning' : 'danger'"
             size="xs"
             class="flex-1"
           />
           <span
-            :class="
-              'min-w-11 text-right font-mono text-sm text-xs font-semibold ' +
-              ((row as any).uptime >= 99
-                ? 'text-[var(--color-success-600)]'
-                : (row as any).uptime >= 95
-                  ? 'text-[var(--color-warning-600)]'
-                  : 'text-[var(--color-error-600)]')
-            "
-            >{{ (row as any).uptime }}%</span
-          >
+            :class="'font-mono text-sm font-semibold min-w-11 text-right text-xs '
+              + ((row as any).uptime >= 99 ? 'text-[var(--color-success-600)]' : (row as any).uptime >= 95 ? 'text-[var(--color-warning-600)]' : 'text-[var(--color-error-600)]')"
+          >{{ (row as any).uptime }}%</span>
         </div>
       </template>
-      <span v-else class="text-text-secondary text-xs">—</span>
+      <span v-else class="text-xs text-text-secondary">—</span>
     </template>
 
     <!-- Locations with tooltip (monitors mode) -->
     <template #cell-locations="{ row }">
-      <div
-        class="flex cursor-default items-center gap-1"
-        @mouseenter="showLoc($event, (row as any).locations)"
-        @mouseleave="hideLoc"
+      <OTooltip
+        v-if="(row as any).locations?.length"
+        :content="formatLocationsList((row as any).locations)"
+        content-class="max-w-[20rem] whitespace-pre-wrap text-xs"
+        :delay="0"
       >
-        <span class="max-w-[4.375rem] truncate text-xs">{{
-          locationLabel((row as any).locations[0])
-        }}</span>
-        <span
-          v-if="(row as any).locations.length > 1"
-          class="rounded-default shrink-0 bg-[var(--color-surface-subtle)] px-1 py-0.5 text-xs font-bold whitespace-nowrap"
-          >+{{ (row as any).locations.length - 1 }}</span
-        >
-      </div>
+        <div class="flex items-center gap-1 cursor-help">
+          <span class="text-xs truncate max-w-[4.375rem]">{{ locationLabel((row as any).locations[0]) }}</span>
+          <span v-if="(row as any).locations.length > 1" class="text-xs font-bold px-1 py-0.5 rounded-default bg-[var(--color-surface-subtle)] whitespace-nowrap shrink-0">+{{ (row as any).locations.length - 1 }}</span>
+        </div>
+      </OTooltip>
+      <span v-else class="text-xs">—</span>
     </template>
 
     <!-- Interval (monitors mode) -->
     <template #cell-interval="{ row }">
-      <span class="truncate">{{ (row as any).interval || "—" }}</span>
+      <span class="truncate">{{ (row as any).interval || '—' }}</span>
     </template>
 
     <!-- Last check -->
     <template #cell-lastCheck="{ row }">
-      <span class="truncate">{{ (row as any).lastCheck || "—" }}</span>
+      <span class="truncate">{{ (row as any).lastCheck || '—' }}</span>
     </template>
 
     <!-- Row actions -->
@@ -197,16 +171,11 @@
         <!-- Enable/Pause toggle with per-row spinner -->
         <div
           v-if="props.toggleLoadingMap[(row as any).id]"
-          class="flex h-8 w-7 items-center justify-center"
+          class="flex items-center justify-center w-7 h-8"
           :data-test="`${dataTest}-toggle-spinner`"
         >
           <OSpinner size="xs" />
-          <OTooltip
-            side="bottom"
-            :content="
-              (row as any).enabled ? t('synthetics.table.pausing') : t('synthetics.table.enabling')
-            "
-          />
+          <OTooltip side="bottom" :content="(row as any).enabled ? t('synthetics.table.pausing') : t('synthetics.table.enabling')" />
         </div>
         <OButton
           v-else
@@ -216,12 +185,7 @@
           :data-test="`${dataTest}-${(row as any).enabled ? 'pause' : 'enable'}-btn`"
           @click.stop="emit('toggle-enabled', row)"
         >
-          <OTooltip
-            side="bottom"
-            :content="
-              (row as any).enabled ? t('synthetics.table.pause') : t('synthetics.table.enable')
-            "
-          />
+          <OTooltip side="bottom" :content="(row as any).enabled ? t('synthetics.table.pause') : t('synthetics.table.enable')" />
         </OButton>
 
         <!-- Edit -->
@@ -252,7 +216,7 @@
             <!-- Show spinner when trigger is in flight for this row -->
             <div
               v-if="props.triggerLoadingMap[(row as any).id]"
-              class="flex h-8 w-7 items-center justify-center"
+              class="flex items-center justify-center w-7 h-8"
               :data-test="`${dataTest}-trigger-spinner`"
             >
               <OSpinner size="xs" />
@@ -270,11 +234,14 @@
             </OButton>
           </template>
 
-          <ODropdownItem :data-test="`${dataTest}-move-item`" @select="emit('move', row)">
+          <ODropdownItem
+            :data-test="`${dataTest}-move-item`"
+            @select="emit('move', row)"
+          >
             <template #icon-left>
               <OIcon name="drive-file-move" size="sm" />
             </template>
-            {{ t("synthetics.table.move") }}
+            {{ t('synthetics.table.move') }}
           </ODropdownItem>
 
           <ODropdownSeparator />
@@ -288,7 +255,7 @@
             <template #icon-left>
               <OIcon name="delete" size="sm" />
             </template>
-            {{ t("synthetics.table.delete") }}
+            {{ t('synthetics.table.delete') }}
           </ODropdownItem>
 
           <ODropdownSeparator />
@@ -301,7 +268,7 @@
             <template #icon-left>
               <OIcon name="sound-sampler" size="sm" />
             </template>
-            {{ t("synthetics.table.trigger") }}
+            {{ t('synthetics.table.trigger') }}
           </ODropdownItem>
         </ODropdown>
       </div>
@@ -316,25 +283,15 @@
         columns
         :description="t('synthetics.table.noResults')"
         :data-test="`${dataTest}-empty-state`"
-        @action="
-          (id?: string) => {
-            if (!id) return;
-            emit('empty-action', id);
-          }
-        "
+        @action="(id?: string) => { if (!id) return; emit('empty-action', id); }"
       />
     </template>
 
     <!-- Footer with count + bulk action buttons -->
     <template #bottom>
-      <div class="flex h-12 w-full items-center justify-between gap-1">
-        <span class="text-secondary min-w-25 text-xs">
-          <template v-if="localSelectedIds.length > 0">{{
-            t("synthetics.table.selectedCount", {
-              selected: localSelectedIds.length,
-              total: data.length,
-            })
-          }}</template>
+      <div class="flex w-full justify-between items-center h-12 gap-1">
+        <span class="text-xs text-secondary min-w-25">
+          <template v-if="localSelectedIds.length > 0">{{ t('synthetics.table.selectedCount', { selected: localSelectedIds.length, total: data.length }) }}</template>
           <template v-else>{{ data.length }} {{ footerTitle }}</template>
         </span>
         <template v-if="localSelectedIds.length > 0">
@@ -345,8 +302,7 @@
             :data-test="`${dataTest}-pause-selected-btn`"
             :disabled="!!props.bulkActionLoading"
             @click="emit('pause-selected')"
-            >{{ t("synthetics.table.pause") }}</OButton
-          >
+          >{{ t('synthetics.table.pause') }}</OButton>
           <OButton
             variant="outline"
             size="sm"
@@ -354,8 +310,7 @@
             :data-test="`${dataTest}-enable-selected-btn`"
             :disabled="!!props.bulkActionLoading"
             @click="emit('enable-selected')"
-            >{{ t("synthetics.table.enable") }}</OButton
-          >
+          >{{ t('synthetics.table.enable') }}</OButton>
           <OButton
             variant="outline"
             size="sm"
@@ -363,16 +318,14 @@
             :data-test="`${dataTest}-trigger-selected-btn`"
             :disabled="!!props.bulkActionLoading"
             @click="emit('trigger-selected')"
-            >{{ t("synthetics.table.trigger") }}</OButton
-          >
+          >{{ t('synthetics.table.trigger') }}</OButton>
           <OButton
             variant="outline"
             size="sm"
             icon-left="drive-file-move"
             :data-test="`${dataTest}-move-selected-btn`"
             @click="emit('move-selected')"
-            >{{ t("synthetics.table.move") }}</OButton
-          >
+          >{{ t('synthetics.table.move') }}</OButton>
           <OButton
             variant="outline-destructive"
             size="sm"
@@ -380,25 +333,11 @@
             :data-test="`${dataTest}-delete-selected-btn`"
             :loading="!!props.bulkActionLoading"
             @click="emit('delete-selected')"
-            >{{ t("synthetics.table.delete") }}</OButton
-          >
+          >{{ t('synthetics.table.delete') }}</OButton>
         </template>
       </div>
     </template>
   </OTable>
-
-  <!-- Locations tooltip -->
-  <Teleport to="body">
-    <div
-      v-if="locTip.show"
-      class="loc-float-tip"
-      :style="{ left: locTip.x + 'px', top: locTip.y + 'px' }"
-    >
-      <div v-for="l in locTip.locs" :key="l" class="loc-float-item">
-        <span class="loc-float-dot" />{{ locationLabel(l) }}
-      </div>
-    </div>
-  </Teleport>
 
   <!-- Spark bar detail tooltip -->
   <Teleport to="body">
@@ -412,13 +351,7 @@
       <div class="stt-header">
         <span class="stt-time">{{ sparkTip.tick.hour }} – {{ sparkTip.tick.nextHour }}</span>
         <span class="stt-badge" :class="'stt-badge--' + sparkTip.tick.status">
-          {{
-            sparkTip.tick.status === "up"
-              ? t("synthetics.table.statusUp")
-              : sparkTip.tick.status === "down"
-                ? t("synthetics.table.statusDown")
-                : t("synthetics.table.statusDegraded")
-          }}
+          {{ sparkTip.tick.status === 'up' ? t('synthetics.table.statusUp') : sparkTip.tick.status === 'down' ? t('synthetics.table.statusDown') : t('synthetics.table.statusDegraded') }}
         </span>
       </div>
       <div class="stt-divider" />
@@ -426,379 +359,227 @@
         <div v-for="c in sparkTip.tick.checks" :key="c.loc" class="stt-check">
           <span class="stt-dot" :class="c.ok ? 'stt-dot--up' : 'stt-dot--down'" />
           <span class="stt-loc">{{ c.loc }}</span>
-          <span class="stt-ms">{{
-            c.ms !== null ? c.ms + t("synthetics.table.ms") : t("synthetics.table.timeout")
-          }}</span>
+          <span class="stt-ms">{{ c.ms !== null ? c.ms + t('synthetics.table.ms') : t('synthetics.table.timeout') }}</span>
         </div>
       </div>
-      <div v-if="sparkTip.tick.avgMs !== null" class="stt-avg">
-        {{ t("synthetics.table.avg") }} · {{ sparkTip.tick.avgMs }}{{ t("synthetics.table.ms") }}
-      </div>
+      <div v-if="sparkTip.tick.avgMs !== null" class="stt-avg">{{ t('synthetics.table.avg') }} · {{ sparkTip.tick.avgMs }}{{ t('synthetics.table.ms') }}</div>
       <div class="stt-arrow" />
     </div>
   </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, onUnmounted, ref } from "vue";
-import { useI18n } from "vue-i18n";
-import OTable from "@/lib/core/Table/OTable.vue";
-import type { OTableColumnDef } from "@/lib/core/Table/OTable.types";
-import { COL } from "@/lib/core/Table/OTable.types";
-import OButton from "@/lib/core/Button/OButton.vue";
-import OIcon from "@/lib/core/Icon/OIcon.vue";
-import OBadge from "@/lib/core/Badge/OBadge.vue";
-import OProgressBar from "@/lib/data/ProgressBar/OProgressBar.vue";
-import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
-import ODropdown from "@/lib/overlay/Dropdown/ODropdown.vue";
-import ODropdownItem from "@/lib/overlay/Dropdown/ODropdownItem.vue";
-import ODropdownSeparator from "@/lib/overlay/Dropdown/ODropdownSeparator.vue";
-import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
-import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
-import { resolveBadge } from "@/lib/core/Badge/badgeGroups";
+import { computed, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import OTable from '@/lib/core/Table/OTable.vue'
+import type { OTableColumnDef } from '@/lib/core/Table/OTable.types'
+import { COL } from '@/lib/core/Table/OTable.types'
+import OButton from '@/lib/core/Button/OButton.vue'
+import OIcon from '@/lib/core/Icon/OIcon.vue'
+import OBadge from '@/lib/core/Badge/OBadge.vue'
+import OProgressBar from '@/lib/data/ProgressBar/OProgressBar.vue'
+import OSpinner from '@/lib/feedback/Spinner/OSpinner.vue'
+import ODropdown from '@/lib/overlay/Dropdown/ODropdown.vue'
+import ODropdownItem from '@/lib/overlay/Dropdown/ODropdownItem.vue'
+import ODropdownSeparator from '@/lib/overlay/Dropdown/ODropdownSeparator.vue'
+import OTooltip from '@/lib/overlay/Tooltip/OTooltip.vue'
+import OEmptyState from '@/lib/core/EmptyState/OEmptyState.vue'
+import { resolveBadge } from '@/lib/core/Badge/badgeGroups'
 
-type Mode = "all" | "browser";
+type Mode = 'all' | 'browser'
 
-const props = withDefaults(
-  defineProps<{
-    mode: Mode;
-    data: any[];
-    loading?: boolean;
-    footerTitle?: string;
-    emptyMessage?: string;
-    dataTest?: string;
-    toggleLoadingMap?: Record<string, boolean>;
-    triggerLoadingMap?: Record<string, boolean>;
-    selectedIds?: string[];
-    showFolderColumn?: boolean;
-    bulkActionLoading?: boolean;
-    hasFilters?: boolean;
-    /** location id -> "Name (region)", for resolving `check.locations` ids to a
-     *  human label. Falls back to the raw id when a location isn't in the map
-     *  (e.g. deleted since the check last ran). */
-    locationNames?: Record<string, string>;
-  }>(),
-  {
-    loading: false,
-    footerTitle: "Checks",
-    emptyMessage: "No results found.",
-    dataTest: "monitor-table",
-    toggleLoadingMap: () => ({}),
-    triggerLoadingMap: () => ({}),
-    selectedIds: () => [],
-    showFolderColumn: false,
-    bulkActionLoading: false,
-    hasFilters: false,
-    locationNames: () => ({}),
-  },
-);
+const props = withDefaults(defineProps<{
+  mode: Mode
+  data: any[]
+  loading?: boolean
+  footerTitle?: string
+  emptyMessage?: string
+  dataTest?: string
+  toggleLoadingMap?: Record<string, boolean>
+  triggerLoadingMap?: Record<string, boolean>
+  selectedIds?: string[]
+  showFolderColumn?: boolean
+  bulkActionLoading?: boolean
+  hasFilters?: boolean
+  /** location id -> "Name (region)", for resolving `check.locations` ids to a
+   *  human label. Falls back to the raw id when a location isn't in the map
+   *  (e.g. deleted since the check last ran). */
+  locationNames?: Record<string, string>
+}>(), {
+  loading: false,
+  footerTitle: 'Checks',
+  emptyMessage: 'No results found.',
+  dataTest: 'monitor-table',
+  toggleLoadingMap: () => ({}),
+  triggerLoadingMap: () => ({}),
+  selectedIds: () => [],
+  showFolderColumn: false,
+  bulkActionLoading: false,
+  hasFilters: false,
+  locationNames: () => ({}),
+})
 
 function locationLabel(id: string): string {
-  return props.locationNames[id] ?? id;
+  return props.locationNames[id] ?? id
 }
 
 const emit = defineEmits<{
-  "row-click": [row: any];
-  edit: [row: any];
-  "toggle-enabled": [row: any];
-  duplicate: [row: any];
-  run: [row: any];
-  delete: [row: any];
-  move: [row: any];
-  "update:selectedIds": [ids: string[]];
-  "delete-selected": [];
-  "move-selected": [];
-  "pause-selected": [];
-  "enable-selected": [];
-  "trigger-selected": [];
-  "navigate-to-folder": [folderId: string];
-  "empty-action": [actionId: string];
-}>();
+  'row-click': [row: any]
+  'edit': [row: any]
+  'toggle-enabled': [row: any]
+  'duplicate': [row: any]
+  'run': [row: any]
+  'delete': [row: any]
+  'move': [row: any]
+  'update:selectedIds': [ids: string[]]
+  'delete-selected': []
+  'move-selected': []
+  'pause-selected': []
+  'enable-selected': []
+  'trigger-selected': []
+  'navigate-to-folder': [folderId: string]
+  'empty-action': [actionId: string]
+}>()
 
-const { t } = useI18n();
+const { t } = useI18n()
 
 const localSelectedIds = computed({
   get: () => props.selectedIds ?? [],
-  set: (val: string[]) => emit("update:selectedIds", val),
-});
+  set: (val: string[]) => emit('update:selectedIds', val),
+})
 
 // ── Column definitions per mode ─────────────────────────────────────
 
 const STATUS_COL: OTableColumnDef = {
-  id: "status",
-  header: t("synthetics.table.status"),
-  accessorKey: "status",
-  size: COL.status,
-  minSize: 72,
-  sortable: true,
-  meta: { align: "left" },
-};
+  id: 'status', header: t('synthetics.table.status'), accessorKey: 'status',
+  size: COL.status, minSize: 72, sortable: true,
+  meta: { align: 'left' },
+}
 const NAME_COL: OTableColumnDef = {
-  id: "name",
-  header: t("synthetics.table.check"),
-  accessorKey: "name",
-  size: COL.name,
-  minSize: 120,
-  sortable: true,
-  hideable: true,
+  id: 'name', header: t('synthetics.table.check'), accessorKey: 'name',
+  size: COL.name, minSize: 120, sortable: true, hideable: true,
   meta: { isName: true, flex: true },
-};
+}
 const TEST_NAME_COL: OTableColumnDef = {
-  id: "name",
-  header: t("synthetics.table.testName"),
-  accessorKey: "name",
-  size: COL.name,
-  minSize: 120,
-  sortable: true,
-  hideable: true,
+  id: 'name', header: t('synthetics.table.testName'), accessorKey: 'name',
+  size: COL.name, minSize: 120, sortable: true, hideable: true,
   meta: { isName: true, flex: true },
-};
+}
 const URL_COL: OTableColumnDef = {
-  id: "url",
-  header: t("synthetics.table.url"),
-  accessorKey: "url",
-  size: COL.url,
-  minSize: 140,
-  sortable: false,
-  hideable: true,
-};
+  id: 'url', header: t('synthetics.table.url'), accessorKey: 'url',
+  size: COL.url, minSize: 140, sortable: false, hideable: true,
+}
 const ENDPOINT_COL: OTableColumnDef = {
-  id: "url",
-  header: t("synthetics.table.endpoint"),
-  accessorKey: "url",
-  size: COL.url,
-  minSize: 140,
-  sortable: false,
-  hideable: true,
-};
+  id: 'url', header: t('synthetics.table.endpoint'), accessorKey: 'url',
+  size: COL.url, minSize: 140, sortable: false, hideable: true,
+}
 const TYPE_COL: OTableColumnDef = {
-  id: "type",
-  header: t("synthetics.table.type"),
-  accessorKey: "type",
-  size: COL.type,
-  minSize: 72,
-  sortable: true,
-  hideable: true,
-};
+  id: 'type', header: t('synthetics.table.type'), accessorKey: 'type',
+  size: COL.type, minSize: 72, sortable: true, hideable: true,
+}
 const HISTORY_COL: OTableColumnDef = {
-  id: "history",
-  header: t("synthetics.table.history"),
-  accessorKey: "history",
-  size: COL.history,
-  minSize: 140,
-  sortable: false,
-  hideable: true,
-};
+  id: 'history', header: t('synthetics.table.history'), accessorKey: 'history',
+  size: COL.history, minSize: 140, sortable: false, hideable: true,
+}
 const RESPONSE_TIME_COL: OTableColumnDef = {
-  id: "responseTime",
-  header: t("synthetics.table.response"),
-  accessorKey: "responseTime",
-  size: COL.responseTime,
-  minSize: 72,
-  sortable: true,
-  meta: { align: "right" },
-  hideable: true,
-};
+  id: 'responseTime', header: t('synthetics.table.response'), accessorKey: 'responseTime',
+  size: COL.responseTime, minSize: 72, sortable: true, meta: { align: 'right' }, hideable: true,
+}
 const PAGE_LOAD_COL: OTableColumnDef = {
-  id: "responseTime",
-  header: t("synthetics.table.pageLoad"),
-  accessorKey: "responseTime",
-  size: COL.responseTime,
-  minSize: 80,
-  sortable: true,
-  meta: { align: "right" },
-  hideable: true,
-};
+  id: 'responseTime', header: t('synthetics.table.pageLoad'), accessorKey: 'responseTime',
+  size: COL.responseTime, minSize: 80, sortable: true, meta: { align: 'right' }, hideable: true,
+}
 const P50_COL: OTableColumnDef = {
-  id: "responseTime",
-  header: t("synthetics.table.p50"),
-  accessorKey: "responseTime",
-  size: COL.responseTime,
-  minSize: 64,
-  sortable: true,
-  meta: { align: "right" },
-  hideable: true,
-};
+  id: 'responseTime', header: t('synthetics.table.p50'), accessorKey: 'responseTime',
+  size: COL.responseTime, minSize: 64, sortable: true, meta: { align: 'right' }, hideable: true,
+}
 const UPTIME_COL: OTableColumnDef = {
-  id: "uptime",
-  header: t("synthetics.table.uptime"),
-  accessorKey: "uptime",
-  size: COL.uptime,
-  minSize: 100,
-  sortable: true,
-  meta: { align: "right" },
-  hideable: true,
-};
+  id: 'uptime', header: t('synthetics.table.uptime'), accessorKey: 'uptime',
+  size: COL.uptime, minSize: 100, sortable: true, meta: { align: 'right' }, hideable: true,
+}
 const LOCATIONS_COL: OTableColumnDef = {
-  id: "locations",
-  header: t("synthetics.table.locations"),
-  accessorKey: "locations",
-  size: COL.locations,
-  minSize: 90,
-  sortable: false,
-  hideable: true,
-};
+  id: 'locations', header: t('synthetics.table.locations'), accessorKey: 'locations',
+  size: COL.locations, minSize: 90, sortable: false, hideable: true,
+}
 const INTERVAL_COL: OTableColumnDef = {
-  id: "interval",
-  header: t("synthetics.table.interval"),
-  accessorKey: "interval",
-  size: COL.interval,
-  minSize: 60,
-  sortable: false,
-  hideable: true,
-};
+  id: 'interval', header: t('synthetics.table.interval'), accessorKey: 'interval',
+  size: COL.interval, minSize: 60, sortable: false, hideable: true,
+}
 const LAST_CHECK_COL: OTableColumnDef = {
-  id: "lastCheck",
-  header: t("synthetics.table.lastCheck"),
-  accessorKey: "lastCheck",
-  size: COL.lastCheck,
-  minSize: 72,
-  sortable: false,
-  hideable: true,
-};
+  id: 'lastCheck', header: t('synthetics.table.lastCheck'), accessorKey: 'lastCheck',
+  size: COL.lastCheck, minSize: 72, sortable: false, hideable: true,
+}
 const LAST_RUN_COL: OTableColumnDef = {
-  id: "lastCheck",
-  header: t("synthetics.table.lastCheck"),
-  accessorKey: "lastCheck",
-  size: COL.lastCheck,
-  minSize: 72,
-  sortable: false,
-  hideable: true,
-};
+  id: 'lastCheck', header: t('synthetics.table.lastCheck'), accessorKey: 'lastCheck',
+  size: COL.lastCheck, minSize: 72, sortable: false, hideable: true,
+}
 const STEPS_COL: OTableColumnDef = {
-  id: "steps",
-  header: t("synthetics.table.steps"),
-  accessorKey: "steps",
-  size: COL.steps,
-  minSize: 60,
-  sortable: false,
-  hideable: true,
-};
+  id: 'steps', header: t('synthetics.table.steps'), accessorKey: 'steps',
+  size: COL.steps, minSize: 60, sortable: false, hideable: true,
+}
 const METHOD_COL: OTableColumnDef = {
-  id: "method",
-  header: t("synthetics.table.method"),
-  accessorKey: "method",
-  size: COL.method,
-  minSize: 56,
-  sortable: false,
-  hideable: true,
-};
+  id: 'method', header: t('synthetics.table.method'), accessorKey: 'method',
+  size: COL.method, minSize: 56, sortable: false, hideable: true,
+}
 const ASSERTIONS_COL: OTableColumnDef = {
-  id: "assertions",
-  header: t("synthetics.table.assertions"),
-  accessorKey: "assertions",
-  size: COL.assertions,
-  minSize: 72,
-  sortable: false,
-  hideable: true,
-};
+  id: 'assertions', header: t('synthetics.table.assertions'), accessorKey: 'assertions',
+  size: COL.assertions, minSize: 72, sortable: false, hideable: true,
+}
 const ACTIONS_COL: OTableColumnDef = {
-  id: "actions",
-  header: "",
-  accessorKey: "id",
-  size: 160,
-  minSize: 160,
-  sortable: false,
-  isAction: true,
-};
+  id: 'actions', header: '', accessorKey: 'id',
+  size: 160, minSize: 160, sortable: false, isAction: true,
+}
 const FOLDER_COL: OTableColumnDef = {
-  id: "folder_name",
-  header: t("synthetics.table.folder"),
-  accessorKey: "folder_name",
-  size: COL.folder,
-  minSize: 90,
-  sortable: true,
-  hideable: true,
-};
+  id: 'folder_name', header: t('synthetics.table.folder'), accessorKey: 'folder_name',
+  size: COL.folder, minSize: 90, sortable: true, hideable: true,
+}
 
 const columns = computed<OTableColumnDef[]>(() => {
-  let cols: OTableColumnDef[];
-  if (props.mode === "browser") {
-    cols = [
-      TEST_NAME_COL,
-      URL_COL,
-      STEPS_COL,
-      HISTORY_COL,
-      PAGE_LOAD_COL,
-      UPTIME_COL,
-      LAST_RUN_COL,
-      STATUS_COL,
-      ACTIONS_COL,
-    ];
+  let cols: OTableColumnDef[]
+  if (props.mode === 'browser') {
+    cols = [TEST_NAME_COL, URL_COL, STEPS_COL, HISTORY_COL, PAGE_LOAD_COL, UPTIME_COL, LAST_RUN_COL, STATUS_COL, ACTIONS_COL]
   } else {
-    cols = [
-      NAME_COL,
-      URL_COL,
-      TYPE_COL,
-      STATUS_COL,
-      RESPONSE_TIME_COL,
-      LOCATIONS_COL,
-      INTERVAL_COL,
-      LAST_CHECK_COL,
-      ACTIONS_COL,
-    ];
+    cols = [NAME_COL, URL_COL, TYPE_COL, STATUS_COL, RESPONSE_TIME_COL, LOCATIONS_COL, INTERVAL_COL, LAST_CHECK_COL, ACTIONS_COL]
   }
   if (props.showFolderColumn) {
-    const nameIdx = cols.findIndex((c) => c.id === "name");
-    cols.splice(nameIdx + 1, 0, FOLDER_COL);
+    const nameIdx = cols.findIndex(c => c.id === 'name')
+    cols.splice(nameIdx + 1, 0, FOLDER_COL)
   }
-  return cols;
-});
+  return cols
+})
 
-// ── Locations tooltip ─────────────────────────────────────────────────
-
-const locTip = ref({ show: false, x: 0, y: 0, locs: [] as string[] });
-let locHideTimer: ReturnType<typeof setTimeout> | null = null;
-
-const showLoc = (e: MouseEvent, locs: string[]) => {
-  if (locHideTimer) {
-    clearTimeout(locHideTimer);
-    locHideTimer = null;
-  }
-  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-  locTip.value = { show: true, x: rect.left, y: rect.bottom + 6, locs };
-};
-const hideLoc = () => {
-  locHideTimer = setTimeout(() => {
-    locTip.value.show = false;
-  }, 120);
-};
+function formatLocationsList(locations: string[]): string {
+  return locations.map(l => locationLabel(l)).join('\n')
+}
 
 // ── Spark tooltip ─────────────────────────────────────────────────────
 
 interface HistoryTick {
-  hour: string;
-  nextHour: string;
-  status: "up" | "down" | "deg";
-  avgMs: number | null;
-  checks: { loc: string; ok: boolean; ms: number | null }[];
+  hour: string
+  nextHour: string
+  status: 'up' | 'down' | 'deg'
+  avgMs: number | null
+  checks: { loc: string; ok: boolean; ms: number | null }[]
 }
 
-const sparkTip = ref({ show: false, x: 0, y: 0, tick: null as HistoryTick | null });
-let sparkHideTimer: ReturnType<typeof setTimeout> | null = null;
+const sparkTip = ref({ show: false, x: 0, y: 0, tick: null as HistoryTick | null })
+let sparkHideTimer: ReturnType<typeof setTimeout> | null = null
 
 const showSparkTip = (e: MouseEvent, tick: HistoryTick) => {
-  if (sparkHideTimer) {
-    clearTimeout(sparkHideTimer);
-    sparkHideTimer = null;
-  }
-  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-  sparkTip.value = { show: true, x: rect.left + rect.width / 2, y: rect.top - 10, tick };
-};
+  if (sparkHideTimer) { clearTimeout(sparkHideTimer); sparkHideTimer = null }
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+  sparkTip.value = { show: true, x: rect.left + rect.width / 2, y: rect.top - 10, tick }
+}
 const hideSparkTip = () => {
-  sparkHideTimer = setTimeout(() => {
-    sparkTip.value.show = false;
-  }, 80);
-};
+  sparkHideTimer = setTimeout(() => { sparkTip.value.show = false }, 80)
+}
 const keepSparkTip = () => {
-  if (sparkHideTimer) {
-    clearTimeout(sparkHideTimer);
-    sparkHideTimer = null;
-  }
-};
+  if (sparkHideTimer) { clearTimeout(sparkHideTimer); sparkHideTimer = null }
+}
 
 onUnmounted(() => {
-  if (locHideTimer) clearTimeout(locHideTimer);
-  if (sparkHideTimer) clearTimeout(sparkHideTimer);
-});
+  if (sparkHideTimer) clearTimeout(sparkHideTimer)
+})
+
+
 </script>

--- a/web/src/components/synthetic-monitoring/MonitorTable.vue
+++ b/web/src/components/synthetic-monitoring/MonitorTable.vue
@@ -31,8 +31,12 @@
 
     <!-- Status badge -->
     <template #cell-status="{ row }">
-      <OBadge :variant="resolveBadge('serviceStatus', (row as any).status).variant" :dot="true" size="sm">
-        {{ resolveBadge('serviceStatus', (row as any).status).label }}
+      <OBadge
+        :variant="resolveBadge('serviceStatus', (row as any).status).variant"
+        :dot="true"
+        size="sm"
+      >
+        {{ resolveBadge("serviceStatus", (row as any).status).label }}
       </OBadge>
     </template>
 
@@ -43,8 +47,8 @@
         :content="(row as any).name"
         content-class="max-w-[25rem] whitespace-normal break-words text-xs"
       >
-        <div class="flex items-center gap-1.5 min-w-0 overflow-hidden">
-          <span class="truncate cursor-help">{{ (row as any).name || '—' }}</span>
+        <div class="flex min-w-0 items-center gap-1.5 overflow-hidden">
+          <span class="cursor-help truncate">{{ (row as any).name || "—" }}</span>
         </div>
       </OTooltip>
       <span v-else class="truncate">—</span>
@@ -57,7 +61,7 @@
         :content="(row as any).url"
         content-class="max-w-[25rem] whitespace-normal break-words text-xs"
       >
-        <span class="truncate cursor-help">{{ (row as any).url }}</span>
+        <span class="cursor-help truncate">{{ (row as any).url }}</span>
       </OTooltip>
       <span v-else class="truncate">—</span>
     </template>
@@ -71,28 +75,31 @@
 
     <!-- Steps count (Browser mode) -->
     <template #cell-steps="{ row }">
-      <span class="truncate">{{ (row as any).steps ? `${(row as any).steps} ${t('synthetics.table.stepsSuffix')}` : '—' }}</span>
+      <span class="truncate">{{
+        (row as any).steps ? `${(row as any).steps} ${t("synthetics.table.stepsSuffix")}` : "—"
+      }}</span>
     </template>
 
     <!-- Assertions count (API mode) -->
     <template #cell-assertions="{ row }">
-      <span class="truncate">{{ (row as any).assertions ? `${(row as any).assertions} ${t('synthetics.table.checksSuffix')}` : '—' }}</span>
+      <span class="truncate">{{
+        (row as any).assertions
+          ? `${(row as any).assertions} ${t("synthetics.table.checksSuffix")}`
+          : "—"
+      }}</span>
     </template>
 
     <!-- Folder name (cross-folder search mode) — click navigates sidebar to that folder -->
     <template #cell-folder_name="{ row }">
-      <div
-        class="cursor-pointer"
-        @click.stop="emit('navigate-to-folder', (row as any).folderId)"
-      >
-        {{ (row as any).folder_name || '—' }}
+      <div class="cursor-pointer" @click.stop="emit('navigate-to-folder', (row as any).folderId)">
+        {{ (row as any).folder_name || "—" }}
       </div>
     </template>
 
     <!-- Type badge (monitors mode) -->
     <template #cell-type="{ row }">
       <OBadge :variant="resolveBadge('syntheticType', (row as any).type).variant" size="sm">
-        {{ resolveBadge('syntheticType', (row as any).type).label }}
+        {{ resolveBadge("syntheticType", (row as any).type).label }}
       </OBadge>
     </template>
 
@@ -103,7 +110,13 @@
           v-for="(tick, i) in (row as any).history"
           :key="i"
           class="spark-bar"
-          :class="tick.status === 'up' ? 'bg-[var(--color-success-500)]' : tick.status === 'down' ? 'bg-[var(--color-error-500)]' : 'bg-[var(--color-warning-500)]'"
+          :class="
+            tick.status === 'up'
+              ? 'bg-[var(--color-success-500)]'
+              : tick.status === 'down'
+                ? 'bg-[var(--color-error-500)]'
+                : 'bg-[var(--color-warning-500)]'
+          "
           @mouseenter="showSparkTip($event, tick)"
           @mouseleave="hideSparkTip"
         />
@@ -115,8 +128,15 @@
       <span
         v-if="(row as any).responseTime"
         class="font-mono text-sm font-semibold"
-        :class="parseFloat((row as any).responseTime) < 300 ? 'text-[var(--color-success-600)]' : parseFloat((row as any).responseTime) < 1000 ? 'text-[var(--color-warning-600)]' : 'text-[var(--color-error-600)]'"
-      >{{ (row as any).responseTime }}</span>
+        :class="
+          parseFloat((row as any).responseTime) < 300
+            ? 'text-[var(--color-success-600)]'
+            : parseFloat((row as any).responseTime) < 1000
+              ? 'text-[var(--color-warning-600)]'
+              : 'text-[var(--color-error-600)]'
+        "
+        >{{ (row as any).responseTime }}</span
+      >
       <span v-else class="text-sm">—</span>
     </template>
 
@@ -126,17 +146,30 @@
         <div class="flex items-center justify-end gap-2">
           <OProgressBar
             :value="(row as any).uptime / 100"
-            :variant="(row as any).uptime >= 99 ? 'default' : (row as any).uptime >= 95 ? 'warning' : 'danger'"
+            :variant="
+              (row as any).uptime >= 99
+                ? 'default'
+                : (row as any).uptime >= 95
+                  ? 'warning'
+                  : 'danger'
+            "
             size="xs"
             class="flex-1"
           />
           <span
-            :class="'font-mono text-sm font-semibold min-w-11 text-right text-xs '
-              + ((row as any).uptime >= 99 ? 'text-[var(--color-success-600)]' : (row as any).uptime >= 95 ? 'text-[var(--color-warning-600)]' : 'text-[var(--color-error-600)]')"
-          >{{ (row as any).uptime }}%</span>
+            :class="
+              'min-w-11 text-right font-mono text-sm text-xs font-semibold ' +
+              ((row as any).uptime >= 99
+                ? 'text-[var(--color-success-600)]'
+                : (row as any).uptime >= 95
+                  ? 'text-[var(--color-warning-600)]'
+                  : 'text-[var(--color-error-600)]')
+            "
+            >{{ (row as any).uptime }}%</span
+          >
         </div>
       </template>
-      <span v-else class="text-xs text-text-secondary">—</span>
+      <span v-else class="text-text-secondary text-xs">—</span>
     </template>
 
     <!-- Locations with tooltip (monitors mode) -->
@@ -147,9 +180,15 @@
         content-class="max-w-[20rem] whitespace-pre-wrap text-xs"
         :delay="0"
       >
-        <div class="flex items-center gap-1 cursor-help">
-          <span class="text-xs truncate max-w-[4.375rem]">{{ locationLabel((row as any).locations[0]) }}</span>
-          <span v-if="(row as any).locations.length > 1" class="text-xs font-bold px-1 py-0.5 rounded-default bg-[var(--color-surface-subtle)] whitespace-nowrap shrink-0">+{{ (row as any).locations.length - 1 }}</span>
+        <div class="flex cursor-help items-center gap-1">
+          <span class="max-w-[4.375rem] truncate text-xs">{{
+            locationLabel((row as any).locations[0])
+          }}</span>
+          <span
+            v-if="(row as any).locations.length > 1"
+            class="rounded-default shrink-0 bg-[var(--color-surface-subtle)] px-1 py-0.5 text-xs font-bold whitespace-nowrap"
+            >+{{ (row as any).locations.length - 1 }}</span
+          >
         </div>
       </OTooltip>
       <span v-else class="text-xs">—</span>
@@ -157,12 +196,12 @@
 
     <!-- Interval (monitors mode) -->
     <template #cell-interval="{ row }">
-      <span class="truncate">{{ (row as any).interval || '—' }}</span>
+      <span class="truncate">{{ (row as any).interval || "—" }}</span>
     </template>
 
     <!-- Last check -->
     <template #cell-lastCheck="{ row }">
-      <span class="truncate">{{ (row as any).lastCheck || '—' }}</span>
+      <span class="truncate">{{ (row as any).lastCheck || "—" }}</span>
     </template>
 
     <!-- Row actions -->
@@ -171,11 +210,16 @@
         <!-- Enable/Pause toggle with per-row spinner -->
         <div
           v-if="props.toggleLoadingMap[(row as any).id]"
-          class="flex items-center justify-center w-7 h-8"
+          class="flex h-8 w-7 items-center justify-center"
           :data-test="`${dataTest}-toggle-spinner`"
         >
           <OSpinner size="xs" />
-          <OTooltip side="bottom" :content="(row as any).enabled ? t('synthetics.table.pausing') : t('synthetics.table.enabling')" />
+          <OTooltip
+            side="bottom"
+            :content="
+              (row as any).enabled ? t('synthetics.table.pausing') : t('synthetics.table.enabling')
+            "
+          />
         </div>
         <OButton
           v-else
@@ -185,7 +229,12 @@
           :data-test="`${dataTest}-${(row as any).enabled ? 'pause' : 'enable'}-btn`"
           @click.stop="emit('toggle-enabled', row)"
         >
-          <OTooltip side="bottom" :content="(row as any).enabled ? t('synthetics.table.pause') : t('synthetics.table.enable')" />
+          <OTooltip
+            side="bottom"
+            :content="
+              (row as any).enabled ? t('synthetics.table.pause') : t('synthetics.table.enable')
+            "
+          />
         </OButton>
 
         <!-- Edit -->
@@ -216,7 +265,7 @@
             <!-- Show spinner when trigger is in flight for this row -->
             <div
               v-if="props.triggerLoadingMap[(row as any).id]"
-              class="flex items-center justify-center w-7 h-8"
+              class="flex h-8 w-7 items-center justify-center"
               :data-test="`${dataTest}-trigger-spinner`"
             >
               <OSpinner size="xs" />
@@ -234,14 +283,11 @@
             </OButton>
           </template>
 
-          <ODropdownItem
-            :data-test="`${dataTest}-move-item`"
-            @select="emit('move', row)"
-          >
+          <ODropdownItem :data-test="`${dataTest}-move-item`" @select="emit('move', row)">
             <template #icon-left>
               <OIcon name="drive-file-move" size="sm" />
             </template>
-            {{ t('synthetics.table.move') }}
+            {{ t("synthetics.table.move") }}
           </ODropdownItem>
 
           <ODropdownSeparator />
@@ -255,7 +301,7 @@
             <template #icon-left>
               <OIcon name="delete" size="sm" />
             </template>
-            {{ t('synthetics.table.delete') }}
+            {{ t("synthetics.table.delete") }}
           </ODropdownItem>
 
           <ODropdownSeparator />
@@ -268,7 +314,7 @@
             <template #icon-left>
               <OIcon name="sound-sampler" size="sm" />
             </template>
-            {{ t('synthetics.table.trigger') }}
+            {{ t("synthetics.table.trigger") }}
           </ODropdownItem>
         </ODropdown>
       </div>
@@ -283,15 +329,25 @@
         columns
         :description="t('synthetics.table.noResults')"
         :data-test="`${dataTest}-empty-state`"
-        @action="(id?: string) => { if (!id) return; emit('empty-action', id); }"
+        @action="
+          (id?: string) => {
+            if (!id) return;
+            emit('empty-action', id);
+          }
+        "
       />
     </template>
 
     <!-- Footer with count + bulk action buttons -->
     <template #bottom>
-      <div class="flex w-full justify-between items-center h-12 gap-1">
-        <span class="text-xs text-secondary min-w-25">
-          <template v-if="localSelectedIds.length > 0">{{ t('synthetics.table.selectedCount', { selected: localSelectedIds.length, total: data.length }) }}</template>
+      <div class="flex h-12 w-full items-center justify-between gap-1">
+        <span class="text-secondary min-w-25 text-xs">
+          <template v-if="localSelectedIds.length > 0">{{
+            t("synthetics.table.selectedCount", {
+              selected: localSelectedIds.length,
+              total: data.length,
+            })
+          }}</template>
           <template v-else>{{ data.length }} {{ footerTitle }}</template>
         </span>
         <template v-if="localSelectedIds.length > 0">
@@ -302,7 +358,8 @@
             :data-test="`${dataTest}-pause-selected-btn`"
             :disabled="!!props.bulkActionLoading"
             @click="emit('pause-selected')"
-          >{{ t('synthetics.table.pause') }}</OButton>
+            >{{ t("synthetics.table.pause") }}</OButton
+          >
           <OButton
             variant="outline"
             size="sm"
@@ -310,7 +367,8 @@
             :data-test="`${dataTest}-enable-selected-btn`"
             :disabled="!!props.bulkActionLoading"
             @click="emit('enable-selected')"
-          >{{ t('synthetics.table.enable') }}</OButton>
+            >{{ t("synthetics.table.enable") }}</OButton
+          >
           <OButton
             variant="outline"
             size="sm"
@@ -318,14 +376,16 @@
             :data-test="`${dataTest}-trigger-selected-btn`"
             :disabled="!!props.bulkActionLoading"
             @click="emit('trigger-selected')"
-          >{{ t('synthetics.table.trigger') }}</OButton>
+            >{{ t("synthetics.table.trigger") }}</OButton
+          >
           <OButton
             variant="outline"
             size="sm"
             icon-left="drive-file-move"
             :data-test="`${dataTest}-move-selected-btn`"
             @click="emit('move-selected')"
-          >{{ t('synthetics.table.move') }}</OButton>
+            >{{ t("synthetics.table.move") }}</OButton
+          >
           <OButton
             variant="outline-destructive"
             size="sm"
@@ -333,7 +393,8 @@
             :data-test="`${dataTest}-delete-selected-btn`"
             :loading="!!props.bulkActionLoading"
             @click="emit('delete-selected')"
-          >{{ t('synthetics.table.delete') }}</OButton>
+            >{{ t("synthetics.table.delete") }}</OButton
+          >
         </template>
       </div>
     </template>
@@ -351,7 +412,13 @@
       <div class="stt-header">
         <span class="stt-time">{{ sparkTip.tick.hour }} – {{ sparkTip.tick.nextHour }}</span>
         <span class="stt-badge" :class="'stt-badge--' + sparkTip.tick.status">
-          {{ sparkTip.tick.status === 'up' ? t('synthetics.table.statusUp') : sparkTip.tick.status === 'down' ? t('synthetics.table.statusDown') : t('synthetics.table.statusDegraded') }}
+          {{
+            sparkTip.tick.status === "up"
+              ? t("synthetics.table.statusUp")
+              : sparkTip.tick.status === "down"
+                ? t("synthetics.table.statusDown")
+                : t("synthetics.table.statusDegraded")
+          }}
         </span>
       </div>
       <div class="stt-divider" />
@@ -359,227 +426,363 @@
         <div v-for="c in sparkTip.tick.checks" :key="c.loc" class="stt-check">
           <span class="stt-dot" :class="c.ok ? 'stt-dot--up' : 'stt-dot--down'" />
           <span class="stt-loc">{{ c.loc }}</span>
-          <span class="stt-ms">{{ c.ms !== null ? c.ms + t('synthetics.table.ms') : t('synthetics.table.timeout') }}</span>
+          <span class="stt-ms">{{
+            c.ms !== null ? c.ms + t("synthetics.table.ms") : t("synthetics.table.timeout")
+          }}</span>
         </div>
       </div>
-      <div v-if="sparkTip.tick.avgMs !== null" class="stt-avg">{{ t('synthetics.table.avg') }} · {{ sparkTip.tick.avgMs }}{{ t('synthetics.table.ms') }}</div>
+      <div v-if="sparkTip.tick.avgMs !== null" class="stt-avg">
+        {{ t("synthetics.table.avg") }} · {{ sparkTip.tick.avgMs }}{{ t("synthetics.table.ms") }}
+      </div>
       <div class="stt-arrow" />
     </div>
   </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, onUnmounted, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
-import OTable from '@/lib/core/Table/OTable.vue'
-import type { OTableColumnDef } from '@/lib/core/Table/OTable.types'
-import { COL } from '@/lib/core/Table/OTable.types'
-import OButton from '@/lib/core/Button/OButton.vue'
-import OIcon from '@/lib/core/Icon/OIcon.vue'
-import OBadge from '@/lib/core/Badge/OBadge.vue'
-import OProgressBar from '@/lib/data/ProgressBar/OProgressBar.vue'
-import OSpinner from '@/lib/feedback/Spinner/OSpinner.vue'
-import ODropdown from '@/lib/overlay/Dropdown/ODropdown.vue'
-import ODropdownItem from '@/lib/overlay/Dropdown/ODropdownItem.vue'
-import ODropdownSeparator from '@/lib/overlay/Dropdown/ODropdownSeparator.vue'
-import OTooltip from '@/lib/overlay/Tooltip/OTooltip.vue'
-import OEmptyState from '@/lib/core/EmptyState/OEmptyState.vue'
-import { resolveBadge } from '@/lib/core/Badge/badgeGroups'
+import { computed, onUnmounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import OTable from "@/lib/core/Table/OTable.vue";
+import type { OTableColumnDef } from "@/lib/core/Table/OTable.types";
+import { COL } from "@/lib/core/Table/OTable.types";
+import OButton from "@/lib/core/Button/OButton.vue";
+import OIcon from "@/lib/core/Icon/OIcon.vue";
+import OBadge from "@/lib/core/Badge/OBadge.vue";
+import OProgressBar from "@/lib/data/ProgressBar/OProgressBar.vue";
+import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
+import ODropdown from "@/lib/overlay/Dropdown/ODropdown.vue";
+import ODropdownItem from "@/lib/overlay/Dropdown/ODropdownItem.vue";
+import ODropdownSeparator from "@/lib/overlay/Dropdown/ODropdownSeparator.vue";
+import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
+import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
+import { resolveBadge } from "@/lib/core/Badge/badgeGroups";
 
-type Mode = 'all' | 'browser'
+type Mode = "all" | "browser";
 
-const props = withDefaults(defineProps<{
-  mode: Mode
-  data: any[]
-  loading?: boolean
-  footerTitle?: string
-  emptyMessage?: string
-  dataTest?: string
-  toggleLoadingMap?: Record<string, boolean>
-  triggerLoadingMap?: Record<string, boolean>
-  selectedIds?: string[]
-  showFolderColumn?: boolean
-  bulkActionLoading?: boolean
-  hasFilters?: boolean
-  /** location id -> "Name (region)", for resolving `check.locations` ids to a
-   *  human label. Falls back to the raw id when a location isn't in the map
-   *  (e.g. deleted since the check last ran). */
-  locationNames?: Record<string, string>
-}>(), {
-  loading: false,
-  footerTitle: 'Checks',
-  emptyMessage: 'No results found.',
-  dataTest: 'monitor-table',
-  toggleLoadingMap: () => ({}),
-  triggerLoadingMap: () => ({}),
-  selectedIds: () => [],
-  showFolderColumn: false,
-  bulkActionLoading: false,
-  hasFilters: false,
-  locationNames: () => ({}),
-})
+const props = withDefaults(
+  defineProps<{
+    mode: Mode;
+    data: any[];
+    loading?: boolean;
+    footerTitle?: string;
+    emptyMessage?: string;
+    dataTest?: string;
+    toggleLoadingMap?: Record<string, boolean>;
+    triggerLoadingMap?: Record<string, boolean>;
+    selectedIds?: string[];
+    showFolderColumn?: boolean;
+    bulkActionLoading?: boolean;
+    hasFilters?: boolean;
+    /** location id -> "Name (region)", for resolving `check.locations` ids to a
+     *  human label. Falls back to the raw id when a location isn't in the map
+     *  (e.g. deleted since the check last ran). */
+    locationNames?: Record<string, string>;
+  }>(),
+  {
+    loading: false,
+    footerTitle: "Checks",
+    emptyMessage: "No results found.",
+    dataTest: "monitor-table",
+    toggleLoadingMap: () => ({}),
+    triggerLoadingMap: () => ({}),
+    selectedIds: () => [],
+    showFolderColumn: false,
+    bulkActionLoading: false,
+    hasFilters: false,
+    locationNames: () => ({}),
+  },
+);
 
 function locationLabel(id: string): string {
-  return props.locationNames[id] ?? id
+  return props.locationNames[id] ?? id;
 }
 
 const emit = defineEmits<{
-  'row-click': [row: any]
-  'edit': [row: any]
-  'toggle-enabled': [row: any]
-  'duplicate': [row: any]
-  'run': [row: any]
-  'delete': [row: any]
-  'move': [row: any]
-  'update:selectedIds': [ids: string[]]
-  'delete-selected': []
-  'move-selected': []
-  'pause-selected': []
-  'enable-selected': []
-  'trigger-selected': []
-  'navigate-to-folder': [folderId: string]
-  'empty-action': [actionId: string]
-}>()
+  "row-click": [row: any];
+  edit: [row: any];
+  "toggle-enabled": [row: any];
+  duplicate: [row: any];
+  run: [row: any];
+  delete: [row: any];
+  move: [row: any];
+  "update:selectedIds": [ids: string[]];
+  "delete-selected": [];
+  "move-selected": [];
+  "pause-selected": [];
+  "enable-selected": [];
+  "trigger-selected": [];
+  "navigate-to-folder": [folderId: string];
+  "empty-action": [actionId: string];
+}>();
 
-const { t } = useI18n()
+const { t } = useI18n();
 
 const localSelectedIds = computed({
   get: () => props.selectedIds ?? [],
-  set: (val: string[]) => emit('update:selectedIds', val),
-})
+  set: (val: string[]) => emit("update:selectedIds", val),
+});
 
 // ── Column definitions per mode ─────────────────────────────────────
 
 const STATUS_COL: OTableColumnDef = {
-  id: 'status', header: t('synthetics.table.status'), accessorKey: 'status',
-  size: COL.status, minSize: 72, sortable: true,
-  meta: { align: 'left' },
-}
+  id: "status",
+  header: t("synthetics.table.status"),
+  accessorKey: "status",
+  size: COL.status,
+  minSize: 72,
+  sortable: true,
+  meta: { align: "left" },
+};
 const NAME_COL: OTableColumnDef = {
-  id: 'name', header: t('synthetics.table.check'), accessorKey: 'name',
-  size: COL.name, minSize: 120, sortable: true, hideable: true,
+  id: "name",
+  header: t("synthetics.table.check"),
+  accessorKey: "name",
+  size: COL.name,
+  minSize: 120,
+  sortable: true,
+  hideable: true,
   meta: { isName: true, flex: true },
-}
+};
 const TEST_NAME_COL: OTableColumnDef = {
-  id: 'name', header: t('synthetics.table.testName'), accessorKey: 'name',
-  size: COL.name, minSize: 120, sortable: true, hideable: true,
+  id: "name",
+  header: t("synthetics.table.testName"),
+  accessorKey: "name",
+  size: COL.name,
+  minSize: 120,
+  sortable: true,
+  hideable: true,
   meta: { isName: true, flex: true },
-}
+};
 const URL_COL: OTableColumnDef = {
-  id: 'url', header: t('synthetics.table.url'), accessorKey: 'url',
-  size: COL.url, minSize: 140, sortable: false, hideable: true,
-}
+  id: "url",
+  header: t("synthetics.table.url"),
+  accessorKey: "url",
+  size: COL.url,
+  minSize: 140,
+  sortable: false,
+  hideable: true,
+};
 const ENDPOINT_COL: OTableColumnDef = {
-  id: 'url', header: t('synthetics.table.endpoint'), accessorKey: 'url',
-  size: COL.url, minSize: 140, sortable: false, hideable: true,
-}
+  id: "url",
+  header: t("synthetics.table.endpoint"),
+  accessorKey: "url",
+  size: COL.url,
+  minSize: 140,
+  sortable: false,
+  hideable: true,
+};
 const TYPE_COL: OTableColumnDef = {
-  id: 'type', header: t('synthetics.table.type'), accessorKey: 'type',
-  size: COL.type, minSize: 72, sortable: true, hideable: true,
-}
+  id: "type",
+  header: t("synthetics.table.type"),
+  accessorKey: "type",
+  size: COL.type,
+  minSize: 72,
+  sortable: true,
+  hideable: true,
+};
 const HISTORY_COL: OTableColumnDef = {
-  id: 'history', header: t('synthetics.table.history'), accessorKey: 'history',
-  size: COL.history, minSize: 140, sortable: false, hideable: true,
-}
+  id: "history",
+  header: t("synthetics.table.history"),
+  accessorKey: "history",
+  size: COL.history,
+  minSize: 140,
+  sortable: false,
+  hideable: true,
+};
 const RESPONSE_TIME_COL: OTableColumnDef = {
-  id: 'responseTime', header: t('synthetics.table.response'), accessorKey: 'responseTime',
-  size: COL.responseTime, minSize: 72, sortable: true, meta: { align: 'right' }, hideable: true,
-}
+  id: "responseTime",
+  header: t("synthetics.table.response"),
+  accessorKey: "responseTime",
+  size: COL.responseTime,
+  minSize: 72,
+  sortable: true,
+  meta: { align: "right" },
+  hideable: true,
+};
 const PAGE_LOAD_COL: OTableColumnDef = {
-  id: 'responseTime', header: t('synthetics.table.pageLoad'), accessorKey: 'responseTime',
-  size: COL.responseTime, minSize: 80, sortable: true, meta: { align: 'right' }, hideable: true,
-}
+  id: "responseTime",
+  header: t("synthetics.table.pageLoad"),
+  accessorKey: "responseTime",
+  size: COL.responseTime,
+  minSize: 80,
+  sortable: true,
+  meta: { align: "right" },
+  hideable: true,
+};
 const P50_COL: OTableColumnDef = {
-  id: 'responseTime', header: t('synthetics.table.p50'), accessorKey: 'responseTime',
-  size: COL.responseTime, minSize: 64, sortable: true, meta: { align: 'right' }, hideable: true,
-}
+  id: "responseTime",
+  header: t("synthetics.table.p50"),
+  accessorKey: "responseTime",
+  size: COL.responseTime,
+  minSize: 64,
+  sortable: true,
+  meta: { align: "right" },
+  hideable: true,
+};
 const UPTIME_COL: OTableColumnDef = {
-  id: 'uptime', header: t('synthetics.table.uptime'), accessorKey: 'uptime',
-  size: COL.uptime, minSize: 100, sortable: true, meta: { align: 'right' }, hideable: true,
-}
+  id: "uptime",
+  header: t("synthetics.table.uptime"),
+  accessorKey: "uptime",
+  size: COL.uptime,
+  minSize: 100,
+  sortable: true,
+  meta: { align: "right" },
+  hideable: true,
+};
 const LOCATIONS_COL: OTableColumnDef = {
-  id: 'locations', header: t('synthetics.table.locations'), accessorKey: 'locations',
-  size: COL.locations, minSize: 90, sortable: false, hideable: true,
-}
+  id: "locations",
+  header: t("synthetics.table.locations"),
+  accessorKey: "locations",
+  size: COL.locations,
+  minSize: 90,
+  sortable: false,
+  hideable: true,
+};
 const INTERVAL_COL: OTableColumnDef = {
-  id: 'interval', header: t('synthetics.table.interval'), accessorKey: 'interval',
-  size: COL.interval, minSize: 60, sortable: false, hideable: true,
-}
+  id: "interval",
+  header: t("synthetics.table.interval"),
+  accessorKey: "interval",
+  size: COL.interval,
+  minSize: 60,
+  sortable: false,
+  hideable: true,
+};
 const LAST_CHECK_COL: OTableColumnDef = {
-  id: 'lastCheck', header: t('synthetics.table.lastCheck'), accessorKey: 'lastCheck',
-  size: COL.lastCheck, minSize: 72, sortable: false, hideable: true,
-}
+  id: "lastCheck",
+  header: t("synthetics.table.lastCheck"),
+  accessorKey: "lastCheck",
+  size: COL.lastCheck,
+  minSize: 72,
+  sortable: false,
+  hideable: true,
+};
 const LAST_RUN_COL: OTableColumnDef = {
-  id: 'lastCheck', header: t('synthetics.table.lastCheck'), accessorKey: 'lastCheck',
-  size: COL.lastCheck, minSize: 72, sortable: false, hideable: true,
-}
+  id: "lastCheck",
+  header: t("synthetics.table.lastCheck"),
+  accessorKey: "lastCheck",
+  size: COL.lastCheck,
+  minSize: 72,
+  sortable: false,
+  hideable: true,
+};
 const STEPS_COL: OTableColumnDef = {
-  id: 'steps', header: t('synthetics.table.steps'), accessorKey: 'steps',
-  size: COL.steps, minSize: 60, sortable: false, hideable: true,
-}
+  id: "steps",
+  header: t("synthetics.table.steps"),
+  accessorKey: "steps",
+  size: COL.steps,
+  minSize: 60,
+  sortable: false,
+  hideable: true,
+};
 const METHOD_COL: OTableColumnDef = {
-  id: 'method', header: t('synthetics.table.method'), accessorKey: 'method',
-  size: COL.method, minSize: 56, sortable: false, hideable: true,
-}
+  id: "method",
+  header: t("synthetics.table.method"),
+  accessorKey: "method",
+  size: COL.method,
+  minSize: 56,
+  sortable: false,
+  hideable: true,
+};
 const ASSERTIONS_COL: OTableColumnDef = {
-  id: 'assertions', header: t('synthetics.table.assertions'), accessorKey: 'assertions',
-  size: COL.assertions, minSize: 72, sortable: false, hideable: true,
-}
+  id: "assertions",
+  header: t("synthetics.table.assertions"),
+  accessorKey: "assertions",
+  size: COL.assertions,
+  minSize: 72,
+  sortable: false,
+  hideable: true,
+};
 const ACTIONS_COL: OTableColumnDef = {
-  id: 'actions', header: '', accessorKey: 'id',
-  size: 160, minSize: 160, sortable: false, isAction: true,
-}
+  id: "actions",
+  header: "",
+  accessorKey: "id",
+  size: 160,
+  minSize: 160,
+  sortable: false,
+  isAction: true,
+};
 const FOLDER_COL: OTableColumnDef = {
-  id: 'folder_name', header: t('synthetics.table.folder'), accessorKey: 'folder_name',
-  size: COL.folder, minSize: 90, sortable: true, hideable: true,
-}
+  id: "folder_name",
+  header: t("synthetics.table.folder"),
+  accessorKey: "folder_name",
+  size: COL.folder,
+  minSize: 90,
+  sortable: true,
+  hideable: true,
+};
 
 const columns = computed<OTableColumnDef[]>(() => {
-  let cols: OTableColumnDef[]
-  if (props.mode === 'browser') {
-    cols = [TEST_NAME_COL, URL_COL, STEPS_COL, HISTORY_COL, PAGE_LOAD_COL, UPTIME_COL, LAST_RUN_COL, STATUS_COL, ACTIONS_COL]
+  let cols: OTableColumnDef[];
+  if (props.mode === "browser") {
+    cols = [
+      TEST_NAME_COL,
+      URL_COL,
+      STEPS_COL,
+      HISTORY_COL,
+      PAGE_LOAD_COL,
+      UPTIME_COL,
+      LAST_RUN_COL,
+      STATUS_COL,
+      ACTIONS_COL,
+    ];
   } else {
-    cols = [NAME_COL, URL_COL, TYPE_COL, STATUS_COL, RESPONSE_TIME_COL, LOCATIONS_COL, INTERVAL_COL, LAST_CHECK_COL, ACTIONS_COL]
+    cols = [
+      NAME_COL,
+      URL_COL,
+      TYPE_COL,
+      STATUS_COL,
+      RESPONSE_TIME_COL,
+      LOCATIONS_COL,
+      INTERVAL_COL,
+      LAST_CHECK_COL,
+      ACTIONS_COL,
+    ];
   }
   if (props.showFolderColumn) {
-    const nameIdx = cols.findIndex(c => c.id === 'name')
-    cols.splice(nameIdx + 1, 0, FOLDER_COL)
+    const nameIdx = cols.findIndex((c) => c.id === "name");
+    cols.splice(nameIdx + 1, 0, FOLDER_COL);
   }
-  return cols
-})
+  return cols;
+});
 
 function formatLocationsList(locations: string[]): string {
-  return locations.map(l => locationLabel(l)).join('\n')
+  return locations.map((l) => locationLabel(l)).join("\n");
 }
 
 // ── Spark tooltip ─────────────────────────────────────────────────────
 
 interface HistoryTick {
-  hour: string
-  nextHour: string
-  status: 'up' | 'down' | 'deg'
-  avgMs: number | null
-  checks: { loc: string; ok: boolean; ms: number | null }[]
+  hour: string;
+  nextHour: string;
+  status: "up" | "down" | "deg";
+  avgMs: number | null;
+  checks: { loc: string; ok: boolean; ms: number | null }[];
 }
 
-const sparkTip = ref({ show: false, x: 0, y: 0, tick: null as HistoryTick | null })
-let sparkHideTimer: ReturnType<typeof setTimeout> | null = null
+const sparkTip = ref({ show: false, x: 0, y: 0, tick: null as HistoryTick | null });
+let sparkHideTimer: ReturnType<typeof setTimeout> | null = null;
 
 const showSparkTip = (e: MouseEvent, tick: HistoryTick) => {
-  if (sparkHideTimer) { clearTimeout(sparkHideTimer); sparkHideTimer = null }
-  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-  sparkTip.value = { show: true, x: rect.left + rect.width / 2, y: rect.top - 10, tick }
-}
+  if (sparkHideTimer) {
+    clearTimeout(sparkHideTimer);
+    sparkHideTimer = null;
+  }
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  sparkTip.value = { show: true, x: rect.left + rect.width / 2, y: rect.top - 10, tick };
+};
 const hideSparkTip = () => {
-  sparkHideTimer = setTimeout(() => { sparkTip.value.show = false }, 80)
-}
+  sparkHideTimer = setTimeout(() => {
+    sparkTip.value.show = false;
+  }, 80);
+};
 const keepSparkTip = () => {
-  if (sparkHideTimer) { clearTimeout(sparkHideTimer); sparkHideTimer = null }
-}
+  if (sparkHideTimer) {
+    clearTimeout(sparkHideTimer);
+    sparkHideTimer = null;
+  }
+};
 
 onUnmounted(() => {
-  if (sparkHideTimer) clearTimeout(sparkHideTimer)
-})
-
-
+  if (sparkHideTimer) clearTimeout(sparkHideTimer);
+});
 </script>

--- a/web/src/composables/synthetics/syntheticResultsSchema.spec.ts
+++ b/web/src/composables/synthetics/syntheticResultsSchema.spec.ts
@@ -25,6 +25,8 @@ import {
   buildLastRunSql,
   buildRunsSql,
   buildRunsWithStepsSql,
+  deviceIconName,
+  deviceLabel,
   mapHistogram,
   mapKpi,
   mapRun,
@@ -247,7 +249,7 @@ describe("aggregateStepStats", () => {
       ts: 1_700_000_000_500_000,
       engine: "chromium",
       location: "us-east-1",
-      device: "laptop_large",
+      device: "desktop",
       error: "",
       run_id: "run-1",
       execution_id: "exec-1",
@@ -430,5 +432,49 @@ describe("aggregateStepStats", () => {
     const loginBuckets = result.trendBuckets.filter((b) => b.stepName === "Click login");
     expect(loginBuckets.length).toBeGreaterThan(0);
     expect(loginBuckets[0].avgDurationMs).toBeGreaterThan(0);
+  });
+});
+
+describe("deviceIconName", () => {
+  it("should return the correct icon for desktop", () => {
+    expect(deviceIconName("desktop")).toBe("computer");
+  });
+
+  it("should return the correct icon for tablet", () => {
+    expect(deviceIconName("tablet")).toBe("tablet");
+  });
+
+  it("should return the correct icon for mobile", () => {
+    expect(deviceIconName("mobile")).toBe("smartphone");
+  });
+
+  it("should fall back to 'devices' icon for an unknown device ID", () => {
+    expect(deviceIconName("unknown_device")).toBe("devices");
+  });
+
+  it("should fall back to 'devices' icon for an empty string", () => {
+    expect(deviceIconName("")).toBe("devices");
+  });
+});
+
+describe("deviceLabel", () => {
+  it("should return the correct label for desktop", () => {
+    expect(deviceLabel("desktop")).toBe("Desktop");
+  });
+
+  it("should return the correct label for tablet", () => {
+    expect(deviceLabel("tablet")).toBe("Tablet");
+  });
+
+  it("should return the correct label for mobile", () => {
+    expect(deviceLabel("mobile")).toBe("Mobile");
+  });
+
+  it("should fall back to the raw device ID for an unknown device", () => {
+    expect(deviceLabel("some_custom_device")).toBe("some_custom_device");
+  });
+
+  it("should fall back to the raw ID for an empty string", () => {
+    expect(deviceLabel("")).toBe("");
   });
 });

--- a/web/src/composables/synthetics/syntheticResultsSchema.ts
+++ b/web/src/composables/synthetics/syntheticResultsSchema.ts
@@ -55,10 +55,7 @@ export const STATUS_VALUES = {
  * Canonical set of known device IDs and their display properties.
  * When the backend adds new devices, add them here only.
  */
-export const KNOWN_DEVICES: Record<
-  string,
-  { label: string; icon: string }
-> = {
+export const KNOWN_DEVICES: Record<string, { label: string; icon: string }> = {
   desktop: { label: "Desktop", icon: "computer" },
   tablet: { label: "Tablet", icon: "tablet" },
   mobile: { label: "Mobile", icon: "smartphone" },
@@ -583,8 +580,8 @@ export function buildRunDetailSql(
 ): string {
   const id = escapeSqlLiteral(monitorId);
   const has = (f: string) => schemaFields === null || schemaFields.has(f);
-  const select = RUN_DETAIL_COLUMNS.map(({ field, alias, fallback }) =>
-    `${has(field) ? field : fallback} as ${alias}`,
+  const select = RUN_DETAIL_COLUMNS.map(
+    ({ field, alias, fallback }) => `${has(field) ? field : fallback} as ${alias}`,
   ).join(", ");
   const orderBy = has(F.location) ? `\nORDER BY ${F.location} ASC` : "";
   return `SELECT ${select}
@@ -654,9 +651,7 @@ export function mapRun(rawHit: Record<string, unknown>): SyntheticRun {
   };
 }
 
-export function mapRunDetail(
-  rawHit: Record<string, unknown>,
-): SyntheticRunDetail | null {
+export function mapRunDetail(rawHit: Record<string, unknown>): SyntheticRunDetail | null {
   if (!rawHit) return null;
   const base = mapRun({
     ts: rawHit.ts ?? rawHit._timestamp,
@@ -683,14 +678,13 @@ export function mapRunDetail(
     attempts: num(rawHit.attempt),
     failedStep: rawHit.failed_step
       ? str(rawHit.failed_step)
-      : (rawStepsArr.find((s: any) => s.status === "fail" || s.status === "failed")?.step_id ?? null),
-    recordedSteps: Array.isArray(rawRecordedSteps)
-      ? (rawRecordedSteps as RecordedStep[])
-      : [],
+      : (rawStepsArr.find((s: any) => s.status === "fail" || s.status === "failed")?.step_id ??
+        null),
+    recordedSteps: Array.isArray(rawRecordedSteps) ? (rawRecordedSteps as RecordedStep[]) : [],
     lastAttemptSteps: rawStepsArr.map((s: any) => ({
-        ...s,
-        status: s.status === "ok" || s.status === "passed" ? "ok" : "fail" as const,
-      })),
+      ...s,
+      status: s.status === "ok" || s.status === "passed" ? "ok" : ("fail" as const),
+    })),
     retryHistory: [],
     network: null,
     webVitals: null,
@@ -698,9 +692,7 @@ export function mapRunDetail(
   };
 }
 
-export function mapProtocolRunDetail(
-  rawHit: Record<string, unknown>,
-): ProtocolRunDetail | null {
+export function mapProtocolRunDetail(rawHit: Record<string, unknown>): ProtocolRunDetail | null {
   if (!rawHit) return null;
 
   const timings: ProtocolTiming[] = [];
@@ -717,8 +709,7 @@ export function mapProtocolRunDetail(
     status: str(rawHit.status),
     error: str(rawHit.error),
     errorClass: str(rawHit.error_class),
-    assertionsPassed:
-      rawHit.assertions_passed == null ? null : Boolean(rawHit.assertions_passed),
+    assertionsPassed: rawHit.assertions_passed == null ? null : Boolean(rawHit.assertions_passed),
     statusCode: rawHit.status_code == null ? null : num(rawHit.status_code),
     responseTimeMs: num(rawHit.response_time_ms),
     responseBytes: rawHit.response_bytes == null ? null : num(rawHit.response_bytes),
@@ -739,9 +730,7 @@ export function mapProtocolRunDetail(
   };
 }
 
-export function mapRunLocationResult(
-  rawHit: Record<string, unknown>,
-): RunLocationResult {
+export function mapRunLocationResult(rawHit: Record<string, unknown>): RunLocationResult {
   return {
     timestampMs: num(rawHit.ts) / 1000,
     status: toRunStatus(rawHit.status),
@@ -855,9 +844,7 @@ export function aggregateStepStats(
   const bucketMs = intervalSeconds(interval) * 1000;
 
   // Process runs oldest-first so sparklines reflect chronological order
-  const sorted = [...rawHits].sort(
-    (a, b) => num(a.ts) - num(b.ts),
-  );
+  const sorted = [...rawHits].sort((a, b) => num(a.ts) - num(b.ts));
 
   for (const hit of sorted) {
     const runTimestamp = num(hit.ts);
@@ -945,14 +932,20 @@ export function aggregateStepStats(
 
       // Browser dimension
       let bStats = acc.browserMap.get(engine);
-      if (!bStats) { bStats = { total: 0, failures: 0, flaky: 0 }; acc.browserMap.set(engine, bStats); }
+      if (!bStats) {
+        bStats = { total: 0, failures: 0, flaky: 0 };
+        acc.browserMap.set(engine, bStats);
+      }
       bStats.total++;
       if (!isOk) bStats.failures++;
       if (isFlaky) bStats.flaky++;
 
       // Location dimension
       let lStats = acc.locationMap.get(location);
-      if (!lStats) { lStats = { total: 0, failures: 0, flaky: 0 }; acc.locationMap.set(location, lStats); }
+      if (!lStats) {
+        lStats = { total: 0, failures: 0, flaky: 0 };
+        acc.locationMap.set(location, lStats);
+      }
       lStats.total++;
       if (!isOk) lStats.failures++;
       if (isFlaky) lStats.flaky++;
@@ -964,7 +957,10 @@ export function aggregateStepStats(
         trendAcc.set(stepName, tAcc);
       }
       let bEntry = tAcc.bucketMap.get(bucketKey);
-      if (!bEntry) { bEntry = { sum: 0, count: 0 }; tAcc.bucketMap.set(bucketKey, bEntry); }
+      if (!bEntry) {
+        bEntry = { sum: 0, count: 0 };
+        tAcc.bucketMap.set(bucketKey, bEntry);
+      }
       bEntry.sum += stepDuration;
       bEntry.count++;
 
@@ -1018,31 +1014,26 @@ export function aggregateStepStats(
     // ── Update recent-run statuses for sparklines ───────────────────
     for (const acc of stepAcc.values()) {
       // Determine this run's status for this step
-      const processedInRun = lastAttemptSteps.some(
-        (s: any) => {
-          const sid = str(s.step_id ?? s.id);
-          const def = stepDefs.get(sid);
-          return (def?.name ?? sid) === acc.name;
-        },
-      );
+      const processedInRun = lastAttemptSteps.some((s: any) => {
+        const sid = str(s.step_id ?? s.id);
+        const def = stepDefs.get(sid);
+        return (def?.name ?? sid) === acc.name;
+      });
 
       if (processedInRun) {
         if (acc.recentRunStatuses.length >= MAX_SPARKLINE_POINTS) {
           acc.recentRunStatuses.shift();
         }
-        const stepFromRun = (lastAttemptSteps as any[]).find(
-          (s: any) => {
-            const sid = str(s.step_id ?? s.id);
-            const def = stepDefs.get(sid);
-            return (def?.name ?? sid) === acc.name;
-          },
-        );
+        const stepFromRun = (lastAttemptSteps as any[]).find((s: any) => {
+          const sid = str(s.step_id ?? s.id);
+          const def = stepDefs.get(sid);
+          return (def?.name ?? sid) === acc.name;
+        });
         if (stepFromRun) {
           const runStepStatus = str(stepFromRun.status);
           const isRunOk = runStepStatus === "ok" || runStepStatus === "passed";
-          const priorFailedForStep = priorStatuses.get(
-            str(stepFromRun.step_id ?? stepFromRun.id),
-          ) === "fail";
+          const priorFailedForStep =
+            priorStatuses.get(str(stepFromRun.step_id ?? stepFromRun.id)) === "fail";
           if (!isRunOk) {
             acc.recentRunStatuses.push("fail");
           } else if (priorFailedForStep && attempts > 1) {
@@ -1063,29 +1054,23 @@ export function aggregateStepStats(
   const flakySteps: FlakyStep[] = [];
 
   for (const [name, acc] of stepAcc) {
-    const failRate = acc.totalExecutions > 0
-      ? Math.round((acc.failures / acc.totalExecutions) * 1000) / 10
-      : 0;
-    const flakyRate = acc.totalExecutions > 0
-      ? Math.round((acc.flakyCount / acc.totalExecutions) * 1000) / 10
-      : 0;
-    const avgDurationMs = acc.totalExecutions > 0
-      ? Math.round(acc.durationSum / acc.totalExecutions)
-      : 0;
-    const failRateFull = acc.totalExecutions > 0
-      ? acc.failures / acc.totalExecutions
-      : 0;
+    const failRate =
+      acc.totalExecutions > 0 ? Math.round((acc.failures / acc.totalExecutions) * 1000) / 10 : 0;
+    const flakyRate =
+      acc.totalExecutions > 0 ? Math.round((acc.flakyCount / acc.totalExecutions) * 1000) / 10 : 0;
+    const avgDurationMs =
+      acc.totalExecutions > 0 ? Math.round(acc.durationSum / acc.totalExecutions) : 0;
+    const failRateFull = acc.totalExecutions > 0 ? acc.failures / acc.totalExecutions : 0;
 
     // p95: sort all collected durations and take the 95th-percentile value
-    const p95DurationMs = acc.durationValues.length > 0
-      ? acc.durationValues.slice().sort((a, b) => a - b)[
-          Math.ceil(acc.durationValues.length * 0.95) - 1
-        ] ?? 0
-      : 0;
+    const p95DurationMs =
+      acc.durationValues.length > 0
+        ? (acc.durationValues.slice().sort((a, b) => a - b)[
+            Math.ceil(acc.durationValues.length * 0.95) - 1
+          ] ?? 0)
+        : 0;
 
-    const recentRates = acc.recentRunStatuses.map((s) =>
-      s === "fail" || s === "flaky" ? 1 : 0,
-    );
+    const recentRates = acc.recentRunStatuses.map((s) => (s === "fail" || s === "flaky" ? 1 : 0));
 
     stepGroups.push({
       key: `step-${name}`,
@@ -1150,9 +1135,7 @@ export function aggregateStepStats(
 
   // Build trend buckets (top N steps, aggregated per time bucket)
   const topSteps = stepDurations.slice(0, TOP_TREND_STEPS).map((s) => s.stepName);
-  const otherStepNames = new Set(
-    stepDurations.slice(TOP_TREND_STEPS).map((s) => s.stepName),
-  );
+  const otherStepNames = new Set(stepDurations.slice(TOP_TREND_STEPS).map((s) => s.stepName));
 
   // Merge "others" into a single series
   let othersAcc: InternalTrendAccumulator | null = null;

--- a/web/src/composables/synthetics/syntheticResultsSchema.ts
+++ b/web/src/composables/synthetics/syntheticResultsSchema.ts
@@ -55,10 +55,13 @@ export const STATUS_VALUES = {
  * Canonical set of known device IDs and their display properties.
  * When the backend adds new devices, add them here only.
  */
-export const KNOWN_DEVICES: Record<string, { label: string; icon: string }> = {
-  laptop_large: { label: "Desktop", icon: "computer" },
+export const KNOWN_DEVICES: Record<
+  string,
+  { label: string; icon: string }
+> = {
+  desktop: { label: "Desktop", icon: "computer" },
   tablet: { label: "Tablet", icon: "tablet" },
-  mobile_small: { label: "Mobile", icon: "smartphone" },
+  mobile: { label: "Mobile", icon: "smartphone" },
 };
 
 /**
@@ -580,8 +583,8 @@ export function buildRunDetailSql(
 ): string {
   const id = escapeSqlLiteral(monitorId);
   const has = (f: string) => schemaFields === null || schemaFields.has(f);
-  const select = RUN_DETAIL_COLUMNS.map(
-    ({ field, alias, fallback }) => `${has(field) ? field : fallback} as ${alias}`,
+  const select = RUN_DETAIL_COLUMNS.map(({ field, alias, fallback }) =>
+    `${has(field) ? field : fallback} as ${alias}`,
   ).join(", ");
   const orderBy = has(F.location) ? `\nORDER BY ${F.location} ASC` : "";
   return `SELECT ${select}
@@ -651,7 +654,9 @@ export function mapRun(rawHit: Record<string, unknown>): SyntheticRun {
   };
 }
 
-export function mapRunDetail(rawHit: Record<string, unknown>): SyntheticRunDetail | null {
+export function mapRunDetail(
+  rawHit: Record<string, unknown>,
+): SyntheticRunDetail | null {
   if (!rawHit) return null;
   const base = mapRun({
     ts: rawHit.ts ?? rawHit._timestamp,
@@ -678,13 +683,14 @@ export function mapRunDetail(rawHit: Record<string, unknown>): SyntheticRunDetai
     attempts: num(rawHit.attempt),
     failedStep: rawHit.failed_step
       ? str(rawHit.failed_step)
-      : (rawStepsArr.find((s: any) => s.status === "fail" || s.status === "failed")?.step_id ??
-        null),
-    recordedSteps: Array.isArray(rawRecordedSteps) ? (rawRecordedSteps as RecordedStep[]) : [],
+      : (rawStepsArr.find((s: any) => s.status === "fail" || s.status === "failed")?.step_id ?? null),
+    recordedSteps: Array.isArray(rawRecordedSteps)
+      ? (rawRecordedSteps as RecordedStep[])
+      : [],
     lastAttemptSteps: rawStepsArr.map((s: any) => ({
-      ...s,
-      status: s.status === "ok" || s.status === "passed" ? "ok" : ("fail" as const),
-    })),
+        ...s,
+        status: s.status === "ok" || s.status === "passed" ? "ok" : "fail" as const,
+      })),
     retryHistory: [],
     network: null,
     webVitals: null,
@@ -692,7 +698,9 @@ export function mapRunDetail(rawHit: Record<string, unknown>): SyntheticRunDetai
   };
 }
 
-export function mapProtocolRunDetail(rawHit: Record<string, unknown>): ProtocolRunDetail | null {
+export function mapProtocolRunDetail(
+  rawHit: Record<string, unknown>,
+): ProtocolRunDetail | null {
   if (!rawHit) return null;
 
   const timings: ProtocolTiming[] = [];
@@ -709,7 +717,8 @@ export function mapProtocolRunDetail(rawHit: Record<string, unknown>): ProtocolR
     status: str(rawHit.status),
     error: str(rawHit.error),
     errorClass: str(rawHit.error_class),
-    assertionsPassed: rawHit.assertions_passed == null ? null : Boolean(rawHit.assertions_passed),
+    assertionsPassed:
+      rawHit.assertions_passed == null ? null : Boolean(rawHit.assertions_passed),
     statusCode: rawHit.status_code == null ? null : num(rawHit.status_code),
     responseTimeMs: num(rawHit.response_time_ms),
     responseBytes: rawHit.response_bytes == null ? null : num(rawHit.response_bytes),
@@ -730,7 +739,9 @@ export function mapProtocolRunDetail(rawHit: Record<string, unknown>): ProtocolR
   };
 }
 
-export function mapRunLocationResult(rawHit: Record<string, unknown>): RunLocationResult {
+export function mapRunLocationResult(
+  rawHit: Record<string, unknown>,
+): RunLocationResult {
   return {
     timestampMs: num(rawHit.ts) / 1000,
     status: toRunStatus(rawHit.status),
@@ -844,7 +855,9 @@ export function aggregateStepStats(
   const bucketMs = intervalSeconds(interval) * 1000;
 
   // Process runs oldest-first so sparklines reflect chronological order
-  const sorted = [...rawHits].sort((a, b) => num(a.ts) - num(b.ts));
+  const sorted = [...rawHits].sort(
+    (a, b) => num(a.ts) - num(b.ts),
+  );
 
   for (const hit of sorted) {
     const runTimestamp = num(hit.ts);
@@ -932,20 +945,14 @@ export function aggregateStepStats(
 
       // Browser dimension
       let bStats = acc.browserMap.get(engine);
-      if (!bStats) {
-        bStats = { total: 0, failures: 0, flaky: 0 };
-        acc.browserMap.set(engine, bStats);
-      }
+      if (!bStats) { bStats = { total: 0, failures: 0, flaky: 0 }; acc.browserMap.set(engine, bStats); }
       bStats.total++;
       if (!isOk) bStats.failures++;
       if (isFlaky) bStats.flaky++;
 
       // Location dimension
       let lStats = acc.locationMap.get(location);
-      if (!lStats) {
-        lStats = { total: 0, failures: 0, flaky: 0 };
-        acc.locationMap.set(location, lStats);
-      }
+      if (!lStats) { lStats = { total: 0, failures: 0, flaky: 0 }; acc.locationMap.set(location, lStats); }
       lStats.total++;
       if (!isOk) lStats.failures++;
       if (isFlaky) lStats.flaky++;
@@ -957,10 +964,7 @@ export function aggregateStepStats(
         trendAcc.set(stepName, tAcc);
       }
       let bEntry = tAcc.bucketMap.get(bucketKey);
-      if (!bEntry) {
-        bEntry = { sum: 0, count: 0 };
-        tAcc.bucketMap.set(bucketKey, bEntry);
-      }
+      if (!bEntry) { bEntry = { sum: 0, count: 0 }; tAcc.bucketMap.set(bucketKey, bEntry); }
       bEntry.sum += stepDuration;
       bEntry.count++;
 
@@ -1014,26 +1018,31 @@ export function aggregateStepStats(
     // ── Update recent-run statuses for sparklines ───────────────────
     for (const acc of stepAcc.values()) {
       // Determine this run's status for this step
-      const processedInRun = lastAttemptSteps.some((s: any) => {
-        const sid = str(s.step_id ?? s.id);
-        const def = stepDefs.get(sid);
-        return (def?.name ?? sid) === acc.name;
-      });
+      const processedInRun = lastAttemptSteps.some(
+        (s: any) => {
+          const sid = str(s.step_id ?? s.id);
+          const def = stepDefs.get(sid);
+          return (def?.name ?? sid) === acc.name;
+        },
+      );
 
       if (processedInRun) {
         if (acc.recentRunStatuses.length >= MAX_SPARKLINE_POINTS) {
           acc.recentRunStatuses.shift();
         }
-        const stepFromRun = (lastAttemptSteps as any[]).find((s: any) => {
-          const sid = str(s.step_id ?? s.id);
-          const def = stepDefs.get(sid);
-          return (def?.name ?? sid) === acc.name;
-        });
+        const stepFromRun = (lastAttemptSteps as any[]).find(
+          (s: any) => {
+            const sid = str(s.step_id ?? s.id);
+            const def = stepDefs.get(sid);
+            return (def?.name ?? sid) === acc.name;
+          },
+        );
         if (stepFromRun) {
           const runStepStatus = str(stepFromRun.status);
           const isRunOk = runStepStatus === "ok" || runStepStatus === "passed";
-          const priorFailedForStep =
-            priorStatuses.get(str(stepFromRun.step_id ?? stepFromRun.id)) === "fail";
+          const priorFailedForStep = priorStatuses.get(
+            str(stepFromRun.step_id ?? stepFromRun.id),
+          ) === "fail";
           if (!isRunOk) {
             acc.recentRunStatuses.push("fail");
           } else if (priorFailedForStep && attempts > 1) {
@@ -1054,23 +1063,29 @@ export function aggregateStepStats(
   const flakySteps: FlakyStep[] = [];
 
   for (const [name, acc] of stepAcc) {
-    const failRate =
-      acc.totalExecutions > 0 ? Math.round((acc.failures / acc.totalExecutions) * 1000) / 10 : 0;
-    const flakyRate =
-      acc.totalExecutions > 0 ? Math.round((acc.flakyCount / acc.totalExecutions) * 1000) / 10 : 0;
-    const avgDurationMs =
-      acc.totalExecutions > 0 ? Math.round(acc.durationSum / acc.totalExecutions) : 0;
-    const failRateFull = acc.totalExecutions > 0 ? acc.failures / acc.totalExecutions : 0;
+    const failRate = acc.totalExecutions > 0
+      ? Math.round((acc.failures / acc.totalExecutions) * 1000) / 10
+      : 0;
+    const flakyRate = acc.totalExecutions > 0
+      ? Math.round((acc.flakyCount / acc.totalExecutions) * 1000) / 10
+      : 0;
+    const avgDurationMs = acc.totalExecutions > 0
+      ? Math.round(acc.durationSum / acc.totalExecutions)
+      : 0;
+    const failRateFull = acc.totalExecutions > 0
+      ? acc.failures / acc.totalExecutions
+      : 0;
 
     // p95: sort all collected durations and take the 95th-percentile value
-    const p95DurationMs =
-      acc.durationValues.length > 0
-        ? (acc.durationValues.slice().sort((a, b) => a - b)[
-            Math.ceil(acc.durationValues.length * 0.95) - 1
-          ] ?? 0)
-        : 0;
+    const p95DurationMs = acc.durationValues.length > 0
+      ? acc.durationValues.slice().sort((a, b) => a - b)[
+          Math.ceil(acc.durationValues.length * 0.95) - 1
+        ] ?? 0
+      : 0;
 
-    const recentRates = acc.recentRunStatuses.map((s) => (s === "fail" || s === "flaky" ? 1 : 0));
+    const recentRates = acc.recentRunStatuses.map((s) =>
+      s === "fail" || s === "flaky" ? 1 : 0,
+    );
 
     stepGroups.push({
       key: `step-${name}`,
@@ -1135,7 +1150,9 @@ export function aggregateStepStats(
 
   // Build trend buckets (top N steps, aggregated per time bucket)
   const topSteps = stepDurations.slice(0, TOP_TREND_STEPS).map((s) => s.stepName);
-  const otherStepNames = new Set(stepDurations.slice(TOP_TREND_STEPS).map((s) => s.stepName));
+  const otherStepNames = new Set(
+    stepDurations.slice(TOP_TREND_STEPS).map((s) => s.stepName),
+  );
 
   // Merge "others" into a single series
   let othersAcc: InternalTrendAccumulator | null = null;

--- a/web/src/views/synthetics/MonitorRuns.spec.ts
+++ b/web/src/views/synthetics/MonitorRuns.spec.ts
@@ -165,6 +165,24 @@ vi.mock("@/composables/synthetics/syntheticResultsSchema", () => {
   };
 });
 
+vi.mock("vuex", () => ({
+  useStore: () => ({
+    state: {
+      selectedOrganization: { identifier: "test-org" },
+    },
+  }),
+}));
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({
+    query: {},
+  }),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
 import MonitorRuns from "./MonitorRuns.vue";
 
 // ── Stubs for every child component ─────────────────────────────────────
@@ -207,6 +225,10 @@ const baseStubs = {
   OTimeCell: {
     template: "<span />",
     props: ["value", "unit", "mode", "emptyLabel"],
+  },
+  OTooltip: {
+    template: "<span><slot /></span>",
+    props: ["content", "class"],
   },
   OBadge: {
     template: "<span :data-test=\"$attrs['data-test']\"><slot /></span>",
@@ -262,6 +284,7 @@ const baseStubs = {
     inheritAttrs: true,
   },
   MonitorStatusTimeline: {
+    name: "MonitorStatusTimeline",
     template: '<div data-test="monitor-status-timeline" />',
     props: [
       "segments",
@@ -291,7 +314,12 @@ const baseStubs = {
 // But the simplest way is to just show all content.
 
 function mountRuns(
-  props: { monitorId: string; monitorName: string; monitorStatus?: string } = {
+  props: {
+    monitorId: string;
+    monitorName: string;
+    monitorStatus?: string;
+    checkType?: string;
+  } = {
     monitorId: "mon-1",
     monitorName: "Test Monitor",
   },
@@ -380,6 +408,174 @@ describe("MonitorRuns", () => {
       wrapper = mountRuns();
       wrapper.vm.$emit("refresh");
       expect(wrapper.emitted("refresh")).toBeTruthy();
+    });
+  });
+
+  describe("breakdown cards visibility", () => {
+    it("should render device breakdown card when checkType is browser", () => {
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "browser",
+      });
+      expect(wrapper.text()).toContain("synthetics.runs.passRateByDevice");
+    });
+
+    it("should not render device breakdown card when checkType is not browser", () => {
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "http",
+      });
+      expect(wrapper.text()).not.toContain("synthetics.runs.passRateByDevice");
+    });
+
+    it("should render protocol duration by location card when checkType is not browser", () => {
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "http",
+      });
+      expect(wrapper.text()).toContain("synthetics.runs.durationByLocation");
+    });
+
+    it("should not render protocol duration by location card when checkType is browser", () => {
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "browser",
+      });
+      expect(wrapper.text()).not.toContain("synthetics.runs.durationByLocation");
+    });
+
+    it("should render browser and device filters when checkType is browser", () => {
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "browser",
+      });
+      expect(wrapper.find('[data-test="monitor-runs-filter-browser"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="monitor-runs-filter-device"]').exists()).toBe(true);
+    });
+
+    it("should not render browser and device filters when checkType is not browser", () => {
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "http",
+      });
+      expect(wrapper.find('[data-test="monitor-runs-filter-browser"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="monitor-runs-filter-device"]').exists()).toBe(false);
+    });
+  });
+
+  describe("steps tab visibility", () => {
+    it("should render steps tab when checkType is browser", () => {
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "browser",
+      });
+      expect(wrapper.find('[data-test="monitor-runs-tab-steps"]').exists()).toBe(true);
+    });
+
+    it("should not render steps tab when checkType is not browser", () => {
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "http",
+      });
+      expect(wrapper.find('[data-test="monitor-runs-tab-steps"]').exists()).toBe(false);
+    });
+  });
+
+  describe("location label resolution", () => {
+    it("should resolve location labels in locationDurationBreakdown when locations are loaded", async () => {
+      mockSyntheticsServiceGetLocations.mockResolvedValue({
+        data: {
+          locations: [
+            { id: "us-east-1", label: "US East", region: "N. Virginia" },
+            { id: "eu-west-1", label: "EU West", region: "Ireland" },
+            { id: "ap-south-1", label: "AP South", region: "Mumbai" },
+          ],
+        },
+      });
+
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "http",
+      });
+      await flushPromises();
+
+      // locationDisplayLabel produces "Name (region)" — check that the DOM
+      // contains resolved labels rather than raw IDs like "us-east-1"
+      // Mock data has runs only from us-east-1 and eu-west-1
+      const text = wrapper.text();
+      expect(text).toContain("US East (N. Virginia)");
+      expect(text).toContain("EU West (Ireland)");
+    });
+
+    it("should resolve location labels in pass rate by location breakdown", async () => {
+      mockSyntheticsServiceGetLocations.mockResolvedValue({
+        data: {
+          locations: [
+            { id: "us-east-1", label: "US East", region: "N. Virginia" },
+            { id: "eu-west-1", label: "EU West", region: "Ireland" },
+          ],
+        },
+      });
+
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "browser",
+      });
+      await flushPromises();
+
+      const text = wrapper.text();
+      expect(text).toContain("US East (N. Virginia)");
+      expect(text).toContain("EU West (Ireland)");
+    });
+
+    it("should resolve location labels in timeline segments when locations are loaded", async () => {
+      mockSyntheticsServiceGetLocations.mockResolvedValue({
+        data: {
+          locations: [
+            { id: "us-east-1", label: "US East", region: "N. Virginia" },
+            { id: "eu-west-1", label: "EU West", region: "Ireland" },
+          ],
+        },
+      });
+
+      wrapper = mountRuns({
+        monitorId: "mon-1",
+        monitorName: "Test Monitor",
+        checkType: "browser",
+      });
+      await flushPromises();
+
+      const timeline = wrapper.findComponent({ name: "MonitorStatusTimeline" });
+      expect(timeline.exists()).toBe(true);
+
+      const segments = timeline.props("segments") as any[];
+      expect(segments.length).toBeGreaterThan(0);
+
+      // Collect all execution locations from timeline segments
+      const allLocations = new Set<string>();
+      for (const seg of segments) {
+        for (const exec of seg.executions) {
+          allLocations.add(exec.location as string);
+        }
+      }
+
+      // Should contain only resolved display labels, not raw IDs
+      expect(allLocations.has("US East (N. Virginia)")).toBe(true);
+      expect(allLocations.has("EU West (Ireland)")).toBe(true);
+
+      // Should NOT contain raw IDs (locationLabel resolves them)
+      expect(allLocations.has("us-east-1")).toBe(false);
+      expect(allLocations.has("eu-west-1")).toBe(false);
     });
   });
 });

--- a/web/src/views/synthetics/MonitorRuns.vue
+++ b/web/src/views/synthetics/MonitorRuns.vue
@@ -33,21 +33,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div
-    class="monitor-runs h-full flex flex-col"
-    data-test="synthetics-monitor-runs"
-  >
+  <div class="monitor-runs flex h-full flex-col" data-test="synthetics-monitor-runs">
     <!-- Full-page empty state — replaces the entire content area when no
          runs exist in the current time window. The parent (MonitorResults)
          passes lastTriggeredAt to distinguish "never triggered" from "no
          runs in this window." -->
     <template v-if="kpiHasLoadedOnce && synthetics.kpi.value.totalRuns === 0">
-      <div class="flex-1 flex items-center justify-center">
+      <div class="flex flex-1 items-center justify-center">
         <OEmptyState
           size="hero"
           :illustration="lastTriggeredAt > 0 ? 'no-results' : 'browser-check'"
-          :title="lastTriggeredAt > 0 ? t('synthetics.results.noRunsInWindow') : t('synthetics.results.noRunsYet')"
-          :description="lastTriggeredAt > 0 ? t('synthetics.results.noRunsInWindowDesc') : t('synthetics.results.noRunsYetDesc')"
+          :title="
+            lastTriggeredAt > 0
+              ? t('synthetics.results.noRunsInWindow')
+              : t('synthetics.results.noRunsYet')
+          "
+          :description="
+            lastTriggeredAt > 0
+              ? t('synthetics.results.noRunsInWindowDesc')
+              : t('synthetics.results.noRunsYetDesc')
+          "
           data-test="monitor-runs-page-empty"
         >
           <template #actions>
@@ -82,984 +87,965 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- ── Tabs ──────────────────────────────────────────────────────── -->
     <template v-else>
-    <OTabs
-      v-model="activeTab"
-      class="shrink-0 px-page-edge border-b border-border-default"
-    >
-      <OTab name="overview" data-test="monitor-runs-tab-overview">
-        {{ t('synthetics.runs.tabOverview') }}
-      </OTab>
-      <OTab v-if="isBrowser" name="steps" data-test="monitor-runs-tab-steps"> {{ t('synthetics.runs.tabSteps') }} </OTab>
-    </OTabs>
+      <OTabs v-model="activeTab" class="px-page-edge border-border-default shrink-0 border-b">
+        <OTab name="overview" data-test="monitor-runs-tab-overview">
+          {{ t("synthetics.runs.tabOverview") }}
+        </OTab>
+        <OTab v-if="isBrowser" name="steps" data-test="monitor-runs-tab-steps">
+          {{ t("synthetics.runs.tabSteps") }}
+        </OTab>
+      </OTabs>
 
-    <div class="flex-1 min-h-0">
-      <OTabPanels v-model="activeTab" grow scroll="y" class="h-full min-h-0">
-        <!-- ════════════ OVERVIEW ════════════ -->
-        <OTabPanel name="overview">
-          <div
-            class="mx-auto py-2 flex flex-col gap-2"
-          >
-            <!-- Status Timeline — gated on runs query -->
-            <template v-if="runsLoading || !runsHasLoadedOnce">
-              <div class="px-page-edge">
-                <div
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
+      <div class="min-h-0 flex-1">
+        <OTabPanels v-model="activeTab" grow scroll="y" class="h-full min-h-0">
+          <!-- ════════════ OVERVIEW ════════════ -->
+          <OTabPanel name="overview">
+            <div class="mx-auto flex flex-col gap-2 py-2">
+              <!-- Status Timeline — gated on runs query -->
+              <template v-if="runsLoading || !runsHasLoadedOnce">
+                <div class="px-page-edge">
                   <div
-                    class="flex items-center gap-2 px-3.5 pt-2.5 pb-2"
+                    class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
                   >
-                    <SkeletonBox width="100px" height="14px" rounded-default />
-                    <span class="flex-1" />
-                    <SkeletonBox width="45px" height="12px" rounded-default />
-                    <SkeletonBox width="50px" height="12px" rounded-default />
-                    <SkeletonBox width="45px" height="12px" rounded-default />
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="flex flex-col gap-1 py-2 px-3.5">
-                    <div class="flex items-center gap-1">
-                      <div class="w-5 h-5 shrink-0" />
-                      <div class="flex-1 h-6.5 rounded-default flex gap-0.5 items-stretch">
-                        <div
-                          v-for="n in 26"
-                          :key="n"
-                          class="flex-1 h-full rounded-default bg-border-default opacity-40"
-                        />
+                    <div class="flex items-center gap-2 px-3.5 pt-2.5 pb-2">
+                      <SkeletonBox width="100px" height="14px" rounded-default />
+                      <span class="flex-1" />
+                      <SkeletonBox width="45px" height="12px" rounded-default />
+                      <SkeletonBox width="50px" height="12px" rounded-default />
+                      <SkeletonBox width="45px" height="12px" rounded-default />
+                    </div>
+                    <div class="border-border-default border-t" />
+                    <div class="flex flex-col gap-1 px-3.5 py-2">
+                      <div class="flex items-center gap-1">
+                        <div class="h-5 w-5 shrink-0" />
+                        <div class="rounded-default flex h-6.5 flex-1 items-stretch gap-0.5">
+                          <div
+                            v-for="n in 26"
+                            :key="n"
+                            class="rounded-default bg-border-default h-full flex-1 opacity-40"
+                          />
+                        </div>
+                        <div class="h-5 w-5 shrink-0" />
                       </div>
-                      <div class="w-5 h-5 shrink-0" />
-                    </div>
-                    <div class="flex justify-between">
-                      <SkeletonBox width="60px" height="10px" rounded-default />
-                      <SkeletonBox width="80px" height="10px" rounded-default />
-                      <SkeletonBox width="60px" height="10px" rounded-default />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </template>
-            <!-- Status Timeline — runs query error state -->
-            <template v-else-if="runsError">
-              <div class="px-page-edge">
-                <div
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-3.5 pt-2.5 pb-2"
-                  >
-                    <span class="font-bold text-sm text-text-heading">{{ t('synthetics.runs.statusTimeline') }}</span>
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="flex items-center justify-center py-6 text-xs text-status-error-text">
-                    <span class="flex items-center gap-1">
-                      <OIcon name="error" size="xs" />
-                      {{ runsError }}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </template>
-            <template v-else>
-              <div class="px-page-edge">
-              <MonitorStatusTimeline
-                :segments="timelineSegments"
-                :is-browser="isBrowser"
-                :fail-count="timelineFailCount"
-                :pass-count="timelinePassCount"
-                :mixed-count="timelineMixedCount"
-                :start-label="timelineStartLabel"
-                :end-label="timelineEndLabel"
-              />
-              </div>
-            </template>
-
-            <!-- KPI Cards — gated on KPI + last-run queries -->
-            <template v-if="kpiLoading || !kpiHasLoadedOnce">
-              <div class="px-page-edge">
-                <div class="grid grid-cols-6 gap-2.5">
-                  <div
-                    v-for="n in 6"
-                    :key="n"
-                    class="card-container rounded-default flex flex-col px-3.5 pt-2.5 pb-2.5 gap-2 bg-surface-base border border-border-default"
-                  >
-                    <SkeletonBox width="60%" height="11px" rounded-default />
-                    <SkeletonBox width="55%" height="22px" rounded-default />
-                  </div>
-                </div>
-              </div>
-            </template>
-            <template v-else>
-              <div class="px-page-edge">
-              <div class="grid grid-cols-6 gap-2.5">
-                <div
-                  v-for="card in kpiCards"
-                  :key="card.key"
-                  class="card-container rounded-default flex flex-col px-2 pt-2.5 pb-2.5 gap-1 bg-surface-base border border-border-default transition-shadow duration-200 hover:shadow-[0_1px_6px_rgba(0,0,0,0.08)]"
-                  :data-test="`monitor-runs-kpi-${card.key}`"
-                >
-                  <div class="flex flex-col gap-1">
-                    <div
-                      class="kpi-label text-2xs font-semibold text-text-muted"
-                    >
-                      {{ card.label }}
-                      <span v-if="card.unit"> ({{ card.unit }}) </span>
-                    </div>
-                    <div class="flex items-baseline gap-[0.2rem]">
-                      <!-- Per-card error indicator -->
-                      <template v-if="kpiError">
-                        <span class="flex items-center gap-1 text-xs text-status-error-text">
-                          <OIcon name="error" size="xs" class="shrink-0" />
-                          {{ kpiError }}
-                        </span>
-                      </template>
-                      <template v-else>
-                        <span
-                          class="text-xl font-bold leading-none text-[var(--color-text-heading)]"
-                          :class="card.valueClass"
-                        >
-                          {{ card.value }}
-                        </span>
-                      </template>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              </div>
-            </template>
-
-            <!-- Charts — gated on histogram query -->
-            <template v-if="histogramLoading || !histogramHasLoadedOnce">
-              <div class="px-page-edge">
-              <div class="grid grid-cols-2 gap-2">
-                <div
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <SkeletonBox width="110px" height="14px" rounded-default />
-                    <span class="flex-1" />
-                    <SkeletonBox width="80px" height="20px" rounded-default />
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="p-4">
-                    <SkeletonBox width="100%" height="160px" rounded-default />
-                  </div>
-                </div>
-                <div
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <SkeletonBox width="120px" height="14px" rounded-default />
-                    <span class="flex-1" />
-                    <SkeletonBox width="90px" height="20px" rounded-default />
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="p-4">
-                    <SkeletonBox width="100%" height="160px" rounded-default />
-                  </div>
-                </div>
-              </div>
-              </div>
-            </template>
-            <template v-else>
-              <div class="px-page-edge">
-              <div class="grid grid-cols-2 gap-2">
-                <div
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <span class="font-bold text-sm text-text-heading">
-                      {{ t('synthetics.results.responseTime') }}
-                    </span>
-                    <span class="flex-1" />
-                    <OBadge v-if="!histogramError" variant="default" size="sm">
-                      p95 {{ p95Label }}
-                    </OBadge>
-                    <span
-                      v-else
-                      class="inline-flex items-center gap-1 text-xs text-status-error-text"
-                    >
-                      <OIcon name="error_outline" size="xs" />
-                      {{ t('synthetics.results.error') }}
-                    </span>
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="min-h-45 p-0">
-                    <ChartRenderer
-                      v-if="!histogramError"
-                      :data="{ options: responseChartOption }"
-                      height="180px"
-                    />
-                    <div v-else class="flex flex-col items-center justify-center h-45 gap-1 text-sm text-text-secondary">
-                      <OIcon name="error_outline" size="sm" class="text-status-error-text" />
-                      <span>{{ histogramError }}</span>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <span class="font-bold text-sm text-text-heading">
-                      {{ t('synthetics.runs.errorsOverTime') }}
-                    </span>
-                    <span class="flex-1" />
-                    <OBadge v-if="!histogramError" variant="error" size="sm">
-                      {{ t('synthetics.runs.failedCount', { count: failCount }) }}
-                    </OBadge>
-                    <span
-                      v-else
-                      class="inline-flex items-center gap-1 text-xs text-status-error-text"
-                    >
-                      <OIcon name="error_outline" size="xs" />
-                      {{ t('synthetics.results.error') }}
-                    </span>
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="min-h-45 p-0">
-                    <ChartRenderer
-                      v-if="!histogramError"
-                      :data="{ options: errorChartOption }"
-                      height="180px"
-                    />
-                    <div v-else class="flex flex-col items-center justify-center h-45 gap-1 text-sm text-text-secondary">
-                      <OIcon name="error_outline" size="sm" class="text-status-error-text" />
-                      <span>{{ histogramError }}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              </div>
-            </template>
-
-            <!-- Breakdown Cards — gated on runs query -->
-            <template v-if="runsLoading || !runsHasLoadedOnce">
-              <div class="px-page-edge">
-              <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
-                <div
-                  v-for="n in (isBrowser ? 3 : 2)"
-                  :key="n"
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <SkeletonBox
-                      width="16px"
-                      height="16px"
-                      :custom-radius="'4px'"
-                    />
-                    <SkeletonBox width="110px" height="14px" rounded-default />
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="px-2 py-2 flex flex-col">
-                    <div
-                      v-for="row in 3"
-                      :key="row"
-                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
-                    >
-                      <SkeletonBox
-                        width="16px"
-                        height="16px"
-                        :custom-radius="'4px'"
-                      />
-                      <SkeletonBox width="70px" height="12px" rounded-default />
-                      <div
-                        class="flex-1 h-1.5 rounded-full bg-border-default opacity-30"
-                      />
-                      <SkeletonBox width="36px" height="12px" rounded-default />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              </div>
-            </template>
-            <!-- Breakdown Cards — runs query error state -->
-            <template v-else-if="runsError">
-              <div class="px-page-edge">
-              <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
-                <div
-                  v-for="dim in breakdownDimensions"
-                  :key="dim"
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <span class="font-bold text-sm text-text-heading">
-                      {{ dim === 'Browser' ? t('synthetics.runs.passRateByBrowser') : dim === 'DurationByLocation' ? t('synthetics.runs.durationByLocation') : dim === 'Location' ? t('synthetics.runs.passRateByLocation') : t('synthetics.runs.passRateByDevice') }}
-                    </span>
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="flex items-center justify-center py-8 text-xs text-status-error-text">
-                    <span class="flex items-center gap-1">
-                      <OIcon name="error" size="xs" />
-                      {{ runsError }}
-                    </span>
-                  </div>
-                </div>
-              </div>
-              </div>
-            </template>
-            <template v-else>
-              <div class="px-page-edge">
-              <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
-                <div
-                  v-if="isBrowser"
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <OIcon name="language" size="sm" class="text-accent" />
-                    <span class="font-bold text-sm text-text-heading">
-                      {{ t('synthetics.runs.passRateByBrowser') }}
-                    </span>
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="px-2 py-2">
-                    <div
-                      v-for="b in browserBreakdown"
-                      :key="b.name"
-                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
-                    >
-                      <OIcon
-                        :name="b.icon"
-                        size="sm"
-                        class="text-text-secondary flex-none"
-                      />
-                      <OTooltip :content="b.name">
-                        <span
-                          class="w-20 flex-none font-semibold text-xs text-text-body truncate cursor-help"
-                        >
-                          {{ b.name }}
-                        </span>
-                      </OTooltip>
-                      <div
-                        class="flex-1 h-1.5 rounded-full bg-text-disabled/25! overflow-hidden min-w-10"
-                      >
-                        <!-- :style for dynamic bar width + computed color — inline required for per-breakdown values -->
-                        <div
-                          class="h-full rounded-full"
-                          :style="{ width: b.barPct || b.pct, background: b.barColor }"
-                        />
+                      <div class="flex justify-between">
+                        <SkeletonBox width="60px" height="10px" rounded-default />
+                        <SkeletonBox width="80px" height="10px" rounded-default />
+                        <SkeletonBox width="60px" height="10px" rounded-default />
                       </div>
-                      <span
-                        class="font-mono tabular-nums font-bold text-xs w-12 text-right"
-                        :style="{ color: b.textColor }"
-                      >
-                        {{ b.pct }}
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <!-- Status Timeline — runs query error state -->
+              <template v-else-if="runsError">
+                <div class="px-page-edge">
+                  <div
+                    class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                  >
+                    <div class="flex items-center gap-2 px-3.5 pt-2.5 pb-2">
+                      <span class="text-text-heading text-sm font-bold">{{
+                        t("synthetics.runs.statusTimeline")
+                      }}</span>
+                    </div>
+                    <div class="border-border-default border-t" />
+                    <div
+                      class="text-status-error-text flex items-center justify-center py-6 text-xs"
+                    >
+                      <span class="flex items-center gap-1">
+                        <OIcon name="error" size="xs" />
+                        {{ runsError }}
                       </span>
                     </div>
                   </div>
                 </div>
-                <div
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <OIcon
-                      name="location-on"
-                      size="sm"
-                      class="text-accent"
-                    />
-                    <span class="font-bold text-sm text-text-heading">
-                      {{ t('synthetics.runs.passRateByLocation') }}
-                    </span>
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="px-2 py-2">
-                    <div
-                      v-for="l in locationBreakdown"
-                      :key="l.id ?? l.name"
-                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
-                    >
-                      <OIcon
-                        :name="l.icon"
-                        size="sm"
-                        class="text-text-secondary flex-none"
-                      />
-                      <OTooltip :content="l.name">
-                        <span
-                          class="w-40 flex-none font-semibold text-xs text-text-body truncate cursor-help"
-                        >
-                          {{ l.name }}
-                        </span>
-                      </OTooltip>
-                      <div
-                        class="flex-1 h-1.5 rounded-full bg-text-disabled/25! overflow-hidden min-w-10"
-                      >
-                        <div
-                          class="h-full rounded-full"
-                          :style="{ width: l.barPct || l.pct, background: l.barColor }"
-                        />
-                      </div>
-                      <span
-                        class="font-mono tabular-nums font-bold text-xs w-12 text-right"
-                        :style="{ color: l.textColor }"
-                      >
-                        {{ l.pct }}
-                      </span>
-                    </div>
-                  </div>
+              </template>
+              <template v-else>
+                <div class="px-page-edge">
+                  <MonitorStatusTimeline
+                    :segments="timelineSegments"
+                    :is-browser="isBrowser"
+                    :fail-count="timelineFailCount"
+                    :pass-count="timelinePassCount"
+                    :mixed-count="timelineMixedCount"
+                    :start-label="timelineStartLabel"
+                    :end-label="timelineEndLabel"
+                  />
                 </div>
-                <div
-                  v-if="isBrowser"
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <OIcon name="devices" size="sm" class="text-accent" />
-                    <span class="font-bold text-sm text-text-heading">
-                      {{ t('synthetics.runs.passRateByDevice') }}
-                    </span>
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="px-2 py-2">
-                    <div
-                      v-for="d in deviceBreakdown"
-                      :key="d.name"
-                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
-                    >
-                      <OIcon
-                        :name="d.icon"
-                        size="sm"
-                        class="text-text-secondary flex-none"
-                      />
-                      <OTooltip :content="d.name">
-                        <span
-                          class="w-18 flex-none font-semibold text-xs text-text-body truncate cursor-help text-capitalize"
-                        >
-                          {{ d.name }}
-                        </span>
-                      </OTooltip>
-                      <div
-                        class="flex-1 h-1.5 rounded-full bg-text-disabled/25! overflow-hidden min-w-10"
-                      >
-                        <div
-                          class="h-full rounded-full"
-                          :style="{ width: d.pct, background: d.barColor }"
-                        />
-                      </div>
-                      <span
-                        class="font-mono tabular-nums font-bold text-xs w-12 text-right"
-                        :style="{ color: d.textColor }"
-                      >
-                        {{ d.pct }}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  v-if="!isBrowser"
-                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
-                >
-                  <div
-                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
-                  >
-                    <OIcon name="schedule" size="sm" class="text-accent" />
-                    <span class="font-bold text-sm text-text-heading">
-                      {{ t('synthetics.runs.durationByLocation') }}
-                    </span>
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="px-2 py-2">
-                    <div
-                      v-for="d in locationDurationBreakdown"
-                      :key="d.id ?? d.name"
-                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
-                    >
-                      <OIcon
-                        :name="d.icon"
-                        size="sm"
-                        class="text-text-secondary flex-none"
-                      />
-                      <OTooltip :content="d.name">
-                        <span
-                          class="w-34 flex-none font-semibold text-xs text-text-body truncate cursor-help"
-                        >
-                          {{ d.name }}
-                        </span>
-                      </OTooltip>
-                      <div
-                        class="flex-1 h-1.5 rounded-full bg-text-disabled/25! overflow-hidden min-w-10"
-                      >
-                        <div
-                          class="h-full rounded-full"
-                          :style="{ width: d.barPct || d.pct, background: d.barColor }"
-                        />
-                      </div>
-                      <span
-                        class="font-mono tabular-nums font-bold text-xs w-12 text-right"
-                        :style="{ color: d.textColor }"
-                      >
-                        {{ d.pct }}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              </div>
-            </template>
-
-            <!-- Filter bar -->
-            <div class="flex items-center gap-2 flex-wrap px-2">
-              <OToggleGroup v-model="statusFilter" variant="default">
-                <OToggleGroupItem
-                  v-for="so in statusOptions"
-                  :key="so.key"
-                  :value="so.key"
-                  size="sm"
-                >
-                  <template #icon-left>
-                    <span
-                      class="w-[0.4375rem] h-[0.4375rem] rounded-full"
-                      :style="{ background: so.dot }"
-                    />
-                  </template>
-                  {{ so.label }}
-                </OToggleGroupItem>
-              </OToggleGroup>
-
-              <OSelect
-                v-if="isBrowser"
-                v-model="browserFilter"
-                :options="browserOptions"
-                icon-key="icon"
-                size="md"
-                class="w-35!"
-                data-test="monitor-runs-filter-browser"
-              />
-              <OSelect
-                v-if="isBrowser"
-                v-model="deviceFilter"
-                :options="deviceOptions"
-                icon-key="icon"
-                size="md"
-                class="w-35!"
-                data-test="monitor-runs-filter-device"
-              />
-              <OSelect
-                v-model="locationFilter"
-                :options="locationOptions"
-                icon-key="icon"
-                size="md"
-                class="w-35!"
-                data-test="monitor-runs-filter-location"
-              />
-
-              <!-- Failure-specific filters -->
-              <template v-if="statusFilter === 'fail' && false">
-                <OSeparator orientation="vertical" class="h-5" />
-                <OSelect
-                  v-model="failedStepFilter"
-                  :options="failedStepOptions"
-                  size="sm"
-                  class="w-40"
-                  data-test="monitor-runs-filter-step"
-                />
-                <OInput
-                  v-model="locatorFilter"
-                  size="sm"
-                  :placeholder="t('synthetics.runs.locatorPlaceholder')"
-                  class="w-42.5"
-                  data-test="monitor-runs-filter-locator"
-                />
-                <OSelect
-                  v-model="actionFilter"
-                  :options="actionOptions"
-                  size="sm"
-                  class="w-32.5"
-                  data-test="monitor-runs-filter-action"
-                />
               </template>
 
-              <span class="flex-1" />
-              <span class="text-xs text-text-secondary">
-                {{ t('synthetics.runs.filterCount', { current: filteredRuns.length, total: allRuns.length }) }}
-              </span>
-            </div>
+              <!-- KPI Cards — gated on KPI + last-run queries -->
+              <template v-if="kpiLoading || !kpiHasLoadedOnce">
+                <div class="px-page-edge">
+                  <div class="grid grid-cols-6 gap-2.5">
+                    <div
+                      v-for="n in 6"
+                      :key="n"
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col gap-2 border px-3.5 pt-2.5 pb-2.5"
+                    >
+                      <SkeletonBox width="60%" height="11px" rounded-default />
+                      <SkeletonBox width="55%" height="22px" rounded-default />
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <template v-else>
+                <div class="px-page-edge">
+                  <div class="grid grid-cols-6 gap-2.5">
+                    <div
+                      v-for="card in kpiCards"
+                      :key="card.key"
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col gap-1 border px-2 pt-2.5 pb-2.5 transition-shadow duration-200 hover:shadow-[0_1px_6px_rgba(0,0,0,0.08)]"
+                      :data-test="`monitor-runs-kpi-${card.key}`"
+                    >
+                      <div class="flex flex-col gap-1">
+                        <div class="kpi-label text-2xs text-text-muted font-semibold">
+                          {{ card.label }}
+                          <span v-if="card.unit"> ({{ card.unit }}) </span>
+                        </div>
+                        <div class="flex items-baseline gap-[0.2rem]">
+                          <!-- Per-card error indicator -->
+                          <template v-if="kpiError">
+                            <span class="text-status-error-text flex items-center gap-1 text-xs">
+                              <OIcon name="error" size="xs" class="shrink-0" />
+                              {{ kpiError }}
+                            </span>
+                          </template>
+                          <template v-else>
+                            <span
+                              class="text-xl leading-none font-bold text-[var(--color-text-heading)]"
+                              :class="card.valueClass"
+                            >
+                              {{ card.value }}
+                            </span>
+                          </template>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
 
-            <!-- Error filter indicator -->
-            <div
-              v-if="errorFilter"
-              class="flex items-center gap-2 px-2"
-              data-test="monitor-runs-error-filter-badge"
-            >
-              <span class="text-xs text-text-secondary"
-                >{{ t('synthetics.runs.filteringByErrorLabel') }}</span
-              >
-              <OBadge variant="error" size="sm" class="gap-1">
-                {{ errorFilter }}
-                <OButton
-                  variant="ghost"
-                  size="icon-xs"
-                  class="text-inherit"
-                  data-test="synthetics-monitor-runs-clear-error-filter-btn"
-                  @click.stop="clearErrorFilter"
-                >
-                  <OIcon name="close" size="xs" />
-                </OButton>
-              </OBadge>
-            </div>
+              <!-- Charts — gated on histogram query -->
+              <template v-if="histogramLoading || !histogramHasLoadedOnce">
+                <div class="px-page-edge">
+                  <div class="grid grid-cols-2 gap-2">
+                    <div
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <SkeletonBox width="110px" height="14px" rounded-default />
+                        <span class="flex-1" />
+                        <SkeletonBox width="80px" height="20px" rounded-default />
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div class="p-4">
+                        <SkeletonBox width="100%" height="160px" rounded-default />
+                      </div>
+                    </div>
+                    <div
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <SkeletonBox width="120px" height="14px" rounded-default />
+                        <span class="flex-1" />
+                        <SkeletonBox width="90px" height="20px" rounded-default />
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div class="p-4">
+                        <SkeletonBox width="100%" height="160px" rounded-default />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <template v-else>
+                <div class="px-page-edge">
+                  <div class="grid grid-cols-2 gap-2">
+                    <div
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <span class="text-text-heading text-sm font-bold">
+                          {{ t("synthetics.results.responseTime") }}
+                        </span>
+                        <span class="flex-1" />
+                        <OBadge v-if="!histogramError" variant="default" size="sm">
+                          p95 {{ p95Label }}
+                        </OBadge>
+                        <span
+                          v-else
+                          class="text-status-error-text inline-flex items-center gap-1 text-xs"
+                        >
+                          <OIcon name="error_outline" size="xs" />
+                          {{ t("synthetics.results.error") }}
+                        </span>
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div class="min-h-45 p-0">
+                        <ChartRenderer
+                          v-if="!histogramError"
+                          :data="{ options: responseChartOption }"
+                          height="180px"
+                        />
+                        <div
+                          v-else
+                          class="text-text-secondary flex h-45 flex-col items-center justify-center gap-1 text-sm"
+                        >
+                          <OIcon name="error_outline" size="sm" class="text-status-error-text" />
+                          <span>{{ histogramError }}</span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <span class="text-text-heading text-sm font-bold">
+                          {{ t("synthetics.runs.errorsOverTime") }}
+                        </span>
+                        <span class="flex-1" />
+                        <OBadge v-if="!histogramError" variant="error" size="sm">
+                          {{ t("synthetics.runs.failedCount", { count: failCount }) }}
+                        </OBadge>
+                        <span
+                          v-else
+                          class="text-status-error-text inline-flex items-center gap-1 text-xs"
+                        >
+                          <OIcon name="error_outline" size="xs" />
+                          {{ t("synthetics.results.error") }}
+                        </span>
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div class="min-h-45 p-0">
+                        <ChartRenderer
+                          v-if="!histogramError"
+                          :data="{ options: errorChartOption }"
+                          height="180px"
+                        />
+                        <div
+                          v-else
+                          class="text-text-secondary flex h-45 flex-col items-center justify-center gap-1 text-sm"
+                        >
+                          <OIcon name="error_outline" size="sm" class="text-status-error-text" />
+                          <span>{{ histogramError }}</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
 
-            <!-- Runs table -->
-            <OCard class="p-0" :key="tableFilterKey">
-              <OTable
-                :columns="runColumns"
-                :data="visibleRuns"
-                :loading="runsLoading"
-                pagination="client"
-                :page-size="10"
-                :page-size-options="[10, 20, 25, 50]"
-                row-key="id"
-                :show-global-filter="false"
-                :enable-column-resize="true"
-                :enable-column-reorder="true"
-                data-test="monitor-runs-runs-table"
-                @row-click="openRun"
-              >
-                <template #cell-status="{ row }">
-                  <OBadge
-                    :variant="(row as VisibleRun).statusBadgeVariant"
+              <!-- Breakdown Cards — gated on runs query -->
+              <template v-if="runsLoading || !runsHasLoadedOnce">
+                <div class="px-page-edge">
+                  <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
+                    <div
+                      v-for="n in isBrowser ? 3 : 2"
+                      :key="n"
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <SkeletonBox width="16px" height="16px" :custom-radius="'4px'" />
+                        <SkeletonBox width="110px" height="14px" rounded-default />
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div class="flex flex-col px-2 py-2">
+                        <div
+                          v-for="row in 3"
+                          :key="row"
+                          class="border-border-default flex items-center gap-3 border-b py-2.25 last:border-b-0"
+                        >
+                          <SkeletonBox width="16px" height="16px" :custom-radius="'4px'" />
+                          <SkeletonBox width="70px" height="12px" rounded-default />
+                          <div class="bg-border-default h-1.5 flex-1 rounded-full opacity-30" />
+                          <SkeletonBox width="36px" height="12px" rounded-default />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <!-- Breakdown Cards — runs query error state -->
+              <template v-else-if="runsError">
+                <div class="px-page-edge">
+                  <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
+                    <div
+                      v-for="dim in breakdownDimensions"
+                      :key="dim"
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <span class="text-text-heading text-sm font-bold">
+                          {{
+                            dim === "Browser"
+                              ? t("synthetics.runs.passRateByBrowser")
+                              : dim === "DurationByLocation"
+                                ? t("synthetics.runs.durationByLocation")
+                                : dim === "Location"
+                                  ? t("synthetics.runs.passRateByLocation")
+                                  : t("synthetics.runs.passRateByDevice")
+                          }}
+                        </span>
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div
+                        class="text-status-error-text flex items-center justify-center py-8 text-xs"
+                      >
+                        <span class="flex items-center gap-1">
+                          <OIcon name="error" size="xs" />
+                          {{ runsError }}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <template v-else>
+                <div class="px-page-edge">
+                  <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
+                    <div
+                      v-if="isBrowser"
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <OIcon name="language" size="sm" class="text-accent" />
+                        <span class="text-text-heading text-sm font-bold">
+                          {{ t("synthetics.runs.passRateByBrowser") }}
+                        </span>
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div class="px-2 py-2">
+                        <div
+                          v-for="b in browserBreakdown"
+                          :key="b.name"
+                          class="border-border-default flex items-center gap-3 border-b py-2.25 last:border-b-0"
+                        >
+                          <OIcon :name="b.icon" size="sm" class="text-text-secondary flex-none" />
+                          <OTooltip :content="b.name">
+                            <span
+                              class="text-text-body w-20 flex-none cursor-help truncate text-xs font-semibold"
+                            >
+                              {{ b.name }}
+                            </span>
+                          </OTooltip>
+                          <div
+                            class="bg-text-disabled/25! h-1.5 min-w-10 flex-1 overflow-hidden rounded-full"
+                          >
+                            <!-- :style for dynamic bar width + computed color — inline required for per-breakdown values -->
+                            <div
+                              class="h-full rounded-full"
+                              :style="{ width: b.barPct || b.pct, background: b.barColor }"
+                            />
+                          </div>
+                          <span
+                            class="w-12 text-right font-mono text-xs font-bold tabular-nums"
+                            :style="{ color: b.textColor }"
+                          >
+                            {{ b.pct }}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <OIcon name="location-on" size="sm" class="text-accent" />
+                        <span class="text-text-heading text-sm font-bold">
+                          {{ t("synthetics.runs.passRateByLocation") }}
+                        </span>
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div class="px-2 py-2">
+                        <div
+                          v-for="l in locationBreakdown"
+                          :key="l.id ?? l.name"
+                          class="border-border-default flex items-center gap-3 border-b py-2.25 last:border-b-0"
+                        >
+                          <OIcon :name="l.icon" size="sm" class="text-text-secondary flex-none" />
+                          <OTooltip :content="l.name">
+                            <span
+                              class="text-text-body w-40 flex-none cursor-help truncate text-xs font-semibold"
+                            >
+                              {{ l.name }}
+                            </span>
+                          </OTooltip>
+                          <div
+                            class="bg-text-disabled/25! h-1.5 min-w-10 flex-1 overflow-hidden rounded-full"
+                          >
+                            <div
+                              class="h-full rounded-full"
+                              :style="{ width: l.barPct || l.pct, background: l.barColor }"
+                            />
+                          </div>
+                          <span
+                            class="w-12 text-right font-mono text-xs font-bold tabular-nums"
+                            :style="{ color: l.textColor }"
+                          >
+                            {{ l.pct }}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      v-if="isBrowser"
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <OIcon name="devices" size="sm" class="text-accent" />
+                        <span class="text-text-heading text-sm font-bold">
+                          {{ t("synthetics.runs.passRateByDevice") }}
+                        </span>
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div class="px-2 py-2">
+                        <div
+                          v-for="d in deviceBreakdown"
+                          :key="d.name"
+                          class="border-border-default flex items-center gap-3 border-b py-2.25 last:border-b-0"
+                        >
+                          <OIcon :name="d.icon" size="sm" class="text-text-secondary flex-none" />
+                          <OTooltip :content="d.name">
+                            <span
+                              class="text-text-body text-capitalize w-18 flex-none cursor-help truncate text-xs font-semibold"
+                            >
+                              {{ d.name }}
+                            </span>
+                          </OTooltip>
+                          <div
+                            class="bg-text-disabled/25! h-1.5 min-w-10 flex-1 overflow-hidden rounded-full"
+                          >
+                            <div
+                              class="h-full rounded-full"
+                              :style="{ width: d.pct, background: d.barColor }"
+                            />
+                          </div>
+                          <span
+                            class="w-12 text-right font-mono text-xs font-bold tabular-nums"
+                            :style="{ color: d.textColor }"
+                          >
+                            {{ d.pct }}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      v-if="!isBrowser"
+                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    >
+                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                        <OIcon name="schedule" size="sm" class="text-accent" />
+                        <span class="text-text-heading text-sm font-bold">
+                          {{ t("synthetics.runs.durationByLocation") }}
+                        </span>
+                      </div>
+                      <div class="border-border-default border-t" />
+                      <div class="px-2 py-2">
+                        <div
+                          v-for="d in locationDurationBreakdown"
+                          :key="d.id ?? d.name"
+                          class="border-border-default flex items-center gap-3 border-b py-2.25 last:border-b-0"
+                        >
+                          <OIcon :name="d.icon" size="sm" class="text-text-secondary flex-none" />
+                          <OTooltip :content="d.name">
+                            <span
+                              class="text-text-body w-34 flex-none cursor-help truncate text-xs font-semibold"
+                            >
+                              {{ d.name }}
+                            </span>
+                          </OTooltip>
+                          <div
+                            class="bg-text-disabled/25! h-1.5 min-w-10 flex-1 overflow-hidden rounded-full"
+                          >
+                            <div
+                              class="h-full rounded-full"
+                              :style="{ width: d.barPct || d.pct, background: d.barColor }"
+                            />
+                          </div>
+                          <span
+                            class="w-12 text-right font-mono text-xs font-bold tabular-nums"
+                            :style="{ color: d.textColor }"
+                          >
+                            {{ d.pct }}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
+
+              <!-- Filter bar -->
+              <div class="flex flex-wrap items-center gap-2 px-2">
+                <OToggleGroup v-model="statusFilter" variant="default">
+                  <OToggleGroupItem
+                    v-for="so in statusOptions"
+                    :key="so.key"
+                    :value="so.key"
                     size="sm"
-                    dot
                   >
-                    {{ (row as VisibleRun).statusLabel }}
-                  </OBadge>
-                </template>
-                <template #cell-scheduled_at="{ row }">
-                  <OTimeCell
-                    :value="(row as VisibleRun).scheduledTs"
-                    unit="ms"
-                    mode="absolute"
-                    empty-label="—"
+                    <template #icon-left>
+                      <span
+                        class="h-[0.4375rem] w-[0.4375rem] rounded-full"
+                        :style="{ background: so.dot }"
+                      />
+                    </template>
+                    {{ so.label }}
+                  </OToggleGroupItem>
+                </OToggleGroup>
+
+                <OSelect
+                  v-if="isBrowser"
+                  v-model="browserFilter"
+                  :options="browserOptions"
+                  icon-key="icon"
+                  size="md"
+                  class="w-35!"
+                  data-test="monitor-runs-filter-browser"
+                />
+                <OSelect
+                  v-if="isBrowser"
+                  v-model="deviceFilter"
+                  :options="deviceOptions"
+                  icon-key="icon"
+                  size="md"
+                  class="w-35!"
+                  data-test="monitor-runs-filter-device"
+                />
+                <OSelect
+                  v-model="locationFilter"
+                  :options="locationOptions"
+                  icon-key="icon"
+                  size="md"
+                  class="w-35!"
+                  data-test="monitor-runs-filter-location"
+                />
+
+                <!-- Failure-specific filters -->
+                <template v-if="statusFilter === 'fail' && false">
+                  <OSeparator orientation="vertical" class="h-5" />
+                  <OSelect
+                    v-model="failedStepFilter"
+                    :options="failedStepOptions"
+                    size="sm"
+                    class="w-40"
+                    data-test="monitor-runs-filter-step"
+                  />
+                  <OInput
+                    v-model="locatorFilter"
+                    size="sm"
+                    :placeholder="t('synthetics.runs.locatorPlaceholder')"
+                    class="w-42.5"
+                    data-test="monitor-runs-filter-locator"
+                  />
+                  <OSelect
+                    v-model="actionFilter"
+                    :options="actionOptions"
+                    size="sm"
+                    class="w-32.5"
+                    data-test="monitor-runs-filter-action"
                   />
                 </template>
-                <template #cell-last_run_at="{ row }">
-                  <OTimeCell
-                    :value="(row as VisibleRun).lastRunTs"
-                    unit="ms"
-                    mode="absolute"
-                    empty-label="—"
-                  />
-                </template>
-                <template #cell-duration="{ row }">
-                  <span class="tabular-nums text-sm">
-                    {{ (row as VisibleRun).duration }}
-                  </span>
-                </template>
-                <template #cell-location="{ row }">
-                  <span
-                    class="inline-flex items-center gap-1 text-sm text-text-body"
-                  >
-                    <OIcon
-                      :name="locationIcon((row as VisibleRun).location)"
-                      size="sm"
-                    />
-                    {{ locationLabel((row as VisibleRun).location) }}
-                  </span>
-                </template>
-                <template #cell-browser="{ row }">
-                  <span
-                    class="inline-flex items-center gap-1 text-sm text-text-body"
-                  >
-                    <OIcon
-                      :name="browserIcon((row as VisibleRun).browser)"
-                      size="sm"
-                    />
-                    {{ (row as VisibleRun).browser }}
-                  </span>
-                </template>
-                <template #cell-device="{ row }">
-                  <span
-                    class="inline-flex items-center gap-1 text-sm text-text-body"
-                  >
-                    <OIcon
-                      :name="deviceIconName((row as VisibleRun).device)"
-                      size="sm"
-                    />
-                    {{ deviceLabel((row as VisibleRun).device) }}
-                  </span>
-                </template>
-                <template #cell-error="{ row }">
-                  <span
-                    v-if="(row as VisibleRun).errorSnippet"
-                    class="cursor-pointer"
-                    @click.stop="
-                      filterByError((row as VisibleRun).errorPattern)
-                    "
-                  >
-                    <OBadge
-                      variant="error-outline"
-                      size="sm"
-                      class="truncate max-w-50"
-                    >
-                      {{ (row as VisibleRun).errorSnippet }}
-                    </OBadge>
-                  </span>
-                </template>
-                <template #cell-trigger_type="{ row }">
-                  <span class="text-sm text-text-body">
-                    {{ (row as VisibleRun).triggerType }}
-                  </span>
-                </template>
 
-                <!-- Empty state: smart — differentiates "never run" vs "no runs in window" -->
-                <template #empty>
-                  <div v-if="kpiHasLoadedOnce" class="px-page-edge">
-                    <!-- Monitor has runs elsewhere — guide to last run + optionally clear filters -->
-                    <OEmptyState
-                      v-if="synthetics.kpi.value.totalRuns > 0"
-                      size="block"
-                      illustration="no-results"
-                      :title="t('synthetics.results.noRunsInWindow')"
-                      :description="t('synthetics.results.noRunsInWindowDesc')"
-                      data-test="monitor-runs-empty"
-                    >
-                      <template #actions>
-                        <EmptyStateActionCard
-                          icon="schedule"
-                          :label="t('synthetics.results.jumpToLastRun')"
-                          :sublabel="lastRunLabel"
-                          data-test="monitor-runs-empty-jump-last-run"
-                          @click="handleEmptyStateAction('jump-to-last-run')"
-                        />
-                        <EmptyStateActionCard
-                          v-if="hasActiveFilters"
-                          icon="filter-list"
-                          :label="t('synthetics.results.clearFilters')"
-                          :sublabel="t('synthetics.results.clearFiltersDesc')"
-                          data-test="monitor-runs-empty-clear-filters"
-                          @click="handleEmptyStateAction('clear-filters')"
-                        />
-                      </template>
-                    </OEmptyState>
-
-                    <!-- Monitor has never been run — prompt to trigger -->
-                    <OEmptyState
-                      v-else
-                      size="block"
-                      illustration="browser-check"
-                      :title="t('synthetics.results.noRunsYet')"
-                      :description="t('synthetics.results.noRunsYetDesc')"
-                      data-test="monitor-runs-empty"
-                    >
-                      <template #actions>
-                        <EmptyStateActionCard
-                          icon="play-arrow"
-                          :label="t('synthetics.results.triggerRunNow')"
-                          :sublabel="t('synthetics.results.triggerRunNowDesc')"
-                          data-test="monitor-runs-empty-trigger-run"
-                          @click="handleEmptyStateAction('trigger-run')"
-                        />
-                      </template>
-                    </OEmptyState>
-                  </div>
-                </template>
-              </OTable>
-            </OCard>
-
-          </div>
-        </OTabPanel>
-
-        <!-- ════════════ STEPS ════════════ -->
-        <!-- ════════════ STEPS ════════════ -->
-        <OTabPanel name="steps">
-          <div
-            class="mx-auto flex flex-col gap-2"
-          >
-            <!-- Loading skeleton -->
-            <template v-if="stepsLoading || !stepsHasLoadedOnce">
-              <div class="grid grid-cols-2 gap-2">
-                <div class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden">
-                  <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                    <SkeletonBox width="100px" height="14px" rounded-default />
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="p-4"><SkeletonBox width="100%" height="160px" rounded-default /></div>
-                </div>
-                <div class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden">
-                  <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                    <SkeletonBox width="100px" height="14px" rounded-default />
-                  </div>
-                  <div class="border-t border-border-default" />
-                  <div class="p-4"><SkeletonBox width="100%" height="160px" rounded-default /></div>
-                </div>
+                <span class="flex-1" />
+                <span class="text-text-secondary text-xs">
+                  {{
+                    t("synthetics.runs.filterCount", {
+                      current: filteredRuns.length,
+                      total: allRuns.length,
+                    })
+                  }}
+                </span>
               </div>
-              <div v-for="n in 5" :key="n" class="card-container rounded-default overflow-hidden">
-                <div class="h-10 bg-[var(--color-border-default)] opacity-20" />
-              </div>
-            </template>
 
-            <!-- Steps query error — compact inline indicator -->
-            <template v-else-if="stepsError">
+              <!-- Error filter indicator -->
               <div
-                class="px-2 flex items-center gap-2"
-                data-test="monitor-runs-steps-error"
+                v-if="errorFilter"
+                class="flex items-center gap-2 px-2"
+                data-test="monitor-runs-error-filter-badge"
               >
-                <OIcon name="error_outline" size="xs" class="text-status-error-text shrink-0" />
-                <span class="text-xs text-status-error-text truncate flex-1 min-w-0">{{ stepsError }}</span>
-                <OButton
-                  variant="ghost"
-                  size="xs"
-                  class="underline! text-xs!"
-                  data-test="monitor-runs-steps-retry-btn"
-                  @click="emit('refresh')"
-                >
-                  {{ t('synthetics.journey.retry') }}
-                </OButton>
+                <span class="text-text-secondary text-xs">{{
+                  t("synthetics.runs.filteringByErrorLabel")
+                }}</span>
+                <OBadge variant="error" size="sm" class="gap-1">
+                  {{ errorFilter }}
+                  <OButton
+                    variant="ghost"
+                    size="icon-xs"
+                    class="text-inherit"
+                    data-test="synthetics-monitor-runs-clear-error-filter-btn"
+                    @click.stop="clearErrorFilter"
+                  >
+                    <OIcon name="close" size="xs" />
+                  </OButton>
+                </OBadge>
               </div>
-            </template>
 
-            <!-- Real content -->
-            <template v-else>
-              <!-- Steps Analysis Table -->
-              <OCard class="p-0">
+              <!-- Runs table -->
+              <OCard class="p-0" :key="tableFilterKey">
                 <OTable
-                  :data="stepTableRows"
-                  :columns="stepTableColumns"
+                  :columns="runColumns"
+                  :data="visibleRuns"
+                  :loading="runsLoading"
+                  pagination="client"
+                  :page-size="10"
+                  :page-size-options="[10, 20, 25, 50]"
                   row-key="id"
-                  :pagination="'none'"
-                  :sorting="'client'"
                   :show-global-filter="false"
-                  :show-header="true"
-                  :dense="true"
-                  :bordered="true"
                   :enable-column-resize="true"
                   :enable-column-reorder="true"
-                  :fill-height="false"
+                  data-test="monitor-runs-runs-table"
+                  @row-click="openRun"
                 >
-                  <!-- cell-name: Step name -->
-                  <template #cell-name="{ row }">
-                    <div class="min-w-0">
-                      <div class="font-semibold text-xs text-[var(--color-text-heading)] truncate">
-                        {{ row.name }}
-                      </div>
-                    </div>
+                  <template #cell-status="{ row }">
+                    <OBadge :variant="(row as VisibleRun).statusBadgeVariant" size="sm" dot>
+                      {{ (row as VisibleRun).statusLabel }}
+                    </OBadge>
                   </template>
-
-                  <!-- cell-failRate: Colored percentage + bar -->
-                  <template #cell-failRate="{ row }">
-                    <div class="flex flex-col gap-1">
-                      <span class="font-mono tabular-nums font-bold text-xs" :style="{ color: row.failColor }">
-                        {{ row.failRatePct }}%&ensp;<span class="font-normal text-[var(--color-text-muted)]">{{ row.failCount }}</span>
-                      </span>
-                      <div class="h-1.25 rounded-full bg-[var(--color-text-disabled)]/25! overflow-hidden">
-                        <div class="h-full rounded-full" :style="{ width: row.failRateBarPct, background: row.failBarColor }" />
-                      </div>
-                    </div>
+                  <template #cell-scheduled_at="{ row }">
+                    <OTimeCell
+                      :value="(row as VisibleRun).scheduledTs"
+                      unit="ms"
+                      mode="absolute"
+                      empty-label="—"
+                    />
                   </template>
-
-                  <!-- cell-flakyRate: Colored percentage -->
-                  <template #cell-flakyRate="{ row }">
-                    <span class="font-mono tabular-nums text-xs" :style="{ color: row.flakyColor }">
-                      {{ row.flakyRatePct }}%&ensp;<span class="font-normal text-[var(--color-text-muted)]">{{ row.flakyCount }}</span>
+                  <template #cell-last_run_at="{ row }">
+                    <OTimeCell
+                      :value="(row as VisibleRun).lastRunTs"
+                      unit="ms"
+                      mode="absolute"
+                      empty-label="—"
+                    />
+                  </template>
+                  <template #cell-duration="{ row }">
+                    <span class="text-sm tabular-nums">
+                      {{ (row as VisibleRun).duration }}
+                    </span>
+                  </template>
+                  <template #cell-location="{ row }">
+                    <span class="text-text-body inline-flex items-center gap-1 text-sm">
+                      <OIcon :name="locationIcon((row as VisibleRun).location)" size="sm" />
+                      {{ locationLabel((row as VisibleRun).location) }}
+                    </span>
+                  </template>
+                  <template #cell-browser="{ row }">
+                    <span class="text-text-body inline-flex items-center gap-1 text-sm">
+                      <OIcon :name="browserIcon((row as VisibleRun).browser)" size="sm" />
+                      {{ (row as VisibleRun).browser }}
+                    </span>
+                  </template>
+                  <template #cell-device="{ row }">
+                    <span class="text-text-body inline-flex items-center gap-1 text-sm">
+                      <OIcon :name="deviceIconName((row as VisibleRun).device)" size="sm" />
+                      {{ deviceLabel((row as VisibleRun).device) }}
+                    </span>
+                  </template>
+                  <template #cell-error="{ row }">
+                    <span
+                      v-if="(row as VisibleRun).errorSnippet"
+                      class="cursor-pointer"
+                      @click.stop="filterByError((row as VisibleRun).errorPattern)"
+                    >
+                      <OBadge variant="error-outline" size="sm" class="max-w-50 truncate">
+                        {{ (row as VisibleRun).errorSnippet }}
+                      </OBadge>
+                    </span>
+                  </template>
+                  <template #cell-trigger_type="{ row }">
+                    <span class="text-text-body text-sm">
+                      {{ (row as VisibleRun).triggerType }}
                     </span>
                   </template>
 
-                  <!-- cell-avgDuration: Duration + bar -->
-                  <template #cell-avgDuration="{ row }">
-                    <div class="flex flex-col gap-1">
-                      <span class="font-mono tabular-nums text-xs text-[var(--color-text-body)]">{{ row.avgDuration }}</span>
-                      <div class="h-1.25 rounded-full bg-[var(--color-text-disabled)]/25! overflow-hidden">
-                        <div class="h-full rounded-full bg-[var(--color-primary-400)]" :style="{ width: row.durationBarPct }" />
-                      </div>
-                    </div>
-                  </template>
-
-                  <!-- cell-p95Duration: Duration + bar -->
-                  <template #cell-p95Duration="{ row }">
-                    <div class="flex flex-col gap-1">
-                      <span class="font-mono tabular-nums text-xs text-[var(--color-text-body)]">{{ row.p95Duration }}</span>
-                      <div class="h-1.25 rounded-full bg-[var(--color-text-disabled)]/25! overflow-hidden">
-                        <div class="h-full rounded-full bg-[var(--color-primary-400)]" :style="{ width: row.p95DurationBarPct }" />
-                      </div>
-                    </div>
-                  </template>
-
-                  <!-- cell-maxDuration: Duration + bar -->
-                  <template #cell-maxDuration="{ row }">
-                    <div class="flex flex-col gap-1">
-                      <span class="font-mono tabular-nums text-xs text-[var(--color-text-body)]">{{ row.maxDuration }}</span>
-                      <div class="h-1.25 rounded-full bg-[var(--color-text-disabled)]/25! overflow-hidden">
-                        <div class="h-full rounded-full bg-[var(--color-primary-400)]" :style="{ width: row.maxDurationBarPct }" />
-                      </div>
-                    </div>
-                  </template>
-
-                  <!-- Empty -->
+                  <!-- Empty state: smart — differentiates "never run" vs "no runs in window" -->
                   <template #empty>
-                    <div class="flex items-center justify-center py-12 text-sm text-[var(--color-text-secondary)]">
-                      {{ t('synthetics.runs.noStepData') }}
+                    <div v-if="kpiHasLoadedOnce" class="px-page-edge">
+                      <!-- Monitor has runs elsewhere — guide to last run + optionally clear filters -->
+                      <OEmptyState
+                        v-if="synthetics.kpi.value.totalRuns > 0"
+                        size="block"
+                        illustration="no-results"
+                        :title="t('synthetics.results.noRunsInWindow')"
+                        :description="t('synthetics.results.noRunsInWindowDesc')"
+                        data-test="monitor-runs-empty"
+                      >
+                        <template #actions>
+                          <EmptyStateActionCard
+                            icon="schedule"
+                            :label="t('synthetics.results.jumpToLastRun')"
+                            :sublabel="lastRunLabel"
+                            data-test="monitor-runs-empty-jump-last-run"
+                            @click="handleEmptyStateAction('jump-to-last-run')"
+                          />
+                          <EmptyStateActionCard
+                            v-if="hasActiveFilters"
+                            icon="filter-list"
+                            :label="t('synthetics.results.clearFilters')"
+                            :sublabel="t('synthetics.results.clearFiltersDesc')"
+                            data-test="monitor-runs-empty-clear-filters"
+                            @click="handleEmptyStateAction('clear-filters')"
+                          />
+                        </template>
+                      </OEmptyState>
+
+                      <!-- Monitor has never been run — prompt to trigger -->
+                      <OEmptyState
+                        v-else
+                        size="block"
+                        illustration="browser-check"
+                        :title="t('synthetics.results.noRunsYet')"
+                        :description="t('synthetics.results.noRunsYetDesc')"
+                        data-test="monitor-runs-empty"
+                      >
+                        <template #actions>
+                          <EmptyStateActionCard
+                            icon="play-arrow"
+                            :label="t('synthetics.results.triggerRunNow')"
+                            :sublabel="t('synthetics.results.triggerRunNowDesc')"
+                            data-test="monitor-runs-empty-trigger-run"
+                            @click="handleEmptyStateAction('trigger-run')"
+                          />
+                        </template>
+                      </OEmptyState>
                     </div>
                   </template>
                 </OTable>
               </OCard>
-
-            </template>
-          </div>
-        </OTabPanel>
-
-        <!-- ════════════ ERRORS ════════════ -->
-        <OTabPanel name="errors">
-          <div
-            class="mx-auto px-2 py-2 pb-7 flex flex-col gap-2"
-          >
-            <div class="flex items-center gap-2.5">
-              <span class="font-bold text-sm text-text-heading">
-                {{ t('synthetics.runs.errorPatterns') }}
-              </span>
-              <span class="text-xs text-text-secondary">
-                {{ t('synthetics.runs.errorPatternsWindowDesc', { window: windowLabel }) }}
-              </span>
             </div>
+          </OTabPanel>
 
-            <OCard class="p-0">
-              <div
-                class="grid grid-cols-[1fr_100px_160px_32px] gap-2.5 px-4 py-2 bg-surface-subtle border-b border-border-default text-2xs font-semibold text-text-secondary uppercase tracking-wide"
-              >
-                <span>{{ t('synthetics.runs.errorPattern') }}</span>
-                <span>{{ t('synthetics.runs.count') }}</span>
-                <span>{{ t('synthetics.runs.lastSeen') }}</span>
-                <span />
+          <!-- ════════════ STEPS ════════════ -->
+          <!-- ════════════ STEPS ════════════ -->
+          <OTabPanel name="steps">
+            <div class="mx-auto flex flex-col gap-2">
+              <!-- Loading skeleton -->
+              <template v-if="stepsLoading || !stepsHasLoadedOnce">
+                <div class="grid grid-cols-2 gap-2">
+                  <div
+                    class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                  >
+                    <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                      <SkeletonBox width="100px" height="14px" rounded-default />
+                    </div>
+                    <div class="border-border-default border-t" />
+                    <div class="p-4">
+                      <SkeletonBox width="100%" height="160px" rounded-default />
+                    </div>
+                  </div>
+                  <div
+                    class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                  >
+                    <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                      <SkeletonBox width="100px" height="14px" rounded-default />
+                    </div>
+                    <div class="border-border-default border-t" />
+                    <div class="p-4">
+                      <SkeletonBox width="100%" height="160px" rounded-default />
+                    </div>
+                  </div>
+                </div>
+                <div v-for="n in 5" :key="n" class="card-container rounded-default overflow-hidden">
+                  <div class="h-10 bg-[var(--color-border-default)] opacity-20" />
+                </div>
+              </template>
+
+              <!-- Steps query error — compact inline indicator -->
+              <template v-else-if="stepsError">
+                <div class="flex items-center gap-2 px-2" data-test="monitor-runs-steps-error">
+                  <OIcon name="error_outline" size="xs" class="text-status-error-text shrink-0" />
+                  <span class="text-status-error-text min-w-0 flex-1 truncate text-xs">{{
+                    stepsError
+                  }}</span>
+                  <OButton
+                    variant="ghost"
+                    size="xs"
+                    class="text-xs! underline!"
+                    data-test="monitor-runs-steps-retry-btn"
+                    @click="emit('refresh')"
+                  >
+                    {{ t("synthetics.journey.retry") }}
+                  </OButton>
+                </div>
+              </template>
+
+              <!-- Real content -->
+              <template v-else>
+                <!-- Steps Analysis Table -->
+                <OCard class="p-0">
+                  <OTable
+                    :data="stepTableRows"
+                    :columns="stepTableColumns"
+                    row-key="id"
+                    :pagination="'none'"
+                    :sorting="'client'"
+                    :show-global-filter="false"
+                    :show-header="true"
+                    :dense="true"
+                    :bordered="true"
+                    :enable-column-resize="true"
+                    :enable-column-reorder="true"
+                    :fill-height="false"
+                  >
+                    <!-- cell-name: Step name -->
+                    <template #cell-name="{ row }">
+                      <div class="min-w-0">
+                        <div
+                          class="truncate text-xs font-semibold text-[var(--color-text-heading)]"
+                        >
+                          {{ row.name }}
+                        </div>
+                      </div>
+                    </template>
+
+                    <!-- cell-failRate: Colored percentage + bar -->
+                    <template #cell-failRate="{ row }">
+                      <div class="flex flex-col gap-1">
+                        <span
+                          class="font-mono text-xs font-bold tabular-nums"
+                          :style="{ color: row.failColor }"
+                        >
+                          {{ row.failRatePct }}%&ensp;<span
+                            class="font-normal text-[var(--color-text-muted)]"
+                            >{{ row.failCount }}</span
+                          >
+                        </span>
+                        <div
+                          class="h-1.25 overflow-hidden rounded-full bg-[var(--color-text-disabled)]/25!"
+                        >
+                          <div
+                            class="h-full rounded-full"
+                            :style="{ width: row.failRateBarPct, background: row.failBarColor }"
+                          />
+                        </div>
+                      </div>
+                    </template>
+
+                    <!-- cell-flakyRate: Colored percentage -->
+                    <template #cell-flakyRate="{ row }">
+                      <span
+                        class="font-mono text-xs tabular-nums"
+                        :style="{ color: row.flakyColor }"
+                      >
+                        {{ row.flakyRatePct }}%&ensp;<span
+                          class="font-normal text-[var(--color-text-muted)]"
+                          >{{ row.flakyCount }}</span
+                        >
+                      </span>
+                    </template>
+
+                    <!-- cell-avgDuration: Duration + bar -->
+                    <template #cell-avgDuration="{ row }">
+                      <div class="flex flex-col gap-1">
+                        <span
+                          class="font-mono text-xs text-[var(--color-text-body)] tabular-nums"
+                          >{{ row.avgDuration }}</span
+                        >
+                        <div
+                          class="h-1.25 overflow-hidden rounded-full bg-[var(--color-text-disabled)]/25!"
+                        >
+                          <div
+                            class="h-full rounded-full bg-[var(--color-primary-400)]"
+                            :style="{ width: row.durationBarPct }"
+                          />
+                        </div>
+                      </div>
+                    </template>
+
+                    <!-- cell-p95Duration: Duration + bar -->
+                    <template #cell-p95Duration="{ row }">
+                      <div class="flex flex-col gap-1">
+                        <span
+                          class="font-mono text-xs text-[var(--color-text-body)] tabular-nums"
+                          >{{ row.p95Duration }}</span
+                        >
+                        <div
+                          class="h-1.25 overflow-hidden rounded-full bg-[var(--color-text-disabled)]/25!"
+                        >
+                          <div
+                            class="h-full rounded-full bg-[var(--color-primary-400)]"
+                            :style="{ width: row.p95DurationBarPct }"
+                          />
+                        </div>
+                      </div>
+                    </template>
+
+                    <!-- cell-maxDuration: Duration + bar -->
+                    <template #cell-maxDuration="{ row }">
+                      <div class="flex flex-col gap-1">
+                        <span
+                          class="font-mono text-xs text-[var(--color-text-body)] tabular-nums"
+                          >{{ row.maxDuration }}</span
+                        >
+                        <div
+                          class="h-1.25 overflow-hidden rounded-full bg-[var(--color-text-disabled)]/25!"
+                        >
+                          <div
+                            class="h-full rounded-full bg-[var(--color-primary-400)]"
+                            :style="{ width: row.maxDurationBarPct }"
+                          />
+                        </div>
+                      </div>
+                    </template>
+
+                    <!-- Empty -->
+                    <template #empty>
+                      <div
+                        class="flex items-center justify-center py-12 text-sm text-[var(--color-text-secondary)]"
+                      >
+                        {{ t("synthetics.runs.noStepData") }}
+                      </div>
+                    </template>
+                  </OTable>
+                </OCard>
+              </template>
+            </div>
+          </OTabPanel>
+
+          <!-- ════════════ ERRORS ════════════ -->
+          <OTabPanel name="errors">
+            <div class="mx-auto flex flex-col gap-2 px-2 py-2 pb-7">
+              <div class="flex items-center gap-2.5">
+                <span class="text-text-heading text-sm font-bold">
+                  {{ t("synthetics.runs.errorPatterns") }}
+                </span>
+                <span class="text-text-secondary text-xs">
+                  {{ t("synthetics.runs.errorPatternsWindowDesc", { window: windowLabel }) }}
+                </span>
               </div>
-              <div
-                v-for="e in errorGroups"
-                :key="e.pattern"
-                class="grid grid-cols-[1fr_100px_160px_32px] gap-2.5 px-4 py-2.75 border-b border-border-default items-center cursor-pointer hover:bg-surface-subtle"
-                data-test="monitor-runs-error-row"
-                @click="filterByErrorPattern(e.pattern)"
-              >
-                <span
-                  class="font-mono tabular-nums text-xs text-text-body truncate"
+
+              <OCard class="p-0">
+                <div
+                  class="bg-surface-subtle border-border-default text-2xs text-text-secondary grid grid-cols-[1fr_100px_160px_32px] gap-2.5 border-b px-4 py-2 font-semibold tracking-wide uppercase"
                 >
-                  {{ e.pattern }}
-                </span>
-                <span class="font-bold text-sm text-status-error-text">
-                  {{ e.count }}
-                </span>
-                <span class="text-xs text-text-secondary">
-                  {{ e.lastSeen }}
-                </span>
-                <OIcon
-                  name="filter_alt"
-                  size="sm"
-                  class="text-text-secondary"
-                />
-              </div>
-            </OCard>
-          </div>
-        </OTabPanel>
-      </OTabPanels>
-    </div>
+                  <span>{{ t("synthetics.runs.errorPattern") }}</span>
+                  <span>{{ t("synthetics.runs.count") }}</span>
+                  <span>{{ t("synthetics.runs.lastSeen") }}</span>
+                  <span />
+                </div>
+                <div
+                  v-for="e in errorGroups"
+                  :key="e.pattern"
+                  class="border-border-default hover:bg-surface-subtle grid cursor-pointer grid-cols-[1fr_100px_160px_32px] items-center gap-2.5 border-b px-4 py-2.75"
+                  data-test="monitor-runs-error-row"
+                  @click="filterByErrorPattern(e.pattern)"
+                >
+                  <span class="text-text-body truncate font-mono text-xs tabular-nums">
+                    {{ e.pattern }}
+                  </span>
+                  <span class="text-status-error-text text-sm font-bold">
+                    {{ e.count }}
+                  </span>
+                  <span class="text-text-secondary text-xs">
+                    {{ e.lastSeen }}
+                  </span>
+                  <OIcon name="filter_alt" size="sm" class="text-text-secondary" />
+                </div>
+              </OCard>
+            </div>
+          </OTabPanel>
+        </OTabPanels>
+      </div>
     </template>
   </div>
 </template>
@@ -1095,10 +1081,7 @@ import MonitorStatusTimeline from "@/views/synthetics/MonitorStatusTimeline.vue"
 import ChartRenderer from "@/components/dashboards/panels/ChartRenderer.vue";
 import useSyntheticResults from "@/composables/useSyntheticResults";
 import type { SyntheticRun } from "@/composables/synthetics/syntheticResultsSchema";
-import {
-  deviceIconName,
-  deviceLabel,
-} from "@/composables/synthetics/syntheticResultsSchema";
+import { deviceIconName, deviceLabel } from "@/composables/synthetics/syntheticResultsSchema";
 import awsSvgUrl from "@/assets/images/ingestion/aws.svg";
 import gcpSvgUrl from "@/assets/images/ingestion/gcp.svg";
 import chromiumSvgUrl from "@/assets/images/synthetics/chromium.svg";
@@ -1138,7 +1121,8 @@ function locationLabel(id: string): string {
 onMounted(async () => {
   try {
     const res = await syntheticsService.getLocations(orgIdentifier.value);
-    const locations: { id: string; label: string; region: string }[] = (res.data as any).locations ?? [];
+    const locations: { id: string; label: string; region: string }[] =
+      (res.data as any).locations ?? [];
     locationNames.value = Object.fromEntries(
       locations.map((loc) => [loc.id, locationDisplayLabel(loc.label, loc.region)]),
     );
@@ -1223,28 +1207,23 @@ function seedRand(seed: number) {
   };
 }
 /** Time range from the parent (microseconds). Updated on each refresh call. */
-const timeRangeMicros = ref<{ startTime: number; endTime: number } | null>(
-  null,
-);
+const timeRangeMicros = ref<{ startTime: number; endTime: number } | null>(null);
 
 /** Human-readable window label derived from the time range duration. */
 function formatWindowLabel(startMicros: number, endMicros: number): string {
   const diffMs = (endMicros - startMicros) / 1000;
   const hours = Math.round(diffMs / 3600000);
-  if (hours >= 48) return t('synthetics.runs.windowDays', { days: Math.round(hours / 24) });
-  if (hours >= 24) return t('synthetics.runs.window24h');
-  if (hours >= 2) return t('synthetics.runs.windowHours', { hours });
+  if (hours >= 48) return t("synthetics.runs.windowDays", { days: Math.round(hours / 24) });
+  if (hours >= 24) return t("synthetics.runs.window24h");
+  if (hours >= 2) return t("synthetics.runs.windowHours", { hours });
   const minutes = Math.round(diffMs / 60000);
-  if (minutes >= 60) return t('synthetics.runs.window1h');
-  return t('synthetics.runs.windowMinutes', { minutes });
+  if (minutes >= 60) return t("synthetics.runs.window1h");
+  return t("synthetics.runs.windowMinutes", { minutes });
 }
 const windowLabel = computed(() =>
   timeRangeMicros.value
-    ? formatWindowLabel(
-        timeRangeMicros.value.startTime,
-        timeRangeMicros.value.endTime,
-      )
-    : t('synthetics.runs.window24h'),
+    ? formatWindowLabel(timeRangeMicros.value.startTime, timeRangeMicros.value.endTime)
+    : t("synthetics.runs.window24h"),
 );
 const statusFilter = ref("all");
 const browserFilter = ref("all");
@@ -1315,20 +1294,25 @@ async function handleEmptyStateAction(id: string) {
     runTriggerLoading.value = true;
     const dismiss = toast({
       variant: "loading",
-      message: t('synthetics.toast.triggeringSingle', { name: props.monitorName }),
+      message: t("synthetics.toast.triggeringSingle", { name: props.monitorName }),
       timeout: 0,
     });
     try {
       await syntheticsService.run(orgIdentifier.value, props.monitorId, {}, folderName.value);
       dismiss();
-      toast({ variant: "success", message: t('synthetics.toast.triggerSuccessSingle', { name: props.monitorName }) });
+      toast({
+        variant: "success",
+        message: t("synthetics.toast.triggerSuccessSingle", { name: props.monitorName }),
+      });
       // Emit refresh so parent reloads data
       emit("refresh");
     } catch (err: any) {
       dismiss();
       toast({
         variant: "error",
-        message: err?.response?.data?.message || t('synthetics.toast.triggerFailedSingle', { name: props.monitorName }),
+        message:
+          err?.response?.data?.message ||
+          t("synthetics.toast.triggerFailedSingle", { name: props.monitorName }),
       });
     } finally {
       runTriggerLoading.value = false;
@@ -1349,7 +1333,7 @@ function uniqueValues(key: "browser" | "device" | "location"): string[] {
   return Array.from(vals).sort();
 }
 const browserOptions = computed<SelectOption[]>(() => [
-  { label: t('synthetics.filters.allBrowsers'), value: "all", icon: "language" },
+  { label: t("synthetics.filters.allBrowsers"), value: "all", icon: "language" },
   ...uniqueValues("browser").map((v) => ({
     label: v,
     value: v,
@@ -1357,7 +1341,7 @@ const browserOptions = computed<SelectOption[]>(() => [
   })),
 ]);
 const deviceOptions = computed<SelectOption[]>(() => [
-  { label: t('synthetics.filters.allDevices'), value: "all", icon: "devices" },
+  { label: t("synthetics.filters.allDevices"), value: "all", icon: "devices" },
   ...uniqueValues("device").map((v) => ({
     label: deviceLabel(v),
     value: v,
@@ -1365,7 +1349,7 @@ const deviceOptions = computed<SelectOption[]>(() => [
   })),
 ]);
 const locationOptions = computed<SelectOption[]>(() => [
-  { label: t('synthetics.filters.allLocations'), value: "all", icon: "location-on" },
+  { label: t("synthetics.filters.allLocations"), value: "all", icon: "location-on" },
   ...uniqueValues("location").map((v) => ({
     label: locationLabel(v),
     value: v,
@@ -1373,15 +1357,15 @@ const locationOptions = computed<SelectOption[]>(() => [
   })),
 ]);
 const durationOptions: SelectOption[] = [
-  { label: t('synthetics.filters.anyDuration'), value: "all" },
-  { label: t('synthetics.filters.durationFast'), value: "fast" },
-  { label: t('synthetics.filters.durationMid'), value: "mid" },
-  { label: t('synthetics.filters.durationSlow'), value: "slow" },
+  { label: t("synthetics.filters.anyDuration"), value: "all" },
+  { label: t("synthetics.filters.durationFast"), value: "fast" },
+  { label: t("synthetics.filters.durationMid"), value: "mid" },
+  { label: t("synthetics.filters.durationSlow"), value: "slow" },
 ];
 const actionOptions: SelectOption[] = [
-  { label: t('synthetics.filters.anyAction'), value: "all" },
-  { label: t('synthetics.filters.actionClick'), value: "click" },
-  { label: t('synthetics.filters.actionType'), value: "type" },
+  { label: t("synthetics.filters.anyAction"), value: "all" },
+  { label: t("synthetics.filters.actionClick"), value: "click" },
+  { label: t("synthetics.filters.actionType"), value: "type" },
 ];
 
 // ── Helper: map SyntheticRun to MockRun shape used by computed properties ─
@@ -1389,10 +1373,13 @@ function toMockRun(r: SyntheticRun, idx: number): MockRun {
   const eng = r.browserEngine;
   const browser = eng ? eng.charAt(0).toUpperCase() + eng.slice(1) : eng;
   const mappedStatus = (
-    r.status === "passed" ? "pass"
-    : r.status === "warning" ? "warning"
-    : r.status === "error" ? "error"
-    : "fail"
+    r.status === "passed"
+      ? "pass"
+      : r.status === "warning"
+        ? "warning"
+        : r.status === "error"
+          ? "error"
+          : "fail"
   ) as MockRun["status"];
   return {
     id: idx + 1,
@@ -1433,51 +1420,34 @@ const filteredRuns = computed(() => {
   return allRuns.value.filter((run) => {
     const s = statusFilter.value;
     if (s !== "all" && run.status !== s) return false;
-    if (browserFilter.value !== "all" && run.browser !== browserFilter.value)
-      return false;
-    if (deviceFilter.value !== "all" && run.device !== deviceFilter.value)
-      return false;
-    if (locationFilter.value !== "all" && run.location !== locationFilter.value)
-      return false;
+    if (browserFilter.value !== "all" && run.browser !== browserFilter.value) return false;
+    if (deviceFilter.value !== "all" && run.device !== deviceFilter.value) return false;
+    if (locationFilter.value !== "all" && run.location !== locationFilter.value) return false;
     if (durationFilter.value === "fast" && run.duration >= 5000) return false;
-    if (
-      durationFilter.value === "mid" &&
-      (run.duration < 5000 || run.duration > 15000)
-    )
+    if (durationFilter.value === "mid" && (run.duration < 5000 || run.duration > 15000))
       return false;
     if (durationFilter.value === "slow" && run.duration <= 15000) return false;
     if (s === "fail") {
-      if (
-        failedStepFilter.value !== "all" &&
-        run.failedStep !== failedStepFilter.value
-      )
+      if (failedStepFilter.value !== "all" && run.failedStep !== failedStepFilter.value)
         return false;
       if (
         locatorFilter.value &&
-        !(run.locator || "")
-          .toLowerCase()
-          .includes(locatorFilter.value.toLowerCase())
+        !(run.locator || "").toLowerCase().includes(locatorFilter.value.toLowerCase())
       )
         return false;
-      if (actionFilter.value !== "all" && run.action !== actionFilter.value)
-        return false;
+      if (actionFilter.value !== "all" && run.action !== actionFilter.value) return false;
     }
-    if (errorFilter.value && run.errorPattern !== errorFilter.value)
-      return false;
+    if (errorFilter.value && run.errorPattern !== errorFilter.value) return false;
     return true;
   });
 });
 
-const totalFails = computed(
-  () => allRuns.value.filter((r) => r.status === "fail").length,
-);
+const totalFails = computed(() => allRuns.value.filter((r) => r.status === "fail").length);
 
 const hasKpiData = computed(() => synthetics.kpi.value.totalRuns > 0);
 
 const p95Label = computed(() =>
-  effectiveP95Ms.value > 0
-    ? fmtDur(effectiveP95Ms.value)
-    : hasKpiData.value ? fmtDur(0) : "—",
+  effectiveP95Ms.value > 0 ? fmtDur(effectiveP95Ms.value) : hasKpiData.value ? fmtDur(0) : "—",
 );
 const p95Ms = computed(() => effectiveP95Ms.value);
 const failCount = computed(() => String(synthetics.kpi.value.failedRuns));
@@ -1495,15 +1465,15 @@ const kpiCards = computed<KpiCard[]>(() => {
     return [
       {
         key: "last-run",
-        label: t('synthetics.results.lastRun'),
+        label: t("synthetics.results.lastRun"),
         value: k.lastRunStatus
           ? k.lastRunStatus === "passed"
-            ? t('synthetics.results.passed')
+            ? t("synthetics.results.passed")
             : k.lastRunStatus === "warning"
-              ? t('synthetics.protocolRun.warning')
+              ? t("synthetics.protocolRun.warning")
               : k.lastRunStatus === "error"
-                ? t('synthetics.results.error')
-                : t('synthetics.results.failed')
+                ? t("synthetics.results.error")
+                : t("synthetics.results.failed")
           : "—",
         valueClass:
           k.lastRunStatus === "passed"
@@ -1516,32 +1486,29 @@ const kpiCards = computed<KpiCard[]>(() => {
       },
       {
         key: "pass-rate",
-        label: t('synthetics.runs.passRate'),
+        label: t("synthetics.runs.passRate"),
         value: k.totalRuns > 0 ? k.uptimePct.toFixed(1) + "%" : "—",
       },
       {
         key: "p95-duration",
-        label: t('synthetics.results.p95Duration'),
+        label: t("synthetics.results.p95Duration"),
         value: effectiveP95Ms.value > 0 ? fmtDur(effectiveP95Ms.value) : "—",
       },
       {
         key: "retry-rate",
-        label: t('synthetics.runs.retryRate'),
-        value:
-          k.totalRuns > 0
-            ? ((k.retriedRuns / k.totalRuns) * 100).toFixed(1) + "%"
-            : "0.0%",
+        label: t("synthetics.runs.retryRate"),
+        value: k.totalRuns > 0 ? ((k.retriedRuns / k.totalRuns) * 100).toFixed(1) + "%" : "0.0%",
         valueClass: k.retriedRuns > 0 ? "text-text-body!" : undefined,
       },
       {
         key: "warning-runs",
-        label: t('synthetics.runs.warningRuns'),
+        label: t("synthetics.runs.warningRuns"),
         value: String(k.warningRuns),
         valueClass: k.warningRuns > 0 ? "text-status-warning-text!" : undefined,
       },
       {
         key: "failed-runs",
-        label: t('synthetics.results.failedRuns'),
+        label: t("synthetics.results.failedRuns"),
         value: String(k.failedRuns),
         valueClass: k.failedRuns > 0 ? "text-status-error-text!" : undefined,
       },
@@ -1560,13 +1527,13 @@ const kpiCards = computed<KpiCard[]>(() => {
   return [
     {
       key: "last-run",
-      label: t('synthetics.results.lastRun'),
+      label: t("synthetics.results.lastRun"),
       value: lastRun
         ? lastRun.status === "pass"
-          ? t('synthetics.results.passed')
+          ? t("synthetics.results.passed")
           : lastRun.status === "warning"
-            ? t('synthetics.protocolRun.warning')
-            : t('synthetics.results.failed')
+            ? t("synthetics.protocolRun.warning")
+            : t("synthetics.results.failed")
         : "—",
       valueClass:
         lastRun?.status === "pass"
@@ -1577,17 +1544,17 @@ const kpiCards = computed<KpiCard[]>(() => {
               ? "text-status-error-text!"
               : undefined,
     },
-    { key: "pass-rate", label: t('synthetics.runs.passRate'), value: fallbackPassPct },
-    { key: "p95-duration", label: t('synthetics.results.p95Duration'), value: "—" },
-    { key: "retry-rate", label: t('synthetics.runs.retryRate'), value: "0.0%" },
+    { key: "pass-rate", label: t("synthetics.runs.passRate"), value: fallbackPassPct },
+    { key: "p95-duration", label: t("synthetics.results.p95Duration"), value: "—" },
+    { key: "retry-rate", label: t("synthetics.runs.retryRate"), value: "0.0%" },
     {
       key: "warning-runs",
-      label: t('synthetics.runs.warningRuns'),
+      label: t("synthetics.runs.warningRuns"),
       value: String(allRuns.value.filter((r) => r.status === "warning").length),
     },
     {
       key: "failed-runs",
-      label: t('synthetics.results.failedRuns'),
+      label: t("synthetics.results.failedRuns"),
       value: String(totalFails.value),
     },
   ];
@@ -1634,12 +1601,8 @@ const timelineSegments = computed<TimelineSegment[]>(() => {
 
   return groupOrder.map((runId) => {
     const executions = groupMap.get(runId)!;
-    const allPass = executions.every(
-      (e) => e.status === "pass" || e.status === "warning",
-    );
-    const allFail = executions.every(
-      (e) => e.status === "fail" || e.status === "error",
-    );
+    const allPass = executions.every((e) => e.status === "pass" || e.status === "warning");
+    const allFail = executions.every((e) => e.status === "fail" || e.status === "error");
     const allWarning = executions.every((e) => e.status === "warning");
     const status: TimelineSegment["status"] = allPass
       ? allWarning
@@ -1664,30 +1627,31 @@ const timelineSegments = computed<TimelineSegment[]>(() => {
     const failCount = executions.length - passCount;
     const title =
       status === "all-pass"
-        ? t('synthetics.runs.timelineAllPassed', { count: executions.length })
+        ? t("synthetics.runs.timelineAllPassed", { count: executions.length })
         : status === "all-warning"
-          ? t('synthetics.runs.timelineAllWarning', { count: executions.length })
+          ? t("synthetics.runs.timelineAllWarning", { count: executions.length })
           : status === "all-fail"
-            ? t('synthetics.runs.timelineAllFailed', { count: executions.length })
-            : t('synthetics.runs.timelineMixed', { passed: passCount, failed: failCount, total: executions.length });
+            ? t("synthetics.runs.timelineAllFailed", { count: executions.length })
+            : t("synthetics.runs.timelineMixed", {
+                passed: passCount,
+                failed: failCount,
+                total: executions.length,
+              });
 
     const execDetails: TimelineExecution[] = executions.map((e) => ({
       location: locationLabel(e.location),
       browserEngine: e.browser,
       device: e.device,
-      status: e.status === "pass"
-        ? "pass"
-        : e.status === "warning"
-          ? "warning"
-          : e.status === "error"
-            ? "error"
-            : "fail",
-      statusIcon: e.status === "pass" || e.status === "warning"
-        ? "check_circle"
-        : "cancel",
-      errorSnippet: e.errorPattern
-        ? e.errorPattern.split(":")[0].substring(0, 50)
-        : null,
+      status:
+        e.status === "pass"
+          ? "pass"
+          : e.status === "warning"
+            ? "warning"
+            : e.status === "error"
+              ? "error"
+              : "fail",
+      statusIcon: e.status === "pass" || e.status === "warning" ? "check_circle" : "cancel",
+      errorSnippet: e.errorPattern ? e.errorPattern.split(":")[0].substring(0, 50) : null,
     }));
 
     return {
@@ -1705,15 +1669,11 @@ const timelineFailCount = computed(() =>
   String(timelineSegments.value.filter((s) => s.status === "all-fail").length),
 );
 const timelinePassCount = computed(() =>
-  String(
-    timelineSegments.value.filter((s) => s.status === "all-pass").length,
-  ),
+  String(timelineSegments.value.filter((s) => s.status === "all-pass").length),
 );
 const timelineMixedCount = computed(() =>
   String(
-    timelineSegments.value.filter(
-      (s) => s.status === "mixed" || s.status === "all-warning",
-    ).length,
+    timelineSegments.value.filter((s) => s.status === "mixed" || s.status === "all-warning").length,
   ),
 );
 
@@ -1748,15 +1708,13 @@ const timelineStartLabel = computed(() => {
   return formatTimelineDate(timeRangeMicros.value.startTime / 1000);
 });
 const timelineEndLabel = computed(() => {
-  if (!timeRangeMicros.value) return t('synthetics.runs.timelineNow');
+  if (!timeRangeMicros.value) return t("synthetics.runs.timelineNow");
   return formatTimelineDate(timeRangeMicros.value.endTime / 1000);
 });
 
 // ── Breakdowns ───────────────────────────────────────────────────────────
 const breakdownDimensions = computed(() =>
-  isBrowser.value
-    ? ["Browser", "Location", "Device"]
-    : ["Location", "DurationByLocation"],
+  isBrowser.value ? ["Browser", "Location", "Device"] : ["Location", "DurationByLocation"],
 );
 
 interface BreakdownItem {
@@ -1852,12 +1810,12 @@ const deviceBreakdown = computed<BreakdownItem[]>(() => {
       textColor: "var(--color-success-700)",
     };
   });
-  });
+});
 
 const locationDurationBreakdown = computed<BreakdownItem[]>(() => {
   const groups = new Map<string, { totalMs: number; count: number }>();
   for (const run of allRuns.value) {
-    const key = run.location || 'Unknown';
+    const key = run.location || "Unknown";
     const g = groups.get(key) ?? { totalMs: 0, count: 0 };
     g.totalMs += run.duration;
     g.count++;
@@ -1865,12 +1823,12 @@ const locationDurationBreakdown = computed<BreakdownItem[]>(() => {
   }
 
   function getIconForRegion(region: string): string {
-    const prefix = region.split('-')[0].toLowerCase();
-    if (prefix === 'aws') return 'img:' + awsSvgUrl;
-    if (prefix === 'gcp') return 'img:' + gcpSvgUrl;
-    if (/^[a-z]{2}-[a-z]+-\d+$/.test(region)) return 'img:' + awsSvgUrl;
-    if (/^[a-z]+-[a-z]+\d*$/.test(region)) return 'img:' + gcpSvgUrl;
-    return 'location-on';
+    const prefix = region.split("-")[0].toLowerCase();
+    if (prefix === "aws") return "img:" + awsSvgUrl;
+    if (prefix === "gcp") return "img:" + gcpSvgUrl;
+    if (/^[a-z]{2}-[a-z]+-\d+$/.test(region)) return "img:" + awsSvgUrl;
+    if (/^[a-z]+-[a-z]+\d*$/.test(region)) return "img:" + gcpSvgUrl;
+    return "location-on";
   }
 
   const entries = Array.from(groups.entries()).map(([name, g]) => ({
@@ -1884,42 +1842,63 @@ const locationDurationBreakdown = computed<BreakdownItem[]>(() => {
     id: rawId,
     icon: getIconForRegion(rawId),
     pct: fmtDur(avgMs),
-    barPct: Math.round((avgMs / maxAvg) * 100) + '%',
-    barColor: 'var(--color-primary-500)',
-    textColor: 'var(--color-text-body)',
+    barPct: Math.round((avgMs / maxAvg) * 100) + "%",
+    barColor: "var(--color-primary-500)",
+    textColor: "var(--color-text-body)",
   }));
 });
 
 // ── Status filter options ────────────────────────────────────────────────
 const statusOptions = [
-  { key: "all", label: t('synthetics.filters.all'), dot: "var(--color-text-secondary)" },
-  { key: "pass", label: t('synthetics.results.passed'), dot: "var(--color-status-success-text)" },
-  { key: "warning", label: t('synthetics.runs.warning'), dot: "var(--color-status-warning-text)" },
-  { key: "fail", label: t('synthetics.results.failed'), dot: "var(--color-status-error-text)" },
+  { key: "all", label: t("synthetics.filters.all"), dot: "var(--color-text-secondary)" },
+  { key: "pass", label: t("synthetics.results.passed"), dot: "var(--color-status-success-text)" },
+  { key: "warning", label: t("synthetics.runs.warning"), dot: "var(--color-status-warning-text)" },
+  { key: "fail", label: t("synthetics.results.failed"), dot: "var(--color-status-error-text)" },
 ];
 
 // ── Mock fallback data (used by Overview/Errors tabs when no real data) ────
 function stepNames(): string[] {
   return [
-    "Open homepage", "Open search", "Search query", "Submit search",
-    "Search results", "Results shown", "Open first product", "Product page",
-    "Add to cart", "Go to checkout", "Fill card number", "Place order",
+    "Open homepage",
+    "Open search",
+    "Search query",
+    "Submit search",
+    "Search results",
+    "Results shown",
+    "Open first product",
+    "Product page",
+    "Add to cart",
+    "Go to checkout",
+    "Fill card number",
+    "Place order",
   ];
 }
 function stepMeta(): Record<string, { locator: string | null; browsers: string[] }> {
   return {
     "Open homepage": { locator: null, browsers: ["Chromium", "Firefox", "WebKit"] },
-    "Open search": { locator: 'css=[data-testid="search-icon"]', browsers: ["Chromium", "Firefox", "WebKit"] },
+    "Open search": {
+      locator: 'css=[data-testid="search-icon"]',
+      browsers: ["Chromium", "Firefox", "WebKit"],
+    },
     "Search query": { locator: "css=#search", browsers: ["Chromium", "Firefox", "WebKit"] },
     "Submit search": { locator: null, browsers: ["Chromium", "Firefox", "WebKit"] },
     "Search results": { locator: null, browsers: ["Chromium", "Firefox", "WebKit"] },
     "Results shown": { locator: 'text="results for"', browsers: ["Chromium", "Firefox", "WebKit"] },
-    "Open first product": { locator: "testid=result-0", browsers: ["Chromium", "Firefox", "WebKit"] },
+    "Open first product": {
+      locator: "testid=result-0",
+      browsers: ["Chromium", "Firefox", "WebKit"],
+    },
     "Product page": { locator: null, browsers: ["Chromium", "Firefox", "WebKit"] },
     "Add to cart": { locator: "css=.btn-add-to-cart", browsers: ["Chromium", "Firefox", "WebKit"] },
     "Go to checkout": { locator: "css=.btn-checkout", browsers: ["Chromium", "Firefox", "WebKit"] },
-    "Fill card number": { locator: "css=#card-number", browsers: ["Chromium", "Firefox", "WebKit"] },
-    "Place order": { locator: "testid=place-order-btn", browsers: ["Chromium", "Firefox", "WebKit"] },
+    "Fill card number": {
+      locator: "css=#card-number",
+      browsers: ["Chromium", "Firefox", "WebKit"],
+    },
+    "Place order": {
+      locator: "testid=place-order-btn",
+      browsers: ["Chromium", "Firefox", "WebKit"],
+    },
   };
 }
 function errorPatterns(): string[] {
@@ -1937,10 +1916,20 @@ function fmtAge(min: number): string {
   return Math.floor(h / 24) + "d ago";
 }
 interface MockRun {
-  id: number; runId: string; ageMin: number; scheduledTs: number;
-  timestamp: number; duration: number; status: "pass" | "warning" | "fail" | "error";
-  location: string; browser: string; device: string; triggerType: string;
-  failedStep: string | null; locator: string | null; action: string | null;
+  id: number;
+  runId: string;
+  ageMin: number;
+  scheduledTs: number;
+  timestamp: number;
+  duration: number;
+  status: "pass" | "warning" | "fail" | "error";
+  location: string;
+  browser: string;
+  device: string;
+  triggerType: string;
+  failedStep: string | null;
+  locator: string | null;
+  action: string | null;
   errorPattern: string | null;
   artifacts: { screenshot: boolean; replay: boolean; trace: boolean; rum: boolean };
 }
@@ -1965,25 +1954,31 @@ function generateRuns(timeRange?: { startTimeMs: number; endTimeMs: number }): M
     for (let execIdx = 0; execIdx < numExecutions; execIdx++) {
       const rand = r();
       const status: MockRun["status"] =
-        rand < 0.05 ? "warning"
-        : rand < 0.22 ? "fail"
-        : rand < 0.24 ? "error"
-        : "pass";
+        rand < 0.05 ? "warning" : rand < 0.22 ? "fail" : rand < 0.24 ? "error" : "pass";
       const isFail = status === "fail" || status === "error";
       const dur = isFail ? Math.round(20000 + r() * 15000) : Math.round(1800 + r() * 3200);
       const errIdx = Math.floor(r() * errs.length);
       const failedStep = isFail ? steps[8 + Math.floor(r() * 4)] : null;
       const locator = failedStep ? meta[failedStep].locator : null;
       runs.push({
-        id: idCounter++, runId,
+        id: idCounter++,
+        runId,
         ageMin: Math.round((baseTime - scheduledBase) / 60000),
-        scheduledTs: scheduledBase, timestamp: scheduledBase + Math.round(r() * 30000),
-        triggerType: "schedule", duration: dur, status,
+        scheduledTs: scheduledBase,
+        timestamp: scheduledBase + Math.round(r() * 30000),
+        triggerType: "schedule",
+        duration: dur,
+        status,
         location: locations[Math.floor(r() * locations.length)],
         browser: browsers[Math.floor(r() * browsers.length)],
         device: devices[r() < 0.7 ? 0 : r() < 0.85 ? 1 : 2],
-        failedStep, locator,
-        action: failedStep ? (["Place order", "Go to checkout", "Add to cart"].includes(failedStep) ? "click" : "type") : null,
+        failedStep,
+        locator,
+        action: failedStep
+          ? ["Place order", "Go to checkout", "Add to cart"].includes(failedStep)
+            ? "click"
+            : "type"
+          : null,
         errorPattern: isFail ? errs[errIdx] : null,
         artifacts: { screenshot: true, replay: r() < 0.7, trace: true, rum: r() < 0.9 },
       });
@@ -1993,7 +1988,11 @@ function generateRuns(timeRange?: { startTimeMs: number; endTimeMs: number }): M
 }
 
 // ── Error groups (Errors tab) ────────────────────────────────────────────
-interface ErrorGroup { pattern: string; count: number; lastSeen: string; }
+interface ErrorGroup {
+  pattern: string;
+  count: number;
+  lastSeen: string;
+}
 const errorGroups = computed<ErrorGroup[]>(() => {
   const errs = errorPatterns();
   const runs = allRuns.value;
@@ -2012,7 +2011,7 @@ const failedStepOptions = computed<SelectOption[]>(() => {
   const meta = stepMeta();
   const withLocator = stepNames().filter((n) => meta[n].locator);
   return [
-    { label: t('synthetics.filters.anyFailedStep'), value: "all" },
+    { label: t("synthetics.filters.anyFailedStep"), value: "all" },
     ...withLocator.map((n) => ({ label: n, value: n })),
   ];
 });
@@ -2041,29 +2040,27 @@ const visibleRuns = computed<VisibleRun[]>(() => {
     const isError = run.status === "error";
     return {
       id: run.id,
-      statusBadgeVariant: isPass
-        ? "success-soft"
-        : isWarning
-          ? "warning-soft"
-          : "error-soft",
+      statusBadgeVariant: isPass ? "success-soft" : isWarning ? "warning-soft" : "error-soft",
       statusIcon: isPass || isWarning ? "check_circle" : "cancel",
       statusLabel: isPass
-        ? t('synthetics.results.passed')
+        ? t("synthetics.results.passed")
         : isWarning
-          ? t('synthetics.protocolRun.warning')
+          ? t("synthetics.protocolRun.warning")
           : isError
-            ? t('synthetics.results.error')
-            : t('synthetics.results.failed'),
+            ? t("synthetics.results.error")
+            : t("synthetics.results.failed"),
       scheduledTs: run.scheduledTs,
       lastRunTs: run.timestamp,
-      triggerType: run.triggerType === "manual" ? t('synthetics.runs.triggerManual') : t('synthetics.runs.triggerSchedule'),
+      triggerType:
+        run.triggerType === "manual"
+          ? t("synthetics.runs.triggerManual")
+          : t("synthetics.runs.triggerSchedule"),
       duration: fmtDur(run.duration),
       location: run.location,
       browser: run.browser,
       device: run.device,
       errorSnippet: run.errorPattern
-        ? run.errorPattern.split(":")[0] +
-          (run.failedStep ? " · " + run.failedStep : "")
+        ? run.errorPattern.split(":")[0] + (run.failedStep ? " · " + run.failedStep : "")
         : null,
       errorPattern: run.errorPattern,
     };
@@ -2072,37 +2069,47 @@ const visibleRuns = computed<VisibleRun[]>(() => {
 
 const runColumns = computed<OTableColumnDef[]>(() => {
   const cols: OTableColumnDef[] = [
-    { id: "status", header: t('synthetics.table.status'), accessorKey: "status", size: 60 },
+    { id: "status", header: t("synthetics.table.status"), accessorKey: "status", size: 60 },
     {
       id: "last_run_at",
-      header: t('synthetics.table.lastRunAt'),
+      header: t("synthetics.table.lastRunAt"),
       accessorKey: "lastRunTs",
       size: 100,
     },
     {
       id: "duration",
-      header: t('synthetics.results.duration'),
+      header: t("synthetics.results.duration"),
       accessorKey: "duration",
       size: 50,
     },
-    { id: "location", header: t('synthetics.results.location'), accessorKey: "location", size: 110 },
+    {
+      id: "location",
+      header: t("synthetics.results.location"),
+      accessorKey: "location",
+      size: 110,
+    },
   ];
   if (isBrowser.value) {
     cols.push(
-      { id: "browser", header: t('synthetics.results.steps.browser'), accessorKey: "browser", size: 100 },
-      { id: "device", header: t('synthetics.results.device'), accessorKey: "device", size: 90 },
+      {
+        id: "browser",
+        header: t("synthetics.results.steps.browser"),
+        accessorKey: "browser",
+        size: 100,
+      },
+      { id: "device", header: t("synthetics.results.device"), accessorKey: "device", size: 90 },
     );
   }
   cols.push(
     {
       id: "trigger_type",
-      header: t('synthetics.table.trigger'),
+      header: t("synthetics.table.trigger"),
       accessorKey: "triggerType",
       size: 90,
     },
     {
       id: "scheduled_at",
-      header: t('synthetics.table.scheduledAt'),
+      header: t("synthetics.table.scheduledAt"),
       accessorKey: "scheduledTs",
       size: 100,
     },
@@ -2179,7 +2186,8 @@ const stepTableRows = computed<StepTableRow[]>(() => {
       failBarColor: barColorForRate(failPct),
       flakyRatePct: flakyPct,
       flakyCount: g.flakyCount,
-      flakyColor: g.flakyRate >= 5 ? "var(--color-status-warning-text)" : "var(--color-text-secondary)",
+      flakyColor:
+        g.flakyRate >= 5 ? "var(--color-status-warning-text)" : "var(--color-text-secondary)",
       avgDuration: fmtDur(g.avgDurationMs),
       avgDurationMs: g.avgDurationMs,
       durationBarPct: Math.round((g.avgDurationMs / maxAvgDuration) * 100) + "%",
@@ -2194,20 +2202,53 @@ const stepTableRows = computed<StepTableRow[]>(() => {
 });
 
 const stepTableColumns: OTableColumnDef<StepTableRow>[] = [
-  { id: "name", header: t('synthetics.results.steps.stepName'), accessorKey: "name", meta: { isName: true } },
-  { id: "failRate", header: t('synthetics.results.steps.failRate'), accessorKey: "failRatePct", size: 110, meta: { align: "right" } },
-  { id: "flakyRate", header: t('synthetics.results.steps.flakyRate'), accessorKey: "flakyRatePct", size: 100, meta: { align: "right" } },
-  { id: "avgDuration", header: t('synthetics.results.steps.avgDuration'), accessorKey: "avgDurationMs", size: 100, meta: { align: "right" } },
-  { id: "p95Duration", header: t('synthetics.results.steps.p95Duration'), accessorKey: "p95DurationMs", size: 96, meta: { align: "right" } },
-  { id: "maxDuration", header: t('synthetics.results.steps.maxDuration'), accessorKey: "maxDurationMs", size: 100, meta: { align: "right" } },
+  {
+    id: "name",
+    header: t("synthetics.results.steps.stepName"),
+    accessorKey: "name",
+    meta: { isName: true },
+  },
+  {
+    id: "failRate",
+    header: t("synthetics.results.steps.failRate"),
+    accessorKey: "failRatePct",
+    size: 110,
+    meta: { align: "right" },
+  },
+  {
+    id: "flakyRate",
+    header: t("synthetics.results.steps.flakyRate"),
+    accessorKey: "flakyRatePct",
+    size: 100,
+    meta: { align: "right" },
+  },
+  {
+    id: "avgDuration",
+    header: t("synthetics.results.steps.avgDuration"),
+    accessorKey: "avgDurationMs",
+    size: 100,
+    meta: { align: "right" },
+  },
+  {
+    id: "p95Duration",
+    header: t("synthetics.results.steps.p95Duration"),
+    accessorKey: "p95DurationMs",
+    size: 96,
+    meta: { align: "right" },
+  },
+  {
+    id: "maxDuration",
+    header: t("synthetics.results.steps.maxDuration"),
+    accessorKey: "maxDurationMs",
+    size: 100,
+    meta: { align: "right" },
+  },
 ];
 
 // ── Chart options ────────────────────────────────────────────────────────
 function cssVar(name: string, fallback: string): string {
   if (typeof window === "undefined") return fallback;
-  return (
-    getComputedStyle(document.body).getPropertyValue(name).trim() || fallback
-  );
+  return getComputedStyle(document.body).getPropertyValue(name).trim() || fallback;
 }
 
 const responseChartOption = computed(() => {
@@ -2218,9 +2259,7 @@ const responseChartOption = computed(() => {
 
   let seriesData: [number, number][];
   if (synthetics.buckets.value.length > 0) {
-    seriesData = synthetics.buckets.value.map(
-      (b) => [b.tsMs, b.p95Ms] as [number, number],
-    );
+    seriesData = synthetics.buckets.value.map((b) => [b.tsMs, b.p95Ms] as [number, number]);
   } else {
     const rB = seedRand(31);
     const bucketCount = 24;
@@ -2270,7 +2309,7 @@ const responseChartOption = computed(() => {
               lineStyle: { color: p95Color, type: "dashed" as const },
               data: [{ yAxis: p95Ms.value }],
               label: {
-                formatter: t('synthetics.runs.chartP95', { value: p95Label.value }),
+                formatter: t("synthetics.runs.chartP95", { value: p95Label.value }),
                 color: p95Color,
                 fontSize: 10,
               },
@@ -2320,7 +2359,7 @@ const errorChartOption = computed(() => {
     grid: { left: 44, right: 16, top: 16, bottom: 28 },
     tooltip: {
       trigger: "axis" as const,
-      valueFormatter: (val: number) => t('synthetics.runs.chartFailures', { count: val }),
+      valueFormatter: (val: number) => t("synthetics.runs.chartFailures", { count: val }),
     },
     xAxis: {
       type: "category" as const,

--- a/web/src/views/synthetics/MonitorRuns.vue
+++ b/web/src/views/synthetics/MonitorRuns.vue
@@ -33,26 +33,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div class="monitor-runs flex h-full flex-col" data-test="synthetics-monitor-runs">
+  <div
+    class="monitor-runs h-full flex flex-col"
+    data-test="synthetics-monitor-runs"
+  >
     <!-- Full-page empty state — replaces the entire content area when no
          runs exist in the current time window. The parent (MonitorResults)
          passes lastTriggeredAt to distinguish "never triggered" from "no
          runs in this window." -->
     <template v-if="kpiHasLoadedOnce && synthetics.kpi.value.totalRuns === 0">
-      <div class="flex flex-1 items-center justify-center">
+      <div class="flex-1 flex items-center justify-center">
         <OEmptyState
           size="hero"
           :illustration="lastTriggeredAt > 0 ? 'no-results' : 'browser-check'"
-          :title="
-            lastTriggeredAt > 0
-              ? t('synthetics.results.noRunsInWindow')
-              : t('synthetics.results.noRunsYet')
-          "
-          :description="
-            lastTriggeredAt > 0
-              ? t('synthetics.results.noRunsInWindowDesc')
-              : t('synthetics.results.noRunsYetDesc')
-          "
+          :title="lastTriggeredAt > 0 ? t('synthetics.results.noRunsInWindow') : t('synthetics.results.noRunsYet')"
+          :description="lastTriggeredAt > 0 ? t('synthetics.results.noRunsInWindowDesc') : t('synthetics.results.noRunsYetDesc')"
           data-test="monitor-runs-page-empty"
         >
           <template #actions>
@@ -87,911 +82,984 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- ── Tabs ──────────────────────────────────────────────────────── -->
     <template v-else>
-      <OTabs v-model="activeTab" class="px-page-edge border-border-default shrink-0 border-b">
-        <OTab name="overview" data-test="monitor-runs-tab-overview">
-          {{ t("synthetics.runs.tabOverview") }}
-        </OTab>
-        <OTab v-if="isBrowser" name="steps" data-test="monitor-runs-tab-steps">
-          {{ t("synthetics.runs.tabSteps") }}
-        </OTab>
-      </OTabs>
+    <OTabs
+      v-model="activeTab"
+      class="shrink-0 px-page-edge border-b border-border-default"
+    >
+      <OTab name="overview" data-test="monitor-runs-tab-overview">
+        {{ t('synthetics.runs.tabOverview') }}
+      </OTab>
+      <OTab v-if="isBrowser" name="steps" data-test="monitor-runs-tab-steps"> {{ t('synthetics.runs.tabSteps') }} </OTab>
+    </OTabs>
 
-      <div class="min-h-0 flex-1">
-        <OTabPanels v-model="activeTab" grow scroll="y" class="h-full min-h-0">
-          <!-- ════════════ OVERVIEW ════════════ -->
-          <OTabPanel name="overview">
-            <div class="mx-auto flex flex-col gap-2 py-2">
-              <!-- Status Timeline — gated on runs query -->
-              <template v-if="runsLoading || !runsHasLoadedOnce">
-                <div class="px-page-edge">
+    <div class="flex-1 min-h-0">
+      <OTabPanels v-model="activeTab" grow scroll="y" class="h-full min-h-0">
+        <!-- ════════════ OVERVIEW ════════════ -->
+        <OTabPanel name="overview">
+          <div
+            class="mx-auto py-2 flex flex-col gap-2"
+          >
+            <!-- Status Timeline — gated on runs query -->
+            <template v-if="runsLoading || !runsHasLoadedOnce">
+              <div class="px-page-edge">
+                <div
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
                   <div
-                    class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    class="flex items-center gap-2 px-3.5 pt-2.5 pb-2"
                   >
-                    <div class="flex items-center gap-2 px-3.5 pt-2.5 pb-2">
-                      <SkeletonBox width="100px" height="14px" rounded-default />
-                      <span class="flex-1" />
-                      <SkeletonBox width="45px" height="12px" rounded-default />
-                      <SkeletonBox width="50px" height="12px" rounded-default />
-                      <SkeletonBox width="45px" height="12px" rounded-default />
+                    <SkeletonBox width="100px" height="14px" rounded-default />
+                    <span class="flex-1" />
+                    <SkeletonBox width="45px" height="12px" rounded-default />
+                    <SkeletonBox width="50px" height="12px" rounded-default />
+                    <SkeletonBox width="45px" height="12px" rounded-default />
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="flex flex-col gap-1 py-2 px-3.5">
+                    <div class="flex items-center gap-1">
+                      <div class="w-5 h-5 shrink-0" />
+                      <div class="flex-1 h-6.5 rounded-default flex gap-0.5 items-stretch">
+                        <div
+                          v-for="n in 26"
+                          :key="n"
+                          class="flex-1 h-full rounded-default bg-border-default opacity-40"
+                        />
+                      </div>
+                      <div class="w-5 h-5 shrink-0" />
                     </div>
-                    <div class="border-border-default border-t" />
-                    <div class="flex flex-col gap-1 px-3.5 py-2">
-                      <div class="flex items-center gap-1">
-                        <div class="h-5 w-5 shrink-0" />
-                        <div class="rounded-default flex h-6.5 flex-1 items-stretch gap-0.5">
-                          <div
-                            v-for="n in 26"
-                            :key="n"
-                            class="rounded-default bg-border-default h-full flex-1 opacity-40"
-                          />
-                        </div>
-                        <div class="h-5 w-5 shrink-0" />
-                      </div>
-                      <div class="flex justify-between">
-                        <SkeletonBox width="60px" height="10px" rounded-default />
-                        <SkeletonBox width="80px" height="10px" rounded-default />
-                        <SkeletonBox width="60px" height="10px" rounded-default />
-                      </div>
+                    <div class="flex justify-between">
+                      <SkeletonBox width="60px" height="10px" rounded-default />
+                      <SkeletonBox width="80px" height="10px" rounded-default />
+                      <SkeletonBox width="60px" height="10px" rounded-default />
                     </div>
                   </div>
                 </div>
-              </template>
-              <!-- Status Timeline — runs query error state -->
-              <template v-else-if="runsError">
-                <div class="px-page-edge">
+              </div>
+            </template>
+            <!-- Status Timeline — runs query error state -->
+            <template v-else-if="runsError">
+              <div class="px-page-edge">
+                <div
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
                   <div
-                    class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
+                    class="flex items-center gap-2 px-3.5 pt-2.5 pb-2"
                   >
-                    <div class="flex items-center gap-2 px-3.5 pt-2.5 pb-2">
-                      <span class="text-text-heading text-sm font-bold">{{
-                        t("synthetics.runs.statusTimeline")
-                      }}</span>
-                    </div>
-                    <div class="border-border-default border-t" />
+                    <span class="font-bold text-sm text-text-heading">{{ t('synthetics.runs.statusTimeline') }}</span>
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="flex items-center justify-center py-6 text-xs text-status-error-text">
+                    <span class="flex items-center gap-1">
+                      <OIcon name="error" size="xs" />
+                      {{ runsError }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </template>
+            <template v-else>
+              <div class="px-page-edge">
+              <MonitorStatusTimeline
+                :segments="timelineSegments"
+                :is-browser="isBrowser"
+                :fail-count="timelineFailCount"
+                :pass-count="timelinePassCount"
+                :mixed-count="timelineMixedCount"
+                :start-label="timelineStartLabel"
+                :end-label="timelineEndLabel"
+              />
+              </div>
+            </template>
+
+            <!-- KPI Cards — gated on KPI + last-run queries -->
+            <template v-if="kpiLoading || !kpiHasLoadedOnce">
+              <div class="px-page-edge">
+                <div class="grid grid-cols-6 gap-2.5">
+                  <div
+                    v-for="n in 6"
+                    :key="n"
+                    class="card-container rounded-default flex flex-col px-3.5 pt-2.5 pb-2.5 gap-2 bg-surface-base border border-border-default"
+                  >
+                    <SkeletonBox width="60%" height="11px" rounded-default />
+                    <SkeletonBox width="55%" height="22px" rounded-default />
+                  </div>
+                </div>
+              </div>
+            </template>
+            <template v-else>
+              <div class="px-page-edge">
+              <div class="grid grid-cols-6 gap-2.5">
+                <div
+                  v-for="card in kpiCards"
+                  :key="card.key"
+                  class="card-container rounded-default flex flex-col px-2 pt-2.5 pb-2.5 gap-1 bg-surface-base border border-border-default transition-shadow duration-200 hover:shadow-[0_1px_6px_rgba(0,0,0,0.08)]"
+                  :data-test="`monitor-runs-kpi-${card.key}`"
+                >
+                  <div class="flex flex-col gap-1">
                     <div
-                      class="text-status-error-text flex items-center justify-center py-6 text-xs"
+                      class="kpi-label text-2xs font-semibold text-text-muted"
                     >
-                      <span class="flex items-center gap-1">
-                        <OIcon name="error" size="xs" />
-                        {{ runsError }}
+                      {{ card.label }}
+                      <span v-if="card.unit"> ({{ card.unit }}) </span>
+                    </div>
+                    <div class="flex items-baseline gap-[0.2rem]">
+                      <!-- Per-card error indicator -->
+                      <template v-if="kpiError">
+                        <span class="flex items-center gap-1 text-xs text-status-error-text">
+                          <OIcon name="error" size="xs" class="shrink-0" />
+                          {{ kpiError }}
+                        </span>
+                      </template>
+                      <template v-else>
+                        <span
+                          class="text-xl font-bold leading-none text-[var(--color-text-heading)]"
+                          :class="card.valueClass"
+                        >
+                          {{ card.value }}
+                        </span>
+                      </template>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              </div>
+            </template>
+
+            <!-- Charts — gated on histogram query -->
+            <template v-if="histogramLoading || !histogramHasLoadedOnce">
+              <div class="px-page-edge">
+              <div class="grid grid-cols-2 gap-2">
+                <div
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
+                  >
+                    <SkeletonBox width="110px" height="14px" rounded-default />
+                    <span class="flex-1" />
+                    <SkeletonBox width="80px" height="20px" rounded-default />
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="p-4">
+                    <SkeletonBox width="100%" height="160px" rounded-default />
+                  </div>
+                </div>
+                <div
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
+                  >
+                    <SkeletonBox width="120px" height="14px" rounded-default />
+                    <span class="flex-1" />
+                    <SkeletonBox width="90px" height="20px" rounded-default />
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="p-4">
+                    <SkeletonBox width="100%" height="160px" rounded-default />
+                  </div>
+                </div>
+              </div>
+              </div>
+            </template>
+            <template v-else>
+              <div class="px-page-edge">
+              <div class="grid grid-cols-2 gap-2">
+                <div
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
+                  >
+                    <span class="font-bold text-sm text-text-heading">
+                      {{ t('synthetics.results.responseTime') }}
+                    </span>
+                    <span class="flex-1" />
+                    <OBadge v-if="!histogramError" variant="default" size="sm">
+                      p95 {{ p95Label }}
+                    </OBadge>
+                    <span
+                      v-else
+                      class="inline-flex items-center gap-1 text-xs text-status-error-text"
+                    >
+                      <OIcon name="error_outline" size="xs" />
+                      {{ t('synthetics.results.error') }}
+                    </span>
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="min-h-45 p-0">
+                    <ChartRenderer
+                      v-if="!histogramError"
+                      :data="{ options: responseChartOption }"
+                      height="180px"
+                    />
+                    <div v-else class="flex flex-col items-center justify-center h-45 gap-1 text-sm text-text-secondary">
+                      <OIcon name="error_outline" size="sm" class="text-status-error-text" />
+                      <span>{{ histogramError }}</span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
+                  >
+                    <span class="font-bold text-sm text-text-heading">
+                      {{ t('synthetics.runs.errorsOverTime') }}
+                    </span>
+                    <span class="flex-1" />
+                    <OBadge v-if="!histogramError" variant="error" size="sm">
+                      {{ t('synthetics.runs.failedCount', { count: failCount }) }}
+                    </OBadge>
+                    <span
+                      v-else
+                      class="inline-flex items-center gap-1 text-xs text-status-error-text"
+                    >
+                      <OIcon name="error_outline" size="xs" />
+                      {{ t('synthetics.results.error') }}
+                    </span>
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="min-h-45 p-0">
+                    <ChartRenderer
+                      v-if="!histogramError"
+                      :data="{ options: errorChartOption }"
+                      height="180px"
+                    />
+                    <div v-else class="flex flex-col items-center justify-center h-45 gap-1 text-sm text-text-secondary">
+                      <OIcon name="error_outline" size="sm" class="text-status-error-text" />
+                      <span>{{ histogramError }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              </div>
+            </template>
+
+            <!-- Breakdown Cards — gated on runs query -->
+            <template v-if="runsLoading || !runsHasLoadedOnce">
+              <div class="px-page-edge">
+              <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
+                <div
+                  v-for="n in (isBrowser ? 3 : 2)"
+                  :key="n"
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
+                  >
+                    <SkeletonBox
+                      width="16px"
+                      height="16px"
+                      :custom-radius="'4px'"
+                    />
+                    <SkeletonBox width="110px" height="14px" rounded-default />
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="px-2 py-2 flex flex-col">
+                    <div
+                      v-for="row in 3"
+                      :key="row"
+                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
+                    >
+                      <SkeletonBox
+                        width="16px"
+                        height="16px"
+                        :custom-radius="'4px'"
+                      />
+                      <SkeletonBox width="70px" height="12px" rounded-default />
+                      <div
+                        class="flex-1 h-1.5 rounded-full bg-border-default opacity-30"
+                      />
+                      <SkeletonBox width="36px" height="12px" rounded-default />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              </div>
+            </template>
+            <!-- Breakdown Cards — runs query error state -->
+            <template v-else-if="runsError">
+              <div class="px-page-edge">
+              <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
+                <div
+                  v-for="dim in breakdownDimensions"
+                  :key="dim"
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
+                  >
+                    <span class="font-bold text-sm text-text-heading">
+                      {{ dim === 'Browser' ? t('synthetics.runs.passRateByBrowser') : dim === 'DurationByLocation' ? t('synthetics.runs.durationByLocation') : dim === 'Location' ? t('synthetics.runs.passRateByLocation') : t('synthetics.runs.passRateByDevice') }}
+                    </span>
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="flex items-center justify-center py-8 text-xs text-status-error-text">
+                    <span class="flex items-center gap-1">
+                      <OIcon name="error" size="xs" />
+                      {{ runsError }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+              </div>
+            </template>
+            <template v-else>
+              <div class="px-page-edge">
+              <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
+                <div
+                  v-if="isBrowser"
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
+                  >
+                    <OIcon name="language" size="sm" class="text-accent" />
+                    <span class="font-bold text-sm text-text-heading">
+                      {{ t('synthetics.runs.passRateByBrowser') }}
+                    </span>
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="px-2 py-2">
+                    <div
+                      v-for="b in browserBreakdown"
+                      :key="b.name"
+                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
+                    >
+                      <OIcon
+                        :name="b.icon"
+                        size="sm"
+                        class="text-text-secondary flex-none"
+                      />
+                      <OTooltip :content="b.name">
+                        <span
+                          class="w-20 flex-none font-semibold text-xs text-text-body truncate cursor-help"
+                        >
+                          {{ b.name }}
+                        </span>
+                      </OTooltip>
+                      <div
+                        class="flex-1 h-1.5 rounded-full bg-text-disabled/25! overflow-hidden min-w-10"
+                      >
+                        <!-- :style for dynamic bar width + computed color — inline required for per-breakdown values -->
+                        <div
+                          class="h-full rounded-full"
+                          :style="{ width: b.barPct || b.pct, background: b.barColor }"
+                        />
+                      </div>
+                      <span
+                        class="font-mono tabular-nums font-bold text-xs w-12 text-right"
+                        :style="{ color: b.textColor }"
+                      >
+                        {{ b.pct }}
                       </span>
                     </div>
                   </div>
                 </div>
-              </template>
-              <template v-else>
-                <div class="px-page-edge">
-                  <MonitorStatusTimeline
-                    :segments="timelineSegments"
-                    :is-browser="isBrowser"
-                    :fail-count="timelineFailCount"
-                    :pass-count="timelinePassCount"
-                    :mixed-count="timelineMixedCount"
-                    :start-label="timelineStartLabel"
-                    :end-label="timelineEndLabel"
-                  />
-                </div>
-              </template>
-
-              <!-- KPI Cards — gated on KPI + last-run queries -->
-              <template v-if="kpiLoading || !kpiHasLoadedOnce">
-                <div class="px-page-edge">
-                  <div class="grid grid-cols-6 gap-2.5">
-                    <div
-                      v-for="n in 6"
-                      :key="n"
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col gap-2 border px-3.5 pt-2.5 pb-2.5"
-                    >
-                      <SkeletonBox width="60%" height="11px" rounded-default />
-                      <SkeletonBox width="55%" height="22px" rounded-default />
-                    </div>
-                  </div>
-                </div>
-              </template>
-              <template v-else>
-                <div class="px-page-edge">
-                  <div class="grid grid-cols-6 gap-2.5">
-                    <div
-                      v-for="card in kpiCards"
-                      :key="card.key"
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col gap-1 border px-2 pt-2.5 pb-2.5 transition-shadow duration-200 hover:shadow-[0_1px_6px_rgba(0,0,0,0.08)]"
-                      :data-test="`monitor-runs-kpi-${card.key}`"
-                    >
-                      <div class="flex flex-col gap-1">
-                        <div class="kpi-label text-2xs text-text-muted font-semibold">
-                          {{ card.label }}
-                          <span v-if="card.unit"> ({{ card.unit }}) </span>
-                        </div>
-                        <div class="flex items-baseline gap-[0.2rem]">
-                          <!-- Per-card error indicator -->
-                          <template v-if="kpiError">
-                            <span class="text-status-error-text flex items-center gap-1 text-xs">
-                              <OIcon name="error" size="xs" class="shrink-0" />
-                              {{ kpiError }}
-                            </span>
-                          </template>
-                          <template v-else>
-                            <span
-                              class="text-xl leading-none font-bold text-[var(--color-text-heading)]"
-                              :class="card.valueClass"
-                            >
-                              {{ card.value }}
-                            </span>
-                          </template>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </template>
-
-              <!-- Charts — gated on histogram query -->
-              <template v-if="histogramLoading || !histogramHasLoadedOnce">
-                <div class="px-page-edge">
-                  <div class="grid grid-cols-2 gap-2">
-                    <div
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                    >
-                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                        <SkeletonBox width="110px" height="14px" rounded-default />
-                        <span class="flex-1" />
-                        <SkeletonBox width="80px" height="20px" rounded-default />
-                      </div>
-                      <div class="border-border-default border-t" />
-                      <div class="p-4">
-                        <SkeletonBox width="100%" height="160px" rounded-default />
-                      </div>
-                    </div>
-                    <div
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                    >
-                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                        <SkeletonBox width="120px" height="14px" rounded-default />
-                        <span class="flex-1" />
-                        <SkeletonBox width="90px" height="20px" rounded-default />
-                      </div>
-                      <div class="border-border-default border-t" />
-                      <div class="p-4">
-                        <SkeletonBox width="100%" height="160px" rounded-default />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </template>
-              <template v-else>
-                <div class="px-page-edge">
-                  <div class="grid grid-cols-2 gap-2">
-                    <div
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                    >
-                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                        <span class="text-text-heading text-sm font-bold">
-                          {{ t("synthetics.results.responseTime") }}
-                        </span>
-                        <span class="flex-1" />
-                        <OBadge v-if="!histogramError" variant="default" size="sm">
-                          p95 {{ p95Label }}
-                        </OBadge>
-                        <span
-                          v-else
-                          class="text-status-error-text inline-flex items-center gap-1 text-xs"
-                        >
-                          <OIcon name="error_outline" size="xs" />
-                          {{ t("synthetics.results.error") }}
-                        </span>
-                      </div>
-                      <div class="border-border-default border-t" />
-                      <div class="min-h-45 p-0">
-                        <ChartRenderer
-                          v-if="!histogramError"
-                          :data="{ options: responseChartOption }"
-                          height="180px"
-                        />
-                        <div
-                          v-else
-                          class="text-text-secondary flex h-45 flex-col items-center justify-center gap-1 text-sm"
-                        >
-                          <OIcon name="error_outline" size="sm" class="text-status-error-text" />
-                          <span>{{ histogramError }}</span>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                    >
-                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                        <span class="text-text-heading text-sm font-bold">
-                          {{ t("synthetics.runs.errorsOverTime") }}
-                        </span>
-                        <span class="flex-1" />
-                        <OBadge v-if="!histogramError" variant="error" size="sm">
-                          {{ t("synthetics.runs.failedCount", { count: failCount }) }}
-                        </OBadge>
-                        <span
-                          v-else
-                          class="text-status-error-text inline-flex items-center gap-1 text-xs"
-                        >
-                          <OIcon name="error_outline" size="xs" />
-                          {{ t("synthetics.results.error") }}
-                        </span>
-                      </div>
-                      <div class="border-border-default border-t" />
-                      <div class="min-h-45 p-0">
-                        <ChartRenderer
-                          v-if="!histogramError"
-                          :data="{ options: errorChartOption }"
-                          height="180px"
-                        />
-                        <div
-                          v-else
-                          class="text-text-secondary flex h-45 flex-col items-center justify-center gap-1 text-sm"
-                        >
-                          <OIcon name="error_outline" size="sm" class="text-status-error-text" />
-                          <span>{{ histogramError }}</span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </template>
-
-              <!-- Breakdown Cards — gated on runs query -->
-              <template v-if="runsLoading || !runsHasLoadedOnce">
-                <div class="px-page-edge">
-                  <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
-                    <div
-                      v-for="n in isBrowser ? 3 : 2"
-                      :key="n"
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                    >
-                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                        <SkeletonBox width="16px" height="16px" :custom-radius="'4px'" />
-                        <SkeletonBox width="110px" height="14px" rounded-default />
-                      </div>
-                      <div class="border-border-default border-t" />
-                      <div class="flex flex-col px-2 py-2">
-                        <div
-                          v-for="row in 3"
-                          :key="row"
-                          class="border-border-default flex items-center gap-3 border-b py-2.25 last:border-b-0"
-                        >
-                          <SkeletonBox width="16px" height="16px" :custom-radius="'4px'" />
-                          <SkeletonBox width="70px" height="12px" rounded-default />
-                          <div class="bg-border-default h-1.5 flex-1 rounded-full opacity-30" />
-                          <SkeletonBox width="36px" height="12px" rounded-default />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </template>
-              <!-- Breakdown Cards — runs query error state -->
-              <template v-else-if="runsError">
-                <div class="px-page-edge">
-                  <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
-                    <div
-                      v-for="dim in breakdownDimensions"
-                      :key="dim"
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                    >
-                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                        <span class="text-text-heading text-sm font-bold">
-                          {{
-                            dim === "Browser"
-                              ? t("synthetics.runs.passRateByBrowser")
-                              : dim === "DurationByLocation"
-                                ? t("synthetics.runs.durationByLocation")
-                                : dim === "Location"
-                                  ? t("synthetics.runs.passRateByLocation")
-                                  : t("synthetics.runs.passRateByDevice")
-                          }}
-                        </span>
-                      </div>
-                      <div class="border-border-default border-t" />
-                      <div
-                        class="text-status-error-text flex items-center justify-center py-8 text-xs"
-                      >
-                        <span class="flex items-center gap-1">
-                          <OIcon name="error" size="xs" />
-                          {{ runsError }}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </template>
-              <template v-else>
-                <div class="px-page-edge">
-                  <div :class="['grid gap-2', isBrowser ? 'grid-cols-3' : 'grid-cols-2']">
-                    <div
-                      v-if="isBrowser"
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                    >
-                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                        <OIcon name="language" size="sm" class="text-accent" />
-                        <span class="text-text-heading text-sm font-bold">
-                          {{ t("synthetics.runs.passRateByBrowser") }}
-                        </span>
-                      </div>
-                      <div class="border-border-default border-t" />
-                      <div class="px-2 py-2">
-                        <div
-                          v-for="b in browserBreakdown"
-                          :key="b.name"
-                          class="border-border-default flex items-center gap-3 border-b py-2.25 last:border-b-0"
-                        >
-                          <OIcon :name="b.icon" size="sm" class="text-text-secondary flex-none" />
-                          <span class="text-text-body w-20 flex-none text-xs font-semibold">
-                            {{ b.name }}
-                          </span>
-                          <div
-                            class="bg-text-disabled/25! h-1.5 min-w-10 flex-1 overflow-hidden rounded-full"
-                          >
-                            <!-- :style for dynamic bar width + computed color — inline required for per-breakdown values -->
-                            <div
-                              class="h-full rounded-full"
-                              :style="{ width: b.barPct || b.pct, background: b.barColor }"
-                            />
-                          </div>
-                          <span
-                            class="w-12 text-right font-mono text-xs font-bold tabular-nums"
-                            :style="{ color: b.textColor }"
-                          >
-                            {{ b.pct }}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                    >
-                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                        <OIcon name="location-on" size="sm" class="text-accent" />
-                        <span class="text-text-heading text-sm font-bold">
-                          {{ t("synthetics.runs.passRateByLocation") }}
-                        </span>
-                      </div>
-                      <div class="border-border-default border-t" />
-                      <div class="px-2 py-2">
-                        <div
-                          v-for="l in locationBreakdown"
-                          :key="l.id ?? l.name"
-                          class="border-border-default flex items-center gap-3 border-b py-2.25 last:border-b-0"
-                        >
-                          <OIcon :name="l.icon" size="sm" class="text-text-secondary flex-none" />
-                          <span class="text-text-body w-27.5 flex-none text-xs font-semibold">
-                            {{ l.name }}
-                          </span>
-                          <div
-                            class="bg-text-disabled/25! h-1.5 min-w-10 flex-1 overflow-hidden rounded-full"
-                          >
-                            <div
-                              class="h-full rounded-full"
-                              :style="{ width: l.barPct || l.pct, background: l.barColor }"
-                            />
-                          </div>
-                          <span
-                            class="w-12 text-right font-mono text-xs font-bold tabular-nums"
-                            :style="{ color: l.textColor }"
-                          >
-                            {{ l.pct }}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      v-if="!isBrowser"
-                      class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                    >
-                      <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                        <OIcon name="devices" size="sm" class="text-accent" />
-                        <span class="text-text-heading text-sm font-bold">
-                          {{ t("synthetics.runs.passRateByDevice") }}
-                        </span>
-                      </div>
-                      <div class="border-border-default border-t" />
-                      <div class="px-2 py-2">
-                        <div
-                          v-for="d in deviceBreakdown"
-                          :key="d.name"
-                          class="border-border-default flex items-center gap-3 border-b py-2.25 last:border-b-0"
-                        >
-                          <OIcon :name="d.icon" size="sm" class="text-text-secondary flex-none" />
-                          <span class="text-text-body w-20 flex-none text-xs font-semibold">
-                            {{ d.name }}
-                          </span>
-                          <div
-                            class="bg-text-disabled/25! h-1.5 min-w-10 flex-1 overflow-hidden rounded-full"
-                          >
-                            <div
-                              class="h-full rounded-full"
-                              :style="{ width: d.pct, background: d.barColor }"
-                            />
-                          </div>
-                          <span
-                            class="w-12 text-right font-mono text-xs font-bold tabular-nums"
-                            :style="{ color: d.textColor }"
-                          >
-                            {{ d.pct }}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </template>
-
-              <!-- Filter bar -->
-              <div class="flex flex-wrap items-center gap-2 px-2">
-                <OToggleGroup v-model="statusFilter" variant="default">
-                  <OToggleGroupItem
-                    v-for="so in statusOptions"
-                    :key="so.key"
-                    :value="so.key"
-                    size="sm"
+                <div
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
                   >
-                    <template #icon-left>
-                      <span
-                        class="h-[0.4375rem] w-[0.4375rem] rounded-full"
-                        :style="{ background: so.dot }"
+                    <OIcon
+                      name="location-on"
+                      size="sm"
+                      class="text-accent"
+                    />
+                    <span class="font-bold text-sm text-text-heading">
+                      {{ t('synthetics.runs.passRateByLocation') }}
+                    </span>
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="px-2 py-2">
+                    <div
+                      v-for="l in locationBreakdown"
+                      :key="l.id ?? l.name"
+                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
+                    >
+                      <OIcon
+                        :name="l.icon"
+                        size="sm"
+                        class="text-text-secondary flex-none"
                       />
-                    </template>
-                    {{ so.label }}
-                  </OToggleGroupItem>
-                </OToggleGroup>
-
-                <OSelect
+                      <OTooltip :content="l.name">
+                        <span
+                          class="w-40 flex-none font-semibold text-xs text-text-body truncate cursor-help"
+                        >
+                          {{ l.name }}
+                        </span>
+                      </OTooltip>
+                      <div
+                        class="flex-1 h-1.5 rounded-full bg-text-disabled/25! overflow-hidden min-w-10"
+                      >
+                        <div
+                          class="h-full rounded-full"
+                          :style="{ width: l.barPct || l.pct, background: l.barColor }"
+                        />
+                      </div>
+                      <span
+                        class="font-mono tabular-nums font-bold text-xs w-12 text-right"
+                        :style="{ color: l.textColor }"
+                      >
+                        {{ l.pct }}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
                   v-if="isBrowser"
-                  v-model="browserFilter"
-                  :options="browserOptions"
-                  icon-key="icon"
-                  size="md"
-                  class="w-35!"
-                  data-test="monitor-runs-filter-browser"
-                />
-                <OSelect
-                  v-if="isBrowser"
-                  v-model="deviceFilter"
-                  :options="deviceOptions"
-                  icon-key="icon"
-                  size="md"
-                  class="w-35!"
-                  data-test="monitor-runs-filter-device"
-                />
-                <OSelect
-                  v-model="locationFilter"
-                  :options="locationOptions"
-                  icon-key="icon"
-                  size="md"
-                  class="w-35!"
-                  data-test="monitor-runs-filter-location"
-                />
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
+                  >
+                    <OIcon name="devices" size="sm" class="text-accent" />
+                    <span class="font-bold text-sm text-text-heading">
+                      {{ t('synthetics.runs.passRateByDevice') }}
+                    </span>
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="px-2 py-2">
+                    <div
+                      v-for="d in deviceBreakdown"
+                      :key="d.name"
+                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
+                    >
+                      <OIcon
+                        :name="d.icon"
+                        size="sm"
+                        class="text-text-secondary flex-none"
+                      />
+                      <OTooltip :content="d.name">
+                        <span
+                          class="w-18 flex-none font-semibold text-xs text-text-body truncate cursor-help text-capitalize"
+                        >
+                          {{ d.name }}
+                        </span>
+                      </OTooltip>
+                      <div
+                        class="flex-1 h-1.5 rounded-full bg-text-disabled/25! overflow-hidden min-w-10"
+                      >
+                        <div
+                          class="h-full rounded-full"
+                          :style="{ width: d.pct, background: d.barColor }"
+                        />
+                      </div>
+                      <span
+                        class="font-mono tabular-nums font-bold text-xs w-12 text-right"
+                        :style="{ color: d.textColor }"
+                      >
+                        {{ d.pct }}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  v-if="!isBrowser"
+                  class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden"
+                >
+                  <div
+                    class="flex items-center gap-2 px-2 pt-2.5 pb-2"
+                  >
+                    <OIcon name="schedule" size="sm" class="text-accent" />
+                    <span class="font-bold text-sm text-text-heading">
+                      {{ t('synthetics.runs.durationByLocation') }}
+                    </span>
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="px-2 py-2">
+                    <div
+                      v-for="d in locationDurationBreakdown"
+                      :key="d.id ?? d.name"
+                      class="flex items-center gap-3 py-2.25 border-b border-border-default last:border-b-0"
+                    >
+                      <OIcon
+                        :name="d.icon"
+                        size="sm"
+                        class="text-text-secondary flex-none"
+                      />
+                      <OTooltip :content="d.name">
+                        <span
+                          class="w-34 flex-none font-semibold text-xs text-text-body truncate cursor-help"
+                        >
+                          {{ d.name }}
+                        </span>
+                      </OTooltip>
+                      <div
+                        class="flex-1 h-1.5 rounded-full bg-text-disabled/25! overflow-hidden min-w-10"
+                      >
+                        <div
+                          class="h-full rounded-full"
+                          :style="{ width: d.barPct || d.pct, background: d.barColor }"
+                        />
+                      </div>
+                      <span
+                        class="font-mono tabular-nums font-bold text-xs w-12 text-right"
+                        :style="{ color: d.textColor }"
+                      >
+                        {{ d.pct }}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              </div>
+            </template>
 
-                <!-- Failure-specific filters -->
-                <template v-if="statusFilter === 'fail' && false">
-                  <OSeparator orientation="vertical" class="h-5" />
-                  <OSelect
-                    v-model="failedStepFilter"
-                    :options="failedStepOptions"
+            <!-- Filter bar -->
+            <div class="flex items-center gap-2 flex-wrap px-2">
+              <OToggleGroup v-model="statusFilter" variant="default">
+                <OToggleGroupItem
+                  v-for="so in statusOptions"
+                  :key="so.key"
+                  :value="so.key"
+                  size="sm"
+                >
+                  <template #icon-left>
+                    <span
+                      class="w-[0.4375rem] h-[0.4375rem] rounded-full"
+                      :style="{ background: so.dot }"
+                    />
+                  </template>
+                  {{ so.label }}
+                </OToggleGroupItem>
+              </OToggleGroup>
+
+              <OSelect
+                v-if="isBrowser"
+                v-model="browserFilter"
+                :options="browserOptions"
+                icon-key="icon"
+                size="md"
+                class="w-35!"
+                data-test="monitor-runs-filter-browser"
+              />
+              <OSelect
+                v-if="isBrowser"
+                v-model="deviceFilter"
+                :options="deviceOptions"
+                icon-key="icon"
+                size="md"
+                class="w-35!"
+                data-test="monitor-runs-filter-device"
+              />
+              <OSelect
+                v-model="locationFilter"
+                :options="locationOptions"
+                icon-key="icon"
+                size="md"
+                class="w-35!"
+                data-test="monitor-runs-filter-location"
+              />
+
+              <!-- Failure-specific filters -->
+              <template v-if="statusFilter === 'fail' && false">
+                <OSeparator orientation="vertical" class="h-5" />
+                <OSelect
+                  v-model="failedStepFilter"
+                  :options="failedStepOptions"
+                  size="sm"
+                  class="w-40"
+                  data-test="monitor-runs-filter-step"
+                />
+                <OInput
+                  v-model="locatorFilter"
+                  size="sm"
+                  :placeholder="t('synthetics.runs.locatorPlaceholder')"
+                  class="w-42.5"
+                  data-test="monitor-runs-filter-locator"
+                />
+                <OSelect
+                  v-model="actionFilter"
+                  :options="actionOptions"
+                  size="sm"
+                  class="w-32.5"
+                  data-test="monitor-runs-filter-action"
+                />
+              </template>
+
+              <span class="flex-1" />
+              <span class="text-xs text-text-secondary">
+                {{ t('synthetics.runs.filterCount', { current: filteredRuns.length, total: allRuns.length }) }}
+              </span>
+            </div>
+
+            <!-- Error filter indicator -->
+            <div
+              v-if="errorFilter"
+              class="flex items-center gap-2 px-2"
+              data-test="monitor-runs-error-filter-badge"
+            >
+              <span class="text-xs text-text-secondary"
+                >{{ t('synthetics.runs.filteringByErrorLabel') }}</span
+              >
+              <OBadge variant="error" size="sm" class="gap-1">
+                {{ errorFilter }}
+                <OButton
+                  variant="ghost"
+                  size="icon-xs"
+                  class="text-inherit"
+                  data-test="synthetics-monitor-runs-clear-error-filter-btn"
+                  @click.stop="clearErrorFilter"
+                >
+                  <OIcon name="close" size="xs" />
+                </OButton>
+              </OBadge>
+            </div>
+
+            <!-- Runs table -->
+            <OCard class="p-0" :key="tableFilterKey">
+              <OTable
+                :columns="runColumns"
+                :data="visibleRuns"
+                :loading="runsLoading"
+                pagination="client"
+                :page-size="10"
+                :page-size-options="[10, 20, 25, 50]"
+                row-key="id"
+                :show-global-filter="false"
+                :enable-column-resize="true"
+                :enable-column-reorder="true"
+                data-test="monitor-runs-runs-table"
+                @row-click="openRun"
+              >
+                <template #cell-status="{ row }">
+                  <OBadge
+                    :variant="(row as VisibleRun).statusBadgeVariant"
                     size="sm"
-                    class="w-40"
-                    data-test="monitor-runs-filter-step"
-                  />
-                  <OInput
-                    v-model="locatorFilter"
-                    size="sm"
-                    :placeholder="t('synthetics.runs.locatorPlaceholder')"
-                    class="w-42.5"
-                    data-test="monitor-runs-filter-locator"
-                  />
-                  <OSelect
-                    v-model="actionFilter"
-                    :options="actionOptions"
-                    size="sm"
-                    class="w-32.5"
-                    data-test="monitor-runs-filter-action"
+                    dot
+                  >
+                    {{ (row as VisibleRun).statusLabel }}
+                  </OBadge>
+                </template>
+                <template #cell-scheduled_at="{ row }">
+                  <OTimeCell
+                    :value="(row as VisibleRun).scheduledTs"
+                    unit="ms"
+                    mode="absolute"
+                    empty-label="—"
                   />
                 </template>
-
-                <span class="flex-1" />
-                <span class="text-text-secondary text-xs">
-                  {{
-                    t("synthetics.runs.filterCount", {
-                      current: filteredRuns.length,
-                      total: allRuns.length,
-                    })
-                  }}
-                </span>
-              </div>
-
-              <!-- Error filter indicator -->
-              <div
-                v-if="errorFilter"
-                class="flex items-center gap-2 px-2"
-                data-test="monitor-runs-error-filter-badge"
-              >
-                <span class="text-text-secondary text-xs">{{
-                  t("synthetics.runs.filteringByErrorLabel")
-                }}</span>
-                <OBadge variant="error" size="sm" class="gap-1">
-                  {{ errorFilter }}
-                  <OButton
-                    variant="ghost"
-                    size="icon-xs"
-                    class="text-inherit"
-                    data-test="synthetics-monitor-runs-clear-error-filter-btn"
-                    @click.stop="clearErrorFilter"
+                <template #cell-last_run_at="{ row }">
+                  <OTimeCell
+                    :value="(row as VisibleRun).lastRunTs"
+                    unit="ms"
+                    mode="absolute"
+                    empty-label="—"
+                  />
+                </template>
+                <template #cell-duration="{ row }">
+                  <span class="tabular-nums text-sm">
+                    {{ (row as VisibleRun).duration }}
+                  </span>
+                </template>
+                <template #cell-location="{ row }">
+                  <span
+                    class="inline-flex items-center gap-1 text-sm text-text-body"
                   >
-                    <OIcon name="close" size="xs" />
-                  </OButton>
-                </OBadge>
-              </div>
+                    <OIcon
+                      :name="locationIcon((row as VisibleRun).location)"
+                      size="sm"
+                    />
+                    {{ locationLabel((row as VisibleRun).location) }}
+                  </span>
+                </template>
+                <template #cell-browser="{ row }">
+                  <span
+                    class="inline-flex items-center gap-1 text-sm text-text-body"
+                  >
+                    <OIcon
+                      :name="browserIcon((row as VisibleRun).browser)"
+                      size="sm"
+                    />
+                    {{ (row as VisibleRun).browser }}
+                  </span>
+                </template>
+                <template #cell-device="{ row }">
+                  <span
+                    class="inline-flex items-center gap-1 text-sm text-text-body"
+                  >
+                    <OIcon
+                      :name="deviceIconName((row as VisibleRun).device)"
+                      size="sm"
+                    />
+                    {{ deviceLabel((row as VisibleRun).device) }}
+                  </span>
+                </template>
+                <template #cell-error="{ row }">
+                  <span
+                    v-if="(row as VisibleRun).errorSnippet"
+                    class="cursor-pointer"
+                    @click.stop="
+                      filterByError((row as VisibleRun).errorPattern)
+                    "
+                  >
+                    <OBadge
+                      variant="error-outline"
+                      size="sm"
+                      class="truncate max-w-50"
+                    >
+                      {{ (row as VisibleRun).errorSnippet }}
+                    </OBadge>
+                  </span>
+                </template>
+                <template #cell-trigger_type="{ row }">
+                  <span class="text-sm text-text-body">
+                    {{ (row as VisibleRun).triggerType }}
+                  </span>
+                </template>
 
-              <!-- Runs table -->
-              <OCard class="p-0" :key="tableFilterKey">
+                <!-- Empty state: smart — differentiates "never run" vs "no runs in window" -->
+                <template #empty>
+                  <div v-if="kpiHasLoadedOnce" class="px-page-edge">
+                    <!-- Monitor has runs elsewhere — guide to last run + optionally clear filters -->
+                    <OEmptyState
+                      v-if="synthetics.kpi.value.totalRuns > 0"
+                      size="block"
+                      illustration="no-results"
+                      :title="t('synthetics.results.noRunsInWindow')"
+                      :description="t('synthetics.results.noRunsInWindowDesc')"
+                      data-test="monitor-runs-empty"
+                    >
+                      <template #actions>
+                        <EmptyStateActionCard
+                          icon="schedule"
+                          :label="t('synthetics.results.jumpToLastRun')"
+                          :sublabel="lastRunLabel"
+                          data-test="monitor-runs-empty-jump-last-run"
+                          @click="handleEmptyStateAction('jump-to-last-run')"
+                        />
+                        <EmptyStateActionCard
+                          v-if="hasActiveFilters"
+                          icon="filter-list"
+                          :label="t('synthetics.results.clearFilters')"
+                          :sublabel="t('synthetics.results.clearFiltersDesc')"
+                          data-test="monitor-runs-empty-clear-filters"
+                          @click="handleEmptyStateAction('clear-filters')"
+                        />
+                      </template>
+                    </OEmptyState>
+
+                    <!-- Monitor has never been run — prompt to trigger -->
+                    <OEmptyState
+                      v-else
+                      size="block"
+                      illustration="browser-check"
+                      :title="t('synthetics.results.noRunsYet')"
+                      :description="t('synthetics.results.noRunsYetDesc')"
+                      data-test="monitor-runs-empty"
+                    >
+                      <template #actions>
+                        <EmptyStateActionCard
+                          icon="play-arrow"
+                          :label="t('synthetics.results.triggerRunNow')"
+                          :sublabel="t('synthetics.results.triggerRunNowDesc')"
+                          data-test="monitor-runs-empty-trigger-run"
+                          @click="handleEmptyStateAction('trigger-run')"
+                        />
+                      </template>
+                    </OEmptyState>
+                  </div>
+                </template>
+              </OTable>
+            </OCard>
+
+          </div>
+        </OTabPanel>
+
+        <!-- ════════════ STEPS ════════════ -->
+        <!-- ════════════ STEPS ════════════ -->
+        <OTabPanel name="steps">
+          <div
+            class="mx-auto flex flex-col gap-2"
+          >
+            <!-- Loading skeleton -->
+            <template v-if="stepsLoading || !stepsHasLoadedOnce">
+              <div class="grid grid-cols-2 gap-2">
+                <div class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden">
+                  <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                    <SkeletonBox width="100px" height="14px" rounded-default />
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="p-4"><SkeletonBox width="100%" height="160px" rounded-default /></div>
+                </div>
+                <div class="card-container rounded-default flex flex-col bg-surface-base border border-border-default overflow-hidden">
+                  <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
+                    <SkeletonBox width="100px" height="14px" rounded-default />
+                  </div>
+                  <div class="border-t border-border-default" />
+                  <div class="p-4"><SkeletonBox width="100%" height="160px" rounded-default /></div>
+                </div>
+              </div>
+              <div v-for="n in 5" :key="n" class="card-container rounded-default overflow-hidden">
+                <div class="h-10 bg-[var(--color-border-default)] opacity-20" />
+              </div>
+            </template>
+
+            <!-- Steps query error — compact inline indicator -->
+            <template v-else-if="stepsError">
+              <div
+                class="px-2 flex items-center gap-2"
+                data-test="monitor-runs-steps-error"
+              >
+                <OIcon name="error_outline" size="xs" class="text-status-error-text shrink-0" />
+                <span class="text-xs text-status-error-text truncate flex-1 min-w-0">{{ stepsError }}</span>
+                <OButton
+                  variant="ghost"
+                  size="xs"
+                  class="underline! text-xs!"
+                  data-test="monitor-runs-steps-retry-btn"
+                  @click="emit('refresh')"
+                >
+                  {{ t('synthetics.journey.retry') }}
+                </OButton>
+              </div>
+            </template>
+
+            <!-- Real content -->
+            <template v-else>
+              <!-- Steps Analysis Table -->
+              <OCard class="p-0">
                 <OTable
-                  :columns="runColumns"
-                  :data="visibleRuns"
-                  :loading="runsLoading"
-                  pagination="client"
-                  :page-size="10"
-                  :page-size-options="[10, 20, 25, 50]"
+                  :data="stepTableRows"
+                  :columns="stepTableColumns"
                   row-key="id"
+                  :pagination="'none'"
+                  :sorting="'client'"
                   :show-global-filter="false"
+                  :show-header="true"
+                  :dense="true"
+                  :bordered="true"
                   :enable-column-resize="true"
                   :enable-column-reorder="true"
-                  data-test="monitor-runs-runs-table"
-                  @row-click="openRun"
+                  :fill-height="false"
                 >
-                  <template #cell-status="{ row }">
-                    <OBadge :variant="(row as VisibleRun).statusBadgeVariant" size="sm" dot>
-                      {{ (row as VisibleRun).statusLabel }}
-                    </OBadge>
+                  <!-- cell-name: Step name -->
+                  <template #cell-name="{ row }">
+                    <div class="min-w-0">
+                      <div class="font-semibold text-xs text-[var(--color-text-heading)] truncate">
+                        {{ row.name }}
+                      </div>
+                    </div>
                   </template>
-                  <template #cell-scheduled_at="{ row }">
-                    <OTimeCell
-                      :value="(row as VisibleRun).scheduledTs"
-                      unit="ms"
-                      mode="absolute"
-                      empty-label="—"
-                    />
+
+                  <!-- cell-failRate: Colored percentage + bar -->
+                  <template #cell-failRate="{ row }">
+                    <div class="flex flex-col gap-1">
+                      <span class="font-mono tabular-nums font-bold text-xs" :style="{ color: row.failColor }">
+                        {{ row.failRatePct }}%&ensp;<span class="font-normal text-[var(--color-text-muted)]">{{ row.failCount }}</span>
+                      </span>
+                      <div class="h-1.25 rounded-full bg-[var(--color-text-disabled)]/25! overflow-hidden">
+                        <div class="h-full rounded-full" :style="{ width: row.failRateBarPct, background: row.failBarColor }" />
+                      </div>
+                    </div>
                   </template>
-                  <template #cell-last_run_at="{ row }">
-                    <OTimeCell
-                      :value="(row as VisibleRun).lastRunTs"
-                      unit="ms"
-                      mode="absolute"
-                      empty-label="—"
-                    />
-                  </template>
-                  <template #cell-duration="{ row }">
-                    <span class="text-sm tabular-nums">
-                      {{ (row as VisibleRun).duration }}
-                    </span>
-                  </template>
-                  <template #cell-location="{ row }">
-                    <span class="text-text-body inline-flex items-center gap-1 text-sm">
-                      <OIcon :name="locationIcon((row as VisibleRun).location)" size="sm" />
-                      {{ locationLabel((row as VisibleRun).location) }}
-                    </span>
-                  </template>
-                  <template #cell-browser="{ row }">
-                    <span class="text-text-body inline-flex items-center gap-1 text-sm">
-                      <OIcon :name="browserIcon((row as VisibleRun).browser)" size="sm" />
-                      {{ (row as VisibleRun).browser }}
-                    </span>
-                  </template>
-                  <template #cell-device="{ row }">
-                    <span class="text-text-body inline-flex items-center gap-1 text-sm">
-                      <OIcon :name="deviceIconName((row as VisibleRun).device)" size="sm" />
-                      {{ deviceLabel((row as VisibleRun).device) }}
-                    </span>
-                  </template>
-                  <template #cell-error="{ row }">
-                    <span
-                      v-if="(row as VisibleRun).errorSnippet"
-                      class="cursor-pointer"
-                      @click.stop="filterByError((row as VisibleRun).errorPattern)"
-                    >
-                      <OBadge variant="error-outline" size="sm" class="max-w-50 truncate">
-                        {{ (row as VisibleRun).errorSnippet }}
-                      </OBadge>
-                    </span>
-                  </template>
-                  <template #cell-trigger_type="{ row }">
-                    <span class="text-text-body text-sm">
-                      {{ (row as VisibleRun).triggerType }}
+
+                  <!-- cell-flakyRate: Colored percentage -->
+                  <template #cell-flakyRate="{ row }">
+                    <span class="font-mono tabular-nums text-xs" :style="{ color: row.flakyColor }">
+                      {{ row.flakyRatePct }}%&ensp;<span class="font-normal text-[var(--color-text-muted)]">{{ row.flakyCount }}</span>
                     </span>
                   </template>
 
-                  <!-- Empty state: smart — differentiates "never run" vs "no runs in window" -->
+                  <!-- cell-avgDuration: Duration + bar -->
+                  <template #cell-avgDuration="{ row }">
+                    <div class="flex flex-col gap-1">
+                      <span class="font-mono tabular-nums text-xs text-[var(--color-text-body)]">{{ row.avgDuration }}</span>
+                      <div class="h-1.25 rounded-full bg-[var(--color-text-disabled)]/25! overflow-hidden">
+                        <div class="h-full rounded-full bg-[var(--color-primary-400)]" :style="{ width: row.durationBarPct }" />
+                      </div>
+                    </div>
+                  </template>
+
+                  <!-- cell-p95Duration: Duration + bar -->
+                  <template #cell-p95Duration="{ row }">
+                    <div class="flex flex-col gap-1">
+                      <span class="font-mono tabular-nums text-xs text-[var(--color-text-body)]">{{ row.p95Duration }}</span>
+                      <div class="h-1.25 rounded-full bg-[var(--color-text-disabled)]/25! overflow-hidden">
+                        <div class="h-full rounded-full bg-[var(--color-primary-400)]" :style="{ width: row.p95DurationBarPct }" />
+                      </div>
+                    </div>
+                  </template>
+
+                  <!-- cell-maxDuration: Duration + bar -->
+                  <template #cell-maxDuration="{ row }">
+                    <div class="flex flex-col gap-1">
+                      <span class="font-mono tabular-nums text-xs text-[var(--color-text-body)]">{{ row.maxDuration }}</span>
+                      <div class="h-1.25 rounded-full bg-[var(--color-text-disabled)]/25! overflow-hidden">
+                        <div class="h-full rounded-full bg-[var(--color-primary-400)]" :style="{ width: row.maxDurationBarPct }" />
+                      </div>
+                    </div>
+                  </template>
+
+                  <!-- Empty -->
                   <template #empty>
-                    <div v-if="kpiHasLoadedOnce" class="px-page-edge">
-                      <!-- Monitor has runs elsewhere — guide to last run + optionally clear filters -->
-                      <OEmptyState
-                        v-if="synthetics.kpi.value.totalRuns > 0"
-                        size="block"
-                        illustration="no-results"
-                        :title="t('synthetics.results.noRunsInWindow')"
-                        :description="t('synthetics.results.noRunsInWindowDesc')"
-                        data-test="monitor-runs-empty"
-                      >
-                        <template #actions>
-                          <EmptyStateActionCard
-                            icon="schedule"
-                            :label="t('synthetics.results.jumpToLastRun')"
-                            :sublabel="lastRunLabel"
-                            data-test="monitor-runs-empty-jump-last-run"
-                            @click="handleEmptyStateAction('jump-to-last-run')"
-                          />
-                          <EmptyStateActionCard
-                            v-if="hasActiveFilters"
-                            icon="filter-list"
-                            :label="t('synthetics.results.clearFilters')"
-                            :sublabel="t('synthetics.results.clearFiltersDesc')"
-                            data-test="monitor-runs-empty-clear-filters"
-                            @click="handleEmptyStateAction('clear-filters')"
-                          />
-                        </template>
-                      </OEmptyState>
-
-                      <!-- Monitor has never been run — prompt to trigger -->
-                      <OEmptyState
-                        v-else
-                        size="block"
-                        illustration="browser-check"
-                        :title="t('synthetics.results.noRunsYet')"
-                        :description="t('synthetics.results.noRunsYetDesc')"
-                        data-test="monitor-runs-empty"
-                      >
-                        <template #actions>
-                          <EmptyStateActionCard
-                            icon="play-arrow"
-                            :label="t('synthetics.results.triggerRunNow')"
-                            :sublabel="t('synthetics.results.triggerRunNowDesc')"
-                            data-test="monitor-runs-empty-trigger-run"
-                            @click="handleEmptyStateAction('trigger-run')"
-                          />
-                        </template>
-                      </OEmptyState>
+                    <div class="flex items-center justify-center py-12 text-sm text-[var(--color-text-secondary)]">
+                      {{ t('synthetics.runs.noStepData') }}
                     </div>
                   </template>
                 </OTable>
               </OCard>
+
+            </template>
+          </div>
+        </OTabPanel>
+
+        <!-- ════════════ ERRORS ════════════ -->
+        <OTabPanel name="errors">
+          <div
+            class="mx-auto px-2 py-2 pb-7 flex flex-col gap-2"
+          >
+            <div class="flex items-center gap-2.5">
+              <span class="font-bold text-sm text-text-heading">
+                {{ t('synthetics.runs.errorPatterns') }}
+              </span>
+              <span class="text-xs text-text-secondary">
+                {{ t('synthetics.runs.errorPatternsWindowDesc', { window: windowLabel }) }}
+              </span>
             </div>
-          </OTabPanel>
 
-          <!-- ════════════ STEPS ════════════ -->
-          <!-- ════════════ STEPS ════════════ -->
-          <OTabPanel name="steps">
-            <div class="mx-auto flex flex-col gap-2">
-              <!-- Loading skeleton -->
-              <template v-if="stepsLoading || !stepsHasLoadedOnce">
-                <div class="grid grid-cols-2 gap-2">
-                  <div
-                    class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                  >
-                    <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                      <SkeletonBox width="100px" height="14px" rounded-default />
-                    </div>
-                    <div class="border-border-default border-t" />
-                    <div class="p-4">
-                      <SkeletonBox width="100%" height="160px" rounded-default />
-                    </div>
-                  </div>
-                  <div
-                    class="card-container rounded-default bg-surface-base border-border-default flex flex-col overflow-hidden border"
-                  >
-                    <div class="flex items-center gap-2 px-2 pt-2.5 pb-2">
-                      <SkeletonBox width="100px" height="14px" rounded-default />
-                    </div>
-                    <div class="border-border-default border-t" />
-                    <div class="p-4">
-                      <SkeletonBox width="100%" height="160px" rounded-default />
-                    </div>
-                  </div>
-                </div>
-                <div v-for="n in 5" :key="n" class="card-container rounded-default overflow-hidden">
-                  <div class="h-10 bg-[var(--color-border-default)] opacity-20" />
-                </div>
-              </template>
-
-              <!-- Steps query error — compact inline indicator -->
-              <template v-else-if="stepsError">
-                <div class="flex items-center gap-2 px-2" data-test="monitor-runs-steps-error">
-                  <OIcon name="error_outline" size="xs" class="text-status-error-text shrink-0" />
-                  <span class="text-status-error-text min-w-0 flex-1 truncate text-xs">{{
-                    stepsError
-                  }}</span>
-                  <OButton
-                    variant="ghost"
-                    size="xs"
-                    class="text-xs! underline!"
-                    data-test="monitor-runs-steps-retry-btn"
-                    @click="emit('refresh')"
-                  >
-                    {{ t("synthetics.journey.retry") }}
-                  </OButton>
-                </div>
-              </template>
-
-              <!-- Real content -->
-              <template v-else>
-                <!-- Steps Analysis Table -->
-                <OCard class="p-0">
-                  <OTable
-                    :data="stepTableRows"
-                    :columns="stepTableColumns"
-                    row-key="id"
-                    :pagination="'none'"
-                    :sorting="'client'"
-                    :show-global-filter="false"
-                    :show-header="true"
-                    :dense="true"
-                    :bordered="true"
-                    :enable-column-resize="true"
-                    :enable-column-reorder="true"
-                    :fill-height="false"
-                  >
-                    <!-- cell-name: Step name -->
-                    <template #cell-name="{ row }">
-                      <div class="min-w-0">
-                        <div
-                          class="truncate text-xs font-semibold text-[var(--color-text-heading)]"
-                        >
-                          {{ row.name }}
-                        </div>
-                      </div>
-                    </template>
-
-                    <!-- cell-failRate: Colored percentage + bar -->
-                    <template #cell-failRate="{ row }">
-                      <div class="flex flex-col gap-1">
-                        <span
-                          class="font-mono text-xs font-bold tabular-nums"
-                          :style="{ color: row.failColor }"
-                        >
-                          {{ row.failRatePct }}%&ensp;<span
-                            class="font-normal text-[var(--color-text-muted)]"
-                            >{{ row.failCount }}</span
-                          >
-                        </span>
-                        <div
-                          class="h-1.25 overflow-hidden rounded-full bg-[var(--color-text-disabled)]/25!"
-                        >
-                          <div
-                            class="h-full rounded-full"
-                            :style="{ width: row.failRateBarPct, background: row.failBarColor }"
-                          />
-                        </div>
-                      </div>
-                    </template>
-
-                    <!-- cell-flakyRate: Colored percentage -->
-                    <template #cell-flakyRate="{ row }">
-                      <span
-                        class="font-mono text-xs tabular-nums"
-                        :style="{ color: row.flakyColor }"
-                      >
-                        {{ row.flakyRatePct }}%&ensp;<span
-                          class="font-normal text-[var(--color-text-muted)]"
-                          >{{ row.flakyCount }}</span
-                        >
-                      </span>
-                    </template>
-
-                    <!-- cell-avgDuration: Duration + bar -->
-                    <template #cell-avgDuration="{ row }">
-                      <div class="flex flex-col gap-1">
-                        <span
-                          class="font-mono text-xs text-[var(--color-text-body)] tabular-nums"
-                          >{{ row.avgDuration }}</span
-                        >
-                        <div
-                          class="h-1.25 overflow-hidden rounded-full bg-[var(--color-text-disabled)]/25!"
-                        >
-                          <div
-                            class="h-full rounded-full bg-[var(--color-primary-400)]"
-                            :style="{ width: row.durationBarPct }"
-                          />
-                        </div>
-                      </div>
-                    </template>
-
-                    <!-- cell-p95Duration: Duration + bar -->
-                    <template #cell-p95Duration="{ row }">
-                      <div class="flex flex-col gap-1">
-                        <span
-                          class="font-mono text-xs text-[var(--color-text-body)] tabular-nums"
-                          >{{ row.p95Duration }}</span
-                        >
-                        <div
-                          class="h-1.25 overflow-hidden rounded-full bg-[var(--color-text-disabled)]/25!"
-                        >
-                          <div
-                            class="h-full rounded-full bg-[var(--color-primary-400)]"
-                            :style="{ width: row.p95DurationBarPct }"
-                          />
-                        </div>
-                      </div>
-                    </template>
-
-                    <!-- cell-maxDuration: Duration + bar -->
-                    <template #cell-maxDuration="{ row }">
-                      <div class="flex flex-col gap-1">
-                        <span
-                          class="font-mono text-xs text-[var(--color-text-body)] tabular-nums"
-                          >{{ row.maxDuration }}</span
-                        >
-                        <div
-                          class="h-1.25 overflow-hidden rounded-full bg-[var(--color-text-disabled)]/25!"
-                        >
-                          <div
-                            class="h-full rounded-full bg-[var(--color-primary-400)]"
-                            :style="{ width: row.maxDurationBarPct }"
-                          />
-                        </div>
-                      </div>
-                    </template>
-
-                    <!-- Empty -->
-                    <template #empty>
-                      <div
-                        class="flex items-center justify-center py-12 text-sm text-[var(--color-text-secondary)]"
-                      >
-                        {{ t("synthetics.runs.noStepData") }}
-                      </div>
-                    </template>
-                  </OTable>
-                </OCard>
-              </template>
-            </div>
-          </OTabPanel>
-
-          <!-- ════════════ ERRORS ════════════ -->
-          <OTabPanel name="errors">
-            <div class="mx-auto flex flex-col gap-2 px-2 py-2 pb-7">
-              <div class="flex items-center gap-2.5">
-                <span class="text-text-heading text-sm font-bold">
-                  {{ t("synthetics.runs.errorPatterns") }}
-                </span>
-                <span class="text-text-secondary text-xs">
-                  {{ t("synthetics.runs.errorPatternsWindowDesc", { window: windowLabel }) }}
-                </span>
+            <OCard class="p-0">
+              <div
+                class="grid grid-cols-[1fr_100px_160px_32px] gap-2.5 px-4 py-2 bg-surface-subtle border-b border-border-default text-2xs font-semibold text-text-secondary uppercase tracking-wide"
+              >
+                <span>{{ t('synthetics.runs.errorPattern') }}</span>
+                <span>{{ t('synthetics.runs.count') }}</span>
+                <span>{{ t('synthetics.runs.lastSeen') }}</span>
+                <span />
               </div>
-
-              <OCard class="p-0">
-                <div
-                  class="bg-surface-subtle border-border-default text-2xs text-text-secondary grid grid-cols-[1fr_100px_160px_32px] gap-2.5 border-b px-4 py-2 font-semibold tracking-wide uppercase"
+              <div
+                v-for="e in errorGroups"
+                :key="e.pattern"
+                class="grid grid-cols-[1fr_100px_160px_32px] gap-2.5 px-4 py-2.75 border-b border-border-default items-center cursor-pointer hover:bg-surface-subtle"
+                data-test="monitor-runs-error-row"
+                @click="filterByErrorPattern(e.pattern)"
+              >
+                <span
+                  class="font-mono tabular-nums text-xs text-text-body truncate"
                 >
-                  <span>{{ t("synthetics.runs.errorPattern") }}</span>
-                  <span>{{ t("synthetics.runs.count") }}</span>
-                  <span>{{ t("synthetics.runs.lastSeen") }}</span>
-                  <span />
-                </div>
-                <div
-                  v-for="e in errorGroups"
-                  :key="e.pattern"
-                  class="border-border-default hover:bg-surface-subtle grid cursor-pointer grid-cols-[1fr_100px_160px_32px] items-center gap-2.5 border-b px-4 py-2.75"
-                  data-test="monitor-runs-error-row"
-                  @click="filterByErrorPattern(e.pattern)"
-                >
-                  <span class="text-text-body truncate font-mono text-xs tabular-nums">
-                    {{ e.pattern }}
-                  </span>
-                  <span class="text-status-error-text text-sm font-bold">
-                    {{ e.count }}
-                  </span>
-                  <span class="text-text-secondary text-xs">
-                    {{ e.lastSeen }}
-                  </span>
-                  <OIcon name="filter_alt" size="sm" class="text-text-secondary" />
-                </div>
-              </OCard>
-            </div>
-          </OTabPanel>
-        </OTabPanels>
-      </div>
+                  {{ e.pattern }}
+                </span>
+                <span class="font-bold text-sm text-status-error-text">
+                  {{ e.count }}
+                </span>
+                <span class="text-xs text-text-secondary">
+                  {{ e.lastSeen }}
+                </span>
+                <OIcon
+                  name="filter_alt"
+                  size="sm"
+                  class="text-text-secondary"
+                />
+              </div>
+            </OCard>
+          </div>
+        </OTabPanel>
+      </OTabPanels>
+    </div>
     </template>
   </div>
 </template>
@@ -1010,6 +1078,7 @@ import OCard from "@/lib/core/Card/OCard.vue";
 import OCardSection from "@/lib/core/Card/OCardSection.vue";
 import OSeparator from "@/lib/core/Separator/OSeparator.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
+import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
 import OButton from "@/lib/core/Button/OButton.vue";
 import OTimeCell from "@/lib/core/Table/cells/OTimeCell.vue";
 import OBadge from "@/lib/core/Badge/OBadge.vue";
@@ -1026,7 +1095,10 @@ import MonitorStatusTimeline from "@/views/synthetics/MonitorStatusTimeline.vue"
 import ChartRenderer from "@/components/dashboards/panels/ChartRenderer.vue";
 import useSyntheticResults from "@/composables/useSyntheticResults";
 import type { SyntheticRun } from "@/composables/synthetics/syntheticResultsSchema";
-import { deviceIconName, deviceLabel } from "@/composables/synthetics/syntheticResultsSchema";
+import {
+  deviceIconName,
+  deviceLabel,
+} from "@/composables/synthetics/syntheticResultsSchema";
 import awsSvgUrl from "@/assets/images/ingestion/aws.svg";
 import gcpSvgUrl from "@/assets/images/ingestion/gcp.svg";
 import chromiumSvgUrl from "@/assets/images/synthetics/chromium.svg";
@@ -1035,6 +1107,7 @@ import webkitSvgUrl from "@/assets/images/synthetics/webkit.svg";
 import SkeletonBox from "@/components/shared/SkeletonBox.vue";
 import syntheticsService from "@/services/synthetics";
 import { locationDisplayLabel } from "@/utils/synthetics/format";
+import { formatTimeWithSuffix } from "@/utils/formatters";
 import { toast } from "@/lib/feedback/Toast/useToast";
 
 defineOptions({ name: "SyntheticMonitorRuns" });
@@ -1065,8 +1138,7 @@ function locationLabel(id: string): string {
 onMounted(async () => {
   try {
     const res = await syntheticsService.getLocations(orgIdentifier.value);
-    const locations: { id: string; label: string; region: string }[] =
-      (res.data as any).locations ?? [];
+    const locations: { id: string; label: string; region: string }[] = (res.data as any).locations ?? [];
     locationNames.value = Object.fromEntries(
       locations.map((loc) => [loc.id, locationDisplayLabel(loc.label, loc.region)]),
     );
@@ -1112,7 +1184,7 @@ const effectiveP95Ms = computed(() => synthetics.effectiveP95Ms.value);
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 function fmtDur(ms: number): string {
-  return ms >= 1000 ? (ms / 1000).toFixed(1) + "s" : ms + "ms";
+  return formatTimeWithSuffix(ms * 1000);
 }
 
 function browserIcon(name: string): string {
@@ -1151,23 +1223,28 @@ function seedRand(seed: number) {
   };
 }
 /** Time range from the parent (microseconds). Updated on each refresh call. */
-const timeRangeMicros = ref<{ startTime: number; endTime: number } | null>(null);
+const timeRangeMicros = ref<{ startTime: number; endTime: number } | null>(
+  null,
+);
 
 /** Human-readable window label derived from the time range duration. */
 function formatWindowLabel(startMicros: number, endMicros: number): string {
   const diffMs = (endMicros - startMicros) / 1000;
   const hours = Math.round(diffMs / 3600000);
-  if (hours >= 48) return t("synthetics.runs.windowDays", { days: Math.round(hours / 24) });
-  if (hours >= 24) return t("synthetics.runs.window24h");
-  if (hours >= 2) return t("synthetics.runs.windowHours", { hours });
+  if (hours >= 48) return t('synthetics.runs.windowDays', { days: Math.round(hours / 24) });
+  if (hours >= 24) return t('synthetics.runs.window24h');
+  if (hours >= 2) return t('synthetics.runs.windowHours', { hours });
   const minutes = Math.round(diffMs / 60000);
-  if (minutes >= 60) return t("synthetics.runs.window1h");
-  return t("synthetics.runs.windowMinutes", { minutes });
+  if (minutes >= 60) return t('synthetics.runs.window1h');
+  return t('synthetics.runs.windowMinutes', { minutes });
 }
 const windowLabel = computed(() =>
   timeRangeMicros.value
-    ? formatWindowLabel(timeRangeMicros.value.startTime, timeRangeMicros.value.endTime)
-    : t("synthetics.runs.window24h"),
+    ? formatWindowLabel(
+        timeRangeMicros.value.startTime,
+        timeRangeMicros.value.endTime,
+      )
+    : t('synthetics.runs.window24h'),
 );
 const statusFilter = ref("all");
 const browserFilter = ref("all");
@@ -1238,25 +1315,20 @@ async function handleEmptyStateAction(id: string) {
     runTriggerLoading.value = true;
     const dismiss = toast({
       variant: "loading",
-      message: t("synthetics.toast.triggeringSingle", { name: props.monitorName }),
+      message: t('synthetics.toast.triggeringSingle', { name: props.monitorName }),
       timeout: 0,
     });
     try {
       await syntheticsService.run(orgIdentifier.value, props.monitorId, {}, folderName.value);
       dismiss();
-      toast({
-        variant: "success",
-        message: t("synthetics.toast.triggerSuccessSingle", { name: props.monitorName }),
-      });
+      toast({ variant: "success", message: t('synthetics.toast.triggerSuccessSingle', { name: props.monitorName }) });
       // Emit refresh so parent reloads data
       emit("refresh");
     } catch (err: any) {
       dismiss();
       toast({
         variant: "error",
-        message:
-          err?.response?.data?.message ||
-          t("synthetics.toast.triggerFailedSingle", { name: props.monitorName }),
+        message: err?.response?.data?.message || t('synthetics.toast.triggerFailedSingle', { name: props.monitorName }),
       });
     } finally {
       runTriggerLoading.value = false;
@@ -1277,7 +1349,7 @@ function uniqueValues(key: "browser" | "device" | "location"): string[] {
   return Array.from(vals).sort();
 }
 const browserOptions = computed<SelectOption[]>(() => [
-  { label: t("synthetics.filters.allBrowsers"), value: "all", icon: "language" },
+  { label: t('synthetics.filters.allBrowsers'), value: "all", icon: "language" },
   ...uniqueValues("browser").map((v) => ({
     label: v,
     value: v,
@@ -1285,7 +1357,7 @@ const browserOptions = computed<SelectOption[]>(() => [
   })),
 ]);
 const deviceOptions = computed<SelectOption[]>(() => [
-  { label: t("synthetics.filters.allDevices"), value: "all", icon: "devices" },
+  { label: t('synthetics.filters.allDevices'), value: "all", icon: "devices" },
   ...uniqueValues("device").map((v) => ({
     label: deviceLabel(v),
     value: v,
@@ -1293,7 +1365,7 @@ const deviceOptions = computed<SelectOption[]>(() => [
   })),
 ]);
 const locationOptions = computed<SelectOption[]>(() => [
-  { label: t("synthetics.filters.allLocations"), value: "all", icon: "location-on" },
+  { label: t('synthetics.filters.allLocations'), value: "all", icon: "location-on" },
   ...uniqueValues("location").map((v) => ({
     label: locationLabel(v),
     value: v,
@@ -1301,15 +1373,15 @@ const locationOptions = computed<SelectOption[]>(() => [
   })),
 ]);
 const durationOptions: SelectOption[] = [
-  { label: t("synthetics.filters.anyDuration"), value: "all" },
-  { label: t("synthetics.filters.durationFast"), value: "fast" },
-  { label: t("synthetics.filters.durationMid"), value: "mid" },
-  { label: t("synthetics.filters.durationSlow"), value: "slow" },
+  { label: t('synthetics.filters.anyDuration'), value: "all" },
+  { label: t('synthetics.filters.durationFast'), value: "fast" },
+  { label: t('synthetics.filters.durationMid'), value: "mid" },
+  { label: t('synthetics.filters.durationSlow'), value: "slow" },
 ];
 const actionOptions: SelectOption[] = [
-  { label: t("synthetics.filters.anyAction"), value: "all" },
-  { label: t("synthetics.filters.actionClick"), value: "click" },
-  { label: t("synthetics.filters.actionType"), value: "type" },
+  { label: t('synthetics.filters.anyAction'), value: "all" },
+  { label: t('synthetics.filters.actionClick'), value: "click" },
+  { label: t('synthetics.filters.actionType'), value: "type" },
 ];
 
 // ── Helper: map SyntheticRun to MockRun shape used by computed properties ─
@@ -1317,13 +1389,10 @@ function toMockRun(r: SyntheticRun, idx: number): MockRun {
   const eng = r.browserEngine;
   const browser = eng ? eng.charAt(0).toUpperCase() + eng.slice(1) : eng;
   const mappedStatus = (
-    r.status === "passed"
-      ? "pass"
-      : r.status === "warning"
-        ? "warning"
-        : r.status === "error"
-          ? "error"
-          : "fail"
+    r.status === "passed" ? "pass"
+    : r.status === "warning" ? "warning"
+    : r.status === "error" ? "error"
+    : "fail"
   ) as MockRun["status"];
   return {
     id: idx + 1,
@@ -1364,34 +1433,51 @@ const filteredRuns = computed(() => {
   return allRuns.value.filter((run) => {
     const s = statusFilter.value;
     if (s !== "all" && run.status !== s) return false;
-    if (browserFilter.value !== "all" && run.browser !== browserFilter.value) return false;
-    if (deviceFilter.value !== "all" && run.device !== deviceFilter.value) return false;
-    if (locationFilter.value !== "all" && run.location !== locationFilter.value) return false;
+    if (browserFilter.value !== "all" && run.browser !== browserFilter.value)
+      return false;
+    if (deviceFilter.value !== "all" && run.device !== deviceFilter.value)
+      return false;
+    if (locationFilter.value !== "all" && run.location !== locationFilter.value)
+      return false;
     if (durationFilter.value === "fast" && run.duration >= 5000) return false;
-    if (durationFilter.value === "mid" && (run.duration < 5000 || run.duration > 15000))
+    if (
+      durationFilter.value === "mid" &&
+      (run.duration < 5000 || run.duration > 15000)
+    )
       return false;
     if (durationFilter.value === "slow" && run.duration <= 15000) return false;
     if (s === "fail") {
-      if (failedStepFilter.value !== "all" && run.failedStep !== failedStepFilter.value)
+      if (
+        failedStepFilter.value !== "all" &&
+        run.failedStep !== failedStepFilter.value
+      )
         return false;
       if (
         locatorFilter.value &&
-        !(run.locator || "").toLowerCase().includes(locatorFilter.value.toLowerCase())
+        !(run.locator || "")
+          .toLowerCase()
+          .includes(locatorFilter.value.toLowerCase())
       )
         return false;
-      if (actionFilter.value !== "all" && run.action !== actionFilter.value) return false;
+      if (actionFilter.value !== "all" && run.action !== actionFilter.value)
+        return false;
     }
-    if (errorFilter.value && run.errorPattern !== errorFilter.value) return false;
+    if (errorFilter.value && run.errorPattern !== errorFilter.value)
+      return false;
     return true;
   });
 });
 
-const totalFails = computed(() => allRuns.value.filter((r) => r.status === "fail").length);
+const totalFails = computed(
+  () => allRuns.value.filter((r) => r.status === "fail").length,
+);
 
 const hasKpiData = computed(() => synthetics.kpi.value.totalRuns > 0);
 
 const p95Label = computed(() =>
-  effectiveP95Ms.value > 0 ? fmtDur(effectiveP95Ms.value) : hasKpiData.value ? fmtDur(0) : "—",
+  effectiveP95Ms.value > 0
+    ? fmtDur(effectiveP95Ms.value)
+    : hasKpiData.value ? fmtDur(0) : "—",
 );
 const p95Ms = computed(() => effectiveP95Ms.value);
 const failCount = computed(() => String(synthetics.kpi.value.failedRuns));
@@ -1409,15 +1495,15 @@ const kpiCards = computed<KpiCard[]>(() => {
     return [
       {
         key: "last-run",
-        label: t("synthetics.results.lastRun"),
+        label: t('synthetics.results.lastRun'),
         value: k.lastRunStatus
           ? k.lastRunStatus === "passed"
-            ? t("synthetics.results.passed")
+            ? t('synthetics.results.passed')
             : k.lastRunStatus === "warning"
-              ? t("synthetics.protocolRun.warning")
+              ? t('synthetics.protocolRun.warning')
               : k.lastRunStatus === "error"
-                ? t("synthetics.results.error")
-                : t("synthetics.results.failed")
+                ? t('synthetics.results.error')
+                : t('synthetics.results.failed')
           : "—",
         valueClass:
           k.lastRunStatus === "passed"
@@ -1430,29 +1516,32 @@ const kpiCards = computed<KpiCard[]>(() => {
       },
       {
         key: "pass-rate",
-        label: t("synthetics.runs.passRate"),
+        label: t('synthetics.runs.passRate'),
         value: k.totalRuns > 0 ? k.uptimePct.toFixed(1) + "%" : "—",
       },
       {
         key: "p95-duration",
-        label: t("synthetics.results.p95Duration"),
+        label: t('synthetics.results.p95Duration'),
         value: effectiveP95Ms.value > 0 ? fmtDur(effectiveP95Ms.value) : "—",
       },
       {
         key: "retry-rate",
-        label: t("synthetics.runs.retryRate"),
-        value: k.totalRuns > 0 ? ((k.retriedRuns / k.totalRuns) * 100).toFixed(1) + "%" : "0.0%",
+        label: t('synthetics.runs.retryRate'),
+        value:
+          k.totalRuns > 0
+            ? ((k.retriedRuns / k.totalRuns) * 100).toFixed(1) + "%"
+            : "0.0%",
         valueClass: k.retriedRuns > 0 ? "text-text-body!" : undefined,
       },
       {
         key: "warning-runs",
-        label: t("synthetics.runs.warningRuns"),
+        label: t('synthetics.runs.warningRuns'),
         value: String(k.warningRuns),
         valueClass: k.warningRuns > 0 ? "text-status-warning-text!" : undefined,
       },
       {
         key: "failed-runs",
-        label: t("synthetics.results.failedRuns"),
+        label: t('synthetics.results.failedRuns'),
         value: String(k.failedRuns),
         valueClass: k.failedRuns > 0 ? "text-status-error-text!" : undefined,
       },
@@ -1471,13 +1560,13 @@ const kpiCards = computed<KpiCard[]>(() => {
   return [
     {
       key: "last-run",
-      label: t("synthetics.results.lastRun"),
+      label: t('synthetics.results.lastRun'),
       value: lastRun
         ? lastRun.status === "pass"
-          ? t("synthetics.results.passed")
+          ? t('synthetics.results.passed')
           : lastRun.status === "warning"
-            ? t("synthetics.protocolRun.warning")
-            : t("synthetics.results.failed")
+            ? t('synthetics.protocolRun.warning')
+            : t('synthetics.results.failed')
         : "—",
       valueClass:
         lastRun?.status === "pass"
@@ -1488,17 +1577,17 @@ const kpiCards = computed<KpiCard[]>(() => {
               ? "text-status-error-text!"
               : undefined,
     },
-    { key: "pass-rate", label: t("synthetics.runs.passRate"), value: fallbackPassPct },
-    { key: "p95-duration", label: t("synthetics.results.p95Duration"), value: "—" },
-    { key: "retry-rate", label: t("synthetics.runs.retryRate"), value: "0.0%" },
+    { key: "pass-rate", label: t('synthetics.runs.passRate'), value: fallbackPassPct },
+    { key: "p95-duration", label: t('synthetics.results.p95Duration'), value: "—" },
+    { key: "retry-rate", label: t('synthetics.runs.retryRate'), value: "0.0%" },
     {
       key: "warning-runs",
-      label: t("synthetics.runs.warningRuns"),
+      label: t('synthetics.runs.warningRuns'),
       value: String(allRuns.value.filter((r) => r.status === "warning").length),
     },
     {
       key: "failed-runs",
-      label: t("synthetics.results.failedRuns"),
+      label: t('synthetics.results.failedRuns'),
       value: String(totalFails.value),
     },
   ];
@@ -1545,8 +1634,12 @@ const timelineSegments = computed<TimelineSegment[]>(() => {
 
   return groupOrder.map((runId) => {
     const executions = groupMap.get(runId)!;
-    const allPass = executions.every((e) => e.status === "pass" || e.status === "warning");
-    const allFail = executions.every((e) => e.status === "fail" || e.status === "error");
+    const allPass = executions.every(
+      (e) => e.status === "pass" || e.status === "warning",
+    );
+    const allFail = executions.every(
+      (e) => e.status === "fail" || e.status === "error",
+    );
     const allWarning = executions.every((e) => e.status === "warning");
     const status: TimelineSegment["status"] = allPass
       ? allWarning
@@ -1571,31 +1664,30 @@ const timelineSegments = computed<TimelineSegment[]>(() => {
     const failCount = executions.length - passCount;
     const title =
       status === "all-pass"
-        ? t("synthetics.runs.timelineAllPassed", { count: executions.length })
+        ? t('synthetics.runs.timelineAllPassed', { count: executions.length })
         : status === "all-warning"
-          ? t("synthetics.runs.timelineAllWarning", { count: executions.length })
+          ? t('synthetics.runs.timelineAllWarning', { count: executions.length })
           : status === "all-fail"
-            ? t("synthetics.runs.timelineAllFailed", { count: executions.length })
-            : t("synthetics.runs.timelineMixed", {
-                passed: passCount,
-                failed: failCount,
-                total: executions.length,
-              });
+            ? t('synthetics.runs.timelineAllFailed', { count: executions.length })
+            : t('synthetics.runs.timelineMixed', { passed: passCount, failed: failCount, total: executions.length });
 
     const execDetails: TimelineExecution[] = executions.map((e) => ({
-      location: e.location,
+      location: locationLabel(e.location),
       browserEngine: e.browser,
       device: e.device,
-      status:
-        e.status === "pass"
-          ? "pass"
-          : e.status === "warning"
-            ? "warning"
-            : e.status === "error"
-              ? "error"
-              : "fail",
-      statusIcon: e.status === "pass" || e.status === "warning" ? "check_circle" : "cancel",
-      errorSnippet: e.errorPattern ? e.errorPattern.split(":")[0].substring(0, 50) : null,
+      status: e.status === "pass"
+        ? "pass"
+        : e.status === "warning"
+          ? "warning"
+          : e.status === "error"
+            ? "error"
+            : "fail",
+      statusIcon: e.status === "pass" || e.status === "warning"
+        ? "check_circle"
+        : "cancel",
+      errorSnippet: e.errorPattern
+        ? e.errorPattern.split(":")[0].substring(0, 50)
+        : null,
     }));
 
     return {
@@ -1613,11 +1705,15 @@ const timelineFailCount = computed(() =>
   String(timelineSegments.value.filter((s) => s.status === "all-fail").length),
 );
 const timelinePassCount = computed(() =>
-  String(timelineSegments.value.filter((s) => s.status === "all-pass").length),
+  String(
+    timelineSegments.value.filter((s) => s.status === "all-pass").length,
+  ),
 );
 const timelineMixedCount = computed(() =>
   String(
-    timelineSegments.value.filter((s) => s.status === "mixed" || s.status === "all-warning").length,
+    timelineSegments.value.filter(
+      (s) => s.status === "mixed" || s.status === "all-warning",
+    ).length,
   ),
 );
 
@@ -1652,13 +1748,15 @@ const timelineStartLabel = computed(() => {
   return formatTimelineDate(timeRangeMicros.value.startTime / 1000);
 });
 const timelineEndLabel = computed(() => {
-  if (!timeRangeMicros.value) return t("synthetics.runs.timelineNow");
+  if (!timeRangeMicros.value) return t('synthetics.runs.timelineNow');
   return formatTimelineDate(timeRangeMicros.value.endTime / 1000);
 });
 
 // ── Breakdowns ───────────────────────────────────────────────────────────
 const breakdownDimensions = computed(() =>
-  isBrowser.value ? ["Browser", "Location", "Device"] : ["Location", "DurationByLocation"],
+  isBrowser.value
+    ? ["Browser", "Location", "Device"]
+    : ["Location", "DurationByLocation"],
 );
 
 interface BreakdownItem {
@@ -1754,12 +1852,12 @@ const deviceBreakdown = computed<BreakdownItem[]>(() => {
       textColor: "var(--color-success-700)",
     };
   });
-});
+  });
 
 const locationDurationBreakdown = computed<BreakdownItem[]>(() => {
   const groups = new Map<string, { totalMs: number; count: number }>();
   for (const run of allRuns.value) {
-    const key = run.location || "Unknown";
+    const key = run.location || 'Unknown';
     const g = groups.get(key) ?? { totalMs: 0, count: 0 };
     g.totalMs += run.duration;
     g.count++;
@@ -1767,12 +1865,12 @@ const locationDurationBreakdown = computed<BreakdownItem[]>(() => {
   }
 
   function getIconForRegion(region: string): string {
-    const prefix = region.split("-")[0].toLowerCase();
-    if (prefix === "aws") return "img:" + awsSvgUrl;
-    if (prefix === "gcp") return "img:" + gcpSvgUrl;
-    if (/^[a-z]{2}-[a-z]+-\d+$/.test(region)) return "img:" + awsSvgUrl;
-    if (/^[a-z]+-[a-z]+\d*$/.test(region)) return "img:" + gcpSvgUrl;
-    return "location-on";
+    const prefix = region.split('-')[0].toLowerCase();
+    if (prefix === 'aws') return 'img:' + awsSvgUrl;
+    if (prefix === 'gcp') return 'img:' + gcpSvgUrl;
+    if (/^[a-z]{2}-[a-z]+-\d+$/.test(region)) return 'img:' + awsSvgUrl;
+    if (/^[a-z]+-[a-z]+\d*$/.test(region)) return 'img:' + gcpSvgUrl;
+    return 'location-on';
   }
 
   const entries = Array.from(groups.entries()).map(([name, g]) => ({
@@ -1781,67 +1879,47 @@ const locationDurationBreakdown = computed<BreakdownItem[]>(() => {
   }));
   const maxAvg = Math.max(...entries.map((e) => e.avgMs), 1);
 
-  return entries.map(({ name, avgMs }) => ({
-    name,
-    icon: getIconForRegion(name),
+  return entries.map(({ name: rawId, avgMs }) => ({
+    name: locationLabel(rawId),
+    id: rawId,
+    icon: getIconForRegion(rawId),
     pct: fmtDur(avgMs),
-    barPct: Math.round((avgMs / maxAvg) * 100) + "%",
-    barColor: "var(--color-primary-500)",
-    textColor: "var(--color-text-body)",
+    barPct: Math.round((avgMs / maxAvg) * 100) + '%',
+    barColor: 'var(--color-primary-500)',
+    textColor: 'var(--color-text-body)',
   }));
 });
 
 // ── Status filter options ────────────────────────────────────────────────
 const statusOptions = [
-  { key: "all", label: t("synthetics.filters.all"), dot: "var(--color-text-secondary)" },
-  { key: "pass", label: t("synthetics.results.passed"), dot: "var(--color-status-success-text)" },
-  { key: "warning", label: t("synthetics.runs.warning"), dot: "var(--color-status-warning-text)" },
-  { key: "fail", label: t("synthetics.results.failed"), dot: "var(--color-status-error-text)" },
+  { key: "all", label: t('synthetics.filters.all'), dot: "var(--color-text-secondary)" },
+  { key: "pass", label: t('synthetics.results.passed'), dot: "var(--color-status-success-text)" },
+  { key: "warning", label: t('synthetics.runs.warning'), dot: "var(--color-status-warning-text)" },
+  { key: "fail", label: t('synthetics.results.failed'), dot: "var(--color-status-error-text)" },
 ];
 
 // ── Mock fallback data (used by Overview/Errors tabs when no real data) ────
 function stepNames(): string[] {
   return [
-    "Open homepage",
-    "Open search",
-    "Search query",
-    "Submit search",
-    "Search results",
-    "Results shown",
-    "Open first product",
-    "Product page",
-    "Add to cart",
-    "Go to checkout",
-    "Fill card number",
-    "Place order",
+    "Open homepage", "Open search", "Search query", "Submit search",
+    "Search results", "Results shown", "Open first product", "Product page",
+    "Add to cart", "Go to checkout", "Fill card number", "Place order",
   ];
 }
 function stepMeta(): Record<string, { locator: string | null; browsers: string[] }> {
   return {
     "Open homepage": { locator: null, browsers: ["Chromium", "Firefox", "WebKit"] },
-    "Open search": {
-      locator: 'css=[data-testid="search-icon"]',
-      browsers: ["Chromium", "Firefox", "WebKit"],
-    },
+    "Open search": { locator: 'css=[data-testid="search-icon"]', browsers: ["Chromium", "Firefox", "WebKit"] },
     "Search query": { locator: "css=#search", browsers: ["Chromium", "Firefox", "WebKit"] },
     "Submit search": { locator: null, browsers: ["Chromium", "Firefox", "WebKit"] },
     "Search results": { locator: null, browsers: ["Chromium", "Firefox", "WebKit"] },
     "Results shown": { locator: 'text="results for"', browsers: ["Chromium", "Firefox", "WebKit"] },
-    "Open first product": {
-      locator: "testid=result-0",
-      browsers: ["Chromium", "Firefox", "WebKit"],
-    },
+    "Open first product": { locator: "testid=result-0", browsers: ["Chromium", "Firefox", "WebKit"] },
     "Product page": { locator: null, browsers: ["Chromium", "Firefox", "WebKit"] },
     "Add to cart": { locator: "css=.btn-add-to-cart", browsers: ["Chromium", "Firefox", "WebKit"] },
     "Go to checkout": { locator: "css=.btn-checkout", browsers: ["Chromium", "Firefox", "WebKit"] },
-    "Fill card number": {
-      locator: "css=#card-number",
-      browsers: ["Chromium", "Firefox", "WebKit"],
-    },
-    "Place order": {
-      locator: "testid=place-order-btn",
-      browsers: ["Chromium", "Firefox", "WebKit"],
-    },
+    "Fill card number": { locator: "css=#card-number", browsers: ["Chromium", "Firefox", "WebKit"] },
+    "Place order": { locator: "testid=place-order-btn", browsers: ["Chromium", "Firefox", "WebKit"] },
   };
 }
 function errorPatterns(): string[] {
@@ -1859,20 +1937,10 @@ function fmtAge(min: number): string {
   return Math.floor(h / 24) + "d ago";
 }
 interface MockRun {
-  id: number;
-  runId: string;
-  ageMin: number;
-  scheduledTs: number;
-  timestamp: number;
-  duration: number;
-  status: "pass" | "warning" | "fail" | "error";
-  location: string;
-  browser: string;
-  device: string;
-  triggerType: string;
-  failedStep: string | null;
-  locator: string | null;
-  action: string | null;
+  id: number; runId: string; ageMin: number; scheduledTs: number;
+  timestamp: number; duration: number; status: "pass" | "warning" | "fail" | "error";
+  location: string; browser: string; device: string; triggerType: string;
+  failedStep: string | null; locator: string | null; action: string | null;
   errorPattern: string | null;
   artifacts: { screenshot: boolean; replay: boolean; trace: boolean; rum: boolean };
 }
@@ -1897,31 +1965,25 @@ function generateRuns(timeRange?: { startTimeMs: number; endTimeMs: number }): M
     for (let execIdx = 0; execIdx < numExecutions; execIdx++) {
       const rand = r();
       const status: MockRun["status"] =
-        rand < 0.05 ? "warning" : rand < 0.22 ? "fail" : rand < 0.24 ? "error" : "pass";
+        rand < 0.05 ? "warning"
+        : rand < 0.22 ? "fail"
+        : rand < 0.24 ? "error"
+        : "pass";
       const isFail = status === "fail" || status === "error";
       const dur = isFail ? Math.round(20000 + r() * 15000) : Math.round(1800 + r() * 3200);
       const errIdx = Math.floor(r() * errs.length);
       const failedStep = isFail ? steps[8 + Math.floor(r() * 4)] : null;
       const locator = failedStep ? meta[failedStep].locator : null;
       runs.push({
-        id: idCounter++,
-        runId,
+        id: idCounter++, runId,
         ageMin: Math.round((baseTime - scheduledBase) / 60000),
-        scheduledTs: scheduledBase,
-        timestamp: scheduledBase + Math.round(r() * 30000),
-        triggerType: "schedule",
-        duration: dur,
-        status,
+        scheduledTs: scheduledBase, timestamp: scheduledBase + Math.round(r() * 30000),
+        triggerType: "schedule", duration: dur, status,
         location: locations[Math.floor(r() * locations.length)],
         browser: browsers[Math.floor(r() * browsers.length)],
         device: devices[r() < 0.7 ? 0 : r() < 0.85 ? 1 : 2],
-        failedStep,
-        locator,
-        action: failedStep
-          ? ["Place order", "Go to checkout", "Add to cart"].includes(failedStep)
-            ? "click"
-            : "type"
-          : null,
+        failedStep, locator,
+        action: failedStep ? (["Place order", "Go to checkout", "Add to cart"].includes(failedStep) ? "click" : "type") : null,
         errorPattern: isFail ? errs[errIdx] : null,
         artifacts: { screenshot: true, replay: r() < 0.7, trace: true, rum: r() < 0.9 },
       });
@@ -1931,11 +1993,7 @@ function generateRuns(timeRange?: { startTimeMs: number; endTimeMs: number }): M
 }
 
 // ── Error groups (Errors tab) ────────────────────────────────────────────
-interface ErrorGroup {
-  pattern: string;
-  count: number;
-  lastSeen: string;
-}
+interface ErrorGroup { pattern: string; count: number; lastSeen: string; }
 const errorGroups = computed<ErrorGroup[]>(() => {
   const errs = errorPatterns();
   const runs = allRuns.value;
@@ -1954,7 +2012,7 @@ const failedStepOptions = computed<SelectOption[]>(() => {
   const meta = stepMeta();
   const withLocator = stepNames().filter((n) => meta[n].locator);
   return [
-    { label: t("synthetics.filters.anyFailedStep"), value: "all" },
+    { label: t('synthetics.filters.anyFailedStep'), value: "all" },
     ...withLocator.map((n) => ({ label: n, value: n })),
   ];
 });
@@ -1983,27 +2041,29 @@ const visibleRuns = computed<VisibleRun[]>(() => {
     const isError = run.status === "error";
     return {
       id: run.id,
-      statusBadgeVariant: isPass ? "success-soft" : isWarning ? "warning-soft" : "error-soft",
+      statusBadgeVariant: isPass
+        ? "success-soft"
+        : isWarning
+          ? "warning-soft"
+          : "error-soft",
       statusIcon: isPass || isWarning ? "check_circle" : "cancel",
       statusLabel: isPass
-        ? t("synthetics.results.passed")
+        ? t('synthetics.results.passed')
         : isWarning
-          ? t("synthetics.protocolRun.warning")
+          ? t('synthetics.protocolRun.warning')
           : isError
-            ? t("synthetics.results.error")
-            : t("synthetics.results.failed"),
+            ? t('synthetics.results.error')
+            : t('synthetics.results.failed'),
       scheduledTs: run.scheduledTs,
       lastRunTs: run.timestamp,
-      triggerType:
-        run.triggerType === "manual"
-          ? t("synthetics.runs.triggerManual")
-          : t("synthetics.runs.triggerSchedule"),
+      triggerType: run.triggerType === "manual" ? t('synthetics.runs.triggerManual') : t('synthetics.runs.triggerSchedule'),
       duration: fmtDur(run.duration),
       location: run.location,
       browser: run.browser,
       device: run.device,
       errorSnippet: run.errorPattern
-        ? run.errorPattern.split(":")[0] + (run.failedStep ? " · " + run.failedStep : "")
+        ? run.errorPattern.split(":")[0] +
+          (run.failedStep ? " · " + run.failedStep : "")
         : null,
       errorPattern: run.errorPattern,
     };
@@ -2012,47 +2072,37 @@ const visibleRuns = computed<VisibleRun[]>(() => {
 
 const runColumns = computed<OTableColumnDef[]>(() => {
   const cols: OTableColumnDef[] = [
-    { id: "status", header: t("synthetics.table.status"), accessorKey: "status", size: 60 },
+    { id: "status", header: t('synthetics.table.status'), accessorKey: "status", size: 60 },
     {
       id: "last_run_at",
-      header: t("synthetics.table.lastRunAt"),
+      header: t('synthetics.table.lastRunAt'),
       accessorKey: "lastRunTs",
       size: 100,
     },
     {
       id: "duration",
-      header: t("synthetics.results.duration"),
+      header: t('synthetics.results.duration'),
       accessorKey: "duration",
       size: 50,
     },
-    {
-      id: "location",
-      header: t("synthetics.results.location"),
-      accessorKey: "location",
-      size: 110,
-    },
+    { id: "location", header: t('synthetics.results.location'), accessorKey: "location", size: 110 },
   ];
   if (isBrowser.value) {
     cols.push(
-      {
-        id: "browser",
-        header: t("synthetics.results.steps.browser"),
-        accessorKey: "browser",
-        size: 100,
-      },
-      { id: "device", header: t("synthetics.results.device"), accessorKey: "device", size: 90 },
+      { id: "browser", header: t('synthetics.results.steps.browser'), accessorKey: "browser", size: 100 },
+      { id: "device", header: t('synthetics.results.device'), accessorKey: "device", size: 90 },
     );
   }
   cols.push(
     {
       id: "trigger_type",
-      header: t("synthetics.table.trigger"),
+      header: t('synthetics.table.trigger'),
       accessorKey: "triggerType",
       size: 90,
     },
     {
       id: "scheduled_at",
-      header: t("synthetics.table.scheduledAt"),
+      header: t('synthetics.table.scheduledAt'),
       accessorKey: "scheduledTs",
       size: 100,
     },
@@ -2129,8 +2179,7 @@ const stepTableRows = computed<StepTableRow[]>(() => {
       failBarColor: barColorForRate(failPct),
       flakyRatePct: flakyPct,
       flakyCount: g.flakyCount,
-      flakyColor:
-        g.flakyRate >= 5 ? "var(--color-status-warning-text)" : "var(--color-text-secondary)",
+      flakyColor: g.flakyRate >= 5 ? "var(--color-status-warning-text)" : "var(--color-text-secondary)",
       avgDuration: fmtDur(g.avgDurationMs),
       avgDurationMs: g.avgDurationMs,
       durationBarPct: Math.round((g.avgDurationMs / maxAvgDuration) * 100) + "%",
@@ -2145,53 +2194,20 @@ const stepTableRows = computed<StepTableRow[]>(() => {
 });
 
 const stepTableColumns: OTableColumnDef<StepTableRow>[] = [
-  {
-    id: "name",
-    header: t("synthetics.results.steps.stepName"),
-    accessorKey: "name",
-    meta: { isName: true },
-  },
-  {
-    id: "failRate",
-    header: t("synthetics.results.steps.failRate"),
-    accessorKey: "failRatePct",
-    size: 110,
-    meta: { align: "right" },
-  },
-  {
-    id: "flakyRate",
-    header: t("synthetics.results.steps.flakyRate"),
-    accessorKey: "flakyRatePct",
-    size: 100,
-    meta: { align: "right" },
-  },
-  {
-    id: "avgDuration",
-    header: t("synthetics.results.steps.avgDuration"),
-    accessorKey: "avgDurationMs",
-    size: 100,
-    meta: { align: "right" },
-  },
-  {
-    id: "p95Duration",
-    header: t("synthetics.results.steps.p95Duration"),
-    accessorKey: "p95DurationMs",
-    size: 96,
-    meta: { align: "right" },
-  },
-  {
-    id: "maxDuration",
-    header: t("synthetics.results.steps.maxDuration"),
-    accessorKey: "maxDurationMs",
-    size: 100,
-    meta: { align: "right" },
-  },
+  { id: "name", header: t('synthetics.results.steps.stepName'), accessorKey: "name", meta: { isName: true } },
+  { id: "failRate", header: t('synthetics.results.steps.failRate'), accessorKey: "failRatePct", size: 110, meta: { align: "right" } },
+  { id: "flakyRate", header: t('synthetics.results.steps.flakyRate'), accessorKey: "flakyRatePct", size: 100, meta: { align: "right" } },
+  { id: "avgDuration", header: t('synthetics.results.steps.avgDuration'), accessorKey: "avgDurationMs", size: 100, meta: { align: "right" } },
+  { id: "p95Duration", header: t('synthetics.results.steps.p95Duration'), accessorKey: "p95DurationMs", size: 96, meta: { align: "right" } },
+  { id: "maxDuration", header: t('synthetics.results.steps.maxDuration'), accessorKey: "maxDurationMs", size: 100, meta: { align: "right" } },
 ];
 
 // ── Chart options ────────────────────────────────────────────────────────
 function cssVar(name: string, fallback: string): string {
   if (typeof window === "undefined") return fallback;
-  return getComputedStyle(document.body).getPropertyValue(name).trim() || fallback;
+  return (
+    getComputedStyle(document.body).getPropertyValue(name).trim() || fallback
+  );
 }
 
 const responseChartOption = computed(() => {
@@ -2202,7 +2218,9 @@ const responseChartOption = computed(() => {
 
   let seriesData: [number, number][];
   if (synthetics.buckets.value.length > 0) {
-    seriesData = synthetics.buckets.value.map((b) => [b.tsMs, b.p95Ms] as [number, number]);
+    seriesData = synthetics.buckets.value.map(
+      (b) => [b.tsMs, b.p95Ms] as [number, number],
+    );
   } else {
     const rB = seedRand(31);
     const bucketCount = 24;
@@ -2252,7 +2270,7 @@ const responseChartOption = computed(() => {
               lineStyle: { color: p95Color, type: "dashed" as const },
               data: [{ yAxis: p95Ms.value }],
               label: {
-                formatter: t("synthetics.runs.chartP95", { value: p95Label.value }),
+                formatter: t('synthetics.runs.chartP95', { value: p95Label.value }),
                 color: p95Color,
                 fontSize: 10,
               },
@@ -2302,7 +2320,7 @@ const errorChartOption = computed(() => {
     grid: { left: 44, right: 16, top: 16, bottom: 28 },
     tooltip: {
       trigger: "axis" as const,
-      valueFormatter: (val: number) => t("synthetics.runs.chartFailures", { count: val }),
+      valueFormatter: (val: number) => t('synthetics.runs.chartFailures', { count: val }),
     },
     xAxis: {
       type: "category" as const,

--- a/web/src/views/synthetics/RunDetail.spec.ts
+++ b/web/src/views/synthetics/RunDetail.spec.ts
@@ -102,22 +102,6 @@ describe("RunDetail", () => {
     wrapper = mount(RunDetail, {
       global: {
         stubs: {
-          OTabs: {
-            template: '<div class="otabs-stub"><slot /></div>',
-            props: ["modelValue"],
-          },
-          OTab: {
-            template: '<div class="otab-stub"><slot /></div>',
-            props: ["name"],
-          },
-          OTabPanels: {
-            template: '<div class="otabpanels-stub"><slot /></div>',
-            props: ["modelValue"],
-          },
-          OTabPanel: {
-            template: '<div class="otabpanel-stub"><slot /></div>',
-            props: ["name"],
-          },
           OCard: {
             template: '<div class="ocard-stub"><slot /></div>',
           },
@@ -140,11 +124,6 @@ describe("RunDetail", () => {
           OBadge: {
             template: '<span class="obadge-stub"><slot /></span>',
             props: ["variant", "size", "icon"],
-          },
-          OEmptyState: {
-            template:
-              '<div class="oemptystate-stub"><slot name="title" /><slot name="description" /></div>',
-            props: ["preset"],
           },
         },
       },
@@ -177,10 +156,6 @@ describe("RunDetail", () => {
     expect(chips.length).toBe(5);
   });
 
-  it("should render the summary tab by default", () => {
-    expect(wrapper.find('[data-test="synthetics-run-detail-summary-tab"]').exists()).toBe(true);
-  });
-
   it("should render prev/next navigation buttons", () => {
     expect(wrapper.find('[data-test="synthetics-run-detail-prev-btn"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="synthetics-run-detail-next-btn"]').exists()).toBe(true);
@@ -192,12 +167,5 @@ describe("RunDetail", () => {
 
   it("should render the back button", () => {
     expect(wrapper.find('[data-test="synthetics-run-detail-back-btn"]').exists()).toBe(true);
-  });
-
-  it("should render three placeholder tabs with correct states", () => {
-    expect(wrapper.find('[data-test="synthetics-run-detail-tab-summary"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="synthetics-run-detail-tab-logs"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="synthetics-run-detail-tab-traces"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="synthetics-run-detail-tab-rum"]').exists()).toBe(true);
   });
 });

--- a/web/src/views/synthetics/RunDetail.vue
+++ b/web/src/views/synthetics/RunDetail.vue
@@ -36,111 +36,88 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :location-names="locationNames"
     @update-status="emit('update-status', $event)"
   />
-  <OPageLayout v-else class="run-detail" data-test="synthetics-run-detail" bleed>
+  <OPageLayout
+    v-else
+    class="run-detail"
+    data-test="synthetics-run-detail"
+    bleed
+  >
     <!-- ════════ HEADER ════════ -->
     <template #header v-if="!drawerMode">
-      <OPageHeader
-        class=""
-        :subtitle="currentRun.timestamp"
-        :back="{
-          label: t('synthetics.results.monitors'),
-          to: { name: 'synthetic-monitor-results', params: { id: monitorId } },
-          dataTest: 'synthetics-run-detail-back-btn',
-        }"
-      >
-        <template #title>
-          <span data-test="synthetics-run-detail-title">{{ displayMonitorName }}</span>
-        </template>
-        <template #title-trail>
-          <OBadge
-            :variant="statusBadgeVariant"
-            size="sm"
-            :icon="statusIcon"
-            data-test="synthetics-run-detail-status-badge"
-          >
-            {{ statusLabel }}
-          </OBadge>
-          <OBadge
-            v-if="currentRun.url"
-            variant="default"
-            size="sm"
-            icon="link"
-            class="max-w-50 truncate"
-            data-test="synthetics-run-detail-url-badge"
-          >
-            {{ currentRun.url }}
-          </OBadge>
-          <div class="ml-1 flex">
-            <OButton
-              variant="ghost"
-              size="icon-xs"
-              icon-left="chevron-left"
-              :disabled="true"
-              data-test="synthetics-run-detail-prev-btn"
-            />
-            <OButton
-              variant="ghost"
-              size="icon-xs"
-              icon-left="chevron-right"
-              :disabled="true"
-              data-test="synthetics-run-detail-next-btn"
-            />
-          </div>
-        </template>
-        <template #actions>
+    <OPageHeader
+      class=""
+      :subtitle="currentRun.timestamp"
+      :back="{
+        label: t('synthetics.results.monitors'),
+        to: { name: 'synthetic-monitor-results', params: { id: monitorId } },
+        dataTest: 'synthetics-run-detail-back-btn',
+      }"
+    >
+      <template #title>
+        <span data-test="synthetics-run-detail-title">{{ displayMonitorName }}</span>
+      </template>
+      <template #title-trail>
+        <OBadge
+          :variant="statusBadgeVariant"
+          size="sm"
+          :icon="statusIcon"
+          data-test="synthetics-run-detail-status-badge"
+        >
+          {{ statusLabel }}
+        </OBadge>
+        <OBadge
+          v-if="currentRun.url"
+          variant="default"
+          size="sm"
+          icon="link"
+          class="truncate max-w-50"
+          data-test="synthetics-run-detail-url-badge"
+        >
+          {{ currentRun.url }}
+        </OBadge>
+        <div class="flex ml-1">
           <OButton
-            variant="outline"
-            size="sm"
-            icon-left="open-in-new"
-            data-test="synthetics-run-detail-trace-btn"
-          >
-            {{ t("synthetics.runDetail.openTrace") }}
-          </OButton>
+            variant="ghost"
+            size="icon-xs"
+            icon-left="chevron-left"
+            :disabled="true"
+            data-test="synthetics-run-detail-prev-btn"
+          />
           <OButton
-            variant="outline"
-            size="sm"
-            icon-left="replay"
-            data-test="synthetics-run-detail-rerun-btn"
-          >
-            {{ t("synthetics.journey.reRun") }}
-          </OButton>
-        </template>
-      </OPageHeader>
+            variant="ghost"
+            size="icon-xs"
+            icon-left="chevron-right"
+            :disabled="true"
+            data-test="synthetics-run-detail-next-btn"
+          />
+        </div>
+      </template>
+      <template #actions>
+        <OButton
+          variant="outline"
+          size="sm"
+          icon-left="open-in-new"
+          data-test="synthetics-run-detail-trace-btn"
+        >
+          {{ t('synthetics.runDetail.openTrace') }}
+        </OButton>
+        <OButton
+          variant="outline"
+          size="sm"
+          icon-left="replay"
+          data-test="synthetics-run-detail-rerun-btn"
+        >
+          {{ t('synthetics.journey.reRun') }}
+        </OButton>
+      </template>
+    </OPageHeader>
     </template>
 
-    <!-- ════════ SUB TABS ════════ -->
-    <OTabs v-model="activeTab" class="px-page-edge border-border-default shrink-0 border-b">
-      <OTab name="summary" data-test="synthetics-run-detail-tab-summary">
-        <span class="flex items-center gap-1.5">
-          <OIcon name="article" size="sm" />
-          {{ t("synthetics.runDetail.tabSummary") }}
-        </span>
-      </OTab>
-      <OTab name="logs" data-test="synthetics-run-detail-tab-logs">
-        <span class="flex items-center gap-1.5">
-          <OIcon name="search" size="sm" />
-          {{ t("synthetics.runDetail.tabLogs") }}
-        </span>
-      </OTab>
-      <OTab name="traces" data-test="synthetics-run-detail-tab-traces">
-        <span class="flex items-center gap-1.5">
-          <OIcon name="account-tree" size="sm" />
-          {{ t("synthetics.runDetail.tabTraces") }}
-        </span>
-      </OTab>
-      <OTab name="rum" data-test="synthetics-run-detail-tab-rum">
-        <span class="flex items-center gap-1.5">
-          <OIcon name="devices" size="sm" />
-          {{ t("synthetics.runDetail.tabRum") }}
-        </span>
-      </OTab>
-    </OTabs>
-
-    <div class="min-h-0 flex-1">
-      <OTabPanels v-model="activeTab" grow scroll="y" class="h-full min-h-0">
-        <!-- ════════════ SUMMARY ════════════ -->
-        <OTabPanel name="summary" data-test="synthetics-run-detail-summary-tab">
-          <div class="flex flex-col py-3.5 pb-7">
+    <!-- ════════ SUMMARY ════════ -->
+    <div class="flex-1 min-h-0">
+      <div
+        class="py-3.5 pb-7 flex flex-col flex-1 min-h-0 h-full"
+          >
             <!-- Info chips skeleton -->
             <template v-if="loading">
               <div
@@ -150,7 +127,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <div
                   v-for="i in 5"
                   :key="i"
-                  class="card-container rounded-default bg-surface-base border-border-default flex flex-row items-center gap-1.5 border px-3.5 py-2.5"
+                  class="card-container rounded-default flex flex-row items-center px-3.5 py-2.5 gap-1.5 bg-surface-base border border-border-default"
                 >
                   <OSkeleton type="circle" class="h-4 w-4 shrink-0" />
                   <OSkeleton type="text" class="h-4 w-20" />
@@ -159,11 +136,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </template>
             <!-- Info chips -->
             <template v-else>
-              <div class="grid grid-cols-5 gap-2.5 px-2" data-test="synthetics-run-detail-info-bar">
+              <div
+                class="grid grid-cols-5 gap-2.5 px-2"
+                data-test="synthetics-run-detail-info-bar"
+              >
                 <div
                   v-for="chip in infoChips"
                   :key="chip.label"
-                  class="card-container rounded-default bg-surface-base border-border-default flex flex-row items-center gap-1.5 border px-3.5 py-2.5"
+                  class="card-container rounded-default flex flex-row items-center px-3.5 py-2.5 gap-1.5 bg-surface-base border border-border-default"
                 >
                   <OIcon
                     v-if="chip.icon"
@@ -173,7 +153,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     :class="chip.colorClass ? chip.colorClass : ''"
                   />
                   <span
-                    class="truncate text-sm leading-none"
+                    class="text-sm leading-none truncate"
                     :class="chip.colorClass || 'text-text-body'"
                   >
                     {{ chip.value }}
@@ -184,7 +164,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
             <!-- Steps skeleton -->
             <template v-if="loading">
-              <OCard class="gap-0 p-0">
+              <OCard class="p-0 gap-0">
                 <OCardSection role="header" class="gap-2">
                   <OSkeleton type="text" class="h-4 w-14" />
                 </OCardSection>
@@ -193,9 +173,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   <div
                     v-for="i in 4"
                     :key="i"
-                    class="rounded-default border-border-default flex items-center gap-2 border p-2"
+                    class="flex items-center gap-2 rounded-default border border-border-default p-2"
                   >
-                    <OSkeleton type="rect" class="rounded-default h-12 w-18 shrink-0" />
+                    <OSkeleton type="rect" class="h-12 w-18 shrink-0 rounded-default" />
                     <OSkeleton type="circle" class="h-6 w-6 shrink-0" />
                     <OSkeleton type="text" class="h-4 flex-1" />
                     <OSkeleton type="text" class="h-4 w-16 shrink-0" />
@@ -206,15 +186,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <!-- Lambda execution error (no steps) -->
             <div
               v-else-if="isErrorRun"
-              class="border-badge-error-ol-border/30 rounded-default m-2 overflow-hidden border bg-[var(--color-badge-error-soft-bg)]"
+              class="bg-[var(--color-badge-error-soft-bg)] border border-badge-error-ol-border/30 rounded-default overflow-hidden m-2"
               role="alert"
               data-test="synthetics-run-detail-steps-error-banner"
             >
               <div class="flex items-start gap-2 p-3">
-                <OIcon name="error" class="text-status-error-text shrink-0" size="md" />
-                <div class="min-w-0 flex-1">
-                  <div class="flex flex-wrap items-center gap-2">
-                    <span class="text-status-error-text text-sm font-bold">
+                <OIcon
+                  name="error"
+                  class="text-status-error-text shrink-0"
+                  size="md"
+                />
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <span class="text-sm font-bold text-status-error-text">
                       {{ currentRun.errorType }}
                     </span>
                   </div>
@@ -234,59 +218,62 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         :class="{ 'rotate-180': stackOpen }"
                       />
                     </template>
-                    <span class="text-2xs text-status-error-text font-semibold">
-                      {{ t("synthetics.runDetail.viewFullError") }}
+                    <span class="text-2xs font-semibold text-status-error-text">
+                      {{ t('synthetics.runDetail.viewFullError') }}
                     </span>
                   </OButton>
                   <pre
                     v-if="stackOpen && currentRun.errorStack"
-                    class="text-2xs text-text-body bg-code-bg rounded-default mt-2 overflow-auto p-[10px_12px] font-mono leading-[1.6] whitespace-pre-wrap"
+                    class="mt-2 text-2xs leading-[1.6] text-text-body bg-code-bg rounded-default p-[10px_12px] overflow-auto whitespace-pre-wrap font-mono"
                     data-test="synthetics-run-detail-error-stack"
-                    >{{ currentRun.errorStack }}</pre
-                  >
+                  >{{ currentRun.errorStack }}</pre>
                 </div>
               </div>
             </div>
 
             <!-- ══ Split: Replay Player (left) + Steps Timeline (right) ══ -->
-            <div v-else-if="steps.length > 0" class="flex items-start">
+            <div v-else-if="steps.length > 0" class="flex items-start flex-1 min-h-0">
               <!-- ── Left: Session Replay Player ── -->
-              <OCard v-if="currentRun.hasReplay" class="w-[30%] min-w-[30rem] gap-0 p-0">
+              <OCard
+                v-if="currentRun.hasReplay"
+                class="p-0 gap-0 w-[30%] min-w-[30rem]"
+              >
                 <OCardSection role="header" class="gap-2">
-                  <OIcon name="smart_display" size="sm" class="text-accent" />
-                  <span class="text-text-heading text-sm font-bold">{{
-                    t("synthetics.runDetail.sessionReplay")
-                  }}</span>
+                  <OIcon
+                    name="smart_display"
+                    size="sm"
+                    class="text-accent"
+                  />
+                  <span class="font-bold text-sm text-text-heading"
+                    >{{ t('synthetics.runDetail.sessionReplay') }}</span
+                  >
                   <span class="flex-1" />
-                  <span class="text-2xs text-text-secondary font-mono">
-                    {{
-                      t("synthetics.runDetail.stepOf", {
-                        selected: selectedStep?.id,
-                        total: steps.length,
-                      })
-                    }}
+                  <span class="font-mono text-2xs text-text-secondary">
+                    {{ t('synthetics.runDetail.stepOf', { selected: selectedStep?.id, total: steps.length }) }}
                   </span>
                 </OCardSection>
                 <OSeparator />
 
-                <div class="flex h-95 flex-col">
-                  <div class="min-h-0 flex-1">
-                    <VideoPlayer :events="[]" :segments="[]" :is-loading="false" />
+                <div class="h-95 flex flex-col">
+                  <div class="flex-1 min-h-0">
+                    <VideoPlayer
+                      :events="[]"
+                      :segments="[]"
+                      :is-loading="false"
+                    />
                   </div>
                 </div>
               </OCard>
 
               <!-- ── Right: Execution Timeline ── -->
-              <div class="flex min-w-0 flex-1 flex-col">
+              <div class="flex-1 min-w-0 min-h-0 flex flex-col h-full">
                 <div class="flex items-center gap-2 px-3 py-4">
-                  <h4 class="text-text-heading m-0 text-sm font-bold">
-                    {{ t("synthetics.journey.steps") }}
-                  </h4>
+                  <h4 class="font-bold text-sm text-text-heading m-0">{{ t('synthetics.journey.steps') }}</h4>
                   <OBadge variant="default" size="sm">{{ steps.length }}</OBadge>
                   <span class="flex-1" />
                 </div>
 
-                <div class="min-h-0 flex-1 overflow-auto pb-2">
+                <div class="flex-1 min-h-0 overflow-auto pb-2">
                   <!-- JourneySteps in results mode -->
                   <JourneySteps
                     :data="stepsWithTotal"
@@ -305,144 +292,95 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         v-if="row.screenshotKey"
                         :src="screenshotUrl(row.screenshotKey)"
                         :alt="t('synthetics.runDetail.screenshotAlt')"
-                        class="h-full w-full object-cover"
+                        class="w-full h-full object-cover"
                       />
-                      <OIcon v-else name="image" size="xs" class="text-text-secondary" />
+                      <OIcon
+                        v-else
+                        name="image"
+                        size="xs"
+                        class="text-text-secondary"
+                      />
                     </template>
 
                     <!-- Expanded content: screenshot + metadata + error -->
                     <template #expansion="{ row }">
                       <div class="flex gap-4 p-3">
                         <div class="w-[40%] shrink-0">
-                          <div class="rounded-default border-border-default overflow-hidden border">
+                          <div class="rounded-default border border-border-default overflow-hidden">
                             <div
-                              class="flex aspect-[16/10] items-center justify-center overflow-hidden"
-                              :class="
-                                row.status === 'fail' ? 'bg-status-error-bg' : 'bg-surface-subtle'
-                              "
+                              class="aspect-[16/10] flex items-center justify-center overflow-hidden"
+                              :class="row.status === 'fail' ? 'bg-status-error-bg' : 'bg-surface-subtle'"
                             >
-                              <div v-if="row.screenshotKey" class="group relative h-full w-full">
+                              <div
+                                v-if="row.screenshotKey"
+                                class="relative w-full h-full group"
+                              >
                                 <OButton
                                   variant="ghost"
                                   size="sm"
-                                  class="h-full! w-full rounded-none! border-0! p-0!"
+                                  class="w-full h-full! p-0! rounded-none! border-0!"
                                   data-test="synthetics-run-detail-step-screenshot-thumb"
                                   @click="openLightbox(row.id)"
                                 >
                                   <img
                                     :src="screenshotUrl(row.screenshotKey)"
                                     :alt="t('synthetics.runDetail.screenshotAlt')"
-                                    class="h-full w-full object-contain transition-opacity group-hover:opacity-90"
+                                    class="w-full h-full object-contain transition-opacity group-hover:opacity-90"
                                   />
                                 </OButton>
                                 <div
-                                  class="rounded-default bg-surface-base/80 pointer-events-none absolute top-2 right-2 flex h-7 w-7 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
+                                  class="absolute top-2 right-2 flex items-center justify-center w-7 h-7 rounded-default bg-surface-base/80 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
                                   aria-hidden="true"
                                 >
                                   <OIcon name="fullscreen" size="sm" class="text-text-body" />
                                 </div>
                               </div>
                               <template v-else>
-                                <OIcon
-                                  name="image"
-                                  :class="
-                                    row.status === 'fail'
-                                      ? 'text-status-error-text'
-                                      : 'text-text-secondary'
-                                  "
-                                  size="lg"
-                                />
-                                <span
-                                  class="text-xs font-semibold"
-                                  :class="
-                                    row.status === 'fail'
-                                      ? 'text-status-error-text'
-                                      : 'text-text-secondary'
-                                  "
-                                >
-                                  {{
-                                    row.status === "fail"
-                                      ? t("synthetics.runDetail.failureScreenshot")
-                                      : t("synthetics.runDetail.screenshotPlaceholder")
-                                  }}
+                                <OIcon name="image" :class="row.status === 'fail' ? 'text-status-error-text' : 'text-text-secondary'" size="lg" />
+                                <span class="text-xs font-semibold" :class="row.status === 'fail' ? 'text-status-error-text' : 'text-text-secondary'">
+                                  {{ row.status === 'fail' ? t('synthetics.runDetail.failureScreenshot') : t('synthetics.runDetail.screenshotPlaceholder') }}
                                 </span>
                               </template>
                             </div>
                           </div>
                         </div>
 
-                        <div class="flex flex-1 flex-col gap-4">
+                        <div class="flex-1 flex flex-col gap-4">
                           <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
-                            <dt
-                              class="text-text-secondary text-sm font-semibold tracking-wide capitalize"
-                            >
-                              {{ t("synthetics.runDetail.detailAction") }}
-                            </dt>
+                            <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.runDetail.detailAction') }}</dt>
                             <dd class="text-text-secondary">{{ row.action }}</dd>
-                            <dt
-                              class="text-text-secondary text-sm font-semibold tracking-wide capitalize"
-                            >
-                              {{ t("synthetics.runDetail.detailSelector") }}
-                            </dt>
+                            <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.runDetail.detailSelector') }}</dt>
                             <dd class="text-text-secondary">{{ row.detail }}</dd>
-                            <dt
-                              class="text-text-secondary text-sm font-semibold tracking-wide capitalize"
-                            >
-                              {{ t("synthetics.runDetail.detailUrl") }}
-                            </dt>
-                            <dd class="text-text-secondary truncate">
-                              {{ row.url || currentRun.url }}
-                            </dd>
-                            <dt
-                              class="text-text-secondary text-sm font-semibold tracking-wide capitalize"
-                            >
-                              {{ t("synthetics.results.duration") }}
-                            </dt>
+                            <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.runDetail.detailUrl') }}</dt>
+                            <dd class="truncate text-text-secondary">{{ row.url || currentRun.url }}</dd>
+                            <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.results.duration') }}</dt>
                             <dd class="text-text-secondary">{{ row.durStr }}</dd>
                           </dl>
 
                           <div
                             v-if="row.status === 'fail' && row.error"
-                            class="rounded-default border-badge-error-ol-border/30 overflow-hidden border"
+                            class="rounded-default border border-badge-error-ol-border/30 overflow-hidden"
                             :data-test="`synthetics-run-detail-step-error-card-${row.id}`"
                           >
-                            <div
-                              class="flex items-center gap-2 bg-[var(--color-badge-error-soft-bg)] px-3 py-2"
-                            >
-                              <OIcon
-                                name="error"
-                                size="sm"
-                                class="text-status-error-text"
-                                aria-hidden="true"
-                              />
-                              <span class="text-text-heading flex-1 text-xs font-semibold">{{
-                                t("synthetics.results.error")
-                              }}</span>
+                            <div class="flex items-center gap-2 px-3 py-2 bg-[var(--color-badge-error-soft-bg)]">
+                              <OIcon name="error" size="sm" class="text-status-error-text" aria-hidden="true" />
+                              <span class="text-xs font-semibold text-text-heading flex-1">{{ t('synthetics.results.error') }}</span>
                             </div>
                             <div class="px-3 py-3">
                               <pre
-                                class="text-text-body m-0 font-mono text-xs leading-relaxed whitespace-pre-wrap"
-                                :class="{
-                                  'max-h-24 overflow-hidden':
-                                    !expandedStepErrors.has(row.id) &&
-                                    (row.error?.length ?? 0) > 200,
-                                }"
-                                >{{ row.error }}</pre
-                              >
-                              <div class="mt-1.5 flex items-center gap-2">
+                                class="text-xs text-text-body m-0 whitespace-pre-wrap font-mono leading-relaxed"
+                                :class="{ 'max-h-24 overflow-hidden': !expandedStepErrors.has(row.id) && (row.error?.length ?? 0) > 200 }"
+                              >{{ row.error }}</pre>
+                              <div class="flex items-center gap-2 mt-1.5">
                                 <OButton
                                   v-if="(row.error?.length ?? 0) > 200"
                                   variant="ghost"
                                   size="xs"
-                                  class="text-text-link text-xs font-semibold"
+                                  class="text-xs font-semibold text-text-link"
                                   data-test="synthetics-run-detail-toggle-step-error-btn"
                                   @click="toggleStepError(row.id)"
                                 >
-                                  {{
-                                    expandedStepErrors.has(row.id)
-                                      ? t("synthetics.runDetail.showLess")
-                                      : t("synthetics.runDetail.showFullError")
-                                  }}
+                                  {{ expandedStepErrors.has(row.id) ? t('synthetics.runDetail.showLess') : t('synthetics.runDetail.showFullError') }}
                                 </OButton>
                                 <OButton
                                   variant="ghost"
@@ -450,7 +388,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                   data-test="synthetics-run-detail-step-view-error-btn"
                                   @click="openErrorFullscreen(row.id)"
                                 >
-                                  {{ t("synthetics.runDetail.viewFullErrorBtn") }}
+                                  {{ t('synthetics.runDetail.viewFullErrorBtn') }}
                                 </OButton>
                               </div>
                             </div>
@@ -463,62 +401,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </div>
             </div>
           </div>
-        </OTabPanel>
-
-        <!-- ════════════ LOGS (placeholder) ════════════ -->
-        <OTabPanel name="logs">
-          <div class="flex h-full items-center justify-center">
-            <OEmptyState
-              preset="no-search-results"
-              size="block"
-              data-test="synthetics-run-detail-logs-empty"
-            >
-              <template #title>
-                <span>{{ t("synthetics.runDetail.noCorrelatedLogs") }}</span>
-              </template>
-              <template #description>
-                <span>{{ t("synthetics.runDetail.noCorrelatedLogsDesc") }}</span>
-              </template>
-            </OEmptyState>
-          </div>
-        </OTabPanel>
-
-        <!-- ════════════ TRACES (placeholder) ════════════ -->
-        <OTabPanel name="traces">
-          <div class="flex h-full items-center justify-center">
-            <OEmptyState
-              preset="no-search-results"
-              size="block"
-              data-test="synthetics-run-detail-traces-empty"
-            >
-              <template #title>
-                <span>{{ t("synthetics.runDetail.noCorrelatedTraces") }}</span>
-              </template>
-              <template #description>
-                <span>{{ t("synthetics.runDetail.noCorrelatedTracesDesc") }}</span>
-              </template>
-            </OEmptyState>
-          </div>
-        </OTabPanel>
-
-        <!-- ════════════ RUM (placeholder) ════════════ -->
-        <OTabPanel name="rum">
-          <div class="flex h-full items-center justify-center">
-            <OEmptyState
-              preset="no-search-results"
-              size="block"
-              data-test="synthetics-run-detail-rum-empty"
-            >
-              <template #title>
-                <span>{{ t("synthetics.runDetail.noCorrelatedRum") }}</span>
-              </template>
-              <template #description>
-                <span>{{ t("synthetics.runDetail.noCorrelatedRumDesc") }}</span>
-              </template>
-            </OEmptyState>
-          </div>
-        </OTabPanel>
-      </OTabPanels>
     </div>
   </OPageLayout>
 
@@ -531,14 +413,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   >
     <div
       v-if="lightboxStep"
-      class="flex h-full items-center justify-center p-6"
-      :class="lightboxStep.status === 'fail' ? 'bg-status-error-bg' : 'bg-surface-subtle'"
+      class="flex items-center justify-center h-full p-6"
+      :class="
+        lightboxStep.status === 'fail'
+          ? 'bg-status-error-bg'
+          : 'bg-surface-subtle'
+      "
     >
       <img
         v-if="lightboxStep.screenshotKey"
         :src="screenshotUrl(lightboxStep.screenshotKey)"
         :alt="t('synthetics.runDetail.screenshotAlt')"
-        class="max-h-[85vh] max-w-full object-contain"
+        class="max-w-full max-h-[85vh] object-contain"
       />
     </div>
   </ODialog>
@@ -550,18 +436,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :title="errorTitle"
     data-test="synthetics-run-detail-step-error-fullscreen"
   >
-    <div v-if="errorStep" class="flex h-full flex-col overflow-y-auto p-6">
-      <div class="rounded-default border-badge-error-ol-border/30 overflow-hidden border">
-        <div class="flex items-center gap-2 bg-[var(--color-badge-error-soft-bg)] px-4 py-2.5">
-          <OIcon name="error" size="sm" class="text-status-error-text" aria-hidden="true" />
-          <span class="text-text-heading flex-1 text-sm font-semibold">{{
-            t("synthetics.results.error")
-          }}</span>
+    <div
+      v-if="errorStep"
+      class="flex flex-col h-full overflow-y-auto p-6"
+    >
+      <div class="rounded-default border border-badge-error-ol-border/30 overflow-hidden">
+        <div
+          class="flex items-center gap-2 px-4 py-2.5 bg-[var(--color-badge-error-soft-bg)]"
+        >
+          <OIcon
+            name="error"
+            size="sm"
+            class="text-status-error-text"
+            aria-hidden="true"
+          />
+          <span
+            class="text-sm font-semibold text-text-heading flex-1"
+            >{{ t('synthetics.results.error') }}</span
+          >
         </div>
         <div class="px-4 py-3">
-          <pre class="text-text-body m-0 font-mono text-sm leading-relaxed whitespace-pre-wrap">{{
-            errorStep.error
-          }}</pre>
+          <pre
+            class="text-sm text-text-body m-0 whitespace-pre-wrap font-mono leading-relaxed"
+          >{{ errorStep.error }}</pre>
         </div>
       </div>
     </div>
@@ -577,10 +474,6 @@ import { useStore } from "vuex";
 import syntheticsService from "@/services/synthetics";
 import { timestampToTimezoneDate } from "@/utils/timezone";
 import { locationDisplayLabel } from "@/utils/synthetics/format";
-import OTabs from "@/lib/navigation/Tabs/OTabs.vue";
-import OTab from "@/lib/navigation/Tabs/OTab.vue";
-import OTabPanels from "@/lib/navigation/Tabs/OTabPanels.vue";
-import OTabPanel from "@/lib/navigation/Tabs/OTabPanel.vue";
 import OCard from "@/lib/core/Card/OCard.vue";
 import OCardSection from "@/lib/core/Card/OCardSection.vue";
 import OSeparator from "@/lib/core/Separator/OSeparator.vue";
@@ -588,8 +481,6 @@ import OButton from "@/lib/core/Button/OButton.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OBadge from "@/lib/core/Badge/OBadge.vue";
 import OSkeleton from "@/lib/feedback/Skeleton/OSkeleton.vue";
-import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
-import OProgressBar from "@/lib/data/ProgressBar/OProgressBar.vue";
 import ODialog from "@/lib/overlay/Dialog/ODialog.vue";
 import VideoPlayer from "@/components/rum/VideoPlayer.vue";
 import OPageHeader from "@/lib/core/PageHeader/OPageHeader.vue";
@@ -652,8 +543,7 @@ function locationLabel(id: string): string {
 syntheticsService
   .getLocations(store.state.selectedOrganization.identifier)
   .then((res) => {
-    const locations: { id: string; label: string; region: string }[] =
-      (res.data as any).locations ?? [];
+    const locations: { id: string; label: string; region: string }[] = (res.data as any).locations ?? [];
     locationNames.value = Object.fromEntries(
       locations.map((loc) => [loc.id, locationDisplayLabel(loc.label, loc.region)]),
     );
@@ -668,7 +558,9 @@ const runIdParam = computed(() =>
   props.drawerMode ? props.overrideRunId : String(route.params.runId ?? ""),
 );
 const executionIdParam = computed(() =>
-  props.drawerMode ? props.overrideExecutionId : String(route.params.executionId ?? ""),
+  props.drawerMode
+    ? props.overrideExecutionId
+    : String(route.params.executionId ?? ""),
 );
 // The check's folder (name), carried on the results-page route as ?folder=.
 // Passed to per-check API calls so RBAC can resolve folder-scoped grants.
@@ -746,7 +638,11 @@ function buildSteps(detail: SyntheticRunDetail | null): StepRow[] {
       id: idx + 1,
       stepId: ex.step_id,
       action: recorded?.action ?? "step",
-      name: recorded?.name || recorded?.selector || recorded?.url || ex.step_id.slice(0, 8),
+      name:
+        recorded?.name ||
+        recorded?.selector ||
+        recorded?.url ||
+        ex.step_id.slice(0, 8),
       detail: recorded?.selector ?? recorded?.url ?? ex.step_id,
       url: recorded?.url ?? "",
       duration: ex.duration_ms,
@@ -754,7 +650,9 @@ function buildSteps(detail: SyntheticRunDetail | null): StepRow[] {
       icon: recorded ? actionIcon(recorded.action) : "radio_button_checked",
       statusIcon: isFail ? "cancel" : "check-circle",
       durStr: fmtDur(ex.duration_ms),
-      durColor: isFail ? "var(--color-status-error-text)" : "var(--color-text-secondary)",
+      durColor: isFail
+        ? "var(--color-status-error-text)"
+        : "var(--color-text-secondary)",
       error: ex.error,
       screenshotKey: ex.screenshot_key,
     };
@@ -812,9 +710,10 @@ const artifactUrls = ref<Record<string, string>>({});
 async function presignRunArtifacts() {
   const detail = synthetics.runDetail.value;
   if (!detail) return;
-  const keys = [...detail.lastAttemptSteps.map((s) => s.screenshot_key), detail.traceKey].filter(
-    (k): k is string => !!k,
-  );
+  const keys = [
+    ...detail.lastAttemptSteps.map((s) => s.screenshot_key),
+    detail.traceKey,
+  ].filter((k): k is string => !!k);
   if (!keys.length) return;
   const orgId = store.state.selectedOrganization.identifier;
   try {
@@ -893,7 +792,11 @@ function toDisplayRun(detail: SyntheticRunDetail | null): DisplayRun {
   return {
     id: detail.runId,
     monitorName: detail.monitorName,
-    status: isFail ? ("fail" as const) : isError ? ("error" as const) : ("pass" as const),
+    status: isFail
+      ? ("fail" as const)
+      : isError
+        ? ("error" as const)
+        : ("pass" as const),
     duration: detail.durationMs,
     browser: capitalizeEngine(detail.browserEngine),
     device: detail.device,
@@ -903,11 +806,11 @@ function toDisplayRun(detail: SyntheticRunDetail | null): DisplayRun {
     hasReplay: false,
     ...(hasIssue
       ? {
-          errorType: detail.error ? detail.error.split(":")[0] : t("synthetics.results.error"),
+          errorType: detail.error ? detail.error.split(":")[0] : t('synthetics.results.error'),
           errorReason: detail.error || "",
           errorStack: detail.error || "",
           failedStepLabel: detail.failedStep
-            ? t("synthetics.runDetail.failedAtStep", { step: detail.failedStep })
+            ? t('synthetics.runDetail.failedAtStep', { step: detail.failedStep })
             : undefined,
           failedStepId: 1,
         }
@@ -916,7 +819,6 @@ function toDisplayRun(detail: SyntheticRunDetail | null): DisplayRun {
 }
 
 // ── State ─────────────────────────────────────────────────────────────────
-const activeTab = ref("summary");
 const stackOpen = ref(true);
 
 /** Multi-expand: set of expanded step IDs (strings — OTable composable uses string keys via getRowId().toString()). */
@@ -928,7 +830,7 @@ function handleUpdateExpanded(ids: string[]) {
 }
 
 function stepDotState(row: any): StepDotState | undefined {
-  return row.status === "fail" ? "fail" : "pass";
+  return row.status === 'fail' ? 'fail' : 'pass';
 }
 
 /** Steps enriched with total duration for progress bar calculation. */
@@ -957,7 +859,7 @@ const lightboxStep = computed(() => {
 
 const lightboxTitle = computed(() => {
   const s = lightboxStep.value;
-  return s ? t("synthetics.runDetail.lightboxTitle", { id: s.id, action: s.action }) : "";
+  return s ? t('synthetics.runDetail.lightboxTitle', { id: s.id, action: s.action }) : "";
 });
 
 function openLightbox(id: number) {
@@ -981,7 +883,7 @@ const errorStep = computed(() => {
 
 const errorTitle = computed(() => {
   const s = errorStep.value;
-  return s ? t("synthetics.runDetail.errorFullscreenTitle", { id: s.id, action: s.action }) : "";
+  return s ? t('synthetics.runDetail.errorFullscreenTitle', { id: s.id, action: s.action }) : "";
 });
 
 function openErrorFullscreen(id: number) {
@@ -991,18 +893,21 @@ function openErrorFullscreen(id: number) {
 // Computed: current run from composable data
 const loading = computed(() => synthetics.loading.value);
 const currentRun = computed<DisplayRun>(() => {
-  return synthetics.runDetail.value ? toDisplayRun(synthetics.runDetail.value) : toDisplayRun(null);
+  return synthetics.runDetail.value
+    ? toDisplayRun(synthetics.runDetail.value)
+    : toDisplayRun(null);
 });
 
 const isFailed = computed(
-  () => currentRun.value.status === "fail" || currentRun.value.status === "error",
+  () =>
+    currentRun.value.status === "fail" || currentRun.value.status === "error",
 );
 
 const isErrorRun = computed(() => currentRun.value.status === "error");
 
 // ── Display monitor name — prefers explicit prop, falls back to SQL result ──
-const displayMonitorName = computed(
-  () => props.overrideMonitorName || currentRun.value.monitorName,
+const displayMonitorName = computed(() =>
+  props.overrideMonitorName || currentRun.value.monitorName,
 );
 
 const steps = computed<StepRow[]>(() => {
@@ -1029,7 +934,7 @@ const failedStepInfo = computed(() => {
   if (!step) return null;
   return {
     step,
-    summary: step.error ? step.error.split("\n")[0] : "",
+    summary: step.error ? step.error.split('\n')[0] : '',
   };
 });
 
@@ -1038,7 +943,7 @@ watch(steps, (newSteps) => {
   const next = new Set(expandedStepIds.value);
   let changed = false;
   for (const st of newSteps) {
-    if (st.status === "fail" && !next.has(String(st.id))) {
+    if (st.status === 'fail' && !next.has(String(st.id))) {
       next.add(String(st.id));
       changed = true;
     }
@@ -1046,7 +951,7 @@ watch(steps, (newSteps) => {
   if (changed) expandedStepIds.value = next;
 
   // Scroll to the first failed step after layout settles
-  const failedStep = newSteps.find((st) => st.status === "fail");
+  const failedStep = newSteps.find((st) => st.status === 'fail');
   if (failedStep) {
     nextTick(() => {
       requestAnimationFrame(() => {
@@ -1054,7 +959,7 @@ watch(steps, (newSteps) => {
           const el = document.querySelector(
             `[data-test="synthetics-run-detail-step-row-${failedStep.id}"]`,
           );
-          el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+          el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         });
       });
     });
@@ -1068,18 +973,14 @@ const statusIcon = computed(() =>
   isErrorRun.value ? "error" : isFailed.value ? "cancel" : "check-circle",
 );
 const statusLabel = computed(() =>
-  isErrorRun.value
-    ? t("synthetics.results.error")
-    : isFailed.value
-      ? t("synthetics.results.failed")
-      : t("synthetics.results.passed"),
+  isErrorRun.value ? t('synthetics.results.error') : isFailed.value ? t('synthetics.results.failed') : t('synthetics.results.passed'),
 );
 
 const statusChip = computed(() => {
   if (isErrorRun.value) {
     return {
-      label: t("synthetics.results.status"),
-      value: t("synthetics.results.error"),
+      label: t('synthetics.results.status'),
+      value: t('synthetics.results.error'),
       icon: "error",
       colorClass: "text-status-error-text",
     };
@@ -1087,17 +988,15 @@ const statusChip = computed(() => {
   if (currentRun.value.status === "fail") {
     const stepNum = failedStepInfo.value?.step?.id;
     return {
-      label: t("synthetics.results.status"),
-      value: stepNum
-        ? t("synthetics.runDetail.failedAtStep", { step: stepNum })
-        : t("synthetics.results.failed"),
+      label: t('synthetics.results.status'),
+      value: stepNum ? t('synthetics.runDetail.failedAtStep', { step: stepNum }) : t('synthetics.results.failed'),
       icon: "cancel",
       colorClass: "text-status-error-text",
     };
   }
   return {
-    label: t("synthetics.results.status"),
-    value: t("synthetics.results.passed"),
+    label: t('synthetics.results.status'),
+    value: t('synthetics.results.passed'),
     icon: "check-circle",
     colorClass: "text-status-success-text",
   };
@@ -1112,23 +1011,19 @@ interface InfoChip {
 
 const infoChips = computed<InfoChip[]>(() => [
   statusChip.value,
+  { label: t('synthetics.results.duration'), value: fmtDur(currentRun.value.duration), icon: "schedule" },
   {
-    label: t("synthetics.results.duration"),
-    value: fmtDur(currentRun.value.duration),
-    icon: "schedule",
-  },
-  {
-    label: t("synthetics.results.steps.browser"),
+    label: t('synthetics.results.steps.browser'),
     value: currentRun.value.browser,
     icon: browserIcon(currentRun.value.browser),
   },
   {
-    label: t("synthetics.results.device"),
+    label: t('synthetics.results.device'),
     value: currentRun.value.device,
     icon: deviceIcon(currentRun.value.device),
   },
   {
-    label: t("synthetics.results.location"),
+    label: t('synthetics.results.location'),
     value: locationLabel(currentRun.value.location),
     icon: locationIcon(currentRun.value.location),
   },
@@ -1144,11 +1039,7 @@ watch(
     emit("update-status", {
       variant: isErr ? "error-soft" : isF ? "error" : "success",
       icon: isErr ? "error" : isF ? "cancel" : "check-circle",
-      label: isErr
-        ? t("synthetics.results.error")
-        : isF
-          ? t("synthetics.results.failed")
-          : t("synthetics.results.passed"),
+      label: isErr ? t('synthetics.results.error') : isF ? t('synthetics.results.failed') : t('synthetics.results.passed'),
       url: currentRun.value.url,
       timestamp: currentRun.value.timestamp,
     });

--- a/web/src/views/synthetics/RunDetail.vue
+++ b/web/src/views/synthetics/RunDetail.vue
@@ -36,371 +36,402 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :location-names="locationNames"
     @update-status="emit('update-status', $event)"
   />
-  <OPageLayout
-    v-else
-    class="run-detail"
-    data-test="synthetics-run-detail"
-    bleed
-  >
+  <OPageLayout v-else class="run-detail" data-test="synthetics-run-detail" bleed>
     <!-- ════════ HEADER ════════ -->
     <template #header v-if="!drawerMode">
-    <OPageHeader
-      class=""
-      :subtitle="currentRun.timestamp"
-      :back="{
-        label: t('synthetics.results.monitors'),
-        to: { name: 'synthetic-monitor-results', params: { id: monitorId } },
-        dataTest: 'synthetics-run-detail-back-btn',
-      }"
-    >
-      <template #title>
-        <span data-test="synthetics-run-detail-title">{{ displayMonitorName }}</span>
-      </template>
-      <template #title-trail>
-        <OBadge
-          :variant="statusBadgeVariant"
-          size="sm"
-          :icon="statusIcon"
-          data-test="synthetics-run-detail-status-badge"
-        >
-          {{ statusLabel }}
-        </OBadge>
-        <OBadge
-          v-if="currentRun.url"
-          variant="default"
-          size="sm"
-          icon="link"
-          class="truncate max-w-50"
-          data-test="synthetics-run-detail-url-badge"
-        >
-          {{ currentRun.url }}
-        </OBadge>
-        <div class="flex ml-1">
+      <OPageHeader
+        class=""
+        :subtitle="currentRun.timestamp"
+        :back="{
+          label: t('synthetics.results.monitors'),
+          to: { name: 'synthetic-monitor-results', params: { id: monitorId } },
+          dataTest: 'synthetics-run-detail-back-btn',
+        }"
+      >
+        <template #title>
+          <span data-test="synthetics-run-detail-title">{{ displayMonitorName }}</span>
+        </template>
+        <template #title-trail>
+          <OBadge
+            :variant="statusBadgeVariant"
+            size="sm"
+            :icon="statusIcon"
+            data-test="synthetics-run-detail-status-badge"
+          >
+            {{ statusLabel }}
+          </OBadge>
+          <OBadge
+            v-if="currentRun.url"
+            variant="default"
+            size="sm"
+            icon="link"
+            class="max-w-50 truncate"
+            data-test="synthetics-run-detail-url-badge"
+          >
+            {{ currentRun.url }}
+          </OBadge>
+          <div class="ml-1 flex">
+            <OButton
+              variant="ghost"
+              size="icon-xs"
+              icon-left="chevron-left"
+              :disabled="true"
+              data-test="synthetics-run-detail-prev-btn"
+            />
+            <OButton
+              variant="ghost"
+              size="icon-xs"
+              icon-left="chevron-right"
+              :disabled="true"
+              data-test="synthetics-run-detail-next-btn"
+            />
+          </div>
+        </template>
+        <template #actions>
           <OButton
-            variant="ghost"
-            size="icon-xs"
-            icon-left="chevron-left"
-            :disabled="true"
-            data-test="synthetics-run-detail-prev-btn"
-          />
+            variant="outline"
+            size="sm"
+            icon-left="open-in-new"
+            data-test="synthetics-run-detail-trace-btn"
+          >
+            {{ t("synthetics.runDetail.openTrace") }}
+          </OButton>
           <OButton
-            variant="ghost"
-            size="icon-xs"
-            icon-left="chevron-right"
-            :disabled="true"
-            data-test="synthetics-run-detail-next-btn"
-          />
-        </div>
-      </template>
-      <template #actions>
-        <OButton
-          variant="outline"
-          size="sm"
-          icon-left="open-in-new"
-          data-test="synthetics-run-detail-trace-btn"
-        >
-          {{ t('synthetics.runDetail.openTrace') }}
-        </OButton>
-        <OButton
-          variant="outline"
-          size="sm"
-          icon-left="replay"
-          data-test="synthetics-run-detail-rerun-btn"
-        >
-          {{ t('synthetics.journey.reRun') }}
-        </OButton>
-      </template>
-    </OPageHeader>
+            variant="outline"
+            size="sm"
+            icon-left="replay"
+            data-test="synthetics-run-detail-rerun-btn"
+          >
+            {{ t("synthetics.journey.reRun") }}
+          </OButton>
+        </template>
+      </OPageHeader>
     </template>
 
     <!-- ════════ SUMMARY ════════ -->
-    <div class="flex-1 min-h-0">
-      <div
-        class="py-3.5 pb-7 flex flex-col flex-1 min-h-0 h-full"
+    <div class="min-h-0 flex-1">
+      <div class="flex h-full min-h-0 flex-1 flex-col py-3.5 pb-7">
+        <!-- Info chips skeleton -->
+        <template v-if="loading">
+          <div
+            class="grid grid-cols-5 gap-2.5 px-2"
+            data-test="synthetics-run-detail-info-skeleton"
           >
-            <!-- Info chips skeleton -->
-            <template v-if="loading">
-              <div
-                class="grid grid-cols-5 gap-2.5 px-2"
-                data-test="synthetics-run-detail-info-skeleton"
-              >
-                <div
-                  v-for="i in 5"
-                  :key="i"
-                  class="card-container rounded-default flex flex-row items-center px-3.5 py-2.5 gap-1.5 bg-surface-base border border-border-default"
-                >
-                  <OSkeleton type="circle" class="h-4 w-4 shrink-0" />
-                  <OSkeleton type="text" class="h-4 w-20" />
-                </div>
-              </div>
-            </template>
-            <!-- Info chips -->
-            <template v-else>
-              <div
-                class="grid grid-cols-5 gap-2.5 px-2"
-                data-test="synthetics-run-detail-info-bar"
-              >
-                <div
-                  v-for="chip in infoChips"
-                  :key="chip.label"
-                  class="card-container rounded-default flex flex-row items-center px-3.5 py-2.5 gap-1.5 bg-surface-base border border-border-default"
-                >
-                  <OIcon
-                    v-if="chip.icon"
-                    :name="chip.icon"
-                    size="sm"
-                    class="shrink-0"
-                    :class="chip.colorClass ? chip.colorClass : ''"
-                  />
-                  <span
-                    class="text-sm leading-none truncate"
-                    :class="chip.colorClass || 'text-text-body'"
-                  >
-                    {{ chip.value }}
-                  </span>
-                </div>
-              </div>
-            </template>
-
-            <!-- Steps skeleton -->
-            <template v-if="loading">
-              <OCard class="p-0 gap-0">
-                <OCardSection role="header" class="gap-2">
-                  <OSkeleton type="text" class="h-4 w-14" />
-                </OCardSection>
-                <OSeparator />
-                <OCardSection role="body" class="flex flex-col gap-2 p-3">
-                  <div
-                    v-for="i in 4"
-                    :key="i"
-                    class="flex items-center gap-2 rounded-default border border-border-default p-2"
-                  >
-                    <OSkeleton type="rect" class="h-12 w-18 shrink-0 rounded-default" />
-                    <OSkeleton type="circle" class="h-6 w-6 shrink-0" />
-                    <OSkeleton type="text" class="h-4 flex-1" />
-                    <OSkeleton type="text" class="h-4 w-16 shrink-0" />
-                  </div>
-                </OCardSection>
-              </OCard>
-            </template>
-            <!-- Lambda execution error (no steps) -->
             <div
-              v-else-if="isErrorRun"
-              class="bg-[var(--color-badge-error-soft-bg)] border border-badge-error-ol-border/30 rounded-default overflow-hidden m-2"
-              role="alert"
-              data-test="synthetics-run-detail-steps-error-banner"
+              v-for="i in 5"
+              :key="i"
+              class="card-container rounded-default bg-surface-base border-border-default flex flex-row items-center gap-1.5 border px-3.5 py-2.5"
             >
-              <div class="flex items-start gap-2 p-3">
-                <OIcon
-                  name="error"
-                  class="text-status-error-text shrink-0"
-                  size="md"
-                />
-                <div class="flex-1 min-w-0">
-                  <div class="flex items-center gap-2 flex-wrap">
-                    <span class="text-sm font-bold text-status-error-text">
-                      {{ currentRun.errorType }}
-                    </span>
-                  </div>
-                  <OButton
-                    v-if="currentRun.errorStack"
-                    variant="ghost-destructive"
+              <OSkeleton type="circle" class="h-4 w-4 shrink-0" />
+              <OSkeleton type="text" class="h-4 w-20" />
+            </div>
+          </div>
+        </template>
+        <!-- Info chips -->
+        <template v-else>
+          <div class="grid grid-cols-5 gap-2.5 px-2" data-test="synthetics-run-detail-info-bar">
+            <div
+              v-for="chip in infoChips"
+              :key="chip.label"
+              class="card-container rounded-default bg-surface-base border-border-default flex flex-row items-center gap-1.5 border px-3.5 py-2.5"
+            >
+              <OIcon
+                v-if="chip.icon"
+                :name="chip.icon"
+                size="sm"
+                class="shrink-0"
+                :class="chip.colorClass ? chip.colorClass : ''"
+              />
+              <span
+                class="truncate text-sm leading-none"
+                :class="chip.colorClass || 'text-text-body'"
+              >
+                {{ chip.value }}
+              </span>
+            </div>
+          </div>
+        </template>
+
+        <!-- Steps skeleton -->
+        <template v-if="loading">
+          <OCard class="gap-0 p-0">
+            <OCardSection role="header" class="gap-2">
+              <OSkeleton type="text" class="h-4 w-14" />
+            </OCardSection>
+            <OSeparator />
+            <OCardSection role="body" class="flex flex-col gap-2 p-3">
+              <div
+                v-for="i in 4"
+                :key="i"
+                class="rounded-default border-border-default flex items-center gap-2 border p-2"
+              >
+                <OSkeleton type="rect" class="rounded-default h-12 w-18 shrink-0" />
+                <OSkeleton type="circle" class="h-6 w-6 shrink-0" />
+                <OSkeleton type="text" class="h-4 flex-1" />
+                <OSkeleton type="text" class="h-4 w-16 shrink-0" />
+              </div>
+            </OCardSection>
+          </OCard>
+        </template>
+        <!-- Lambda execution error (no steps) -->
+        <div
+          v-else-if="isErrorRun"
+          class="border-badge-error-ol-border/30 rounded-default m-2 overflow-hidden border bg-[var(--color-badge-error-soft-bg)]"
+          role="alert"
+          data-test="synthetics-run-detail-steps-error-banner"
+        >
+          <div class="flex items-start gap-2 p-3">
+            <OIcon name="error" class="text-status-error-text shrink-0" size="md" />
+            <div class="min-w-0 flex-1">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="text-status-error-text text-sm font-bold">
+                  {{ currentRun.errorType }}
+                </span>
+              </div>
+              <OButton
+                v-if="currentRun.errorStack"
+                variant="ghost-destructive"
+                size="xs"
+                class="mt-1"
+                data-test="synthetics-run-detail-error-expand-btn"
+                @click="stackOpen = !stackOpen"
+              >
+                <template #icon-left>
+                  <OIcon
+                    name="expand-more"
                     size="xs"
-                    class="mt-1"
-                    data-test="synthetics-run-detail-error-expand-btn"
-                    @click="stackOpen = !stackOpen"
-                  >
-                    <template #icon-left>
-                      <OIcon
-                        name="expand-more"
-                        size="xs"
-                        class="transition-transform duration-150"
-                        :class="{ 'rotate-180': stackOpen }"
-                      />
-                    </template>
-                    <span class="text-2xs font-semibold text-status-error-text">
-                      {{ t('synthetics.runDetail.viewFullError') }}
-                    </span>
-                  </OButton>
-                  <pre
-                    v-if="stackOpen && currentRun.errorStack"
-                    class="mt-2 text-2xs leading-[1.6] text-text-body bg-code-bg rounded-default p-[10px_12px] overflow-auto whitespace-pre-wrap font-mono"
-                    data-test="synthetics-run-detail-error-stack"
-                  >{{ currentRun.errorStack }}</pre>
-                </div>
+                    class="transition-transform duration-150"
+                    :class="{ 'rotate-180': stackOpen }"
+                  />
+                </template>
+                <span class="text-2xs text-status-error-text font-semibold">
+                  {{ t("synthetics.runDetail.viewFullError") }}
+                </span>
+              </OButton>
+              <pre
+                v-if="stackOpen && currentRun.errorStack"
+                class="text-2xs text-text-body bg-code-bg rounded-default mt-2 overflow-auto p-[10px_12px] font-mono leading-[1.6] whitespace-pre-wrap"
+                data-test="synthetics-run-detail-error-stack"
+                >{{ currentRun.errorStack }}</pre
+              >
+            </div>
+          </div>
+        </div>
+
+        <!-- ══ Split: Replay Player (left) + Steps Timeline (right) ══ -->
+        <div v-else-if="steps.length > 0" class="flex min-h-0 flex-1 items-start">
+          <!-- ── Left: Session Replay Player ── -->
+          <OCard v-if="currentRun.hasReplay" class="w-[30%] min-w-[30rem] gap-0 p-0">
+            <OCardSection role="header" class="gap-2">
+              <OIcon name="smart_display" size="sm" class="text-accent" />
+              <span class="text-text-heading text-sm font-bold">{{
+                t("synthetics.runDetail.sessionReplay")
+              }}</span>
+              <span class="flex-1" />
+              <span class="text-2xs text-text-secondary font-mono">
+                {{
+                  t("synthetics.runDetail.stepOf", {
+                    selected: selectedStep?.id,
+                    total: steps.length,
+                  })
+                }}
+              </span>
+            </OCardSection>
+            <OSeparator />
+
+            <div class="flex h-95 flex-col">
+              <div class="min-h-0 flex-1">
+                <VideoPlayer :events="[]" :segments="[]" :is-loading="false" />
               </div>
             </div>
+          </OCard>
 
-            <!-- ══ Split: Replay Player (left) + Steps Timeline (right) ══ -->
-            <div v-else-if="steps.length > 0" class="flex items-start flex-1 min-h-0">
-              <!-- ── Left: Session Replay Player ── -->
-              <OCard
-                v-if="currentRun.hasReplay"
-                class="p-0 gap-0 w-[30%] min-w-[30rem]"
+          <!-- ── Right: Execution Timeline ── -->
+          <div class="flex h-full min-h-0 min-w-0 flex-1 flex-col">
+            <div class="flex items-center gap-2 px-3 py-4">
+              <h4 class="text-text-heading m-0 text-sm font-bold">
+                {{ t("synthetics.journey.steps") }}
+              </h4>
+              <OBadge variant="default" size="sm">{{ steps.length }}</OBadge>
+              <span class="flex-1" />
+            </div>
+
+            <div class="min-h-0 flex-1 overflow-auto pb-2">
+              <!-- JourneySteps in results mode -->
+              <JourneySteps
+                :data="stepsWithTotal"
+                mode="results"
+                action-key="action"
+                name-key="name"
+                detail-key="detail"
+                icon-key="icon"
+                :dot-state-fn="stepDotState"
+                :expanded-ids="expandedStepIdsArr"
+                @update:expanded-ids="handleUpdateExpanded"
               >
-                <OCardSection role="header" class="gap-2">
-                  <OIcon
-                    name="smart_display"
-                    size="sm"
-                    class="text-accent"
+                <!-- Screenshot thumbnail -->
+                <template #screenshot-thumb="{ row }">
+                  <img
+                    v-if="row.screenshotKey"
+                    :src="screenshotUrl(row.screenshotKey)"
+                    :alt="t('synthetics.runDetail.screenshotAlt')"
+                    class="h-full w-full object-cover"
                   />
-                  <span class="font-bold text-sm text-text-heading"
-                    >{{ t('synthetics.runDetail.sessionReplay') }}</span
-                  >
-                  <span class="flex-1" />
-                  <span class="font-mono text-2xs text-text-secondary">
-                    {{ t('synthetics.runDetail.stepOf', { selected: selectedStep?.id, total: steps.length }) }}
-                  </span>
-                </OCardSection>
-                <OSeparator />
+                  <OIcon v-else name="image" size="xs" class="text-text-secondary" />
+                </template>
 
-                <div class="h-95 flex flex-col">
-                  <div class="flex-1 min-h-0">
-                    <VideoPlayer
-                      :events="[]"
-                      :segments="[]"
-                      :is-loading="false"
-                    />
-                  </div>
-                </div>
-              </OCard>
-
-              <!-- ── Right: Execution Timeline ── -->
-              <div class="flex-1 min-w-0 min-h-0 flex flex-col h-full">
-                <div class="flex items-center gap-2 px-3 py-4">
-                  <h4 class="font-bold text-sm text-text-heading m-0">{{ t('synthetics.journey.steps') }}</h4>
-                  <OBadge variant="default" size="sm">{{ steps.length }}</OBadge>
-                  <span class="flex-1" />
-                </div>
-
-                <div class="flex-1 min-h-0 overflow-auto pb-2">
-                  <!-- JourneySteps in results mode -->
-                  <JourneySteps
-                    :data="stepsWithTotal"
-                    mode="results"
-                    action-key="action"
-                    name-key="name"
-                    detail-key="detail"
-                    icon-key="icon"
-                    :dot-state-fn="stepDotState"
-                    :expanded-ids="expandedStepIdsArr"
-                    @update:expanded-ids="handleUpdateExpanded"
-                  >
-                    <!-- Screenshot thumbnail -->
-                    <template #screenshot-thumb="{ row }">
-                      <img
-                        v-if="row.screenshotKey"
-                        :src="screenshotUrl(row.screenshotKey)"
-                        :alt="t('synthetics.runDetail.screenshotAlt')"
-                        class="w-full h-full object-cover"
-                      />
-                      <OIcon
-                        v-else
-                        name="image"
-                        size="xs"
-                        class="text-text-secondary"
-                      />
-                    </template>
-
-                    <!-- Expanded content: screenshot + metadata + error -->
-                    <template #expansion="{ row }">
-                      <div class="flex gap-4 p-3">
-                        <div class="w-[40%] shrink-0">
-                          <div class="rounded-default border border-border-default overflow-hidden">
-                            <div
-                              class="aspect-[16/10] flex items-center justify-center overflow-hidden"
-                              :class="row.status === 'fail' ? 'bg-status-error-bg' : 'bg-surface-subtle'"
+                <!-- Expanded content: screenshot + metadata + error -->
+                <template #expansion="{ row }">
+                  <div class="flex gap-4 p-3">
+                    <div class="w-[40%] shrink-0">
+                      <div class="rounded-default border-border-default overflow-hidden border">
+                        <div
+                          class="flex aspect-[16/10] items-center justify-center overflow-hidden"
+                          :class="
+                            row.status === 'fail' ? 'bg-status-error-bg' : 'bg-surface-subtle'
+                          "
+                        >
+                          <div v-if="row.screenshotKey" class="group relative h-full w-full">
+                            <OButton
+                              variant="ghost"
+                              size="sm"
+                              class="h-full! w-full rounded-none! border-0! p-0!"
+                              data-test="synthetics-run-detail-step-screenshot-thumb"
+                              @click="openLightbox(row.id)"
                             >
-                              <div
-                                v-if="row.screenshotKey"
-                                class="relative w-full h-full group"
-                              >
-                                <OButton
-                                  variant="ghost"
-                                  size="sm"
-                                  class="w-full h-full! p-0! rounded-none! border-0!"
-                                  data-test="synthetics-run-detail-step-screenshot-thumb"
-                                  @click="openLightbox(row.id)"
-                                >
-                                  <img
-                                    :src="screenshotUrl(row.screenshotKey)"
-                                    :alt="t('synthetics.runDetail.screenshotAlt')"
-                                    class="w-full h-full object-contain transition-opacity group-hover:opacity-90"
-                                  />
-                                </OButton>
-                                <div
-                                  class="absolute top-2 right-2 flex items-center justify-center w-7 h-7 rounded-default bg-surface-base/80 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
-                                  aria-hidden="true"
-                                >
-                                  <OIcon name="fullscreen" size="sm" class="text-text-body" />
-                                </div>
-                              </div>
-                              <template v-else>
-                                <OIcon name="image" :class="row.status === 'fail' ? 'text-status-error-text' : 'text-text-secondary'" size="lg" />
-                                <span class="text-xs font-semibold" :class="row.status === 'fail' ? 'text-status-error-text' : 'text-text-secondary'">
-                                  {{ row.status === 'fail' ? t('synthetics.runDetail.failureScreenshot') : t('synthetics.runDetail.screenshotPlaceholder') }}
-                                </span>
-                              </template>
+                              <img
+                                :src="screenshotUrl(row.screenshotKey)"
+                                :alt="t('synthetics.runDetail.screenshotAlt')"
+                                class="h-full w-full object-contain transition-opacity group-hover:opacity-90"
+                              />
+                            </OButton>
+                            <div
+                              class="rounded-default bg-surface-base/80 pointer-events-none absolute top-2 right-2 flex h-7 w-7 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
+                              aria-hidden="true"
+                            >
+                              <OIcon name="fullscreen" size="sm" class="text-text-body" />
                             </div>
                           </div>
+                          <template v-else>
+                            <OIcon
+                              name="image"
+                              :class="
+                                row.status === 'fail'
+                                  ? 'text-status-error-text'
+                                  : 'text-text-secondary'
+                              "
+                              size="lg"
+                            />
+                            <span
+                              class="text-xs font-semibold"
+                              :class="
+                                row.status === 'fail'
+                                  ? 'text-status-error-text'
+                                  : 'text-text-secondary'
+                              "
+                            >
+                              {{
+                                row.status === "fail"
+                                  ? t("synthetics.runDetail.failureScreenshot")
+                                  : t("synthetics.runDetail.screenshotPlaceholder")
+                              }}
+                            </span>
+                          </template>
                         </div>
+                      </div>
+                    </div>
 
-                        <div class="flex-1 flex flex-col gap-4">
-                          <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
-                            <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.runDetail.detailAction') }}</dt>
-                            <dd class="text-text-secondary">{{ row.action }}</dd>
-                            <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.runDetail.detailSelector') }}</dt>
-                            <dd class="text-text-secondary">{{ row.detail }}</dd>
-                            <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.runDetail.detailUrl') }}</dt>
-                            <dd class="truncate text-text-secondary">{{ row.url || currentRun.url }}</dd>
-                            <dt class="text-sm font-semibold text-text-secondary capitalize tracking-wide">{{ t('synthetics.results.duration') }}</dt>
-                            <dd class="text-text-secondary">{{ row.durStr }}</dd>
-                          </dl>
+                    <div class="flex flex-1 flex-col gap-4">
+                      <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
+                        <dt
+                          class="text-text-secondary text-sm font-semibold tracking-wide capitalize"
+                        >
+                          {{ t("synthetics.runDetail.detailAction") }}
+                        </dt>
+                        <dd class="text-text-secondary">{{ row.action }}</dd>
+                        <dt
+                          class="text-text-secondary text-sm font-semibold tracking-wide capitalize"
+                        >
+                          {{ t("synthetics.runDetail.detailSelector") }}
+                        </dt>
+                        <dd class="text-text-secondary">{{ row.detail }}</dd>
+                        <dt
+                          class="text-text-secondary text-sm font-semibold tracking-wide capitalize"
+                        >
+                          {{ t("synthetics.runDetail.detailUrl") }}
+                        </dt>
+                        <dd class="text-text-secondary truncate">
+                          {{ row.url || currentRun.url }}
+                        </dd>
+                        <dt
+                          class="text-text-secondary text-sm font-semibold tracking-wide capitalize"
+                        >
+                          {{ t("synthetics.results.duration") }}
+                        </dt>
+                        <dd class="text-text-secondary">{{ row.durStr }}</dd>
+                      </dl>
 
-                          <div
-                            v-if="row.status === 'fail' && row.error"
-                            class="rounded-default border border-badge-error-ol-border/30 overflow-hidden"
-                            :data-test="`synthetics-run-detail-step-error-card-${row.id}`"
+                      <div
+                        v-if="row.status === 'fail' && row.error"
+                        class="rounded-default border-badge-error-ol-border/30 overflow-hidden border"
+                        :data-test="`synthetics-run-detail-step-error-card-${row.id}`"
+                      >
+                        <div
+                          class="flex items-center gap-2 bg-[var(--color-badge-error-soft-bg)] px-3 py-2"
+                        >
+                          <OIcon
+                            name="error"
+                            size="sm"
+                            class="text-status-error-text"
+                            aria-hidden="true"
+                          />
+                          <span class="text-text-heading flex-1 text-xs font-semibold">{{
+                            t("synthetics.results.error")
+                          }}</span>
+                        </div>
+                        <div class="px-3 py-3">
+                          <pre
+                            class="text-text-body m-0 font-mono text-xs leading-relaxed whitespace-pre-wrap"
+                            :class="{
+                              'max-h-24 overflow-hidden':
+                                !expandedStepErrors.has(row.id) && (row.error?.length ?? 0) > 200,
+                            }"
+                            >{{ row.error }}</pre
                           >
-                            <div class="flex items-center gap-2 px-3 py-2 bg-[var(--color-badge-error-soft-bg)]">
-                              <OIcon name="error" size="sm" class="text-status-error-text" aria-hidden="true" />
-                              <span class="text-xs font-semibold text-text-heading flex-1">{{ t('synthetics.results.error') }}</span>
-                            </div>
-                            <div class="px-3 py-3">
-                              <pre
-                                class="text-xs text-text-body m-0 whitespace-pre-wrap font-mono leading-relaxed"
-                                :class="{ 'max-h-24 overflow-hidden': !expandedStepErrors.has(row.id) && (row.error?.length ?? 0) > 200 }"
-                              >{{ row.error }}</pre>
-                              <div class="flex items-center gap-2 mt-1.5">
-                                <OButton
-                                  v-if="(row.error?.length ?? 0) > 200"
-                                  variant="ghost"
-                                  size="xs"
-                                  class="text-xs font-semibold text-text-link"
-                                  data-test="synthetics-run-detail-toggle-step-error-btn"
-                                  @click="toggleStepError(row.id)"
-                                >
-                                  {{ expandedStepErrors.has(row.id) ? t('synthetics.runDetail.showLess') : t('synthetics.runDetail.showFullError') }}
-                                </OButton>
-                                <OButton
-                                  variant="ghost"
-                                  size="xs"
-                                  data-test="synthetics-run-detail-step-view-error-btn"
-                                  @click="openErrorFullscreen(row.id)"
-                                >
-                                  {{ t('synthetics.runDetail.viewFullErrorBtn') }}
-                                </OButton>
-                              </div>
-                            </div>
+                          <div class="mt-1.5 flex items-center gap-2">
+                            <OButton
+                              v-if="(row.error?.length ?? 0) > 200"
+                              variant="ghost"
+                              size="xs"
+                              class="text-text-link text-xs font-semibold"
+                              data-test="synthetics-run-detail-toggle-step-error-btn"
+                              @click="toggleStepError(row.id)"
+                            >
+                              {{
+                                expandedStepErrors.has(row.id)
+                                  ? t("synthetics.runDetail.showLess")
+                                  : t("synthetics.runDetail.showFullError")
+                              }}
+                            </OButton>
+                            <OButton
+                              variant="ghost"
+                              size="xs"
+                              data-test="synthetics-run-detail-step-view-error-btn"
+                              @click="openErrorFullscreen(row.id)"
+                            >
+                              {{ t("synthetics.runDetail.viewFullErrorBtn") }}
+                            </OButton>
                           </div>
                         </div>
                       </div>
-                    </template>
-                  </JourneySteps>
-                </div>
-              </div>
+                    </div>
+                  </div>
+                </template>
+              </JourneySteps>
             </div>
           </div>
+        </div>
+      </div>
     </div>
   </OPageLayout>
 
@@ -413,18 +444,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   >
     <div
       v-if="lightboxStep"
-      class="flex items-center justify-center h-full p-6"
-      :class="
-        lightboxStep.status === 'fail'
-          ? 'bg-status-error-bg'
-          : 'bg-surface-subtle'
-      "
+      class="flex h-full items-center justify-center p-6"
+      :class="lightboxStep.status === 'fail' ? 'bg-status-error-bg' : 'bg-surface-subtle'"
     >
       <img
         v-if="lightboxStep.screenshotKey"
         :src="screenshotUrl(lightboxStep.screenshotKey)"
         :alt="t('synthetics.runDetail.screenshotAlt')"
-        class="max-w-full max-h-[85vh] object-contain"
+        class="max-h-[85vh] max-w-full object-contain"
       />
     </div>
   </ODialog>
@@ -436,29 +463,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :title="errorTitle"
     data-test="synthetics-run-detail-step-error-fullscreen"
   >
-    <div
-      v-if="errorStep"
-      class="flex flex-col h-full overflow-y-auto p-6"
-    >
-      <div class="rounded-default border border-badge-error-ol-border/30 overflow-hidden">
-        <div
-          class="flex items-center gap-2 px-4 py-2.5 bg-[var(--color-badge-error-soft-bg)]"
-        >
-          <OIcon
-            name="error"
-            size="sm"
-            class="text-status-error-text"
-            aria-hidden="true"
-          />
-          <span
-            class="text-sm font-semibold text-text-heading flex-1"
-            >{{ t('synthetics.results.error') }}</span
-          >
+    <div v-if="errorStep" class="flex h-full flex-col overflow-y-auto p-6">
+      <div class="rounded-default border-badge-error-ol-border/30 overflow-hidden border">
+        <div class="flex items-center gap-2 bg-[var(--color-badge-error-soft-bg)] px-4 py-2.5">
+          <OIcon name="error" size="sm" class="text-status-error-text" aria-hidden="true" />
+          <span class="text-text-heading flex-1 text-sm font-semibold">{{
+            t("synthetics.results.error")
+          }}</span>
         </div>
         <div class="px-4 py-3">
-          <pre
-            class="text-sm text-text-body m-0 whitespace-pre-wrap font-mono leading-relaxed"
-          >{{ errorStep.error }}</pre>
+          <pre class="text-text-body m-0 font-mono text-sm leading-relaxed whitespace-pre-wrap">{{
+            errorStep.error
+          }}</pre>
         </div>
       </div>
     </div>
@@ -543,7 +559,8 @@ function locationLabel(id: string): string {
 syntheticsService
   .getLocations(store.state.selectedOrganization.identifier)
   .then((res) => {
-    const locations: { id: string; label: string; region: string }[] = (res.data as any).locations ?? [];
+    const locations: { id: string; label: string; region: string }[] =
+      (res.data as any).locations ?? [];
     locationNames.value = Object.fromEntries(
       locations.map((loc) => [loc.id, locationDisplayLabel(loc.label, loc.region)]),
     );
@@ -558,9 +575,7 @@ const runIdParam = computed(() =>
   props.drawerMode ? props.overrideRunId : String(route.params.runId ?? ""),
 );
 const executionIdParam = computed(() =>
-  props.drawerMode
-    ? props.overrideExecutionId
-    : String(route.params.executionId ?? ""),
+  props.drawerMode ? props.overrideExecutionId : String(route.params.executionId ?? ""),
 );
 // The check's folder (name), carried on the results-page route as ?folder=.
 // Passed to per-check API calls so RBAC can resolve folder-scoped grants.
@@ -638,11 +653,7 @@ function buildSteps(detail: SyntheticRunDetail | null): StepRow[] {
       id: idx + 1,
       stepId: ex.step_id,
       action: recorded?.action ?? "step",
-      name:
-        recorded?.name ||
-        recorded?.selector ||
-        recorded?.url ||
-        ex.step_id.slice(0, 8),
+      name: recorded?.name || recorded?.selector || recorded?.url || ex.step_id.slice(0, 8),
       detail: recorded?.selector ?? recorded?.url ?? ex.step_id,
       url: recorded?.url ?? "",
       duration: ex.duration_ms,
@@ -650,9 +661,7 @@ function buildSteps(detail: SyntheticRunDetail | null): StepRow[] {
       icon: recorded ? actionIcon(recorded.action) : "radio_button_checked",
       statusIcon: isFail ? "cancel" : "check-circle",
       durStr: fmtDur(ex.duration_ms),
-      durColor: isFail
-        ? "var(--color-status-error-text)"
-        : "var(--color-text-secondary)",
+      durColor: isFail ? "var(--color-status-error-text)" : "var(--color-text-secondary)",
       error: ex.error,
       screenshotKey: ex.screenshot_key,
     };
@@ -710,10 +719,9 @@ const artifactUrls = ref<Record<string, string>>({});
 async function presignRunArtifacts() {
   const detail = synthetics.runDetail.value;
   if (!detail) return;
-  const keys = [
-    ...detail.lastAttemptSteps.map((s) => s.screenshot_key),
-    detail.traceKey,
-  ].filter((k): k is string => !!k);
+  const keys = [...detail.lastAttemptSteps.map((s) => s.screenshot_key), detail.traceKey].filter(
+    (k): k is string => !!k,
+  );
   if (!keys.length) return;
   const orgId = store.state.selectedOrganization.identifier;
   try {
@@ -792,11 +800,7 @@ function toDisplayRun(detail: SyntheticRunDetail | null): DisplayRun {
   return {
     id: detail.runId,
     monitorName: detail.monitorName,
-    status: isFail
-      ? ("fail" as const)
-      : isError
-        ? ("error" as const)
-        : ("pass" as const),
+    status: isFail ? ("fail" as const) : isError ? ("error" as const) : ("pass" as const),
     duration: detail.durationMs,
     browser: capitalizeEngine(detail.browserEngine),
     device: detail.device,
@@ -806,11 +810,11 @@ function toDisplayRun(detail: SyntheticRunDetail | null): DisplayRun {
     hasReplay: false,
     ...(hasIssue
       ? {
-          errorType: detail.error ? detail.error.split(":")[0] : t('synthetics.results.error'),
+          errorType: detail.error ? detail.error.split(":")[0] : t("synthetics.results.error"),
           errorReason: detail.error || "",
           errorStack: detail.error || "",
           failedStepLabel: detail.failedStep
-            ? t('synthetics.runDetail.failedAtStep', { step: detail.failedStep })
+            ? t("synthetics.runDetail.failedAtStep", { step: detail.failedStep })
             : undefined,
           failedStepId: 1,
         }
@@ -830,7 +834,7 @@ function handleUpdateExpanded(ids: string[]) {
 }
 
 function stepDotState(row: any): StepDotState | undefined {
-  return row.status === 'fail' ? 'fail' : 'pass';
+  return row.status === "fail" ? "fail" : "pass";
 }
 
 /** Steps enriched with total duration for progress bar calculation. */
@@ -859,7 +863,7 @@ const lightboxStep = computed(() => {
 
 const lightboxTitle = computed(() => {
   const s = lightboxStep.value;
-  return s ? t('synthetics.runDetail.lightboxTitle', { id: s.id, action: s.action }) : "";
+  return s ? t("synthetics.runDetail.lightboxTitle", { id: s.id, action: s.action }) : "";
 });
 
 function openLightbox(id: number) {
@@ -883,7 +887,7 @@ const errorStep = computed(() => {
 
 const errorTitle = computed(() => {
   const s = errorStep.value;
-  return s ? t('synthetics.runDetail.errorFullscreenTitle', { id: s.id, action: s.action }) : "";
+  return s ? t("synthetics.runDetail.errorFullscreenTitle", { id: s.id, action: s.action }) : "";
 });
 
 function openErrorFullscreen(id: number) {
@@ -893,21 +897,18 @@ function openErrorFullscreen(id: number) {
 // Computed: current run from composable data
 const loading = computed(() => synthetics.loading.value);
 const currentRun = computed<DisplayRun>(() => {
-  return synthetics.runDetail.value
-    ? toDisplayRun(synthetics.runDetail.value)
-    : toDisplayRun(null);
+  return synthetics.runDetail.value ? toDisplayRun(synthetics.runDetail.value) : toDisplayRun(null);
 });
 
 const isFailed = computed(
-  () =>
-    currentRun.value.status === "fail" || currentRun.value.status === "error",
+  () => currentRun.value.status === "fail" || currentRun.value.status === "error",
 );
 
 const isErrorRun = computed(() => currentRun.value.status === "error");
 
 // ── Display monitor name — prefers explicit prop, falls back to SQL result ──
-const displayMonitorName = computed(() =>
-  props.overrideMonitorName || currentRun.value.monitorName,
+const displayMonitorName = computed(
+  () => props.overrideMonitorName || currentRun.value.monitorName,
 );
 
 const steps = computed<StepRow[]>(() => {
@@ -934,7 +935,7 @@ const failedStepInfo = computed(() => {
   if (!step) return null;
   return {
     step,
-    summary: step.error ? step.error.split('\n')[0] : '',
+    summary: step.error ? step.error.split("\n")[0] : "",
   };
 });
 
@@ -943,7 +944,7 @@ watch(steps, (newSteps) => {
   const next = new Set(expandedStepIds.value);
   let changed = false;
   for (const st of newSteps) {
-    if (st.status === 'fail' && !next.has(String(st.id))) {
+    if (st.status === "fail" && !next.has(String(st.id))) {
       next.add(String(st.id));
       changed = true;
     }
@@ -951,7 +952,7 @@ watch(steps, (newSteps) => {
   if (changed) expandedStepIds.value = next;
 
   // Scroll to the first failed step after layout settles
-  const failedStep = newSteps.find((st) => st.status === 'fail');
+  const failedStep = newSteps.find((st) => st.status === "fail");
   if (failedStep) {
     nextTick(() => {
       requestAnimationFrame(() => {
@@ -959,7 +960,7 @@ watch(steps, (newSteps) => {
           const el = document.querySelector(
             `[data-test="synthetics-run-detail-step-row-${failedStep.id}"]`,
           );
-          el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
         });
       });
     });
@@ -973,14 +974,18 @@ const statusIcon = computed(() =>
   isErrorRun.value ? "error" : isFailed.value ? "cancel" : "check-circle",
 );
 const statusLabel = computed(() =>
-  isErrorRun.value ? t('synthetics.results.error') : isFailed.value ? t('synthetics.results.failed') : t('synthetics.results.passed'),
+  isErrorRun.value
+    ? t("synthetics.results.error")
+    : isFailed.value
+      ? t("synthetics.results.failed")
+      : t("synthetics.results.passed"),
 );
 
 const statusChip = computed(() => {
   if (isErrorRun.value) {
     return {
-      label: t('synthetics.results.status'),
-      value: t('synthetics.results.error'),
+      label: t("synthetics.results.status"),
+      value: t("synthetics.results.error"),
       icon: "error",
       colorClass: "text-status-error-text",
     };
@@ -988,15 +993,17 @@ const statusChip = computed(() => {
   if (currentRun.value.status === "fail") {
     const stepNum = failedStepInfo.value?.step?.id;
     return {
-      label: t('synthetics.results.status'),
-      value: stepNum ? t('synthetics.runDetail.failedAtStep', { step: stepNum }) : t('synthetics.results.failed'),
+      label: t("synthetics.results.status"),
+      value: stepNum
+        ? t("synthetics.runDetail.failedAtStep", { step: stepNum })
+        : t("synthetics.results.failed"),
       icon: "cancel",
       colorClass: "text-status-error-text",
     };
   }
   return {
-    label: t('synthetics.results.status'),
-    value: t('synthetics.results.passed'),
+    label: t("synthetics.results.status"),
+    value: t("synthetics.results.passed"),
     icon: "check-circle",
     colorClass: "text-status-success-text",
   };
@@ -1011,19 +1018,23 @@ interface InfoChip {
 
 const infoChips = computed<InfoChip[]>(() => [
   statusChip.value,
-  { label: t('synthetics.results.duration'), value: fmtDur(currentRun.value.duration), icon: "schedule" },
   {
-    label: t('synthetics.results.steps.browser'),
+    label: t("synthetics.results.duration"),
+    value: fmtDur(currentRun.value.duration),
+    icon: "schedule",
+  },
+  {
+    label: t("synthetics.results.steps.browser"),
     value: currentRun.value.browser,
     icon: browserIcon(currentRun.value.browser),
   },
   {
-    label: t('synthetics.results.device'),
+    label: t("synthetics.results.device"),
     value: currentRun.value.device,
     icon: deviceIcon(currentRun.value.device),
   },
   {
-    label: t('synthetics.results.location'),
+    label: t("synthetics.results.location"),
     value: locationLabel(currentRun.value.location),
     icon: locationIcon(currentRun.value.location),
   },
@@ -1039,7 +1050,11 @@ watch(
     emit("update-status", {
       variant: isErr ? "error-soft" : isF ? "error" : "success",
       icon: isErr ? "error" : isF ? "cancel" : "check-circle",
-      label: isErr ? t('synthetics.results.error') : isF ? t('synthetics.results.failed') : t('synthetics.results.passed'),
+      label: isErr
+        ? t("synthetics.results.error")
+        : isF
+          ? t("synthetics.results.failed")
+          : t("synthetics.results.passed"),
       url: currentRun.value.url,
       timestamp: currentRun.value.timestamp,
     });


### PR DESCRIPTION
## What changed

- **MonitorRuns.vue**: Fixed protocol check breakdown cards showing "Pass Rate by Device" instead of "Duration by Location (Avg)". Added `OTooltip` with truncation and `cursor-help` on all breakdown card name spans. Resolved private location labels in the timeline tooltip. Unified duration formatting to 2 decimal places. Added back the device breakdown card for browser checks. Fixed `locationDurationBreakdown` to resolve location IDs to human-readable labels.
- **syntheticResultsSchema.ts**: Renamed device keys `laptop_large` → `desktop` and `mobile_small` → `mobile` to match the incoming data schema.

## Why

Protocol check monitors were showing an irrelevant "Pass Rate by Device" card (device data doesn't exist for protocol checks) instead of the correct "Duration by Location" card. Browser names and location names in breakdown cards were untruncated, causing layout issues with long names. Private location labels in the timeline tooltip displayed raw KSUIDs instead of human-readable names. Duration values had inconsistent decimal precision (some clipped, some raw).