### PR TITLE
fix(synthetics): name the degradation instead of calling it flaky

### DIFF
--- a/src/api/management/src/request/synthetics/mod.rs
+++ b/src/api/management/src/request/synthetics/mod.rs
@@ -1142,6 +1142,7 @@ async fn process_ack(
             consecutive_failures: resp.consecutive_failures,
             flaky,
             degraded,
+            status_reason: resp.status_reason.clone(),
             failing_locations: resp.failing_locations.clone(),
         };
         tokio::spawn(async move {

--- a/src/core/src/synthetics.rs
+++ b/src/core/src/synthetics.rs
@@ -51,6 +51,10 @@ pub struct CheckNotification {
     /// Kept distinct from `flaky` because they arrive as the same `warning`
     /// status: a flaky run fixed itself and needs no action, a degrading one
     /// will not fix itself and needs action before it becomes an outage.
+    /// Why the run was a warning, straight from the probe: `cert_expiring`,
+    /// `sftp_degraded`, `flaky`. `None` from a probe too old to report one, in
+    /// which case the message stays generic rather than guessing.
+    pub status_reason: Option<String>,
     pub degraded: bool,
     /// Locations that did not pass, worst first.
     ///
@@ -101,9 +105,22 @@ pub async fn notify_check_result(n: CheckNotification) {
                         n.monitor_name
                     )
                 } else if n.degraded {
-                    // Not "is WARNING": the point of the message is that this
-                    // needs action before it becomes an outage.
-                    format!("[OpenObserve Synthetics] 🟡 {} is DEGRADED", n.monitor_name)
+                    // Not "is WARNING": the point of the message is that this needs
+                    // action before it becomes an outage. Named where we know the
+                    // condition, because the subject is the line that decides
+                    // whether anyone opens the alert — and "CERTIFICATE EXPIRING"
+                    // gets renewed where a generic "DEGRADED" gets skimmed.
+                    match n.status_reason.as_deref() {
+                        Some("cert_expiring") => format!(
+                            "[OpenObserve Synthetics] 🟡 {} — CERTIFICATE EXPIRING SOON",
+                            n.monitor_name
+                        ),
+                        Some("sftp_degraded") => format!(
+                            "[OpenObserve Synthetics] 🟡 {} — SFTP DEGRADED",
+                            n.monitor_name
+                        ),
+                        _ => format!("[OpenObserve Synthetics] 🟡 {} is DEGRADED", n.monitor_name),
+                    }
                 } else if n.flaky {
                     format!("[OpenObserve Synthetics] 🔁 {} is FLAKY", n.monitor_name)
                 } else {
@@ -151,10 +168,24 @@ fn status_headline(n: &CheckNotification) -> String {
     // `warning` covers two unrelated things, and they need opposite responses:
     // a flaky run already fixed itself, a degrading target will not.
     if n.degraded {
-        return format!(
-            "{} is reachable but degrading — this needs attention before it fails",
-            n.monitor_name
-        );
+        // Name the condition. "Degrading" is true but not actionable, and the
+        // reader's next step differs entirely: renew a certificate, or go and look
+        // at an SFTP subsystem. QA reported the generic case as the bug — an
+        // expiring certificate that read as "passed only after retries (flaky)".
+        return match n.status_reason.as_deref() {
+            Some("cert_expiring") => format!(
+                "{} — the TLS certificate is expiring soon, renew it before it lapses",
+                n.monitor_name
+            ),
+            Some("sftp_degraded") => format!(
+                "{} connects and authenticates, but its SFTP subsystem is failing",
+                n.monitor_name
+            ),
+            _ => format!(
+                "{} is reachable but degrading — this needs attention before it fails",
+                n.monitor_name
+            ),
+        };
     }
     if n.flaky {
         return format!(


### PR DESCRIPTION
QA reported an alert that contradicts itself:

```
🟡 EU - TLS cert passed only after retries (flaky)
   Error: certificate expiring soon
```

Flaky means the check already fixed itself and there is nothing to do. A certificate running out will not fix itself. The headline is the part that gets read first, and it was pointing the reader away from the problem.

Notification half. Pairs with synthetic-o2-agent#8 and o2-enterprise#2312 — each is inert without the others, since the reason has to travel probe → control plane → notification.

### What changed

`CheckNotification` carries `status_reason`, so the Slack subject and the headline can name the condition:

| | before | after |
| --- | --- | --- |
| subject | `🟡 <name> is DEGRADED` | `🟡 <name> — CERTIFICATE EXPIRING SOON` |
| headline | `is reachable but degrading` | `the TLS certificate is expiring soon, renew it before it lapses` |

The subject matters most: it is what decides whether anyone opens the alert. `CERTIFICATE EXPIRING SOON` gets renewed; a generic `DEGRADED` gets skimmed.

Falls back to the existing generic wording when the probe sends no reason, so an older probe reads exactly as it does today.

Covers `sftp_degraded` too — an SSH check that connects and authenticates but whose SFTP probe fails was mislabelled the same way, just never reported.

### Verified live

Local o2 built from these branches, against `eu1.openobserve.ai` (28 days left, 30-day window):

```
🟡 LCL - TLS cert expiring — the TLS certificate is expiring soon, renew it before it lapses
   Target: eu1.openobserve.ai
   Error:  certificate expiring soon
```

Record: `status=warning`, `attempts=1`. That number is the point — the reported alert required attempts > 1 to claim retries had happened.

Binary confirmed to contain the new strings before testing, so the result is not a stale build.

`cargo check` clean on both OSS and enterprise.