### PR TITLE
refactor(core): make src/core module graph acyclic

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Check code formatting
         run: cargo fmt --all -- --check
 
+      - name: Check src/core module layering
+        run: python3 scripts/check_core_layering.py
+
       - name: Run clippy
         run: cargo --config net.git-fetch-with-cli=true clippy -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7430,7 +7430,6 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "reqwest 0.13.2",
- "search",
  "serde",
  "serde_json",
  "stream",

--- a/scripts/check_core_layering.py
+++ b/scripts/check_core_layering.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Enforce the module layering inside src/core.
+
+`openobserve-core` is being broken up into per-domain crates so that api/ and jobs/ can depend on
+the services they actually use instead of one 70k-line crate. Rust crates cannot be mutually
+recursive, so before any module can move out, the reference graph inside core has to be a DAG that
+respects the intended crate boundaries.
+
+This script assigns every top-level module in src/core/src to a target layer and fails if a module
+references something in a layer at or above its own. Run it from the repo root:
+
+    python3 scripts/check_core_layering.py
+
+Exit status is 1 when a violation is found, and the offending file, symbol and layer are printed.
+When a new module is added to src/core/src it must be given a layer here, otherwise the script
+fails as well -- that is deliberate, the layer is a design decision and should not default.
+"""
+
+import os
+import re
+import sys
+from collections import defaultdict
+
+BASE = os.path.join("src", "core", "src")
+
+# Lowest first. A module may only reference modules in a strictly lower layer.
+LAYERS = ["sink", "identity", "alerting", "ingest", "dashboards", "admin", "top"]
+RANK = {name: i for i, name in enumerate(LAYERS)}
+
+# Modules that carry no internal dependencies and everything else may use.
+SINK = {
+    "backfill_cleanup",
+    "cloud_events",
+    "error_suggest",
+    "functions_cache",
+    "http_error",
+    "ingestion_tokens",
+    "kv",
+    "ofga",
+    "service",
+    "service_graph_query",
+    "session",
+    "short_url",
+    "stream_utils",
+    "system_settings",
+    "trial_quota",
+    "usage_search",
+}
+IDENTITY = {"auth", "authz", "organization", "providers", "users"}
+ALERTING = {"alerts", "workflows"}
+INGEST = {
+    "ingestion",
+    "llm_evaluations",
+    "logs",
+    "metadata",
+    "metrics",
+    "pipeline",
+    "traces",
+    "workflow_execution",
+}
+DASHBOARDS = {"dashboards"}
+# Everything that composes the domains above: schedulers, cleanup jobs, reporting.
+ADMIN = {
+    "anomaly_detection",
+    "bootstrap",
+    "functions",
+    "org_cleanup",
+    "org_summary",
+    "org_usage",
+    "ratelimit",
+    "self_reporting",
+    "stream",
+    "synthetics",
+}
+# Reaches into every domain; nothing inside the crate may depend on it.
+TOP = {"http"}
+
+# `alerts` is split across two layers: the scheduler half drives pipelines and dashboards, so it
+# sits in admin, while alert evaluation, incidents and notification stay down in alerting.
+ALERTS_ADMIN_SUBMODULES = {"scheduler", "backfill"}
+
+
+def layer_of(top: str, sub: str) -> str:
+    if top in SINK:
+        return "sink"
+    if top in IDENTITY:
+        return "identity"
+    if top == "alerts":
+        return "admin" if sub in ALERTS_ADMIN_SUBMODULES else "alerting"
+    if top in ALERTING:
+        return "alerting"
+    if top in INGEST:
+        return "ingest"
+    if top in DASHBOARDS:
+        return "dashboards"
+    if top in ADMIN:
+        return "admin"
+    if top in TOP:
+        return "top"
+    raise KeyError(top)
+
+
+def strip_comments_and_strings(src: str) -> str:
+    """Blank out // and /* */ comments so doc references are not treated as dependencies."""
+    out = []
+    i, n = 0, len(src)
+    in_str = in_block = in_line = False
+    while i < n:
+        c = src[i]
+        if in_line:
+            if c == "\n":
+                in_line = False
+                out.append(c)
+            i += 1
+        elif in_block:
+            if c == "*" and i + 1 < n and src[i + 1] == "/":
+                in_block = False
+                i += 2
+                continue
+            if c == "\n":
+                out.append(c)
+            i += 1
+        elif in_str:
+            out.append(c)
+            if c == "\\":
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+            i += 1
+        elif c == "/" and i + 1 < n and src[i + 1] == "/":
+            in_line = True
+            i += 2
+        elif c == "/" and i + 1 < n and src[i + 1] == "*":
+            in_block = True
+            i += 2
+        else:
+            if c == '"':
+                in_str = True
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def module_path(path: str):
+    rel = os.path.relpath(path, BASE)
+    parts = rel[:-3].split(os.sep)
+    if parts[-1] == "mod":
+        parts = parts[:-1]
+    return parts
+
+
+def group_items(text: str, i: int):
+    """text[i] == '{' -> the comma-separated items at brace depth 1."""
+    depth, j, cur, items = 1, i + 1, "", []
+    while j < len(text) and depth > 0:
+        ch = text[j]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                items.append(cur)
+                break
+        if depth == 1 and ch == ",":
+            items.append(cur)
+            cur = ""
+        elif not (depth == 1 and ch == ","):
+            cur += ch
+        j += 1
+    return items
+
+
+def first_two_idents(s: str):
+    m = re.match(r"([A-Za-z_]\w*)\s*::\s*([A-Za-z_]\w*)", s.strip())
+    if m:
+        return m.group(1), m.group(2)
+    m = re.match(r"([A-Za-z_]\w*)", s.strip())
+    return (m.group(1), "") if m else None
+
+
+def references(path: str, modules):
+    """Top-level modules referenced from `path`, via `crate::` or a root-reaching `super::`."""
+    src = strip_comments_and_strings(open(path, encoding="utf8", errors="ignore").read())
+    depth = len(module_path(path))
+    found = []
+
+    def scan(i):
+        if i < len(src) and src[i] == "{":
+            for item in group_items(src, i):
+                pair = first_two_idents(item)
+                if pair:
+                    found.append(pair)
+        else:
+            pair = first_two_idents(src[i:])
+            if pair:
+                found.append(pair)
+
+    for m in re.finditer(r"\bcrate::", src):
+        scan(m.end())
+    # `super::` only reaches the crate root when it climbs out of every enclosing module.
+    for m in re.finditer(r"\b((?:super::)+)", src):
+        if depth - m.group(1).count("super::") == 0:
+            scan(m.end())
+
+    return [(t, s) for (t, s) in found if t in modules]
+
+
+def main() -> int:
+    if not os.path.isdir(BASE):
+        print(f"error: {BASE} not found; run from the repository root", file=sys.stderr)
+        return 2
+
+    modules = set()
+    for entry in os.listdir(BASE):
+        full = os.path.join(BASE, entry)
+        if os.path.isdir(full):
+            modules.add(entry)
+        elif entry.endswith(".rs") and entry != "lib.rs":
+            modules.add(entry[:-3])
+
+    known = SINK | IDENTITY | ALERTING | INGEST | DASHBOARDS | ADMIN | TOP
+    unassigned = modules - known
+    if unassigned:
+        print("error: these src/core/src modules have no layer assigned in this script:")
+        for name in sorted(unassigned):
+            print(f"    {name}")
+        print("\nAdd each one to the appropriate set at the top of the file.")
+        return 1
+
+    violations = defaultdict(list)
+    for root, _, files in os.walk(BASE):
+        for fname in sorted(files):
+            if not fname.endswith(".rs"):
+                continue
+            path = os.path.join(root, fname)
+            parts = module_path(path)
+            # lib.rs only declares the modules; it is above all of them by construction.
+            if not parts or parts == ["lib"]:
+                continue
+            src_layer = layer_of(parts[0], parts[1] if len(parts) > 1 else "")
+            for target, sub in references(path, modules):
+                dst_layer = layer_of(target, sub)
+                if src_layer == dst_layer or RANK[dst_layer] < RANK[src_layer]:
+                    continue
+                rel = os.path.relpath(path, BASE)
+                violations[(src_layer, dst_layer)].append((rel, f"{target}::{sub}"))
+
+    if not violations:
+        print(f"core layering OK ({' < '.join(LAYERS)})")
+        return 0
+
+    total = sum(len(v) for v in violations.values())
+    print(f"core layering violated: {total} reference(s)\n")
+    print(f"layer order is {' < '.join(LAYERS)}; a module may only use lower layers\n")
+    for (src_layer, dst_layer), items in sorted(violations.items(), key=lambda kv: -len(kv[1])):
+        print(f"  {src_layer} -> {dst_layer}")
+        for rel, symbol in sorted(set(items)):
+            print(f"      {rel}: {symbol}")
+        print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/common/src/auth/jwt.rs
+++ b/src/api/common/src/auth/jwt.rs
@@ -15,13 +15,13 @@
 
 #[cfg(feature = "cloud")]
 use config::DEFAULT_ORG;
-#[cfg(all(feature = "enterprise", not(feature = "cloud")))]
-use openobserve_core::{organization, users};
 #[cfg(feature = "cloud")]
 use openobserve_core::{
+    cloud_events::{CloudEvent, EventType, enqueue_cloud_event},
     organization::list_org_users_by_user,
-    self_reporting::cloud_events::{CloudEvent, EventType, enqueue_cloud_event},
 };
+#[cfg(all(feature = "enterprise", not(feature = "cloud")))]
+use openobserve_core::{organization, users};
 #[cfg(all(feature = "enterprise", not(feature = "cloud")))]
 use {
     crate::common::meta::user::RoleOrg,

--- a/src/api/http/Cargo.toml
+++ b/src/api/http/Cargo.toml
@@ -51,7 +51,6 @@ openobserve-core.workspace = true
 openobserve-tls.workspace = true
 ingestion-common.workspace = true
 stream.workspace = true
-search.workspace = true
 openobserve-api-ingest.workspace = true
 openobserve-api-management.workspace = true
 openobserve-api-pipelines.workspace = true

--- a/src/api/management/src/request/cloud/billings.rs
+++ b/src/api/management/src/request/cloud/billings.rs
@@ -36,8 +36,8 @@ use crate::{
         CheckoutSessionDetailRequestQuery, ListInvoicesResponseBody, ListSubscriptionResponseBody,
     },
     service::{
+        cloud_events::{CloudEvent, EventType, enqueue_cloud_event},
         organization,
-        self_reporting::cloud_events::{CloudEvent, EventType, enqueue_cloud_event},
     },
 };
 

--- a/src/api/management/src/request/organization/org.rs
+++ b/src/api/management/src/request/organization/org.rs
@@ -294,7 +294,7 @@ pub async fn all_organizations(
 )]
 pub async fn org_summary(Path(org_id): Path<String>) -> impl IntoResponse {
     let org = org_id;
-    let org_summary = organization::get_summary(&org).await;
+    let org_summary = openobserve_core::org_summary::get_summary(&org).await;
     Json(org_summary)
 }
 

--- a/src/api/management/src/request/status/mod.rs
+++ b/src/api/management/src/request/status/mod.rs
@@ -49,7 +49,7 @@ use infra::{
     },
 };
 use openobserve_api_common::extractors::Headers;
-use openobserve_core::{auth::UserEmail, cache::STREAM_EXECUTABLE_PIPELINES};
+use openobserve_core::{auth::UserEmail, pipeline::cache::STREAM_EXECUTABLE_PIPELINES};
 use search::{
     datafusion::{storage::file_statistics_cache, udf::DEFAULT_FUNCTIONS},
     tantivy::cache as tantivy_result_cache,

--- a/src/api/management/src/request/workflows/mod.rs
+++ b/src/api/management/src/request/workflows/mod.rs
@@ -39,7 +39,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     common::{meta::http::HttpResponse as MetaHttpResponse, utils::http::get_or_create_trace_id},
-    service::workflows::{self, InputMap, WorkflowTriggerType},
+    service::{
+        workflow_execution,
+        workflows::{self, InputMap, WorkflowTriggerType},
+    },
 };
 
 #[derive(Deserialize)]
