### PR TITLE
fix(synthetics): stop reporting unevaluated HTTP assertions as passed

### DIFF
--- a/web/src/components/synthetics/results/ProtocolRunSummary.spec.ts
+++ b/web/src/components/synthetics/results/ProtocolRunSummary.spec.ts
@@ -88,6 +88,10 @@ function makeProtocolRun(overrides: Record<string, unknown> = {}) {
     error: "",
     errorClass: "",
     assertionsPassed: true,
+    // Default to the legacy shape (no per-assertion array) so the existing
+    // inference-path tests keep exercising that path; tests for the reported
+    // path pass their own array.
+    assertions: [],
     statusCode: 200,
     responseTimeMs: 245,
     responseBytes: 1234,
@@ -326,6 +330,196 @@ describe("ProtocolRunSummary", () => {
       await flushPromises();
 
       expect(wrapper.text()).toContain("synthetics.protocolRun.assertionsFailed");
+    });
+
+    it("should report assertions as not evaluated when the request never responded", async () => {
+      loading.value = false;
+      protocolRunDetail.value = makeProtocolRun({
+        type: "http",
+        // The probe omits assertions_passed when it never got a response.
+        assertionsPassed: null,
+        error: 'Get "https://httpstat.us/200": EOF',
+        errorClass: "unknown",
+      });
+
+      mockGetSynthetics.mockResolvedValueOnce({
+        data: {
+          config: {
+            assertions: [{ field: "status_code", operator: "equals", value: "200" }],
+          },
+        },
+      });
+
+      wrapper = mountComponent();
+      await flushPromises();
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("synthetics.protocolRun.assertionsNotEvaluated");
+      expect(wrapper.text()).not.toContain("synthetics.protocolRun.assertionsPassed");
+      expect(wrapper.text()).toContain("synthetics.protocolRun.assertionsNotEvaluatedHint");
+    });
+
+    it("should keep reporting a pass when assertions actually ran", async () => {
+      loading.value = false;
+      protocolRunDetail.value = makeProtocolRun({ type: "http", assertionsPassed: true });
+
+      mockGetSynthetics.mockResolvedValueOnce({
+        data: {
+          config: {
+            assertions: [{ field: "status_code", operator: "equals", value: "200" }],
+          },
+        },
+      });
+
+      wrapper = mountComponent();
+      await flushPromises();
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("synthetics.protocolRun.assertionsPassed");
+      expect(wrapper.text()).not.toContain("synthetics.protocolRun.assertionsNotEvaluated");
+    });
+
+    it("should render every verdict the probe reported, not just the first failure", async () => {
+      loading.value = false;
+      protocolRunDetail.value = makeProtocolRun({
+        type: "http",
+        assertionsPassed: false,
+        error: "status 503 eq 200",
+        errorClass: "assertion",
+        assertions: [
+          {
+            field: "status_code",
+            operator: "eq",
+            value: "200",
+            passed: false,
+            detail: "status 503 eq 200",
+          },
+          { field: "body", operator: "contains", value: "ok", passed: true, detail: "" },
+          {
+            field: "response_time_ms",
+            operator: "lt",
+            value: "1",
+            passed: false,
+            detail: "response_time 4ms lt 1",
+          },
+        ],
+      });
+
+      wrapper = mountComponent();
+      await flushPromises();
+      await flushPromises();
+
+      const variants = [0, 1, 2].map((i) =>
+        wrapper
+          .find(`[data-test="synthetics-protocol-run-assertion-${i}"]`)
+          .findComponent({ name: "OBadge" })
+          .props("variant"),
+      );
+      expect(variants).toEqual(["error", "success", "error"]);
+      // Both failures show their own comparison, not one shared error string.
+      expect(
+        wrapper.find('[data-test="synthetics-protocol-run-assertion-detail-0"]').text(),
+      ).toContain("status 503 eq 200");
+      expect(
+        wrapper.find('[data-test="synthetics-protocol-run-assertion-detail-2"]').text(),
+      ).toContain("response_time 4ms lt 1");
+    });
+
+    it("should render reported rows even when the check config could not be loaded", async () => {
+      loading.value = false;
+      protocolRunDetail.value = makeProtocolRun({
+        type: "http",
+        assertionsPassed: false,
+        error: "status 503 eq 200",
+        errorClass: "assertion",
+        assertions: [
+          {
+            field: "status_code",
+            operator: "eq",
+            value: "200",
+            passed: false,
+            detail: "status 503 eq 200",
+          },
+        ],
+      });
+      // Config fetch fails → assertionDefs stays empty; the run record alone
+      // must still be enough to render the section.
+      mockGetSynthetics.mockRejectedValueOnce(new Error("403"));
+
+      wrapper = mountComponent();
+      await flushPromises();
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("synthetics.protocolRun.assertions");
+      expect(wrapper.find('[data-test="synthetics-protocol-run-assertion-0"]').exists()).toBe(true);
+    });
+
+    // Legacy record (no per-assertion array): both assertions fail, but the
+    // probe short-circuited on the first, so the record only ever names that
+    // one. The second row therefore renders as passing — a limit of the old
+    // single-verdict wire shape, not something the view can infer around.
+    it("should only flag the assertion the probe named on a legacy record", async () => {
+      loading.value = false;
+      protocolRunDetail.value = makeProtocolRun({
+        type: "http",
+        assertionsPassed: false,
+        error: "status 200 eq 999",
+        errorClass: "assertion",
+      });
+
+      mockGetSynthetics.mockResolvedValueOnce({
+        data: {
+          config: {
+            assertions: [
+              { field: "status_code", operator: "eq", value: "999" },
+              { field: "body", operator: "contains", value: "NOPE" },
+            ],
+          },
+        },
+      });
+
+      wrapper = mountComponent();
+      await flushPromises();
+      await flushPromises();
+
+      const rows = [0, 1].map((i) =>
+        wrapper
+          .find(`[data-test="synthetics-protocol-run-assertion-${i}"]`)
+          .findComponent({ name: "OBadge" }),
+      );
+      expect(rows[0].props("variant")).toBe("error");
+      expect(rows[1].props("variant")).toBe("success");
+      expect(wrapper.text()).toContain("synthetics.protocolRun.assertionsFailed");
+    });
+
+    it("should flag the response_time_ms row the probe reported as failing", async () => {
+      loading.value = false;
+      protocolRunDetail.value = makeProtocolRun({
+        type: "http",
+        assertionsPassed: false,
+        // The probe's detail leads with `response_time`, not the config's
+        // `response_time_ms` — the row must still be matched.
+        error: "response_time 5300ms lt 5000",
+        errorClass: "assertion",
+      });
+
+      mockGetSynthetics.mockResolvedValueOnce({
+        data: {
+          config: {
+            assertions: [{ field: "response_time_ms", operator: "lt", value: "5000" }],
+          },
+        },
+      });
+
+      wrapper = mountComponent();
+      await flushPromises();
+      await flushPromises();
+
+      const badge = wrapper
+        .find('[data-test="synthetics-protocol-run-assertion-0"]')
+        .findComponent({ name: "OBadge" });
+      expect(badge.props("variant")).toBe("error");
+      expect(badge.props("icon")).toBe("cancel");
     });
   });
 

