### PR TITLE
feat: add wal pack backlog metrics ingest_pack_segments/ingest_pack_files

### DIFF
--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -163,6 +163,32 @@ pub static INGEST_PARQUET_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .expect("Metric created")
 });
+pub static INGEST_PACK_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "ingest_pack_files",
+            "Number of wal pack files in the ingester.".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static INGEST_PACK_SEGMENTS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "ingest_pack_segments",
+            "Number of wal pack segments in the ingester pending upload to object store."
+                .to_owned()
+                + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
 pub static INGEST_WAL_WRITE_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
@@ -1960,6 +1986,12 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(INGEST_PARQUET_FILES.clone()))
         .expect("Metric registered");
     registry
+        .register(Box::new(INGEST_PACK_FILES.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(INGEST_PACK_SEGMENTS.clone()))
+        .expect("Metric registered");
+    registry
         .register(Box::new(INGEST_WAL_WRITE_BYTES.clone()))
         .expect("Metric registered");
     registry
@@ -2537,6 +2569,8 @@ mod tests {
         let _ = INGEST_ERRORS.clone();
         let _ = INGEST_WAL_USED_BYTES.clone();
         let _ = INGEST_PARQUET_FILES.clone();
+        let _ = INGEST_PACK_FILES.clone();
+        let _ = INGEST_PACK_SEGMENTS.clone();
         let _ = INGEST_WAL_WRITE_BYTES.clone();
         let _ = INGEST_WAL_READ_BYTES.clone();
         let _ = INGEST_MEMTABLE_BYTES.clone();

--- a/src/ingester/src/lib.rs
+++ b/src/ingester/src/lib.rs
@@ -38,9 +38,9 @@ pub use immutable::{
     read_from_immutable,
 };
 pub use pack::{
-    PackSegment, PackSegmentMeta, PendingStreamStats, get_pending_stream_stats,
-    get_segment_index_stats, get_stream_segments, mark_segments_consumed, read_from_pack,
-    read_segment,
+    PackSegment, PackSegmentMeta, PendingStreamStats, collect_pack_metrics,
+    get_pending_stream_stats, get_segment_index_stats, get_stream_segments, mark_segments_consumed,
+    read_from_pack, read_segment,
 };
 use snafu::ResultExt;
 use tokio::sync::{Mutex, mpsc};

--- a/src/ingester/src/pack.rs
+++ b/src/ingester/src/pack.rs
@@ -38,6 +38,7 @@ use arrow_schema::Schema;
 use config::{
     FileFormat, RwAHashMap,
     meta::{search::ScanStats, stream::FileMeta},
+    metrics,
     utils::hash::{Sum64, gxhash},
 };
 use hashbrown::{HashMap, HashSet};
@@ -557,6 +558,19 @@ pub async fn get_segment_index_stats() -> (usize, usize) {
     let streams = r.len();
     let segments = r.values().map(|v| v.segments.len()).sum();
     (streams, segments)
+}
+
+/// Refresh the pack backlog gauges: total pack files on disk and total
+/// segments pending upload. Unlabeled totals, set every cycle.
+pub async fn collect_pack_metrics() {
+    let (_, segments) = get_segment_index_stats().await;
+    let files = PACK_REGISTRY.read().await.len();
+    metrics::INGEST_PACK_FILES
+        .with_label_values::<&str>(&[])
+        .set(files as i64);
+    metrics::INGEST_PACK_SEGMENTS
+        .with_label_values::<&str>(&[])
+        .set(segments as i64);
 }
 
 /// Acquire read guards so the mover will not delete these packs mid-read.
@@ -1505,5 +1519,38 @@ mod tests {
                 .map(|v| v.segments.iter().all(|s| s.memtable_id != 77))
                 .unwrap_or(true)
         );
+    }
+
+    #[tokio::test]
+    async fn test_collect_pack_metrics() {
+        let dir = tempfile::tempdir().unwrap();
+        let finished = write_test_pack(dir.path(), 79).await;
+        let pack = &finished[0];
+        fs::rename(&pack.tmp_path, &pack.path).await.unwrap();
+        register_pack(
+            pack.path.clone(),
+            &pack.footer,
+            config::utils::time::now_micros(),
+            &Default::default(),
+        )
+        .await;
+
+        collect_pack_metrics().await;
+        // the totals are global and other tests register their own packs
+        // concurrently, so only assert this pack's contribution is included
+        assert!(
+            metrics::INGEST_PACK_SEGMENTS
+                .with_label_values::<&str>(&[])
+                .get()
+                >= 2
+        );
+        assert!(
+            metrics::INGEST_PACK_FILES
+                .with_label_values::<&str>(&[])
+                .get()
+                >= 1
+        );
+
+        unregister_pack(&pack.path).await;
     }
 }

--- a/src/jobs/src/job/metrics.rs
+++ b/src/jobs/src/job/metrics.rs
@@ -270,6 +270,8 @@ async fn update_parquet_metrics() -> Result<(), anyhow::Error> {
     ingester::collect_wal_parquet_metrics()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to collect parquet metrics: {}", e))?;
+    // and the wal pack backlog gauges (pack files/segments totals)
+    ingester::collect_pack_metrics().await;
     Ok(())
 }
 


### PR DESCRIPTION
Design at: #13538

## Summary

With `ZO_FEATURE_WAL_PACK_ENABLED` (#13497), metrics streams persist into pack files under `{data_wal_dir}/pack/`, which the `zo_ingest_parquet_files` collector (a scan of `{data_wal_dir}/files/**/*.parquet`) never sees — so the pending-upload backlog of packed streams was invisible.

This PR adds two **unlabeled** gauges (the pack path is metrics-only, so per-org/per-stream-type labels add no information):

- `zo_ingest_pack_files` — number of wal pack files on disk (pack registry size).
- `zo_ingest_pack_segments` — number of pack segments pending upload to object store (segment index totals, via the existing `get_segment_index_stats()`).

Both are cheap O(streams)/O(packs) reads of in-memory state — no disk scans, no per-segment walking under locks — and are set unconditionally every cycle of the existing ingester metrics job, so there is no per-label bookkeeping and no stale-series problem by construction.

## Changes

- `src/config/src/metrics.rs`: define + register the two gauges.
- `src/ingester/src/pack.rs`: `collect_pack_metrics()` + unit test.
- `src/jobs/src/job/metrics.rs`: call it from `update_parquet_metrics()`.

## Testing

- `cargo test -p ingester` — 60 passed.
- `cargo test -p config metrics::` — 20 passed.
- `cargo check` clean on config/ingester/jobs; `cargo fmt --check` clean.
