### PR TITLE
fix: metric stream name rbac migration (backport v0.91.0)

### DIFF
--- a/src/common/infra/ofga/migrations/mod.rs
+++ b/src/common/infra/ofga/migrations/mod.rs
@@ -3,6 +3,7 @@ use infra::db::{ORM_CLIENT, connect_to_orm};
 pub(super) mod alert_folders;
 pub(super) mod anomaly_detection;
 pub(super) mod report_folders;
+pub(super) mod stream_name_migration;
 
 pub async fn migrate_alert_folders() -> Result<(), anyhow::Error> {
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
@@ -17,4 +18,9 @@ pub async fn migrate_anomaly_detection() -> Result<(), anyhow::Error> {
 pub async fn migrate_report_folders() -> Result<(), anyhow::Error> {
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
     report_folders::migrate_report_folders(db).await
+}
+
+pub async fn migrate_stream_names() -> Result<(), anyhow::Error> {
+    let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
+    stream_name_migration::migrate_stream_names(db).await
 }

--- a/src/common/infra/ofga/migrations/stream_name_migration.rs
+++ b/src/common/infra/ofga/migrations/stream_name_migration.rs
@@ -16,7 +16,7 @@
 use std::collections::HashSet;
 
 use o2_openfga::{authorizer, config::get_config as get_ofga_config};
-use sea_orm::{ColumnTrait, ConnectionTrait, PaginatorTrait, QueryFilter, QuerySelect};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait, QueryFilter, QuerySelect};
 
 use crate::common::utils::auth::{into_ofga_supported_format, is_ofga_unsupported};
 
@@ -62,7 +62,7 @@ pub async fn migrate_stream_names<C: ConnectionTrait>(db: &C) -> Result<(), anyh
             // key2 is `{stream_type}/{stream_name}`; the stream name is
             // everything after the first `/` (names may themselves contain `/`).
             let Some((stream_type, stream_name)) = key2.split_once('/') else {
-                log::warn!("Unexpected schema key format (no '/'): {org_id}/{key2}");
+                log::warn!("Unexpected schema key format (no '/'): {}/{}", org_id, key2);
                 continue;
             };
 
@@ -71,13 +71,14 @@ pub async fn migrate_stream_names<C: ConnectionTrait>(db: &C) -> Result<(), anyh
             }
 
             let sanitized = into_ofga_supported_format(stream_name);
-            let dedupe_key = format!("{org_id}/{stream_type}/{sanitized}");
+            let dedupe_key = format!("{}/{}/{}", org_id, stream_type, sanitized);
             if !seen.insert(dedupe_key) {
                 continue;
             }
 
             log::debug!(
-                "Migrating stream ownership tuple -> org: {org_id}, type: {stream_type}, name: {stream_name} -> {sanitized}"
+                "Migrating stream ownership tuple -> org: {}, type: {}, name: {} -> {}",
+                org_id, stream_type, stream_name, sanitized
             );
             authorizer::authz::get_ownership_tuple(&org_id, stream_type, &sanitized, &mut tuples);
             len += 1;