--- a/web/src/components/synthetics/results/ProtocolRunSummary.vue
+++ b/web/src/components/synthetics/results/ProtocolRunSummary.vue
@@ -167,24 +167,56 @@ const timingBars = computed(() => {
   }));
 });
 
-// Per-assertion verdict: the record only has a bool + first-failure detail, so
-// when the run failed on an assertion we mark the row whose field appears at
-// the start of `error` (probe detail format: "status 503 eq 200" etc.).
+// `assertions_passed` is omitted by the probe when the request never produced a
+// response (connection refused, EOF, timeout) — there was nothing to assert
+// against, so the checker returns before evaluating. That absent case maps to
+// null here and is NOT a pass: rendering it as one told the operator their
+// `status_code eq 200` held on a run that never got a status code.
+const assertionsEvaluated = computed(() => run.value?.assertionsPassed != null);
+
+// The probe's failure detail leads with its own word for the field, which is not
+// always the field name the check config uses. Only needed on the legacy path
+// below — probes that echo per-assertion results carry the field name verbatim.
+const PROBE_FIELD_WORD: Record<string, string> = {
+  status_code: "status",
+  response_time_ms: "response_time",
+};
+
+// Per-assertion verdicts.
+//
+// Preferred source is the probe's own `assertions` array: one row per assertion
+// with its real verdict, so a run where several assertions fail shows all of
+// them. Records written before the probe echoed that array carry only a single
+// roll-up bool plus the FIRST failure's message, and the best that can be done
+// there is to mark whichever row that message names — which is why a legacy
+// multi-failure run still shows only one red row.
 const assertionRows = computed(() => {
   if (!run.value) return [];
+
+  const reported = run.value.assertions;
+  if (reported.length) {
+    return reported.map((a) => ({
+      field: a.field,
+      operator: a.operator,
+      value: a.value,
+      failed: !a.passed,
+      detail: a.detail,
+    }));
+  }
+
   const passedAll = run.value.assertionsPassed;
   return assertionDefs.value.map((a) => {
     let failed = false;
     if (passedAll === false && run.value) {
       const err = run.value.error;
-      const fieldWord = a.field === "status_code" ? "status" : a.field;
+      const fieldWord = PROBE_FIELD_WORD[a.field] ?? a.field;
       failed = run.value.errorClass === "assertion" && err.startsWith(fieldWord);
     }
-    return { ...a, failed };
+    return { ...a, failed, detail: "" };
   });
 });
 
