### PR TITLE
feat(mcp): support MCP spec revision 2026-07-28 (stateless, dual-era server)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7766,6 +7766,7 @@ name = "openobserve-mcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "bytes",
  "config",
  "futures-util",

--- a/src/api/http/src/handler/http/request/mcp/mod.rs
+++ b/src/api/http/src/handler/http/request/mcp/mod.rs
@@ -22,20 +22,172 @@ use axum::{
 };
 use futures_util::StreamExt;
 use openobserve_mcp::{
-    MCP_PROTOCOL_VERSION, MCPRequest, handle_mcp_request, handle_mcp_request_stream,
+    MCP_PROTOCOL_VERSION_MODERN, MCP_SUPPORTED_PROTOCOL_VERSIONS, MCPRequest,
+    decode_mcp_header_value, handle_mcp_request, handle_mcp_request_stream,
+    is_supported_protocol_version,
 };
 #[cfg(feature = "enterprise")]
 use openobserve_mcp::{OAuthProtectedResourceMetadata, OAuthServerMetadata};
+use serde_json::{Value, json};
 
-/// MCP protocol version header name (MCP 2025-11-25)
+/// MCP protocol version header name
 const MCP_PROTOCOL_VERSION_HEADER: &str = "MCP-Protocol-Version";
+/// Mirrors the JSON-RPC `method` field (required on 2026-07-28 requests)
+const MCP_METHOD_HEADER: &str = "Mcp-Method";
+/// Mirrors `params.name` on tools/call (required on 2026-07-28 requests)
+const MCP_NAME_HEADER: &str = "Mcp-Name";
+
+/// JSON-RPC error codes surfaced with a non-200 HTTP status per the
+/// 2026-07-28 Streamable HTTP transport.
+const JSONRPC_HEADER_MISMATCH: i32 = -32020;
+const JSONRPC_UNSUPPORTED_PROTOCOL_VERSION: i32 = -32022;
+const JSONRPC_METHOD_NOT_FOUND: i32 = -32601;
+
+/// Build an HTTP response carrying a JSON-RPC error body.
+fn jsonrpc_error_response(
+    status: StatusCode,
+    id: Option<&Value>,
+    code: i32,
+    message: String,
+    data: Option<Value>,
+) -> Response {
+    let mut error = json!({ "code": code, "message": message });
+    if let Some(data) = data {
+        error["data"] = data;
+    }
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": id.cloned().unwrap_or(Value::Null),
+        "error": error,
+    });
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+/// Validate the Streamable HTTP request metadata headers (dual-era).
+///
+/// Legacy (initialize-handshake, ≤2025-11-25) clients may omit all of these
+/// headers. Modern requests — those whose body `_meta` declares a protocol
+/// version — must carry `MCP-Protocol-Version`, `Mcp-Method`, and (for
+/// tools/call) `Mcp-Name`, each matching the body. Per 2026-07-28:
+/// header/body mismatches → 400 + HeaderMismatch (-32020); an unsupported
+/// version (header or body) → 400 + UnsupportedProtocolVersionError
+/// (-32022) listing the versions we support.
+fn validate_mcp_headers(headers: &HeaderMap, request: &MCPRequest) -> Option<Response> {
+    let id = request.id.as_ref();
+    let unsupported = |requested: &str| {
+        jsonrpc_error_response(
+            StatusCode::BAD_REQUEST,
+            id,
+            JSONRPC_UNSUPPORTED_PROTOCOL_VERSION,
+            "Unsupported protocol version".to_string(),
+            Some(json!({
+                "supported": MCP_SUPPORTED_PROTOCOL_VERSIONS,
+                "requested": requested,
+            })),
+        )
+    };
+    let mismatch = |message: String| {
+        jsonrpc_error_response(
+            StatusCode::BAD_REQUEST,
+            id,
+            JSONRPC_HEADER_MISMATCH,
+            message,
+            None,
+        )
+    };
+
+    let header_version = headers
+        .get(MCP_PROTOCOL_VERSION_HEADER)
+        .and_then(|v| v.to_str().ok());
+    let meta_version = request.meta_protocol_version();
+
+    if let Some(hv) = header_version {
+        if !is_supported_protocol_version(hv) {
+            return Some(unsupported(hv));
+        }
+        if let Some(mv) = meta_version
+            && mv != hv
+        {
+            return Some(mismatch(format!(
+                "Header mismatch: MCP-Protocol-Version header value '{hv}' does not match body value '{mv}'"
+            )));
+        }
+    }
+    if let Some(mv) = meta_version
+        && !is_supported_protocol_version(mv)
+    {
+        return Some(unsupported(mv));
+    }
+
+    // Modern requests must mirror body fields into headers so that
+    // intermediaries can route without parsing the body.
+    if meta_version == Some(MCP_PROTOCOL_VERSION_MODERN) {
+        if header_version.is_none() {
+            return Some(mismatch(
+                "Header mismatch: missing required MCP-Protocol-Version header".to_string(),
+            ));
+        }
+        match headers.get(MCP_METHOD_HEADER).and_then(|v| v.to_str().ok()) {
+            None => {
+                return Some(mismatch(
+                    "Header mismatch: missing required Mcp-Method header".to_string(),
+                ));
+            }
+            Some(m) if m != request.method => {
+                return Some(mismatch(format!(
+                    "Header mismatch: Mcp-Method header value '{m}' does not match body value '{}'",
+                    request.method
+                )));
+            }
+            _ => {}
+        }
+        if request.method == "tools/call" {
+            let body_name = request
+                .params
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            match headers
+                .get(MCP_NAME_HEADER)
+                .and_then(|v| v.to_str().ok())
+                .map(decode_mcp_header_value)
+            {
+                None => {
+                    return Some(mismatch(
+                        "Header mismatch: missing required Mcp-Name header".to_string(),
+                    ));
+                }
+                Some(None) => {
+                    return Some(mismatch(
+                        "Header mismatch: Mcp-Name header value is malformed".to_string(),
+                    ));
+                }
+                Some(Some(name)) if name != body_name => {
+                    return Some(mismatch(format!(
+                        "Header mismatch: Mcp-Name header value '{name}' does not match body value '{body_name}'"
+                    )));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    None
+}
 
 /// Handler for MCP POST requests (single request/response)
 ///
-/// Per MCP 2025-11-25 (Streamable HTTP transport):
+/// Dual-era (MCP 2025-11-25 + 2026-07-28) Streamable HTTP transport:
 /// - Requests with `id` → 200 with JSON or SSE response
 /// - Notifications (no `id`) → 202 Accepted, no body
-/// - Validates `MCP-Protocol-Version` header on non-initialize requests
+/// - Validates protocol version and the 2026-07-28 request metadata headers (`Mcp-Method`,
+///   `Mcp-Name`) on modern requests
+/// - Maps modern JSON-RPC errors to HTTP status codes (unsupported version → 400, unknown method →
+///   404)
 #[utoipa::path(
     post,
     path = "/{org_id}/mcp",
@@ -52,7 +204,8 @@ const MCP_PROTOCOL_VERSION_HEADER: &str = "MCP-Protocol-Version";
     responses(
         (status = 200, description = "Success", content_type = "application/json"),
         (status = 202, description = "Accepted (notification, no response body)"),
-        (status = 400, description = "Bad Request (unsupported protocol version)"),
+        (status = 400, description = "Bad Request (unsupported protocol version or header mismatch)"),
+        (status = 404, description = "Not Found (unknown method, 2026-07-28 requests)"),
         (status = 500, description = "Internal Server Error"),
     ),
     extensions(
@@ -71,26 +224,15 @@ pub async fn handle_mcp_post(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
-    // Per MCP 2025-11-25: validate MCP-Protocol-Version header on all
-    // requests after initialization (initialize itself won't have it yet).
-    if mcp_request.method != "initialize"
-        && let Some(client_version) = headers
-            .get(MCP_PROTOCOL_VERSION_HEADER)
-            .and_then(|v| v.to_str().ok())
-        && client_version != MCP_PROTOCOL_VERSION
-    {
-        return Response::builder()
-            .status(StatusCode::BAD_REQUEST)
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(format!(
-                "{{\"error\": \"Unsupported MCP protocol version '{}', expected '{}'\"}}",
-                client_version, MCP_PROTOCOL_VERSION
-            )))
-            .unwrap();
+    // Validate protocol version and (for 2026-07-28 requests) the mirrored
+    // request metadata headers before doing any work.
+    if let Some(error_response) = validate_mcp_headers(&headers, &mcp_request) {
+        return error_response;
     }
+    let modern = mcp_request.is_modern();
 
-    // Per MCP 2025-11-25: JSON-RPC notifications (no `id`) require HTTP 202,
-    // no response body. Process the notification but return 202.
+    // JSON-RPC notifications (no `id`) require HTTP 202, no response body.
+    // Process the notification but return 202.
     if mcp_request.id.is_none() && mcp_request.method != "initialize" {
         // Fire-and-forget: process notification asynchronously, don't wait
         let _ = handle_mcp_request(mcp_request, auth_token).await;
@@ -109,45 +251,43 @@ pub async fn handle_mcp_post(
     // Determine if client wants SSE streaming
     let wants_sse = accept_header.contains("text/event-stream");
 
-    if wants_sse {
-        // Return streaming SSE response (MCP Streamable HTTP spec)
-        let stream = match handle_mcp_request_stream(mcp_request, auth_token).await {
-            Ok(s) => s,
-            Err(e) => {
-                return Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(format!("{{\"error\": \"MCP error: {}\"}}", e)))
-                    .unwrap();
-            }
-        };
+    let response = match handle_mcp_request(mcp_request, auth_token).await {
+        Ok(r) => r,
+        Err(e) => {
+            log::error!("MCP handle_mcp_request error: {e}");
+            return Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(format!("{{\"error\": \"MCP error: {}\"}}", e)))
+                .unwrap();
+        }
+    };
 
-        let body_stream =
-            stream.map(|result| result.map_err(|e| std::io::Error::other(e.to_string())));
+    // Per 2026-07-28, some JSON-RPC errors carry a non-200 HTTP status so
+    // dual-era clients can distinguish a modern server from a legacy one.
+    // Legacy responses keep 200 with the error in-band, as before.
+    let status = match response.error.as_ref().map(|e| e.code) {
+        Some(JSONRPC_UNSUPPORTED_PROTOCOL_VERSION) => StatusCode::BAD_REQUEST,
+        Some(JSONRPC_METHOD_NOT_FOUND) if modern => StatusCode::NOT_FOUND,
+        _ => StatusCode::OK,
+    };
 
+    if wants_sse && status == StatusCode::OK {
+        // SSE response stream scoped to this request (single final event)
+        let sse_data = format!(
+            "data: {}\n\n",
+            serde_json::to_string(&response).unwrap_or_default()
+        );
         Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "text/event-stream")
             .header(header::CACHE_CONTROL, "no-cache")
             .header("X-Accel-Buffering", "no")
-            .body(Body::from_stream(body_stream))
+            .body(Body::from(sse_data))
             .unwrap()
     } else {
-        // Return single JSON response (fallback for simpler clients)
-        let response = match handle_mcp_request(mcp_request, auth_token).await {
-            Ok(r) => r,
-            Err(e) => {
-                log::error!("MCP handle_mcp_request error: {e}");
-                return Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(format!("{{\"error\": \"MCP error: {}\"}}", e)))
-                    .unwrap();
-            }
-        };
-
         Response::builder()
-            .status(StatusCode::OK)
+            .status(status)
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(serde_json::to_string(&response).unwrap()))
             .unwrap()
@@ -492,6 +632,34 @@ mod tests {
         }
     }
 
+    /// A 2026-07-28 request: protocol version in `_meta`, plus `name` for tools/call
+    fn modern_request(method: &str, name: Option<&str>) -> MCPRequest {
+        let mut params = json!({
+            "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" }
+        });
+        if let Some(name) = name {
+            params["name"] = json!(name);
+            params["arguments"] = json!({});
+        }
+        MCPRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(json!(1)),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    /// Matching 2026-07-28 request metadata headers
+    fn modern_headers(method: &str, name: Option<&str>) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(MCP_PROTOCOL_VERSION_HEADER, "2026-07-28".parse().unwrap());
+        headers.insert(MCP_METHOD_HEADER, method.parse().unwrap());
+        if let Some(name) = name {
+            headers.insert(MCP_NAME_HEADER, name.parse().unwrap());
+        }
+        headers
+    }
+
     #[tokio::test]
     async fn post_ping_is_available() {
         let response = handle_mcp_post(
@@ -513,6 +681,95 @@ mod tests {
             handle_mcp_post(Path("default".to_string()), headers, Json(ping_request())).await;
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn legacy_version_header_is_accepted() {
+        let mut headers = HeaderMap::new();
+        headers.insert(MCP_PROTOCOL_VERSION_HEADER, "2025-11-25".parse().unwrap());
+
+        let response =
+            handle_mcp_post(Path("default".to_string()), headers, Json(ping_request())).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn modern_server_discover_is_available() {
+        let response = handle_mcp_post(
+            Path("default".to_string()),
+            modern_headers("server/discover", None),
+            Json(modern_request("server/discover", None)),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn modern_request_without_version_header_is_rejected() {
+        let response = handle_mcp_post(
+            Path("default".to_string()),
+            HeaderMap::new(),
+            Json(modern_request("server/discover", None)),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn modern_request_missing_mcp_method_header_is_rejected() {
+        let mut headers = modern_headers("server/discover", None);
+        headers.remove(MCP_METHOD_HEADER);
+
+        let response = handle_mcp_post(
+            Path("default".to_string()),
+            headers,
+            Json(modern_request("server/discover", None)),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn modern_tools_call_with_mismatched_name_header_is_rejected() {
+        let response = handle_mcp_post(
+            Path("default".to_string()),
+            modern_headers("tools/call", Some("other_tool")),
+            Json(modern_request("tools/call", Some("tool_search"))),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn version_header_body_mismatch_is_rejected() {
+        let mut headers = modern_headers("server/discover", None);
+        headers.insert(MCP_PROTOCOL_VERSION_HEADER, "2025-11-25".parse().unwrap());
+
+        let response = handle_mcp_post(
+            Path("default".to_string()),
+            headers,
+            Json(modern_request("server/discover", None)),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn modern_unknown_method_returns_not_found() {
+        let response = handle_mcp_post(
+            Path("default".to_string()),
+            modern_headers("bogus/method", None),
+            Json(modern_request("bogus/method", None)),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/src/mcp/Cargo.toml
+++ b/src/mcp/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
+base64.workspace = true
 bytes.workspace = true
 config.workspace = true
 futures-util.workspace = true

--- a/src/mcp/src/lib.rs
+++ b/src/mcp/src/lib.rs
@@ -30,4 +30,7 @@ pub use handler::{
     OAuthProtectedResourceMetadata, OAuthServerMetadata, handle_mcp_request,
     handle_mcp_request_stream,
 };
-pub use types::{MCP_PROTOCOL_VERSION, MCPRequest, MCPResponse};
+pub use types::{
+    MCP_PROTOCOL_VERSION, MCP_PROTOCOL_VERSION_MODERN, MCP_SUPPORTED_PROTOCOL_VERSIONS, MCPRequest,
+    MCPResponse, decode_mcp_header_value, is_supported_protocol_version,
+};

--- a/src/mcp/src/protocol.rs
+++ b/src/mcp/src/protocol.rs
@@ -36,6 +36,25 @@ pub async fn route_request(request: MCPRequest, auth_token: Option<String>) -> R
         ));
     }
 
+    // Modern (2026-07-28) clients declare their protocol version on every
+    // request. An unsupported version must be answered with
+    // UnsupportedProtocolVersionError listing the versions we do support so
+    // the client can retry with one of them.
+    if let Some(version) = request.meta_protocol_version().map(str::to_owned)
+        && !is_supported_protocol_version(&version)
+    {
+        return Ok(MCPResponse::error(
+            request.id,
+            MCPErrorCode::UnsupportedProtocolVersion,
+            "Unsupported protocol version".to_string(),
+            Some(json!({
+                "supported": MCP_SUPPORTED_PROTOCOL_VERSIONS,
+                "requested": version,
+            })),
+        ));
+    }
+    let modern = request.is_modern();
+
     // Parse method
     let method = match MCPMethod::from_str(&request.method) {
         Ok(m) => m,
@@ -55,12 +74,18 @@ pub async fn route_request(request: MCPRequest, auth_token: Option<String>) -> R
         MCPMethod::Ping => handle_ping(),
         MCPMethod::ToolsList => handle_tools_list(),
         MCPMethod::ToolsCall => handle_tools_call(request.params, auth_token).await,
+        MCPMethod::ServerDiscover => handle_server_discover(),
         // Notifications are one-way; no response body required (HTTP layer returns 202)
         MCPMethod::NotificationsInitialized => Ok(Value::Null),
     };
 
     match result {
-        Ok(value) => Ok(MCPResponse::success(request.id, value)),
+        Ok(mut value) => {
+            if modern {
+                decorate_modern_result(&mut value, &method);
+            }
+            Ok(MCPResponse::success(request.id, value))
+        }
         Err(e) => Ok(MCPResponse::error(
             request.id,
             MCPErrorCode::InternalError,
@@ -68,6 +93,66 @@ pub async fn route_request(request: MCPRequest, auth_token: Option<String>) -> R
             None,
         )),
     }
+}
+
+/// Cache lifetime advertised on `server/discover` results (1 hour); the
+/// version/capability surface only changes across deployments.
+const DISCOVER_TTL_MS: u64 = 3_600_000;
+/// Cache lifetime advertised on modern `tools/list` results (5 minutes);
+/// the tool set is fixed per process but kept shorter to bound staleness
+/// across rolling upgrades.
+const TOOLS_LIST_TTL_MS: u64 = 300_000;
+
+/// Server identity for `_meta` (`io.modelcontextprotocol/serverInfo`).
+fn server_info_meta() -> Value {
+    json!({
+        "name": MCP_SERVER_NAME,
+        "version": MCP_SERVER_VERSION,
+        "title": "OpenObserve MCP Server",
+    })
+}
+
+/// Add the fields a 2026-07-28 result must or should carry: `resultType`,
+/// `_meta` server identity, and cache-control fields on list results.
+/// Legacy (initialize-negotiated) responses are left untouched so
+/// 2025-11-25 clients never see fields their revision doesn't define.
+fn decorate_modern_result(value: &mut Value, method: &MCPMethod) {
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    obj.entry("resultType").or_insert_with(|| json!("complete"));
+    if matches!(method, MCPMethod::ToolsList) {
+        obj.entry("ttlMs")
+            .or_insert_with(|| json!(TOOLS_LIST_TTL_MS));
+        obj.entry("cacheScope").or_insert_with(|| json!("public"));
+    }
+    let meta = obj
+        .entry("_meta")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if let Some(meta) = meta.as_object_mut() {
+        meta.entry(META_KEY_SERVER_INFO)
+            .or_insert_with(server_info_meta);
+    }
+}
+
+/// Handle server/discover (2026-07-28)
+///
+/// Required entry point for modern clients (and the stdio
+/// backward-compatibility probe): advertises supported protocol versions,
+/// capabilities, and identity in a single cacheable result.
+fn handle_server_discover() -> Result<Value> {
+    Ok(json!({
+        "resultType": "complete",
+        "supportedVersions": MCP_SUPPORTED_PROTOCOL_VERSIONS,
+        "capabilities": {
+            "tools": {},
+            "completions": {},
+        },
+        "instructions": "OpenObserve observability tools. Call tool_search to discover tools for streams, logs, metrics, traces, alerts, dashboards, etc., then execute them via tools_call.",
+        "ttlMs": DISCOVER_TTL_MS,
+        "cacheScope": "public",
+        "_meta": { (META_KEY_SERVER_INFO): server_info_meta() },
+    }))
 }
 
 /// Handle initialize request
@@ -528,6 +613,99 @@ mod tests {
         let response = route_request(request, None).await.unwrap();
         assert!(response.result.is_some());
         assert!(response.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_server_discover() {
+        let request = MCPRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: Some(Value::from(1)),
+            method: "server/discover".to_string(),
+            params: json!({
+                "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" }
+            }),
+        };
+
+        let response = route_request(request, None).await.unwrap();
+        assert!(response.error.is_none());
+        let result = response.result.unwrap();
+        assert_eq!(result["resultType"], json!("complete"));
+        let versions = result["supportedVersions"].as_array().unwrap();
+        assert!(versions.contains(&json!("2026-07-28")));
+        assert!(versions.contains(&json!("2025-11-25")));
+        assert!(result["capabilities"]["tools"].is_object());
+        assert!(result["ttlMs"].is_u64());
+        assert_eq!(result["cacheScope"], json!("public"));
+        assert_eq!(
+            result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+            json!(MCP_SERVER_NAME)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_meta_protocol_version() {
+        let request = MCPRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: Some(Value::from(1)),
+            method: "tools/list".to_string(),
+            params: json!({
+                "_meta": { "io.modelcontextprotocol/protocolVersion": "1900-01-01" }
+            }),
+        };
+
+        let response = route_request(request, None).await.unwrap();
+        let error = response.error.unwrap();
+        assert_eq!(error.code, -32022);
+        let data = error.data.unwrap();
+        assert_eq!(data["requested"], json!("1900-01-01"));
+        assert!(
+            data["supported"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("2026-07-28"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_modern_tools_list_is_decorated() {
+        tools::init_test_tools().await;
+
+        let request = MCPRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: Some(Value::from(1)),
+            method: "tools/list".to_string(),
+            params: json!({
+                "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" }
+            }),
+        };
+
+        let response = route_request(request, None).await.unwrap();
+        let result = response.result.unwrap();
+        assert_eq!(result["resultType"], json!("complete"));
+        assert!(result["ttlMs"].is_u64());
+        assert_eq!(result["cacheScope"], json!("public"));
+        assert!(result["_meta"]["io.modelcontextprotocol/serverInfo"].is_object());
+        assert!(result["tools"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_legacy_tools_list_is_not_decorated() {
+        tools::init_test_tools().await;
+
+        let request = MCPRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: Some(Value::from(1)),
+            method: "tools/list".to_string(),
+            params: Value::Null,
+        };
+
+        let response = route_request(request, None).await.unwrap();
+        let result = response.result.unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(!obj.contains_key("resultType"));
+        assert!(!obj.contains_key("ttlMs"));
+        assert!(!obj.contains_key("cacheScope"));
+        assert!(!obj.contains_key("_meta"));
     }
 
     #[tokio::test]

--- a/src/mcp/src/types.rs
+++ b/src/mcp/src/types.rs
@@ -20,10 +20,42 @@ use serde_json::Value;
 use utoipa::ToSchema;
 
 // MCP Protocol Constants
+/// Legacy protocol revision, negotiated through the `initialize` handshake.
 pub const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+/// Modern stateless protocol revision, declared per-request via `_meta`.
+pub const MCP_PROTOCOL_VERSION_MODERN: &str = "2026-07-28";
+/// Protocol revisions this server accepts, newest first.
+pub const MCP_SUPPORTED_PROTOCOL_VERSIONS: [&str; 2] =
+    [MCP_PROTOCOL_VERSION_MODERN, MCP_PROTOCOL_VERSION];
+/// `_meta` key carrying the protocol version on modern requests.
+pub const META_KEY_PROTOCOL_VERSION: &str = "io.modelcontextprotocol/protocolVersion";
+/// `_meta` key carrying the server identity on modern results.
+pub const META_KEY_SERVER_INFO: &str = "io.modelcontextprotocol/serverInfo";
 pub const MCP_SERVER_NAME: &str = "openobserve-mcp";
 pub const MCP_SERVER_VERSION: &str = "1.0.0";
 pub const JSONRPC_VERSION: &str = "2.0";
+
+pub fn is_supported_protocol_version(version: &str) -> bool {
+    MCP_SUPPORTED_PROTOCOL_VERSIONS.contains(&version)
+}
+
+/// Decode a header value that may use the Base64 sentinel format
+/// (`=?base64?{value}?=`) defined by the 2026-07-28 Streamable HTTP
+/// transport for `Mcp-Name` / `Mcp-Param-*`. Plain values pass through
+/// unchanged; a malformed sentinel yields `None`.
+pub fn decode_mcp_header_value(value: &str) -> Option<String> {
+    let Some(inner) = value
+        .strip_prefix("=?base64?")
+        .and_then(|v| v.strip_suffix("?="))
+    else {
+        return Some(value.to_string());
+    };
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(inner)
+        .ok()?;
+    String::from_utf8(bytes).ok()
+}
 
 // MCP Methods
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -32,6 +64,8 @@ pub enum MCPMethod {
     Ping,
     ToolsList,
     ToolsCall,
+    /// server/discover — modern (2026-07-28) capability/version discovery
+    ServerDiscover,
     /// notifications/initialized — sent by client after initialize, no response expected
     NotificationsInitialized,
 }
@@ -43,6 +77,7 @@ impl MCPMethod {
             Self::Ping => "ping",
             Self::ToolsList => "tools/list",
             Self::ToolsCall => "tools/call",
+            Self::ServerDiscover => "server/discover",
             Self::NotificationsInitialized => "notifications/initialized",
         }
     }
@@ -62,6 +97,7 @@ impl FromStr for MCPMethod {
             "ping" => Ok(Self::Ping),
             "tools/list" => Ok(Self::ToolsList),
             "tools/call" => Ok(Self::ToolsCall),
+            "server/discover" => Ok(Self::ServerDiscover),
             "notifications/initialized" => Ok(Self::NotificationsInitialized),
             _ => Err(format!("'{s}' is not a valid MCP method")),
         }
@@ -78,6 +114,10 @@ pub enum MCPErrorCode {
     InvalidParams = -32602,
     InternalError = -32603,
     ToolExecutionFailed = -32000,
+    /// 2026-07-28: HTTP headers do not match the request body (-32020)
+    HeaderMismatch = -32020,
+    /// 2026-07-28: requested protocol version is not supported (-32022)
+    UnsupportedProtocolVersion = -32022,
     Custom(i32),
 }
 
@@ -90,6 +130,8 @@ impl MCPErrorCode {
             Self::InvalidParams => -32602,
             Self::InternalError => -32603,
             Self::ToolExecutionFailed => -32000,
+            Self::HeaderMismatch => -32020,
+            Self::UnsupportedProtocolVersion => -32022,
             Self::Custom(code) => *code,
         }
     }
@@ -104,6 +146,8 @@ impl From<i32> for MCPErrorCode {
             -32602 => Self::InvalidParams,
             -32603 => Self::InternalError,
             -32000 => Self::ToolExecutionFailed,
+            -32020 => Self::HeaderMismatch,
+            -32022 => Self::UnsupportedProtocolVersion,
             _ => Self::Custom(code),
         }
     }
@@ -117,6 +161,22 @@ pub struct MCPRequest {
     pub method: String,
     #[serde(default)]
     pub params: Value,
+}
+
+impl MCPRequest {
+    /// Protocol version declared in the request's `_meta`, present on
+    /// modern (2026-07-28) requests and absent on legacy ones.
+    pub fn meta_protocol_version(&self) -> Option<&str> {
+        self.params
+            .get("_meta")?
+            .get(META_KEY_PROTOCOL_VERSION)?
+            .as_str()
+    }
+
+    /// True when the request uses modern per-request-metadata semantics.
+    pub fn is_modern(&self) -> bool {
+        self.meta_protocol_version() == Some(MCP_PROTOCOL_VERSION_MODERN)
+    }
 }
 
 // JSON-RPC Response
@@ -389,6 +449,63 @@ mod tests {
             MCPMethod::NotificationsInitialized
         );
         assert!(MCPMethod::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_server_discover_method() {
+        assert_eq!(MCPMethod::ServerDiscover.as_str(), "server/discover");
+        assert_eq!(
+            MCPMethod::from_str("server/discover").unwrap(),
+            MCPMethod::ServerDiscover
+        );
+        assert!(!MCPMethod::ServerDiscover.is_notification());
+    }
+
+    #[test]
+    fn test_is_supported_protocol_version() {
+        assert!(is_supported_protocol_version("2026-07-28"));
+        assert!(is_supported_protocol_version("2025-11-25"));
+        assert!(!is_supported_protocol_version("2025-03-26"));
+        assert!(!is_supported_protocol_version("unsupported"));
+    }
+
+    #[test]
+    fn test_meta_protocol_version() {
+        let request = MCPRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: Some(Value::from(1)),
+            method: "tools/list".to_string(),
+            params: serde_json::json!({
+                "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" }
+            }),
+        };
+        assert_eq!(request.meta_protocol_version(), Some("2026-07-28"));
+        assert!(request.is_modern());
+
+        let legacy = MCPRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: Some(Value::from(1)),
+            method: "tools/list".to_string(),
+            params: Value::Null,
+        };
+        assert_eq!(legacy.meta_protocol_version(), None);
+        assert!(!legacy.is_modern());
+    }
+
+    #[test]
+    fn test_decode_mcp_header_value() {
+        // Plain values pass through unchanged
+        assert_eq!(
+            decode_mcp_header_value("get_weather").as_deref(),
+            Some("get_weather")
+        );
+        // Base64 sentinel is decoded ("Hello, 世界")
+        assert_eq!(
+            decode_mcp_header_value("=?base64?SGVsbG8sIOS4lueVjA==?=").as_deref(),
+            Some("Hello, 世界")
+        );
+        // Malformed sentinel payload yields None
+        assert_eq!(decode_mcp_header_value("=?base64?!!!?="), None);
     }
 
     #[test]


### PR DESCRIPTION
Design at: #13526

## Summary

Implements MCP specification revision **2026-07-28** (stateless protocol) alongside the existing 2025-11-25 behavior on the same endpoint, following the spec's dual-era server model: requests carrying modern per-request `_meta` are served per 2026-07-28, while `initialize` selects legacy semantics. Legacy clients are unaffected.

## Changes

- **Version negotiation** (`src/api/http/.../mcp/mod.rs`, `src/mcp/src/protocol.rs`): the `MCP-Protocol-Version` header is now validated against a supported-version set (`2026-07-28`, `2025-11-25`) instead of strict equality — the old check would have rejected every client that upgrades to the new revision. Unsupported versions (header or body `_meta`) get `400` + JSON-RPC `-32022` (`UnsupportedProtocolVersionError`) listing the supported versions so clients can retry.
- **`server/discover`** (`src/mcp/src/protocol.rs`): new RPC required by 2026-07-28, returning `supportedVersions`, `capabilities`, server identity in `_meta`, `instructions`, and `ttlMs`/`cacheScope` cache fields.
- **Modern result decoration** (`src/mcp/src/protocol.rs`): requests declaring `io.modelcontextprotocol/protocolVersion: 2026-07-28` in `_meta` get `resultType: "complete"` and `_meta` server identity on results, plus `ttlMs`/`cacheScope` on `tools/list`. Legacy responses carry none of these fields — byte-for-byte unchanged.
- **Request metadata headers** (`src/api/http/.../mcp/mod.rs`): modern requests must mirror body fields into `Mcp-Method` / `Mcp-Name` headers (including the Base64 sentinel encoding for `Mcp-Name`); missing or mismatched headers are rejected with `400` + JSON-RPC `-32020` (`HeaderMismatch`), per the transport's server-validation rules.
- **HTTP status mapping**: unknown methods on modern requests return `404` + `-32601` so dual-era clients can distinguish a modern server from a legacy one; version errors return `400`. Legacy requests keep errors in-band with `200` as before.
- **Legacy paths untouched**: `initialize`, `ping`, the GET SSE keepalive channel, DELETE no-op, and notification → `202` handling are unchanged.

Tool ordering was already deterministic (sorted at init), satisfying the new caching guidance.

## Testing

- `cargo test -p openobserve-mcp` — 94 tests pass (new coverage: `server/discover` shape, unsupported-version error payload, modern decoration, legacy non-decoration, sentinel decoding, version set).
- `cargo test -p openobserve-api-http --lib handler::http::request::mcp` — 13 tests pass (new coverage: modern happy path, missing/mismatched `Mcp-Method`/`Mcp-Name`, header↔body version mismatch, missing version header on modern requests, modern unknown method → 404, legacy header accepted).
- `cargo clippy` clean on both crates.