--- a/src/common/infra/ofga/migrations/stream_name_migration.rs
+++ b/src/common/infra/ofga/migrations/stream_name_migration.rs
@@ -1,0 +1,127 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use o2_openfga::{authorizer, config::get_config as get_ofga_config};
+use sea_orm::{ColumnTrait, ConnectionTrait, PaginatorTrait, QueryFilter, QuerySelect};
+
+use crate::common::utils::auth::{into_ofga_supported_format, is_ofga_unsupported};
+
+/// Backfill OpenFGA ownership tuples for streams whose names contain characters
+/// that OpenFGA object ids cannot represent (e.g. metric names with `:`).
+///
+/// OpenFGA objects are `type:id`, so an id like `k8s:container:cpu` is rejected
+/// and the ownership tuple written at ingestion time never landed. Auth checks
+/// now sanitize the stream name via [`into_ofga_supported_format`] before
+/// looking it up (`k8s.container.cpu`), so those streams need a matching
+/// ownership tuple written under the sanitized id — otherwise no non-root user
+/// can ever be granted access to them.
+///
+/// This migration walks every stream schema in the `meta` table (`module =
+/// "schema"`, key `/schema/{org}/{stream_type}/{stream_name}`) and, for each
+/// stream whose name is not OpenFGA-safe, writes an `{ofga_type}:{sanitized}`
+/// ownership tuple owned by its org. Writes are idempotent (OpenFGA ignores
+/// duplicates), so re-running is safe.
+pub async fn migrate_stream_names<C: ConnectionTrait>(db: &C) -> Result<(), anyhow::Error> {
+    log::info!("Migrating stream names with colon to openfga supported name format");
+    if !get_ofga_config().enabled {
+        return Ok(());
+    }
+
+    let mut len = 0;
+    // Dedupe across schema history: a stream can have many `meta` rows (one per
+    // schema version / start_dt), but they all map to the same ownership tuple.
+    let mut seen: HashSet<String> = HashSet::new();
+
+    // Only pull the key columns — schema `value` blobs can be large and we never
+    // need them here.
+    let mut schema_pages = schema_meta::Entity::find()
+        .filter(schema_meta::Column::Module.eq("schema"))
+        .select_only()
+        .column(schema_meta::Column::Key1)
+        .column(schema_meta::Column::Key2)
+        .into_tuple::<(String, String)>()
+        .paginate(db, 1000);
+
+    let mut tuples = vec![];
+    while let Some(page) = schema_pages.fetch_and_next().await? {
+        for (org_id, key2) in page {
+            // key2 is `{stream_type}/{stream_name}`; the stream name is
+            // everything after the first `/` (names may themselves contain `/`).
+            let Some((stream_type, stream_name)) = key2.split_once('/') else {
+                log::warn!("Unexpected schema key format (no '/'): {org_id}/{key2}");
+                continue;
+            };
+
+            if !is_ofga_unsupported(stream_name) {
+                continue;
+            }
+
+            let sanitized = into_ofga_supported_format(stream_name);
+            let dedupe_key = format!("{org_id}/{stream_type}/{sanitized}");
+            if !seen.insert(dedupe_key) {
+                continue;
+            }
+
+            log::debug!(
+                "Migrating stream ownership tuple -> org: {org_id}, type: {stream_type}, name: {stream_name} -> {sanitized}"
+            );
+            authorizer::authz::get_ownership_tuple(&org_id, stream_type, &sanitized, &mut tuples);
+            len += 1;
+        }
+
+        // Flush per page to keep the tuple buffer bounded.
+        if !tuples.is_empty() {
+            let batch = std::mem::take(&mut tuples);
+            match authorizer::authz::update_tuples(batch, vec![]).await {
+                Ok(_) => log::debug!("Stream name ownership tuples migrated to openfga"),
+                Err(e) => log::error!("Error migrating stream name tuples to openfga: {e}"),
+            }
+        }
+    }
+
+    log::info!("Processed {len} stream(s) with unsupported names for ofga migration");
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Local entity definitions — snapshots of the relevant DB tables at the time
+// this migration executes.
+// ---------------------------------------------------------------------------
+
+/// Representation of the `meta` table. Stream schemas are stored here under
+/// `module = "schema"` with `key1 = org_id` and `key2 = "{stream_type}/{stream_name}"`.
+mod schema_meta {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
+    #[sea_orm(table_name = "meta")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i64,
+        pub module: String,
+        pub key1: String,
+        pub key2: String,
+        pub start_dt: i64,
+        pub value: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/src/common/infra/ofga/migrations/stream_name_migration.rs
+++ b/src/common/infra/ofga/migrations/stream_name_migration.rs
@@ -16,7 +16,9 @@
 use std::collections::HashSet;
 
 use o2_openfga::{authorizer, config::get_config as get_ofga_config};
-use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait, QueryFilter, QuerySelect};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait, QueryFilter, QuerySelect,
+};
 
 use crate::common::utils::auth::{into_ofga_supported_format, is_ofga_unsupported};
 
@@ -78,7 +80,10 @@ pub async fn migrate_stream_names<C: ConnectionTrait>(db: &C) -> Result<(), anyh
 
             log::debug!(
                 "Migrating stream ownership tuple -> org: {}, type: {}, name: {} -> {}",
-                org_id, stream_type, stream_name, sanitized
+                org_id,
+                stream_type,
+                stream_name,
+                sanitized
             );
             authorizer::authz::get_ownership_tuple(&org_id, stream_type, &sanitized, &mut tuples);
             len += 1;

