### PR TITLE
test: heal logs scroll-retention selector after histogram-pinning change

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -10597,31 +10597,60 @@ export class LogsPage {
     }
 
     /**
+     * Locate the results scroll container in the browser context and return it.
+     * Shared by getScrollContainerPosition()/scrollToResultsBottom() so both
+     * always act on the same element.
+     *
+     * Since the histogram-pinning change in logs/SearchResult.vue the histogram
+     * strip no longer scrolls: the results table below it (`<TenstackTable>`,
+     * rendered as `[data-test="logs-search-result-logs-table"]`) owns the
+     * scrollbar. Its scroll parent is the `ref="parentRef"` div
+     * (`.o2-scroll-container`, `overflow: auto`) — the outer `scrollContainerRef`
+     * pane is now `overflow: hidden` in the logs view. So walk UP from the table
+     * to the nearest ancestor with a scrollable computed overflow-y (class
+     * renames don't break it).
+     *
+     * Falls back to the older pagination sibling-walk for the patterns view,
+     * where the whole `scrollContainerRef` pane still scrolls as one.
+     * @returns {string} evaluate-able IIFE body returning the container element.
+     */
+    static _scrollContainerFinder() {
+        return `(() => {
+            const isScrollable = (el) => /(auto|scroll)/.test(getComputedStyle(el).overflowY);
+            // Logs view: the results table owns the scrollbar.
+            const table = document.querySelector('[data-test="logs-search-result-logs-table"]');
+            if (table) {
+                let el = table.parentElement;
+                while (el && el !== document.body) {
+                    if (isScrollable(el)) return el;
+                    el = el.parentElement;
+                }
+            }
+            // Patterns view / fallback: scrollable sibling below the pagination header.
+            const pagination = document.querySelector('[data-test="logs-search-result-pagination"]');
+            if (pagination) {
+                let el = pagination.parentElement;
+                while (el && el !== document.body) {
+                    const container = Array.from(el.children).find(
+                        (child) => !child.contains(pagination) && isScrollable(child)
+                    );
+                    if (container) return container;
+                    el = el.parentElement;
+                }
+            }
+            return null;
+        })()`;
+    }
+
+    /**
      * Get the scroll position (scrollTop) of the main results scroll container.
      * Call waitForResultsLoaded() first to ensure the container exists.
-     * Post design-token migration (#13173) the `.search-list` wrapper is gone:
-     * the scroller is the combined scroll area (`ref="scrollContainerRef"` in
-     * logs/SearchResult.vue), a scrollable sibling below the pagination header.
-     * Walk up from the pagination until an ancestor has a scrollable child
-     * that is not the header itself (matched by computed overflow-y, so class
-     * renames don't break it).
      * @returns {Promise<number>}
      */
     async getScrollContainerPosition() {
-        return await this.page.evaluate(() => {
-            const pagination = document.querySelector('[data-test="logs-search-result-pagination"]');
-            if (!pagination) return -1;
-            let el = pagination.parentElement;
-            while (el && el !== document.body) {
-                const container = Array.from(el.children).find(
-                    (child) => !child.contains(pagination) &&
-                        /(auto|scroll)/.test(getComputedStyle(child).overflowY)
-                );
-                if (container) return container.scrollTop;
-                el = el.parentElement;
-            }
-            return -1;
-        });
+        return await this.page.evaluate(
+            `(() => { const c = ${LogsPage._scrollContainerFinder()}; return c ? c.scrollTop : -1; })()`
+        );
     }
 
     /**
@@ -10630,22 +10659,9 @@ export class LogsPage {
      * Uses the same container discovery as getScrollContainerPosition().
      */
     async scrollToResultsBottom() {
-        await this.page.evaluate(() => {
-            const pagination = document.querySelector('[data-test="logs-search-result-pagination"]');
-            if (!pagination) return;
-            let el = pagination.parentElement;
-            while (el && el !== document.body) {
-                const container = Array.from(el.children).find(
-                    (child) => !child.contains(pagination) &&
-                        /(auto|scroll)/.test(getComputedStyle(child).overflowY)
-                );
-                if (container) {
-                    container.scrollTop = container.scrollHeight;
-                    return;
-                }
-                el = el.parentElement;
-            }
-        });
+        await this.page.evaluate(
+            `(() => { const c = ${LogsPage._scrollContainerFinder()}; if (c) c.scrollTop = c.scrollHeight; })()`
+        );
         await this.page.waitForTimeout(500);
     }
 


### PR DESCRIPTION
## Problem

The scheduled Playwright Regression runs failed on `Logs-Regression` in **both repos** on the same 3 tests in `logs-9044-7354.spec.js` (issue 9044 scroll-retention):

- OSS run [30150748275](https://github.com/openobserve/openobserve/actions/runs/30150748275)
- ENT run [30150717648](https://github.com/openobserve/o2-enterprise/actions/runs/30150717648)

All three failed identically — `expect(scroll).toBeGreaterThan(10)` received `0`, i.e. scrolling the results container no longer moved it.

## Root cause

`web/src/plugins/logs/SearchResult.vue` now **pins the histogram** and hands the scrollbar to the results table (`TenstackTable` → `[data-test="logs-search-result-logs-table"]`). Its scroll parent is the `ref="parentRef"` div (`.o2-scroll-container`, `overflow: auto`). The outer `scrollContainerRef` pane is now `overflow: hidden` in the logs view.

The page-object helpers `getScrollContainerPosition()` / `scrollToResultsBottom()` walked *down* from the pagination header looking for a scrollable sibling, which latched onto a non-overflowing element — so `scrollTop` stayed `0`. (This is the same area healed once before in #13316; the histogram-pinning change moved the scroller again.)

## Fix

Discover the scroll container from the results table itself: walk **up** from `[data-test="logs-search-result-logs-table"]` to the nearest ancestor with a scrollable computed `overflow-y` (the `.o2-scroll-container`). Matched by computed style so class renames don't break it. The old pagination sibling-walk is kept as a fallback for the patterns view (which still scrolls as one pane).

Only the shared OSS page object `logsPage.js` changes, so this heals both OSS and ENT (ENT merges the OSS test folder).

## Verification

Ran against a fresh local build (localhost:5080):

```
3 passed (46.8s)
Scrolled to: 358   →   Scroll correctly reset to top on page change
```

Confirmed via a DOM probe that `.o2-scroll-container` is the real scroller (scrollHeight 1112 > clientHeight 754; scrollTop → 358 after scrolling to bottom).