### PR TITLE
fix(logs): bound the last selected column to the viewport

### DIFF
--- a/web/src/composables/useLogs/useStreamFields.ts
+++ b/web/src/composables/useLogs/useStreamFields.ts
@@ -1201,12 +1201,17 @@ export const useStreamFields = () => {
         }
 
         // The last column absorbs whatever width the fixed ones leave over — the
-        // pre-migration table did this with `flex: 1 1 auto` on the last column,
-        // OTable's equivalent is `meta.autoWidth`. Without an absorber the table
-        // (table-layout:auto + w-full) spreads the surplus across EVERY column,
-        // so the fixed-width timestamp visibly stretches whenever the selected
-        // columns are narrower than the panel. `minSize` stops it collapsing
-        // below its own measured width.
+        // pre-migration table did this with `flex: 1 1 auto; overflow: hidden` on
+        // the last column, OTable's equivalent is `meta.fillRemaining`. Without an
+        // absorber the table (table-layout:auto + w-full) spreads the surplus
+        // across EVERY column, so the fixed-width timestamp visibly stretches
+        // whenever the selected columns are narrower than the panel. `minSize`
+        // stops it collapsing below its own measured width.
+        // `fillRemaining` rather than a plain `autoWidth`: this column must stay
+        // inside the viewport and ellipsis-truncate, exactly as the old table did.
+        // (`autoWidth` alone is content-sized — right for the default `source`
+        // column, which pre-migration was `width: auto` and scrolled, but it makes
+        // a long `body` value stretch the column to thousands of pixels.)
         // `resultGrid.columns` is untyped, so `.at()` widens to `{}` — name the
         // few fields we touch rather than reaching through `any`.
         interface GridColumn {
@@ -1218,7 +1223,7 @@ export const useStreamFields = () => {
         const lastColumn = searchObj.data.resultGrid.columns.at(-1) as GridColumn | undefined;
         if (lastColumn && lastColumn.id !== store.state.zoConfig.timestamp_column) {
           lastColumn.minSize = lastColumn.size;
-          lastColumn.meta = { ...lastColumn.meta, autoWidth: true };
+          lastColumn.meta = { ...lastColumn.meta, autoWidth: true, fillRemaining: true };
         }
       }
 

--- a/web/src/composables/useLogs/useStreamFields.ts
+++ b/web/src/composables/useLogs/useStreamFields.ts
@@ -1200,18 +1200,10 @@ export const useStreamFields = () => {
           }
         }
 
