### PR TITLE
perf(schema): enumerate streams with one grouped cache scan per job cycle

### DIFF
--- a/src/cli/basic/gc.rs
+++ b/src/cli/basic/gc.rs
@@ -30,7 +30,7 @@
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use config::{
     get_config, is_local_disk_storage,
-    meta::stream::{ALL_STREAM_TYPES, StreamType, TimeRange},
+    meta::stream::{StreamType, TimeRange},
     utils::time::now,
 };
 use db;
@@ -89,9 +89,9 @@ pub async fn run(
     } else {
         // process every stream: load schema cache to enumerate orgs/streams
         db::schema::cache().await?;
-        let orgs = db::schema::list_organizations_from_cache().await;
-        for org_id in orgs {
-            for stream_type in ALL_STREAM_TYPES {
+        let grouped = db::schema::list_all_streams_grouped().await;
+        for (org_id, stream_types) in grouped {
+            for (stream_type, streams) in stream_types {
                 // enrichment tables and file_list streams are not subject to data
                 // retention, skip them (same as compactor retention::generate_jobs)
                 if stream_type == StreamType::EnrichmentTables
@@ -99,7 +99,6 @@ pub async fn run(
                 {
                     continue;
                 }
-                let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
                 for stream_name in streams {
                     let (dirs, files) = gc_stream(
                         &org_id,

--- a/src/cli/basic/stream.rs
+++ b/src/cli/basic/stream.rs
@@ -14,10 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use chrono::{DateTime, Utc};
-use config::{
-    meta::stream::{ALL_STREAM_TYPES, StreamType},
-    utils::json,
-};
+use config::{meta::stream::StreamType, utils::json};
 use db;
 use infra::schema::unwrap_stream_settings;
 
@@ -32,9 +29,9 @@ pub async fn reset_index_updated_at(stream: &str, time: Option<i64>) -> Result<(
         // load the schema cache so we can enumerate all streams from it
         db::schema::cache().await?;
         let mut all = Vec::new();
-        for org_id in db::schema::list_organizations_from_cache().await {
-            for stream_type in ALL_STREAM_TYPES {
-                for stream_name in db::schema::list_streams_from_cache(&org_id, stream_type).await {
+        for (org_id, stream_types) in db::schema::list_all_streams_grouped().await {
+            for (stream_type, stream_names) in stream_types {
+                for stream_name in stream_names {
                     all.push((org_id.clone(), stream_type, stream_name));
                 }
             }

--- a/src/compaction/src/flatten.rs
+++ b/src/compaction/src/flatten.rs
@@ -47,16 +47,16 @@ static PROCESSING_FILES: Lazy<RwLock<HashSet<String>>> = Lazy::new(|| RwLock::ne
 
 pub async fn run_generate(worker_tx: mpsc::Sender<FileKey>) -> Result<(), anyhow::Error> {
     let semaphore = std::sync::Arc::new(Semaphore::new(get_config().limit.file_merge_thread_num));
-    let orgs = db::schema::list_organizations_from_cache().await;
+    let grouped = db::schema::list_all_streams_grouped().await;
     let stream_types = [StreamType::Logs];
-    for org_id in orgs {
+    for (org_id, mut org_streams) in grouped {
         // check backlist
         if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id)
         {
             continue;
         }
         for stream_type in stream_types {
-            let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
+            let streams = org_streams.remove(&stream_type).unwrap_or_default();
             let mut tasks = Vec::with_capacity(streams.len());
             for stream_name in streams {
                 // check if this stream need flatten

--- a/src/compaction/src/lib.rs
+++ b/src/compaction/src/lib.rs
@@ -20,7 +20,7 @@ use config::{
     get_config,
     meta::{
         cluster::{CompactionJobType, Role},
-        stream::{ALL_STREAM_TYPES, PartitionTimeLevel, StreamType},
+        stream::{PartitionTimeLevel, StreamType},
     },
 };
 use infra::{
@@ -98,15 +98,14 @@ pub async fn run_retention() -> Result<(), anyhow::Error> {
 
 /// Generate job for compactor
 pub async fn run_generate_job(job_type: CompactionJobType) -> Result<(), anyhow::Error> {
-    let orgs = db::schema::list_organizations_from_cache().await;
-    for org_id in orgs {
+    let grouped = db::schema::list_all_streams_grouped().await;
+    for (org_id, stream_types) in grouped {
         // check backlist
         if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id)
         {
             continue;
         }
-        for stream_type in ALL_STREAM_TYPES {
-            let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
+        for (stream_type, streams) in stream_types {
             for stream_name in streams {
                 let Some(node_name) =
                     get_node_from_consistent_hash(&stream_name, &Role::Compactor, None).await
@@ -192,15 +191,15 @@ pub async fn run_generate_job(job_type: CompactionJobType) -> Result<(), anyhow:
 /// Generate downsampling job for Metrics
 #[cfg(feature = "enterprise")]
 pub async fn run_generate_downsampling_job() -> Result<(), anyhow::Error> {
-    let orgs = db::schema::list_organizations_from_cache().await;
-    for org_id in orgs {
+    let grouped = db::schema::list_all_streams_grouped().await;
+    for (org_id, mut stream_types) in grouped {
         // check backlist
         if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id)
         {
             continue;
         }
         let stream_type = StreamType::Metrics;
-        let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
+        let streams = stream_types.remove(&stream_type).unwrap_or_default();
         for stream_name in streams {
             let Some(node_name) =
                 get_node_from_consistent_hash(&stream_name, &Role::Compactor, None).await

--- a/src/compaction/src/retention.rs
+++ b/src/compaction/src/retention.rs
@@ -22,8 +22,8 @@ use config::{
     meta::{
         cluster::Role,
         stream::{
-            ALL_STREAM_TYPES, FileKey, FileListBookKeepMode, FileListDeleted, PartitionTimeLevel,
-            StreamType, TimeRange,
+            FileKey, FileListBookKeepMode, FileListDeleted, PartitionTimeLevel, StreamType,
+            TimeRange,
         },
     },
     utils::time::{BASE_TIME, HourFormat, day_micros, get_ymdh_from_micros, hour_micros},
@@ -68,13 +68,12 @@ pub(crate) async fn generate_jobs() -> Result<(), anyhow::Error> {
     let now = config::utils::time::now();
     let data_lifecycle_end = now - Duration::try_days(cfg.compact.data_retention_days).unwrap();
 
-    let orgs = db::schema::list_organizations_from_cache().await;
-    for org_id in orgs {
-        for stream_type in ALL_STREAM_TYPES {
+    let grouped = db::schema::list_all_streams_grouped().await;
+    for (org_id, stream_types) in grouped {
+        for (stream_type, streams) in stream_types {
             if stream_type == StreamType::EnrichmentTables || stream_type == StreamType::Filelist {
                 continue; // skip data retention for enrichment tables and filelist
             }
-            let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
             for stream_name in streams {
                 let Some(node_name) =
                     get_node_from_consistent_hash(&stream_name, &Role::Compactor, None).await

--- a/src/compaction/src/stats.rs
+++ b/src/compaction/src/stats.rs
@@ -15,7 +15,7 @@
 
 use config::{
     cluster::LOCAL_NODE,
-    meta::stream::{ALL_STREAM_TYPES, StreamType},
+    meta::stream::StreamType,
     metrics,
     utils::time::{HourFormat, day_micros, get_ymdh_from_micros, now_micros},
 };
@@ -74,14 +74,13 @@ pub async fn update_stats_from_file_list() -> Result<(), anyhow::Error> {
 
     let iter = [(new_data_range, true), (old_data_range, false)];
 
-    let orgs = db::schema::list_organizations_from_cache().await;
+    let grouped = db::schema::list_all_streams_grouped().await;
     let mut total_streams = 0;
-    for org_id in orgs {
-        for stream_type in ALL_STREAM_TYPES {
+    for (org_id, stream_types) in grouped {
+        for (stream_type, streams) in stream_types {
             if stream_type == StreamType::Index || stream_type == StreamType::Filelist {
                 continue;
             }
-            let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
             total_streams += streams.len();
             let stream_type_str = stream_type.to_string();
             for stream_name in streams {

--- a/src/core/src/traces/service_graph/processor.rs
+++ b/src/core/src/traces/service_graph/processor.rs
@@ -128,11 +128,16 @@ pub async fn process_service_graph() -> Result<(), anyhow::Error> {
         .collect();
     match crate::organization::list_all_orgs(None).await {
         Ok(orgs) => {
+            // one pass over the schema cache instead of a full scan per org
+            let mut grouped = crate::db::schema::list_all_streams_grouped().await;
             for org in orgs {
-                for stream_name in
-                    crate::db::schema::list_streams_from_cache(&org.identifier, StreamType::Traces)
-                        .await
-                {
+                let Some(streams) = grouped
+                    .get_mut(&org.identifier)
+                    .and_then(|types| types.remove(&StreamType::Traces))
+                else {
+                    continue;
+                };
+                for stream_name in streams {
                     if seen.insert((org.identifier.clone(), stream_name.clone())) {
                         discovered.push(RecentIngestedTraceStream {
                             org_id: org.identifier.clone(),

--- a/src/db/src/schema.rs
+++ b/src/db/src/schema.rs
@@ -625,6 +625,40 @@ pub async fn get_stream_count_cached(org_id: &str, stream_type: StreamType) -> u
     count
 }
 
+/// One-pass enumeration of all cached streams grouped by org and stream type.
+///
+/// Periodic jobs that iterate every org and stream type should call this once
+/// per cycle instead of calling [`list_streams_from_cache`] per (org, type)
+/// pair, which rescans the whole schema cache on every call.
+pub async fn list_all_streams_grouped() -> HashMap<String, HashMap<StreamType, Vec<String>>> {
+    let mut grouped: HashMap<String, HashMap<StreamType, Vec<String>>> = HashMap::new();
+    let r = STREAM_SCHEMAS_LATEST.read().await;
+    for schema_key in r.keys() {
+        let mut parts = schema_key.split('/');
+        let (Some(org_id), Some(stream_type), Some(stream_name)) =
+            (parts.next(), parts.next(), parts.next())
+        else {
+            continue;
+        };
+        grouped
+            .entry(org_id.to_string())
+            .or_default()
+            .entry(StreamType::from(stream_type))
+            .or_default()
+            .push(stream_name.to_string());
+    }
+    drop(r);
+    // cache keys are unique, but names truncated at the third segment may
+    // collide; dedup to match list_streams_from_cache
+    for types in grouped.values_mut() {
+        for names in types.values_mut() {
+            names.sort_unstable();
+            names.dedup();
+        }
+    }
+    grouped
+}
+
 pub async fn list_streams_from_cache(org_id: &str, stream_type: StreamType) -> Vec<String> {
     let mut names = HashSet::new();
     let r = STREAM_SCHEMAS_LATEST.read().await;
@@ -663,6 +697,42 @@ mod tests {
 
     fn schema_without_end_dt() -> Schema {
         Schema::new_with_metadata(vec![] as Vec<arrow_schema::Field>, HashMap::new())
+    }
+
+    #[tokio::test]
+    async fn test_list_all_streams_grouped() {
+        // unique org name so the shared global cache can host parallel tests
+        let org = "grouped_enum_test_org";
+        let keys = [
+            format!("{org}/logs/app_a"),
+            format!("{org}/logs/app_b"),
+            format!("{org}/traces/svc"),
+        ];
+        {
+            let mut w = STREAM_SCHEMAS_LATEST.write().await;
+            for key in &keys {
+                w.insert(key.clone(), SchemaCache::new(Schema::empty()));
+            }
+        }
+
+        let grouped = list_all_streams_grouped().await;
+        let org_streams = grouped.get(org).unwrap();
+        let mut logs = org_streams.get(&StreamType::Logs).unwrap().clone();
+        logs.sort();
+        assert_eq!(logs, vec!["app_a".to_string(), "app_b".to_string()]);
+        assert_eq!(
+            org_streams.get(&StreamType::Traces).unwrap(),
+            &vec!["svc".to_string()]
+        );
+        // matches the per-(org, type) enumeration
+        let mut listed = list_streams_from_cache(org, StreamType::Logs).await;
+        listed.sort();
+        assert_eq!(logs, listed);
+
+        let mut w = STREAM_SCHEMAS_LATEST.write().await;
+        for key in &keys {
+            w.remove(key);
+        }
     }
 
     // ── filter_schema_version_id ──────────────────────────────────────────────

--- a/src/jobs/src/job/metrics.rs
+++ b/src/jobs/src/job/metrics.rs
@@ -154,13 +154,18 @@ async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
     }
 
     let stream_types = [StreamType::Logs, StreamType::Metrics, StreamType::Traces];
-    let orgs = db::schema::list_organizations_from_cache().await;
+    let grouped = db::schema::list_all_streams_grouped().await;
+    // orgs are derived from the same schema cache as before, so the org count
+    // metric is unchanged
+    let orgs = grouped.keys().cloned().collect::<Vec<_>>();
     metrics::META_NUM_ORGANIZATIONS
         .with_label_values::<&str>(&[])
         .set(orgs.len() as i64);
-    for org_id in &orgs {
+    for (org_id, org_streams) in &grouped {
         for stream_type in stream_types {
-            let streams = db::schema::list_streams_from_cache(org_id, stream_type).await;
+            let Some(streams) = org_streams.get(&stream_type) else {
+                continue;
+            };
             if !streams.is_empty() {
                 metrics::META_NUM_STREAMS
                     .with_label_values::<&str>(&[org_id.as_str(), stream_type.as_str()])


### PR DESCRIPTION
Design at: #13465

PR 3 of the plan in #13465 (finding 2: full schema-cache rescans per (org, stream type) pair).

## Background

`list_streams_from_cache(org, type)` scans every key in `STREAM_SCHEMAS_LATEST` and allocates a `Vec` per key to parse it. The periodic jobs called it inside `for org { for stream_type { ... } }` loops, so one cycle cost O(orgs × types × streams) key visits. With 100k+ streams, hundreds of orgs and 8 stream types, a single compactor generate cycle performs billions of allocating key parses — and several of these jobs run every cycle (`run_generate_job`, retention, stats) or every 60s (metadata metrics).

## Changes

**New API:** `list_all_streams_grouped() → HashMap<org, HashMap<StreamType, Vec<name>>>` — one pass over the cache, allocation-free key parsing (iterator-based split instead of `split().collect::<Vec<_>>()`), same name-truncation and dedup semantics as the per-pair function. Covered by a unit test that also asserts it matches `list_streams_from_cache` output.

**Callers rewritten to one scan per cycle:**

- compaction `run_generate_job` and (enterprise) `run_generate_downsampling_job`
- compaction retention `generate_jobs`
- compaction stats `update_stats_from_file_list`
- flatten compactor `run_generate`
- metadata metrics job (also derives the org list and org-count metric from the same grouped result, dropping the separate `list_organizations_from_cache` full scan)
- trace service-graph stream discovery (orgs still come from the org table; the per-org cache scan is gone)
- CLI `reset_index_updated_at` and `gc-file-list`

Per-type skip conditions (EnrichmentTables/Filelist in retention and gc, Index/Filelist in stats, Logs-only in flatten, Logs/Metrics/Traces in metrics) and the org blocklist checks are unchanged. Iterating the grouped result is equivalent to iterating `ALL_STREAM_TYPES` since that constant covers all `StreamType` variants and absent groups were empty scans before.

`list_streams_from_cache` stays for point callers (per-stream lookups, `get_stream_count_cached`'s TTL cache is untouched).

## Testing

- new unit test `test_list_all_streams_grouped` (grouping, per-type contents, equivalence with the per-pair enumeration)
- test suites pass for db, compaction, jobs, core; the only failures are the two pre-existing sqlite-path retention tests that also fail on main
- clippy: no findings in touched files

Note: overlaps #13531 (metrics.rs/stats.rs hunks) — whichever merges second rebases trivially. Independent of #13535.