### PR TITLE
fix: skip account column widen when already VARCHAR(128)

### DIFF
--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -2727,6 +2727,7 @@ async fn apply_autovacuum_tuning(pool: &sqlx::Pool<Postgres>) -> Result<()> {
 }
 
 const FILE_COLUMN_TARGET_WIDTH: i32 = 1024;
+const ACCOUNT_COLUMN_TARGET_WIDTH: i32 = 128;
 
 /// Return the declared max length of a VARCHAR column, if the column exists.
 async fn get_varchar_column_width(
@@ -2746,6 +2747,33 @@ async fn get_varchar_column_width(
     Ok(width)
 }
 
+/// Widen a VARCHAR column to `target_width` if it is currently narrower.
+async fn widen_varchar_column(
+    pool: &sqlx::Pool<Postgres>,
+    table: &str,
+    column: &str,
+    target_width: i32,
+) -> Result<()> {
+    match get_varchar_column_width(pool, table, column).await? {
+        Some(width) if width >= target_width => {
+            log::info!(
+                "[POSTGRES] Skipping {column} column widen for {table}: already VARCHAR({width})"
+            );
+            return Ok(());
+        }
+        _ => {}
+    }
+
+    let sql =
+        format!("ALTER TABLE IF EXISTS {table} ALTER COLUMN {column} TYPE VARCHAR({target_width})");
+    if let Err(e) = sqlx::query(&sql).execute(pool).await {
+        log::warn!("[POSTGRES] Failed to widen {column} column for {table}: {e}");
+    } else {
+        log::info!("[POSTGRES] Widened {column} column for {table} to VARCHAR({target_width})");
+    }
+    Ok(())
+}
+
 /// Apply column width compatibility for VARCHAR(file).
 async fn apply_column_width_compat(pool: &sqlx::Pool<Postgres>) -> Result<()> {
     let tables = [
@@ -2755,22 +2783,7 @@ async fn apply_column_width_compat(pool: &sqlx::Pool<Postgres>) -> Result<()> {
         "file_list_dump_stats",
     ];
     for table in &tables {
-        match get_varchar_column_width(pool, table, "file").await? {
-            Some(width) if width >= FILE_COLUMN_TARGET_WIDTH => {
-                log::info!(
-                    "[POSTGRES] Skipping file column widen for {table}: already VARCHAR({width})"
-                );
-                continue;
-            }
-            _ => {}
-        }
-
-        let sql = format!(
-            "ALTER TABLE IF EXISTS {table} ALTER COLUMN file TYPE VARCHAR({FILE_COLUMN_TARGET_WIDTH})"
-        );
-        if let Err(e) = sqlx::query(&sql).execute(pool).await {
-            log::warn!("[POSTGRES] Failed to widen file column for {table}: {e}");
-        }
+        widen_varchar_column(pool, table, "file", FILE_COLUMN_TARGET_WIDTH).await?;
     }
     Ok(())
 }
@@ -3045,15 +3058,9 @@ CREATE TABLE IF NOT EXISTS stream_stats
     }
 
     // after introducing org_storage, the account can have value of org_id:default,
-    // and we restrict org_id to 100 characters so here we change it to 256 from original 32
+    // and we restrict org_id to 100 characters so here we change it to 128 from original 32
     for table in &["file_list", "file_list_history", "file_list_deleted"] {
-        log::info!("[POSTGRES] updating account col to 128 for table {table}");
-        sqlx::query(&format!(
-            "ALTER TABLE {table} ALTER COLUMN account TYPE VARCHAR(128);"
-        ))
-        .execute(&pool)
-        .await?;
-        log::info!("[POSTGRES] successfully updated account col to 128 for table {table}");
+        widen_varchar_column(&pool, table, "account", ACCOUNT_COLUMN_TARGET_WIDTH).await?;
     }
 
     Ok(())


### PR DESCRIPTION
Design at: #10521

Port of #13469 to main.

## Summary

The `ALTER TABLE {table} ALTER COLUMN account TYPE VARCHAR(128)` migration in `create_table` ran the ALTER unconditionally on every startup for `file_list`, `file_list_history`, and `file_list_deleted`. This ALTER takes an `ACCESS EXCLUSIVE` lock on each table (and cascades to all partitions for partitioned tables), which can block or fail startup when the tables are busy — even though the column is already `VARCHAR(128)` on any instance that has started once since the migration was introduced.

This applies the same treatment as the `file` column widening in `apply_column_width_compat` (#10521), without changing any control flow:

- New `widen_varchar_column` helper extracted from `apply_column_width_compat`: checks `information_schema.columns` first and skips the ALTER when the column is already at (or above) the target width, uses `ALTER TABLE IF EXISTS`, and logs a warning instead of failing startup if the ALTER errors (info log on success).
- The account loop in `create_table` now goes through this helper (still unconditional, same tables), so the ALTER only executes when the column is actually narrower than 128.
- `apply_column_width_compat` (file → VARCHAR(1024)) also uses the helper and stays under the existing `meta_partition_mode == "auto"` gate, unchanged.

## Testing

- `cargo check -p infra` passes.