### PR TITLE
fix(metrics): heatmap step unit, explorer back nav, gauge percentiles

### DIFF
--- a/web/src/composables/dashboard/usePanelPromQLExecutor.spec.ts
+++ b/web/src/composables/dashboard/usePanelPromQLExecutor.spec.ts
@@ -376,56 +376,67 @@ describe("usePanelPromQLExecutor", () => {
 
 describe("the heatmap column cap", () => {
   /**
-   * `usePanelDataLoader` builds start/end with `new Date(...).getTime()` — they are
-   * MILLISECONDS. The cap divided by 1e6 as if they were microseconds, which made
-   * every range look ~1000x shorter, collapsed the step to MIN_STEP_SECONDS (15s),
-   * and inverted the cap: a 24h heatmap asked for 5,760 columns instead of 120 —
-   * worse than no cap at all, since the backend's own default returns ~300.
+   * The start/end `usePanelDataLoader` passes here are MICROSECONDS, not ms. They
+   * come from `meta.dateTime`, whose Dates are built straight off
+   * `getConsumableDateTime()` — which is in µs — with no conversion
+   * (`plugins/metrics/Index.vue:419-428`, `views/Dashboards/ViewDashboard.vue`).
+   * `usePanelVariableSubstitution` reads the same pair and divides by 1e6.
    *
-   * The original bug survived review because it was only ever tested at 15m, the
-   * one range where a 15s step happens to land under the cap (60 columns). So this
-   * table starts at 15m and does not stop there.
+   * A previous revision of the cap divided by 1000, so every range looked 1000x
+   * LONGER: a 15m heatmap asked for a 7500s step over a 900s window, Prometheus
+   * returned a single sample per series, and the chart collapsed to one full-width
+   * column per bucket. This spec asserted the same wrong unit, so it stayed green
+   * while the product was broken — hence the explicit magnitude checks below.
    */
-  const MS = {
-    "15m": 15 * 60_000,
-    "1h": 3_600_000,
-    "6h": 21_600_000,
-    "24h": 86_400_000,
-    "7d": 604_800_000,
+  const US = {
+    "15m": 900_000_000,
+    "1h": 3_600_000_000,
+    "6h": 21_600_000_000,
+    "24h": 86_400_000_000,
+    "7d": 604_800_000_000,
   };
 
-  const stepFor = async (rangeMs: number) => {
+  const stepFor = async (rangeUs: number) => {
     const panelSchema = makePanelSchema();
     panelSchema.value.type = "heatmap";
     const { ctx, fetchQueryDataWithHttpStream } = makeCtx({ panelSchema });
     const { executePromQL } = usePanelPromQLExecutor(ctx as any);
-    // Exactly what the loader passes: getTime() milliseconds.
-    await executePromQL(1_700_000_000_000, 1_700_000_000_000 + rangeMs, null);
+    // Exactly what the loader passes: getTime() on a Date built from µs.
+    await executePromQL(1_700_000_000_000_000, 1_700_000_000_000_000 + rangeUs, null);
     const step = fetchQueryDataWithHttpStream.mock.calls[0][0].queryReq.step;
     return Number(String(step).replace(/s$/, ""));
   };
 
-  for (const [label, rangeMs] of Object.entries(MS)) {
+  for (const [label, rangeUs] of Object.entries(US)) {
     it(`keeps a ${label} heatmap within ${HEATMAP_MAX_COLUMNS} columns`, async () => {
-      const stepSeconds = await stepFor(rangeMs);
-      const columns = rangeMs / 1000 / stepSeconds;
+      const stepSeconds = await stepFor(rangeUs);
+      const columns = rangeUs / 1_000_000 / stepSeconds;
 
       expect(stepSeconds).toBeGreaterThan(0);
       expect(columns).toBeLessThanOrEqual(HEATMAP_MAX_COLUMNS);
     });
   }
 
-  it("does not collapse to the 15s floor at long ranges (the actual bug)", async () => {
-    // With the ms/µs confusion the step was 15s at EVERY range. It must scale.
-    expect(await stepFor(MS["24h"])).toBeGreaterThan(15);
-    expect(await stepFor(MS["7d"])).toBeGreaterThan(await stepFor(MS["6h"]));
+  it("still returns enough columns to be a heatmap (the reported bug)", async () => {
+    // The 1000x-too-large step yielded ONE column. Every range must stay plural,
+    // and a 15m window must match what the metrics-explorer card already renders.
+    for (const [label, rangeUs] of Object.entries(US)) {
+      const columns = rangeUs / 1_000_000 / (await stepFor(rangeUs));
+      expect(columns, `${label} collapsed to ${columns} column(s)`).toBeGreaterThan(10);
+    }
+    expect(await stepFor(US["15m"])).toBeLessThanOrEqual(30);
+  });
+
+  it("does not collapse to the 15s floor at long ranges", async () => {
+    expect(await stepFor(US["24h"])).toBeGreaterThan(15);
+    expect(await stepFor(US["7d"])).toBeGreaterThan(await stepFor(US["6h"]));
   });
 
   it("leaves a non-heatmap panel on the server default", async () => {
     const panelSchema = makePanelSchema(); // type: line
     const { ctx, fetchQueryDataWithHttpStream } = makeCtx({ panelSchema });
     const { executePromQL } = usePanelPromQLExecutor(ctx as any);
-    await executePromQL(1_700_000_000_000, 1_700_000_000_000 + MS["24h"], null);
+    await executePromQL(1_700_000_000_000_000, 1_700_000_000_000_000 + US["24h"], null);
     expect(fetchQueryDataWithHttpStream.mock.calls[0][0].queryReq.step).toBe("0");
   });
 
@@ -435,7 +446,7 @@ describe("the heatmap column cap", () => {
     panelSchema.value.queries[0].config = { step_value: "300" };
     const { ctx, fetchQueryDataWithHttpStream } = makeCtx({ panelSchema });
     const { executePromQL } = usePanelPromQLExecutor(ctx as any);
-    await executePromQL(1_700_000_000_000, 1_700_000_000_000 + MS["24h"], null);
+    await executePromQL(1_700_000_000_000_000, 1_700_000_000_000_000 + US["24h"], null);
     expect(fetchQueryDataWithHttpStream.mock.calls[0][0].queryReq.step).toBe("300");
   });
 });

--- a/web/src/composables/dashboard/usePanelPromQLExecutor.ts
+++ b/web/src/composables/dashboard/usePanelPromQLExecutor.ts
@@ -157,11 +157,12 @@ export const usePanelPromQLExecutor = (ctx: {
             const heatmapStepValue =
               isHeatmap && !queryStepValue && !panelStepValue
                 ? `${computeStepSeconds(
-                    // MILLISECONDS. `usePanelDataLoader` builds these with
-                    // `new Date(...).getTime()`; only the request payload converts
-                    // to the microseconds the backend wants — these raw values
-                    // never are. Divide by 1000 (not 1e6) to get seconds.
-                    (endISOTimestamp - startISOTimestamp) / 1000,
+                    // MICROSECONDS. `selectedTimeObj` carries Dates built from the
+                    // microsecond epoch the pickers emit, so the `.getTime()` values
+                    // `usePanelDataLoader` derives keep that magnitude — see the
+                    // matching `__range_seconds` conversion in
+                    // usePanelVariableSubstitution. Divide by 1e6 to get seconds.
+                    (endISOTimestamp - startISOTimestamp) / 1_000_000,
                     HEATMAP_MAX_COLUMNS,
                   )}s`
                 : undefined;

--- a/web/src/composables/dashboard/usePanelVariableSubstitution.spec.ts
+++ b/web/src/composables/dashboard/usePanelVariableSubstitution.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { ref } from "vue";
 import { usePanelVariableSubstitution } from "./usePanelVariableSubstitution";
+import { computePercentileWindow } from "@/utils/metrics/metricDefaults";
 
 // Mock utilities that have heavy dependencies (vuex, services, async parser)
 vi.mock("@/utils/query/sqlUtils", () => ({
@@ -470,5 +471,92 @@ describe("applyDynamicVariables", () => {
     expect(metadata).toHaveLength(2);
     expect(metadata.map((m: any) => m.name)).toContain("env");
     expect(metadata.map((m: any) => m.name)).toContain("region");
+  });
+});
+
+/**
+ * `$__percentile_interval` is the `quantile_over_time` counterpart to
+ * `$__rate_interval`. It exists because the rate window — sized for rate()'s
+ * two-sample need — left a quantile with so few samples that p90 and p99
+ * interpolated between the same top pair and drew as one line.
+ */
+describe("$__percentile_interval", () => {
+  // 1h in MICROSECONDS: the substitution reads these as µs (see __range_seconds).
+  const HOUR_US = 3_600_000_000;
+  const substitute = (query: string) => {
+    const { replaceQueryValue } = makeComposable();
+    // Returns { query, metadata } — the substituted text is `.query`.
+    return replaceQueryValue(query, 0, HOUR_US, "promql").query as string;
+  };
+
+  it("resolves to at least MIN_PERCENTILE_SAMPLES x the scrape interval", () => {
+    const out = substitute("quantile_over_time(0.99, up[$__percentile_interval])");
+    expect(out).not.toContain("$__percentile_interval");
+
+    const seconds = [...out.matchAll(/(\d+)([hms])/g)].reduce(
+      (acc, m) => acc + Number(m[1]) * { h: 3600, m: 60, s: 1 }[m[2] as "h"],
+      0,
+    );
+    // makeStore declares a 15s scrape, so the floor is 20 x 15s = 300s.
+    expect(seconds).toBeGreaterThanOrEqual(300);
+  });
+
+  it("is wider than $__rate_interval — the whole point of a separate variable", () => {
+    const asSeconds = (out: string) =>
+      [...out.matchAll(/(\d+)([hms])/g)].reduce(
+        (acc, m) => acc + Number(m[1]) * { h: 3600, m: 60, s: 1 }[m[2] as "h"],
+        0,
+      );
+    expect(asSeconds(substitute("up[$__percentile_interval]"))).toBeGreaterThan(
+      asSeconds(substitute("up[$__rate_interval]")),
+    );
+  });
+
+  it("does not collide with $__interval or $__rate_interval in one query", () => {
+    // Naive replaceAll over overlapping names is how this class of bug happens.
+    const out = substitute("a[$__interval] b[$__rate_interval] c[$__percentile_interval]");
+    expect(out).not.toContain("$__");
+    expect(out).not.toContain("percentile");
+  });
+
+  /**
+   * The explorer card executes its own preview and computes a concrete window;
+   * the panel resolves this variable. If the two disagree, clicking a card
+   * re-smooths the metric and the chart visibly changes for no reason — the
+   * exact failure `computeRateWindow`'s doc warns about. The panel initially
+   * shipped without the range/4 cap and gave 5m where the card gave 3m45s.
+   */
+  it("agrees with the card's computePercentileWindow at short ranges", () => {
+    const { replaceQueryValue } = makeComposable();
+    for (const rangeSeconds of [900, 3600, 21600]) {
+      const panel = String(
+        replaceQueryValue("x[$__percentile_interval]", 0, rangeSeconds * 1_000_000, "promql").query,
+      ).replace(/^x\[|\]$/g, "");
+      expect(panel, `range=${rangeSeconds}s`).toBe(computePercentileWindow(rangeSeconds, 120, 15));
+    }
+  });
+
+  it("caps at a quarter of the range, like the card does", () => {
+    const { replaceQueryValue } = makeComposable();
+    // 15m: the uncapped target (20 x 15s = 5m) is a THIRD of the view.
+    const panel = String(
+      replaceQueryValue("x[$__percentile_interval]", 0, 900 * 1_000_000, "promql").query,
+    );
+    expect(panel).toBe("x[3m45s]");
+  });
+
+  it("still emits a parseable duration when the range is not finite", () => {
+    // formatRateInterval(NaN) is "", which would emit the unparseable `x[]`.
+    const { replaceQueryValue } = makeComposable();
+    for (const end of [NaN, undefined as any]) {
+      const out = String(replaceQueryValue("x[$__percentile_interval]", 0, end, "promql").query);
+      expect(out, `end=${end}`).toMatch(/^x\[\d+[dhms]/);
+    }
+  });
+
+  it("supports the ${...} and {{...}} spellings the other fixed variables do", () => {
+    for (const q of ["up[${__percentile_interval}]", "up[{{__percentile_interval}}]"]) {
+      expect(substitute(q)).not.toContain("__percentile_interval");
+    }
   });
 });

--- a/web/src/composables/dashboard/usePanelVariableSubstitution.ts
+++ b/web/src/composables/dashboard/usePanelVariableSubstitution.ts
@@ -23,6 +23,7 @@ import {
 } from "@/utils/dashboard/variables/variablesUtils";
 import { escapeSingleQuotes } from "@/utils/zincutils";
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
+import { MIN_PERCENTILE_SAMPLES } from "@/utils/metrics/metricDefaults";
 
 /**
  * Composable that encapsulates all panel-level variable substitution logic.
@@ -411,6 +412,21 @@ export const usePanelVariableSubstitution = ({
     const __range_micros = endISOTimestamp - startISOTimestamp;
     const __range_seconds = __range_micros / 1000000; // Convert microseconds to seconds
 
+    // `quantile_over_time`'s window — the same three bounds as the explorer's
+    // `computePercentileWindow`, so a card and the panel it drills into smooth
+    // the metric identically:
+    //   FLOOR  the rate interval (no gaps between evaluation points)
+    //   TARGET MIN_PERCENTILE_SAMPLES x scrape, so p90 and p99 stop interpolating
+    //          between the same top pair and drawing as one line
+    //   CAP    a quarter of the range, or the window flattens the whole chart
+    // A non-finite range must not reach the cap: Math.max/min propagate NaN, and
+    // formatRateInterval(NaN) is "", which would emit the unparseable `x[]`.
+    const cappableRange = Number.isFinite(__range_seconds) ? Math.max(0, __range_seconds) : 0;
+    const __percentile_interval: any = Math.min(
+      Math.max(__rate_interval, MIN_PERCENTILE_SAMPLES * scrapeInterval),
+      Math.max(__rate_interval, cappableRange / 4),
+    );
+
     // format range, ensuring it's never empty (minimum 1s for PromQL compatibility)
     const formattedRange = formatRateInterval(__range_seconds) || "1s";
 
@@ -426,6 +442,10 @@ export const usePanelVariableSubstitution = ({
       {
         name: "__rate_interval",
         value: `${formatRateInterval(__rate_interval)}`,
+      },
+      {
+        name: "__percentile_interval",
+        value: `${formatRateInterval(__percentile_interval)}`,
       },
       {
         name: "__range",

--- a/web/src/composables/metrics/useMetricsExplorerGrid.ts
+++ b/web/src/composables/metrics/useMetricsExplorerGrid.ts
@@ -41,6 +41,7 @@ import {
 import {
   buildPresenceQuery,
   computeRateWindow,
+  computePercentileWindow,
   computeStepSeconds,
   DEFAULT_SCRAPE_INTERVAL_SECONDS,
   getMetricDefaults,
@@ -956,14 +957,14 @@ export function useMetricsExplorerGrid() {
   const effectiveVariant = (
     card: MetricCard,
     points = pointsFor(card),
-    opts?: { applyNanGuard?: boolean; rateWindow?: string },
+    opts?: { applyNanGuard?: boolean; rateWindow?: string; percentileWindow?: string },
   ) => {
     const epoch = variantEpoch.value;
     if (epoch !== cachedEpoch) {
       variantCache.clear();
       cachedEpoch = epoch;
     }
-    const cacheKey = `${card.name}|${points}|${opts?.applyNanGuard ? 1 : 0}|${opts?.rateWindow ?? ""}`;
+    const cacheKey = `${card.name}|${points}|${opts?.applyNanGuard ? 1 : 0}|${opts?.rateWindow ?? ""}|${opts?.percentileWindow ?? ""}`;
     const hit = variantCache.get(cacheKey);
     if (hit) return hit;
 
@@ -990,6 +991,11 @@ export function useMetricsExplorerGrid() {
         rateWindow:
           opts?.rateWindow ??
           computeRateWindow(rangeSeconds.value, points, scrapeIntervalSeconds.value),
+        // Wider than the rate window on purpose — a quantile needs samples, not
+        // just two points. See `computePercentileWindow`.
+        percentileWindow:
+          opts?.percentileWindow ??
+          computePercentileWindow(rangeSeconds.value, points, scrapeIntervalSeconds.value),
         labels: card.labels ?? labelsByStream.value[card.name],
         applyNanGuard: opts?.applyNanGuard,
       },

--- a/web/src/plugins/metrics/explorer/MetricCardChart.spec.ts
+++ b/web/src/plugins/metrics/explorer/MetricCardChart.spec.ts
@@ -120,6 +120,58 @@ describe("MetricCardChart builds the panel schema from its props", () => {
   });
 });
 
+/**
+ * `fixed` resolves to `fixedColor[0]` for EVERY series name (colorPalette.ts),
+ * and these charts carry no legend. So a multi-series variant — Percentiles,
+ * Min / Max — drew every line in one colour: three indistinguishable lines, or,
+ * when they coincided, something that looked like a single line and read as a
+ * bug in the query.
+ */
+describe("MetricCardChart colours multi-series charts per series", () => {
+  const matrix = (n: number) => [
+    {
+      resultType: "matrix",
+      result: Array.from({ length: n }, (_, i) => ({
+        metric: { le: String(i) },
+        values: [[1, "1"]],
+      })),
+    },
+  ];
+
+  it("keeps the card's accent colour when there is a single series", () => {
+    const color = panelProp(mountChart({ results: matrix(1) }), "panelSchema").config.color;
+    expect(color).toEqual({ mode: "fixed", fixedColor: ["#60a5fa"] });
+  });
+
+  it("switches to a per-series palette once there is more than one", () => {
+    const color = panelProp(mountChart({ results: matrix(3) }), "panelSchema").config.color;
+    expect(color.mode).toBe("palette-classic-by-series");
+  });
+
+  it("counts series ACROSS queries — one per percentile, one series each", () => {
+    // What the Percentiles variant actually returns: three separate responses.
+    const results = [50, 90, 99].map(() => ({
+      resultType: "matrix",
+      result: [{ metric: {}, values: [[1, "1"]] }],
+    }));
+    const wrapper = mountChart({
+      results,
+      queries: [50, 90, 99].map((p) => ({ expr: `q${p}`, legendTemplate: `p${p}` })),
+    });
+    expect(panelProp(wrapper, "panelSchema").config.color.mode).toBe("palette-classic-by-series");
+  });
+
+  it("re-evaluates when the results change", async () => {
+    const wrapper = mountChart({ results: matrix(1) });
+    expect(panelProp(wrapper, "panelSchema").config.color.mode).toBe("fixed");
+
+    await wrapper.setProps({ results: matrix(4) });
+    await nextTick();
+
+    expect(panelProp(wrapper, "panelSchema").config.color.mode).toBe("palette-classic-by-series");
+  });
+});
+
 describe("MetricCardChart feeds the queue's results in as injected data", () => {
   it("hands the results and the queried window (µs) to the panel", () => {
     const wrapper = mountChart();

--- a/web/src/plugins/metrics/explorer/MetricCardChart.vue
+++ b/web/src/plugins/metrics/explorer/MetricCardChart.vue
@@ -111,6 +111,28 @@ export default defineComponent({
       return 2;
     };
 
+    /** How many series the chart will actually draw, across every query. */
+    const seriesCount = () => {
+      let n = 0;
+      for (const response of props.results ?? []) n += response?.result?.length ?? 0;
+      return n;
+    };
+
+    /**
+     * A single series keeps the card's accent colour — that colour is the card's
+     * identity, and a lone line needs no distinguishing. The moment there is more
+     * than one, `fixed` paints them all the SAME colour (colorPalette resolves
+     * `fixed` to `fixedColor[0]` for every series name), which on a legend-less
+     * tile makes a Percentiles or Min/Max variant unreadable: three lines you
+     * cannot tell apart, or — when they coincide — indistinguishable from one.
+     * Hashing the series NAME into the palette also keeps p50 the same colour on
+     * every re-render and between the tile and the card it applies to.
+     */
+    const colorConfig = () =>
+      seriesCount() > 1
+        ? { mode: "palette-classic-by-series" }
+        : { mode: "fixed", fixedColor: [props.color] };
+
     /**
      * The panel schema. The same shape the drill-in hands the editor, which is
      * what keeps "what you click is what you get" true. `type` is fixed from the
@@ -139,7 +161,7 @@ export default defineComponent({
         connect_nulls: true,
         line_interpolation: "smooth",
         line_thickness: 1.5,
-        color: { mode: "fixed", fixedColor: [props.color] },
+        color: colorConfig(),
         // Injected data is never "loading", so the converter would auto-range
         // the x-axis; pin it to the queried window instead. See `timeRange`.
         pin_x_axis_to_range: true,

--- a/web/src/plugins/metrics/explorer/MetricsExplorer.spec.ts
+++ b/web/src/plugins/metrics/explorer/MetricsExplorer.spec.ts
@@ -107,9 +107,11 @@ vi.mock("vuex", async (importOriginal) => ({
 // Controllable route/router so the URL-state tests can seed `route.query` before
 // mount (hydration) and inspect `router.replace` (sync). `name` must be "metrics"
 // or syncVisualizeUrl and the route.query watcher short-circuit.
+// Both verbs resolve a promise, as the real router does — syncUrlState chains
+// `.catch()` on whichever it picks.
 const routerState = vi.hoisted(() => ({
   replace: vi.fn().mockResolvedValue(undefined),
-  push: vi.fn(),
+  push: vi.fn().mockResolvedValue(undefined),
   query: {} as Record<string, any>,
 }));
 vi.mock("vue-router", () => ({
@@ -819,6 +821,57 @@ describe("MetricsExplorer wiring", () => {
           (c: any) => c[0]?.query && !("metrics_data" in c[0].query),
         );
         expect(stripped).toBe(true);
+      });
+
+      // Explore -> Visualize never changes ROUTE (mode is a query param on
+      // `metrics`), so a `replace` here overwrote the Explore entry outright and
+      // Back jumped clean over the page to whatever preceded it — /logs, in
+      // practice, since useLogs pushes an entry per search. The mode transition
+      // has to push; nothing else may.
+      it("pushes a history entry when switching to Visualize, so Back returns here", async () => {
+        routerState.query = { org_identifier: "org1" };
+        const wrapper = mountExplorer();
+        routerState.push.mockClear();
+        routerState.replace.mockClear();
+
+        await enterVisualizeWith(wrapper, "up");
+
+        const pushedModes = routerState.push.mock.calls.map((c: any) => c[0]?.query?.mode);
+        expect(pushedModes).toContain("visualize");
+        expect(routerState.replace.mock.calls.map((c: any) => c[0]?.query?.mode)).not.toContain(
+          "visualize",
+        );
+      });
+
+      it("pushes on the way back out of Visualize too", async () => {
+        const wrapper = mountExplorer();
+        await enterVisualizeWith(wrapper, "up");
+        // The mock's route.query does not follow navigations, so stand it up by
+        // hand: this is the URL the push above just produced.
+        routerState.query = { mode: "visualize" };
+        routerState.push.mockClear();
+
+        (wrapper.vm as any).setMode("explore");
+        await wrapper.vm.$nextTick();
+
+        // `explore` serializes to an absent key, so the pushed query has no mode.
+        expect(routerState.push).toHaveBeenCalled();
+        expect(routerState.push.mock.calls.at(-1)[0].query.mode).toBeUndefined();
+      });
+
+      it("still REPLACES a same-mode edit — those must not stack history", async () => {
+        const wrapper = mountExplorer();
+        routerState.push.mockClear();
+        routerState.replace.mockClear();
+
+        // refreshInterval is a real component ref (the grid mock's fields are
+        // plain objects and drive nothing), so this exercises syncUrlState with
+        // mode held constant.
+        (wrapper.vm as any).refreshInterval = 60;
+        await wrapper.vm.$nextTick();
+
+        expect(routerState.replace).toHaveBeenCalled();
+        expect(routerState.push).not.toHaveBeenCalled();
       });
 
       it("does not touch metrics_data while in a grid mode", async () => {

--- a/web/src/plugins/metrics/explorer/MetricsExplorer.vue
+++ b/web/src/plugins/metrics/explorer/MetricsExplorer.vue
@@ -583,7 +583,7 @@ import {
   encodeMetricsConfig,
   decodeMetricsConfig,
 } from "@/composables/metrics/metricsUrlState";
-import { PANEL_RATE_WINDOW } from "@/utils/metrics/metricDefaults";
+import { PANEL_PERCENTILE_WINDOW, PANEL_RATE_WINDOW } from "@/utils/metrics/metricDefaults";
 import { BADGE_LABELS, cardColorForIndex } from "@/utils/metrics/metricPalette";
 import {
   EXPLORER_FILTER_PARAM_KEYS,
@@ -1182,6 +1182,7 @@ export default defineComponent({
       // not a chart of anything.
       const { defaults, resolved } = grid.effectiveVariant(card, undefined, {
         rateWindow: PANEL_RATE_WINDOW,
+        percentileWindow: PANEL_PERCENTILE_WINDOW,
       });
       if (!resolved) return;
 
@@ -1289,6 +1290,7 @@ export default defineComponent({
         if (!card) continue;
         const { defaults, resolved } = grid.effectiveVariant(card, undefined, {
           rateWindow: PANEL_RATE_WINDOW,
+          percentileWindow: PANEL_PERCENTILE_WINDOW,
         });
         if (!resolved) continue;
         const data = buildPanelDataForCard(card, resolved, defaults.bucketUnit);
@@ -1304,6 +1306,12 @@ export default defineComponent({
     // Managed keys are wiped first — a cleared filter must leave the URL, and
     // anything else (org_identifier) rides along untouched. Defaults serialize
     // to nothing, so an unfiltered grid keeps a bare /metrics URL.
+    //
+    // The ONE exception is `mode`. Explore -> Visualize is in-page (no route
+    // change: mode is a query param on `metrics`), so replacing here overwrote
+    // the Explore entry and Back skipped past the whole page to whatever came
+    // before it — in practice /logs. A mode switch is a navigation the user
+    // expects Back to undo, so it pushes; everything else still replaces.
     const syncUrlState = () => {
       const query: Record<string, any> = { ...route.query };
       for (const key of MANAGED_PARAM_KEYS) delete query[key];
@@ -1312,7 +1320,13 @@ export default defineComponent({
       const changed =
         Object.keys(query).some((k) => String(query[k]) !== String(route.query[k] ?? "")) ||
         Object.keys(route.query).some((k) => !(k in query));
-      if (changed) router.replace({ query }).catch(() => {});
+      if (!changed) return;
+
+      // `explore` serializes to an ABSENT key, so compare against "" — not
+      // `undefined` vs "explore", which would read as a change on every sync.
+      const modeChanged = String(query.mode ?? "") !== String(route.query.mode ?? "");
+      const navigate = modeChanged ? router.push : router.replace;
+      navigate.call(router, { query }).catch(() => {});
     };
 
     // A getter, not an array of refs: reading `.value` inside it tracks every

--- a/web/src/utils/metrics/metricDefaults.spec.ts
+++ b/web/src/utils/metrics/metricDefaults.spec.ts
@@ -18,10 +18,12 @@ import {
   CARD_KIND,
   baseNameOf,
   buildSelector,
+  computePercentileWindow,
   computeRateWindow,
   computeStepSeconds,
   formatPromDuration,
   getMetricDefaults,
+  MIN_PERCENTILE_SAMPLES,
   inferUnit,
   resolveCardKind,
   resolveVariant,
@@ -30,6 +32,10 @@ import {
 
 /** The rate window every truth-table expectation below is written against. */
 const W = "4m";
+/** The percentile window a gauge falls back to when no time context is given:
+ *  MIN_PERCENTILE_SAMPLES x the 15s default scrape. Deliberately NOT `W` — a
+ *  quantile needs far more samples than a rate. */
+const PW = "5m";
 
 /** Shorthand: the default (index 0) query for a metric, with no filters. */
 const defaultQuery = (name: string, type?: string, ctx?: Record<string, any>) =>
@@ -126,6 +132,72 @@ describe("rate window (PRD 6.4)", () => {
     expect(formatPromDuration(3660)).toBe("1h1m");
     expect(formatPromDuration(90)).toBe("1m30s");
     expect(formatPromDuration(86400)).toBe("1d");
+  });
+});
+
+/**
+ * The rate window is sized for `rate()`, which needs two samples. Reusing it for
+ * `quantile_over_time` gave a 15m view a 1m window — FOUR samples at a 15s
+ * scrape — where p90 lands at index 0.9 x 3 = 2.7 and p99 at 2.97: both
+ * interpolate between the same top pair and draw as one line. Widening the
+ * window is what makes the percentiles actually separate.
+ */
+describe("percentile window", () => {
+  const toSeconds = (d: string) =>
+    [...d.matchAll(/(\d+)([dhms])/g)].reduce(
+      (acc, m) => acc + Number(m[1]) * { d: 86400, h: 3600, m: 60, s: 1 }[m[2] as "d"],
+      0,
+    );
+  const RANGES = { "15m": 900, "1h": 3600, "6h": 21600, "24h": 86400, "7d": 604800 };
+
+  it("is never narrower than the rate window", () => {
+    // The rate window already guarantees no gaps between evaluation points; a
+    // quantile can never want LESS data than a rate. Includes ranges so short
+    // that the range/4 cap would otherwise undercut it.
+    for (const range of [60, 300, ...Object.values(RANGES), 3600 * 300]) {
+      for (const scrape of [10, 15, 60]) {
+        expect(
+          toSeconds(computePercentileWindow(range, undefined, scrape)),
+          `range=${range} scrape=${scrape}`,
+        ).toBeGreaterThanOrEqual(toSeconds(computeRateWindow(range, undefined, scrape)));
+      }
+    }
+  });
+
+  it("gives a 15m view far more than the four samples the rate window did", () => {
+    const before = toSeconds(computeRateWindow(RANGES["15m"], 120, 15)) / 15;
+    const after = toSeconds(computePercentileWindow(RANGES["15m"], 120, 15)) / 15;
+    expect(before).toBe(4); // the bug
+    expect(after).toBeGreaterThanOrEqual(15);
+  });
+
+  it("reaches the sample target once the range allows it", () => {
+    for (const label of ["1h", "6h", "24h", "7d"] as const) {
+      const samples = toSeconds(computePercentileWindow(RANGES[label], 120, 15)) / 15;
+      expect(samples, label).toBeGreaterThanOrEqual(MIN_PERCENTILE_SAMPLES);
+    }
+  });
+
+  it("caps at a quarter of the view so the chart keeps its variation", () => {
+    // Without the cap a 15m view would ask for 5m — a third of the range — and
+    // every point would report nearly the same global quantile.
+    for (const range of Object.values(RANGES)) {
+      const w = toSeconds(computePercentileWindow(range, 120, 15));
+      const rate = toSeconds(computeRateWindow(range, 120, 15));
+      // The cap may only be overridden by the floor (the rate window itself).
+      expect(w <= range / 4 || w === rate, `range=${range}`).toBe(true);
+    }
+  });
+
+  it("scales with the scrape interval rather than assuming 15s", () => {
+    expect(computePercentileWindow(6 * 3600, 120, 15)).toBe("5m"); // 20 x 15s
+    expect(computePercentileWindow(6 * 3600, 120, 30)).toBe("10m"); // 20 x 30s
+  });
+
+  it("survives a zero/garbage range without emitting an invalid duration", () => {
+    for (const bad of [0, -1, NaN, undefined as any]) {
+      expect(computePercentileWindow(bad, 120, 15)).toMatch(/^\d+[dhms]/);
+    }
   });
 });
 
@@ -610,7 +682,7 @@ describe("percentile checkbox sets are honoured", () => {
     const r = resolveVariant(gauge(), "percentiles", { percentiles: [75] });
     expect(r?.queries).toHaveLength(1);
     expect(r?.queries[0].legendTemplate).toBe("p75");
-    expect(r?.queries[0].expr).toBe('quantile(0.75, {__name__="queue_depth"})');
+    expect(r?.queries[0].expr).toBe(`quantile_over_time(0.75, {__name__="queue_depth"}[${PW}])`);
   });
 
   it("resolves a mixed subset exactly", () => {
@@ -621,6 +693,44 @@ describe("percentile checkbox sets are honoured", () => {
   it("defaults to p50/p90/p99 out of the five offered", () => {
     const r = resolveVariant(gauge(), "percentiles");
     expect(r?.queries.map((q: any) => q.legendTemplate)).toEqual(["p50", "p90", "p99"]);
+  });
+
+  /**
+   * `quantile(φ, v)` aggregates ACROSS the series present at each timestamp, so
+   * on a single-series gauge every percentile returns that one series' own value
+   * — three identical lines under three different legends. Percentiles for a
+   * gauge are a question about TIME.
+   */
+  it("asks for percentiles over time, not across series", () => {
+    const r = resolveVariant(gauge(), "percentiles", { percentiles: [50, 99] });
+    for (const q of r!.queries) {
+      expect(q.expr).toMatch(/^quantile_over_time\(/);
+      expect(q.expr).toContain(`[${PW}]`);
+    }
+    // Distinct ratios — the whole point is that the series no longer coincide.
+    expect(new Set(r!.queries.map((q: any) => q.expr)).size).toBe(2);
+  });
+
+  /**
+   * A range vector may only be taken over a SELECTOR. The NaN-guard retry path
+   * rewrites the selector into `(x and x > -Inf)`, and `(...)[5m]` does not
+   * parse — nor does the subquery form `(...)[5m:]`, which the engine rejects
+   * unless the inner expression is already a matrix. So the percentile queries
+   * must be built from the UNGUARDED selector even in guarded mode.
+   */
+  it("keeps a parseable range vector when the NaN guard is on", () => {
+    const guarded = getMetricDefaults("queue_depth", "gauge", undefined, {
+      rateWindow: W,
+      applyNanGuard: true,
+    });
+    const r = resolveVariant(guarded, "percentiles", { percentiles: [99] });
+
+    expect(r!.queries[0].expr).toBe(`quantile_over_time(0.99, {__name__="queue_depth"}[${PW}])`);
+    expect(r!.queries[0].expr).not.toContain("> -Inf");
+
+    // The guard still applies to the variants that can carry it.
+    const avg = resolveVariant(guarded, "avg");
+    expect(avg!.queries[0].expr).toContain("> -Inf");
   });
 });
 

--- a/web/src/utils/metrics/metricDefaults.ts
+++ b/web/src/utils/metrics/metricDefaults.ts
@@ -79,9 +79,18 @@ interface BuildVariantsContext {
   metricName: string;
   base: string;
   sel: string;
+  /**
+   * `sel` with the NaN guard NEVER applied. A range vector `[w]` may only be
+   * taken over a SELECTOR, so any variant that builds one has to start here —
+   * `(x and x > -Inf)[5m]` does not parse, and the subquery form `(...)[5m:]`
+   * is rejected by the engine unless the inner expression is already a matrix.
+   */
+  rawSel: string;
   baseSel?: string;
   countSel: string;
   w: string;
+  /** The `[w]` for `quantile_over_time`. Wider than `w` — see MIN_PERCENTILE_SAMPLES. */
+  pw: string;
   labels?: string[];
   unit: string;
   builderLabels: PromqlLabelMatcher[];
@@ -115,6 +124,7 @@ interface MetricDefaultsContext {
   familyType?: string;
   filters?: FilterInput[];
   rateWindow?: string;
+  percentileWindow?: string;
   labels?: string[];
   applyNanGuard?: boolean;
 }
@@ -712,14 +722,21 @@ export function computeStepSeconds(
  *
  * @returns {string} a PromQL duration, e.g. "4m"
  */
+function rateWindowSeconds(
+  rangeSeconds: number,
+  maxDataPoints: number,
+  scrapeIntervalSeconds: number,
+): number {
+  const step = computeStepSeconds(rangeSeconds, maxDataPoints);
+  return Math.max(4 * scrapeIntervalSeconds, step + scrapeIntervalSeconds);
+}
+
 export function computeRateWindow(
   rangeSeconds: number,
   maxDataPoints: number = MAX_DATA_POINTS,
   scrapeIntervalSeconds: number = DEFAULT_SCRAPE_INTERVAL_SECONDS,
 ): string {
-  const step = computeStepSeconds(rangeSeconds, maxDataPoints);
-  const w = Math.max(4 * scrapeIntervalSeconds, step + scrapeIntervalSeconds);
-  return formatPromDuration(w);
+  return formatPromDuration(rateWindowSeconds(rangeSeconds, maxDataPoints, scrapeIntervalSeconds));
 }
 
 /**
@@ -740,6 +757,56 @@ export const PANEL_RATE_WINDOW = "$__rate_interval";
 
 /** The window used when a caller supplies no time context. */
 const DEFAULT_RATE_WINDOW = formatPromDuration(4 * DEFAULT_SCRAPE_INTERVAL_SECONDS);
+
+/**
+ * Samples a `quantile_over_time` window should contain before its percentiles
+ * mean anything.
+ *
+ * The rate window is sized for `rate()`, which needs two samples — 4 x scrape is
+ * plenty. A quantile is a different question: over 4 samples, p90 lands at index
+ * 0.9 x 3 = 2.7 and p99 at 2.97, so both interpolate between the same top pair
+ * and draw as one line. That is the whole reason percentiles looked broken.
+ */
+export const MIN_PERCENTILE_SAMPLES = 20;
+
+/**
+ * The `[w]` for a `quantile_over_time`, in a card the explorer executes itself.
+ *
+ * Three bounds, in order of who wins when:
+ *  - FLOOR, the rate window itself: it already guarantees consecutive evaluation
+ *    points leave no gaps, and a quantile can never want LESS data than a rate.
+ *    This dominates at long ranges, where the step is already large — there the
+ *    two windows coincide.
+ *  - TARGET `MIN_PERCENTILE_SAMPLES x scrape`: enough samples to separate the
+ *    percentiles. This dominates at short ranges, where the step is at its floor.
+ *  - CAP `range / 4`: a window near the width of the view returns one global
+ *    quantile per series and flattens the chart. Keeping four windows across the
+ *    view leaves visible variation. Never allowed to undercut the FLOOR.
+ *
+ * @returns {string} a PromQL duration, e.g. "5m"
+ */
+export function computePercentileWindow(
+  rangeSeconds: number,
+  maxDataPoints: number = MAX_DATA_POINTS,
+  scrapeIntervalSeconds: number = DEFAULT_SCRAPE_INTERVAL_SECONDS,
+): string {
+  const floor = rateWindowSeconds(rangeSeconds, maxDataPoints, scrapeIntervalSeconds);
+  const target = MIN_PERCENTILE_SAMPLES * scrapeIntervalSeconds;
+  const cap = Math.max(floor, Math.max(0, Number(rangeSeconds) || 0) / 4);
+  return formatPromDuration(Math.min(Math.max(floor, target), cap));
+}
+
+/**
+ * The percentile window to hand to a PANEL — the `$__rate_interval` counterpart
+ * for `quantile_over_time`, resolved by usePanelVariableSubstitution against the
+ * panel's own range and width. Same reasoning as `PANEL_RATE_WINDOW`.
+ */
+export const PANEL_PERCENTILE_WINDOW = "$__percentile_interval";
+
+/** The percentile window used when a caller supplies no time context. */
+const DEFAULT_PERCENTILE_WINDOW = formatPromDuration(
+  MIN_PERCENTILE_SAMPLES * DEFAULT_SCRAPE_INTERVAL_SECONDS,
+);
 
 /* -------------------------------------------------------------------------- */
 /* Rule set B — unit inference                                                 */
@@ -877,9 +944,10 @@ const TOPK = (k: number, byLabels: string[] = []): PromqlStep => ({
   id: PromqlStepId.TopK,
   params: [k, [...byLabels]],
 });
-const QUANTILE = (ratio: number, byLabels: string[] = []): PromqlStep => ({
-  id: PromqlStepId.Quantile,
-  params: [ratio, [...byLabels]],
+/** `quantile_over_time(ratio, sel[window])` — params are [ratio, window]. */
+const QUANTILE_OVER_TIME = (ratio: number, window: string): PromqlStep => ({
+  id: PromqlStepId.QuantileOverTime,
+  params: [ratio, window],
 });
 const HISTOGRAM_QUANTILE = (ratio: number): PromqlStep => ({
   id: PromqlStepId.HistogramQuantile,
@@ -910,7 +978,19 @@ function resolveTopkLabel(labels: string[] | undefined): string | null {
  * and an ExponentialHistogram fallback gets only its count line.
  */
 function buildVariants(cardKind: string, ctx: BuildVariantsContext): Variant[] {
-  const { metricName, base, sel, countSel, w, labels, unit, builderLabels, builderSafe } = ctx;
+  const {
+    metricName,
+    base,
+    sel,
+    rawSel,
+    countSel,
+    w,
+    pw,
+    labels,
+    unit,
+    builderLabels,
+    builderSafe,
+  } = ctx;
 
   /**
    * Builder state for one query, or `undefined` when this variant cannot be
@@ -963,8 +1043,26 @@ function buildVariants(cardKind: string, ctx: BuildVariantsContext): Variant[] {
           // `resolveVariant` narrows these queries down to the checked set — so
           // any percentile without a query here is a checkbox that silently does
           // nothing (or worse, empties the subset and falls back to all of them).
+          //
+          // Percentiles OVER TIME, not across series. `quantile(φ, v)` aggregates
+          // the series present at each timestamp, so on a single-series gauge —
+          // the common case — p50, p90 and p99 all collapse onto the raw value
+          // and the tile draws one line under three legends. `quantile_over_time`
+          // asks the question a gauge actually poses ("what was the p99 of this
+          // signal over the last [w]?") and stays meaningful at any series count.
+          //
+          // Built from `rawSel`: a range vector needs a SELECTOR, so the guarded
+          // `(x and x > -Inf)` form cannot carry a range. See `rawSel`'s doc.
+          //
+          // `pw`, NOT `w`: the rate window is sized for rate()'s two-sample need
+          // and leaves a quantile with too few samples to separate. See
+          // MIN_PERCENTILE_SAMPLES.
           queries: GAUGE_PERCENTILES.map((p) =>
-            q(`quantile(${p / 100}, ${sel})`, `p${p}`, b(metricName, [QUANTILE(p / 100)])),
+            q(
+              `quantile_over_time(${p / 100}, ${rawSel}[${pw}])`,
+              `p${p}`,
+              b(metricName, [QUANTILE_OVER_TIME(p / 100, pw)]),
+            ),
           ),
           chartType: "line",
           // Checked by default; the other offered percentiles start unchecked.
@@ -1288,6 +1386,7 @@ const FOOTER_LABEL = {
  *   familyType?: string,         // the family's declared type
  *   filters?: Array<{label: string, value: string, operator?: string}>,
  *   rateWindow?: string,         // PromQL duration; defaults to the 4m floor
+ *   percentileWindow?: string,   // quantile_over_time's window; defaults to 20 x scrape
  *   labels?: string[],           // the stream's label names, when known
  *   applyNanGuard?: boolean, // retry mode: guard the selector against NaN samples
  * }} [ctx]
@@ -1302,12 +1401,14 @@ export function getMetricDefaults(
   const base = baseNameOf(metricName);
   const filters = ctx?.filters ?? [];
   const w = ctx?.rateWindow || DEFAULT_RATE_WINDOW;
+  const pw = ctx?.percentileWindow || DEFAULT_PERCENTILE_WINDOW;
 
   const supportsNanGuard = RATE_FREE_KINDS.includes(cardKind);
   const guarded = !!ctx?.applyNanGuard && supportsNanGuard;
   const guard = guarded ? withNanGuard : (selector: string) => selector;
 
-  const sel = guard(buildSelector(metricName, filters));
+  const rawSel = buildSelector(metricName, filters);
+  const sel = guard(rawSel);
   const baseSel = guard(buildSelector(base, filters));
   const countSel = buildSelector(`${base}_count`, filters);
 
@@ -1318,9 +1419,11 @@ export function getMetricDefaults(
     metricName,
     base,
     sel,
+    rawSel,
     baseSel,
     countSel,
     w,
+    pw,
     labels: ctx?.labels,
     unit,
     builderLabels: builderLabelsOf(filters),

--- a/web/src/utils/metrics/metricPanelSeed.ts
+++ b/web/src/utils/metrics/metricPanelSeed.ts
@@ -26,7 +26,12 @@
  */
 
 import { buildMetricCardFor, type MetricStream } from "./metricFamily";
-import { getMetricDefaults, PANEL_RATE_WINDOW, resolveVariant } from "./metricDefaults";
+import {
+  getMetricDefaults,
+  PANEL_PERCENTILE_WINDOW,
+  PANEL_RATE_WINDOW,
+  resolveVariant,
+} from "./metricDefaults";
 import { buildPanelDataForCard } from "./metricsHandoff";
 
 export interface PromqlSeed {
@@ -67,6 +72,7 @@ export interface SeedOptions {
    * was picked.
    */
   rateWindow?: string;
+  percentileWindow?: string;
 }
 
 /**
@@ -123,6 +129,7 @@ export function buildPromqlSeed(
       familyType: card.familyType,
       labels: card.labels,
       rateWindow: opts.rateWindow ?? PANEL_RATE_WINDOW,
+      percentileWindow: opts.percentileWindow ?? PANEL_PERCENTILE_WINDOW,
     },
   );
 


### PR DESCRIPTION
Four fixes to the metrics explorer and the panel editor it drills into. Each was reproduced from a real symptom; the root causes turned out to be independent.

## 1. Histogram heatmap rendered as a single column in the panel editor

The same panel that renders correctly as a card collapsed to one full-width bar per bucket once opened in the editor.

`usePanelPromQLExecutor` computed the heatmap step with `range / 1000`, but `startISOTimestamp`/`endISOTimestamp` are **microseconds**:

- `plugins/metrics/Index.vue:294` documents `getConsumableDateTime()` as microseconds, and line 424 builds `meta.dateTime` from it with no conversion
- `usePanelDataLoader.ts:412` preserves that magnitude via `.getTime()`
- `usePanelVariableSubstitution.ts:410-412` reads the *same pair* and correctly divides by `1_000_000`

So every range looked 1000x longer. A 15m window asked for a **7500s step over a 900s range** → Prometheus returned one sample per series → one bar per `le`. Now `max(15, ceil(900/120))` = 15s / 60 columns, matching the card.

Only heatmaps were affected — every other chart type sends `step: "0"` and lets the backend choose.

**Why this shipped:** the spec asserted the same wrong unit, feeding `1_700_000_000_000` ms — a value the loader never produces — so it passed while the product was broken. Rewritten to microseconds, with an assertion that no range collapses below 10 columns.

## 2. Browser Back from Visualize landed on Logs

Explore → Visualize is entirely in-page (`mode` is a query param on the `metrics` route; `MetricsVisualize.vue` is a child component, not a route). The only URL write was `router.replace`, so the Explore entry was **overwritten** rather than stacked, and Back popped straight past the page to whatever preceded `/metrics` — reliably `/logs`, since `logsUtils.ts:519-528` pushes an entry per search.

Mode transitions now `push`; filter, time-range and refresh edits still `replace` so they don't stack history. `syncVisualizeUrl` stays `replace` — it fires repeatedly while editing. The existing mode-only fast path (`MetricsExplorer.vue:1388-1392`) restores Explore without re-querying the ~40 cards.

## 3. Gauge percentiles all drew the same line

`quantile(φ, v)` aggregates **across the series** present at each timestamp, so on a single-series gauge p50, p90 and p99 all return that series' own value — three identical lines under three legends.

Switched to `quantile_over_time` — percentiles over **time**, which is the question a gauge actually poses and which stays meaningful at any series count. (Histogram percentiles still use `histogram_quantile`, correctly untouched.)

Two constraints shaped this:

- **A range vector may only be taken over a selector.** The NaN-guard retry rewrites the gauge selector into `(x and x > -Inf)`, and `(...)[5m]` doesn't parse — the hazard already documented at `metricDefaults.ts:586`. The subquery escape is closed too: `src/promql/src/engine.rs:281-299` rejects a non-matrix inner expression. So these queries are built from an unguarded `rawSel`. The guard still applies to every variant that can carry it (asserted in tests).
- **The rate window is the wrong size for a quantile.** Sized for `rate()`'s two-sample need, it gave a 15m view a 1m window — four samples, where p90 (index 2.7) and p99 (2.97) interpolate between the *same* top pair and draw as one line. Percentiles now get `computePercentileWindow`: floored at the rate window (no gaps between evaluation points), targeting `MIN_PERCENTILE_SAMPLES (20) × scrape`, capped at `range / 4` (a wider window flattens the chart).

| Range | Rate window | Percentile window | Samples |
|---|---|---|---|
| 15m | 1m | **3m45s** | 4 → **15** |
| 1h | 1m | **5m** | 4 → **20** |
| 6h | 3m15s | **5m** | 13 → **20** |
| 24h | 12m15s | 12m15s | 49 (unchanged) |
| 7d | 1h24m15s | 1h24m15s | 337 (unchanged) |

At long ranges the floor dominates and nothing changes, correctly.

A new `$__percentile_interval` panel variable mirrors all three bounds so the card and the panel it drills into resolve to the **same** window — asserted directly against `computePercentileWindow`. Without it the editor would have kept the narrow window and disagreed with the card, the exact failure `computeRateWindow`'s own doc warns about.

## 4. Multi-series charts were monochrome

`fixed` resolves to `fixedColor[0]` for *every* series name (`colorPalette.ts:279`), and these charts carry no legend — so Percentiles and Min/Max drew every line in one colour: indistinguishable when they differ, and invisible when they coincide.

Now `palette-classic-by-series` above one series; a single series keeps the card's accent colour. Hashing the series *name* keeps `p50` the same colour across re-renders and between the preview tile and the card. Verified `p50`/`p90`/`p99` and `min`/`max` land on distinct palette slots in both light and dark themes.

Heatmaps are unaffected — `convertPromQLHeatmapChart.ts` uses a hardcoded `HEATMAP_VISUAL_MAP_COLORS` and never reads `config.color`.

## Testing

- **15,743 passed, 0 failed** across `src/utils`, `src/composables`, `src/plugins/metrics`, `src/components/promql`, `src/components/dashboards`
- `vue-tsc` and `eslint` clean on every changed file
- New coverage: heatmap step at five ranges, mode-transition push/replace, percentiles-over-time shape, the NaN-guard/range-vector interaction, window bounds (including the invariant that the percentile window is never narrower than the rate window, across ranges and scrape intervals), card↔panel window agreement, and four colour-mode cases

Two existing assertions were corrected: one pinned the old `quantile()` string, and the router mock's `push: vi.fn()` returned `undefined` where the real router returns a Promise.

## Not addressed

A separate issue found while reviewing: `cache_hit_ratio` displays as ~8500%. `metricDefaults.ts:236` infers any `*_ratio` name as `percent-1` (0.0–1.0), whose formatter multiplies by 100, but that producer emits 0–100. The inference follows Prometheus/Grafana convention, so the fix is arguably in the emitter — and `FnOverride` currently has no unit field, so there's no UI escape hatch. Left out deliberately pending a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
