### PR TITLE
chore: add Vortex native compression toggle

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1013,6 +1013,12 @@ pub struct Common {
         help = "File format for data storage: parquet or vortex"
     )]
     pub file_format: FileFormat,
+    #[env_config(
+        name = "ZO_VORTEX_USE_NATIVE_COMPRESSION",
+        default = false,
+        help = "Use Vortex's built-in compression strategy. By default, OpenObserve's custom UTF8/Zstd compressor is used"
+    )]
+    pub vortex_use_native_compression: bool,
     #[env_config(name = "ZO_PARQUET_COMPRESSION", default = "zstd")]
     pub parquet_compression: String,
     #[env_config(

--- a/src/search/src/datafusion/merge/downsampling.rs
+++ b/src/search/src/datafusion/merge/downsampling.rs
@@ -35,7 +35,7 @@ use vortex::{
     VortexSessionDefault,
     array::{ArrayRef, arrow::FromArrowArray},
     dtype::{DType, arrow::FromArrowType},
-    file::{VortexWriteOptions, WriteStrategyBuilder},
+    file::VortexWriteOptions,
     io::session::RuntimeSessionExt,
     session::VortexSession,
 };
@@ -44,7 +44,7 @@ use crate::datafusion::{
     exec::DataFusionContextBuilder,
     merge::{MergeParquetResult, append_metadata},
     table_provider::uniontable::NewUnionTable,
-    vortex::{Utf8Compressor, VORTEX_RUNTIME},
+    vortex::{VORTEX_RUNTIME, vortex_write_strategy},
 };
 
 const TIMESTAMP_ALIAS: &str = "_timestamp_alias";
