### PR TITLE
fix(downsampling): write footer meta for the last parquet file

### DIFF
--- a/src/search/src/datafusion/merge/downsampling.rs
+++ b/src/search/src/datafusion/merge/downsampling.rs
@@ -190,6 +190,7 @@ async fn write_downsampled_parquet(
     // Finalize last file if it has data
     if file_meta.records > 0 {
         file_meta.min_ts = last_min_ts;
+        append_metadata(&mut writer, &file_meta)?;
         writer.close().await?;
         bufs.push(buf);
         file_metas.push(file_meta);
@@ -401,6 +402,40 @@ mod tests {
             ],
         )
         .unwrap()
+    }
+
+    /// Every downsampled file must carry its own meta in the parquet footer,
+    /// including the last one.
+    #[tokio::test]
+    async fn test_write_downsampled_parquet_writes_metadata_for_every_file() {
+        let schema = create_test_schema();
+        let batch = create_test_record_batch();
+
+        // one batch per file
+        let mut cfg = config::Config::default();
+        cfg.compact.max_file_size = 1;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<RecordBatch>(2);
+        tx.send(batch.clone()).await.unwrap();
+        tx.send(batch).await.unwrap();
+        drop(tx);
+
+        let (bufs, file_metas) =
+            write_downsampled_parquet(rx, &schema, &[], &FileMeta::default(), &cfg)
+                .await
+                .unwrap();
+
+        assert_eq!(bufs.len(), 2);
+        assert_eq!(file_metas.len(), 2);
+        for (buf, file_meta) in bufs.into_iter().zip(file_metas) {
+            let footer = config::utils::parquet::read_metadata_from_bytes(&bytes::Bytes::from(buf))
+                .await
+                .unwrap();
+            assert_eq!(footer.min_ts, file_meta.min_ts);
+            assert_eq!(footer.max_ts, file_meta.max_ts);
+            assert_eq!(footer.records, file_meta.records);
+            assert_eq!(footer.original_size, file_meta.original_size);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`write_downsampled_parquet` splits its output into several files and calls `append_metadata` when it rolls over to a new one, but the **final** file was closed without it:

```rust
// Finalize last file if it has data
if file_meta.records > 0 {
    file_meta.min_ts = last_min_ts;
    writer.close().await?;   // <- no append_metadata
```

So the last file of every downsampling run shipped with an empty footer — `min_ts` / `max_ts` / `records` / `original_size` all read back as 0. file_list is unaffected (the correct meta is returned via `MergeParquetResult::Multiple.file_metas`), the file itself just was not self-describing, which matters for anything that recovers meta from the object store.

## Fix

Call `append_metadata` before closing the last file, same as the rollover branch.

## Test

`test_write_downsampled_parquet_writes_metadata_for_every_file` drives the writer with a 1-byte file-size limit so each batch becomes its own file, then reads every buffer's footer back and compares it against the returned `FileMeta`. Verified it fails without the one-line fix (footer `min_ts` 0 vs expected 3000) and passes with it.

Both the fix and the test live behind the `enterprise` feature, so they were checked and run against the real enterprise workspace, not the OSS stub.