### PR TITLE
fix(synthetics): complete reaped runs, bound leases, guard the ack

### DIFF
--- a/src/config/src/meta/synthetics.rs
+++ b/src/config/src/meta/synthetics.rs
@@ -1744,7 +1744,6 @@ fn validate_browser_config(
             "config.journey_budget_ms: must be {MIN_JOURNEY_BUDGET_MS}..={MAX_JOURNEY_BUDGET_MS}, got {budget_ms}"
         ));
     }
-    let attempts = i64::from(retries) + 1;
     // Multiplied by the device count, because the probe runs `browser_devices`
     // SEQUENTIALLY INSIDE the leased job (`browser-probe/src/index.ts:124`) — the
     // lease covers the whole job, not one device.

--- a/src/config/src/meta/synthetics.rs
+++ b/src/config/src/meta/synthetics.rs
@@ -936,14 +936,94 @@ const DEFAULT_JOURNEY_BUDGET_MS: u32 = 300_000;
 const MIN_JOURNEY_BUDGET_MS: u32 = 5_000;
 const MAX_JOURNEY_BUDGET_MS: u32 = 900_000;
 
-/// Lease held on a browser job while it runs — must stay in sync with
-/// `LEASE_SECS` in o2-enterprise `synthetics/dispatcher/mod.rs`.
+/// Lease held on a job while it runs — must stay in sync with `LEASE_SECS` in
+/// o2-enterprise `synthetics/dispatcher/mod.rs`, and is the floor the job API
+/// applies to every agent lease (`synthetics_jobs::lease_batch`).
+///
+/// Applies to every check type, not just browser. Both agents ask for a 300s
+/// lease, so any check whose retry sequence runs longer than that has its lease
+/// expire while the probe is still working — the reaper then terminates the job
+/// and completes the run as an error, and the probe's real result is rejected
+/// when it finally acks. The validation below is what keeps every check's worst
+/// case inside this number, which is in turn what lets the server lease for it
+/// unconditionally.
 ///
 /// NOTE: the AWS Lambda function timeout must be >= this value, or runs are
 /// killed mid-journey. That setting lives outside this repository and cannot be
 /// asserted here. 900s is also AWS's maximum, so raising `retries` or
 /// `journey_budget_ms` further requires re-deriving all three together.
-const BROWSER_LEASE_SECS: i64 = 900;
+pub const JOB_LEASE_SECS: i64 = 900;
+
+/// Ceiling for ONE attempt of a non-browser check, in milliseconds.
+///
+/// Net `timeout_ms` was previously unbounded: every protocol config defaults it
+/// to 10s, but nothing rejected `timeout_ms: 3_600_000`, so the worst case of a
+/// retry sequence had no upper limit and could not be checked against the lease.
+const MAX_NET_TIMEOUT_MS: u32 = 300_000;
+const MIN_NET_TIMEOUT_MS: u32 = 1_000;
+
+/// Worst-case wall clock for one leased job, in milliseconds.
+///
+/// Retries happen INSIDE the leased job, so the lease has to cover the whole
+/// sequence rather than one attempt: `attempts x per_attempt + gaps`. The
+/// `multiplier` is for work the probe repeats sequentially within the same job —
+/// browser device combos — which the lease also covers.
+///
+/// Shared by the browser and protocol paths so the two cannot drift; they differ
+/// only in what one attempt costs and whether anything multiplies it.
+fn worst_case_run_ms(
+    per_attempt_ms: u32,
+    multiplier: i64,
+    retries: i32,
+    wait_before_retry_secs: i32,
+) -> i64 {
+    let attempts = i64::from(retries) + 1;
+    multiplier
+        * (attempts * i64::from(per_attempt_ms)
+            + i64::from(retries) * i64::from(wait_before_retry_secs) * 1_000)
+}
+
+/// Bounds a protocol check's `timeout_ms` and its full retry sequence.
+///
+/// The browser path has had this since `journey_budget_ms` was introduced; the
+/// protocol path never did. Both agents ask for a 300s lease while
+/// `timeout_ms` was unbounded and `retries` goes to 3, so a check needing more
+/// than the lease was accepted, and then on every single run the reaper
+/// terminated the job mid-flight and the probe's real result was thrown away as
+/// a stale ack — a passing check reporting an error forever.
+///
+/// `timeout_ms` is read from the raw config rather than a typed struct because
+/// every protocol config declares the same field with the same serde default, so
+/// an absent field legitimately means the default.
+fn validate_net_retry_budget(
+    config: &serde_json::Value,
+    retries: i32,
+    wait_before_retry_secs: i32,
+) -> Result<(), String> {
+    let timeout_ms = config
+        .get("timeout_ms")
+        .and_then(|v| v.as_u64())
+        .and_then(|v| u32::try_from(v).ok())
+        .unwrap_or_else(default_timeout_ms);
+
+    if !(MIN_NET_TIMEOUT_MS..=MAX_NET_TIMEOUT_MS).contains(&timeout_ms) {
+        return Err(format!(
+            "config.timeout_ms: must be {MIN_NET_TIMEOUT_MS}..={MAX_NET_TIMEOUT_MS}, got {timeout_ms}"
+        ));
+    }
+
+    let worst_case_ms = worst_case_run_ms(timeout_ms, 1, retries, wait_before_retry_secs);
+    if worst_case_ms > JOB_LEASE_SECS * 1_000 {
+        return Err(format!(
+            "config: a full retry sequence must fit inside the {JOB_LEASE_SECS}s job lease, but \
+             (retries={retries} + 1) x timeout_ms={timeout_ms} + retries x \
+             wait_before_retry_secs={wait_before_retry_secs} needs {worst_case_ms}ms. Lower \
+             timeout_ms, retries, or wait_before_retry_secs — a check that outlives its lease has \
+             its job terminated mid-run and its real result rejected as a stale ack."
+        ));
+    }
+    Ok(())
+}
 
 /// The complete v2 action vocabulary — exactly Playwright's recorder action
 /// model, minus what a monitor cannot use.
