### PR TITLE
fix: canonicalize model names in service graph to prevent node splitting

### DIFF
--- a/src/core/src/traces/otel/pricing.rs
+++ b/src/core/src/traces/otel/pricing.rs
@@ -64,6 +64,30 @@ pub fn calculate_cost(
     Some((input_cost, output_cost, total_cost))
 }
 
+/// Canonicalize a raw model name string to a stable identifier.
+///
+/// Different vendors/instrumentation frameworks report the same model under
+/// different raw strings (e.g. "anthropic/claude-sonnet-4-6" vs.
+/// "claude-sonnet-4-6"), which otherwise land as distinct nodes/keys in
+/// aggregations like the service graph. This reuses the same pattern list as
+/// `calculate_cost` so cost lookup and node identity stay consistent.
+///
+/// Returns `None` if no known pattern matches (caller should fall back to the
+/// raw string).
+pub fn canonical_model_pattern(model_name: &str) -> Option<&'static str> {
+    MODEL_PRICING
+        .iter()
+        .find(|p| p.matches(model_name))
+        .map(|p| p.pattern.as_str())
+}
+
+/// All known model-name patterns in match priority order (most specific
+/// first), for callers that need to build a SQL expression covering every
+/// pattern rather than matching a single Rust string.
+pub fn model_patterns() -> impl Iterator<Item = &'static str> {
+    MODEL_PRICING.iter().map(|p| p.pattern.as_str())
+}
+
 /// Pricing tier based on token count or other conditions
 #[derive(Debug, Clone)]
 pub struct PricingTier {
@@ -294,6 +318,51 @@ pub static MODEL_PRICING: Lazy<Vec<ModelPricing>> = Lazy::new(|| {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_canonical_model_pattern_merges_vendor_prefix_variants() {
+        // Introspection instance (Google-ADK/gateway style, direct-vs-gateway path)
+        // and CrewAI/LiteLLM (provider/model style) both report claude-sonnet-4-6
+        // under different raw strings. They must canonicalize to the same pattern.
+        let raw_strings = ["claude-sonnet-4-6", "anthropic/claude-sonnet-4-6"];
+        let canon: Vec<_> = raw_strings
+            .iter()
+            .map(|s| canonical_model_pattern(s))
+            .collect();
+        assert_eq!(canon[0], canon[1]);
+        assert_eq!(canon[0], Some("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn test_canonical_model_pattern_merges_dated_and_undated_variants() {
+        let direct = canonical_model_pattern("anthropic/claude-sonnet-4-5-20250929");
+        let gateway = canonical_model_pattern("claude-sonnet-4-5-20250929");
+        assert_eq!(direct, gateway);
+        assert_eq!(direct, Some("claude-sonnet-4-5"));
+    }
+
+    #[test]
+    fn test_canonical_model_pattern_older_dated_snapshot_is_distinct_bucket() {
+        // A pre-4.5/4.6 dated snapshot (older CrewAI/LiteLLM deployments) does not
+        // contain "4-5" or "4-6" as a substring, so it falls into the broader
+        // "claude-sonnet-4" bucket rather than merging with newer snapshots. This
+        // is expected: it is plausibly a materially different model.
+        let older = canonical_model_pattern("anthropic/claude-sonnet-4-20250514");
+        assert_eq!(older, Some("claude-sonnet-4"));
+    }
+
+    #[test]
+    fn test_canonical_model_pattern_unknown_model_returns_none() {
+        assert_eq!(canonical_model_pattern("some-unlisted-custom-model"), None);
+    }
+
+    #[test]
+    fn test_model_patterns_nonempty_and_matches_pricing_table() {
+        let patterns: Vec<_> = model_patterns().collect();
+        assert!(!patterns.is_empty());
+        assert!(patterns.contains(&"claude-sonnet-4-6"));
+        assert_eq!(patterns.len(), MODEL_PRICING.len());
+    }
 
     #[test]
     fn test_calculate_cost_gpt4() {

--- a/src/core/src/traces/service_graph/processor.rs
+++ b/src/core/src/traces/service_graph/processor.rs
@@ -303,6 +303,23 @@ fn env_fragments(has_agent_env: bool, aliased: bool) -> (&'static str, &'static 
     }
 }
 
+/// Wrap a raw model-name SQL expression in a `CASE` that maps it to the same
+/// canonical pattern used for cost lookup (`otel::pricing`), so vendor-prefix
+/// / date-suffix variants of the same model (e.g. "anthropic/claude-sonnet-4-6"
+/// vs. "claude-sonnet-4-6") collapse into one service-graph node instead of
+/// splitting. Falls back to the raw expression when no pattern matches.
+/// Patterns are regex fragments (may contain `'`-unsafe chars only via the
+/// hardcoded static list in pricing.rs — never from user input), matched with
+/// DataFusion's `regexp_like`.
+#[cfg(feature = "enterprise")]
+fn build_model_canonicalization_case(model_expr: &str) -> String {
+    let arms: String = crate::traces::otel::pricing::model_patterns()
+        .map(|pattern| format!("WHEN regexp_like({model_expr}, '{pattern}') THEN '{pattern}'"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("CASE {arms} ELSE {model_expr} END")
+}
+
 /// Process a single trace stream
 #[cfg(feature = "enterprise")]
 /// Aggregate one trace stream into service-graph edge hits for a window WITHOUT
@@ -583,6 +600,13 @@ async fn compute_stream_edges(
             (false, false) => "CAST(NULL AS STRING)",
         };
         let model_predicate = format!("{model_expr} IS NOT NULL AND {model_expr} != ''");
+        // Canonicalize the raw model string before it becomes a graph node key.
+        // Different frameworks/vendors report the same model under different raw
+        // strings (e.g. "anthropic/claude-sonnet-4-6" vs. "claude-sonnet-4-6"),
+        // which otherwise split into separate nodes. Reuses the same pattern list
+        // as cost lookup (pricing.rs) so node identity and cost stay consistent.
+        // Falls back to the raw expression when no known pattern matches.
+        let model_canon_expr = build_model_canonicalization_case(model_expr);
 
         // Metric aggregates shared by every edge query (aliased to child `c`
         // where a join is present, so it works in both flat and joined forms).
@@ -636,7 +660,7 @@ async fn compute_stream_edges(
                 ),
                 format!(
                     r#"{trace_agent_cte}
-                    SELECT {model_from} AS client, {model_expr_c} AS server,
+                    SELECT {model_from} AS client, {model_canon_expr_c} AS server,
                         'model' AS connection_type{env_sel_c}, {mc}
                     FROM "{stream_name}" AS c
                     {ancestor_joins}
@@ -644,9 +668,12 @@ async fn compute_stream_edges(
                         AND {model_predicate_c}
                         AND ({model_from}) IS NOT NULL AND ({model_from}) != ''
                         AND ({model_from}) != ({model_expr_c})
-                    GROUP BY {model_from}, {model_expr_c}{env_grp_c}"#,
+                    GROUP BY {model_from}, {model_canon_expr_c}{env_grp_c}"#,
                     model_expr_c = model_expr.replace("gen_ai_", "c.gen_ai_"),
                     model_predicate_c = model_predicate.replace("gen_ai_", "c.gen_ai_"),
+                    model_canon_expr_c = build_model_canonicalization_case(
+                        &model_expr.replace("gen_ai_", "c.gen_ai_")
+                    ),
                 ),
             )
         } else {
@@ -663,14 +690,14 @@ async fn compute_stream_edges(
                     GROUP BY {agent_or_service}, gen_ai_tool_name{env_grp_flat}"#,
                 ),
                 format!(
-                    r#"SELECT {agent_or_service} AS client, {model_expr} AS server,
+                    r#"SELECT {agent_or_service} AS client, {model_canon_expr} AS server,
                         'model' AS connection_type{env_sel_flat}, {m}
                     FROM "{stream_name}"
                     WHERE _timestamp >= {start_time} AND _timestamp < {end_time}
                         AND {model_predicate}
                         AND ({agent_or_service}) IS NOT NULL AND ({agent_or_service}) != ''
                         AND ({agent_or_service}) != ({model_expr})
-                    GROUP BY {agent_or_service}, {model_expr}{env_grp_flat}"#,
+                    GROUP BY {agent_or_service}, {model_canon_expr}{env_grp_flat}"#,
                 ),
             )
         };


### PR DESCRIPTION
## Summary
- The Agent Graph model-edge query previously used the raw `gen_ai_request_model`/`gen_ai_response_model` string verbatim as the node key. Different instrumentation frameworks/vendors report the same model under different raw strings (e.g. `anthropic/claude-sonnet-4-6` vs. `claude-sonnet-4-6`), which split what should be one model into two separate graph nodes.
- Adds `canonical_model_pattern`/`model_patterns` to `otel::pricing`, reusing the existing `MODEL_PRICING` regex table (already used for cost calculation) so cost lookup and node identity stay consistent.
- Wraps the model-edge node-key expression in a SQL `CASE` in `service_graph::processor::compute_stream_edges`, applied at query time (no ingest-time mutation, no backfill needed — raw `gen_ai_*` columns are untouched for audit/debugging, and historical data self-heals on the next hourly aggregation pass).

## Test plan
- [x] `cargo test -p openobserve-core --lib traces::otel::pricing::` — 25/25 pass, including 5 new tests covering vendor-prefix merge, dated/undated suffix merge, older-snapshot distinct-bucket behavior, unknown-model fallback, and pattern-list sanity — using real-world sample strings gathered from both a Google-ADK/gateway-style agent and CrewAI/LiteLLM-style instrumentation.
- [x] `cargo build -p openobserve-core` (non-enterprise, default) — green, confirms zero OSS-build impact (new code is fully `#[cfg(feature = "enterprise")]`-gated).
- [x] `cargo fmt --all -- --check` clean for both changed files.
- [ ] Full `--features enterprise` build/test of `processor.rs` itself — not completed in this session (local worktree lacked a fully-wired sibling `o2-enterprise` checkout); recommend CI or a follow-up local verification pass before merge.
- [ ] Live verification against a running instance's `_o2_service_graph` data — not done, would need a deployed instance.

See `docs/ak_review/pr-fix-model-node-canonicalization-review.md` for the full review-pr writeup (0 P0/P1 findings; 2 P2 notes on PB-scale timing and minor duplication, 1 P3 doc note).