@@ -329,7 +332,9 @@ pub async fn test_workflow(
     Path((org_id, workflow_id)): Path<(String, String)>,
     Json(inputs): Json<WorkflowTestInput>,
 ) -> Response {
-    match workflows::test_workflow(&org_id, &workflow_id, inputs.inputs, inputs.from_node).await {
+    match workflow_execution::test_workflow(&org_id, &workflow_id, inputs.inputs, inputs.from_node)
+        .await
+    {
         Ok(v) => MetaHttpResponse::json(WorkflowTestResult { errors: v.errors }),
         Err(e) => MetaHttpResponse::bad_request(e),
     }
@@ -430,7 +435,9 @@ pub async fn retry_workflow(
     Path((org_id, workflow_id)): Path<(String, String)>,
     Json(details): Json<WorkflowRetryDetails>,
 ) -> Response {
-    match workflows::retry_run(&org_id, &workflow_id, &details.run_id, details.from_node).await {
+    match workflow_execution::retry_run(&org_id, &workflow_id, &details.run_id, details.from_node)
+        .await
+    {
         Ok(v) => MetaHttpResponse::json(WorkflowTestResult { errors: v.errors }),
         Err(e) => MetaHttpResponse::bad_request(e),
     }

--- a/src/core/src/alerts/backfill.rs
+++ b/src/core/src/alerts/backfill.rs
@@ -461,55 +461,6 @@ pub async fn delete_backfill_job(org_id: &str, job_id: &str) -> Result<(), anyho
     Err(anyhow::anyhow!("Backfill job not found"))
 }
 
-pub async fn delete_backfill_jobs_by_pipeline(
-    org_id: &str,
-    pipeline_id: &str,
-) -> Result<(), anyhow::Error> {
-    log::info!(
-        "[BACKFILL] Deleting all backfill jobs for pipeline {} in org {}",
-        pipeline_id,
-        org_id
-    );
-
-    // Get all backfill jobs for this pipeline
-    let jobs = db::backfill::list_by_pipeline(org_id, pipeline_id).await?;
-    let jobs_count = jobs.len();
-
-    for job in jobs {
-        log::info!("delete jobs: {:#?}", job);
-        // Delete the trigger from scheduled_jobs
-        if let Err(e) = db::scheduler::delete(org_id, TriggerModule::Backfill, &job.id).await {
-            log::warn!(
-                "[BACKFILL] Failed to delete trigger for job {} from scheduled_jobs: {}",
-                job.id,
-                e
-            );
-            // Continue even if trigger deletion fails - it might not exist
-        }
-
-        // Delete from backfill_jobs table
-        if let Err(e) = db::backfill::delete(org_id, &job.id).await {
-            log::error!(
-                "[BACKFILL] Failed to delete backfill job {} from backfill_jobs table: {}",
-                job.id,
-                e
-            );
-            return Err(anyhow::anyhow!(
-                "Failed to delete backfill job {}: {}",
-                job.id,
-                e
-            ));
-        }
-    }
-
-    log::info!(
-        "[BACKFILL] Successfully deleted {} backfill jobs for pipeline {}",
-        jobs_count,
-        pipeline_id
-    );
-    Ok(())
-}
-
 pub async fn enable_backfill_job(
     org_id: &str,
     job_id: &str,

--- a/src/core/src/alerts/incidents.rs
+++ b/src/core/src/alerts/incidents.rs
@@ -1354,7 +1354,7 @@ pub async fn enrich_with_topology(
     use AlertNode;
     use EdgeType;
 
-    use crate::traces::service_graph;
+    use crate::service_graph_query as service_graph;
 
     // Get current topology or create new
     let mut topology = infra::table::alert_incidents::get_topology(org_id, incident_id)

--- a/src/core/src/backfill_cleanup.rs
+++ b/src/core/src/backfill_cleanup.rs
@@ -1,0 +1,74 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Backfill-job teardown that other domains have to run as a cascade.
+//!
+//! This is deliberately separate from [`crate::alerts::backfill`]: everything else in that module
+//! belongs to the scheduler, which sits well above the pipeline code, but deleting a pipeline has
+//! to drop that pipeline's backfill jobs too. The cascade only touches the `backfill_jobs` and
+//! `scheduled_jobs` tables, so it lives down here where the pipeline layer can reach it.
+
+use config::meta::triggers::TriggerModule;
+
+use crate::db;
+
+pub async fn delete_backfill_jobs_by_pipeline(
+    org_id: &str,
+    pipeline_id: &str,
+) -> Result<(), anyhow::Error> {
+    log::info!(
+        "[BACKFILL] Deleting all backfill jobs for pipeline {} in org {}",
+        pipeline_id,
+        org_id
+    );
+
+    // Get all backfill jobs for this pipeline
+    let jobs = db::backfill::list_by_pipeline(org_id, pipeline_id).await?;
+    let jobs_count = jobs.len();
+
+    for job in jobs {
+        log::info!("delete jobs: {:#?}", job);
+        // Delete the trigger from scheduled_jobs
+        if let Err(e) = db::scheduler::delete(org_id, TriggerModule::Backfill, &job.id).await {
+            log::warn!(
+                "[BACKFILL] Failed to delete trigger for job {} from scheduled_jobs: {}",
+                job.id,
+                e
+            );
+            // Continue even if trigger deletion fails - it might not exist
+        }
+
+        // Delete from backfill_jobs table
+        if let Err(e) = db::backfill::delete(org_id, &job.id).await {
+            log::error!(
+                "[BACKFILL] Failed to delete backfill job {} from backfill_jobs table: {}",
+                job.id,
+                e
+            );
+            return Err(anyhow::anyhow!(
+                "Failed to delete backfill job {}: {}",
+                job.id,
+                e
+            ));
+        }
+    }
+
+    log::info!(
+        "[BACKFILL] Successfully deleted {} backfill jobs for pipeline {}",
+        jobs_count,
+        pipeline_id
+    );
+    Ok(())
+}

--- a/src/core/src/cloud_events.rs
+++ b/src/core/src/cloud_events.rs
@@ -1,0 +1,61 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The producer half of cloud event reporting: the event types and the enqueue path.
+//!
+//! Enqueuing is just a push onto an in-memory queue, so it has no dependencies of its own and can
+//! be called from anywhere -- organization management, log and trace ingestion. Draining the queue
+//! is what needs the ingestion service, and that half lives in
+//! [`crate::self_reporting::cloud_events`].
+
+use std::sync::LazyLock as Lazy;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+#[derive(Serialize, Deserialize, Debug, Hash)]
+pub enum EventType {
+    OrgCreated,
+    OrgDeleted,
+    OrgCleanupFailed,
+    UserJoined,
+    CheckoutSessionCreated,
+    SubscriptionCreated,
+    SubscriptionChanged,
+    SubscriptionDeleted,
+    StreamCreated,
+}
+
+#[derive(Serialize, Deserialize, Debug, Hash)]
+pub struct CloudEvent {
+    pub org_id: String,
+    pub org_name: String,
+    pub org_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    pub event: EventType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_name: Option<String>,
+}
+
+pub(crate) static CLOUD_EVENT_QUEUE: Lazy<Mutex<Vec<CloudEvent>>> =
+    Lazy::new(|| Mutex::new(vec![]));
+
+pub async fn enqueue_cloud_event(event: CloudEvent) {
+    let mut q = CLOUD_EVENT_QUEUE.lock().await;
+    q.push(event);
+}

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -39,7 +39,7 @@ use crate::{
         authz::Authz,
         http::{ERROR_HEADER, HttpResponse as MetaHttpResponse},
     },
-    http::map_error_to_http_response,
+    http_error::map_error_to_http_response,
 };
 
 const FN_SUCCESS: &str = "Function saved successfully";

--- a/src/core/src/http.rs
+++ b/src/core/src/http.rs
@@ -13,17 +13,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use axum::{
-    Json,
-    http::{HeaderValue, StatusCode},
-    response::{IntoResponse, Response},
-};
-use db::alerts::{destinations::DestinationError, templates::TemplateError};
-use infra::errors;
+//! Per-domain error-to-response conversions.
+//!
+//! Each `From<SomeError> for Response` below has to live in the crate that declares the error
+//! type, so this module ends up reaching into every domain and must stay above all of them.
+//! Nothing inside the crate may depend on it -- use [`crate::http_error`] for the generic mapper
+//! instead. When the domains become their own crates these impls move out with their error types.
 
+use axum::response::Response;
+use db::alerts::{destinations::DestinationError, templates::TemplateError};
+
+pub use crate::http_error::map_error_to_http_response;
 use crate::{
     alerts::alert::AlertError,
-    common::meta::http::{ERROR_HEADER, HttpResponse as MetaHttpResponse},
+    common::meta::http::HttpResponse as MetaHttpResponse,
     dashboards::{DashboardError, reports::ReportError},
     pipeline::db::PipelineError,
 };
@@ -32,31 +35,6 @@ use crate::{
     llm_evaluations::eval_jobs::EvalJobError, providers::ProviderError,
     ratelimit::rule::RatelimitError,
 };
-
-pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>) -> Response {
-    // the status code mapping lives on `infra::errors::Error` so that other
-    // consumers (e.g. audit logging) stay consistent with the HTTP responses
-    let status =
-        StatusCode::from_u16(err.http_status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-    match err {
-        errors::Error::ErrorCode(code) => {
-            let mut body = MetaHttpResponse::error_code_with_trace_id(code, trace_id);
-            // attach hint/did-you-mean suggestions where the code carries
-            // enough information (no-op for the rest)
-            crate::error_suggest::enrich(&mut body, code);
-            (
-                status,
-                [(ERROR_HEADER, HeaderValue::from(code.get_code()))],
-                Json(body),
-            )
-                .into_response()
-        }
-        // These errors don't carry a structured error code, so we don't set the
-        // `X-Error-Message` header (it should only carry error codes). The full
-        // message is still returned in the JSON response body.
-        _ => (status, Json(MetaHttpResponse::error(status, err))).into_response(),
-    }
-}
 
 impl From<AlertError> for Response {
     fn from(value: AlertError) -> Self {
@@ -269,34 +247,5 @@ impl From<RatelimitError> for Response {
             RatelimitError::NotFound(_) => MetaHttpResponse::not_found(value),
             error => MetaHttpResponse::bad_request(error),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_error_code_response_sets_numeric_code_header() {
-        // Error-code responses carry only the numeric error code in the header
-        // (e.g. 20002 for SearchStreamNotFound), never the message.
-        let err = errors::Error::ErrorCode(errors::ErrorCodes::SearchStreamNotFound(
-            "nginx".to_string(),
-        ));
-        let resp = map_error_to_http_response(&err, None);
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-        assert_eq!(resp.headers().get(ERROR_HEADER).unwrap(), "20002");
-    }
-
-    #[test]
-    fn test_non_code_error_omits_header() {
-        // Errors without a structured code don't set the header at all; the
-        // message is surfaced only in the JSON body.
-        let err = errors::Error::SerdeJsonError(
-            serde_json::from_str::<serde_json::Value>("{").unwrap_err(),
-        );
-        let resp = map_error_to_http_response(&err, None);
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-        assert!(resp.headers().get(ERROR_HEADER).is_none());
     }
 }

--- a/src/core/src/http_error.rs
+++ b/src/core/src/http_error.rs
@@ -1,0 +1,86 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Rendering an [`infra::errors::Error`] as an HTTP response.
+//!
+//! This is the domain-agnostic half of [`crate::http`]: it only needs the error type itself, so it
+//! sits at the bottom of the crate where any service can reach it. The per-domain
+//! `From<SomeError> for Response` impls have to stay next to the error types they convert (the
+//! orphan rule), and those live in [`crate::http`].
+
+use axum::{
+    Json,
+    http::{HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+use infra::errors;
+
+use crate::common::meta::http::{ERROR_HEADER, HttpResponse as MetaHttpResponse};
+
+pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>) -> Response {
+    // the status code mapping lives on `infra::errors::Error` so that other
+    // consumers (e.g. audit logging) stay consistent with the HTTP responses
+    let status =
+        StatusCode::from_u16(err.http_status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    match err {
+        errors::Error::ErrorCode(code) => {
+            let mut body = MetaHttpResponse::error_code_with_trace_id(code, trace_id);
+            // attach hint/did-you-mean suggestions where the code carries
+            // enough information (no-op for the rest)
+            crate::error_suggest::enrich(&mut body, code);
+            (
+                status,
+                [(ERROR_HEADER, HeaderValue::from(code.get_code()))],
+                Json(body),
+            )
+                .into_response()
+        }
+        // These errors don't carry a structured error code, so we don't set the
+        // `X-Error-Message` header (it should only carry error codes). The full
+        // message is still returned in the JSON response body.
+        _ => (status, Json(MetaHttpResponse::error(status, err))).into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+
+    use super::*;
+
+    #[test]
+    fn test_error_code_response_sets_numeric_code_header() {
+        // Error-code responses carry only the numeric error code in the header
+        // (e.g. 20002 for SearchStreamNotFound), never the message.
+        let err = errors::Error::ErrorCode(errors::ErrorCodes::SearchStreamNotFound(
+            "nginx".to_string(),
+        ));
+        let resp = map_error_to_http_response(&err, None);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resp.headers().get(ERROR_HEADER).unwrap(), "20002");
+    }
+
+    #[test]
+    fn test_non_code_error_omits_header() {
+        // Errors without a structured code don't set the header at all; the
+        // message is surfaced only in the JSON body.
+        let err = errors::Error::SerdeJsonError(
+            serde_json::from_str::<serde_json::Value>("{").unwrap_err(),
+        );
+        let resp = map_error_to_http_response(&err, None);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(resp.headers().get(ERROR_HEADER).is_none());
+    }
+}

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -22,8 +22,10 @@ pub mod alerts;
 pub mod anomaly_detection;
 pub mod auth;
 pub mod authz;
+pub mod backfill_cleanup;
 pub mod bootstrap;
-pub mod cache;
+#[cfg(feature = "cloud")]
+pub mod cloud_events;
 pub mod dashboards;
 use ::common;
 use ::db;
@@ -32,6 +34,7 @@ use ::db::folders;
 pub mod functions;
 pub mod functions_cache;
 pub mod http;
+pub mod http_error;
 pub mod ingestion;
 pub mod ingestion_tokens;
 pub mod kv;
@@ -43,6 +46,7 @@ pub mod metrics;
 #[cfg(feature = "enterprise")]
 pub mod ofga;
 pub mod org_cleanup;
+pub mod org_summary;
 #[cfg(feature = "cloud")]
 pub mod org_usage;
 pub mod organization;
@@ -54,6 +58,7 @@ pub mod ratelimit;
 use search_service as search;
 pub mod self_reporting;
 pub mod service;
+pub mod service_graph_query;
 pub mod session;
 pub mod short_url;
 pub mod stream;
@@ -63,6 +68,9 @@ pub mod system_settings;
 pub mod traces;
 #[cfg(feature = "cloud")]
 pub mod trial_quota;
+pub mod usage_search;
 pub mod users;
+#[cfg(feature = "enterprise")]
+pub mod workflow_execution;
 #[cfg(feature = "enterprise")]
 pub mod workflows;

--- a/src/core/src/logs/mod.rs
+++ b/src/core/src/logs/mod.rs
@@ -222,17 +222,15 @@ async fn write_logs_by_stream(
                 Some(org) => org,
             };
 
-            super::self_reporting::cloud_events::enqueue_cloud_event(
-                super::self_reporting::cloud_events::CloudEvent {
-                    org_id: org.identifier.clone(),
-                    org_name: org.name.clone(),
-                    org_type: org.org_type.clone(),
-                    user: Some(user_email.to_string()),
-                    event: super::self_reporting::cloud_events::EventType::StreamCreated,
-                    subscription_type: None,
-                    stream_name: Some(stream_name.clone()),
-                },
-            )
+            super::cloud_events::enqueue_cloud_event(super::cloud_events::CloudEvent {
+                org_id: org.identifier.clone(),
+                org_name: org.name.clone(),
+                org_type: org.org_type.clone(),
+                user: Some(user_email.to_string()),
+                event: super::cloud_events::EventType::StreamCreated,
+                subscription_type: None,
+                stream_name: Some(stream_name.clone()),
+            })
             .await;
         }
 

--- a/src/core/src/org_cleanup.rs
+++ b/src/core/src/org_cleanup.rs
@@ -273,7 +273,7 @@ async fn process_org_tasks(
 async fn emit_failed_alert(org_id: &str, _step: &str) {
     #[cfg(feature = "cloud")]
     {
-        use crate::self_reporting::cloud_events::{CloudEvent, EventType, enqueue_cloud_event};
+        use crate::cloud_events::{CloudEvent, EventType, enqueue_cloud_event};
         enqueue_cloud_event(CloudEvent {
             event: EventType::OrgCleanupFailed,
             org_id: org_id.to_string(),

--- a/src/core/src/org_summary.rs
+++ b/src/core/src/org_summary.rs
@@ -1,0 +1,119 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The per-organization overview shown on the landing page.
+//!
+//! This aggregates across most of the product -- streams, pipelines, alerts, functions,
+//! dashboards -- so it sits above all of them rather than in `organization`, which the same
+//! domains depend on.
+
+use config::{
+    meta::{
+        alerts::alert::ListAlertsParams, dashboards::ListDashboardsParams,
+        pipeline::components::PipelineSource, self_reporting::usage, stream::StreamType,
+    },
+    utils::{json, time},
+};
+use infra::table;
+use stream::get_streams;
+
+use crate::{
+    common::meta::organization::{
+        AlertSummary, OrgSummary, PipelineSummary, StreamSummary, TriggerStatus,
+        TriggerStatusSearchResult,
+    },
+    db,
+};
+
+pub async fn get_summary(org_id: &str) -> OrgSummary {
+    let streams = get_streams(org_id, None, false, None).await;
+    let mut stream_summary = StreamSummary::default();
+    let mut has_trigger_stream = false;
+    for stream in streams.iter() {
+        if stream.name == usage::TRIGGERS_STREAM {
+            has_trigger_stream = true;
+        }
+        if !stream.stream_type.eq(&StreamType::Index)
+            && !stream.stream_type.eq(&StreamType::Metadata)
+        {
+            stream_summary.num_streams += 1;
+            stream_summary.total_records += stream.stats.doc_num;
+            stream_summary.total_storage_size += stream.stats.storage_size;
+            stream_summary.total_compressed_size += stream.stats.compressed_size;
+            stream_summary.total_index_size += stream.stats.index_size;
+        }
+    }
+
+    let trigger_status_results = if !has_trigger_stream {
+        vec![]
+    } else {
+        let sql = format!(
+            "SELECT module, status FROM {} WHERE org = '{}' GROUP BY module, status, key",
+            usage::TRIGGERS_STREAM,
+            org_id
+        );
+        let end_time = time::now_micros();
+        let start_time = end_time - time::second_micros(900); // 15 mins
+        crate::usage_search::get_usage(sql, start_time, end_time, false)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|v| json::from_value::<TriggerStatusSearchResult>(v).ok())
+            .collect::<Vec<_>>()
+    };
+
+    let pipelines = crate::pipeline::list_user_pipelines(org_id, None)
+        .await
+        .unwrap_or_default();
+    let pipeline_summary = PipelineSummary {
+        num_realtime: pipelines
+            .iter()
+            .filter(|p| matches!(p.source, PipelineSource::Realtime(_)))
+            .count() as i64,
+        num_scheduled: pipelines
+            .iter()
+            .filter(|p| matches!(p.source, PipelineSource::Scheduled(_)))
+            .count() as i64,
+        trigger_status: TriggerStatus::from_search_results(
+            &trigger_status_results,
+            usage::TriggerDataType::DerivedStream,
+        ),
+    };
+
+    let alerts = crate::alerts::alert::list_with_folders_db(ListAlertsParams::new(org_id))
+        .await
+        .unwrap_or_default();
+    let alert_summary = AlertSummary {
+        num_realtime: alerts.iter().filter(|(_, a)| a.is_real_time).count() as i64,
+        num_scheduled: alerts.iter().filter(|(_, a)| !a.is_real_time).count() as i64,
+        trigger_status: TriggerStatus::from_search_results(
+            &trigger_status_results,
+            usage::TriggerDataType::Alert,
+        ),
+    };
+
+    let functions = db::functions::list(org_id).await.unwrap_or_default();
+    let dashboards = table::dashboards::list(ListDashboardsParams::new(org_id))
+        .await
+        .unwrap_or_default();
+
+    OrgSummary {
+        streams: stream_summary,
+        pipelines: pipeline_summary,
+        alerts: alert_summary,
+        total_functions: functions.len() as i64,
+        total_dashboards: dashboards.len() as i64,
+    }
+}

--- a/src/core/src/org_usage.rs
+++ b/src/core/src/org_usage.rs
@@ -26,7 +26,7 @@ use o2_enterprise::enterprise::{
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::self_reporting::search::get_usage;
+use crate::usage_search::get_usage;
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
 pub struct GetOrgUsageResponseBody {

--- a/src/core/src/organization.rs
+++ b/src/core/src/organization.rs
@@ -15,21 +15,13 @@
 
 use config::{
     DEFAULT_ORG, ider,
-    meta::{
-        alerts::alert::ListAlertsParams,
-        dashboards::ListDashboardsParams,
-        pipeline::components::PipelineSource,
-        self_reporting::usage,
-        stream::StreamType,
-        user::{UserOrg, UserRole},
-    },
-    utils::{json, rand::generate_random_string, time},
+    meta::user::{UserOrg, UserRole},
+    utils::rand::generate_random_string,
 };
 use db::{self, org_users, user::is_root_user};
-use infra::table::{self, org_users::UserOrgExpandedRecord};
+use infra::table::org_users::UserOrgExpandedRecord;
 #[cfg(feature = "enterprise")]
 use o2_openfga::config::get_config as get_openfga_config;
-use stream::get_streams;
 #[cfg(feature = "cloud")]
 use {
     chrono::{Duration, Utc},
@@ -45,18 +37,16 @@ use {
 };
 
 #[cfg(feature = "cloud")]
-use super::self_reporting::cloud_events::{CloudEvent, EventType, enqueue_cloud_event};
+use super::cloud_events::{CloudEvent, EventType, enqueue_cloud_event};
 use crate::{
     auth::{delete_org_tuples, save_org_tuples},
     common::{
         infra::config::ORG_USERS,
         meta::organization::{
-            AlertSummary, CUSTOM, IngestionPasscode, IngestionTokensContainer, OrgSummary,
-            Organization, PipelineSummary, RumIngestionToken, StreamSummary, TriggerStatus,
-            TriggerStatusSearchResult,
+            CUSTOM, IngestionPasscode, IngestionTokensContainer, Organization, RumIngestionToken,
         },
     },
-    ingestion_tokens, self_reporting,
+    ingestion_tokens,
     users::add_admin_to_org,
 };
 
@@ -111,87 +101,6 @@ async fn create_and_assign_sre_readonly_role(
         service_account_email,
     )
     .await
-}
-
-pub async fn get_summary(org_id: &str) -> OrgSummary {
-    let streams = get_streams(org_id, None, false, None).await;
-    let mut stream_summary = StreamSummary::default();
-    let mut has_trigger_stream = false;
-    for stream in streams.iter() {
-        if stream.name == usage::TRIGGERS_STREAM {
-            has_trigger_stream = true;
-        }
-        if !stream.stream_type.eq(&StreamType::Index)
-            && !stream.stream_type.eq(&StreamType::Metadata)
-        {
-            stream_summary.num_streams += 1;
-            stream_summary.total_records += stream.stats.doc_num;
-            stream_summary.total_storage_size += stream.stats.storage_size;
-            stream_summary.total_compressed_size += stream.stats.compressed_size;
-            stream_summary.total_index_size += stream.stats.index_size;
-        }
-    }
-
-    let trigger_status_results = if !has_trigger_stream {
-        vec![]
-    } else {
-        let sql = format!(
-            "SELECT module, status FROM {} WHERE org = '{}' GROUP BY module, status, key",
-            usage::TRIGGERS_STREAM,
-            org_id
-        );
-        let end_time = time::now_micros();
-        let start_time = end_time - time::second_micros(900); // 15 mins
-        self_reporting::search::get_usage(sql, start_time, end_time, false)
-            .await
-            .unwrap_or_default()
-            .into_iter()
-            .filter_map(|v| json::from_value::<TriggerStatusSearchResult>(v).ok())
-            .collect::<Vec<_>>()
-    };
-
-    let pipelines = super::pipeline::list_user_pipelines(org_id, None)
-        .await
-        .unwrap_or_default();
-    let pipeline_summary = PipelineSummary {
-        num_realtime: pipelines
-            .iter()
-            .filter(|p| matches!(p.source, PipelineSource::Realtime(_)))
-            .count() as i64,
-        num_scheduled: pipelines
-            .iter()
-            .filter(|p| matches!(p.source, PipelineSource::Scheduled(_)))
-            .count() as i64,
-        trigger_status: TriggerStatus::from_search_results(
-            &trigger_status_results,
-            usage::TriggerDataType::DerivedStream,
-        ),
-    };
-
-    let alerts = super::alerts::alert::list_with_folders_db(ListAlertsParams::new(org_id))
-        .await
-        .unwrap_or_default();
-    let alert_summary = AlertSummary {
-        num_realtime: alerts.iter().filter(|(_, a)| a.is_real_time).count() as i64,
-        num_scheduled: alerts.iter().filter(|(_, a)| !a.is_real_time).count() as i64,
-        trigger_status: TriggerStatus::from_search_results(
-            &trigger_status_results,
-            usage::TriggerDataType::Alert,
-        ),
-    };
-
-    let functions = db::functions::list(org_id).await.unwrap_or_default();
-    let dashboards = table::dashboards::list(ListDashboardsParams::new(org_id))
-        .await
-        .unwrap_or_default();
-
-    OrgSummary {
-        streams: stream_summary,
-        pipelines: pipeline_summary,
-        alerts: alert_summary,
-        total_functions: functions.len() as i64,
-        total_dashboards: dashboards.len() as i64,
-    }
 }
 
 pub async fn get_passcode(

--- a/src/core/src/pipeline/cache.rs
+++ b/src/core/src/pipeline/cache.rs
@@ -17,7 +17,7 @@ use std::sync::LazyLock as Lazy;
 
 use config::{RwAHashMap, meta::stream::StreamParams};
 
-use crate::pipeline::batch_execution::ExecutablePipeline;
+use super::batch_execution::ExecutablePipeline;
 
 pub static STREAM_EXECUTABLE_PIPELINES: Lazy<RwAHashMap<StreamParams, Vec<ExecutablePipeline>>> =
     Lazy::new(Default::default);

--- a/src/core/src/pipeline/db.rs
+++ b/src/core/src/pipeline/db.rs
@@ -28,9 +28,8 @@ use infra::{
 };
 
 use crate::{
-    cache::STREAM_EXECUTABLE_PIPELINES,
     common::infra::config::{PIPELINE_ID_TO_ORG, PIPELINE_STREAM_MAPPING, SCHEDULED_PIPELINES},
-    pipeline::batch_execution::ExecutablePipeline,
+    pipeline::{batch_execution::ExecutablePipeline, cache::STREAM_EXECUTABLE_PIPELINES},
 };
 
 #[derive(Debug, thiserror::Error)]

--- a/src/core/src/pipeline/mod.rs
+++ b/src/core/src/pipeline/mod.rs
@@ -31,6 +31,7 @@ use config::meta::{
 use self::{db as pipeline, db::PipelineError};
 
 pub mod batch_execution;
+pub mod cache;
 pub mod db;
 
 /// Validates that no JavaScript functions are used in the pipeline.
@@ -383,7 +384,7 @@ pub async fn delete_pipeline(pipeline_id: &str) -> Result<(), PipelineError> {
     }
 
     // Delete all backfill jobs associated with this pipeline
-    if let Err(error) = super::alerts::backfill::delete_backfill_jobs_by_pipeline(
+    if let Err(error) = super::backfill_cleanup::delete_backfill_jobs_by_pipeline(
         &existing_pipeline.org,
         pipeline_id,
     )

--- a/src/core/src/self_reporting/cloud_events.rs
+++ b/src/core/src/self_reporting/cloud_events.rs
@@ -1,49 +1,14 @@
-use std::sync::LazyLock as Lazy;
+//! The consumer half of cloud event reporting: draining the queue to the usage stream and/or the
+//! external reporting endpoint. The event types and the enqueue path live in
+//! [`crate::cloud_events`], which carries no dependencies so that ingestion can reach it.
 
 use config::{META_ORG_ID, meta::stream::StreamType, utils::json};
 use o2_enterprise::enterprise::common::config::get_config;
 use proto::cluster_rpc;
-use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
 
-use crate::ingestion::ingestion_service;
+use crate::{cloud_events::CLOUD_EVENT_QUEUE, ingestion::ingestion_service};
 
 const CLOUD_EVENT_STREAM: &str = "cloud_events";
-
-#[derive(Serialize, Deserialize, Debug, Hash)]
-pub enum EventType {
-    OrgCreated,
-    OrgDeleted,
-    OrgCleanupFailed,
-    UserJoined,
-    CheckoutSessionCreated,
-    SubscriptionCreated,
-    SubscriptionChanged,
-    SubscriptionDeleted,
-    StreamCreated,
-}
-
-#[derive(Serialize, Deserialize, Debug, Hash)]
-pub struct CloudEvent {
-    pub org_id: String,
-    pub org_name: String,
-    pub org_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<String>,
-    pub event: EventType,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub subscription_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stream_name: Option<String>,
-}
-
-pub(super) static CLOUD_EVENT_QUEUE: Lazy<Mutex<Vec<CloudEvent>>> =
-    Lazy::new(|| Mutex::new(vec![]));
-
-pub async fn enqueue_cloud_event(event: CloudEvent) {
-    let mut q = CLOUD_EVENT_QUEUE.lock().await;
-    q.push(event);
-}
 
 async fn _inner_flush() {
     let cfg = get_config();

--- a/src/core/src/self_reporting/mod.rs
+++ b/src/core/src/self_reporting/mod.rs
@@ -21,7 +21,6 @@ mod ingestion;
 #[cfg(feature = "enterprise")]
 pub mod llm_scores_schema;
 pub(crate) mod persistence;
-pub mod search;
 mod triggers_schema;
 mod usage_schema;
 

--- a/src/core/src/service_graph_query.rs
+++ b/src/core/src/service_graph_query.rs
@@ -1,0 +1,238 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Reader for the `_o2_service_graph` stream.
+//!
+//! Kept apart from [`crate::traces::service_graph`] because reading the stream only needs the
+//! search service, while the rest of that module builds and writes the graph off the trace
+//! ingestion path. Incident topology enrichment reads the graph and must not drag traces in with
+//! it, so the query lives here.
+
+/// Default window (in minutes) used when no explicit time range is provided.
+/// The UI has its own time range picker, so this only applies as the server-side fallback.
+pub const DEFAULT_QUERY_WINDOW_MINUTES: i64 = 60;
+
+/// Build the SQL used to read edge records from the `_o2_service_graph` stream.
+///
+/// Pure helper (no DB access) so the query construction can be unit-tested.
+///
+/// `agent_pred` is an optional, caller-built predicate fragment (e.g.
+/// `agent_env = 'prod'`) appended to the WHERE clause. When `None`, the emitted
+/// SQL is byte-identical to the pre-B4 query so behavior is unchanged.
+///
+/// NOTE: This stream is version-agnostic — there is no `agent_version` column,
+/// so predicates must never reference it.
+#[cfg(feature = "enterprise")]
+fn build_edges_sql(
+    stream_name: &str,
+    stream_filter: Option<&str>,
+    start_time: i64,
+    end_time: i64,
+    org_id: &str,
+    agent_pred: Option<&str>,
+) -> String {
+    let agent_clause = agent_pred
+        .map(|p| format!("\n             AND {p}"))
+        .unwrap_or_default();
+    if let Some(stream) = stream_filter {
+        format!(
+            "SELECT * FROM \"{}\"
+             WHERE _timestamp >= {} AND _timestamp < {}
+             AND org_id = '{}'
+             AND trace_stream_name = '{}'{}
+             LIMIT 10000",
+            stream_name, start_time, end_time, org_id, stream, agent_clause
+        )
+    } else {
+        format!(
+            "SELECT * FROM \"{}\"
+             WHERE _timestamp >= {} AND _timestamp < {}
+             AND org_id = '{}'{}
+             LIMIT 10000",
+            stream_name, start_time, end_time, org_id, agent_clause
+        )
+    }
+}
+
+#[cfg(feature = "enterprise")]
+/// Query edge records from the _o2_service_graph stream
+///
+/// Internal version exposed for incident topology enrichment.
+/// Supports optional custom time range via start_time/end_time parameters.
+///
+/// `agent_pred` is an optional predicate fragment (env-only, version-agnostic)
+/// appended to the WHERE clause to scope edges to the selected agent env.
+pub async fn query_edges_from_stream_internal(
+    org_id: &str,
+    stream_filter: Option<&str>,
+    custom_start_time: Option<i64>,
+    custom_end_time: Option<i64>,
+    agent_pred: Option<&str>,
+) -> Result<Vec<serde_json::Value>, infra::errors::Error> {
+    use config::meta::stream::StreamType;
+
+    let stream_name = "_o2_service_graph";
+
+    // Use custom time range if provided, otherwise fall back to configured window
+    let (start_time, end_time) =
+        if let (Some(start), Some(end)) = (custom_start_time, custom_end_time) {
+            (start, end)
+        } else {
+            let now = chrono::Utc::now().timestamp_micros();
+            let window_micros = DEFAULT_QUERY_WINDOW_MINUTES * 60 * 1_000_000;
+            (now - window_micros, now)
+        };
+
+    // Query pre-aggregated edge state (already summarized per minute)
+    let sql = build_edges_sql(
+        stream_name,
+        stream_filter,
+        start_time,
+        end_time,
+        org_id,
+        agent_pred,
+    );
+
+    // Build search request
+    let req = config::meta::search::Request {
+        query: config::meta::search::Query {
+            sql: sql.clone(),
+            from: 0,
+            size: 100000,
+            start_time,
+            end_time,
+            quick_mode: false,
+            query_type: "".to_string(),
+            track_total_hits: false,
+            uses_zo_fn: false,
+            query_fn: None,
+            skip_wal: false,
+            action_id: None,
+            histogram_interval: 0,
+            streaming_id: None,
+            streaming_output: false,
+            sampling_config: None,
+            sampling_ratio: None,
+            timezone: None,
+        },
+        encoding: config::meta::search::RequestEncoding::Empty,
+        regions: vec![],
+        clusters: vec![],
+        timeout: 30,
+        search_type: None,
+        search_event_context: None,
+        use_cache: false,
+        clear_cache: false,
+        local_mode: Some(false),
+        agent_options: None,
+    };
+
+    // Check if stream exists (using Logs type since we write as logs stream)
+    let schema = infra::schema::get(org_id, stream_name, StreamType::Logs).await;
+    if schema.is_err() {
+        log::debug!(
+            "[ServiceGraph] Stream '{}' does not exist yet for org '{}'",
+            stream_name,
+            org_id
+        );
+        return Ok(Vec::new());
+    }
+
+    // Execute search
+    let trace_id = config::ider::generate();
+    let resp = crate::search::search(&trace_id, org_id, StreamType::Logs, None, &req)
+        .await
+        .map_err(|e| {
+            log::error!("[ServiceGraph] Stream query failed: {}", e);
+            infra::errors::Error::ErrorCode(infra::errors::ErrorCodes::SearchStreamNotFound(
+                stream_name.to_string(),
+            ))
+        })?;
+
+    log::debug!(
+        "[ServiceGraph] Retrieved {} edge records from stream for org '{}'",
+        resp.hits.len(),
+        org_id
+    );
+
+    Ok(resp.hits)
+}
+
+#[cfg(all(test, feature = "enterprise"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_edges_sql_none_pred_is_byte_identical_unfiltered() {
+        // When agent_pred is None and no stream filter, the SQL must be
+        // byte-identical to the pre-B4 baseline query.
+        let expected = "SELECT * FROM \"_o2_service_graph\"
+             WHERE _timestamp >= 100 AND _timestamp < 200
+             AND org_id = 'org1'
+             LIMIT 10000";
+        let sql = build_edges_sql("_o2_service_graph", None, 100, 200, "org1", None);
+        assert_eq!(sql, expected);
+    }
+
+    #[test]
+    fn test_build_edges_sql_none_pred_is_byte_identical_stream_filtered() {
+        // When agent_pred is None with a stream filter, the SQL must be
+        // byte-identical to the pre-B4 stream-filtered query.
+        let expected = "SELECT * FROM \"_o2_service_graph\"
+             WHERE _timestamp >= 100 AND _timestamp < 200
+             AND org_id = 'org1'
+             AND trace_stream_name = 'my_stream'
+             LIMIT 10000";
+        let sql = build_edges_sql(
+            "_o2_service_graph",
+            Some("my_stream"),
+            100,
+            200,
+            "org1",
+            None,
+        );
+        assert_eq!(sql, expected);
+    }
+
+    #[test]
+    fn test_build_edges_sql_with_pred_unfiltered() {
+        let sql = build_edges_sql(
+            "_o2_service_graph",
+            None,
+            100,
+            200,
+            "org1",
+            Some("agent_env = 'prod'"),
+        );
+        assert!(sql.contains("agent_env = 'prod'"));
+        assert!(sql.contains("AND agent_env = 'prod'"));
+        assert!(sql.contains("LIMIT 10000"));
+    }
+
+    #[test]
+    fn test_build_edges_sql_with_pred_stream_filtered() {
+        let sql = build_edges_sql(
+            "_o2_service_graph",
+            Some("my_stream"),
+            100,
+            200,
+            "org1",
+            Some("agent_env = 'prod'"),
+        );
+        assert!(sql.contains("agent_env = 'prod'"));
+        assert!(sql.contains("AND trace_stream_name = 'my_stream'"));
+        assert!(sql.contains("AND agent_env = 'prod'"));
+    }
+}

--- a/src/core/src/traces/agent_signals/api.rs
+++ b/src/core/src/traces/agent_signals/api.rs
@@ -140,9 +140,9 @@ pub async fn get_agent_signals(
 /// rollup-write bound — not the span-time window. 30 days matches the FE's
 /// version-enumeration retention.
 ///
-/// Only referenced from the enterprise compare path; also compiled under `test`
-/// so the pure-helper unit tests below build in the OSS (non-enterprise) config.
-#[cfg(any(feature = "enterprise", test))]
+/// Only referenced from the enterprise compare path. Unlike the pure helpers below it is not
+/// compiled under `test`: no test uses it, so an OSS test build would flag it as dead code.
+#[cfg(feature = "enterprise")]
 const COMPARE_ROLLUP_LOOKBACK_MICROS: i64 = 30 * 24 * 60 * 60 * 1_000_000;
 
 /// One arm (A or B) of a version-compare request.

--- a/src/core/src/traces/mod.rs
+++ b/src/core/src/traces/mod.rs
@@ -1341,17 +1341,15 @@ async fn write_traces_by_stream(
         {
             let org = super::organization::get_org(org_id).await.unwrap();
 
-            super::self_reporting::cloud_events::enqueue_cloud_event(
-                super::self_reporting::cloud_events::CloudEvent {
-                    org_id: org.identifier.clone(),
-                    org_name: org.name.clone(),
-                    org_type: org.org_type.clone(),
-                    user: None,
-                    event: super::self_reporting::cloud_events::EventType::StreamCreated,
-                    subscription_type: None,
-                    stream_name: Some(traces_stream_name.clone()),
-                },
-            )
+            super::cloud_events::enqueue_cloud_event(super::cloud_events::CloudEvent {
+                org_id: org.identifier.clone(),
+                org_name: org.name.clone(),
+                org_type: org.org_type.clone(),
+                user: None,
+                event: super::cloud_events::EventType::StreamCreated,
+                subscription_type: None,
+                stream_name: Some(traces_stream_name.clone()),
+            })
             .await;
         }
 

--- a/src/core/src/traces/service_graph/api.rs
+++ b/src/core/src/traces/service_graph/api.rs
@@ -22,6 +22,9 @@ use axum::response::Response as HttpResponse;
 use common::meta::http::HttpResponse as MetaHttpResponse;
 use serde::Deserialize;
 
+#[cfg(feature = "enterprise")]
+use crate::service_graph_query::query_edges_from_stream_internal;
+
 /// Query parameters for service graph API
 #[derive(Debug, Deserialize)]
 pub struct ServiceGraphQuery {
@@ -219,152 +222,6 @@ fn aggregate_baselines(
             Some((key, (sp50 / total, sp95 / total, sp99 / total)))
         })
         .collect()
-}
-
-/// Build the SQL used to read edge records from the `_o2_service_graph` stream.
-///
-/// Pure helper (no DB access) so the query construction can be unit-tested.
-///
-/// `agent_pred` is an optional, caller-built predicate fragment (e.g.
-/// `agent_env = 'prod'`) appended to the WHERE clause. When `None`, the emitted
-/// SQL is byte-identical to the pre-B4 query so behavior is unchanged.
-///
-/// NOTE: This stream is version-agnostic — there is no `agent_version` column,
-/// so predicates must never reference it.
-#[cfg(feature = "enterprise")]
-fn build_edges_sql(
-    stream_name: &str,
-    stream_filter: Option<&str>,
-    start_time: i64,
-    end_time: i64,
-    org_id: &str,
-    agent_pred: Option<&str>,
-) -> String {
-    let agent_clause = agent_pred
-        .map(|p| format!("\n             AND {p}"))
-        .unwrap_or_default();
-    if let Some(stream) = stream_filter {
-        format!(
-            "SELECT * FROM \"{}\"
-             WHERE _timestamp >= {} AND _timestamp < {}
-             AND org_id = '{}'
-             AND trace_stream_name = '{}'{}
-             LIMIT 10000",
-            stream_name, start_time, end_time, org_id, stream, agent_clause
-        )
-    } else {
-        format!(
-            "SELECT * FROM \"{}\"
-             WHERE _timestamp >= {} AND _timestamp < {}
-             AND org_id = '{}'{}
-             LIMIT 10000",
-            stream_name, start_time, end_time, org_id, agent_clause
-        )
-    }
-}
-
-#[cfg(feature = "enterprise")]
-/// Query edge records from the _o2_service_graph stream
-///
-/// Internal version exposed for incident topology enrichment.
-/// Supports optional custom time range via start_time/end_time parameters.
-///
-/// `agent_pred` is an optional predicate fragment (env-only, version-agnostic)
-/// appended to the WHERE clause to scope edges to the selected agent env.
-pub async fn query_edges_from_stream_internal(
-    org_id: &str,
-    stream_filter: Option<&str>,
-    custom_start_time: Option<i64>,
-    custom_end_time: Option<i64>,
-    agent_pred: Option<&str>,
-) -> Result<Vec<serde_json::Value>, infra::errors::Error> {
-    use config::meta::stream::StreamType;
-
-    let stream_name = "_o2_service_graph";
-
-    // Use custom time range if provided, otherwise fall back to configured window
-    let (start_time, end_time) =
-        if let (Some(start), Some(end)) = (custom_start_time, custom_end_time) {
-            (start, end)
-        } else {
-            let now = chrono::Utc::now().timestamp_micros();
-            let window_micros = super::DEFAULT_QUERY_WINDOW_MINUTES * 60 * 1_000_000;
-            (now - window_micros, now)
-        };
-
-    // Query pre-aggregated edge state (already summarized per minute)
-    let sql = build_edges_sql(
-        stream_name,
-        stream_filter,
-        start_time,
-        end_time,
-        org_id,
-        agent_pred,
-    );
-
-    // Build search request
-    let req = config::meta::search::Request {
-        query: config::meta::search::Query {
-            sql: sql.clone(),
-            from: 0,
-            size: 100000,
-            start_time,
-            end_time,
-            quick_mode: false,
-            query_type: "".to_string(),
-            track_total_hits: false,
-            uses_zo_fn: false,
-            query_fn: None,
-            skip_wal: false,
-            action_id: None,
-            histogram_interval: 0,
-            streaming_id: None,
-            streaming_output: false,
-            sampling_config: None,
-            sampling_ratio: None,
-            timezone: None,
-        },
-        encoding: config::meta::search::RequestEncoding::Empty,
-        regions: vec![],
-        clusters: vec![],
-        timeout: 30,
-        search_type: None,
-        search_event_context: None,
-        use_cache: false,
-        clear_cache: false,
-        local_mode: Some(false),
-        agent_options: None,
-    };
-
-    // Check if stream exists (using Logs type since we write as logs stream)
-    let schema = infra::schema::get(org_id, stream_name, StreamType::Logs).await;
-    if schema.is_err() {
-        log::debug!(
-            "[ServiceGraph] Stream '{}' does not exist yet for org '{}'",
-            stream_name,
-            org_id
-        );
-        return Ok(Vec::new());
-    }
-
-    // Execute search
-    let trace_id = config::ider::generate();
-    let resp = crate::search::search(&trace_id, org_id, StreamType::Logs, None, &req)
-        .await
-        .map_err(|e| {
-            log::error!("[ServiceGraph] Stream query failed: {}", e);
-            infra::errors::Error::ErrorCode(infra::errors::ErrorCodes::SearchStreamNotFound(
-                stream_name.to_string(),
-            ))
-        })?;
-
-    log::debug!(
-        "[ServiceGraph] Retrieved {} edge records from stream for org '{}'",
-        resp.hits.len(),
-        org_id
-    );
-
-    Ok(resp.hits)
 }
 
 /// Query parameters for edge trend endpoint
@@ -638,68 +495,6 @@ mod tests {
         let records = vec![make_record(Some("svc-a"), "svc-b", 100, 200, 300, 0)];
         let result = aggregate_baselines(records);
         assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_build_edges_sql_none_pred_is_byte_identical_unfiltered() {
-        // When agent_pred is None and no stream filter, the SQL must be
-        // byte-identical to the pre-B4 baseline query.
-        let expected = "SELECT * FROM \"_o2_service_graph\"
-             WHERE _timestamp >= 100 AND _timestamp < 200
-             AND org_id = 'org1'
-             LIMIT 10000";
-        let sql = build_edges_sql("_o2_service_graph", None, 100, 200, "org1", None);
-        assert_eq!(sql, expected);
-    }
-
-    #[test]
-    fn test_build_edges_sql_none_pred_is_byte_identical_stream_filtered() {
-        // When agent_pred is None with a stream filter, the SQL must be
-        // byte-identical to the pre-B4 stream-filtered query.
-        let expected = "SELECT * FROM \"_o2_service_graph\"
-             WHERE _timestamp >= 100 AND _timestamp < 200
-             AND org_id = 'org1'
-             AND trace_stream_name = 'my_stream'
-             LIMIT 10000";
-        let sql = build_edges_sql(
-            "_o2_service_graph",
-            Some("my_stream"),
-            100,
-            200,
-            "org1",
-            None,
-        );
-        assert_eq!(sql, expected);
-    }
-
-    #[test]
-    fn test_build_edges_sql_with_pred_unfiltered() {
-        let sql = build_edges_sql(
-            "_o2_service_graph",
-            None,
-            100,
-            200,
-            "org1",
-            Some("agent_env = 'prod'"),
-        );
-        assert!(sql.contains("agent_env = 'prod'"));
-        assert!(sql.contains("AND agent_env = 'prod'"));
-        assert!(sql.contains("LIMIT 10000"));
-    }
-
-    #[test]
-    fn test_build_edges_sql_with_pred_stream_filtered() {
-        let sql = build_edges_sql(
-            "_o2_service_graph",
-            Some("my_stream"),
-            100,
-            200,
-            "org1",
-            Some("agent_env = 'prod'"),
-        );
-        assert!(sql.contains("agent_env = 'prod'"));
-        assert!(sql.contains("AND trace_stream_name = 'my_stream'"));
-        assert!(sql.contains("AND agent_env = 'prod'"));
     }
 
     #[test]

--- a/src/core/src/traces/service_graph/mod.rs
+++ b/src/core/src/traces/service_graph/mod.rs
@@ -18,9 +18,11 @@
 //! Daemon-based service graph that queries traces periodically.
 //! No inline processing during trace ingestion.
 
-/// Default window (in minutes) used when no explicit time range is provided.
-/// The UI has its own time range picker, so this only applies as the server-side fallback.
-pub const DEFAULT_QUERY_WINDOW_MINUTES: i64 = 60;
+// The stream reader lives outside this module so that incident topology enrichment can use it
+// without depending on traces; see `crate::service_graph_query`.
+pub use crate::service_graph_query::DEFAULT_QUERY_WINDOW_MINUTES;
+#[cfg(feature = "enterprise")]
+pub use crate::service_graph_query::query_edges_from_stream_internal;
 
 // OSS modules
 pub mod aggregator;
@@ -30,8 +32,6 @@ pub mod processor;
 // Re-export API handler for router
 // Re-export aggregator function (used by processor)
 pub use aggregator::write_sql_aggregated_edges;
-#[cfg(feature = "enterprise")]
-pub use api::query_edges_from_stream_internal;
 pub use api::{get_current_topology, get_edge_history};
 // Re-export enterprise types and functions
 #[cfg(feature = "enterprise")]

--- a/src/core/src/traces/service_graph/processor.rs
+++ b/src/core/src/traces/service_graph/processor.rs
@@ -71,7 +71,7 @@ pub async fn process_service_graph() -> Result<(), anyhow::Error> {
         GROUP BY org_id, stream_name"#
         .to_string();
 
-    let usage_results = match crate::self_reporting::search::get_usage(
+    let usage_results = match crate::usage_search::get_usage(
         sql,
         last_updated_at,
         next_updated_at,

--- a/src/core/src/usage_search.rs
+++ b/src/core/src/usage_search.rs
@@ -13,6 +13,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//! Queries against the self-reporting (`usage`, `triggers`) streams.
+//!
+//! This lives outside `self_reporting` on purpose: reading those streams only needs the search
+//! service, while `self_reporting` itself writes through the ingestion path. Keeping the reader
+//! here lets low-level callers (organization summaries, the service graph) query usage without
+//! depending on the ingestion side.
+
 use anyhow::{Result, anyhow};
 use config::{
     META_ORG_ID, ider,

--- a/src/core/src/workflow_execution.rs
+++ b/src/core/src/workflow_execution.rs
@@ -1,0 +1,379 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Running a workflow, as opposed to defining one.
+//!
+//! Execution needs `ExecutablePipeline`, which sits above the alerting code -- but alerts also
+//! fire workflows as a notification target, so [`crate::workflows`] has to stay below them. That
+//! module therefore keeps the definitions, CRUD and the trigger-enqueue path, and everything that
+//! actually runs a workflow lives here.
+
+use std::{collections::HashMap, sync::Arc};
+
+use config::meta::self_reporting::usage::{TriggerData, TriggerDataStatus, TriggerDataType};
+use infra::{
+    coordinator::get_coordinator,
+    db::Event,
+    table::workflows::{self, WorkflowError, WorkflowRunErrors},
+};
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::common::config::get_config as get_o2_config;
+use serde_json::Value;
+use usage_reporting::publish_triggers_usage;
+
+use crate::{
+    common::utils::get_nats_lock,
+    db,
+    pipeline::batch_execution::{ExecutablePipeline, WorkflowResult},
+    workflows::{
+        InputMap, WorkflowTrigger, get_error_input_data, get_trigger_run_data, get_workflow_by_id,
+        runtime::WORKFLOW_TRIGGER_PREFIX,
+    },
+};
+
+enum WorkflowExecutionStatus {
+    Success,
+    Errored,
+}
+
+pub async fn test_workflow(
+    org_id: &str,
+    id: &str,
+    inputs: Vec<serde_json::Value>,
+    from_node: Option<String>,
+) -> Result<WorkflowResult, anyhow::Error> {
+    let workflow = get_workflow_by_id(org_id, id)
+        .await?
+        .ok_or(anyhow::anyhow!("workflow with given id not found"))?;
+    let executable = ExecutablePipeline::new_from_workflow(&workflow).await?;
+
+    let res = executable
+        .process_workflow(org_id, inputs, from_node)
+        .await?;
+    Ok(res)
+}
+
+async fn execute_workflow(
+    org_id: &str,
+    id: &str,
+    run_id: &str,
+    inputs: Vec<serde_json::Value>,
+) -> Result<WorkflowExecutionStatus, anyhow::Error> {
+    let workflow = get_workflow_by_id(org_id, id)
+        .await?
+        .ok_or(anyhow::anyhow!("workflow with given id not found"))?;
+
+    if !workflow.enabled {
+        return Ok(WorkflowExecutionStatus::Success);
+    }
+
+    let executable = ExecutablePipeline::new_from_workflow(&workflow).await?;
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let input_copy = inputs.clone();
+    let res = executable.process_workflow(org_id, inputs, None).await?;
+
+    let mut errored_input_map = HashMap::new();
+    let mut workflow_errors = Vec::new();
+
+    for (node_id, errors) in res.errors {
+        let mut inputs = Vec::with_capacity(errors.error_count as usize);
+        let mut err_list = Vec::with_capacity(errors.error_count as usize);
+
+        for (mut e, val) in errors.errors {
+            // because we are storing the errors in db, we don't want to have
+            // a long string * a lot of errors
+            // so we truncate the length here, and then limit the count below
+            e.truncate(100);
+            err_list.push(e);
+            if let Some(mut v) = val {
+                // top level value should always be a single json value,
+                // except when the erroring node was a vrl fn over a result array
+                // in that case we actually want to store the individual entries
+                // instead of the whole array, so we can replay it correctly
+                if let Some(arr) = v.as_array_mut() {
+                    for v in arr.drain(0..) {
+                        inputs.push(v);
+                    }
+                } else {
+                    inputs.push(v);
+                }
+            }
+        }
+        // it is possible that we have errors, but no corresponding inputs
+        // we should always show the errors to user, so we store it in db
+        // but only create entry in input map if inputs are present
+        if !err_list.is_empty() {
+            err_list.truncate(50);
+            workflow_errors.push(WorkflowError {
+                node_id: node_id.clone(),
+                error: err_list,
+            });
+        }
+        if !inputs.is_empty() {
+            errored_input_map.insert(node_id, inputs);
+        }
+    }
+
+    if !workflow_errors.is_empty() {
+        let ip_map = InputMap {
+            complete: input_copy,
+            node_map: errored_input_map,
+        };
+
+        let errors = WorkflowRunErrors {
+            org_id: org_id.to_string(),
+            cluster: config::get_cluster_name(),
+            id: 0, // will be set directly in db
+            workflow_id: id.to_string(),
+            run_id: run_id.to_string(),
+            ran_at: now,
+            data: workflow_errors,
+            input_data: Some(serde_json::to_string(&ip_map).unwrap()),
+        };
+        // workflow has already run, so not much point in returning error because
+        // we couldn't save the errors to db, log and ignore
+        if let Err(e) = db::workflows::save_workflow_errors(errors).await {
+            log::error!(
+                "[Workflows] : error saving workflow run errors for run id {run_id} for workflow {org_id}/{id} in db : {e}"
+            );
+        }
+        return Ok(WorkflowExecutionStatus::Errored);
+    }
+
+    Ok(WorkflowExecutionStatus::Success)
+}
+
+pub async fn retry_run(
+    org_id: &str,
+    wid: &str,
+    run_id: &str,
+    from_node: Option<String>,
+) -> Result<WorkflowResult, anyhow::Error> {
+    let workflow = workflows::get_by_org_wid(org_id, wid)
+        .await?
+        .ok_or(anyhow::anyhow!("workflow with given id not found"))?;
+    let executable = ExecutablePipeline::new_from_workflow(&workflow).await?;
+
+    let errors = match workflows::list_errors_for_workflow_run(org_id, wid, run_id).await {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            return Err(anyhow::anyhow!("Errored run info not found"));
+        }
+        Err(e) => {
+            log::error!(
+                "error getting workflow run error info from db for {org_id}/{wid} run_id {run_id} : {e}"
+            );
+            return Err(anyhow::anyhow!("error getting workflow run info : {e}"));
+        }
+    };
+
+    let data_str = match get_error_input_data(&errors).await {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!(
+                "error getting workflow run error input file for {org_id}/{wid} run_id {run_id} : {e}"
+            );
+            return Err(anyhow::anyhow!("error getting workflow run info : {e}"));
+        }
+    };
+
+    let mut ip_map: InputMap = serde_json::from_str(&data_str).map_err(|e| {
+        log::error!(
+            "error deserializing input data for workflow {org_id}/{wid} run id {run_id} : {e}"
+        );
+        anyhow::anyhow!("error deserializing inputs : {e}")
+    })?;
+
+    let inputs = match from_node.as_ref() {
+        Some(node) => ip_map.node_map.remove(node).ok_or(anyhow::anyhow!(
+            "node id {node} does not have any associated input data in the stored inputs"
+        ))?,
+        None => ip_map.complete,
+    };
+
+    let res = executable
+        .process_workflow(org_id, inputs, from_node)
+        .await?;
+    Ok(res)
+}
+
+pub async fn handle_workflow_trigger(trigger: WorkflowTrigger) {
+    let o2_cfg = get_o2_config();
+    if !o2_cfg.common.workflows_enabled {
+        return;
+    }
+    match get_nats_lock(format!(
+        "/workflow-trigger-{:?}-handler",
+        trigger.trigger_type
+    ))
+    .await
+    {
+        Err(e) => {
+            log::error!(
+                "error getting lock for workflow handling for event {:?} with trace id {} source id {} for workflow id {}, skipping : {e}",
+                trigger.trigger_type,
+                trigger.trace_id,
+                trigger.source_id,
+                trigger.workflow_id,
+            );
+            return;
+        }
+        Ok(node) => {
+            if node != config::cluster::LOCAL_NODE.uuid {
+                log::debug!(
+                    "lock for workflow handling for event {:?} is obtained by node {node} for trace id {} source id {} for workflow id {}, skipping",
+                    trigger.trigger_type,
+                    trigger.trace_id,
+                    trigger.source_id,
+                    trigger.workflow_id,
+                );
+                return;
+            }
+        }
+    }
+
+    let run_id = trigger.run_id.clone();
+    log::info!(
+        "received workflow trigger for event {:?} with trace id {} source id {} for workflow id {}, assigning run id {}",
+        trigger.trigger_type,
+        trigger.trace_id,
+        trigger.source_id,
+        trigger.workflow_id,
+        run_id
+    );
+
+    let trace_id = trigger.trace_id;
+
+    let file_data = match get_trigger_run_data(
+        &trigger.origin_cluster,
+        &trigger.org_id,
+        &trigger.workflow_id,
+        &trigger.run_id,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!(
+                "[workflow_trigger {trace_id}] run id {run_id} error getting data file : {e}, skipping"
+            );
+            return;
+        }
+    };
+
+    let data: Vec<Value> = match serde_json::from_str(&file_data) {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!(
+                "[workflow_trigger {trace_id}] run id {run_id} error deserializing run data for {}/{}/{} : {e}, skipping",
+                trigger.org_id,
+                trigger.workflow_id,
+                trigger.run_id
+            );
+            return;
+        }
+    };
+
+    let final_data = serde_json::json!({
+        "meta":trigger.metadata,
+        "data": data
+    });
+
+    let start_time = chrono::Utc::now().timestamp_micros();
+    let workflow_run_result = execute_workflow(
+        &trigger.org_id,
+        &trigger.workflow_id,
+        &run_id,
+        vec![final_data],
+    )
+    .await;
+    let end_time = chrono::Utc::now().timestamp_micros();
+
+    let error = match workflow_run_result {
+        Ok(WorkflowExecutionStatus::Errored) => {
+            Some("some node errored during execution".to_string())
+        }
+        Err(e) => Some(e.to_string()),
+        _ => None,
+    };
+
+    let trigger_data_stream: TriggerData = TriggerData {
+        _timestamp: start_time,
+        org: trigger.org_id.clone(),
+        module: TriggerDataType::Workflow,
+        // this order matters in the workflow history api, as we parse this there
+        key: format!(
+            "{}/{:?}/{}/{}",
+            trigger.workflow_id, trigger.trigger_type, trigger.source_id, run_id
+        ),
+        is_realtime: false,
+        is_silenced: false,
+        status: TriggerDataStatus::Completed,
+        start_time,
+        end_time,
+        error,
+        source_node: Some(config::cluster::LOCAL_NODE.name.clone()),
+        evaluation_took_in_secs: Some((end_time - start_time) as f64 / 1_000_000.0),
+        scheduler_trace_id: Some(trace_id.clone()),
+        ..Default::default()
+    };
+    publish_triggers_usage(trigger_data_stream);
+
+    if let Err(e) = infra::table::workflows::delete_run_data(
+        &trigger.org_id,
+        &trigger.workflow_id,
+        &trigger.run_id,
+    )
+    .await
+    {
+        log::error!(
+            "error deleting run data from db for {}/{}/{} : {e}",
+            trigger.org_id,
+            trigger.workflow_id,
+            trigger.run_id
+        );
+    }
+
+    log::info!("[workflow_trigger {trace_id}] run id {run_id} completed execution");
+}
+
+pub async fn watch_workflow_triggers() -> Result<(), anyhow::Error> {
+    let mut events = get_coordinator()
+        .await
+        .watch(WORKFLOW_TRIGGER_PREFIX)
+        .await?;
+    let events = Arc::get_mut(&mut events).unwrap();
+    log::info!("Start watching workflow triggers");
+
+    loop {
+        let Some(event) = events.recv().await else {
+            log::error!("watch_workflow_triggers: event channel closed");
+            return Ok(());
+        };
+
+        if let Event::Put(event) = event {
+            let Some(value) = event.value else {
+                log::error!("watch_workflow_triggers: missing value for put");
+                continue;
+            };
+            let Ok(trigger) = serde_json::from_slice::<WorkflowTrigger>(&value) else {
+                log::error!("watch_workflow_triggers: invalid json value for put");
+                continue;
+            };
+            handle_workflow_trigger(trigger).await;
+        }
+    }
+}

--- a/src/core/src/workflows/mod.rs
+++ b/src/core/src/workflows/mod.rs
@@ -15,25 +15,18 @@
 
 use std::collections::HashMap;
 
-use config::meta::{
-    pipeline::components::NodeData,
-    self_reporting::usage::{TriggerData, TriggerDataStatus, TriggerDataType},
-};
+use config::meta::pipeline::components::NodeData;
 use db::{
     self,
     authz::{remove_ownership, set_ownership},
 };
-use infra::table::workflows::{self, Workflow, WorkflowError, WorkflowRunData, WorkflowRunErrors};
+use infra::table::workflows::{self, Workflow, WorkflowRunData, WorkflowRunErrors};
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::common::config::get_config as get_o2_config;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use usage_reporting::publish_triggers_usage;
 
-use crate::{
-    common::{infra::config::ALERTS, meta::authz::Authz, utils::get_nats_lock},
-    pipeline::batch_execution::{ExecutablePipeline, WorkflowResult},
-};
+use crate::common::{infra::config::ALERTS, meta::authz::Authz};
 
 pub mod runtime;
 
@@ -54,8 +47,8 @@ impl From<&str> for WorkflowTriggerType {
 
 #[derive(Serialize, Deserialize)]
 pub struct InputMap {
-    complete: Vec<Value>,
-    node_map: HashMap<String, Vec<Value>>,
+    pub(crate) complete: Vec<Value>,
+    pub(crate) node_map: HashMap<String, Vec<Value>>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -68,11 +61,6 @@ pub struct WorkflowTrigger {
     pub metadata: HashMap<String, String>,
     pub run_id: String,
     pub origin_cluster: String,
-}
-
-enum WorkflowExecutionStatus {
-    Success,
-    Errored,
 }
 
 // this function does not return error, as we do not have retry.
@@ -93,7 +81,7 @@ async fn store_inputs_error_locally(mut errors: WorkflowRunErrors, data: String)
 }
 
 // TODO YJDoc2: reuse in the get_inputs_file_data fn below
-async fn get_trigger_run_data(
+pub(crate) async fn get_trigger_run_data(
     source_cluster: &str,
     org_id: &str,
     workflow_id: &str,
@@ -380,174 +368,12 @@ pub async fn delete_workflow(org_id: &str, id: &str) -> Result<(), anyhow::Error
     Ok(())
 }
 
-pub async fn test_workflow(
-    org_id: &str,
-    id: &str,
-    inputs: Vec<serde_json::Value>,
-    from_node: Option<String>,
-) -> Result<WorkflowResult, anyhow::Error> {
-    let workflow = get_workflow_by_id(org_id, id)
-        .await?
-        .ok_or(anyhow::anyhow!("workflow with given id not found"))?;
-    let executable = ExecutablePipeline::new_from_workflow(&workflow).await?;
-
-    let res = executable
-        .process_workflow(org_id, inputs, from_node)
-        .await?;
-    Ok(res)
-}
-
-async fn execute_workflow(
-    org_id: &str,
-    id: &str,
-    run_id: &str,
-    inputs: Vec<serde_json::Value>,
-) -> Result<WorkflowExecutionStatus, anyhow::Error> {
-    let workflow = get_workflow_by_id(org_id, id)
-        .await?
-        .ok_or(anyhow::anyhow!("workflow with given id not found"))?;
-
-    if !workflow.enabled {
-        return Ok(WorkflowExecutionStatus::Success);
-    }
-
-    let executable = ExecutablePipeline::new_from_workflow(&workflow).await?;
-
-    let now = chrono::Utc::now().timestamp_micros();
-    let input_copy = inputs.clone();
-    let res = executable.process_workflow(org_id, inputs, None).await?;
-
-    let mut errored_input_map = HashMap::new();
-    let mut workflow_errors = Vec::new();
-
-    for (node_id, errors) in res.errors {
-        let mut inputs = Vec::with_capacity(errors.error_count as usize);
-        let mut err_list = Vec::with_capacity(errors.error_count as usize);
-
-        for (mut e, val) in errors.errors {
-            // because we are storing the errors in db, we don't want to have
-            // a long string * a lot of errors
-            // so we truncate the length here, and then limit the count below
-            e.truncate(100);
-            err_list.push(e);
-            if let Some(mut v) = val {
-                // top level value should always be a single json value,
-                // except when the erroring node was a vrl fn over a result array
-                // in that case we actually want to store the individual entries
-                // instead of the whole array, so we can replay it correctly
-                if let Some(arr) = v.as_array_mut() {
-                    for v in arr.drain(0..) {
-                        inputs.push(v);
-                    }
-                } else {
-                    inputs.push(v);
-                }
-            }
-        }
-        // it is possible that we have errors, but no corresponding inputs
-        // we should always show the errors to user, so we store it in db
-        // but only create entry in input map if inputs are present
-        if !err_list.is_empty() {
-            err_list.truncate(50);
-            workflow_errors.push(WorkflowError {
-                node_id: node_id.clone(),
-                error: err_list,
-            });
-        }
-        if !inputs.is_empty() {
-            errored_input_map.insert(node_id, inputs);
-        }
-    }
-
-    if !workflow_errors.is_empty() {
-        let ip_map = InputMap {
-            complete: input_copy,
-            node_map: errored_input_map,
-        };
-
-        let errors = WorkflowRunErrors {
-            org_id: org_id.to_string(),
-            cluster: config::get_cluster_name(),
-            id: 0, // will be set directly in db
-            workflow_id: id.to_string(),
-            run_id: run_id.to_string(),
-            ran_at: now,
-            data: workflow_errors,
-            input_data: Some(serde_json::to_string(&ip_map).unwrap()),
-        };
-        // workflow has already run, so not much point in returning error because
-        // we couldn't save the errors to db, log and ignore
-        if let Err(e) = db::workflows::save_workflow_errors(errors).await {
-            log::error!(
-                "[Workflows] : error saving workflow run errors for run id {run_id} for workflow {org_id}/{id} in db : {e}"
-            );
-        }
-        return Ok(WorkflowExecutionStatus::Errored);
-    }
-
-    Ok(WorkflowExecutionStatus::Success)
-}
-
 pub async fn get_workflow_errors(
     org_id: &str,
     wid: &str,
     run_id: &str,
 ) -> Result<Option<WorkflowRunErrors>, anyhow::Error> {
     let res = workflows::get_errors_for_run(org_id, wid, run_id).await?;
-    Ok(res)
-}
-
-pub async fn retry_run(
-    org_id: &str,
-    wid: &str,
-    run_id: &str,
-    from_node: Option<String>,
-) -> Result<WorkflowResult, anyhow::Error> {
-    let workflow = workflows::get_by_org_wid(org_id, wid)
-        .await?
-        .ok_or(anyhow::anyhow!("workflow with given id not found"))?;
-    let executable = ExecutablePipeline::new_from_workflow(&workflow).await?;
-
-    let errors = match workflows::list_errors_for_workflow_run(org_id, wid, run_id).await {
-        Ok(Some(v)) => v,
-        Ok(None) => {
-            return Err(anyhow::anyhow!("Errored run info not found"));
-        }
-        Err(e) => {
-            log::error!(
-                "error getting workflow run error info from db for {org_id}/{wid} run_id {run_id} : {e}"
-            );
-            return Err(anyhow::anyhow!("error getting workflow run info : {e}"));
-        }
-    };
-
-    let data_str = match get_error_input_data(&errors).await {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!(
-                "error getting workflow run error input file for {org_id}/{wid} run_id {run_id} : {e}"
-            );
-            return Err(anyhow::anyhow!("error getting workflow run info : {e}"));
-        }
-    };
-
-    let mut ip_map: InputMap = serde_json::from_str(&data_str).map_err(|e| {
-        log::error!(
-            "error deserializing input data for workflow {org_id}/{wid} run id {run_id} : {e}"
-        );
-        anyhow::anyhow!("error deserializing inputs : {e}")
-    })?;
-
-    let inputs = match from_node.as_ref() {
-        Some(node) => ip_map.node_map.remove(node).ok_or(anyhow::anyhow!(
-            "node id {node} does not have any associated input data in the stored inputs"
-        ))?,
-        None => ip_map.complete,
-    };
-
-    let res = executable
-        .process_workflow(org_id, inputs, from_node)
-        .await?;
     Ok(res)
 }
 
@@ -596,146 +422,6 @@ pub async fn send_workflow_trigger(
     log::info!("successfully sent workflow trigger for trace id {trace_id} run id {run_id}");
 
     Ok(())
-}
-
-pub async fn handle_workflow_trigger(trigger: WorkflowTrigger) {
-    let o2_cfg = get_o2_config();
-    if !o2_cfg.common.workflows_enabled {
-        return;
-    }
-    match get_nats_lock(format!(
-        "/workflow-trigger-{:?}-handler",
-        trigger.trigger_type
-    ))
-    .await
-    {
-        Err(e) => {
-            log::error!(
-                "error getting lock for workflow handling for event {:?} with trace id {} source id {} for workflow id {}, skipping : {e}",
-                trigger.trigger_type,
-                trigger.trace_id,
-                trigger.source_id,
-                trigger.workflow_id,
-            );
-            return;
-        }
-        Ok(node) => {
-            if node != config::cluster::LOCAL_NODE.uuid {
-                log::debug!(
-                    "lock for workflow handling for event {:?} is obtained by node {node} for trace id {} source id {} for workflow id {}, skipping",
-                    trigger.trigger_type,
-                    trigger.trace_id,
-                    trigger.source_id,
-                    trigger.workflow_id,
-                );
-                return;
-            }
-        }
-    }
-
-    let run_id = trigger.run_id.clone();
-    log::info!(
-        "received workflow trigger for event {:?} with trace id {} source id {} for workflow id {}, assigning run id {}",
-        trigger.trigger_type,
-        trigger.trace_id,
-        trigger.source_id,
-        trigger.workflow_id,
-        run_id
-    );
-
-    let trace_id = trigger.trace_id;
-
-    let file_data = match get_trigger_run_data(
-        &trigger.origin_cluster,
-        &trigger.org_id,
-        &trigger.workflow_id,
-        &trigger.run_id,
-    )
-    .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!(
-                "[workflow_trigger {trace_id}] run id {run_id} error getting data file : {e}, skipping"
-            );
-            return;
-        }
-    };
-
-    let data: Vec<Value> = match serde_json::from_str(&file_data) {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!(
-                "[workflow_trigger {trace_id}] run id {run_id} error deserializing run data for {}/{}/{} : {e}, skipping",
-                trigger.org_id,
-                trigger.workflow_id,
-                trigger.run_id
-            );
-            return;
-        }
-    };
-
-    let final_data = serde_json::json!({
-        "meta":trigger.metadata,
-        "data": data
-    });
-
-    let start_time = chrono::Utc::now().timestamp_micros();
-    let workflow_run_result = execute_workflow(
-        &trigger.org_id,
-        &trigger.workflow_id,
-        &run_id,
-        vec![final_data],
-    )
-    .await;
-    let end_time = chrono::Utc::now().timestamp_micros();
-
-    let error = match workflow_run_result {
-        Ok(WorkflowExecutionStatus::Errored) => {
-            Some("some node errored during execution".to_string())
-        }
-        Err(e) => Some(e.to_string()),
-        _ => None,
-    };
-
-    let trigger_data_stream: TriggerData = TriggerData {
-        _timestamp: start_time,
-        org: trigger.org_id.clone(),
-        module: TriggerDataType::Workflow,
-        // this order matters in the workflow history api, as we parse this there
-        key: format!(
-            "{}/{:?}/{}/{}",
-            trigger.workflow_id, trigger.trigger_type, trigger.source_id, run_id
-        ),
-        is_realtime: false,
-        is_silenced: false,
-        status: TriggerDataStatus::Completed,
-        start_time,
-        end_time,
-        error,
-        source_node: Some(config::cluster::LOCAL_NODE.name.clone()),
-        evaluation_took_in_secs: Some((end_time - start_time) as f64 / 1_000_000.0),
-        scheduler_trace_id: Some(trace_id.clone()),
-        ..Default::default()
-    };
-    publish_triggers_usage(trigger_data_stream);
-
-    if let Err(e) = infra::table::workflows::delete_run_data(
-        &trigger.org_id,
-        &trigger.workflow_id,
-        &trigger.run_id,
-    )
-    .await
-    {
-        log::error!(
-            "error deleting run data from db for {}/{}/{} : {e}",
-            trigger.org_id,
-            trigger.workflow_id,
-            trigger.run_id
-        );
-    }
-
-    log::info!("[workflow_trigger {trace_id}] run id {run_id} completed execution");
 }
 
 pub async fn get_data_for_run(

--- a/src/core/src/workflows/runtime.rs
+++ b/src/core/src/workflows/runtime.rs
@@ -13,12 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
-
 use config::get_config;
-use infra::{coordinator::get_coordinator, db::Event};
+use infra::coordinator::get_coordinator;
 
-use super::{WorkflowTrigger, handle_workflow_trigger};
+use super::WorkflowTrigger;
 
 const CHECK_INTERVAL_MIN: u64 = 30;
 pub const WORKFLOW_TRIGGER_PREFIX: &str = "/workflow_trigger/";
@@ -92,32 +90,4 @@ pub async fn send_workflow_trigger(trigger: WorkflowTrigger) -> Result<(), anyho
         }
     }
     Ok(())
-}
-
-pub async fn watch_workflow_triggers() -> Result<(), anyhow::Error> {
-    let mut events = get_coordinator()
-        .await
-        .watch(WORKFLOW_TRIGGER_PREFIX)
-        .await?;
-    let events = Arc::get_mut(&mut events).unwrap();
-    log::info!("Start watching workflow triggers");
-
-    loop {
-        let Some(event) = events.recv().await else {
-            log::error!("watch_workflow_triggers: event channel closed");
-            return Ok(());
-        };
-
-        if let Event::Put(event) = event {
-            let Some(value) = event.value else {
-                log::error!("watch_workflow_triggers: missing value for put");
-                continue;
-            };
-            let Ok(trigger) = serde_json::from_slice::<WorkflowTrigger>(&value) else {
-                log::error!("watch_workflow_triggers: invalid json value for put");
-                continue;
-            };
-            handle_workflow_trigger(trigger).await;
-        }
-    }
 }

--- a/src/jobs/src/job/cloud.rs
+++ b/src/jobs/src/job/cloud.rs
@@ -28,7 +28,7 @@ use stream::get_streams;
 
 use crate::{
     common::{infra::config::ORGANIZATIONS, meta::telemetry},
-    service::{organization::is_org_in_free_trial_period, self_reporting::search::get_usage},
+    service::{organization::is_org_in_free_trial_period, usage_search::get_usage},
 };
 
 /// This file has all odd-jobs that are specific to cloud installation,

--- a/src/jobs/src/job/mod.rs
+++ b/src/jobs/src/job/mod.rs
@@ -1086,7 +1086,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         tokio::task::spawn(openobserve_core::workflows::runtime::clean());
         tokio::task::spawn(db::workflows::watch());
         if LOCAL_NODE.is_alert_manager() {
-            tokio::task::spawn(openobserve_core::workflows::runtime::watch_workflow_triggers());
+            tokio::task::spawn(openobserve_core::workflow_execution::watch_workflow_triggers());
         }
     }
 
@@ -1112,7 +1112,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
             .await
             .expect("cloud ofga migrations failed");
 
-        use openobserve_core::self_reporting::{ingest_data_retention_usages, search::get_usage};
+        use openobserve_core::{
+            self_reporting::ingest_data_retention_usages, usage_search::get_usage,
+        };
         o2_enterprise::enterprise::metering::init(
             get_metering_lock,
             get_usage,
@@ -1144,9 +1146,9 @@ pub async fn init_deferred() -> Result<(), anyhow::Error> {
     #[cfg(feature = "enterprise")]
     {
         o2_enterprise::enterprise::license::start_license_check(
-            openobserve_core::self_reporting::search::get_usage,
+            openobserve_core::usage_search::get_usage,
             get_nats_lock,
-            openobserve_core::self_reporting::search::get_license_usage_data_from_node,
+            openobserve_core::usage_search::get_license_usage_data_from_node,
             LOCAL_NODE.is_router() || LOCAL_NODE.is_single_role(),
         )
         .await;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3939,7 +3939,7 @@ mod tests {
     }
 
     async fn test_backfill_job_delete_by_pipeline() {
-        use openobserve_core::alerts::backfill::delete_backfill_jobs_by_pipeline;
+        use openobserve_core::backfill_cleanup::delete_backfill_jobs_by_pipeline;
 
         // Test deleting jobs by pipeline
         let org_id = "e2e";


### PR DESCRIPTION
Two changes; the first is the substance, the second is a one-line tidy-up that came out of the same investigation.

---

## 1. Make the `src/core` module graph acyclic

Groundwork for splitting `openobserve-core` so api/ and jobs/ can depend on the services they actually use instead of one 70k-line crate. Rust crates cannot be mutually recursive, so the reference graph inside core has to be a DAG along the intended crate boundaries before anything can move out.

Today **15 of core's 36 top-level modules sit in one strongly connected component**: `alerts, auth, authz, cache, dashboards, ingestion, llm_evaluations, logs, metadata, organization, pipeline, self_reporting, traces, users, workflows`.

Every module now has a layer, and a module may only reference a strictly lower one:

```
sink < identity < alerting < ingest < dashboards < admin < top
```

16 references pointed sideways or upwards. The recurring fix is splitting a module that mixed a **dependency-free producer** with a **consumer that pulls in a higher layer**:

| Cycle | Fix |
|---|---|
| logs / traces / organization → `self_reporting` (7 refs) | `cloud_events` was already a queue: the types and `enqueue_cloud_event` (a push, no deps) move down; the flusher, which needs the ingestion service, stays in `self_reporting` |
| `workflows` ↔ `pipeline` | CRUD and `send_workflow_trigger` stay in `workflows` so alerts can keep firing workflows as a notification target; everything needing `ExecutablePipeline` moves to `workflow_execution` |
| `incidents` → `traces` | the `_o2_service_graph` reader only needs the search service → `service_graph_query`. Same shape for `self_reporting::search` → `usage_search` |
| `organization` → `pipeline` / `alerts` | `get_summary` aggregates streams, pipelines, alerts, functions and dashboards, so it moves up to `org_summary` instead of sitting in a module those domains depend on |
| `functions` → `http` | `map_error_to_http_response` is domain-agnostic and moves down to `http_error` |

**`http.rs` deliberately did not move.** The `From<SomeError> for Response` impls are pinned to the crate declaring the error type by the orphan rule, so they have to travel with those types when the domains are extracted. Only the generic mapper moved down; `http` is now a pure top-layer module nothing else depends on.

### Enforcement

`scripts/check_core_layering.py` fails on any upward or sideways reference and runs in `backend_static_checks`. It parses `crate::` plus root-reaching `super::` chains — the latter matters, `ingestion/mod.rs` reaches the crate root through `super::` and a `crate::`-only scan misses those edges.

A module added without a layer assignment fails the check rather than defaulting, so the boundary stays a deliberate decision.

I verified the check actually catches regressions rather than passing vacuously, by injecting an `identity -> alerting` reference and confirming it fails.

### Scope

No behaviour change — this is all code movement. `build_edges_sql`, added to `service_graph/api.rs` after this work started, moves to `service_graph_query.rs` with its four tests since it is only used by the query that moved.

---

## 2. Drop the unused `search` dependency from `openobserve-api-http`

`openobserve-api-http` declares `search` but never uses it. The `search::` paths in the router resolve to the alias imported at [`handler/http/router/mod.rs:31`](src/api/http/src/handler/http/router/mod.rs#L31):

```rust
use openobserve_api_search::{promql, search, traces};
```

— the `search` **module** of `openobserve-api-search`, not the `search` **crate**. There is no other binding of that name in the crate under any cfg.

**This is not a perf change.** The SQL-parser and DataFusion generic surface that dominates this crate's codegen arrives transitively through `openobserve-api-search` and `openobserve-core`, both of which do use `search`. Measured on a release build, touching `api-http`: **91.1s** without the dependency vs **92.2s** with it — within noise.

`cargo machete` did not catch it, and the `[package.metadata.cargo-machete]` ignore list does not cover it, so a sweep of the other crates for the same class of dead dependency may be worthwhile.

---

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo check --workspace` all clean. `openobserve-core` 1097 tests and `openobserve-jobs` 6 tests pass.

Enterprise and cloud feature combinations were verified against the pre-rebase base. On current `main` my local `o2-enterprise` checkout is 3 commits behind and fails to build for unrelated reasons — clean `main` without these changes fails identically — so those combinations are left to enterprise CI.

Note for whoever pairs this with the enterprise repo: no workspace members were added, so `Cargo.toml.openobserve` needs no change.