### PR TITLE
chore(deps): bump vortex to 1cb48912

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -344,7 +344,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1643,7 +1643,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -4049,7 +4049,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4387,7 +4387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5338,7 +5338,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5737,7 +5737,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5808,7 +5808,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6807,7 +6807,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7162,6 +7162,16 @@ checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "onpair"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf79077d8decdf5714242f1813f844f23c80a0cf009aba52881effb4c36ecbe"
+dependencies = [
+ "hashbrown 0.16.1",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -8760,7 +8770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -8781,7 +8791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8794,7 +8804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9147,7 +9157,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9185,7 +9195,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10135,7 +10145,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10194,7 +10204,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10551,6 +10561,7 @@ dependencies = [
  "url",
  "utoipa",
  "vortex",
+ "vortex-btrblocks",
  "vortex-datafusion",
  "vrl",
 ]
@@ -11073,7 +11084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11882,7 +11893,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11902,7 +11913,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12890,15 +12901,17 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "vortex-alp",
  "vortex-array",
+ "vortex-arrow",
  "vortex-btrblocks",
  "vortex-buffer",
  "vortex-bytebool",
  "vortex-datetime-parts",
  "vortex-decimal-byte-parts",
+ "vortex-edition",
  "vortex-error",
  "vortex-fastlanes",
  "vortex-file",
@@ -12924,7 +12937,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -12942,19 +12955,11 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "arc-swap",
  "arcref",
- "arrow-arith",
- "arrow-array",
  "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
  "async-lock",
  "bytes",
  "cfg-if",
@@ -12966,6 +12971,7 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "jiff",
+ "memchr",
  "num-traits",
  "num_enum",
  "parking_lot 0.12.5",
@@ -12973,6 +12979,8 @@ dependencies = [
  "pin-project-lite",
  "prost 0.14.3",
  "rand 0.10.1",
+ "regex",
+ "regex-syntax",
  "rustc-hash 2.1.1",
  "simdutf8",
  "smallvec",
@@ -12982,6 +12990,7 @@ dependencies = [
  "uuid",
  "vortex-array-macros",
  "vortex-buffer",
+ "vortex-compute",
  "vortex-error",
  "vortex-flatbuffers",
  "vortex-mask",
@@ -12993,7 +13002,7 @@ dependencies = [
 [[package]]
 name = "vortex-array-macros"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13001,12 +13010,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "vortex-btrblocks"
+name = "vortex-arrow"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "itertools 0.14.0",
  "num-traits",
+ "tracing",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-runend",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-btrblocks"
+version = "0.1.0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+dependencies = [
+ "itertools 0.14.0",
  "pco",
  "rand 0.10.1",
  "vortex-alp",
@@ -13030,7 +13060,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "arrow-buffer",
  "bitvec",
@@ -13043,20 +13073,19 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "num-traits",
  "vortex-array",
  "vortex-buffer",
  "vortex-error",
- "vortex-mask",
  "vortex-session",
 ]
 
 [[package]]
 name = "vortex-compressor"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -13072,10 +13101,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "vortex-compute"
+version = "0.1.0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+dependencies = [
+ "vortex-buffer",
+]
+
+[[package]]
 name = "vortex-datafusion"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
+ "arrow-array",
  "arrow-schema",
  "async-trait",
  "datafusion-catalog",
@@ -13085,6 +13123,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
+ "datafusion-functions-nested",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
@@ -13097,13 +13136,14 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "vortex",
+ "vortex-arrow",
  "vortex-utils",
 ]
 
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -13117,7 +13157,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -13129,9 +13169,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "vortex-edition"
+version = "0.1.0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+dependencies = [
+ "parking_lot 0.12.5",
+ "vortex-session",
+]
+
+[[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -13144,7 +13193,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "fastlanes",
  "itertools 0.14.0",
@@ -13161,7 +13210,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -13176,6 +13225,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+ "url",
  "vortex-alp",
  "vortex-array",
  "vortex-btrblocks",
@@ -13191,6 +13241,7 @@ dependencies = [
  "vortex-layout",
  "vortex-mask",
  "vortex-metrics",
+ "vortex-onpair",
  "vortex-pco",
  "vortex-runend",
  "vortex-scan",
@@ -13205,7 +13256,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -13215,9 +13266,10 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "fsst-rs",
+ "num-traits",
  "prost 0.14.3",
  "vortex-array",
  "vortex-buffer",
@@ -13229,7 +13281,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "async-fs",
  "async-stream",
@@ -13258,7 +13310,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -13275,7 +13327,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "arcref",
  "arrow-array",
@@ -13300,6 +13352,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vortex-array",
+ "vortex-arrow",
  "vortex-btrblocks",
  "vortex-buffer",
  "vortex-error",
@@ -13317,7 +13370,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -13327,16 +13380,31 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "parking_lot 0.12.5",
  "sketches-ddsketch",
 ]
 
 [[package]]
+name = "vortex-onpair"
+version = "0.1.0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+dependencies = [
+ "num-traits",
+ "onpair",
+ "prost 0.14.3",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "pco",
  "prost 0.14.3",
@@ -13350,7 +13418,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
@@ -13359,9 +13427,8 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
- "arrow-array",
  "itertools 0.14.0",
  "num-traits",
  "prost 0.14.3",
@@ -13375,7 +13442,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "async-trait",
  "futures",
@@ -13391,7 +13458,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -13407,9 +13474,9 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
- "dashmap",
+ "arc-swap",
  "lasso",
  "parking_lot 0.12.5",
  "vortex-error",
@@ -13419,7 +13486,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -13434,17 +13501,16 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "dashmap",
  "hashbrown 0.17.1",
- "vortex-error",
 ]
 
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "vortex-array",
  "vortex-buffer",
@@ -13457,7 +13523,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=57ffbf2b2dde0d63df03ff1f4788cd85206388a0#57ffbf2b2dde0d63df03ff1f4788cd85206388a0"
+source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.3",
@@ -13924,7 +13990,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,10 +350,11 @@ o2_dex = { path = "src/enterprise/o2_dex" }
 o2_enterprise = { path = "src/enterprise/o2_enterprise", default-features = false }
 o2_openfga = { path = "src/enterprise/o2_openfga" }
 o2_ratelimit = { path = "src/enterprise/o2_ratelimit" }
-vortex = { git = "https://github.com/openobserve/vortex", rev = "57ffbf2b2dde0d63df03ff1f4788cd85206388a0", features = [
+vortex = { git = "https://github.com/openobserve/vortex", rev = "1cb48912c14d9c7bd29832d9aff5666d730e1f0e", features = [
     "tokio",
 ] }
-vortex-datafusion = { git = "https://github.com/openobserve/vortex", rev = "57ffbf2b2dde0d63df03ff1f4788cd85206388a0" }
+vortex-btrblocks = { git = "https://github.com/openobserve/vortex", rev = "1cb48912c14d9c7bd29832d9aff5666d730e1f0e" }
+vortex-datafusion = { git = "https://github.com/openobserve/vortex", rev = "1cb48912c14d9c7bd29832d9aff5666d730e1f0e" }
 aes-siv = "0.7.0"
 ahash = { version = "0.8", features = ["serde"] }
 axum = { version = "0.8", features = ["macros", "multipart", "tracing"] }

--- a/src/config/src/utils/parquet.rs
+++ b/src/config/src/utils/parquet.rs
@@ -36,7 +36,8 @@ use parquet::{
 };
 use vortex::{
     VortexSessionDefault,
-    array::{ArrayRef, VortexSessionExecute, arrow::ArrowSessionExt},
+    array::{ArrayRef, VortexSessionExecute},
+    arrow::{ArrowSessionExt, ToArrowType},
     buffer::Buffer,
     file::OpenOptionsSessionExt,
     io::session::RuntimeSessionExt,

--- a/src/search/Cargo.toml
+++ b/src/search/Cargo.toml
@@ -62,4 +62,5 @@ tracing-opentelemetry.workspace = true
 url.workspace = true
 utoipa.workspace = true
 vortex = { workspace = true }
+vortex-btrblocks = { workspace = true }
 vortex-datafusion = { workspace = true }

--- a/src/search/src/datafusion/merge/downsampling.rs
+++ b/src/search/src/datafusion/merge/downsampling.rs
@@ -33,8 +33,9 @@ use datafusion::{
 use futures::TryStreamExt;
 use vortex::{
     VortexSessionDefault,
-    array::{ArrayRef, arrow::FromArrowArray},
-    dtype::{DType, arrow::FromArrowType},
+    array::ArrayRef,
+    arrow::{FromArrowArray, FromArrowType},
+    dtype::DType,
     file::VortexWriteOptions,
     io::session::RuntimeSessionExt,
     session::VortexSession,

--- a/src/search/src/datafusion/merge/mod.rs
+++ b/src/search/src/datafusion/merge/mod.rs
@@ -31,8 +31,9 @@ use futures::TryStreamExt;
 use parquet::{arrow::AsyncArrowWriter, file::metadata::KeyValue};
 use vortex::{
     VortexSessionDefault,
-    array::{ArrayRef, arrow::FromArrowArray},
-    dtype::{DType, arrow::FromArrowType},
+    array::ArrayRef,
+    arrow::{FromArrowArray, FromArrowType},
+    dtype::DType,
     file::VortexWriteOptions,
     io::session::RuntimeSessionExt,
     session::VortexSession,

--- a/src/search/src/datafusion/vortex.rs
+++ b/src/search/src/datafusion/vortex.rs
@@ -26,9 +26,7 @@ use tokio::runtime::Runtime;
 use vortex::{
     array::{ArrayRef, Canonical, ExecutionCtx, IntoArray},
     buffer::Buffer,
-    compressor::{
-        BtrBlocksCompressor, BtrBlocksCompressorBuilder, SchemeExt, schemes::integer::IntDictScheme,
-    },
+    compressor::{BtrBlocksCompressor, BtrBlocksCompressorBuilder},
     dtype::DType,
     encodings::zstd::Zstd,
     error::VortexResult,
@@ -36,6 +34,7 @@ use vortex::{
     layout::{LayoutStrategy, layouts::compressed::CompressorPlugin},
     scan::selection::Selection,
 };
+use vortex_btrblocks::{SchemeExt, schemes::integer::IntDictScheme};
 use vortex_datafusion::VortexAccessPlan;
 
 pub static VORTEX_RUNTIME: LazyLock<Arc<Runtime>> = LazyLock::new(|| {

--- a/src/tantivy_utils/src/index_builder/parallel.rs
+++ b/src/tantivy_utils/src/index_builder/parallel.rs
@@ -570,8 +570,9 @@ mod tests {
         use tantivy::directory::RamDirectory;
         use vortex::{
             VortexSessionDefault,
-            array::{ArrayRef, arrow::FromArrowArray},
-            dtype::{DType, arrow::FromArrowType},
+            array::ArrayRef,
+            arrow::{FromArrowArray, FromArrowType},
+            dtype::DType,
             file::{VortexWriteOptions, WriteStrategyBuilder},
             io::session::RuntimeSessionExt,
             session::VortexSession,

--- a/src/tantivy_utils/src/index_builder/reader/vortex.rs
+++ b/src/tantivy_utils/src/index_builder/reader/vortex.rs
@@ -24,6 +24,7 @@ use futures::StreamExt;
 use vortex::{
     VortexSessionDefault,
     array::ArrayRef,
+    arrow::ToArrowType,
     expr::{root, select},
     file::{OpenOptionsSessionExt, VortexFile},
     io::{


### PR DESCRIPTION
Bumps the `openobserve/vortex` pin from `57ffbf2b` to `1cb48912` in the workspace manifest.

## Upstream API changes handled

- Arrow interop moved into a dedicated `vortex-arrow` crate, surfaced as `vortex::arrow`. `vortex::array::arrow::*` and `vortex::dtype::arrow::*` no longer exist, so `FromArrowArray`, `FromArrowType`, `ToArrowType` and `ArrowSessionExt` are now imported from `vortex::arrow`.
- `ToArrowType` is no longer in scope implicitly; added the explicit import where `DType::to_arrow_schema()` is called.
- The `vortex::compressor` facade narrowed to `BtrBlocksCompressor`, `BtrBlocksCompressorBuilder`, `Scheme`, `SchemeId`. `SchemeExt` and the scheme list are no longer re-exported there, so `search` takes a direct `vortex-btrblocks` dependency (same git rev) for `SchemeExt` / `schemes::integer::IntDictScheme`, which the UTF8 compressor uses to exclude the int-dict scheme.

No behavior change intended — the compressor configuration and write strategies are identical.

## Verification

- `cargo check --workspace --all-targets` clean
- `cargo fmt --all -- --check` clean
- `cargo test -p search --lib datafusion::vortex` — 6 passed
- `cargo test -p tantivy_utils --lib vortex` — 3 passed
- `cargo test -p config --lib utils::parquet` — 21 passed

Paired enterprise PR (same branch name): https://github.com/openobserve/o2-enterprise/pull/2303