### PR TITLE
fix(db): avoid O(n^2) stream settings clone during schema cache load (v0.92.0)

### DIFF
--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -672,7 +672,6 @@ pub async fn cache() -> Result<(), anyhow::Error> {
         }
         let mut w = STREAM_SETTINGS.write().await;
         w.insert(item_key.to_string(), settings);
-        infra::schema::set_stream_settings_atomic(w.clone());
         drop(w);
         let mut w = STREAM_SCHEMAS_LATEST.write().await;
         w.insert(
@@ -699,6 +698,11 @@ pub async fn cache() -> Result<(), anyhow::Error> {
             log::info!("Stream schemas Cached progress: {}/{}", i, keys.len());
         }
     }
+    // sync the atomic cache once after the loop; cloning the settings map per
+    // stream inside the loop is O(n^2) and stalls startup with many streams
+    let w = STREAM_SETTINGS.read().await;
+    infra::schema::set_stream_settings_atomic(w.clone());
+    drop(w);
     log::info!("Stream schemas Cached {keys_num} streams");
     Ok(())
 }


### PR DESCRIPTION
Design at: #13461

Backport of #13462 to branch-v0.92.0.

## Problem

Startup schema cache loading degrades quadratically: with ~122k streams it starts at ~0.1s per 1000 streams and slows to 14s+ per 1000, taking 40+ minutes in total.

## Root cause

`set_stream_settings_atomic(w.clone())` inside the per-stream loop of `cache()` in `src/service/db/schema.rs` clones the entire `STREAM_SETTINGS` map for every stream. The map grows by one entry per iteration, so total work is O(n^2).

## Fix

Only insert into `STREAM_SETTINGS` inside the loop; sync the atomic cache once after the loop completes. The watch-handler single updates are left unchanged.

## Verification

- `cargo check` passes on this branch