### PR TITLE
perf: backport file download cache and compactor db call improvements to v0.40.0

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1770,6 +1770,10 @@ pub struct MemoryCache {
     pub gc_size: usize,
     #[env_config(name = "ZO_MEMORY_CACHE_GC_INTERVAL", default = 60)] // seconds
     pub gc_interval: u64,
+    // Days, files with data older than this will not be downloaded into the cache,
+    // queries read them directly from object storage. default 0 means no limit
+    #[env_config(name = "ZO_MEMORY_CACHE_MAX_AGE_DAYS", default = 0)]
+    pub max_age_days: i64,
     #[env_config(name = "ZO_MEMORY_CACHE_SKIP_DISK_CHECK", default = false)]
     pub skip_disk_check: bool,
     // MB, default is 50% of system memory
@@ -1808,6 +1812,10 @@ pub struct DiskCache {
     pub gc_size: usize,
     #[env_config(name = "ZO_DISK_CACHE_GC_INTERVAL", default = 60)] // seconds
     pub gc_interval: u64,
+    // Days, files with data older than this will not be downloaded into the cache,
+    // queries read them directly from object storage. default 0 means no limit
+    #[env_config(name = "ZO_DISK_CACHE_MAX_AGE_DAYS", default = 0)]
+    pub max_age_days: i64,
     #[env_config(name = "ZO_DISK_CACHE_MULTI_DIR", default = "")] // dir1,dir2,dir3...
     pub multi_dir: String,
 }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1351,6 +1351,8 @@ pub struct Limit {
     pub query_index_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_THREAD_NUM", default = 0)]
     pub file_download_thread_num: usize,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_MIN_RECORDS", default = 100)]
+    pub file_download_min_records: i64,
     #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_THREAD_NUM", default = 0)]
     pub file_download_priority_queue_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_WINDOW_SECS", default = 3600)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1657,6 +1657,12 @@ pub struct Compact {
     pub enabled: bool,
     #[env_config(name = "ZO_COMPACT_INTERVAL", default = 10)] // seconds
     pub interval: u64,
+    #[env_config(
+        name = "ZO_COMPACT_DATA_RETENTION_INTERVAL",
+        default = 3600,
+        help = "Interval in seconds for the data retention job, default is 3600. Retention works at day granularity, so it doesn't need to run at ZO_COMPACT_INTERVAL"
+    )] // seconds
+    pub data_retention_interval: u64,
     #[env_config(name = "ZO_COMPACT_OLD_DATA_INTERVAL", default = 3600)] // seconds
     pub old_data_interval: u64,
     #[env_config(name = "ZO_COMPACT_STRATEGY", default = "file_time")]
@@ -2982,6 +2988,9 @@ fn check_compact_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         cfg.compact.delete_files_delay_hours = 2;
     }
 
