### PR TITLE
fix: restore Table default log-detail view (#13368) + heal alert-name inline-edit read

### DIFF
--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -67,6 +67,8 @@ export class AlertsPage {
             // trigger swaps to an input on click. -trigger opens, -input edits.
             alertNameTrigger: '[data-test="add-alert-name-input-trigger"]',
             alertNameInputField: '[data-test="add-alert-name-input-input"]',
+            // Display-mode value of the inline-edit title (present when NOT editing).
+            alertNameValue: '[data-test="add-alert-name-input-value"]',
             alertSubmitButton: '[data-test="add-alert-submit-btn"]',
             alertBackButton: '[data-test="add-alert-back-btn"]',
 
@@ -824,6 +826,22 @@ export class AlertsPage {
         await this.page.locator(this.locators.alertNameInputField).waitFor({ state: 'visible', timeout: 3000 });
         await this.page.locator(this.locators.alertNameInputField).fill(name);
         testLogger.info(`Filled alert name: ${name}`);
+    }
+
+    /**
+     * Read the current alert name from the inline-edit title (OFormInlineEdit).
+     * In display mode the value is the `-value` span; only in edit mode is there
+     * an `-input`. Reads the committed display value, falling back to the live
+     * input value if the editor happens to be open.
+     * @returns {Promise<string>}
+     */
+    async getAlertName() {
+        const valueSpan = this.page.locator(this.locators.alertNameValue).first();
+        if (await valueSpan.count() > 0) {
+            return (await valueSpan.innerText()).trim();
+        }
+        // Editor is open (edit mode) — read the live input value instead.
+        return (await this.page.locator(this.locators.alertNameInputField).inputValue()).trim();
     }
 
     /**

--- a/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-stream-switching.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-stream-switching.spec.js
@@ -438,9 +438,11 @@ test.describe("Alerts Stream Switching Regression", () => {
     // === SAVE + VERIFY: Full alert creation flow ===
 
     // Capture the alert name that setupToQueryConfig filled.
-    // O2: OInput wraps the native <input>; use alertNameInputField to hit the real <input>.
-    const alertNameInput = page.locator(pm.alertsPage.alertNameInputField);
-    const alertName = await alertNameInput.inputValue();
+    // O2: the alert name is an OInlineEdit title — in display mode the committed
+    // value lives in the `-value` span; the `-input` only exists while editing.
+    // Reading inputValue() here times out because there is no input in the DOM,
+    // so read the display value instead.
+    const alertName = await pm.alertsPage.getAlertName();
     testLogger.info(`Saving alert: ${alertName}`);
 
     // Select destination using POM locator

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -1322,7 +1322,7 @@ export default defineComponent({
     const correlationDashboardProps = ref<any>(null);
     const correlationLoading = ref(false);
     const correlationError = ref<string | null>(null);
-    const detailTableInitialTab = ref<string>("json");
+    const detailTableInitialTab = ref<string>("table");
     const { findRelatedTelemetry, semanticGroups } = useServiceCorrelation();
 
     // Flag to prevent duplicate correlation API calls
@@ -1622,7 +1622,7 @@ export default defineComponent({
     const openLogDetails = (props: any, index: number) => {
       searchObj.meta.showDetailTab = true;
       searchObj.meta.resultGrid.navigation.currentRowIndex = index;
-      detailTableInitialTab.value = "json"; // Reset to default tab
+      detailTableInitialTab.value = "table"; // Reset to default tab (#13368: Table is the default log-detail view)
 
       // Prepare correlation context (but don't open panel automatically)
       const logData = searchObj.data.queryResults?.hits?.[index];


### PR DESCRIPTION
## What & why

Two **Playwright Regression** nightly failures, reproduced identically on both OSS ([run 30785096054](https://github.com/openobserve/openobserve/actions/runs/30785096054)) and ENT ([run 30785071382](https://github.com/openobserve/o2-enterprise/actions/runs/30785071382)) — same two shared-`tests/` specs, all 3 retries failed each. Both are OSS-owned specs (ENT overlays only its own `tests/*` and builds OSS `web/`), so this single OSS PR fixes both nightlies.

### 1. Logs — real product regression (`logs-regression.spec.js:1158`)
`Log detail sidebar opens with Table tab by default (#13368)` → `Error: Table tab should be selected by default`.

**Root cause:** [#13368](https://github.com/openobserve/openobserve/pull/13368) (Jul 23) deliberately made the log-detail sidebar open on the **Table** tab. [#13451](https://github.com/openobserve/openobserve/pull/13451) (Jul 30, *"table migration to same components"*) silently flipped `detailTableInitialTab` back to `"json"` in `SearchResult.vue` (both the `ref` init and the per-open reset). The unchanged test correctly caught the reverted behavior.

**Fix:** restore `"table"` as the default log-detail tab. Product fix — no test change.

### 2. Alerts — stale test vs redesigned component (`alerts-stream-switching.spec.js:443`)
`Bug #11577: Alert preview chart y-axis displays numeric values` → `TimeoutError: locator.inputValue: Timeout 45000ms exceeded`.

**Root cause:** the alert name became an **`OInlineEdit`** title (`OFormInlineEdit`, from the [#13547](https://github.com/openobserve/openobserve/pull/13547) Alerts revamp). In display mode the value lives in the `…-value` span; the `…-input` only exists **while editing**. The test read `.inputValue()` on the non-existent input → 45s timeout.

**Fix:** read the committed display value via a new `getAlertName()` page-object helper (with an edit-mode `inputValue()` fallback).

## Verification
- **Alerts #11577** — ✅ passed locally against a local O2 build (`1 passed`); `getAlertName()` reads the name and the full save/verify/delete flow works.
- **Logs #13368** — restores the exact `detailTableInitialTab = "table"` value #13368 set and the unchanged test already validated as green. Confirmed by this run's Logs-Regression job + the dispatched ENT e2e gate.

## Scope
- `web/src/plugins/logs/SearchResult.vue` — 2 lines (product)
- `tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-stream-switching.spec.js` — read display value
- `tests/ui-testing/pages/alertsPages/alertsPage.js` — `alertNameValue` locator + `getAlertName()` helper