-const showAssertions = computed(() => run.value?.type === "http" && assertionDefs.value.length > 0);
+const showAssertions = computed(() => run.value?.type === "http" && assertionRows.value.length > 0);
 </script>
 
 <template>
@@ -327,13 +359,22 @@ const showAssertions = computed(() => run.value?.type === "http" && assertionDef
             </h3>
             <OBadge
               class="ml-2"
-              :variant="run.assertionsPassed === false ? 'error' : 'success'"
+              :variant="
+                !assertionsEvaluated
+                  ? 'default'
+                  : run.assertionsPassed === false
+                    ? 'error'
+                    : 'success'
+              "
               size="sm"
+              data-test="synthetics-protocol-run-assertions-badge"
             >
               {{
-                run.assertionsPassed === false
-                  ? t("synthetics.protocolRun.assertionsFailed")
-                  : t("synthetics.protocolRun.assertionsPassed")
+                !assertionsEvaluated
+                  ? t("synthetics.protocolRun.assertionsNotEvaluated")
+                  : run.assertionsPassed === false
+                    ? t("synthetics.protocolRun.assertionsFailed")
+                    : t("synthetics.protocolRun.assertionsPassed")
               }}
             </OBadge>
           </div>
@@ -345,13 +386,31 @@ const showAssertions = computed(() => run.value?.type === "http" && assertionDef
               :data-test="`synthetics-protocol-run-assertion-${i}`"
             >
               <OBadge
-                :variant="a.failed ? 'error' : 'success'"
+                :variant="!assertionsEvaluated ? 'default' : a.failed ? 'error' : 'success'"
                 size="sm"
-                :icon="a.failed ? 'cancel' : 'check-circle'"
+                :icon="!assertionsEvaluated ? 'remove' : a.failed ? 'cancel' : 'check-circle'"
               />
-              <span class="font-mono text-xs">{{ a.field }} {{ a.operator }} {{ a.value }}</span>
+              <span class="font-mono text-xs" :class="assertionsEvaluated ? '' : 'text-text-muted'"
+                >{{ a.field }} {{ a.operator }} {{ a.value }}</span
+              >
+              <!-- The probe's own comparison for this row, e.g. "status 503 eq
+                   200" — failures only, and only from probes that report
+                   per-assertion results. -->
+              <span
+                v-if="a.detail"
+                class="text-status-error-text font-mono text-xs"
+                :data-test="`synthetics-protocol-run-assertion-detail-${i}`"
+                >— {{ a.detail }}</span
+              >
             </li>
           </ul>
+          <p
+            v-if="!assertionsEvaluated"
+            class="text-text-muted px-3 pb-2 text-xs"
+            data-test="synthetics-protocol-run-assertions-not-evaluated-hint"
+          >
+            {{ t("synthetics.protocolRun.assertionsNotEvaluatedHint") }}
+          </p>
         </div>
 
         <!-- ── TLS certificate ── -->

--- a/web/src/composables/synthetics/syntheticResultsSchema.ts
+++ b/web/src/composables/synthetics/syntheticResultsSchema.ts
@@ -133,6 +133,16 @@ export interface ProtocolTiming {
   ms: number;
 }
 
+/** One assertion's outcome as echoed back by the probe. */
+export interface ProtocolAssertionResult {
+  field: string;
+  operator: string;
+  value: string;
+  passed: boolean;
+  /** Comparison the probe made, e.g. "status 503 eq 200". Failures only. */
+  detail: string;
+}
+
 /**
  * Detail row for a protocol (http/tcp/tls/ssh) run — flat fields from the
  * probe's result record; no steps/screenshots/replay.
@@ -146,6 +156,12 @@ export interface ProtocolRunDetail {
   error: string;
   errorClass: string;
   assertionsPassed: boolean | null;
+  /**
+   * Per-assertion verdicts as reported by the probe, in declaration order.
+   * Empty for records written before the probe echoed them — callers fall back
+   * to inferring a single failing row from `error` in that case.
+   */
+  assertions: ProtocolAssertionResult[];
   statusCode: number | null;
   responseTimeMs: number;
   responseBytes: number | null;
@@ -368,6 +384,21 @@ function parseJsonArray(raw: unknown): any[] {
     }
   }
   return [];
+}
+
+/**
+ * The probe writes `assertions` as an array; OpenObserve stores it as a JSON
+ * string (same as last_attempt_steps), so accept either. `value` is normalised
+ * to a string because the probe sends numerics as numbers.
+ */
+function parseAssertions(raw: unknown): ProtocolAssertionResult[] {
+  return parseJsonArray(raw).map((a: any) => ({
+    field: str(a?.field),
+    operator: str(a?.operator),
+    value: a?.value == null ? "" : String(a.value),
+    passed: Boolean(a?.passed),
+    detail: str(a?.detail),
+  }));
 }
 
 function parseSteps(raw: unknown): StepResult[] {
@@ -710,6 +741,7 @@ export function mapProtocolRunDetail(rawHit: Record<string, unknown>): ProtocolR
     error: str(rawHit.error),
     errorClass: str(rawHit.error_class),
     assertionsPassed: rawHit.assertions_passed == null ? null : Boolean(rawHit.assertions_passed),
+    assertions: parseAssertions(rawHit.assertions),
     statusCode: rawHit.status_code == null ? null : num(rawHit.status_code),
     responseTimeMs: num(rawHit.response_time_ms),
     responseBytes: rawHit.response_bytes == null ? null : num(rawHit.response_bytes),

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -9771,6 +9771,8 @@
       "assertions": "Assertions",
       "assertionsFailed": "Failed",
       "assertionsPassed": "Passed",
+      "assertionsNotEvaluated": "Not evaluated",
+      "assertionsNotEvaluatedHint": "The request never returned a response, so nothing was asserted.",
       "certExpires": "Expires {date}",
       "completed": "completed",
       "daysRemaining": "{days} days remaining",


### PR DESCRIPTION
## Problem

A failing HTTP check showed **Failed** at the top of the run detail and **Assertions: Passed** below it — a green tick against `status_code eq 200` on a run that never got a status code.

The probe is right to omit `assertions_passed` when the request never returned a response (connection refused, EOF, timeout): it returns before evaluating anything, because there is nothing to assert against. The view had two branches for three states:

```vue
:variant="run.assertionsPassed === false ? 'error' : 'success'"
```

`null` is not `false`, so "never ran" landed in the success branch.

| `assertions_passed` | means | UI showed |
|---|---|---|
| `true` | ran, all passed | Passed ✅ |
| `false` | ran, one failed | Failed ✅ |
| *absent* | never ran | Passed ❌ |

## Changes

1. **Three states, not two.** Absent renders as a neutral **Not evaluated** badge with neutral rows and a line explaining why.

2. **Render the probe's per-assertion results** when the record carries them (see synthetic-o2-agent#4), so a run with several failing assertions shows each one with its own comparison string instead of a single inferred red row. Records written before the probe echoed that array keep the old inference path.

3. **Fix `response_time_ms` on the legacy path.** The probe's detail leads with `response_time`, so `startsWith` never matched the configured field name and a failing latency assertion left every row green. The two renamed fields now go through a lookup map rather than one special case.

4. Reported rows are self-describing, so the assertions card no longer depends on the check-config fetch succeeding (403 on community builds, deleted check, …).

## Testing

`ProtocolRunSummary.spec.ts` — 7 new tests covering the not-evaluated state, the still-passes case, the reported-array path, config-fetch failure, the legacy single-failure record, and `response_time_ms`. Full synthetics sweep: 499 passed, 0 failed.

Verified end to end against a local deployment with five checks covering each case:

| Check | Assertions | Record | UI |
|---|---|---|---|
| AT-A | `status_code eq 200` | `assertions_passed: true` | Passed, row green |
| AT-B | `status_code eq 999` | `false` + array | Failed, row red |
| AT-C | `status_code eq 999` + `body contains NOPE` | `false` + array of 2 | Failed, **both** rows red |
| AT-D | `response_time_ms lt 1` | `false` + array | Failed, row red |
| AT-E | unreachable target | `assertions_passed` absent | **Not evaluated** |

Before: AT-C showed one red row and one green, AT-D showed no red row, AT-E showed Passed.