### PR TITLE
fix(alerts): resolve tz_offset null for cross-timezone Browser Time l…

### DIFF
--- a/web/src/utils/date.spec.ts
+++ b/web/src/utils/date.spec.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   parseDuration,
   generateDurationLabel,
@@ -480,13 +480,101 @@ describe("Date Utilities", () => {
       // Test with different date formats that might cause issues
       const result1 = convertDateToTimestamp("31-12-2023", "23:59", "UTC");
       const result2 = convertDateToTimestamp("01-01-2024", "00:00", "UTC");
-      
+
       expect(result1.timestamp).toBeGreaterThanOrEqual(0);
       expect(result2.timestamp).toBeGreaterThanOrEqual(0);
       // Only compare if both timestamps are valid (not 0)
       if (result1.timestamp > 0 && result2.timestamp > 0) {
         expect(result2.timestamp).toBeGreaterThan(result1.timestamp);
       }
+    });
+
+    describe("Browser Time label across timezones", () => {
+      // Force what the code sees as the *browser* timezone without breaking
+      // Luxon. The function reads the browser zone via `Intl.DateTimeFormat()`
+      // with NO arguments; Luxon computes offsets via
+      // `new Intl.DateTimeFormat(locale, { timeZone, ... })` (always WITH
+      // arguments). We override the resolved timeZone only for the zero-arg
+      // "what's my zone" query and delegate every arg-carrying call to the real
+      // implementation, so offset math stays correct while each test pins the
+      // browser zone.
+      const RealDateTimeFormat = Intl.DateTimeFormat;
+
+      function mockBrowserTimezone(zone: string) {
+        vi.spyOn(Intl, "DateTimeFormat").mockImplementation((...args: any[]) => {
+          const instance = new (RealDateTimeFormat as any)(...args);
+          if (args.length === 0) {
+            const realResolved = instance.resolvedOptions.bind(instance);
+            instance.resolvedOptions = () => ({
+              ...realResolved(),
+              timeZone: zone,
+            });
+          }
+          return instance;
+        });
+      }
+
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      // A fixed summer date keeps offsets deterministic: LA is on PDT
+      // (UTC-7 = -420); India is UTC+5:30 = +330, no DST.
+      const DATE = "27-07-2026";
+      const TIME = "10:00";
+
+      it("unwraps a Browser Time label that matches the current browser", () => {
+        mockBrowserTimezone("America/Los_Angeles");
+        const { offset } = convertDateToTimestamp(
+          DATE,
+          TIME,
+          "Browser Time (America/Los_Angeles)",
+        );
+        expect(offset).toBe(-420);
+      });
+
+      // Regression: a label saved on a machine in one zone, re-opened/re-saved
+      // from a machine in a DIFFERENT zone. Previously the label went to Luxon
+      // verbatim (not a valid IANA zone), producing an invalid DateTime whose
+      // `.offset` is NaN — which serialized to null in the saved payload (e.g.
+      // an alert's tz_offset). Luxon does not throw, so the try/catch missed it.
+      it("unwraps a Browser Time label from a DIFFERENT browser (tz_offset null regression)", () => {
+        mockBrowserTimezone("Asia/Kolkata");
+        const { offset } = convertDateToTimestamp(
+          DATE,
+          TIME,
+          "Browser Time (America/Los_Angeles)",
+        );
+        expect(Number.isNaN(offset)).toBe(false);
+        expect(offset).toBe(-420);
+      });
+
+      it("resolves a raw IANA zone regardless of the browser zone", () => {
+        mockBrowserTimezone("Asia/Kolkata");
+        const { offset } = convertDateToTimestamp(
+          DATE,
+          TIME,
+          "America/Los_Angeles",
+        );
+        expect(offset).toBe(-420);
+      });
+
+      it("never returns NaN for an unresolvable zone (falls back to browser zone)", () => {
+        mockBrowserTimezone("Asia/Kolkata"); // +330
+        const { offset } = convertDateToTimestamp(DATE, TIME, "Not/AZone");
+        expect(Number.isNaN(offset)).toBe(false);
+        expect(offset).toBe(330);
+      });
+
+      it("is case-insensitive for the Browser Time label", () => {
+        mockBrowserTimezone("America/Los_Angeles");
+        const { offset } = convertDateToTimestamp(
+          DATE,
+          TIME,
+          "browser time (America/Los_Angeles)",
+        );
+        expect(offset).toBe(-420);
+      });
     });
   });
 });

