### PR TITLE
test(ci): loud stdout banner when Playwright retries a test

### DIFF
--- a/tests/ui-testing/playwright-alpha1.config.js
+++ b/tests/ui-testing/playwright-alpha1.config.js
@@ -81,6 +81,9 @@ module.exports = defineConfig({
   reporter: process.env.CI
     ? [
         ['blob', { outputDir: 'blob-report' }],
+        // Prints a LOUD banner to stdout whenever a test is retried (blob writes nothing to
+        // the log, so retries are otherwise invisible in the CI output). Log-only, never fails.
+        ['./playwright-tests/utils/retry-banner-reporter.js'],
       ]
     : [
         ['html', { outputFolder: 'playwright-results/html-report', open: 'never' }],

--- a/tests/ui-testing/playwright-tests/utils/retry-banner-reporter.js
+++ b/tests/ui-testing/playwright-tests/utils/retry-banner-reporter.js
@@ -1,0 +1,82 @@
+/**
+ * Retry Banner Reporter
+ * ---------------------
+ * In CI the reporter is `blob`, which writes nothing to stdout — so when Playwright
+ * retries a failed test (retries: 3 in playwright.config.js) there is no signal in the
+ * GitHub Actions logs that a retry is even happening. This reporter fixes that: it prints
+ * a LOUD, unmissable banner to stdout the moment any test starts a retry attempt, and a
+ * short roll-up at the end listing every test that had to be retried.
+ *
+ * It only logs — it never sends anything or fails the run, so it is safe to run alongside
+ * the blob/html/json reporters.
+ *
+ * Playwright reporter API: https://playwright.dev/docs/api/class-reporter
+ */
+class RetryBannerReporter {
+  constructor() {
+    // Map<string, number> — testId -> highest retry attempt observed (for the end summary).
+    this.retried = new Map();
+    // Parallel map of testId -> { title, file } for the summary print.
+    this.meta = new Map();
+  }
+
+  /**
+   * Fires when each test attempt begins. `result.retry` is 0 for the first attempt and
+   * increments for every retry, so `> 0` means "this is a retry".
+   */
+  onTestBegin(test, result) {
+    if (!result || result.retry <= 0) return;
+
+    const retryNum = result.retry;
+    const maxRetries = test.retries || 0;         // configured retries for this test
+    const attempt = retryNum + 1;                 // human-friendly attempt number
+    const totalAttempts = maxRetries + 1;
+    const title = test.titlePath().filter(Boolean).join(' › ') || test.title;
+    const file = this._shortFile(test.location && test.location.file);
+
+    this.retried.set(test.id, retryNum);
+    this.meta.set(test.id, { title, file });
+
+    // A fat, high-contrast banner. Emojis + repeated chars make it trivial to spot when
+    // eyeballing or Ctrl+F-ing ("RETRY") a long CI log.
+    const bar = '🔁🔁🔁' + '═'.repeat(58) + '🔁🔁🔁';
+    const lines = [
+      '',
+      bar,
+      `🔁  R E T R Y   # ${retryNum}   ·   attempt ${attempt} of ${totalAttempts}  (test previously failed — re-running)`,
+      `🔁  ▶ ${title}`,
+      `🔁  ▶ ${file}`,
+      bar,
+      '',
+    ];
+    // Single write so the banner never interleaves with parallel-worker output.
+    process.stdout.write(lines.join('\n') + '\n');
+  }
+
+  onEnd() {
+    if (this.retried.size === 0) return;
+
+    const bar = '🔁🔁🔁' + '═'.repeat(58) + '🔁🔁🔁';
+    const out = ['', bar, `🔁  RETRY SUMMARY — ${this.retried.size} test(s) were retried in this shard:`];
+    for (const [id, retries] of this.retried) {
+      const m = this.meta.get(id) || {};
+      out.push(`🔁    • [${retries} retr${retries === 1 ? 'y' : 'ies'}] ${m.title || id}  (${m.file || 'unknown'})`);
+    }
+    out.push(bar, '');
+    process.stdout.write(out.join('\n') + '\n');
+  }
+
+  _shortFile(file) {
+    if (!file) return 'unknown';
+    // Keep the last two path segments (folder/file.spec.js) — enough to locate the test.
+    const parts = file.split(/[\\/]/);
+    return parts.slice(-2).join('/');
+  }
+
+  // Quieter than the default reporter about everything else.
+  printsToStdio() {
+    return false;
+  }
+}
+
+module.exports = RetryBannerReporter;

--- a/tests/ui-testing/playwright.config.js
+++ b/tests/ui-testing/playwright.config.js
@@ -39,6 +39,9 @@ module.exports = defineConfig({
   reporter: process.env.CI
     ? [
         ['blob', { outputDir: 'blob-report' }], // Use blob reporter in CI - JSON created during merge
+        // Prints a LOUD banner to stdout whenever a test is retried (blob writes nothing to
+        // the log, so retries are otherwise invisible in the CI output). Log-only, never fails.
+        ['./playwright-tests/utils/retry-banner-reporter.js'],
       ]
     : [
         ['html', { outputFolder: 'playwright-results/html-report', open: 'never' }], // HTML reporter


### PR DESCRIPTION
## What

Adds a small **log-only** Playwright reporter that prints a LOUD, unmissable banner to stdout **the moment any test starts a retry attempt**, plus an end-of-shard summary listing every test that was retried.

## Why

In CI the reporter is `blob`, which writes nothing to stdout. So when a failed test is retried (`retries: process.env.CI ? 3 : 0` in `playwright.config.js`) there is **no signal in the GitHub Actions logs that a retry is even happening** — a test silently re-runs up to 3 more times and the log just shows the next `Test Started` line. This makes flaky-vs-real failures hard to spot when scanning CI output.

The retry is internal to `npx playwright test`, so the workflow YAML can't see it — it has to be emitted from the Playwright reporter layer. This is that layer.

## What it looks like

```
🔁🔁🔁══════════════════════════════════════════════════════════🔁🔁🔁
🔁  R E T R Y   # 1   ·   attempt 2 of 4  (test previously failed — re-running)
🔁  ▶ chromium › logsqueries.cte.spec.js › should query with simple TotalCols CTE
🔁  ▶ Logs/logsqueries.cte.spec.js
🔁🔁🔁══════════════════════════════════════════════════════════🔁🔁🔁
```

…and once per shard at the end:

```
🔁  RETRY SUMMARY — N test(s) were retried in this shard:
🔁    • [2 retries] chromium › … › should query …  (Logs/logsqueries.cte.spec.js)
```

## Scope / safety

- Added to the **CI** reporter list only, alongside `blob` (multiple reporters are fine). It only `console.log`s — never sends anything, never fails the run.
- **ENT gets this for free**: the ENT Playwright workflow checks out and runs the OSS `tests/ui-testing` tree, so this one OSS change makes retries loud in both OSS and ENT CI. There is no ENT test tree to change.
- Verified locally with a forced-failure probe (`CI=true`, `retries: 2`): the per-retry banner fires on attempt 2 and 3, and the summary lists the retried test.

## Files

- `tests/ui-testing/playwright-tests/utils/retry-banner-reporter.js` — new reporter
- `tests/ui-testing/playwright.config.js` — wire it into the CI reporter array