@@ -1344,7 +1424,7 @@ impl Synthetic {
         allowed_browsers: &[String],
         allowed_devices: &[String],
     ) -> Result<(), String> {
-        match self.monitor_type {
+        let type_check = match self.monitor_type {
             SyntheticType::Browser => {
                 let cfg: BrowserConfig = serde_json::from_value(self.config.clone())
                     .map_err(|e| format!("config: not a valid browser config: {e}"))?;
@@ -1420,7 +1500,20 @@ impl Synthetic {
                 // banner check (a rejected auth still proves SSH is up).
                 Ok(())
             }
+        };
+        // Type errors first: "not a valid tcp config" is more fundamental than
+        // anything derived from its fields, and a config that fails to parse has
+        // no meaningful timeout to report on.
+        type_check?;
+
+        // Every protocol check gets the same retry-budget-vs-lease bound the
+        // browser path applies inside `validate_browser_config`. Done here, once,
+        // rather than in each arm: the arms are per-type and this rule is not, and
+        // adding a check type should not be able to opt out of it silently.
+        if self.monitor_type != SyntheticType::Browser {
+            validate_net_retry_budget(&self.config, self.retries, self.wait_before_retry_secs)?;
         }
+        Ok(())
     }
 }
 
@@ -1664,14 +1757,11 @@ fn validate_browser_config(
     // duplicate. Which is verbatim what the LEASE_SECS comment in
     // `dispatcher/mod.rs` was written to prevent.
     let devices = i64::try_from(cfg.browser_devices.len().max(1)).unwrap_or(1);
-    let worst_case_ms = devices
-        * (attempts * i64::from(budget_ms)
-            + i64::from(retries) * i64::from(wait_before_retry_secs) * 1_000);
-    let lease_ms = BROWSER_LEASE_SECS * 1_000;
-    if worst_case_ms > lease_ms {
+    let worst_case_ms = worst_case_run_ms(budget_ms, devices, retries, wait_before_retry_secs);
+    if worst_case_ms > JOB_LEASE_SECS * 1_000 {
         return Err(format!(
             "config: a full retry sequence across all browser/device combos must fit inside the \
-             {BROWSER_LEASE_SECS}s job lease, but browser_devices={devices} x (retries={retries} x \
+             {JOB_LEASE_SECS}s job lease, but browser_devices={devices} x (retries={retries} x \
              journey_budget_ms={budget_ms} + wait_before_retry_secs={wait_before_retry_secs}) needs \
              {worst_case_ms}ms. Lower journey_budget_ms, retries, or the number of browser/device \
              combos — a run that outlives its lease is requeued and executed a second time."
@@ -2162,6 +2252,95 @@ mod tests {
             vec!["chromium".to_string(), "firefox".to_string()],
             vec!["desktop".to_string(), "mobile".to_string()],
         )
+    }
+
+    fn valid_tcp_synthetic() -> Synthetic {
+        Synthetic {
+            name: "db port".to_string(),
+            monitor_type: SyntheticType::Tcp,
+            target: "db.example.com".to_string(),
+            frequency: SyntheticFrequency {
+                frequency_type: SyntheticFrequencyType::Minutes,
+                interval: 5,
+                cron: String::new(),
+                timezone: None,
+            },
+            locations: vec!["aws-us-east-1".to_string()],
+            enabled: true,
+            alert_if_fails: 1,
+            wait_before_retry_secs: 5,
+            config: serde_json::json!({ "port": 5432, "timeout_ms": 10000 }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn net_retry_sequence_must_fit_the_job_lease() {
+        let (locs, brs, devs) = allowed();
+        // The lease covers the whole retry sequence because retries run inside
+        // the leased job. 4 x 300s alone is 1200s, past the 900s lease.
+        let mut s = valid_tcp_synthetic();
+        s.config = serde_json::json!({ "port": 5432, "timeout_ms": 300_000 });
+        s.retries = 3;
+        s.wait_before_retry_secs = 0;
+        let err = s.validate(&locs, &brs, &devs, true).unwrap_err();
+        assert!(err.contains("job lease"), "{err}");
+
+        // The gaps count too: 3 x 250s = 750s of attempts is fine on its own,
+        // but not with 300s of waiting between them.
+        let mut s = valid_tcp_synthetic();
+        s.config = serde_json::json!({ "port": 5432, "timeout_ms": 250_000 });
+        s.retries = 2;
+        s.wait_before_retry_secs = 300;
+        let err = s.validate(&locs, &brs, &devs, true).unwrap_err();
+        assert!(err.contains("job lease"), "{err}");
+    }
+
+    #[test]
+    fn net_timeout_is_bounded_at_all() {
+        let (locs, brs, devs) = allowed();
+        // Was previously unbounded: every protocol config defaults timeout_ms to
+        // 10s, but nothing rejected an hour, so the worst case had no ceiling to
+        // check the lease against.
+        let mut s = valid_tcp_synthetic();
+        s.config = serde_json::json!({ "port": 5432, "timeout_ms": 3_600_000 });
+        s.retries = 0;
+        let err = s.validate(&locs, &brs, &devs, true).unwrap_err();
+        assert!(err.starts_with("config.timeout_ms:"), "{err}");
+    }
+
+    #[test]
+    fn net_defaults_and_ordinary_configs_still_validate() {
+        let (locs, brs, devs) = allowed();
+        // A config with no timeout_ms at all must use the serde default rather
+        // than 0, which would otherwise trip the new minimum.
+        let mut s = valid_tcp_synthetic();
+        s.config = serde_json::json!({ "port": 5432 });
+        assert!(s.validate(&locs, &brs, &devs, true).is_ok());
+
+        // The worst realistic config: max retries and a 60s timeout is 240s of
+        // attempts plus 90s of gaps — comfortably inside the lease. This must
+        // keep passing, or the bound is too tight to be shipped.
+        let mut s = valid_tcp_synthetic();
+        s.config = serde_json::json!({ "port": 5432, "timeout_ms": 60_000 });
+        s.retries = 3;
+        s.wait_before_retry_secs = 30;
+        assert!(
+            s.validate(&locs, &brs, &devs, true).is_ok(),
+            "{:?}",
+            s.validate(&locs, &brs, &devs, true)
+        );
+    }
+
+    #[test]
+    fn worst_case_counts_attempts_gaps_and_the_multiplier() {
+        // retries=0 is one attempt and no gaps.
+        assert_eq!(worst_case_run_ms(10_000, 1, 0, 30), 10_000);
+        // retries=2 is three attempts and two gaps.
+        assert_eq!(worst_case_run_ms(10_000, 1, 2, 30), 30_000 + 60_000);
+        // The multiplier applies to the whole sequence, not one attempt — the
+        // probe repeats the entire retry sequence per device inside one lease.
+        assert_eq!(worst_case_run_ms(10_000, 2, 2, 30), 2 * (30_000 + 60_000));
     }
 
     #[test]

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -163,6 +163,46 @@ pub static INGEST_PARQUET_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .expect("Metric created")
 });
+/// Checks waiting to be leased, per location and pool.
+///
+/// The other half of queue-lag visibility. A result record carries `scheduled_ts`
+/// and `started_ts`, so the delay of work that RAN is already derivable — but a
+/// check nobody leased produces no record at all, so the backlog it sits in is
+/// invisible from the results side by construction. Without this, "the queue is
+/// backed up" and "concurrency fixed it" are both unfalsifiable.
+pub static SYNTHETICS_PENDING_JOBS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "synthetics_pending_jobs",
+            "Number of synthetics checks pending lease.".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["location", "pool"],
+    )
+    .expect("Metric created")
+});
+
+/// Age of the oldest check still waiting, in seconds, per location and pool.
+///
+/// Reported alongside the count because they fail differently: a large count that
+/// drains every tick is throughput, while a small count whose oldest entry keeps
+/// ageing is a location that has stopped being served at all — one agent down, or
+/// no agent ever polling that pool. The count alone cannot tell those apart.
+pub static SYNTHETICS_OLDEST_PENDING_AGE_SECONDS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "synthetics_oldest_pending_age_seconds",
+            "Age of the oldest synthetics check pending lease, in seconds.".to_owned()
+                + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["location", "pool"],
+    )
+    .expect("Metric created")
+});
+
 pub static INGEST_PACK_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