+    if cfg.compact.data_retention_interval < 1 {
+        cfg.compact.data_retention_interval = 3600;
+    }
     if cfg.compact.old_data_interval < 1 {
         cfg.compact.old_data_interval = 3600;
     }

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -64,6 +64,9 @@ impl Event for Eventer {
 
             // Collect files to download
             for item in put_items.iter() {
+                if !crate::job::should_download(item.meta.records) {
+                    continue;
+                }
                 // files with data older than the cache max age should not be
                 // cached, e.g. merged files from compaction of old partitions
                 if crate::job::exceeds_cache_max_age(item.meta.max_ts, CacheType::Disk) {

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -64,6 +64,11 @@ impl Event for Eventer {
 
             // Collect files to download
             for item in put_items.iter() {
+                // files with data older than the cache max age should not be
+                // cached, e.g. merged files from compaction of old partitions
+                if crate::job::exceeds_cache_max_age(item.meta.max_ts, CacheType::Disk) {
+                    continue;
+                }
                 // cache parquet
                 if cfg.cache_latest_files.cache_parquet {
                     files_to_download.push((

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -161,12 +161,6 @@ pub trait FileList: Sync + Send + 'static {
         is_recent: bool,
     ) -> Result<()>;
     async fn reset_stream_stats(&self) -> Result<()>;
-    async fn reset_stream_stats_min_ts(
-        &self,
-        org_id: &str,
-        stream: &str,
-        min_ts: i64,
-    ) -> Result<()>;
     async fn len(&self) -> usize;
     async fn is_empty(&self) -> bool;
     async fn clear(&self) -> Result<()>;
@@ -476,13 +470,6 @@ pub async fn set_stream_stats(
 #[inline]
 pub async fn reset_stream_stats() -> Result<()> {
     CLIENT.reset_stream_stats().await
-}
-
-#[inline]
-pub async fn reset_stream_stats_min_ts(org_id: &str, stream: &str, min_ts: i64) -> Result<()> {
-    CLIENT
-        .reset_stream_stats_min_ts(org_id, stream, min_ts)
-        .await
 }
 
 #[inline]

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -1165,33 +1165,6 @@ ON DUPLICATE KEY UPDATE
         Ok(())
     }
 
-    async fn reset_stream_stats_min_ts(
-        &self,
-        _org_id: &str,
-        stream: &str,
-        min_ts: i64,
-    ) -> Result<()> {
-        let pool = CLIENT.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats"])
-            .inc();
-        sqlx::query(r#"UPDATE stream_stats SET min_ts = ? WHERE stream = ?;"#)
-            .bind(min_ts)
-            .bind(stream)
-            .execute(&pool)
-            .await?;
-        DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats"])
-            .inc();
-        sqlx::query(
-            r#"UPDATE stream_stats SET max_ts = min_ts WHERE stream = ? AND max_ts < min_ts;"#,
-        )
-        .bind(stream)
-        .execute(&pool)
-        .await?;
-        Ok(())
-    }
-
     async fn len(&self) -> usize {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
@@ -1297,6 +1270,17 @@ ON DUPLICATE KEY UPDATE
     }
 
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {
+        // quick check without the lock, if there are no pending jobs we can skip the
+        // locked transaction.
+        let pool = CLIENT_RO.clone();
+        let has_pending = sqlx::query("SELECT id FROM file_list_jobs WHERE status = ? LIMIT 1;")
+            .bind(super::FileListJobStatus::Pending)
+            .fetch_optional(&pool)
+            .await?;
+        if has_pending.is_none() {
+            return Ok(Vec::new());
+        }
+
         let lock_pool = CLIENT.clone();
         let lock_key = "file_list_jobs:get_pending_jobs";
         let lock_id = config::utils::hash::gxhash::new().sum64(lock_key);

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1110,33 +1110,6 @@ DO UPDATE SET
         Ok(())
     }
 
-    async fn reset_stream_stats_min_ts(
-        &self,
-        _org_id: &str,
-        stream: &str,
-        min_ts: i64,
-    ) -> Result<()> {
-        let pool = CLIENT.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats"])
-            .inc();
-        sqlx::query(r#"UPDATE stream_stats SET min_ts = $1 WHERE stream = $2;"#)
-            .bind(min_ts)
-            .bind(stream)
-            .execute(&pool)
-            .await?;
-        DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats"])
-            .inc();
-        sqlx::query(
-            r#"UPDATE stream_stats SET max_ts = min_ts WHERE stream = $1 AND max_ts < min_ts;"#,
-        )
-        .bind(stream)
-        .execute(&pool)
-        .await?;
-        Ok(())
-    }
-
     async fn len(&self) -> usize {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
@@ -1241,6 +1214,17 @@ DO UPDATE SET
     }
 
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {
+        // quick check without the advisory lock, if there are no pending jobs we can skip the
+        // locked transaction.
+        let pool = CLIENT_RO.clone();
+        let has_pending = sqlx::query("SELECT id FROM file_list_jobs WHERE status = $1 LIMIT 1;")
+            .bind(super::FileListJobStatus::Pending)
+            .fetch_optional(&pool)
+            .await?;
+        if has_pending.is_none() {
+            return Ok(Vec::new());
+        }
+
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
         let lock_key = "file_list_jobs:get_pending_jobs";

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -890,28 +890,6 @@ DO UPDATE SET
         Ok(())
     }
 
-    async fn reset_stream_stats_min_ts(
-        &self,
-        _org_id: &str,
-        stream: &str,
-        min_ts: i64,
-    ) -> Result<()> {
-        let client = CLIENT_RW.clone();
-        let client = client.lock().await;
-        sqlx::query(r#"UPDATE stream_stats SET min_ts = $1 WHERE stream = $2;"#)
-            .bind(min_ts)
-            .bind(stream)
-            .execute(&*client)
-            .await?;
-        sqlx::query(
-            r#"UPDATE stream_stats SET max_ts = min_ts WHERE stream = $1 AND max_ts < min_ts;"#,
-        )
-        .bind(stream)
-        .execute(&*client)
-        .await?;
-        Ok(())
-    }
-
     async fn reset_stream_stats(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;

--- a/src/job/compactor.rs
+++ b/src/job/compactor.rs
@@ -92,12 +92,16 @@ pub async fn run() -> Result<(), anyhow::Error> {
         }
     });
 
-    spawn_pausable_job!("run_retention", get_config().compact.interval + 3, {
-        log::debug!("[COMPACTOR::JOB] Running data retention");
-        if let Err(e) = compact::run_retention().await {
-            log::error!("[COMPACTOR::JOB] run data retention error: {e}");
+    spawn_pausable_job!(
+        "run_retention",
+        get_config().compact.data_retention_interval + 3,
+        {
+            log::debug!("[COMPACTOR::JOB] Running data retention");
+            if let Err(e) = compact::run_retention().await {
+                log::error!("[COMPACTOR::JOB] run data retention error: {e}");
+            }
         }
-    });
+    );
 
     spawn_pausable_job!("run_delay_deletion", get_config().compact.interval + 4, {
         log::debug!("[COMPACTOR::JOB] Running data delay deletion");

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -538,6 +538,14 @@ pub async fn queue_download(
     Ok(())
 }
 
+/// Returns true when the record count is unknown or the file contains enough
+/// records to be worth downloading into the cache.
+pub fn should_download(records: i64) -> bool {
+    // A zero value can mean the record count was not populated by an older
+    // gRPC sender. Treat it as unknown rather than as an undersized file.
+    records == 0 || records >= get_config().limit.file_download_min_records
+}
+
 // if the file timestamp is in the past window, it should be prioritized
 fn should_prioritize_file(ts: i64, window_secs: i64) -> bool {
     let window_micros = window_secs * 1_000_000;
@@ -570,7 +578,15 @@ fn exceeds_max_age(ts: i64, max_age_days: i64) -> bool {
 mod tests {
     use config::utils::time::{day_micros, hour_micros, now_micros};
 
-    use super::exceeds_max_age;
+    use super::{exceeds_max_age, should_download};
+
+    #[test]
+    fn test_should_download() {
+        assert!(should_download(0));
+        assert!(!should_download(99));
+        assert!(should_download(100));
+        assert!(should_download(101));
+    }
 
     #[test]
     fn test_exceeds_max_age_disabled() {

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -20,7 +20,7 @@ use config::{
     get_config,
     meta::cluster::{Role, RoleGroup, get_internal_grpc_token},
     metrics,
-    utils::time::now_micros,
+    utils::time::{day_micros, now_micros},
 };
 use futures_util::StreamExt;
 use hashbrown::{HashMap, HashSet};
@@ -492,6 +492,18 @@ pub async fn queue_download(
     log::debug!(
         "[FILE_CACHE_DOWNLOAD:JOB] [trace_id {trace_id}] enqueue file: {file}, size: {size}, ts: {ts}"
     );
+
+    // files with data older than the cache max age are not worth caching: with
+    // time_lru they become the oldest bucket and are evicted first, so the
+    // download would be wasted work. Skip the queue and let the query read
+    // them directly from object storage.
+    if exceeds_cache_max_age(ts, cache_type) {
+        log::debug!(
+            "[FILE_CACHE_DOWNLOAD:JOB] [trace_id {trace_id}] skip file: {file}, data is older than the cache max age"
+        );
+        return Ok(());
+    }
+
     let cfg = get_config();
     if cfg.limit.file_download_enable_priority_queue
         && should_prioritize_file(ts, cfg.limit.file_download_priority_queue_window_secs)
@@ -531,4 +543,59 @@ fn should_prioritize_file(ts: i64, window_secs: i64) -> bool {
     let window_micros = window_secs * 1_000_000;
     let now = now_micros();
     ts > now - window_micros
+}
+
+/// Returns true if the file's data is older than the cache max age and should
+/// not be downloaded into the cache.
+pub fn exceeds_cache_max_age(ts: i64, cache_type: file_data::CacheType) -> bool {
+    let cfg = get_config();
+    let max_age_days = match cache_type {
+        file_data::CacheType::Memory => cfg.memory_cache.max_age_days,
+        file_data::CacheType::Disk => cfg.disk_cache.max_age_days,
+        file_data::CacheType::None => 0,
+    };
+    exceeds_max_age(ts, max_age_days)
+}
+
+// if the file data is older than max_age_days, it should not be cached.
+// max_age_days == 0 means no limit, ts <= 0 means the timestamp is unknown.
+fn exceeds_max_age(ts: i64, max_age_days: i64) -> bool {
+    if max_age_days <= 0 || ts <= 0 {
+        return false;
+    }
+    ts < now_micros() - day_micros(max_age_days)
+}
+
+#[cfg(test)]
+mod tests {
+    use config::utils::time::{day_micros, hour_micros, now_micros};
+
+    use super::exceeds_max_age;
+
+    #[test]
+    fn test_exceeds_max_age_disabled() {
+        // max_age_days == 0 means no limit, nothing is too old
+        let one_year_ago = now_micros() - day_micros(365);
+        assert!(!exceeds_max_age(one_year_ago, 0));
+        assert!(!exceeds_max_age(one_year_ago, -1));
+    }
+
+    #[test]
+    fn test_exceeds_max_age_unknown_ts() {
+        // unknown timestamp should not be skipped
+        assert!(!exceeds_max_age(0, 3));
+        assert!(!exceeds_max_age(-1, 3));
+    }
+
+    #[test]
+    fn test_exceeds_max_age_recent_file() {
+        let one_hour_ago = now_micros() - hour_micros(1);
+        assert!(!exceeds_max_age(one_hour_ago, 3));
+    }
+
+    #[test]
+    fn test_exceeds_max_age_old_file() {
+        let thirty_days_ago = now_micros() - day_micros(30);
+        assert!(exceeds_max_age(thirty_days_ago, 3));
+    }
 }

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -54,7 +54,7 @@ mod promql_self_consume;
 mod service_graph;
 mod stats;
 
-pub use file_downloader::{download_from_node, queue_download};
+pub use file_downloader::{download_from_node, exceeds_cache_max_age, queue_download};
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 #[cfg(feature = "enterprise")]

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -54,7 +54,9 @@ mod promql_self_consume;
 mod service_graph;
 mod stats;
 
-pub use file_downloader::{download_from_node, exceeds_cache_max_age, queue_download};
+pub use file_downloader::{
+    download_from_node, exceeds_cache_max_age, queue_download, should_download,
+};
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 #[cfg(feature = "enterprise")]

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -22,6 +22,7 @@ use config::{
         cluster::{CompactionJobType, Role},
         stream::{ALL_STREAM_TYPES, PartitionTimeLevel, StreamType},
     },
+    utils::time::day_micros,
 };
 use infra::{
     cluster::get_node_from_consistent_hash,
@@ -100,6 +101,17 @@ pub async fn run_retention() -> Result<(), anyhow::Error> {
                 } else {
                     data_lifecycle_end
                 };
+
+                // quick check with the cached stream stats, if the stream has no data older than
+                // the retention boundary we can skip it without any db call.
+                let retention_end_micros = stream_data_retention_end.timestamp_micros();
+                let retention_day_start =
+                    retention_end_micros - retention_end_micros % day_micros(1);
+                let stats =
+                    infra::cache::stats::get_stream_stats(&org_id, &stream_name, stream_type);
+                if stats.doc_time_min > 0 && stats.doc_time_min >= retention_day_start {
+                    continue;
+                }
 
                 let extended_retention_days = &stream_settings.extended_retention_days;
                 // creates jobs to delete data

--- a/src/service/file_list_dump.rs
+++ b/src/service/file_list_dump.rs
@@ -185,6 +185,7 @@ pub async fn exec(
                     &f.key,
                     f.meta.compressed_size,
                     f.meta.max_ts,
+                    f.meta.records,
                 )
             })
             .collect_vec(),

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -158,6 +158,7 @@ pub(crate) async fn create_context(
                     &f.key,
                     f.meta.compressed_size,
                     f.meta.max_ts,
+                    f.meta.records,
                 )
             })
             .collect_vec(),

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -175,6 +175,7 @@ pub async fn search(
                     &f.key,
                     f.meta.compressed_size,
                     f.meta.max_ts,
+                    f.meta.records,
                 )
             })
             .collect_vec(),
@@ -291,7 +292,7 @@ pub async fn search(
 #[tracing::instrument(name = "service:search:grpc:storage:cache_files", skip_all)]
 pub async fn cache_files(
     trace_id: &str,
-    files: &[(i64, &String, &String, i64, i64)],
+    files: &[(i64, &String, &String, i64, i64, i64)],
     scan_stats: &mut ScanStats,
     file_type: &str,
 ) -> (file_data::CacheType, u64, u64) {
@@ -300,7 +301,7 @@ pub async fn cache_files(
     let (mut cache_hits, mut cache_misses) = (0, 0);
 
     let start = std::time::Instant::now();
-    for (_id, _account, file, _size, max_ts) in files.iter() {
+    for (_id, _account, file, _size, max_ts, _records) in files.iter() {
         if file_data::memory::exist(file).await {
             scan_stats.querier_memory_cached_files += 1;
             cached_files.insert(file);
@@ -374,8 +375,8 @@ pub async fn cache_files(
     let trace_id = trace_id.to_string();
     let files = files
         .iter()
-        .filter_map(|(id, account, file, size, ts)| {
-            if cached_files.contains(&file) {
+        .filter_map(|(id, account, file, size, ts, records)| {
+            if cached_files.contains(file) || !crate::job::should_download(*records) {
                 None
             } else {
                 Some((*id, account.to_string(), file.to_string(), *size, *ts))
@@ -455,7 +456,16 @@ pub async fn tantivy_search(
         &query.trace_id,
         &index_file_names
             .iter()
-            .map(|(ttv_file, f)| (f.id, &f.account, ttv_file, f.meta.index_size, f.meta.max_ts))
+            .map(|(ttv_file, f)| {
+                (
+                    f.id,
+                    &f.account,
+                    ttv_file,
+                    f.meta.index_size,
+                    f.meta.max_ts,
+                    f.meta.records,
+                )
+            })
             .collect_vec(),
         &mut scan_stats,
         "index",


### PR DESCRIPTION
## Summary

Backports three file-download / compactor performance changes from `branch-v0.80.0` to `branch-v0.40.0`.

| Upstream commit | Change |
|---|---|
| `b0d9259` | feat: skip file download cache for data older than configurable max age (#13300) |
| `8f65e02` | fix: skip caching files below record threshold (#13296) |
| `f107aa7` | fix: reduce compactor db calls per round (#13059) (#13349) |

## What changed

**Cache admission by data age** — adds `ZO_DISK_CACHE_MAX_AGE_DAYS` and `ZO_MEMORY_CACHE_MAX_AGE_DAYS` (`0` = existing behavior). Files whose data is older than the configured age skip the download queue and are read directly from object storage, since with `time_lru` they land in the oldest bucket and get evicted first anyway. The same filter is applied to the `cache_latest_files` gRPC path.

**Cache admission by record count** — adds `ZO_FILE_DOWNLOAD_MIN_RECORDS` (default `100`). Files with a known positive record count below the threshold are not queued for download. `records == 0` is treated as unknown (older gRPC senders may not populate it) and remains cache-eligible. Threading the record count through required widening the `cache_files` tuple to include `records`.

**Compactor DB calls** — adds `ZO_COMPACT_DATA_RETENTION_INTERVAL` (default `3600`) so the retention job no longer runs at `ZO_COMPACT_INTERVAL`; retention works at day granularity. Also adds a pre-lock existence check in `get_pending_jobs` to avoid the locked transaction when nothing is pending, a cached-stream-stats short-circuit in the retention loop, and removes the now-unused `reset_stream_stats_min_ts` trait method.

## Adaptations for the v0.40.0 layout

These are not pure cherry-picks; three places needed adaptation because the branches have diverged:

1. **`src/job/file_downloader.rs`** — `branch-v0.80.0` has a `queued_files` dedup module and a different `PriorityDownloadQueue` constructor that don't exist on this branch. Only `exceeds_cache_max_age` / `should_download` and their tests were taken; the unrelated queue-dedup code that sat in the same hunk was left out.

2. **`src/service/compact/mod.rs`** — upstream patched `retention::generate_jobs()`, which doesn't exist here; the equivalent retention loop lives in `compact::run_retention()`, so the cached-stream-stats check was applied there.

3. **`src/infra/src/file_list/mysql.rs`** — `branch-v0.80.0` has no MySQL backend, so the original commit never touched it. Since the change removes `reset_stream_stats_min_ts` from the `FileList` trait, the orphaned MySQL impl was removed (it would not compile otherwise), and the same pre-lock pending-jobs check was applied to the MySQL `get_pending_jobs` so MySQL deployments get the same reduction.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo check -p openobserve --lib` — clean, no new warnings (`mysql.rs` is compiled unconditionally, so it is covered)
- `cargo test -p openobserve --lib file_downloader` — 5 passed, 0 failed

The new MySQL query path is only exercised against a live MySQL backend, which was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