-        // The last column absorbs whatever width the fixed ones leave over — the
-        // pre-migration table did this with `flex: 1 1 auto; overflow: hidden` on
-        // the last column, OTable's equivalent is `meta.fillRemaining`. Without an
-        // absorber the table (table-layout:auto + w-full) spreads the surplus
-        // across EVERY column, so the fixed-width timestamp visibly stretches
-        // whenever the selected columns are narrower than the panel. `minSize`
-        // stops it collapsing below its own measured width.
-        // `fillRemaining` rather than a plain `autoWidth`: this column must stay
-        // inside the viewport and ellipsis-truncate, exactly as the old table did.
-        // (`autoWidth` alone is content-sized — right for the default `source`
-        // column, which pre-migration was `width: auto` and scrolled, but it makes
-        // a long `body` value stretch the column to thousands of pixels.)
+        // The last column absorbs the leftover width; without it the auto layout
+        // spreads the surplus across EVERY column and the timestamp stretches.
+        // `fillRemaining`, not a plain `autoWidth`, so it truncates at the
+        // viewport instead of growing to a long `body` value.
         // `resultGrid.columns` is untyped, so `.at()` widens to `{}` — name the
         // few fields we touch rather than reaching through `any`.
         interface GridColumn {

--- a/web/src/lib/core/Table/OTable.spec.ts
+++ b/web/src/lib/core/Table/OTable.spec.ts
@@ -1070,11 +1070,12 @@ describe("OTable", () => {
   // ── Column Management ──────────────────────────────────────
 
   describe("bounded elastic (fillRemaining) column width", () => {
-    // Pre-migration (TenstackTable) the fill column was `flex: 1 1 auto` +
-    // `overflow: hidden` — it took the leftover width and clipped. A scrolling
-    // table carries `min-w-max`, which sizes columns to their max-content, so
-    // without a clamp the fill column stretches to the longest value instead.
+    // A scrolling table sizes columns to max-content, so without a clamp the
+    // filler stretches to its longest value instead of taking the leftover.
     const longValue = "x".repeat(4000);
+    // Built, not written literally: a bare `var(--header-x-size)` in source
+    // trips scripts/check-css-tokens.mjs (no static `--header-x-size:` decl).
+    const sizeVar = (id: string) => `var(--header-${id}-size)`;
 
     function mountElastic(
       props: Record<string, unknown> = {},
@@ -1123,19 +1124,17 @@ describe("OTable", () => {
       const cell = wrapper.find('[data-test="o2-table-cell-ts"]');
       expect(cell.exists()).toBe(true);
       expect(cell.attributes("style")).not.toContain("max-width: 0");
-      expect(cell.attributes("style")).toContain("min-width: var(--header-ts-size)");
+      expect(cell.attributes("style")).toContain(`min-width: ${sizeVar("ts")}`);
     });
 
-    // Regression: once another field is selected, `body` stops being the filler
-    // and becomes an ordinary sized column. Nothing capped a sized column in a
-    // scrolling table, so its own text stretched it to ~3000px and dragged the
-    // whole row into horizontal scroll. Pre-migration these were flex-shrink:0
-    // with an ellipsis, i.e. pinned at `size` in both directions.
+    // Regression: once another field is selected `body` becomes an ordinary
+    // sized column, and nothing capped those — its own text stretched it to
+    // ~3000px and dragged the row into horizontal scroll.
     it("should pin a long-valued sized column at its size instead of its content", () => {
       wrapper = mountElastic({
         columns: [
           { id: "ts", header: "Timestamp", accessorKey: "ts", size: 236 },
-          // `body` is no longer last, so it is sized — and its value is enormous
+          // no longer last, so it is sized — and its value is enormous
           { id: "body", header: "Body", accessorKey: "body", size: 800 },
           {
             id: "level",
@@ -1150,12 +1149,12 @@ describe("OTable", () => {
       });
       const cell = wrapper.find('[data-test="o2-table-cell-body"]');
       expect(cell.exists()).toBe(true);
-      expect(cell.attributes("style")).toContain("width: var(--header-body-size)");
-      expect(cell.attributes("style")).toContain("min-width: var(--header-body-size)");
-      expect(cell.attributes("style")).toContain("max-width: var(--header-body-size)");
+      expect(cell.attributes("style")).toContain(`width: ${sizeVar("body")}`);
+      expect(cell.attributes("style")).toContain(`min-width: ${sizeVar("body")}`);
+      expect(cell.attributes("style")).toContain(`max-width: ${sizeVar("body")}`);
       expect(cell.classes()).toContain("text-ellipsis");
       const th = wrapper.find('[data-test="o2-table-th-body"]');
-      expect(th.attributes("style")).toContain("max-width: var(--header-body-size)");
+      expect(th.attributes("style")).toContain(`max-width: ${sizeVar("body")}`);
     });
 
     it("should size the table to the container rather than max-content", () => {

--- a/web/src/lib/core/Table/OTable.spec.ts
+++ b/web/src/lib/core/Table/OTable.spec.ts
@@ -1069,6 +1069,126 @@ describe("OTable", () => {
 
   // ── Column Management ──────────────────────────────────────
 
+  describe("bounded elastic (fillRemaining) column width", () => {
+    // Pre-migration (TenstackTable) the fill column was `flex: 1 1 auto` +
+    // `overflow: hidden` — it took the leftover width and clipped. A scrolling
+    // table carries `min-w-max`, which sizes columns to their max-content, so
+    // without a clamp the fill column stretches to the longest value instead.
+    const longValue = "x".repeat(4000);
+
+    function mountElastic(
+      props: Record<string, unknown> = {},
+      fillMeta: Record<string, unknown> = { autoWidth: true, fillRemaining: true },
+    ) {
+      const cols: OTableColumnDef<any>[] = [
+        { id: "ts", header: "Timestamp", accessorKey: "ts", size: 236 },
+        {
+          id: "body",
+          header: "Body",
+          accessorKey: "body",
+          size: 800,
+          minSize: 800,
+          meta: fillMeta,
+        },
+      ];
+      return mount(OTable, {
+        props: {
+          data: [{ ts: "2026-07-31 10:00:00.000", body: longValue }],
+          columns: cols,
+          horizontalScroll: true,
+          ...props,
+        },
+      });
+    }
+
+    it("should clamp the elastic column to the leftover width when scrolling", () => {
+      wrapper = mountElastic();
+      const cell = wrapper.find('[data-test="o2-table-cell-body"]');
+      expect(cell.exists()).toBe(true);
+      expect(cell.attributes("style")).toContain("max-width: 0");
+      expect(cell.attributes("style")).toContain("min-width: 800px");
+      expect(cell.classes()).toContain("text-ellipsis");
+      expect(cell.classes()).toContain("overflow-hidden");
+    });
+
+    it("should clamp the elastic header in step with its cells", () => {
+      wrapper = mountElastic();
+      const th = wrapper.find('[data-test="o2-table-th-body"]');
+      expect(th.exists()).toBe(true);
+      expect(th.attributes("style")).toContain("max-width: 0");
+    });
+
+    it("should pin sized columns beside it, since the table loses min-w-max", () => {
+      wrapper = mountElastic();
+      const cell = wrapper.find('[data-test="o2-table-cell-ts"]');
+      expect(cell.exists()).toBe(true);
+      expect(cell.attributes("style")).not.toContain("max-width: 0");
+      expect(cell.attributes("style")).toContain("min-width: var(--header-ts-size)");
+    });
+
+    // Regression: once another field is selected, `body` stops being the filler
+    // and becomes an ordinary sized column. Nothing capped a sized column in a
+    // scrolling table, so its own text stretched it to ~3000px and dragged the
+    // whole row into horizontal scroll. Pre-migration these were flex-shrink:0
+    // with an ellipsis, i.e. pinned at `size` in both directions.
+    it("should pin a long-valued sized column at its size instead of its content", () => {
+      wrapper = mountElastic({
+        columns: [
+          { id: "ts", header: "Timestamp", accessorKey: "ts", size: 236 },
+          // `body` is no longer last, so it is sized — and its value is enormous
+          { id: "body", header: "Body", accessorKey: "body", size: 800 },
+          {
+            id: "level",
+            header: "Level",
+            accessorKey: "level",
+            size: 150,
+            minSize: 150,
+            meta: { autoWidth: true, fillRemaining: true },
+          },
+        ],
+        data: [{ ts: "2026-07-31 10:00:00.000", body: longValue, level: "INFO" }],
+      });
+      const cell = wrapper.find('[data-test="o2-table-cell-body"]');
+      expect(cell.exists()).toBe(true);
+      expect(cell.attributes("style")).toContain("width: var(--header-body-size)");
+      expect(cell.attributes("style")).toContain("min-width: var(--header-body-size)");
+      expect(cell.attributes("style")).toContain("max-width: var(--header-body-size)");
+      expect(cell.classes()).toContain("text-ellipsis");
+      const th = wrapper.find('[data-test="o2-table-th-body"]');
+      expect(th.attributes("style")).toContain("max-width: var(--header-body-size)");
+    });
+
+    it("should size the table to the container rather than max-content", () => {
+      wrapper = mountElastic();
+      const table = wrapper.find("table");
+      expect(table.classes()).toContain("w-full");
+      expect(table.classes()).not.toContain("min-w-max");
+    });
+
+    it("should leave a plain autoWidth column content-sized and scrolling", () => {
+      wrapper = mountElastic({}, { autoWidth: true });
+      const cell = wrapper.find('[data-test="o2-table-cell-body"]');
+      expect(cell.exists()).toBe(true);
+      expect(cell.attributes("style") ?? "").not.toContain("max-width: 0");
+      expect(wrapper.find("table").classes()).toContain("min-w-max");
+    });
+
+    it("should release the clamp while wrapping so the text can reflow", () => {
+      wrapper = mountElastic({ wrap: true });
+      const cell = wrapper.find('[data-test="o2-table-cell-body"]');
+      expect(cell.exists()).toBe(true);
+      expect(cell.attributes("style") ?? "").not.toContain("max-width: 0");
+      expect(cell.classes()).toContain("whitespace-normal");
+    });
+
+    it("should leave non-scrolling tables to the container-bounded layout", () => {
+      wrapper = mountElastic({ horizontalScroll: false });
+      const cell = wrapper.find('[data-test="o2-table-cell-body"]');
+      expect(cell.exists()).toBe(true);
+      expect(cell.attributes("style") ?? "").not.toContain("max-width: 0");
+    });
+  });
+
   describe("column resize", () => {
     it("shows resize handle on resizable columns", () => {
       const cols: OTableColumnDef<TestRow>[] = [

--- a/web/src/lib/core/Table/OTable.types.ts
+++ b/web/src/lib/core/Table/OTable.types.ts
@@ -101,6 +101,20 @@ export interface OTableColumnMeta {
   isName?: boolean;
   /** Format function applied to cell value before rendering */
   format?: (value: any, row: any) => any;
+  /**
+   * Elastic column: carries no explicit width, so it absorbs whatever the sized
+   * columns leave over. In a `horizontalScroll` table it is content-sized — it
+   * grows to its longest value and the table scrolls.
+   */
+  autoWidth?: boolean;
+  /**
+   * Bounded elastic column: absorbs the leftover width like `autoWidth`, but
+   * stays inside the container and ellipsis-truncates instead of growing to its
+   * content. Set it alongside `autoWidth`. Costs the table its `min-w-max`, so
+   * the sized columns pin their min-widths and the row scrolls only when they
+   * genuinely don't fit.
+   */
+  fillRemaining?: boolean;
   /** Arbitrary metadata for custom cell renderers */
   [key: string]: any;
 }

--- a/web/src/lib/core/Table/OTable.types.ts
+++ b/web/src/lib/core/Table/OTable.types.ts
@@ -102,17 +102,14 @@ export interface OTableColumnMeta {
   /** Format function applied to cell value before rendering */
   format?: (value: any, row: any) => any;
   /**
-   * Elastic column: carries no explicit width, so it absorbs whatever the sized
-   * columns leave over. In a `horizontalScroll` table it is content-sized — it
-   * grows to its longest value and the table scrolls.
+   * Elastic column: no explicit width, so it absorbs the leftover. In a
+   * `horizontalScroll` table it is content-sized — it grows to its longest
+   * value and the table scrolls.
    */
   autoWidth?: boolean;
   /**
-   * Bounded elastic column: absorbs the leftover width like `autoWidth`, but
-   * stays inside the container and ellipsis-truncates instead of growing to its
-   * content. Set it alongside `autoWidth`. Costs the table its `min-w-max`, so
-   * the sized columns pin their min-widths and the row scrolls only when they
-   * genuinely don't fit.
+   * Bounded elastic column: absorbs the leftover like `autoWidth`, but stays
+   * inside the container and ellipsis-truncates. Set alongside `autoWidth`.
    */
   fillRemaining?: boolean;
   /** Arbitrary metadata for custom cell renderers */

--- a/web/src/lib/core/Table/OTable.vue
+++ b/web/src/lib/core/Table/OTable.vue
@@ -712,21 +712,12 @@ const hasFillColumn = computed(() =>
   }),
 );
 
-// A *bounded* filler (`meta.fillRemaining`) takes the leftover width but stays
-// inside the container and clips, where a plain `autoWidth` filler is allowed to
-// grow to its longest value and push the table into horizontal scroll. The
-// pre-migration logs table drew exactly this line: the default `source` column
-// was `width: auto` (content-sized, scrolls), while the last *selected* column
-// was `flex: 1 1 auto; overflow: hidden` (leftover, clipped). A bounded filler
-// therefore has to drop the table's `min-w-max`, which would otherwise size
-// every column to max-content and defeat the clamp.
+// A bounded filler clips instead of growing, so the table must drop `min-w-max`
+// — that would size every column to max-content and defeat the clamp.
 const hasBoundedFill = computed(() =>
   table.getVisibleLeafColumns().some((c) => (c.columnDef.meta as any)?.fillRemaining),
 );
 
-// Sized cells need this: without `min-w-max` the auto layout would squeeze them
-// to fit the container, so they pin their min-width and let the ROW scroll —
-// only the filler is allowed to give up space (same rule as wrap mode).
 provide("o2TableBoundedFill", hasBoundedFill);
 
 // Suppress the horizontal scrollbar for fill tables that aren't intentionally

--- a/web/src/lib/core/Table/OTable.vue
+++ b/web/src/lib/core/Table/OTable.vue
@@ -712,6 +712,23 @@ const hasFillColumn = computed(() =>
   }),
 );
 
+// A *bounded* filler (`meta.fillRemaining`) takes the leftover width but stays
+// inside the container and clips, where a plain `autoWidth` filler is allowed to
+// grow to its longest value and push the table into horizontal scroll. The
+// pre-migration logs table drew exactly this line: the default `source` column
+// was `width: auto` (content-sized, scrolls), while the last *selected* column
+// was `flex: 1 1 auto; overflow: hidden` (leftover, clipped). A bounded filler
+// therefore has to drop the table's `min-w-max`, which would otherwise size
+// every column to max-content and defeat the clamp.
+const hasBoundedFill = computed(() =>
+  table.getVisibleLeafColumns().some((c) => (c.columnDef.meta as any)?.fillRemaining),
+);
+
+// Sized cells need this: without `min-w-max` the auto layout would squeeze them
+// to fit the container, so they pin their min-width and let the ROW scroll —
+// only the filler is allowed to give up space (same rule as wrap mode).
+provide("o2TableBoundedFill", hasBoundedFill);
+
 // Suppress the horizontal scrollbar for fill tables that aren't intentionally
 // scrolling (sub-pixel rounding otherwise shows a 1-2px scrollbar). Keep it for
 // horizontal-scroll tables and frozen flex tables ONLY when the columns
@@ -1147,7 +1164,7 @@ defineExpose({
             // at its longest line so the text never wraps. Sticky total columns
             // still need their explicit content width.
             props.horizontalScroll
-              ? props.wrap && !props.stickyColTotals
+              ? (props.wrap || hasBoundedFill) && !props.stickyColTotals
                 ? 'w-full'
                 : isDelegatedScroll
                   ? 'min-w-max'

--- a/web/src/lib/core/Table/sub-components/OTableBodyCell.vue
+++ b/web/src/lib/core/Table/sub-components/OTableBodyCell.vue
@@ -154,25 +154,16 @@ const pivotTotalStyle = computed<Record<string, any>>(() => {
 
 const isAutoWidth = computed(() => meta.value?.autoWidth === true);
 
-// Bounded filler: takes the leftover width but stays inside the container and
-// clips, rather than growing to its longest value. Held there by `max-width: 0`
-// (see `cellStyle`), so it must also clip — the pre-migration table's
-// `overflow: hidden` — instead of spilling over the next column.
 const boundedFillTable = inject<{ value: boolean } | null>("o2TableBoundedFill", null);
-// Only meaningful on a scrolling table: the clamp exists to counteract
-// `min-w-max`, and a container-bounded table already sizes the filler correctly.
+// The clamp only counteracts `min-w-max`; a container-bounded table needs none.
 const inBoundedFillTable = computed(
   () => !!boundedFillTable?.value && !!horizontalScroll?.value && !props.wrap,
 );
 const isBoundedFill = computed(
   () => meta.value?.fillRemaining === true && inBoundedFillTable.value,
 );
-// Sized columns SHARING a table with a bounded filler are pinned to their own
-// size and clip. Without this a long value stretches the column well past its
-// width (nothing caps it in a scrolling table), which is what made `body` jump
-// to ~3000px the moment another field was added and it stopped being the filler.
-// Pre-migration these were `{ width: size, minWidth: size, flexShrink: 0 }` with
-// an ellipsis, i.e. never content-sized.
+// Sized siblings of a bounded filler pin to their own size and clip — otherwise
+// a long value stretches the column (nothing else caps it when scrolling).
 const isSizeClamped = computed(
   () =>
     inBoundedFillTable.value && !isAutoWidth.value && !isAction.value && !meta.value?.fixedWidth,
@@ -188,12 +179,10 @@ const cellStyle = computed(() => {
     // wrapped. Keeping minSize here pins the column open and nothing ever wraps.
     const min = props.cell.column.columnDef.minSize;
     if (min && !props.wrap) base.minWidth = `${min}px`;
-    // A bounded filler must not report its text as intrinsic width, or the auto
-    // layout sizes the column to the longest log line. `max-width: 0` takes it
-    // out of that calculation — min-width still floors it, and with no `width`
-    // it collects whatever the sized columns leave over. Do NOT set `width:100%`
-    // here: the percentage resolves against the table, which is itself sized
-    // from its cells, and the column runs away to ~500000px.
+    // `max-width: 0` keeps the filler's text out of the intrinsic-width sum, so
+    // it takes the leftover instead of sizing to its longest value; min-width
+    // still floors it. Never `width: 100%` — the percentage resolves against a
+    // table sized from its own cells and the column runs away to ~500000px.
     if (isBoundedFill.value) base.maxWidth = "0";
   } else {
     const sizeVar = `var(--header-${props.cell.column.id.replace(/[^a-zA-Z0-9]/g, "-")}-size)`;
@@ -206,8 +195,7 @@ const cellStyle = computed(() => {
     } else if (!horizontalScroll?.value) {
       base.maxWidth = sizeVar;
     } else if (isSizeClamped.value) {
-      // Pinned both ways: min so the auto layout can't squeeze it (the table has
-      // no `min-w-max` here), max so its own content can't stretch it.
+      // min: auto layout can't squeeze it; max: its content can't stretch it.
       base.minWidth = sizeVar;
       base.maxWidth = sizeVar;
     } else if (props.wrap) {

--- a/web/src/lib/core/Table/sub-components/OTableBodyCell.vue
+++ b/web/src/lib/core/Table/sub-components/OTableBodyCell.vue
@@ -154,6 +154,30 @@ const pivotTotalStyle = computed<Record<string, any>>(() => {
 
 const isAutoWidth = computed(() => meta.value?.autoWidth === true);
 
+// Bounded filler: takes the leftover width but stays inside the container and
+// clips, rather than growing to its longest value. Held there by `max-width: 0`
+// (see `cellStyle`), so it must also clip — the pre-migration table's
+// `overflow: hidden` — instead of spilling over the next column.
+const boundedFillTable = inject<{ value: boolean } | null>("o2TableBoundedFill", null);
+// Only meaningful on a scrolling table: the clamp exists to counteract
+// `min-w-max`, and a container-bounded table already sizes the filler correctly.
+const inBoundedFillTable = computed(
+  () => !!boundedFillTable?.value && !!horizontalScroll?.value && !props.wrap,
+);
+const isBoundedFill = computed(
+  () => meta.value?.fillRemaining === true && inBoundedFillTable.value,
+);
+// Sized columns SHARING a table with a bounded filler are pinned to their own
+// size and clip. Without this a long value stretches the column well past its
+// width (nothing caps it in a scrolling table), which is what made `body` jump
+// to ~3000px the moment another field was added and it stopped being the filler.
+// Pre-migration these were `{ width: size, minWidth: size, flexShrink: 0 }` with
+// an ellipsis, i.e. never content-sized.
+const isSizeClamped = computed(
+  () =>
+    inBoundedFillTable.value && !isAutoWidth.value && !isAction.value && !meta.value?.fixedWidth,
+);
+
 const cellStyle = computed(() => {
   const base: Record<string, any> = {};
   if (isAutoWidth.value) {
@@ -164,6 +188,13 @@ const cellStyle = computed(() => {
     // wrapped. Keeping minSize here pins the column open and nothing ever wraps.
     const min = props.cell.column.columnDef.minSize;
     if (min && !props.wrap) base.minWidth = `${min}px`;
+    // A bounded filler must not report its text as intrinsic width, or the auto
+    // layout sizes the column to the longest log line. `max-width: 0` takes it
+    // out of that calculation — min-width still floors it, and with no `width`
+    // it collects whatever the sized columns leave over. Do NOT set `width:100%`
+    // here: the percentage resolves against the table, which is itself sized
+    // from its cells, and the column runs away to ~500000px.
+    if (isBoundedFill.value) base.maxWidth = "0";
   } else {
     const sizeVar = `var(--header-${props.cell.column.id.replace(/[^a-zA-Z0-9]/g, "-")}-size)`;
     base.width = sizeVar;
@@ -173,6 +204,11 @@ const cellStyle = computed(() => {
       base.minWidth = sizeVar;
       base.maxWidth = sizeVar;
     } else if (!horizontalScroll?.value) {
+      base.maxWidth = sizeVar;
+    } else if (isSizeClamped.value) {
+      // Pinned both ways: min so the auto layout can't squeeze it (the table has
+      // no `min-w-max` here), max so its own content can't stretch it.
+      base.minWidth = sizeVar;
       base.maxWidth = sizeVar;
     } else if (props.wrap) {
       // Wrapping drops the table's `min-w-max`, so auto layout would otherwise
@@ -299,7 +335,9 @@ function onCellActionsLeave() {
       wrap
         ? 'wrap-anywhere whitespace-normal'
         : horizontalScroll?.value
-          ? 'whitespace-nowrap'
+          ? isBoundedFill || isSizeClamped
+            ? 'overflow-hidden text-ellipsis whitespace-nowrap'
+            : 'whitespace-nowrap'
           : isAction
             ? 'overflow-hidden whitespace-nowrap'
             : 'overflow-hidden text-ellipsis whitespace-nowrap',

--- a/web/src/lib/core/Table/sub-components/OTableHeader.vue
+++ b/web/src/lib/core/Table/sub-components/OTableHeader.vue
@@ -126,6 +126,9 @@ function startResize(header: any, event: MouseEvent | TouchEvent) {
 }
 
 const horizontalScroll = inject<{ value: boolean } | null>("o2TableHorizontalScroll", null);
+// The table drops `min-w-max` when a bounded filler is present, so sized columns
+// must pin their min-width the same way they do while wrapping.
+const boundedFillTable = inject<{ value: boolean } | null>("o2TableBoundedFill", null);
 
 function handleSort(columnId: string, toggleHandler?: (event: Event) => void, event?: MouseEvent) {
   const meta = props.table.getColumn(columnId)?.columnDef?.meta as any;
@@ -188,8 +191,38 @@ function handleDraggableUpdate(next: string[]): void {
   emit("update:columnOrder", pinFirst(cursor === reordered.length ? fullOrder : reordered));
 }
 
+// Sized columns sharing a table with a bounded filler are pinned to their own
+// size in BOTH directions: min so the auto layout can't squeeze them (the table
+// has no `min-w-max` here), max so their content can't stretch them. Must stay
+// in step with `isSizeClamped` in OTableBodyCell.
+function sizeClamped(header: any): boolean {
+  const meta = header.column.columnDef.meta as any;
+  return (
+    !!boundedFillTable?.value &&
+    !props.wrap &&
+    !meta?.autoWidth &&
+    !meta?.fixedWidth &&
+    !meta?.isAction
+  );
+}
+
 function isAutoWidthColumn(header: any): boolean {
   return (header.column.columnDef.meta as any)?.autoWidth === true;
+}
+
+/**
+ * Elastic (fill) column header. Must stay in step with the matching branch in
+ * OTableBodyCell's `cellStyle` — see the comments there for why a scrolling
+ * table needs `max-width: 0` to keep the column at the viewport instead of
+ * stretching to its longest value.
+ */
+function autoWidthHeaderStyle(header: any): Record<string, string> {
+  const style: Record<string, string> = {};
+  const min = header.column.columnDef.minSize;
+  if (min && !props.wrap) style.minWidth = `${min}px`;
+  const meta = header.column.columnDef.meta as any;
+  if (meta?.fillRemaining && horizontalScroll?.value && !props.wrap) style.maxWidth = "0";
+  return style;
 }
 
 function headerAlignClass(header: any): string {
@@ -458,9 +491,7 @@ function getStandardStickyTotalStyle(header: any): Record<string, any> {
         ]"
         :style="{
           ...(isAutoWidthColumn(header)
-            ? header.column.columnDef.minSize && !wrap
-              ? { minWidth: `${header.column.columnDef.minSize}px` }
-              : {}
+            ? autoWidthHeaderStyle(header)
             : (header.column.columnDef.meta as any)?.fixedWidth
               ? {
                   width: headerSizeVar(header),
@@ -468,9 +499,15 @@ function getStandardStickyTotalStyle(header: any): Record<string, any> {
                   maxWidth: headerSizeVar(header),
                 }
               : horizontalScroll?.value
-                ? wrap
-                  ? { width: headerSizeVar(header), minWidth: headerSizeVar(header) }
-                  : { width: headerSizeVar(header) }
+                ? sizeClamped(header)
+                  ? {
+                      width: headerSizeVar(header),
+                      minWidth: headerSizeVar(header),
+                      maxWidth: headerSizeVar(header),
+                    }
+                  : wrap
+                    ? { width: headerSizeVar(header), minWidth: headerSizeVar(header) }
+                    : { width: headerSizeVar(header) }
                 : { width: headerSizeVar(header), maxWidth: headerSizeVar(header) }),
           ...(header.column.getIsPinned?.() === 'left'
             ? {
@@ -732,9 +769,7 @@ function getStandardStickyTotalStyle(header: any): Record<string, any> {
         ]"
         :style="{
           ...(isAutoWidthColumn(header)
-            ? header.column.columnDef.minSize && !wrap
-              ? { minWidth: `${header.column.columnDef.minSize}px` }
-              : {}
+            ? autoWidthHeaderStyle(header)
             : (header.column.columnDef.meta as any)?.fixedWidth
               ? {
                   width: headerSizeVar(header),
@@ -742,9 +777,15 @@ function getStandardStickyTotalStyle(header: any): Record<string, any> {
                   maxWidth: headerSizeVar(header),
                 }
               : horizontalScroll?.value
-                ? wrap
-                  ? { width: headerSizeVar(header), minWidth: headerSizeVar(header) }
-                  : { width: headerSizeVar(header) }
+                ? sizeClamped(header)
+                  ? {
+                      width: headerSizeVar(header),
+                      minWidth: headerSizeVar(header),
+                      maxWidth: headerSizeVar(header),
+                    }
+                  : wrap
+                    ? { width: headerSizeVar(header), minWidth: headerSizeVar(header) }
+                    : { width: headerSizeVar(header) }
                 : { width: headerSizeVar(header), maxWidth: headerSizeVar(header) }),
           ...(header.column.getIsPinned?.() === 'left'
             ? {

--- a/web/src/lib/core/Table/sub-components/OTableHeader.vue
+++ b/web/src/lib/core/Table/sub-components/OTableHeader.vue
@@ -126,8 +126,6 @@ function startResize(header: any, event: MouseEvent | TouchEvent) {
 }
 
 const horizontalScroll = inject<{ value: boolean } | null>("o2TableHorizontalScroll", null);
-// The table drops `min-w-max` when a bounded filler is present, so sized columns
-// must pin their min-width the same way they do while wrapping.
 const boundedFillTable = inject<{ value: boolean } | null>("o2TableBoundedFill", null);
 
 function handleSort(columnId: string, toggleHandler?: (event: Event) => void, event?: MouseEvent) {
@@ -191,10 +189,7 @@ function handleDraggableUpdate(next: string[]): void {
   emit("update:columnOrder", pinFirst(cursor === reordered.length ? fullOrder : reordered));
 }
 
-// Sized columns sharing a table with a bounded filler are pinned to their own
-// size in BOTH directions: min so the auto layout can't squeeze them (the table
-// has no `min-w-max` here), max so their content can't stretch them. Must stay
-// in step with `isSizeClamped` in OTableBodyCell.
+// Mirrors `isSizeClamped` in OTableBodyCell — keep the two in step.
 function sizeClamped(header: any): boolean {
   const meta = header.column.columnDef.meta as any;
   return (
@@ -210,12 +205,7 @@ function isAutoWidthColumn(header: any): boolean {
   return (header.column.columnDef.meta as any)?.autoWidth === true;
 }
 
-/**
- * Elastic (fill) column header. Must stay in step with the matching branch in
- * OTableBodyCell's `cellStyle` — see the comments there for why a scrolling
- * table needs `max-width: 0` to keep the column at the viewport instead of
- * stretching to its longest value.
- */
+// Mirrors the autoWidth branch of OTableBodyCell's `cellStyle`.
 function autoWidthHeaderStyle(header: any): Record<string, string> {
   const style: Record<string, string> = {};
   const min = header.column.columnDef.minSize;


### PR DESCRIPTION
`body` — and any last selected field — sized itself to its longest value instead of taking the leftover width, dragging the row into thousands of pixels of horizontal scroll. Two separate causes:

- the absorber marked the column `meta.autoWidth`, which in OTable means "no width at all", and a horizontalScroll table carries `min-w-max`, which sizes every column to its max-content;
- sized columns in a scrolling table had no `max-width`, so as soon as another field was added and `body` stopped being the absorber, its own text stretched it to ~3000px.

Split the two behaviours the pre-migration table kept separate: plain `autoWidth` stays content-sized (the default `source` column was `width: auto` and scrolled), while the new `meta.fillRemaining` takes the leftover width but stays inside the container and ellipsis-truncates (pre-migration `flex: 1 1 auto; overflow: hidden`). A bounded filler drops the table's `min-w-max` and pins its sized siblings at their own size in both directions.

Opt-in, so the other horizontalScroll tables (traces, dashboard panels, monitors, search history) keep their existing layout untouched.

Verified against the pre-migration build (044f561506) running side by side on identical data: column widths and scroll offsets match exactly.