### PR TITLE
fix: group Synthetics and RUM under an Experience menu

### DIFF
--- a/web/src/lib/core/Navbar/navGroups.spec.ts
+++ b/web/src/lib/core/Navbar/navGroups.spec.ts
@@ -128,6 +128,33 @@ describe("groupNavLinks", () => {
     expect(keysOf(entries)).toEqual(["link:home", "link:dashboards"]);
   });
 
+  it("groups RUM and Synthetics under the Experience tile", () => {
+    const entries = groupNavLinks([
+      link("home"),
+      link("rum"),
+      link("synthetics"),
+      link("alertList"),
+    ]);
+    // rum/synthetics are absorbed; the Experience tile takes rum's slot.
+    expect(keysOf(entries)).toEqual(["link:home", "linkGroup:experience", "link:alertList"]);
+    const experience = entries.find(
+      (e): e is Extract<RailEntry, { type: "linkGroup" }> =>
+        e.type === "linkGroup" && e.item.name === "experience",
+    );
+    // Clicking the tile lands on RUM (always-present route).
+    expect(experience?.item.link).toBe("/rum");
+    // Children navigate by route name: RUM + synthetics.
+    expect(experience?.children.map((c) => c.name)).toEqual(["RUM", "synthetics"]);
+  });
+
+  it("keeps RUM a plain link when Synthetics is absent", () => {
+    // Synthetics is feature-gated; with only RUM present the Experience group has
+    // a single child, so it doesn't collapse and RUM stays a plain link.
+    const entries = groupNavLinks([link("home"), link("rum"), link("dashboards")]);
+    expect(keysOf(entries)).toEqual(["link:home", "link:rum", "link:dashboards"]);
+    expect(entries.some((e) => e.type === "linkGroup")).toBe(false);
+  });
+
   it("only includes Data children whose required top-level item is present", () => {
     const entries = groupNavLinks([link("home"), link("pipeline")]);
     const data = dataGroup(entries);

--- a/web/src/lib/core/Navbar/navGroups.ts
+++ b/web/src/lib/core/Navbar/navGroups.ts
@@ -133,6 +133,18 @@ export const NAV_GROUPS: NavGroupDef[] = [
       { titleKey: "menu.report", icon: "description", name: "reports", requires: "reports" },
     ],
   },
+  {
+    key: "experience",
+    titleKey: "menu.experience",
+    icon: "devices",
+    // RUM's route always exists; Synthetics is feature-gated, so land on RUM.
+    parentLink: "/rum",
+    absorbs: ["rum", "synthetics"],
+    children: [
+      { titleKey: "menu.rum", icon: "devices", name: "RUM", requires: "rum" },
+      { titleKey: "menu.synthetic", icon: "radar", name: "synthetics", requires: "synthetics" },
+    ],
+  },
 ];
 
 /**

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -905,7 +905,8 @@
     "language": "Language",
     "actions": "Actions",
     "keyboardShortcuts": "Keyboard Shortcuts",
-    "synthetic": "Synthetics"
+    "synthetic": "Synthetics",
+    "experience": "Experience"
   },
   "rum": {
     "title": "Real User Monitoring",

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -9771,7 +9771,7 @@
       "clearFiltersDesc": "Remove all active filters",
       "device": "Device",
       "duration": "Duration",
-      "editMonitor": "Edit Monitor",
+      "editCheck": "Edit Check",
       "error": "Error",
       "failed": "Failed",
       "failedRuns": "Failed Runs",

--- a/web/src/views/synthetics/MonitorResults.vue
+++ b/web/src/views/synthetics/MonitorResults.vue
@@ -58,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         data-test="synthetic-monitor-results-edit-btn"
         @click="editMonitor"
       >
-        {{ t("synthetics.results.editMonitor") }}
+        {{ t("synthetics.results.editCheck") }}
       </OButton>
       <OButton
         variant="outline"


### PR DESCRIPTION
Collapse the two top-level RUM and Synthetics rail items into a single Experience group tile, mirroring how Data groups Streams/Pipelines and Dashboards groups Reports. Driven entirely by a new NAV_GROUPS entry in navGroups.ts; when Synthetics is disabled the group auto-collapses and RUM falls back to a plain link.