--- a/src/common/infra/ofga/mod.rs
+++ b/src/common/infra/ofga/mod.rs
@@ -75,6 +75,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     let mut need_anomaly_detection_migration = false;
     let mut need_online_eval_migration = false;
     let mut need_billing_group_migration = false;
+    let mut need_stream_names_migration = false;
 
     let existing_meta: Option<o2_openfga::meta::mapping::OFGAModel> =
         match db::ofga::get_ofga_model().await {
@@ -258,6 +259,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
                 let v0_0_33 = version_compare::Version::from("0.0.33").unwrap();
                 let v0_0_34 = version_compare::Version::from("0.0.34").unwrap();
                 let v0_0_35 = version_compare::Version::from("0.0.35").unwrap();
+                let v0_0_36 = version_compare::Version::from("0.0.36").unwrap();
 
                 if meta_version > v0_0_5 && existing_model_version < v0_0_6 {
                     need_pipeline_migration = true;
@@ -331,6 +333,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
                 if existing_model_version < v0_0_35 {
                     log::info!("[OFGA:Local] online eval permissions migration needed");
                     need_online_eval_migration = true;
+                }
+                if existing_model_version < v0_0_36 {
+                    log::info!("[OFGA:Local] stream names migration needed");
+                    need_stream_names_migration = true;
                 }
             }
 
@@ -503,6 +509,16 @@ pub async fn init() -> Result<(), anyhow::Error> {
                             log::error!(
                                 "[OFGA:Local] Error migrating anomaly detection to openfga: {e}"
                             );
+                        }
+                    }
+                }
+                if need_stream_names_migration {
+                    match migrations::migrate_stream_names().await {
+                        Ok(_) => {
+                            log::info!("[OFGA:Local] Stream names migrated to openfga");
+                        }
+                        Err(e) => {
+                            log::error!("[OFGA:Local] Error migrating stream names to openfga: {e}");
                         }
                     }
                 }

--- a/src/common/infra/ofga/mod.rs
+++ b/src/common/infra/ofga/mod.rs
@@ -518,7 +518,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
                             log::info!("[OFGA:Local] Stream names migrated to openfga");
                         }
                         Err(e) => {
-                            log::error!("[OFGA:Local] Error migrating stream names to openfga: {e}");
+                            log::error!(
+                                "[OFGA:Local] Error migrating stream names to openfga: {e}"
+                            );
                         }
                     }
                 }

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -91,6 +91,15 @@ pub fn is_valid_email(email: &str) -> bool {
     EMAIL_REGEX.is_match(email)
 }
 