--- a/web/src/utils/date.ts
+++ b/web/src/utils/date.ts
@@ -266,8 +266,8 @@ export const convertDateToTimestamp = (
   timezone: string,
 ) => {
   try {
-    const browserTime =
-      "Browser Time (" + Intl.DateTimeFormat().resolvedOptions().timeZone + ")";
+    const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const browserTime = "Browser Time (" + browserTimezone + ")";
 
     const [day, month, year] = date.split("-");
     const [hour, minute] = time.split(":");
@@ -280,17 +280,38 @@ export const convertDateToTimestamp = (
       minute: Number(minute),
     };
 
-    if (timezone.toLowerCase() == browserTime.toLowerCase()) {
-      timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    // Timezone values may be a raw IANA zone ("America/Los_Angeles") or the
+    // wrapped "Browser Time (<zone>)" label the pickers store. The label's inner
+    // zone is a real IANA zone regardless of which machine produced it, so it
+    // must be unwrapped whether or not it matches THIS browser — otherwise Luxon
+    // receives the literal "Browser Time (…)" string as a zone, produces an
+    // invalid DateTime, and `.offset` is NaN (which serializes to null in the
+    // saved payload, e.g. an alert's tz_offset). Note Luxon does NOT throw on an
+    // invalid zone, so the surrounding try/catch does not cover this case.
+    const browserTimeMatch = timezone.match(/^Browser Time \((.+)\)$/i);
+    if (browserTimeMatch) {
+      // Exact match with the current browser resolves to the live browser zone;
+      // a label from another machine falls back to the zone named in the label.
+      timezone =
+        timezone.toLowerCase() === browserTime.toLowerCase()
+          ? browserTimezone
+          : browserTimeMatch[1];
     }
 
     // Create a DateTime instance from date and time, then set the timezone
     const dateTime = _DateTime.fromObject(_date, { zone: timezone });
 
-    // Convert the DateTime to a Unix timestamp in milliseconds
-    const unixTimestampMillis = dateTime.toMillis();
+    // Guard against an unresolvable zone: an invalid Luxon DateTime returns NaN
+    // for both toMillis() and offset. Fall back to the browser zone so callers
+    // always get a usable numeric offset instead of NaN/null.
+    const resolved = dateTime.isValid
+      ? dateTime
+      : _DateTime.fromObject(_date, { zone: browserTimezone });
 
-    return { timestamp: unixTimestampMillis * 1000, offset: dateTime.offset }; // timestamp in microseconds
+    // Convert the DateTime to a Unix timestamp in milliseconds
+    const unixTimestampMillis = resolved.toMillis();
+
+    return { timestamp: unixTimestampMillis * 1000, offset: resolved.offset }; // timestamp in microseconds
   } catch (error) {
     console.log("Error converting date to timestamp");
     return { timestamp: 0, offset: 0 };

--- a/web/src/utils/zincutils.spec.ts
+++ b/web/src/utils/zincutils.spec.ts
@@ -1101,6 +1101,28 @@ if .severity == "error" {
       });
     });
 
+    // Force what the code sees as the *browser* timezone without breaking
+    // Luxon. These functions read the browser zone via `Intl.DateTimeFormat()`
+    // with NO arguments; Luxon computes offsets via
+    // `new Intl.DateTimeFormat(locale, { timeZone, ... })` (always WITH
+    // arguments). We override the resolved timeZone only for the zero-arg
+    // "what's my zone" query and delegate every arg-carrying call to the real
+    // implementation. The suite's top-level afterEach restores the spy.
+    const RealDateTimeFormat = Intl.DateTimeFormat;
+    const mockBrowserTimezone = (zone: string) => {
+      vi.spyOn(Intl, "DateTimeFormat").mockImplementation((...args: any[]) => {
+        const instance = new (RealDateTimeFormat as any)(...args);
+        if (args.length === 0) {
+          const realResolved = instance.resolvedOptions.bind(instance);
+          instance.resolvedOptions = () => ({
+            ...realResolved(),
+            timeZone: zone,
+          });
+        }
+        return instance;
+      });
+    };
+
     describe("getTimezoneOffset", () => {
       it("should return timezone offset", () => {
         const result = getTimezoneOffset("UTC");
@@ -1111,15 +1133,69 @@ if .severity == "error" {
         const result = getTimezoneOffset();
         expect(typeof result).toBe("number");
       });
+
+      it("should return a finite offset for a Browser Time label from another browser", () => {
+        mockBrowserTimezone("Asia/Kolkata");
+        const result = getTimezoneOffset("Browser Time (America/Los_Angeles)");
+        expect(Number.isNaN(result)).toBe(false);
+        // LA is either -420 (PDT) or -480 (PST) depending on today's date.
+        expect([-420, -480]).toContain(result);
+      });
     });
 
     describe("convertDateToTimestamp", () => {
+      // Fixed summer date → deterministic offsets: LA on PDT = -420,
+      // India = +330 (no DST).
+      const DATE = "27-07-2026";
+      const TIME = "10:00";
+
       it("should convert date and time to timestamp", () => {
         const result = convertDateToTimestamp("01-01-2022", "12:00", "UTC");
         expect(result).toHaveProperty("timestamp");
         expect(result).toHaveProperty("offset");
         expect(typeof result.timestamp).toBe("number");
         expect(typeof result.offset).toBe("number");
+      });
+
+      it("unwraps a Browser Time label that matches the current browser", () => {
+        mockBrowserTimezone("America/Los_Angeles");
+        const { offset } = convertDateToTimestamp(
+          DATE,
+          TIME,
+          "Browser Time (America/Los_Angeles)",
+        );
+        expect(offset).toBe(-420);
+      });
+
+      // Regression: a Browser Time label saved on one machine and re-saved from
+      // a machine in a different zone previously produced NaN (invalid Luxon
+      // zone) → null in the saved payload (e.g. an alert's tz_offset).
+      it("unwraps a Browser Time label from a DIFFERENT browser (tz_offset null regression)", () => {
+        mockBrowserTimezone("Asia/Kolkata");
+        const { offset } = convertDateToTimestamp(
+          DATE,
+          TIME,
+          "Browser Time (America/Los_Angeles)",
+        );
+        expect(Number.isNaN(offset)).toBe(false);
+        expect(offset).toBe(-420);
+      });
+
+      it("resolves a raw IANA zone regardless of the browser zone", () => {
+        mockBrowserTimezone("Asia/Kolkata");
+        const { offset } = convertDateToTimestamp(
+          DATE,
+          TIME,
+          "America/Los_Angeles",
+        );
+        expect(offset).toBe(-420);
+      });
+
+      it("never returns NaN for an unresolvable zone (falls back to browser zone)", () => {
+        mockBrowserTimezone("Asia/Kolkata"); // +330
+        const { offset } = convertDateToTimestamp(DATE, TIME, "Not/AZone");
+        expect(Number.isNaN(offset)).toBe(false);
+        expect(offset).toBe(330);
       });
     });
   });