@@ -215,10 +215,8 @@ async fn write_downsampled_vortex(
             let session = VortexSession::default().with_tokio();
             let dtype = DType::from_arrow(schema.as_ref());
 
-            // Helper to create write options - need to recreate for each writer
-            let strategy = WriteStrategyBuilder::default()
-                .with_compressor(Utf8Compressor::default())
-                .build();
+            // Reuse the strategy across files; write options are recreated for each writer.
+            let strategy = vortex_write_strategy();
 
             let write_options =
                 VortexWriteOptions::new(session.clone()).with_strategy(strategy.clone());

--- a/src/search/src/datafusion/merge/mod.rs
+++ b/src/search/src/datafusion/merge/mod.rs
@@ -29,9 +29,20 @@ use datafusion::{
 };
 use futures::TryStreamExt;
 use parquet::{arrow::AsyncArrowWriter, file::metadata::KeyValue};
+use vortex::{
+    VortexSessionDefault,
+    array::{ArrayRef, arrow::FromArrowArray},
+    dtype::{DType, arrow::FromArrowType},
+    file::VortexWriteOptions,
+    io::session::RuntimeSessionExt,
+    session::VortexSession,
+};
 
 use super::table_provider::uniontable::NewUnionTable;
-use crate::datafusion::exec::DataFusionContextBuilder;
+use crate::datafusion::{
+    exec::DataFusionContextBuilder,
+    vortex::{VORTEX_RUNTIME, vortex_write_strategy},
+};
 
 #[cfg(feature = "enterprise")]
 pub mod downsampling;
@@ -242,10 +253,41 @@ async fn write_parquet(
 
 async fn write_vortex(
     schema: Arc<Schema>,
-    rx: tokio::sync::mpsc::Receiver<RecordBatch>,
+    mut rx: tokio::sync::mpsc::Receiver<RecordBatch>,
     read_task: tokio::task::JoinHandle<Result<()>>,
 ) -> Result<Vec<u8>> {
-    crate::datafusion::vortex::write_vortex(schema, rx, read_task).await
+    let writer_task = VORTEX_RUNTIME.spawn_blocking(move || {
+        VORTEX_RUNTIME.block_on(async move {
+            let mut buf = Vec::new();
+            let session = VortexSession::default().with_tokio();
+            let dtype = DType::from_arrow(schema.as_ref());
+            let write_options =
+                VortexWriteOptions::new(session.clone()).with_strategy(vortex_write_strategy());
+            let mut writer = write_options.writer(&mut buf, dtype);
+
+            while let Some(batch) = rx.recv().await {
+                let array: ArrayRef = ArrayRef::from_arrow(batch, false).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to convert arrow array to vortex array: {e}"
+                    ))
+                })?;
+                writer.push(array).await?;
+            }
+
+            writer.finish().await?;
+
+            Ok::<Vec<u8>, anyhow::Error>(buf)
+        })
+    });
+
+    read_task
+        .await
+        .map_err(|e| DataFusionError::External(Box::new(e)))??;
+
+    writer_task
+        .await
+        .map_err(|e| DataFusionError::Execution(format!("Vortex runtime task failed: {e}")))?
+        .map_err(|e| DataFusionError::Execution(format!("Failed to write vortex file: {e}")))
 }
 
 pub fn append_metadata(

--- a/src/search/src/datafusion/vortex.rs
+++ b/src/search/src/datafusion/vortex.rs
@@ -16,29 +16,25 @@
 //! Vortex file format support.
 //!
 //! This module provides:
-//! - `Utf8Compressor`: A smart compressor for UTF8 fields using Zstd compression
-//! - Vortex file reading utilities for reading record batches and schemas
+//! - A custom compressor for UTF8 fields using Zstd compression
+//! - Shared Vortex write strategy and access plan utilities
 
 use std::sync::{Arc, LazyLock};
 
-use arrow::{buffer::BooleanBuffer, record_batch::RecordBatch};
-use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use arrow::buffer::BooleanBuffer;
 use tokio::runtime::Runtime;
 use vortex::{
-    VortexSessionDefault,
-    array::{ArrayRef, Canonical, ExecutionCtx, IntoArray, arrow::FromArrowArray},
+    array::{ArrayRef, Canonical, ExecutionCtx, IntoArray},
     buffer::Buffer,
     compressor::{
         BtrBlocksCompressor, BtrBlocksCompressorBuilder, SchemeExt, schemes::integer::IntDictScheme,
     },
-    dtype::{DType, arrow::FromArrowType},
+    dtype::DType,
     encodings::zstd::Zstd,
     error::VortexResult,
-    file::{VortexWriteOptions, WriteStrategyBuilder},
-    io::session::RuntimeSessionExt,
-    layout::layouts::compressed::CompressorPlugin,
+    file::WriteStrategyBuilder,
+    layout::{LayoutStrategy, layouts::compressed::CompressorPlugin},
     scan::selection::Selection,
-    session::VortexSession,
 };
 use vortex_datafusion::VortexAccessPlan;
 
@@ -64,7 +60,7 @@ pub static VORTEX_RUNTIME: LazyLock<Arc<Runtime>> = LazyLock::new(|| {
 /// For all other data types:
 /// - Delegates to BtrBlocksCompressor for optimal encoding
 #[derive(Clone)]
-pub struct Utf8Compressor {
+struct Utf8Compressor {
     /// The underlying BtrBlocks compressor for general compression
     btr_compressor: BtrBlocksCompressor,
     /// Zstd compression level (default: 3)
@@ -75,7 +71,7 @@ pub struct Utf8Compressor {
 
 impl Utf8Compressor {
     /// Create a new smart compressor with default settings.
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             btr_compressor: BtrBlocksCompressorBuilder::default()
                 .exclude_schemes([IntDictScheme.id()])
@@ -86,13 +82,15 @@ impl Utf8Compressor {
     }
 
     /// Set the Zstd compression level (1-22, default: 3).
-    pub fn with_zstd_level(mut self, level: i32) -> Self {
+    #[cfg(test)]
+    fn with_zstd_level(mut self, level: i32) -> Self {
         self.zstd_level = level;
         self
     }
 
     /// Set the number of values per Zstd compression frame (default: 8192).
-    pub fn with_values_per_page(mut self, values: usize) -> Self {
+    #[cfg(test)]
+    fn with_values_per_page(mut self, values: usize) -> Self {
         self.values_per_page = values;
         self
     }
@@ -141,6 +139,24 @@ impl CompressorPlugin for Utf8Compressor {
     }
 }
 
+/// Build the configured Vortex file write strategy.
+///
+/// OpenObserve's custom UTF8/Zstd compressor is used by default. Vortex's
+/// native compression strategy can be enabled with
+/// `ZO_VORTEX_USE_NATIVE_COMPRESSION=true`.
+pub(super) fn vortex_write_strategy() -> Arc<dyn LayoutStrategy> {
+    build_vortex_write_strategy(config::get_config().common.vortex_use_native_compression)
+}
+
+fn build_vortex_write_strategy(use_native_compression: bool) -> Arc<dyn LayoutStrategy> {
+    let builder = WriteStrategyBuilder::default();
+    if use_native_compression {
+        builder.build()
+    } else {
+        builder.with_compressor(Utf8Compressor::default()).build()
+    }
+}
+
 /// Generate a vortex access plan from a per-row match bitmap.
 pub fn generate_vortex_access_plan(row_ids: &BooleanBuffer) -> Option<VortexAccessPlan> {
     let indices: Vec<u64> = row_ids.set_indices().map(|i| i as u64).collect();
@@ -150,55 +166,15 @@ pub fn generate_vortex_access_plan(row_ids: &BooleanBuffer) -> Option<VortexAcce
     Some(selection)
 }
 
-/// Write record batches to a vortex file.
-pub async fn write_vortex(
-    schema: Arc<arrow::datatypes::Schema>,
-    mut rx: tokio::sync::mpsc::Receiver<RecordBatch>,
-    read_task: tokio::task::JoinHandle<DataFusionResult<()>>,
-) -> DataFusionResult<Vec<u8>> {
-    let writer_task = VORTEX_RUNTIME.spawn_blocking(move || {
-        VORTEX_RUNTIME.block_on(async move {
-            let mut buf = Vec::new();
-            let session = VortexSession::default().with_tokio();
-            let dtype = DType::from_arrow(schema.as_ref());
-            let write_options = VortexWriteOptions::new(session.clone()).with_strategy(
-                WriteStrategyBuilder::default()
-                    .with_compressor(Utf8Compressor::default())
-                    .build(),
-            );
-            let mut writer = write_options.writer(&mut buf, dtype);
-
-            while let Some(batch) = rx.recv().await {
-                let array: ArrayRef = ArrayRef::from_arrow(batch, false).map_err(|e| {
-                    DataFusionError::Execution(format!(
-                        "Failed to convert arrow array to vortex array: {e}"
-                    ))
-                })?;
-                writer.push(array).await?;
-            }
-
-            writer.finish().await?;
-
-            Ok::<Vec<u8>, anyhow::Error>(buf)
-        })
-    });
-
-    // Wait for both tasks to complete
-    read_task
-        .await
-        .map_err(|e| DataFusionError::External(Box::new(e)))??;
-
-    writer_task
-        .await
-        .map_err(|e| DataFusionError::Execution(format!("Vortex runtime task failed: {e}")))?
-        .map_err(|e| DataFusionError::Execution(format!("Failed to write vortex file: {e}")))
-}
-
 #[cfg(test)]
 mod tests {
     use vortex::{
+        VortexSessionDefault,
         array::{IntoArray, arrays::VarBinViewArray},
         dtype::{DType, Nullability},
+        file::VortexWriteOptions,
+        io::session::RuntimeSessionExt,
+        session::VortexSession,
     };
 
     use super::*;
@@ -285,5 +261,25 @@ mod tests {
         let compressed = compressor.compress(&array, &mut ctx).unwrap();
         assert_eq!(compressed.len(), 3);
         assert!(compressed.nbytes() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_native_and_custom_write_strategies_create_files() {
+        for use_native_compression in [true, false] {
+            let strings = vec![Some("test"), Some("data"), Some("test")];
+            let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable))
+                .into_array();
+            let dtype = array.dtype().clone();
+            let session = VortexSession::default().with_tokio();
+            let write_options = VortexWriteOptions::new(session)
+                .with_strategy(build_vortex_write_strategy(use_native_compression));
+            let mut buf = Vec::new();
+            let mut writer = write_options.writer(&mut buf, dtype);
+
+            writer.push(array).await.unwrap();
+            writer.finish().await.unwrap();
+
+            assert!(!buf.is_empty());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add ZO_VORTEX_USE_NATIVE_COMPRESSION with a default of false
- keep the custom UTF8/Zstd compressor as the default and allow opting into the native Vortex strategy
- share the configured strategy across regular merge and downsampling writes
- move Vortex writing into the merge call site and keep the custom compressor private

## Testing
- cargo check -p search
- cargo test -p search datafusion::vortex::tests --lib
- cargo fmt --all -- --check
- git diff --check