+/// Rewrite a resource name into an OpenFGA-safe object id.
+///
+/// OpenFGA-unsupported characters (`:#?\s'"%&`) are collapsed to `.`. We use `.`
+/// rather than `_` on purpose: the only real-world names that carry an
+/// unsupported character are Prometheus metric streams, whose grammar is
+/// `[a-zA-Z0-9_:]`. Mapping `:` to `_` would let a metric named `a:b` collide
+/// with a distinct metric named `a_b`; `.` can never appear in a metric name, so
+/// the mapping stays collision-free for the case that actually occurs. `.` is a
+/// valid OpenFGA object-id character.
 pub fn into_ofga_supported_format(name: &str) -> String {
     // remove spaces around special characters
     let result = RE_SPACE_AROUND.replace_all(name, |caps: &regex::Captures| {
@@ -101,7 +110,7 @@ pub fn into_ofga_supported_format(name: &str) -> String {
             .to_string()
     });
     RE_OFGA_UNSUPPORTED_NAME
-        .replace_all(&result, "_")
+        .replace_all(&result, ".")
         .to_string()
 }
 
@@ -831,14 +840,14 @@ mod tests {
 
     #[test]
     fn test_into_ofga_supported_format() {
-        assert_eq!(into_ofga_supported_format("foo:bar"), "foo_bar");
-        assert_eq!(into_ofga_supported_format("foo bar"), "foo_bar");
-        assert_eq!(into_ofga_supported_format("foo#bar"), "foo_bar");
-        assert_eq!(into_ofga_supported_format("foo : bar"), "foo_bar");
-        assert_eq!(into_ofga_supported_format(" a  & b "), "_a_b_");
-        assert_eq!(into_ofga_supported_format("a   b"), "a_b");
-        assert_eq!(into_ofga_supported_format("a:b#c?d e"), "a_b_c_d_e");
-        assert_eq!(into_ofga_supported_format("foo & bar % baz"), "foo_bar_baz");
+        assert_eq!(into_ofga_supported_format("foo:bar"), "foo.bar");
+        assert_eq!(into_ofga_supported_format("foo bar"), "foo.bar");
+        assert_eq!(into_ofga_supported_format("foo#bar"), "foo.bar");
+        assert_eq!(into_ofga_supported_format("foo : bar"), "foo.bar");
+        assert_eq!(into_ofga_supported_format(" a  & b "), ".a.b.");
+        assert_eq!(into_ofga_supported_format("a   b"), "a.b");
+        assert_eq!(into_ofga_supported_format("a:b#c?d e"), "a.b.c.d.e");
+        assert_eq!(into_ofga_supported_format("foo & bar % baz"), "foo.bar.baz");
     }
 
     #[test]
@@ -970,29 +979,29 @@ mod tests {
         assert_eq!(into_ofga_supported_format("123"), "123");
 
         // Special characters
-        assert_eq!(into_ofga_supported_format("a:b"), "a_b");
-        assert_eq!(into_ofga_supported_format("a#b"), "a_b");
-        assert_eq!(into_ofga_supported_format("a?b"), "a_b");
-        assert_eq!(into_ofga_supported_format("a'b"), "a_b");
-        assert_eq!(into_ofga_supported_format("a\"b"), "a_b");
-        assert_eq!(into_ofga_supported_format("a%b"), "a_b");
-        assert_eq!(into_ofga_supported_format("a&b"), "a_b");
+        assert_eq!(into_ofga_supported_format("a:b"), "a.b");
+        assert_eq!(into_ofga_supported_format("a#b"), "a.b");
+        assert_eq!(into_ofga_supported_format("a?b"), "a.b");
+        assert_eq!(into_ofga_supported_format("a'b"), "a.b");
+        assert_eq!(into_ofga_supported_format("a\"b"), "a.b");
+        assert_eq!(into_ofga_supported_format("a%b"), "a.b");
+        assert_eq!(into_ofga_supported_format("a&b"), "a.b");
 
         // Multiple spaces
-        assert_eq!(into_ofga_supported_format("a   b"), "a_b");
-        assert_eq!(into_ofga_supported_format("  a  b  "), "_a_b_");
+        assert_eq!(into_ofga_supported_format("a   b"), "a.b");
+        assert_eq!(into_ofga_supported_format("  a  b  "), ".a.b.");
 
         // Complex combinations
         assert_eq!(
             into_ofga_supported_format("test:name with spaces"),
-            "test_name_with_spaces"
+            "test.name.with.spaces"
         );
-        assert_eq!(into_ofga_supported_format("a & b : c # d"), "a_b_c_d");
+        assert_eq!(into_ofga_supported_format("a & b : c # d"), "a.b.c.d");
 
         // Edge cases
         assert_eq!(into_ofga_supported_format(""), "");
-        assert_eq!(into_ofga_supported_format(":::"), "_");
-        assert_eq!(into_ofga_supported_format("   "), "_");
+        assert_eq!(into_ofga_supported_format(":::"), ".");
+        assert_eq!(into_ofga_supported_format("   "), ".");
     }
 
     #[test]

--- a/src/handler/http/request/promql/mod.rs
+++ b/src/handler/http/request/promql/mod.rs
@@ -202,7 +202,7 @@ async fn query(
                             OFGA_MODELS
                                 .get(stream_type_str)
                                 .map_or(stream_type_str, |model| model.key),
-                            name
+                            crate::common::utils::auth::into_ofga_supported_format(&name)
                         ),
                         org_id: org_id.to_string(),
                         bypass_check: false,
@@ -493,7 +493,7 @@ async fn query_range(
                                 OFGA_MODELS
                                     .get(stream_type_str)
                                     .map_or(stream_type_str, |model| model.key),
-                                name
+                                crate::common::utils::auth::into_ofga_supported_format(&name)
                             ),
                             org_id: org_id.to_string(),
                             bypass_check: false,
@@ -850,7 +850,7 @@ async fn series(
                             OFGA_MODELS
                                 .get(stream_type_str)
                                 .map_or(stream_type_str, |model| model.key),
-                            metric_name
+                            crate::common::utils::auth::into_ofga_supported_format(&metric_name)
                         ),
                         org_id: org_id.to_string(),
                         bypass_check: false,

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -305,7 +305,7 @@ pub async fn search_multi(
                             OFGA_MODELS
                                 .get(stream_type_str)
                                 .map_or(stream_type_str, |model| model.key),
-                            stream_name
+                            crate::common::utils::auth::into_ofga_supported_format(&stream_name)
                         ),
                         org_id: org_id.clone(),
                         bypass_check: false,
@@ -1331,7 +1331,7 @@ pub async fn search_multi_stream(
                             OFGA_MODELS
                                 .get(stream_type_str)
                                 .map_or(stream_type_str, |model| model.key),
-                            stream_name
+                            crate::common::utils::auth::into_ofga_supported_format(&stream_name)
                         ),
                         org_id: org_id.clone(),
                         bypass_check: false,

--- a/src/handler/http/request/search/utils.rs
+++ b/src/handler/http/request/search/utils.rs
@@ -89,7 +89,10 @@ pub async fn check_stream_permissions(
             AuthExtractor {
                 auth: "".to_string(),
                 method: "GET".to_string(),
-                o2_type: format!("{o2_model_type}:{stream_name}"),
+                o2_type: format!(
+                    "{o2_model_type}:{}",
+                    crate::common::utils::auth::into_ofga_supported_format(stream_name)
+                ),
                 org_id: org_id.to_string(),
                 bypass_check: false,
                 parent_id: "".to_string(),

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -250,7 +250,7 @@ pub async fn get_latest_traces(
                         OFGA_MODELS
                             .get(stream_type_str)
                             .map_or(stream_type_str, |model| model.key),
-                        stream_name
+                        crate::common::utils::auth::into_ofga_supported_format(&stream_name)
                     ),
                     org_id: org_id.clone(),
                     bypass_check: false,
@@ -1070,7 +1070,7 @@ pub async fn get_latest_traces_stream(
                         OFGA_MODELS
                             .get(stream_type_str)
                             .map_or(stream_type_str, |model| model.key),
-                        stream_name
+                        crate::common::utils::auth::into_ofga_supported_format(&stream_name)
                     ),
                     org_id: org_id.clone(),
                     bypass_check: false,


### PR DESCRIPTION
Backport of the metric-stream colon RBAC fix to `branch-v0.91.0`.

This is a **manual behavior backport**, not a cherry-pick — `branch-v0.91.0` predates the crate-split refactor (`src/core`, `src/config`, `src/api_query`), so the changes were re-applied on the older monolithic layout (`src/common/utils/auth.rs`, `src/common/infra/ofga/`, `src/handler/http/request/...`).

### What changed
- `src/common/utils/auth.rs`: `into_ofga_supported_format` now collapses OpenFGA-unsupported chars to `.` instead of `_`. Rationale: Prometheus metric names are `[a-zA-Z0-9_:]`, so mapping `:`→`_` would make `a:b` collide with a distinct metric `a_b`; `.` can never appear in a metric name → collision-free. Tests updated.
- Direct auth checks sanitize the stream name before the OpenFGA lookup: `check_stream_permissions` (search `utils.rs`) + promql (`query`/`query_range`/`series`), `multi_streams`, and `traces` handlers.
- New OFGA migration `stream_name_migration.rs`: walks stream schemas in the `meta` table and backfills ownership tuples under the sanitized id for streams whose names were previously rejected by OpenFGA (idempotent).
- OFGA model version gate added at `v0_0_36`.

### ⚠️ Reviewer note — version-gate coupling
The paired enterprise PR bumps the OFGA model `0.0.34` → `0.0.36`. Because migrations are gated on a single monotonic model version, this bump also activates the **already-staged `online_eval` migration** (gate `v0_0_35`), which is merged on 0.91 but not yet released (model still at 0.0.34). This is inherent to the branch state — any model bump triggers it. Please confirm releasing `online_eval` alongside this fix is acceptable, or advise on decoupling.

Depends on the o2-enterprise PR (route-permission sanitization + model bump).
