### PR TITLE
fix(synthetics): make probe-token, location & agent migrations idempotent

### DIFF
--- a/src/infra/src/table/migration/m20260707_000004_create_synthetics_probe_tokens.rs
+++ b/src/infra/src/table/migration/m20260707_000004_create_synthetics_probe_tokens.rs
@@ -17,7 +17,9 @@
 //! existing org. New orgs receive their token at creation time.
 
 use config::utils::rand::generate_random_string;
-use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder, Set, TransactionTrait};
+use sea_orm::{
+    ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -79,6 +81,7 @@ impl MigrationTrait for Migration {
         manager
             .create_index(
                 Index::create()
+                    .if_not_exists()
                     .table(SyntheticsProbeTokens::Table)
                     .name("idx_synthetics_probe_tokens_org_id")
                     .col(SyntheticsProbeTokens::OrgId)
@@ -98,6 +101,18 @@ impl MigrationTrait for Migration {
             let mut new_tokens: Vec<synthetics_probe_tokens::ActiveModel> = vec![];
 
             for org in orgs {
+                // Idempotency: skip orgs that already have a probe token. The
+                // migration can legitimately re-run against a DB where a prior
+                // run committed this backfill but was not recorded, and we must
+                // not seed a second `system` token for the same org.
+                let existing = synthetics_probe_tokens::Entity::find()
+                    .filter(synthetics_probe_tokens::Column::OrgId.eq(org.identifier.clone()))
+                    .one(&txn)
+                    .await?;
+                if existing.is_some() {
+                    continue;
+                }
+
                 let now = chrono::Utc::now().timestamp_micros();
                 let token = format!(
                     "{}{}",

--- a/src/infra/src/table/migration/m20260714_000001_create_synthetics_locations.rs
+++ b/src/infra/src/table/migration/m20260714_000001_create_synthetics_locations.rs
@@ -89,6 +89,7 @@ impl MigrationTrait for Migration {
         manager
             .create_index(
                 Index::create()
+                    .if_not_exists()
                     .table(SyntheticsLocations::Table)
                     .name("idx_synthetics_locations_org_id")
                     .col(SyntheticsLocations::OrgId)

--- a/src/infra/src/table/migration/m20260714_000002_create_synthetics_agents.rs
+++ b/src/infra/src/table/migration/m20260714_000002_create_synthetics_agents.rs
@@ -67,6 +67,7 @@ impl MigrationTrait for Migration {
         manager
             .create_index(
                 Index::create()
+                    .if_not_exists()
                     .table(SyntheticsAgents::Table)
                     .name("idx_synthetics_agents_location_id")
                     .col(SyntheticsAgents::LocationId)
@@ -77,6 +78,7 @@ impl MigrationTrait for Migration {
         manager
             .create_index(
                 Index::create()
+                    .if_not_exists()
                     .table(SyntheticsAgents::Table)
                     .name("idx_synthetics_agents_org_id")
                     .col(SyntheticsAgents::OrgId)


### PR DESCRIPTION
## What

Makes three synthetics DB migrations idempotent so they don't panic `db init` on startup when re-run against a database that already has the tables.

## Why

While upgrading an environment (schema 48 → 53), startup crashed repeatedly:

```
db init failed: Execution Error: error returned from database:
relation "idx_synthetics_probe_tokens_org_id" already exists
```
…then the same for `idx_synthetics_locations_org_id`, then the agent indexes.

Root cause: the `create_index` calls in the probe_tokens, locations and agents migrations omitted `.if_not_exists()`. Their sibling migrations from the very same feature (monitors / runs / jobs, PR 12849) **do** use `.if_not_exists()`. When a migration re-runs against a DB where the table + index already exist but the migration row is not recorded in `seaql_migrations`, sea-orm re-issues `CREATE INDEX`, the DB rejects it as already existing, and startup panics. The siblings survive that exact condition (they log `already exists, skipping`); these three didn't because the flag was missing. So this was a genuine miss, not house style.

## Changes

- Add `.if_not_exists()` to the four index creates (probe_tokens ×1, locations ×1, agents ×2), matching the sibling synthetics migrations.
- Guard the probe_tokens backfill to skip orgs that already have a token, so a re-run can't seed a duplicate `system` token per org. This mirrors the idempotency check already used in `m20260331_000001_create_sys_rca_agent_service_accounts`.

## Testing

- `cargo check -p infra` passes.
- Verified against the affected environment: after clearing the leftover objects the migrations apply cleanly and record; with this patch the `CREATE INDEX` re-run is skipped instead of crashing.
