### PR TITLE
docs: update protoc setup instructions with current version and Linux env var note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,10 @@ Install `protoc`:
 
 ```
 # Linux
-# Replace VERSION with the latest release from https://github.com/protocolbuffers/protobuf/releases
-# (e.g. 29.3)
-VERSION=29.3
-wget https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-x86_64.zip
-unzip protoc-${VERSION}-linux-x86_64.zip -d protoc
+# Download the latest release from https://github.com/protocolbuffers/protobuf/releases
+# Replace <VERSION> and <ARCH> with the appropriate values (e.g. 29.3 and linux-x86_64)
+wget https://github.com/protocolbuffers/protobuf/releases/download/v<VERSION>/protoc-<VERSION>-<ARCH>.zip
+unzip protoc-<VERSION>-<ARCH>.zip -d protoc
 sudo cp protoc/bin/protoc /usr/local/bin/
 sudo cp -r protoc/include/google /usr/local/include/
 
@@ -61,10 +60,9 @@ export PROTOC_INCLUDE=/usr/local/include
 # You could also set it in your .env file
 
 # Windows
-# Replace VERSION with the latest release from https://github.com/protocolbuffers/protobuf/releases
-VERSION=29.3
-curl -L -o protoc-${VERSION}-win64.zip https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-win64.zip
-unzip protoc-${VERSION}-win64.zip -d protoc
+# Download the latest release from https://github.com/protocolbuffers/protobuf/releases
+curl -L -o protoc-win64.zip https://github.com/protocolbuffers/protobuf/releases/download/v<VERSION>/protoc-<VERSION>-win64.zip
+unzip protoc-win64.zip -d protoc
 cp protoc/bin/protoc.exe C:/windows/system32/protoc.exe
 cp -r protoc/include/google C:/windows/system32/
 
@@ -74,7 +72,7 @@ brew install protobuf
 # Set environment variable for protobuf include path (macOS)
 export PROTOC_INCLUDE=/opt/homebrew/include
 # Add this to your shell profile (~/.zshrc, ~/.bashrc, etc.) to make it permanent
-# You could also set it in your .env file
+You could also set it in your .env file
 ```
 
 Build the binary:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,14 +47,24 @@ Install `protoc`:
 
 ```
 # Linux
-wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
-unzip protoc-21.12-linux-x86_64.zip -d protoc
+# Replace VERSION with the latest release from https://github.com/protocolbuffers/protobuf/releases
+# (e.g. 29.3)
+VERSION=29.3
+wget https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-x86_64.zip
+unzip protoc-${VERSION}-linux-x86_64.zip -d protoc
 sudo cp protoc/bin/protoc /usr/local/bin/
 sudo cp -r protoc/include/google /usr/local/include/
 
+# Set environment variable for protobuf include path (Linux)
+export PROTOC_INCLUDE=/usr/local/include
+# Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.) to make it permanent
+# You could also set it in your .env file
+
 # Windows
-curl -L -o protoc-21.12-win64.zip https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip
-unzip protoc-21.12-win64.zip -d protoc
+# Replace VERSION with the latest release from https://github.com/protocolbuffers/protobuf/releases
+VERSION=29.3
+curl -L -o protoc-${VERSION}-win64.zip https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-win64.zip
+unzip protoc-${VERSION}-win64.zip -d protoc
 cp protoc/bin/protoc.exe C:/windows/system32/protoc.exe
 cp -r protoc/include/google C:/windows/system32/
 
@@ -64,7 +74,7 @@ brew install protobuf
 # Set environment variable for protobuf include path (macOS)
 export PROTOC_INCLUDE=/opt/homebrew/include
 # Add this to your shell profile (~/.zshrc, ~/.bashrc, etc.) to make it permanent
-You could also set it in your .env file
+# You could also set it in your .env file
 ```
 
 Build the binary:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,10 @@ Install `protoc`:
 
 ```
 # Linux
-# Download the latest release from https://github.com/protocolbuffers/protobuf/releases
-# Replace <VERSION> and <ARCH> with the appropriate values (e.g. 29.3 and linux-x86_64)
-wget https://github.com/protocolbuffers/protobuf/releases/download/v<VERSION>/protoc-<VERSION>-<ARCH>.zip
-unzip protoc-<VERSION>-<ARCH>.zip -d protoc
+# Download the latest protoc release for your platform from:
+# https://github.com/protocolbuffers/protobuf/releases
+# Then install it:
+unzip protoc-*-linux-x86_64.zip -d protoc
 sudo cp protoc/bin/protoc /usr/local/bin/
 sudo cp -r protoc/include/google /usr/local/include/
 
@@ -60,9 +60,10 @@ export PROTOC_INCLUDE=/usr/local/include
 # You could also set it in your .env file
 
 # Windows
-# Download the latest release from https://github.com/protocolbuffers/protobuf/releases
-curl -L -o protoc-win64.zip https://github.com/protocolbuffers/protobuf/releases/download/v<VERSION>/protoc-<VERSION>-win64.zip
-unzip protoc-win64.zip -d protoc
+# Download the latest protoc release for your platform from:
+# https://github.com/protocolbuffers/protobuf/releases
+# Then install it:
+unzip protoc-*-win64.zip -d protoc
 cp protoc/bin/protoc.exe C:/windows/system32/protoc.exe
 cp -r protoc/include/google C:/windows/system32/
 


### PR DESCRIPTION
Closing this — after checking the codebase more thoroughly, `v21.12` is intentionally pinned across all Dockerfiles, CI workflows, and build scripts (8 files total including `.github/protoc.sh`, `release.yml`, `build-fork-pr-image.yml`, `Dockerfile.sccache.amd64`, `Dockerfile.sccache.aarch64`, `buildspec-test.yml`, and `cross/Dockerfile.musl`). The CONTRIBUTING.md URL is consistent with that deliberate pin, not a stale oversight.

The only valid change from this PR was the Linux `PROTOC_INCLUDE` note. Happy to open a smaller focused PR for just that if maintainers find it useful.