### PR TITLE
fix(db): avoid O(n^2) stream settings clone during schema cache load

### DIFF
--- a/src/db/src/schema.rs
+++ b/src/db/src/schema.rs
@@ -517,7 +517,6 @@ pub async fn cache() -> Result<(), anyhow::Error> {
         }
         let mut w = STREAM_SETTINGS.write().await;
         w.insert(item_key.to_string(), settings);
-        infra::schema::set_stream_settings_atomic(w.clone());
         drop(w);
         let mut w = STREAM_SCHEMAS_LATEST.write().await;
         w.insert(
@@ -547,6 +546,11 @@ pub async fn cache() -> Result<(), anyhow::Error> {
             log::info!("Stream schemas Cached progress: {}/{}", i, keys.len());
         }
     }
+    // sync the atomic cache once after the loop; cloning the settings map per
+    // stream inside the loop is O(n^2) and stalls startup with many streams
+    let w = STREAM_SETTINGS.read().await;
+    infra::schema::set_stream_settings_atomic(w.clone());
+    drop(w);
     log::info!("Stream schemas Cached {keys_num} streams");
     Ok(())
 }


### PR DESCRIPTION
Design at: #13461

Fixes #13461

## Problem

Startup schema cache loading degrades quadratically: with ~122k streams it starts at ~0.1s per 1000 streams and slows to 14s+ per 1000, taking 40+ minutes in total.

## Root cause

`set_stream_settings_atomic(w.clone())` inside the per-stream loop of `db::schema::cache()` clones the entire `STREAM_SETTINGS` map for every stream and swaps it into the ArcSwap atomic cache. The map grows by one entry per iteration, so total work is O(n^2).

## Fix

Only insert into `STREAM_SETTINGS` inside the loop; sync the atomic cache once after the loop completes. `cache()` runs during startup init before the node serves traffic, so deferring the atomic sync to the end has no behavioral impact.

The per-event single updates in the watch handler keep the in-place `w.clone()` sync — those are single-key updates on a warm cache, not a loop.

## Verification

- `cargo check -p db` passes
- Same fix already validated on the `hotfix/v92-schema-cache` branch built from the production commit