### PR TITLE
fix(incidents): prevent event-timeline loss on unknown event types

### DIFF
--- a/src/api/management/src/request/alerts/incidents.rs
+++ b/src/api/management/src/request/alerts/incidents.rs
@@ -352,6 +352,24 @@ pub struct RcaResponse {
     pub rca_content: String,
 }
 
+/// Response for cancelling an in-flight RCA analysis
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CancelRcaResponse {
+    pub message: String,
+    /// Whether an in-process task handle was found and aborted on this node. False when the
+    /// analysis is running on another node — the cancellation event is still recorded.
+    pub aborted_local_task: bool,
+}
+
+/// Response listing an incident's current and superseded RCA reports
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RcaHistoryResponse {
+    /// The active report, if one has been generated
+    pub current: Option<String>,
+    /// Superseded reports, newest first
+    pub previous: Vec<config::meta::alerts::incidents::ArchivedRcaReport>,
+}
+
 /// Query parameters for RCA trigger
 #[derive(Debug, Deserialize, IntoParams, ToSchema)]
 pub struct TriggerRcaQuery {
@@ -697,7 +715,7 @@ pub async fn trigger_incident_rca(
         ("incident_id" = String, Path, description = "Incident ID"),
     ),
     responses(
-        (status = 200, description = "Analysis cancelled", content_type = "application/json", body = ()),
+        (status = 200, description = "Analysis cancelled", content_type = "application/json", body = CancelRcaResponse),
         (status = 400, description = "No analysis in progress", content_type = "application/json", body = ()),
         (status = 500, description = "Internal error", content_type = "application/json", body = ()),
     ),
@@ -713,26 +731,24 @@ pub async fn cancel_incident_rca(
     use o2_enterprise::enterprise::common::config::get_config as get_o2_config;
 
     let cooldown = get_o2_config().incidents.reanalysis_cooldown_minutes;
-    let events = infra::table::incident_events::get(&org_id, &incident_id)
-        .await
-        .unwrap_or_default();
 
-    // Nothing running — report it rather than writing a spurious terminal event.
-    if !openobserve_core::alerts::incidents::is_analysis_in_flight(&events, cooldown * 2) {
-        return MetaHttpResponse::bad_request("No analysis is currently in progress");
-    }
-
+    // The in-flight check lives inside cancel_rca_for_incident, after the abort handle is
+    // atomically removed — checking here first would leave a window in which a new
+    // analysis could start and be cancelled in place of the one the user targeted.
     match openobserve_core::alerts::incidents::cancel_rca_for_incident(
         &org_id,
         &incident_id,
         Some(user_email.user_id.clone()),
+        cooldown * 2,
     )
     .await
     {
-        Ok(aborted) => MetaHttpResponse::json(serde_json::json!({
-            "message": "Analysis cancelled",
-            "aborted_local_task": aborted,
-        })),
+        // Nothing running — report it rather than writing a spurious terminal event.
+        Ok(None) => MetaHttpResponse::bad_request("No analysis is currently in progress"),
+        Ok(Some(aborted)) => MetaHttpResponse::json(CancelRcaResponse {
+            message: "Analysis cancelled".to_string(),
+            aborted_local_task: aborted,
+        }),
         Err(e) => MetaHttpResponse::internal_error(format!("Failed to cancel analysis: {e}")),
     }
 }
@@ -753,8 +769,8 @@ pub async fn cancel_incident_rca(
         ("incident_id" = String, Path, description = "Incident ID"),
     ),
     responses(
-        (status = 200, description = "RCA report history", content_type = "application/json", body = ()),
-        (status = 404, description = "Not found", content_type = "application/json", body = ()),
+        (status = 200, description = "RCA report history", content_type = "application/json", body = RcaHistoryResponse),
+        (status = 500, description = "Internal error", content_type = "application/json", body = ()),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Alerts", "operation": "get"})),
@@ -767,15 +783,18 @@ pub async fn get_incident_rca_history(
     let topology = match infra::table::alert_incidents::get_topology(&org_id, &incident_id).await {
         Ok(Some(t)) => t,
         Ok(None) => {
-            return MetaHttpResponse::json(serde_json::json!({ "current": null, "previous": [] }));
+            return MetaHttpResponse::json(RcaHistoryResponse {
+                current: None,
+                previous: vec![],
+            });
         }
         Err(e) => return MetaHttpResponse::internal_error(e),
     };
 
-    MetaHttpResponse::json(serde_json::json!({
-        "current": topology.suggested_root_cause,
-        "previous": topology.previous_analyses,
-    }))
+    MetaHttpResponse::json(RcaHistoryResponse {
+        current: topology.suggested_root_cause,
+        previous: topology.previous_analyses,
+    })
 }
 
 /// Get incident events timeline
@@ -989,7 +1008,6 @@ pub async fn update_incident(
         ("incident_id" = String, Path, description = "Incident ID"),
     ),
     responses(
-        (status = 200, description = "Analysis cancelled", content_type = "application/json", body = ()),
         (status = 403, description = "Enterprise feature", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -1019,8 +1037,7 @@ pub async fn cancel_incident_rca(
         ("incident_id" = String, Path, description = "Incident ID"),
     ),
     responses(
-        (status = 200, description = "RCA report history", content_type = "application/json", body = ()),
-        (status = 403, description = "Enterprise feature", content_type = "application/json", body = ()),
+        (status = 200, description = "RCA report history (always empty without enterprise features)", content_type = "application/json", body = RcaHistoryResponse),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Alerts", "operation": "get"})),
@@ -1028,7 +1045,10 @@ pub async fn cancel_incident_rca(
     )
 )]
 pub async fn get_incident_rca_history(_path: Path<(String, String)>) -> Response {
-    MetaHttpResponse::json(serde_json::json!({ "current": null, "previous": [] }))
+    MetaHttpResponse::json(RcaHistoryResponse {
+        current: None,
+        previous: vec![],
+    })
 }
 
 #[cfg(test)]

--- a/src/config/src/meta/alerts/incidents.rs
+++ b/src/config/src/meta/alerts/incidents.rs
@@ -675,6 +675,18 @@ pub enum IncidentEventType {
         /// User who cancelled the run. `None` when cancelled by the system.
         user_id: Option<String>,
     },
+
+    /// Forward-compatibility catch-all for event types this binary does not know.
+    ///
+    /// During a rolling deploy an old node reads rows written by a newer node. Without
+    /// this variant a single unrecognized `type` tag fails the whole `Vec<IncidentEvent>`
+    /// parse; combined with `unwrap_or_default()` on the read path that silently yields an
+    /// empty timeline, which the next `append` then writes back — destroying every prior
+    /// event. Capturing unknown events verbatim keeps them intact across the round-trip.
+    ///
+    /// Must stay LAST: `#[serde(untagged)]` variants are only tried after all tagged ones.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl IncidentEvent {
@@ -831,6 +843,49 @@ impl IncidentEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A node that predates an event type must still recover the whole timeline.
+    ///
+    /// Without the `Unknown` catch-all the array parse fails on the first unrecognized
+    /// tag, and callers that decode-then-write persist the truncated result — silently
+    /// destroying every prior event during a rolling deploy.
+    #[test]
+    fn test_unknown_event_type_preserves_timeline() {
+        let stored = serde_json::json!([
+            {"timestamp": 1, "type": "Created"},
+            {"timestamp": 2, "type": "some_future_event", "data": {"foo": "bar"}},
+            {"timestamp": 3, "type": "ai_analysis_complete"},
+        ]);
+
+        let events: Vec<IncidentEvent> = serde_json::from_value(stored.clone()).unwrap();
+        assert_eq!(events.len(), 3, "unknown tag must not discard other events");
+        assert!(matches!(
+            events[1].event_type,
+            IncidentEventType::Unknown(_)
+        ));
+
+        // The unknown event must survive a read/write cycle byte-for-byte, otherwise an
+        // old node rewriting the row would strip data a newer node depends on.
+        let rewritten = serde_json::to_value(&events).unwrap();
+        assert_eq!(rewritten, stored, "unknown events must round-trip verbatim");
+    }
+
+    /// Known variants must still win over the untagged catch-all.
+    #[test]
+    fn test_known_event_types_not_captured_as_unknown() {
+        let event = IncidentEvent {
+            timestamp: 5,
+            event_type: IncidentEventType::AIAnalysisCancelled {
+                user_id: Some("bob".into()),
+            },
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        let roundtrip: IncidentEvent = serde_json::from_value(json).unwrap();
+        assert!(matches!(
+            roundtrip.event_type,
+            IncidentEventType::AIAnalysisCancelled { .. }
+        ));
+    }
 
     #[test]
     fn test_incident_event_serde_created() {

--- a/src/core/src/alerts/incidents.rs
+++ b/src/core/src/alerts/incidents.rs
@@ -1542,13 +1542,19 @@ pub fn unregister_rca_task(org_id: &str, incident_id: &str) {
 /// `AIAnalysisCancelled` event. The event is written even when no local handle exists,
 /// so a run stranded by a restart can be cleared without waiting for the stale window.
 ///
-/// Returns `true` if a local task was actually aborted.
+/// Re-checks in-flight state here, after the abort handle has been atomically removed,
+/// rather than trusting a check made by the caller. The caller's check is separated from
+/// this call by an await, during which a fresh analysis can start — cancelling then would
+/// abort the wrong run. Returns `Ok(None)` when nothing was in flight.
+///
+/// Returns `Ok(Some(true))` if a local task was actually aborted.
 #[cfg(feature = "enterprise")]
 pub async fn cancel_rca_for_incident(
     org_id: &str,
     incident_id: &str,
     user_id: Option<String>,
-) -> Result<bool, anyhow::Error> {
+    stale_threshold_minutes: u64,
+) -> Result<Option<bool>, anyhow::Error> {
     let aborted = match RCA_ABORT_HANDLES.remove(&rca_task_key(org_id, incident_id)) {
         Some((_, handle)) => {
             handle.abort();
@@ -1556,6 +1562,16 @@ pub async fn cancel_rca_for_incident(
         }
         None => false,
     };
+
+    // Authoritative check: no local handle means the run may be on another node, or may
+    // never have existed. Consult the event log before writing a terminal event, so a
+    // cancel for an already-settled run doesn't leave a spurious event behind.
+    if !aborted {
+        let events = infra::table::incident_events::get(org_id, incident_id).await?;
+        if !is_analysis_in_flight(&events, stale_threshold_minutes) {
+            return Ok(None);
+        }
+    }
 
     infra::table::incident_events::append(
         org_id,
@@ -1566,7 +1582,7 @@ pub async fn cancel_rca_for_incident(
 
     log::info!("[INCIDENTS::RCA] Cancelled analysis for {incident_id} (local_task={aborted})");
 
-    Ok(aborted)
+    Ok(Some(aborted))
 }
 
 /// Returns true if an analysis is currently in-flight (started but not yet completed).

--- a/src/infra/src/table/incident_events.rs
+++ b/src/infra/src/table/incident_events.rs
@@ -21,11 +21,63 @@ use crate::{
     table::entity::incident_events,
 };
 
+/// Encode events for storage, surfacing failures instead of writing a null column.
+///
+/// `unwrap_or_default()` here would persist JSON `null`, erasing the timeline on a write
+/// that was meant to extend it. Propagating the error aborts the surrounding transaction
+/// and leaves the existing row untouched.
+fn encode_events(events: &[IncidentEvent]) -> Result<serde_json::Value, sea_orm::DbErr> {
+    serde_json::to_value(events)
+        .map_err(|e| sea_orm::DbErr::Custom(format!("serialize incident events: {e}")))
+}
+
+/// Decode a stored `events` JSON column into events.
+///
+/// Decodes element-wise rather than parsing the array as a whole: one malformed entry must
+/// not discard the entire timeline. Every caller that decodes then writes back (`append`,
+/// `record_alert`) would otherwise persist the truncated list, turning a transient read
+/// failure into permanent data loss.
+///
+/// Unknown-but-well-formed event types are preserved by `IncidentEventType::Unknown`, so
+/// they survive a read/write cycle on an older node during a rolling deploy.
+fn decode_events(org_id: &str, incident_id: &str, raw: &serde_json::Value) -> Vec<IncidentEvent> {
+    let Some(items) = raw.as_array() else {
+        if !raw.is_null() {
+            log::error!(
+                "[INCIDENTS] events column for {org_id}/{incident_id} is not an array; \
+                 ignoring stored value"
+            );
+        }
+        return vec![];
+    };
+
+    let mut events = Vec::with_capacity(items.len());
+    let mut dropped = 0usize;
+    for item in items {
+        match serde_json::from_value::<IncidentEvent>(item.clone()) {
+            Ok(event) => events.push(event),
+            Err(e) => {
+                dropped += 1;
+                log::error!(
+                    "[INCIDENTS] skipping undecodable event for {org_id}/{incident_id}: {e}"
+                );
+            }
+        }
+    }
+    if dropped > 0 {
+        log::error!(
+            "[INCIDENTS] dropped {dropped} of {} events for {org_id}/{incident_id}",
+            items.len()
+        );
+    }
+    events
+}
+
 /// Initialize events row for a new incident with a Created event
 pub async fn init(org_id: &str, incident_id: &str) -> Result<(), sea_orm::DbErr> {
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let event = IncidentEvent::created();
-    let events_json = serde_json::to_value(vec![event]).unwrap_or_default();
+    let events_json = encode_events(&[event])?;
 
     let model = incident_events::ActiveModel {
         org_id: Set(org_id.to_string()),
@@ -46,11 +98,7 @@ pub async fn get(org_id: &str, incident_id: &str) -> Result<Vec<IncidentEvent>, 
         .await?;
 
     match row {
-        Some(model) => {
-            let events: Vec<IncidentEvent> =
-                serde_json::from_value(model.events.clone()).unwrap_or_default();
-            Ok(events)
-        }
+        Some(model) => Ok(decode_events(org_id, incident_id, &model.events)),
         None => Ok(vec![]),
     }
 }
@@ -72,17 +120,17 @@ pub async fn append(
 
     match row {
         Some(model) => {
-            let mut events: Vec<IncidentEvent> =
-                serde_json::from_value(model.events.clone()).unwrap_or_default();
+            let mut events = decode_events(org_id, incident_id, &model.events);
             events.push(event);
+            let events_json = encode_events(&events)?;
 
             let mut active: incident_events::ActiveModel = model.into();
-            active.events = Set(serde_json::to_value(events).unwrap_or_default());
+            active.events = Set(events_json);
             active.update(&txn).await?;
         }
         None => {
             // Row doesn't exist yet (incident created before events table)
-            let events_json = serde_json::to_value(vec![event]).unwrap_or_default();
+            let events_json = encode_events(&[event])?;
             let model = incident_events::ActiveModel {
                 org_id: Set(org_id.to_string()),
                 incident_id: Set(incident_id.to_string()),
@@ -118,8 +166,7 @@ pub async fn record_alert(
 
     match row {
         Some(model) => {
-            let mut events: Vec<IncidentEvent> =
-                serde_json::from_value(model.events.clone()).unwrap_or_default();
+            let mut events = decode_events(org_id, incident_id, &model.events);
 
             // Scan backwards through the trailing block of Alert events.
             // If a matching alert_id is found within that block, increment it.
@@ -140,9 +187,10 @@ pub async fn record_alert(
             if !compacted {
                 events.push(IncidentEvent::alert(alert_id, alert_name, triggered_at));
             }
+            let events_json = encode_events(&events)?;
 
             let mut active: incident_events::ActiveModel = model.into();
-            active.events = Set(serde_json::to_value(events).unwrap_or_default());
+            active.events = Set(events_json);
             active.update(&txn).await?;
         }
         None => {
@@ -151,7 +199,7 @@ pub async fn record_alert(
             let model = incident_events::ActiveModel {
                 org_id: Set(org_id.to_string()),
                 incident_id: Set(incident_id.to_string()),
-                events: Set(serde_json::to_value(events).unwrap_or_default()),
+                events: Set(encode_events(&events)?),
             };
             model.insert(&txn).await?;
         }


### PR DESCRIPTION
Follow-up addressing the review findings on #13388, which merged before they were applied.

## Blocker: silent event-timeline loss during rolling deploy

`IncidentEventType` is adjacently tagged (`#[serde(tag = "type", content = "data")]`). When a newer node writes an event type an older node doesn't know (e.g. `ai_analysis_cancelled`), the older node's `serde_json::from_value::<Vec<IncidentEvent>>` fails on the **whole array**, not just that element. `unwrap_or_default()` on the read path turns that into `vec![]`, and `append`/`record_alert` then write the empty vec back — permanently destroying every prior event.

Reproduced: a 3-event timeline containing one unknown tag decoded to **0 events**.

Fixes:
- **`Unknown` catch-all variant** (`#[serde(untagged)]`) so unrecognized events round-trip verbatim rather than failing the parse. Kept last — untagged variants are only tried after all tagged ones, so known types still win.
- **Element-wise decoding**, so one malformed entry can't discard the timeline; skipped entries are logged rather than swallowed.
- **Serialization errors propagate** instead of persisting JSON `null`, which would erase the column on a write meant to extend it.

Note: the `unwrap_or_default()` calls are pre-existing — the new event variant is what turns that latent flaw into active data loss, so the fix belongs with it.

## TOCTOU in the RCA cancel path

The in-flight check and the `RCA_ABORT_HANDLES` removal were split across an await in the handler, so an analysis starting in between could be aborted in place of the intended one. The check now runs inside `cancel_rca_for_incident`, after the handle is atomically removed; `Ok(None)` signals nothing was in flight.

## OpenAPI accuracy

Added `CancelRcaResponse` / `RcaHistoryResponse` to replace `body = ()`, removed a 404 the handler never returns, and corrected the OSS stub status codes (each declared a status it never returns).

## Not included

One review finding was a **false positive**: `rca_history_limit` was flagged as a missing enterprise config field, but it exists at `o2_enterprise/.../common/config.rs` with `default = 25`, matching `DEFAULT_RCA_HISTORY_LIMIT`. Since `enterprise` is in the default feature set, a genuinely missing field would break the build immediately — it doesn't.

## Verification

- Enterprise **and** OSS (`--no-default-features`) builds compile
- `cargo clippy` and `cargo fmt --check` clean
- 2034 config + 304 api-management tests pass
- Two new regression tests cover the rolling-deploy case, including byte-for-byte round-trip of unknown events

## Operational note

This protects timelines written from here on. Any row already corrupted by a mixed-version deploy is **not** recoverable from the events table — worth checking before release if the cancel variant has already run in a mixed-version environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)