--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -1040,8 +1040,8 @@ export const convertDateToTimestamp = (
   time: string,
   timezone: string,
 ) => {
-  const browserTime =
-    "Browser Time (" + Intl.DateTimeFormat().resolvedOptions().timeZone + ")";
+  const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const browserTime = "Browser Time (" + browserTimezone + ")";
 
   const [day, month, year] = date.split("-");
   const [hour, minute] = time.split(":");
@@ -1054,17 +1054,37 @@ export const convertDateToTimestamp = (
     minute: Number(minute),
   };
 
-  if (timezone.toLowerCase() == browserTime.toLowerCase()) {
-    timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  // Timezone values may be a raw IANA zone ("America/Los_Angeles") or the
+  // wrapped "Browser Time (<zone>)" label the pickers store. The label's inner
+  // zone is a real IANA zone regardless of which machine produced it, so it
+  // must be unwrapped whether or not it matches THIS browser — otherwise Luxon
+  // receives the literal "Browser Time (…)" string as a zone, produces an
+  // invalid DateTime, and `.offset` is NaN (which serializes to null in the
+  // saved payload, e.g. an alert's tz_offset).
+  const browserTimeMatch = timezone.match(/^Browser Time \((.+)\)$/i);
+  if (browserTimeMatch) {
+    // Exact match with the current browser resolves to the live browser zone;
+    // a label from another machine falls back to the zone named in the label.
+    timezone =
+      timezone.toLowerCase() === browserTime.toLowerCase()
+        ? browserTimezone
+        : browserTimeMatch[1];
   }
 
   // Create a DateTime instance from date and time, then set the timezone
   const dateTime = _DateTime.fromObject(_date, { zone: timezone });
 
-  // Convert the DateTime to a Unix timestamp in milliseconds
-  const unixTimestampMillis = dateTime.toMillis();
+  // Guard against an unresolvable zone: an invalid Luxon DateTime returns NaN
+  // for both toMillis() and offset. Fall back to the browser zone so callers
+  // always get a usable numeric offset instead of NaN/null.
+  const resolved = dateTime.isValid
+    ? dateTime
+    : _DateTime.fromObject(_date, { zone: browserTimezone });
 
-  return { timestamp: unixTimestampMillis * 1000, offset: dateTime.offset }; // timestamp in microseconds
+  // Convert the DateTime to a Unix timestamp in milliseconds
+  const unixTimestampMillis = resolved.toMillis();
+
+  return { timestamp: unixTimestampMillis * 1000, offset: resolved.offset }; // timestamp in microseconds
 };
 
 export const isValidResourceName = (name: string) => {


### PR DESCRIPTION
…abels

convertDateToTimestamp only unwrapped a "Browser Time (<zone>)" label when it matched the current browser's zone. A label saved on a machine in one zone and re-saved from another was passed to Luxon verbatim — an invalid zone — yielding an invalid DateTime whose .offset is NaN, which serializes to null in the saved payload (e.g. an alert's tz_offset). Luxon does not throw on an invalid zone, so date.ts's surrounding try/catch never caught it.

Fixed in both copies — utils/date.ts (feeds the alert tz_offset via useAlertForm) and utils/zincutils.ts (feeds getTimezoneOffset used by pipelines, reports, and conditions):

- Extract the inner IANA zone from any "Browser Time (<zone>)" label regardless of the current browser: exact match resolves to the live browser zone, a label from another machine falls back to the zone named in the label.
- Guard against an unresolvable zone by falling back to the browser zone so the function never returns NaN/null.
- Extend date.spec.ts and zincutils.spec.ts with cases covering raw IANA zones, matching/non-matching Browser Time labels, the regression, case-insensitivity, and the fallback.