### PR TITLE
perf(cache): remove per-org full scans and hot-path shrink_to_fit calls

### DIFF
--- a/src/common/src/infra/wal.rs
+++ b/src/common/src/infra/wal.rs
@@ -50,10 +50,6 @@ impl SearchingFileLocker {
         }
     }
 
-    pub fn shrink_to_fit(&mut self) {
-        self.inner.shrink_to_fit()
-    }
-
     pub fn len(&self) -> usize {
         self.inner.len()
     }
@@ -85,7 +81,6 @@ pub fn release_files(files: &[String]) {
     for file in files.iter() {
         locker.release(file);
     }
-    locker.shrink_to_fit();
 }
 
 pub fn lock_files_exists(file: &str) -> bool {
@@ -110,7 +105,6 @@ pub fn release_request(trace_id: &str) {
     log::info!("[trace_id: {trace_id}] release_request for wal files");
     let mut locker = SEARCHING_REQUESTS.write();
     let files = locker.remove(trace_id);
-    locker.shrink_to_fit();
     drop(locker);
     if let Some(files) = files {
         release_files(&files);
@@ -122,8 +116,14 @@ mod tests {
 
     use super::*;
 
+    // tests below mutate the shared global SEARCHING_FILES map; serialize the
+    // ones that assert on lock presence so clean_lock_files() from a parallel
+    // test cannot clear locks mid-assertion
+    static TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
     #[tokio::test]
     async fn test_wal_file_locking() {
+        let _guard = TEST_LOCK.lock();
         let files = vec![
             "files/test_org/logs/test_stream/1/2025/06/06/01/1/md5/test_key1.json".to_string(),
             "files/test_org/logs/test_stream/1/2025/06/06/01/1/md5/test_key2.json".to_string(),
@@ -142,6 +142,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_wal_request_locking() {
+        let _guard = TEST_LOCK.lock();
         let trace_id = "test_trace_1234";
         let files = vec![
             "files/test_org/logs/test_stream/1/2025/06/06/01/1/md5/test_key3.json".to_string(),
@@ -176,6 +177,7 @@ mod tests {
 
     #[test]
     fn test_clean_lock_files_clears_all() {
+        let _guard = TEST_LOCK.lock();
         let files = vec![
             "files/org/logs/stream/1/md5/clean_test_a.json".to_string(),
             "files/org/logs/stream/1/md5/clean_test_b.json".to_string(),
@@ -189,6 +191,7 @@ mod tests {
 
     #[test]
     fn test_file_lock_reference_counting() {
+        let _guard = TEST_LOCK.lock();
         let files = vec!["files/org/logs/stream/1/md5/refcount_test.json".to_string()];
         lock_files(&files);
         lock_files(&files);

--- a/src/compaction/src/stats.rs
+++ b/src/compaction/src/stats.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashSet;
+
 use config::{
     cluster::LOCAL_NODE,
     meta::stream::{ALL_STREAM_TYPES, StreamType},
@@ -62,10 +64,14 @@ pub async fn update_stats_from_file_list() -> Result<(), anyhow::Error> {
     );
 
     // get updated streams if we don't need to update old stats
-    let updated_streams = if no_need_update_old_stats {
-        infra_file_list::get_updated_streams((last_updated_at, latest_updated_at)).await?
+    // empty set means update all streams
+    let updated_streams: HashSet<String> = if no_need_update_old_stats {
+        infra_file_list::get_updated_streams((last_updated_at, latest_updated_at))
+            .await?
+            .into_iter()
+            .collect()
     } else {
-        vec![]
+        HashSet::new()
     };
 
     let yesterday_boundary = get_yesterday_boundary();

--- a/src/jobs/src/job/metrics.rs
+++ b/src/jobs/src/job/metrics.rs
@@ -175,16 +175,11 @@ async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
     metrics::META_NUM_USERS_TOTAL
         .with_label_values::<&str>(&[])
         .set(users as i64);
+    let org_user_counts = count_org_users();
     for org_id in &orgs {
-        let mut count: i64 = 0;
-        for user in ORG_USERS.iter() {
-            if user.key().starts_with(&format!("{org_id}/")) {
-                count += 1;
-            }
-        }
         metrics::META_NUM_USERS
             .with_label_values(&[org_id.as_str()])
-            .set(count);
+            .set(org_user_counts.get(org_id.as_str()).copied().unwrap_or(0));
     }
 
     metrics::META_NUM_FUNCTIONS.reset();
@@ -209,6 +204,17 @@ async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
     // TODO dashboard
 
     Ok(())
+}
+
+/// Aggregate user counts by org in one pass instead of scanning ORG_USERS per org.
+fn count_org_users() -> HashMap<String, i64> {
+    let mut counts: HashMap<String, i64> = HashMap::new();
+    for user in ORG_USERS.iter() {
+        if let Some((org_id, _)) = user.key().split_once('/') {
+            *counts.entry(org_id.to_string()).or_default() += 1;
+        }
+    }
+    counts
 }
 
 async fn update_storage_metrics() -> Result<(), anyhow::Error> {
@@ -272,4 +278,54 @@ async fn update_parquet_metadata_cache_metrics() -> Result<(), anyhow::Error> {
         .with_label_values::<&str>(&[])
         .set(mem_size as i64);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use config::meta::user::UserRole;
+    use infra::table::org_users::OrgUserRecord;
+
+    use super::*;
+
+    fn org_user_record(org_id: &str, email: &str) -> OrgUserRecord {
+        OrgUserRecord {
+            email: email.to_string(),
+            org_id: org_id.to_string(),
+            role: UserRole::Admin,
+            token: "".to_string(),
+            rum_token: None,
+            created_at: 0,
+            allow_static_token: false,
+        }
+    }
+
+    #[test]
+    fn test_count_org_users() {
+        // unique org names so the global map can be shared with other tests
+        let entries = [
+            ("count_org_users_a", "u1@example.com"),
+            ("count_org_users_a", "u2@example.com"),
+            ("count_org_users_b", "u1@example.com"),
+        ];
+        for (org_id, email) in entries {
+            ORG_USERS.insert(format!("{org_id}/{email}"), org_user_record(org_id, email));
+        }
+        // a key without a separator must be ignored, not counted or panicked on
+        ORG_USERS.insert(
+            "count_org_users_no_separator".to_string(),
+            org_user_record("count_org_users_no_separator", "u1@example.com"),
+        );
+
+        let counts = count_org_users();
+        assert_eq!(counts.get("count_org_users_a").copied(), Some(2));
+        assert_eq!(counts.get("count_org_users_b").copied(), Some(1));
+        // an org with no users is absent; callers default to 0
+        assert_eq!(counts.get("count_org_users_empty"), None);
+        assert_eq!(counts.get("count_org_users_no_separator"), None);
+
+        for (org_id, email) in entries {
+            ORG_USERS.remove(&format!("{org_id}/{email}"));
+        }
+        ORG_USERS.remove("count_org_users_no_separator");
+    }
 }

--- a/src/schema/src/watcher.rs
+++ b/src/schema/src/watcher.rs
@@ -224,19 +224,13 @@ async fn watch(
                 }
                 let mut w = STREAM_SCHEMAS.write().await;
                 w.remove(item_key);
-                w.shrink_to_fit();
                 drop(w);
                 let mut w = STREAM_SCHEMAS_LATEST.write().await;
                 w.remove(item_key);
-                w.shrink_to_fit();
                 drop(w);
-                {
-                    STREAM_RECORD_ID_GENERATOR.remove(item_key);
-                    STREAM_RECORD_ID_GENERATOR.shrink_to_fit();
-                }
+                STREAM_RECORD_ID_GENERATOR.remove(item_key);
                 let mut w = STREAM_SETTINGS.write().await;
                 w.remove(item_key);
-                w.shrink_to_fit();
                 infra::schema::set_stream_settings_atomic(w.clone());
                 drop(w);
                 cache::stats::remove_stream_stats(org_id, stream_name, stream_type);


### PR DESCRIPTION
Design at: #13465

PR 1 of the plan in #13465 (the mechanical fixes: findings 3, 4, 5).

## Changes

**Metadata metrics job (finding 3)** — `update_metadata_metrics` counted users by scanning all of `ORG_USERS` once per organization, with a `format!` allocation inside the inner loop: O(orgs × org_users) iterations and allocations every 60 seconds on the compactor. Replaced with a single pass that aggregates counts per org (`count_org_users()`); per-org metric output is unchanged, including 0 for organizations with no users. Covered by a unit test.

**Incremental stats (finding 4)** — `update_stats_from_file_list` checked every enumerated stream against `updated_streams: Vec<String>` with a linear `contains`, O(streams × updated) and effectively quadratic when most streams changed. The list is now collected into a `HashSet` once; the empty-set-means-update-all semantics are preserved.

**Per-operation `shrink_to_fit` (finding 5)** — removed from:
- the schema watcher delete path, which shrank four global maps (`STREAM_SCHEMAS`, `STREAM_SCHEMAS_LATEST`, `STREAM_RECORD_ID_GENERATOR`, `STREAM_SETTINGS`) after every single-stream deletion — bulk deletes rehashed a large table repeatedly while holding write locks;
- the WAL search-lock release paths (`release_files`, `release_request`), which shrank `SEARCHING_FILES`/`SEARCHING_REQUESTS` on every request completion.

`shrink_to_fit` rehashes the entire table but only reclaims the bucket array — the entry payloads are already freed by `remove()` — so these calls cost O(map size) under a write lock for a few MB upper-bound of savings. The shrink inside the rare full-clear `clean()` path is kept.

**Test flakiness fix (pre-existing)** — the WAL locking tests mutate the shared global map and run in parallel; `clean_lock_files()` from one test could clear locks another test had just asserted on. Verified flaky on main (2 of 3 runs failed). The tests that assert on lock presence now serialize on a test-local mutex; 5 consecutive full runs pass.

## Testing

- `cargo test -p common infra::wal` — 6 passed, stable across 5 runs
- `cargo test -p compaction stats` — 10 passed
- `cargo test -p openobserve-jobs job::metrics` — new `test_count_org_users` passes
- `cargo clippy --all-targets` clean on the four touched crates

Findings 1 (settings cache Arc-ification + mutation centralization) and 2 (grouped stream enumeration) follow in separate PRs per the plan.