@@ -1986,6 +2026,12 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(INGEST_PARQUET_FILES.clone()))
         .expect("Metric registered");
     registry
+        .register(Box::new(SYNTHETICS_PENDING_JOBS.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(SYNTHETICS_OLDEST_PENDING_AGE_SECONDS.clone()))
+        .expect("Metric registered");
+    registry
         .register(Box::new(INGEST_PACK_FILES.clone()))
         .expect("Metric registered");
     registry
@@ -2569,6 +2615,8 @@ mod tests {
         let _ = INGEST_ERRORS.clone();
         let _ = INGEST_WAL_USED_BYTES.clone();
         let _ = INGEST_PARQUET_FILES.clone();
+        let _ = SYNTHETICS_PENDING_JOBS.clone();
+        let _ = SYNTHETICS_OLDEST_PENDING_AGE_SECONDS.clone();
         let _ = INGEST_PACK_FILES.clone();
         let _ = INGEST_PACK_SEGMENTS.clone();
         let _ = INGEST_WAL_WRITE_BYTES.clone();

--- a/src/infra/src/table/synthetics_jobs.rs
+++ b/src/infra/src/table/synthetics_jobs.rs
@@ -238,6 +238,15 @@ pub async fn drain_monitor<C: ConnectionTrait>(
 ///
 /// Three steps: SELECT candidate IDs → UPDATE status/lease fields → SELECT
 /// full rows. No raw SQL, works on SQLite and Postgres.
+///
+/// `lease_secs` is a floor request, not the decision. Both probes hardcode 300s
+/// client-side while a check's retry sequence — which runs *inside* the leased
+/// job — is bounded only by `JOB_LEASE_SECS`, so an under-lease means the lease
+/// expires while the probe is still working: the reaper terminates the job,
+/// completes the run as an error, and the probe's real result is then rejected as
+/// a stale ack. A client cannot be trusted to know how long its job may take, so
+/// the server raises any request up to the budget the config validation already
+/// guarantees every check fits inside.
 pub async fn lease_batch<C: ConnectionTrait>(
     conn: &C,
     pool: &str,
@@ -247,6 +256,7 @@ pub async fn lease_batch<C: ConnectionTrait>(
     lease_secs: i64,
     browser: Option<bool>,
 ) -> Result<Vec<LeasedRow>, errors::Error> {
+    let lease_secs = lease_secs.max(config::meta::synthetics::JOB_LEASE_SECS);
     let lease_expires_at = now_us + lease_secs * 1_000_000;
 
     // Step 1: pick candidate IDs.

--- a/src/infra/src/table/synthetics_jobs.rs
+++ b/src/infra/src/table/synthetics_jobs.rs
@@ -79,7 +79,8 @@ pub struct LeasedRow {
     pub metadata: String,
 }
 
-/// Returned by `dead_letter_expired` for each job that exhausted all retries.
+/// Returned by `dead_letter_expired` for each job it terminated. The caller owns
+/// completing the job's run — see `reason` for which of the three ways it ended.
 #[derive(Debug)]
 pub struct DeadLetteredRow {
     pub id: String,
@@ -90,6 +91,47 @@ pub struct DeadLetteredRow {
     pub dispatch_attempts: i32,
     pub run_id: String,
     pub metadata: String,
+    pub reason: DeadLetterReason,
+}
+
+/// Why a job was terminated without a probe result.
+///
+/// All three end the same way — the run is completed with Error — but they are
+/// different operational problems, and collapsing them into one message costs
+/// the reader the only clue about which one they have. `NeverDispatched` means
+/// no probe polled that location at all (a dead private agent); the other two
+/// mean a probe took the job and went away.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeadLetterReason {
+    /// A probe held the lease, never acked, and has no dispatch attempts left.
+    AttemptsExhausted,
+    /// The lease expired and the job is now past `valid_until`. Requeueing it
+    /// would produce a result stamped for a window that has already closed, so
+    /// the next scheduled run is the right retry, not this one.
+    Expired,
+    /// Never claimed by anything before `valid_until` passed.
+    NeverDispatched,
+}
+
+/// Classifies a row selected by `dead_letter_expired`. Split out from the query
+/// so the mapping is testable without a database.
+///
+/// `status` is on the `synthetics_jobs` scale (0=Pending, 1=Leased).
+pub fn dead_letter_reason(
+    status: i32,
+    dispatch_attempts: i32,
+    max_attempts: i32,
+) -> DeadLetterReason {
+    if status == 0 {
+        // Pending and past its window: nothing ever leased it, so the attempt
+        // count says nothing about why. A leased row with 0 attempts would be a
+        // different story, which is why status is checked first.
+        DeadLetterReason::NeverDispatched
+    } else if dispatch_attempts >= max_attempts {
+        DeadLetterReason::AttemptsExhausted
+    } else {
+        DeadLetterReason::Expired
+    }
 }
 
 // ── Scheduler: enqueue ────────────────────────────────────────────────────────
@@ -370,7 +412,16 @@ pub async fn ack_complete<C: ConnectionTrait>(
 
 // ── Reaper ────────────────────────────────────────────────────────────────────
 
-/// Resets expired leases back to Pending (status=0) when dispatch_attempts < max_attempts.
+/// Resets expired leases back to Pending (status=0) when the job has dispatch
+/// attempts left *and* is still inside its validity window.
+///
+/// The `valid_until` guard is what makes the retry budget real. Without it this
+/// requeues a job whose window has already closed, and `prune_stale` — which
+/// runs later in the same reaper tick — deletes it again immediately, because
+/// `valid_until` is one interval (60s for a 1-minute check) while a lease is
+/// 300s or more. So the row went Pending → deleted within one tick,
+/// `dispatch_attempts` never got past 1, `max_attempts` was unreachable, and
+/// the run it belonged to was never completed by anyone.
 pub async fn requeue_expired<C: ConnectionTrait>(
     conn: &C,
     now_us: i64,
@@ -381,6 +432,7 @@ pub async fn requeue_expired<C: ConnectionTrait>(
         SET status = 0, claimed_by = NULL, claimed_at = NULL, lease_expires_at = NULL
         WHERE status = 1
           AND lease_expires_at < $1
+          AND valid_until >= $1
           AND dispatch_attempts < $2
     "#;
     let res = conn
@@ -393,20 +445,38 @@ pub async fn requeue_expired<C: ConnectionTrait>(
     Ok(res.rows_affected())
 }
 
-/// Marks permanently failed rows as Dead (status=2) when dispatch_attempts >= max_attempts.
-/// Returns the affected rows so the reaper can update monitor status and write to streams.
+/// Marks every job that can no longer produce a probe result as Dead (status=2)
+/// and returns the rows the caller must now account for.
+///
+/// Covers all three terminal shapes, because each one leaves a run that nobody
+/// else will ever finish:
+///
+/// - leased, lease expired, no attempts left → `AttemptsExhausted`
+/// - leased, lease expired, past `valid_until` → `Expired` (a retry would report against a closed
+///   window; the next scheduled run is the right retry)
+/// - pending, past `valid_until` → `NeverDispatched`, previously the business of `prune_stale`,
+///   which DELETEd the row and so destroyed the only record that the run was still owed a job
+///
+/// The caller **must** complete the run for every row returned. The per-row
+/// compare-and-swap below is what makes that safe to do exactly once: the reaper
+/// runs on every alert_manager node, and a bulk `UPDATE ... WHERE id IN (...)`
+/// after a separate SELECT lets two nodes both believe they terminated the same
+/// job. That was harmless while the caller only wrote to a stream; it is not
+/// harmless now that the caller increments a run counter, because a double
+/// increment pushes `jobs_done` past `job_count` and completes the run early,
+/// with a result that is missing a location.
 pub async fn dead_letter_expired<C: ConnectionTrait>(
     conn: &C,
     now_us: i64,
     max_attempts: i32,
 ) -> Result<Vec<DeadLetteredRow>, errors::Error> {
-    // Step 1: find candidates before marking them dead.
+    // Step 1: find candidates before marking them dead. `status` comes back so
+    // the CAS can require the row not to have moved under us.
     let select_sql = r#"
-        SELECT id, synthetics_id, synthetics_name, org_id, location, dispatch_attempts, run_id, metadata
+        SELECT id, synthetics_id, synthetics_name, org_id, location, dispatch_attempts, run_id, metadata, status
         FROM synthetics_jobs
-        WHERE status = 1
-          AND lease_expires_at < $1
-          AND dispatch_attempts >= $2
+        WHERE (status = 1 AND lease_expires_at < $1 AND (dispatch_attempts >= $2 OR valid_until < $1))
+           OR (status = 0 AND valid_until < $1)
     "#;
     let rows = conn
         .query_all(Statement::from_sql_and_values(
@@ -420,40 +490,45 @@ pub async fn dead_letter_expired<C: ConnectionTrait>(
         return Ok(vec![]);
     }
 
-    let dead: Vec<DeadLetteredRow> = rows
+    let candidates: Vec<(DeadLetteredRow, i32)> = rows
         .into_iter()
         .filter_map(|row| {
-            Some(DeadLetteredRow {
-                id: row.try_get::<String>("", "id").ok()?,
-                synthetics_id: row.try_get("", "synthetics_id").ok()?,
-                synthetics_name: row.try_get("", "synthetics_name").ok()?,
-                org_id: row.try_get("", "org_id").ok()?,
-                location: row.try_get("", "location").ok()?,
-                dispatch_attempts: row.try_get("", "dispatch_attempts").ok()?,
-                run_id: row.try_get("", "run_id").ok()?,
-                metadata: row.try_get("", "metadata").unwrap_or_default(),
-            })
+            let status: i32 = row.try_get("", "status").ok()?;
+            let dispatch_attempts: i32 = row.try_get("", "dispatch_attempts").ok()?;
+            let reason = dead_letter_reason(status, dispatch_attempts, max_attempts);
+            Some((
+                DeadLetteredRow {
+                    id: row.try_get::<String>("", "id").ok()?,
+                    synthetics_id: row.try_get("", "synthetics_id").ok()?,
+                    synthetics_name: row.try_get("", "synthetics_name").ok()?,
+                    org_id: row.try_get("", "org_id").ok()?,
+                    location: row.try_get("", "location").ok()?,
+                    dispatch_attempts,
+                    run_id: row.try_get("", "run_id").ok()?,
+                    metadata: row.try_get("", "metadata").unwrap_or_default(),
+                    reason,
+                },
+                status,
+            ))
         })
         .collect();
 
-    // Step 2: mark them all dead.
-    let ids: Vec<Value> = dead.iter().map(|r| Value::from(r.id.clone())).collect();
-    let placeholders: String = ids
-        .iter()
-        .enumerate()
-        .map(|(i, _)| format!("${}", i + 1))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let update_sql = format!(
-        "UPDATE synthetics_jobs SET status = 2 WHERE id IN ({})",
-        placeholders
-    );
-    conn.execute(Statement::from_sql_and_values(
-        conn.get_database_backend(),
-        &update_sql,
-        ids,
-    ))
-    .await?;
+    // Step 2: claim each row individually. Only rows this call actually
+    // transitioned are returned, so only one node ever accounts for a job.
+    let update_sql = "UPDATE synthetics_jobs SET status = 2 WHERE id = $1 AND status = $2";
+    let mut dead = Vec::with_capacity(candidates.len());
+    for (row, prev_status) in candidates {
+        let res = conn
+            .execute(Statement::from_sql_and_values(
+                conn.get_database_backend(),
+                update_sql,
+                [Value::from(row.id.clone()), Value::from(prev_status)],
+            ))
+            .await?;
+        if res.rows_affected() == 1 {
+            dead.push(row);
+        }
+    }
 
     Ok(dead)
 }
@@ -545,6 +620,15 @@ pub async fn failing_locations<C: ConnectionTrait>(
     Ok(out)
 }
 
+/// Backstop for pending rows past `valid_until`.
+///
+/// `dead_letter_expired` runs earlier in the same reaper tick and moves these to
+/// Dead after completing their runs, so in normal operation this matches nothing.
+/// It stays as a floor: if the dead-letter path ever fails to claim a row, the
+/// row is still removed rather than left to be re-examined every 30 seconds
+/// forever. A row this deletes is a run that will not complete, so a non-zero
+/// count here is a bug signal, not routine housekeeping — the reaper logs it at
+/// warn for that reason.
 pub async fn prune_stale<C: ConnectionTrait>(conn: &C, now_us: i64) -> Result<u64, errors::Error> {
     let sql = r#"
         DELETE FROM synthetics_jobs
@@ -606,5 +690,45 @@ mod tests {
         assert_eq!(row.synthetics_id, "mon-1");
         assert_eq!(row.run_id, "3Fzn001XXXXXXXXXXXXXXXX");
         assert_eq!(row.dispatch_attempts, 1);
+    }
+
+    const MAX: i32 = 3;
+
+    #[test]
+    fn pending_row_is_never_dispatched_whatever_its_attempt_count() {
+        // Status decides this, not the counter. A Pending row past `valid_until`
+        // was never leased for the window that just closed, so reporting
+        // "did not respond after N attempts" would blame a probe that was never
+        // asked. Both counts must classify the same way.
+        assert_eq!(
+            dead_letter_reason(0, 0, MAX),
+            DeadLetterReason::NeverDispatched
+        );
+        assert_eq!(
+            dead_letter_reason(0, MAX, MAX),
+            DeadLetterReason::NeverDispatched
+        );
+    }
+
+    #[test]
+    fn leased_row_separates_a_spent_budget_from_a_closed_window() {
+        // At or over the budget: retries are genuinely exhausted.
+        assert_eq!(
+            dead_letter_reason(1, MAX, MAX),
+            DeadLetterReason::AttemptsExhausted
+        );
+        assert_eq!(
+            dead_letter_reason(1, MAX + 1, MAX),
+            DeadLetterReason::AttemptsExhausted
+        );
+        // Under the budget: attempts were left, but the window closed first, so
+        // this is the case `requeue_expired` deliberately declines to retry.
+        // Before the `valid_until` guard, this row was requeued and then deleted
+        // by `prune_stale` in the same tick, which is why it needs its own name.
+        assert_eq!(dead_letter_reason(1, 0, MAX), DeadLetterReason::Expired);
+        assert_eq!(
+            dead_letter_reason(1, MAX - 1, MAX),
+            DeadLetterReason::Expired
+        );
     }
 }

--- a/src/infra/src/table/synthetics_jobs.rs
+++ b/src/infra/src/table/synthetics_jobs.rs
@@ -352,14 +352,23 @@ pub async fn lease_batch<C: ConnectionTrait>(
 /// Status values: 3=Passed, 4=Failed, 5=Warning, 6=Error (dispatch error).
 ///
 /// Returns `Some(run_id)` when the ack applied, and **`None` when it did not** —
-/// either the job does not exist or it was no longer Claimed, i.e. a duplicate or
-/// stale ack. The caller must treat `None` as "do not touch run accounting".
+/// the job does not exist, it was no longer Claimed, or it is now held by someone
+/// else. The caller must treat `None` as "do not touch run accounting".
+///
+/// `claimed_by` is the acking probe's agent id. `None` means the probe did not
+/// send one, which is the **compatibility window**: a probe built before this
+/// change acks without it, and rejecting those would drop every result until both
+/// probes are redeployed. Such an ack falls back to the status guard alone, i.e.
+/// exactly the behaviour before this change — so an old probe is no worse off,
+/// and a new one gets the ownership guard immediately. The window closes by
+/// making this argument non-optional once both probes have shipped.
 pub async fn ack_complete<C: ConnectionTrait>(
     conn: &C,
     job_id: &str,
     status: i32,
     result_json: Option<&str>,
     now_us: i64,
+    claimed_by: Option<&str>,
 ) -> Result<Option<String>, errors::Error> {
     // `AND status = 1` makes the ack idempotent: only a job still in the Claimed
     // state can be completed. Without it a duplicate ack succeeded, the caller
@@ -372,20 +381,31 @@ pub async fn ack_complete<C: ConnectionTrait>(
     // aws-sdk-lambda client retries a timed-out `RequestResponse` invoke, which
     // re-executes a check that is already running.
     //
-    // This does NOT cover the reaper-reassignment case — the row goes back to
-    // status 1 for the new holder, so the evicted holder's late ack still
-    // matches. That needs `claimed_by` on the ack, which spans both probes and a
-    // compatibility window, and is tracked separately.
-    let sql = r#"
-        UPDATE synthetics_jobs
-        SET status = $1, result = $2, completed_at = $3
-        WHERE id = $4 AND status = 1
-    "#;
-    let applied = conn
-        .execute(Statement::from_sql_and_values(
-            conn.get_database_backend(),
-            sql,
-            [
+    // The status guard alone does NOT cover reaper reassignment: the reaper puts
+    // the row back to Pending, another agent leases it, and the row is at status 1
+    // again — so the EVICTED holder's late ack still matches and overwrites the
+    // new holder's result, or lands before it and gets overwritten. Either way one
+    // job produced two results and `increment_jobs_done` ran twice for it.
+    //
+    // `claimed_by` closes that: only the agent the row is currently leased to can
+    // complete it. The lease already stamps `claimed_by`, so this compares against
+    // what the server itself recorded rather than anything the probe asserts.
+    let (owner_clause, values) = match claimed_by {
+        Some(agent) => (
+            " AND claimed_by = $5",
+            vec![
+                Value::from(status),
+                result_json
+                    .map(Value::from)
+                    .unwrap_or(Value::from(None::<String>)),
+                Value::from(now_us),
+                Value::from(job_id.to_owned()),
+                Value::from(agent.to_owned()),
+            ],
+        ),
+        None => (
+            "",
+            vec![
                 Value::from(status),
                 result_json
                     .map(Value::from)
@@ -393,6 +413,17 @@ pub async fn ack_complete<C: ConnectionTrait>(
                 Value::from(now_us),
                 Value::from(job_id.to_owned()),
             ],
+        ),
+    };
+    let sql = format!(
+        "UPDATE synthetics_jobs SET status = $1, result = $2, completed_at = $3 \
+         WHERE id = $4 AND status = 1{owner_clause}"
+    );
+    let applied = conn
+        .execute(Statement::from_sql_and_values(
+            conn.get_database_backend(),
+            &sql,
+            values,
         ))
         .await?;
 
@@ -554,6 +585,20 @@ pub enum DispatchFailureOutcome {
     /// via the dispatcher's existing `mark_failure`), so writing an
     /// intermediate status here would just be overwritten and wastes a query.
     DeadLettered,
+    /// The job is no longer Claimed — it has already been completed by a probe
+    /// ack, or reassigned to another holder. **The caller must do nothing:** no
+    /// requeue, no failure record, no run accounting.
+    ///
+    /// Reachable whenever a dispatch is judged failed *after* the probe already
+    /// reported: a Lambda that acks and then panics returns `FunctionError`, and
+    /// the SDK can also fail reading a response for an invocation that ran fine.
+    /// Without this the requeue reset a finished job to Pending, it was leased
+    /// again, and the check ran a second time — producing a duplicate result and a
+    /// second `increment_jobs_done` for one job.
+    ///
+    /// Enforced by the compiler rather than a test: the dispatcher matches all three
+    /// variants with no wildcard arm, so adding this one made "handle it" mandatory.
+    AlreadySettled,
 }
 
 /// Called when dispatching a leased job failed *before* the probe could run
@@ -571,19 +616,43 @@ pub async fn fail_dispatch<C: ConnectionTrait>(
     max_attempts: i32,
 ) -> Result<DispatchFailureOutcome, errors::Error> {
     if current_attempts < max_attempts {
+        // `AND status = 1` is what keeps this from resurrecting finished work. A
+        // dispatch can be judged failed after the probe has already acked — a
+        // Lambda that reports and then panics is exactly that — and without the
+        // guard the requeue reset a COMPLETED job to Pending, so it was leased and
+        // run again: duplicate result, and `increment_jobs_done` twice for one job.
         let sql = r#"
             UPDATE synthetics_jobs
             SET status = 0, claimed_by = NULL, claimed_at = NULL, lease_expires_at = NULL
-            WHERE id = $1
+            WHERE id = $1 AND status = 1
         "#;
-        conn.execute(Statement::from_sql_and_values(
-            conn.get_database_backend(),
-            sql,
-            [Value::from(job_id.to_owned())],
-        ))
-        .await?;
+        let applied = conn
+            .execute(Statement::from_sql_and_values(
+                conn.get_database_backend(),
+                sql,
+                [Value::from(job_id.to_owned())],
+            ))
+            .await?;
+        if applied.rows_affected() == 0 {
+            return Ok(DispatchFailureOutcome::AlreadySettled);
+        }
         Ok(DispatchFailureOutcome::Requeued)
     } else {
+        // Same check on the terminal branch, for the same reason: the caller's
+        // `mark_failure` would otherwise write a dispatch error over a real result.
+        // `ack_complete` would refuse it, but the caller also writes to the results
+        // stream and increments the run, and neither of those can be taken back.
+        let still_claimed = Entity::find()
+            .select_only()
+            .column(Column::Id)
+            .filter(Column::Id.eq(job_id))
+            .filter(Column::Status.eq(1i32))
+            .into_tuple::<String>()
+            .one(conn)
+            .await?;
+        if still_claimed.is_none() {
+            return Ok(DispatchFailureOutcome::AlreadySettled);
+        }
         Ok(DispatchFailureOutcome::DeadLettered)
     }
 }
@@ -628,6 +697,69 @@ pub async fn failing_locations<C: ConnectionTrait>(
         }
     }
     Ok(out)
+}
+
+/// One location+pool's share of the pending queue.
+#[derive(Debug, PartialEq, Eq)]
+pub struct PendingBacklogRow {
+    pub location: String,
+    pub pool: String,
+    /// Checks still waiting to be leased.
+    pub pending: i64,
+    /// `scheduled_ts` of the oldest one, in microseconds. The caller turns this
+    /// into an age; doing it here would bake in a clock reading the caller may
+    /// already have.
+    pub oldest_scheduled_ts: i64,
+}
+
+/// Per-location, per-pool count of checks waiting to be leased, with the oldest
+/// one's scheduled time.
+///
+/// Counts only rows that are still leasable — Pending and inside `valid_until`.
+/// Rows past their window are excluded on purpose: they are the reaper's to
+/// terminate and counting them would report a backlog that no amount of probe
+/// capacity can drain, which is a different problem wearing the same number.
+pub async fn pending_backlog<C: ConnectionTrait>(
+    conn: &C,
+    now_us: i64,
+) -> Result<Vec<PendingBacklogRow>, errors::Error> {
+    let sql = r#"
+        SELECT location, pool, COUNT(*) AS pending, MIN(scheduled_ts) AS oldest_scheduled_ts
+        FROM synthetics_jobs
+        WHERE status = 0 AND valid_until > $1
+        GROUP BY location, pool
+    "#;
+    let rows = conn
+        .query_all(Statement::from_sql_and_values(
+            conn.get_database_backend(),
+            sql,
+            [Value::from(now_us)],
+        ))
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            Some(PendingBacklogRow {
+                location: row.try_get("", "location").ok()?,
+                pool: row.try_get("", "pool").ok()?,
+                // SQLite hands COUNT back as i32 on some builds and i64 on others,
+                // so try the wider type first and fall back rather than dropping
+                // the row and reporting an empty backlog.
+                pending: row
+                    .try_get::<i64>("", "pending")
+                    .or_else(|_| row.try_get::<i32>("", "pending").map(i64::from))
+                    .unwrap_or(0),
+                // Falls back to `now_us`, i.e. age 0 — NOT to 0, which is the
+                // epoch and would publish a ~55-year-old backlog and page whoever
+                // is on call for a column we simply failed to decode.
+                oldest_scheduled_ts: row
+                    .try_get::<i64>("", "oldest_scheduled_ts")
+                    .or_else(|_| row.try_get::<i32>("", "oldest_scheduled_ts").map(i64::from))
+                    .unwrap_or(now_us),
+            })
+        })
+        .collect())
 }
 
 /// Backstop for pending rows past `valid_until`.
@@ -703,6 +835,20 @@ mod tests {
     }
 
     const MAX: i32 = 3;
+
+    #[test]
+    fn pending_backlog_row_carries_location_pool_and_the_oldest_entry() {
+        // The oldest entry is the half that distinguishes a deep queue that drains
+        // every tick from a location nothing is serving at all.
+        let row = PendingBacklogRow {
+            location: "private-dc1".to_string(),
+            pool: "private-dc1-pool".to_string(),
+            pending: 42,
+            oldest_scheduled_ts: 1_750_000_000_000_000,
+        };
+        assert_eq!(row.pending, 42);
+        assert_eq!(row.oldest_scheduled_ts, 1_750_000_000_000_000);
+    }
 
     #[test]
     fn pending_row_is_never_dispatched_whatever_its_attempt_count() {

--- a/src/infra/src/table/synthetics_jobs.rs
+++ b/src/infra/src/table/synthetics_jobs.rs
@@ -232,6 +232,14 @@ pub async fn drain_monitor<C: ConnectionTrait>(
     Ok(res.rows_affected())
 }
 
+/// Hard ceiling on one lease call, whatever the caller asks for.
+///
+/// Well above every real caller — the dispatcher takes 10, a Go agent
+/// `min(4 x NumCPU, 16)`, a browser agent 1 — so it never binds in normal
+/// operation. It exists so that no single probe can drain the queue, by
+/// misconfiguration or otherwise.
+const MAX_LEASE_BATCH: i64 = 100;
+
 // ── Dispatcher: lease ─────────────────────────────────────────────────────────
 
 /// Leases up to `limit` pending checks from a pool.
@@ -258,6 +266,13 @@ pub async fn lease_batch<C: ConnectionTrait>(
 ) -> Result<Vec<LeasedRow>, errors::Error> {
     let lease_secs = lease_secs.max(config::meta::synthetics::JOB_LEASE_SECS);
     let lease_expires_at = now_us + lease_secs * 1_000_000;
+
+    // `limit` arrives from a client and is cast to u64 below, where a negative
+    // wraps to ~1.8e19 and the query becomes unbounded — one agent would lease the
+    // entire pending queue for its pool and then hold a lease on every row of it.
+    // Reachable from a single mistyped env var, so it is clamped here rather than
+    // trusted: a probe does not get to decide how much of the queue it may take.
+    let limit = limit.clamp(1, MAX_LEASE_BATCH);
 
     // Step 1: pick candidate IDs.
     //
@@ -835,6 +850,23 @@ mod tests {
     }
 
     const MAX: i32 = 3;
+
+    #[test]
+    fn a_lease_limit_is_clamped_before_it_reaches_the_query() {
+        // `limit` is cast to u64 in the query. A negative wraps to ~1.8e19, making
+        // the LIMIT unbounded — one agent leases the entire pending queue for its
+        // pool and holds a 900s lease on every row. Reachable from one mistyped
+        // env var, so the server clamps rather than trusting the client.
+        assert_eq!((-4i64).clamp(1, MAX_LEASE_BATCH), 1);
+        assert_eq!(0i64.clamp(1, MAX_LEASE_BATCH), 1);
+        // Real callers are far below the ceiling and pass through untouched:
+        // dispatcher 10, Go agent min(4 x NumCPU, 16), browser agent 1.
+        for asked in [1i64, 10, 16, 25] {
+            assert_eq!(asked.clamp(1, MAX_LEASE_BATCH), asked);
+        }
+        // And nobody drains the queue by asking louder.
+        assert_eq!(i64::MAX.clamp(1, MAX_LEASE_BATCH), MAX_LEASE_BATCH);
+    }
 
     #[test]
     fn pending_backlog_row_carries_location_pool_and_the_oldest_entry() {


### PR DESCRIPTION
Stacked on `feat/synthetics-reliability`. **These repos squash-merge, so after that branch merges, rebase this one onto `main` before merging** — GitHub retargets the base automatically, but the branch will still carry reliability's individual commits while `main` has them as one, which replays the diff and can conflict.

Completes the concurrency/retry scope. Every item below is a correctness fix; none of it is throughput work.

### The reaper never completed a run, on any path
Only the probe ack and the dispatcher's failed invoke move `jobs_done`. So every path the reaper owned orphaned a run — including `dead_letter_expired`, whose entire purpose is to report "we gave up": it wrote a customer-visible error record into a run that then stayed open forever, with no `completed_at` and no `resolve_alert` evaluation, so the failure streak never moved.

The mechanism was `requeue_expired` ignoring `valid_until`. It reset a job to Pending, and `prune_stale` — later in the **same** tick — deleted it again, because `valid_until` is one interval (60s for a 1-minute check) while a lease is 300s+. `dispatch_attempts` never got past 1, so `MAX_DISPATCH_ATTEMPTS` was unreachable and the retry budget was dead code on the agent path.

- requeue only while the job is still inside its window
- dead-letter everything that can no longer report, tagged with *why* (attempts exhausted / window closed / never dispatched), so a dead agent doesn't read as an unresponsive probe
- per-row compare-and-swap instead of SELECT-then-bulk-UPDATE; the reaper runs on every alert_manager node, and double-terminating one job was harmless until the caller started incrementing a run counter
- increment **before** the ingest-token lookup, which returns early when an org has no token

### Every check's retry sequence is now bounded by the lease
Retries run *inside* the leased job. The browser path has checked this since `journey_budget_ms`; the protocol path never did, and its inputs were unbounded — the `5_000..=300_000` bound on `timeout_ms` is **browser-only**, so a TCP check with `timeout_ms: 3_600_000` saved fine.

With the reaper now completing runs, the symptom is a wrong answer rather than a stuck one: the lease expires mid-flight, the reaper completes the run as Error, and the probe's real ack is rejected as stale. A passing check reports Error, permanently. `timeout_ms=100s, retries=2, wait=30` needs 360s and hits it.

`lease_batch` now treats the client's `lease_secs` as a floor request, not the decision — both probes guess 300s, and a probe cannot know how long its own job may take.

### Ownership guard on the ack (M1b)
`AND claimed_by = $5`. The status guard doesn't cover reaper reassignment: the row returns to status 1 for a new holder, so the evicted holder's late ack still matched. `claimed_by` is `Option` — an older probe acks without it and falls back to the status guard, so nothing is discarded during rollout. **Make it non-optional to close the window once both probes ship.**

### `fail_dispatch` could resurrect a finished job
Found while wiring `function_error`. Its requeue was `WHERE id = $1` with no status guard, so a dispatch judged failed *after* the probe acked reset a **completed** job to Pending — leased again, run again, duplicate result, `increment_jobs_done` twice. Third outcome `AlreadySettled` added; the dispatcher matches all three with no wildcard, so handling it is compile-time enforced.

### Queue backlog is now observable
`synthetics_pending_jobs` and `synthetics_oldest_pending_age_seconds`, per location and pool. `started_ts - scheduled_ts` already covers work that *ran*; a check nobody leased produces no record, so its backlog was invisible by construction. Reported together because a deep queue that drains is throughput, while a shallow one whose oldest entry keeps ageing is a location nothing serves.

### Verification
OSS and enterprise builds clean, clippy 0 warnings, 23 infra + 2083 config tests.

### Before merge
`timeout_ms` validation is a **breaking change for existing protocol configs** — it runs at create/update only, so nothing stops on deploy, but an over-budget check is rejected the next time someone edits it. Worth auditing dev and prod first:

`retries` and `wait_before_retry_secs` live in `settings`, `timeout_ms` in `config`. Defaults match serde: `retries` 0, `wait` 5, `timeout_ms` 10000.

```sql
WITH c AS (
  SELECT id, org_id, name, synthetics_type,
         COALESCE((config->>'timeout_ms')::bigint, 10000)              AS t,
         COALESCE((settings->>'retries')::bigint, 0)                   AS r,
         COALESCE((settings->>'wait_before_retry_secs')::bigint, 5)    AS w
  FROM synthetics WHERE synthetics_type <> 'browser'
)
SELECT id, org_id, name, synthetics_type, t AS timeout_ms, r AS retries, w AS wait_s,
       (r + 1) * t + r * w * 1000 AS worst_case_ms
FROM c
WHERE t NOT BETWEEN 1000 AND 300000                    -- the new range rule
   OR (r + 1) * t + r * w * 1000 > 900000              -- the budget rule
ORDER BY worst_case_ms DESC;
```

**Expected result is zero rows.** `retries` of 0 or 1 cannot trip the budget rule at all — even at the extreme (`timeout_ms` 300s, `wait` 300s) one retry reaches exactly 900000ms, which is not over. It takes `retries >= 2`, and the defaults sit at 10000ms, 1.1% of the lease. Anything that does come back is a check that **cannot work today either**: its lease expires mid-run, the reaper completes the run as Error, and the probe's real ack is rejected as stale. Fix the config rather than loosening the rule.

One config trips unconditionally: `retries=3` with `wait_before_retry_secs=300` is 900s of sleeping before any timeout is counted. Related gap, not fixed here: `wait_before_retry_secs` is not validated against the schedule interval, so a 1-minute check may be configured to sleep 5 minutes between retries.

### Not done
Wiring the reaper's now-completing runs to a **notification**. The send lives in a crate that depends on `o2_enterprise`, so the reaper cannot call up into it; it needs the send moved into `openobserve_core::synthetics` or a queue. Architectural, with page-storm risk. No regression — before this, the run never completed, so there was no notification either.
