### PR TITLE
fix(nats): stop kv watchers from leaking a consumer per reconnect

### DIFF
--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -28,7 +28,7 @@ use bytes::Bytes;
 use config::{
     cluster, get_config, ider,
     utils::{
-        base64,
+        base64, hash,
         time::{now_micros, second_micros},
     },
 };
@@ -47,6 +47,19 @@ use crate::{
 };
 
 const SUPER_CLUSTER_PREFIX: &str = "super_cluster_kv_";
+
+/// Backoff bounds used when a kv watcher has to be recreated. Every recreation creates a new
+/// consumer on the nats server, so a watcher that keeps failing must not retry in a tight loop.
+const KV_WATCH_BACKOFF_MIN: u64 = 1;
+const KV_WATCH_BACKOFF_MAX: u64 = 30;
+
+/// Header the kv store puts on a message to mark it as something other than a put.
+const KV_OPERATION: &str = "KV-Operation";
+
+/// Same values the kv store uses for its own watchers: the server heartbeats every 5s so a
+/// watcher notices a consumer that went away, and drops the consumer 30s after we stop listening.
+const KV_WATCH_IDLE_HEARTBEAT: Duration = Duration::from_secs(5);
+const KV_WATCH_INACTIVE_THRESHOLD: Duration = Duration::from_secs(30);
 
 static NATS_CLIENT: OnceCell<Client> = OnceCell::const_new();
 
@@ -158,6 +171,11 @@ impl NatsDb {
         let prefix = prefix.to_string();
         let self_prefix = self.prefix.to_string();
         let _task: JoinHandle<Result<()>> = tokio::task::spawn(async move {
+            let consumer_name = kv_watch_consumer_name(&prefix);
+            // stream sequence of the last message we consumed, so recreating the watcher resumes
+            // where it stopped instead of dropping everything published while it was down
+            let mut last_sequence = 0;
+            let mut backoff = KV_WATCH_BACKOFF_MIN;
             loop {
                 if cluster::is_offline() {
                     break;
@@ -166,72 +184,90 @@ impl NatsDb {
                     Ok(v) => v,
                     Err(e) => {
                         log::error!("[NATS:kv_watch] prefix: {prefix}, get bucket error: {e}");
-                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                        backoff = kv_watch_backoff(backoff).await;
                         continue;
                     }
                 };
                 let bucket_prefix = "/".to_string() + bucket.name.trim_start_matches(&self_prefix);
+                let subject_prefix = format!("$KV.{}.", bucket.name);
                 log::debug!(
-                    "[NATS:kv_watch] bucket: {}, prefix: {}",
+                    "[NATS:kv_watch] bucket: {}, prefix: {}, consumer: {}",
                     bucket.name,
-                    prefix
+                    prefix,
+                    consumer_name
                 );
-                let mut entries = match bucket.watch_all().await {
-                    Ok(v) => v,
+                let mut messages = match create_kv_watcher(
+                    &bucket,
+                    &prefix,
+                    &consumer_name,
+                    last_sequence,
+                )
+                .await
+                {
+                    Ok((messages, start_sequence)) => {
+                        last_sequence = start_sequence;
+                        messages
+                    }
                     Err(e) => {
-                        log::error!(
-                            "[NATS:kv_watch] prefix: {prefix}, bucket.watch_all error: {e}"
-                        );
-                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                        log::error!("[NATS:kv_watch] prefix: {prefix}, create watcher error: {e}");
+                        backoff = kv_watch_backoff(backoff).await;
                         continue;
                     }
                 };
                 loop {
-                    match entries.next().await {
+                    let message = match messages.next().await {
                         None => {
-                            log::error!("[NATS:kv_watch] prefix: {prefix}, get message error");
+                            log::error!("[NATS:kv_watch] prefix: {prefix}, watcher closed");
                             break;
                         }
-                        Some(entry) => {
-                            let entry = match entry {
-                                Ok(entry) => entry,
-                                Err(e) => {
-                                    log::error!(
-                                        "[NATS:kv_watch] prefix: {prefix}, get message error: {e}"
-                                    );
-                                    break;
-                                }
-                            };
-                            let item_key = key_decode(&entry.key);
-                            if !item_key.starts_with(new_key) {
-                                continue;
-                            }
-                            let new_key = bucket_prefix.to_string() + &item_key;
-                            let ret = match entry.operation {
-                                jetstream::kv::Operation::Put => {
-                                    tx.try_send(Event::Put(EventData {
-                                        key: new_key.clone(),
-                                        value: Some(entry.value),
-                                        start_dt: None,
-                                    }))
-                                }
-                                jetstream::kv::Operation::Delete
-                                | jetstream::kv::Operation::Purge => {
-                                    tx.try_send(Event::Delete(EventData {
-                                        key: new_key.clone(),
-                                        value: None,
-                                        start_dt: None,
-                                    }))
-                                }
-                            };
-                            if let Err(e) = ret {
-                                log::warn!(
-                                    "[NATS:kv_watch] prefix: {prefix}, key: {new_key}, send error: {e}"
-                                );
-                            }
+                        Some(Err(e)) => {
+                            log::error!("[NATS:kv_watch] prefix: {prefix}, get message error: {e}");
+                            break;
                         }
+                        Some(Ok(v)) => v,
+                    };
+                    // the watcher is healthy, so the next failure starts over from the minimum
+                    backoff = KV_WATCH_BACKOFF_MIN;
+                    if let Ok(info) = message.info() {
+                        last_sequence = info.stream_sequence;
+                    }
+                    let Some(item_key) = message
+                        .subject
+                        .strip_prefix(&subject_prefix)
+                        .and_then(try_key_decode)
+                    else {
+                        log::warn!(
+                            "[NATS:kv_watch] prefix: {prefix}, invalid subject: {}",
+                            message.subject
+                        );
+                        continue;
+                    };
+                    if !item_key.starts_with(new_key) {
+                        continue;
+                    }
+                    let new_key = bucket_prefix.to_string() + &item_key;
+                    let ret = match kv_operation(&message) {
+                        jetstream::kv::Operation::Put => tx.try_send(Event::Put(EventData {
+                            key: new_key.clone(),
+                            value: Some(message.payload.clone()),
+                            start_dt: None,
+                        })),
+                        jetstream::kv::Operation::Delete | jetstream::kv::Operation::Purge => tx
+                            .try_send(Event::Delete(EventData {
+                                key: new_key.clone(),
+                                value: None,
+                                start_dt: None,
+                            })),
+                    };
+                    if let Err(e) = ret {
+                        log::warn!(
+                            "[NATS:kv_watch] prefix: {prefix}, key: {new_key}, send error: {e}"
+                        );
                     }
                 }
+                // the watcher died, wait before recreating it, otherwise a nats disruption turns
+                // into a consumer creation storm across the whole cluster
+                backoff = kv_watch_backoff(backoff).await;
             }
             Ok(())
         });
@@ -927,6 +963,146 @@ fn key_decode(key: &str) -> String {
     base64::decode(key.replace('-', "+").replace('_', "/")).unwrap()
 }
 
+/// Same as [key_decode] but for keys that come off the wire, where a key we did not write must
+/// not take the process down.
+#[inline]
+fn try_key_decode(key: &str) -> Option<String> {
+    base64::decode(key.replace('-', "+").replace('_', "/")).ok()
+}
+
+/// Deterministic consumer name for a kv watcher, so that a node reconnecting to nats reuses one
+/// consumer instead of leaving a new ephemeral one behind on every reconnect.
+fn kv_watch_consumer_name(prefix: &str) -> String {
+    // the name ends up in a subject, so anything but alphanumerics has to go; the hash keeps two
+    // prefixes that sanitize (or truncate) to the same label apart
+    let label: String = prefix
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .take(32)
+        .collect();
+    format!(
+        "o2_watch_{}_{label}_{:x}",
+        cluster::LOCAL_NODE.uuid,
+        hash::sum64(prefix)
+    )
+}
+
+/// Sleep for the current backoff, then return the next one.
+async fn kv_watch_backoff(secs: u64) -> u64 {
+    tokio::time::sleep(Duration::from_secs(secs)).await;
+    next_kv_watch_backoff(secs)
+}
+
+#[inline]
+fn next_kv_watch_backoff(secs: u64) -> u64 {
+    std::cmp::min(secs * 2, KV_WATCH_BACKOFF_MAX)
+}
+
+/// Create the push consumer backing a kv watcher.
+///
+/// This is what [`jetstream::kv::Store::watch_all`] does, with two differences:
+///
+/// 1. the consumer gets a deterministic name owned by this node and is deleted before being
+///    recreated. Ephemeral consumers are only reclaimed by the server once `inactive_threshold`
+///    passes without interest, which we have seen fail to happen for days, so anonymous consumers
+///    pile up on the stream: one per reconnect, per watcher, per node, forever.
+/// 2. it is a plain push consumer rather than an ordered one. An ordered consumer recreates itself
+///    behind our back, retrying forever without ever handing us an error, so a consumer it cannot
+///    recreate stalls the watcher for good. A plain one reports a missing heartbeat to the caller
+///    and lets [`NatsDb::kv_watch`] do the recovery, which it can do because it deletes first.
+///
+/// Returns the watcher and the stream sequence it starts after, so that a watcher which has not
+/// seen a single message yet still knows where to resume from.
+async fn create_kv_watcher(
+    bucket: &jetstream::kv::Store,
+    prefix: &str,
+    consumer_name: &str,
+    last_sequence: u64,
+) -> Result<(jetstream::consumer::push::Messages, u64)> {
+    let client = get_nats_client().await.clone();
+    let jetstream = jetstream::new(client.clone());
+    let stream_name = format!("KV_{}", bucket.name);
+    let stream = jetstream.get_stream(&stream_name).await.map_err(|e| {
+        Error::Message(format!(
+            "[NATS:kv_watch] get stream {stream_name} error: {e}"
+        ))
+    })?;
+    // drop the consumer left over by our previous incarnation, if the server still has it
+    if let Err(e) = stream.delete_consumer(consumer_name).await {
+        log::debug!("[NATS:kv_watch] delete consumer {consumer_name} error: {e}");
+    }
+    // resume from where the previous watcher stopped, a fresh watcher only wants new messages
+    let (deliver_policy, start_sequence) = if last_sequence == 0 {
+        (
+            jetstream::consumer::DeliverPolicy::New,
+            stream.cached_info().state.last_sequence,
+        )
+    } else {
+        (
+            jetstream::consumer::DeliverPolicy::ByStartSequence {
+                start_sequence: last_sequence + 1,
+            },
+            last_sequence,
+        )
+    };
+    let consumer = stream
+        .create_consumer(jetstream::consumer::push::Config {
+            deliver_subject: client.new_inbox(),
+            name: Some(consumer_name.to_string()),
+            // makes an idle consumer attributable to the node that owns it
+            description: Some(format!(
+                "kv watch consumer, node: {}, prefix: {prefix}",
+                cluster::LOCAL_NODE.name
+            )),
+            filter_subject: format!("$KV.{}.>", bucket.name),
+            replay_policy: jetstream::consumer::ReplayPolicy::Instant,
+            deliver_policy,
+            ack_policy: jetstream::consumer::AckPolicy::None,
+            max_deliver: 1,
+            // without a heartbeat a watcher whose consumer went away waits forever
+            idle_heartbeat: KV_WATCH_IDLE_HEARTBEAT,
+            flow_control: true,
+            inactive_threshold: KV_WATCH_INACTIVE_THRESHOLD,
+            memory_storage: true,
+            num_replicas: 1,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| {
+            Error::Message(format!(
+                "[NATS:kv_watch] create consumer {consumer_name} error: {e}"
+            ))
+        })?;
+    let messages = consumer.messages().await.map_err(|e| {
+        Error::Message(format!(
+            "[NATS:kv_watch] consume {consumer_name} error: {e}"
+        ))
+    })?;
+    Ok((messages, start_sequence))
+}
+
+/// Which kv operation a raw stream message represents, mirroring what the kv store does when it
+/// turns a message into an `Entry`.
+fn kv_operation(message: &jetstream::Message) -> jetstream::kv::Operation {
+    let Some(headers) = message.headers.as_ref() else {
+        return jetstream::kv::Operation::Put;
+    };
+    match headers.get(KV_OPERATION).map(|v| v.as_str()) {
+        Some("DEL") => jetstream::kv::Operation::Delete,
+        Some("PURGE") => jetstream::kv::Operation::Purge,
+        Some(_) => jetstream::kv::Operation::Put,
+        // v2.11 buckets with limit markers report removals through a marker header instead
+        None => match headers
+            .get(async_nats::header::NATS_MARKER_REASON)
+            .map(|v| v.as_str())
+        {
+            Some("MaxAge") | Some("Purge") => jetstream::kv::Operation::Purge,
+            Some("Remove") => jetstream::kv::Operation::Delete,
+            _ => jetstream::kv::Operation::Put,
+        },
+    }
+}
+
 #[inline]
 fn use_kv_watcher(key: &str) -> bool {
     config::NATS_KV_WATCH_MODULES
@@ -943,6 +1119,63 @@ mod tests {
         assert!(!use_kv_watcher("/super_cluster_kv_nodes/"));
         assert!(!use_kv_watcher("/super_cluster_kv_clusters/"));
         assert!(!use_kv_watcher("/other_prefix/"));
+    }
+
+    #[test]
+    fn test_kv_watch_consumer_name_is_stable() {
+        // the same watcher must resolve to the same consumer on every reconnect, otherwise the
+        // server keeps the abandoned one until its inactive threshold expires
+        assert_eq!(
+            kv_watch_consumer_name("/compact/delete/"),
+            kv_watch_consumer_name("/compact/delete/")
+        );
+    }
+
+    #[test]
+    fn test_kv_watch_consumer_name_is_subject_safe() {
+        let name = kv_watch_consumer_name("/compact/delete/");
+        assert!(!name.contains('/'));
+        assert!(!name.contains('.'));
+        assert!(!name.contains('*'));
+        assert!(!name.contains('>'));
+        assert!(!name.contains(' '));
+    }
+
+    #[test]
+    fn test_kv_watch_consumer_name_per_prefix() {
+        assert_ne!(
+            kv_watch_consumer_name("/compact/delete/"),
+            kv_watch_consumer_name("/compact/files/")
+        );
+        // prefixes that sanitize to the same label are still told apart by the hash
+        let long = "a".repeat(32);
+        assert_ne!(
+            kv_watch_consumer_name(&format!("/{long}/one/")),
+            kv_watch_consumer_name(&format!("/{long}/two/"))
+        );
+    }
+
+    #[test]
+    fn test_try_key_decode() {
+        assert_eq!(
+            try_key_decode(&key_encode("/compact/delete/org/logs")).as_deref(),
+            Some("/compact/delete/org/logs")
+        );
+        // a key we did not write must not panic the watcher
+        assert_eq!(try_key_decode("not base64!"), None);
+    }
+
+    #[test]
+    fn test_kv_watch_backoff_grows_and_is_capped() {
+        let mut backoff = KV_WATCH_BACKOFF_MIN;
+        backoff = next_kv_watch_backoff(backoff);
+        assert_eq!(backoff, 2);
+        backoff = next_kv_watch_backoff(backoff);
+        assert_eq!(backoff, 4);
+        for _ in 0..10 {
+            backoff = next_kv_watch_backoff(backoff);
+        }
+        assert_eq!(backoff, KV_WATCH_BACKOFF_MAX);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A production cluster of ~100 nodes accumulated **587 consumers on a single KV stream** (`KV_<prefix>_compact`). Consumer creation timestamps show this is not a per-node baseline:

| Window (UTC) | Consumers created |
|---|---|
| 07-24 05:02 | 101 |
| 07-24 05:03 | 20 |
| 07-24 05:04 | 309 (262 of them in the single second 05:04:09) |
| 07-24 05:05 | 9 |
| 07-24 05:10–05:12 | 141 |
| next 10 days | 7 total |

580 of 587 were created inside one ~10 minute window — roughly 6 fleet-wide reconnect rounds — and **none were reclaimed in the 10 days since**. Each one keeps a 5s idle heartbeat alive, so the stream was pushing ~117 heartbeats/sec at inboxes with no owner.

Two causes:

1. **No backoff on the paths that lose the stream.** In `kv_watch`, the two errors that fail to *reach* the stream slept 1s, but the two that lose the stream itself (`None` / `Err` from the entry stream) broke straight back into `watch_all()`. Every node then minted a consumer per round trip for as long as the disruption lasted — hence 262 in one second.
2. **Anonymous ephemeral consumers.** `watch_all()` names nothing, so a node cannot reclaim the consumer it abandoned. That is left to the server's 30s `inactive_threshold`, which does not fire while stale interest lingers — exactly what happened here.

## Fix

- **Backoff** on every retry path: 1s doubling to 30s, reset as soon as a message arrives.
- **Named, self-owned consumers.** The name is derived from the node uuid and the watched prefix, and the watcher **deletes it before recreating it**, so reclamation no longer depends on the server's inactive threshold. The description carries `node: <instance_name>, prefix: <prefix>` so an idle consumer is attributable to its pod.
- **Gap-free resume.** The watcher tracks the last stream sequence it consumed and recreates with `ByStartSequence{last+1}` instead of `New`. A watcher that has never seen a message anchors to the stream's current `last_sequence` at creation, so even a permanently idle watcher does not silently drop events published during a blip. Worst case is a duplicate event, never a missed one.
- **Ordered → plain push consumer.** `Ordered` recreates itself internally via `tryhard::retry_fn(...).retries(u32::MAX)` and never surfaces the error, so a consumer it cannot recreate would stall the watcher forever — in precisely the environment where consumers are not reclaimed. A plain push consumer reports `MissingHeartbeat` to the caller and lets `kv_watch` run its delete-then-create recovery. Consumer config mirrors what the KV store used: ack none, `max_deliver` 1, flow control, 5s heartbeat, 30s inactive threshold, memory storage, R1.

Only affects prefixes routed through the KV watcher (`ZO_NATS_KV_WATCH_MODULES`); everything else still goes through the shared `coordinator_events` consumer.

## Not covered

A pod restart still leaks one consumer per watcher, because `LOCAL_NODE.uuid` is regenerated per process and the new incarnation does not know its predecessor's name. That is the small tail in the data above (7 in 10 days vs 580 in 10 minutes). A hostname-based identity would close it, but two nodes sharing an `instance_name` — normal in local multi-node dev — would then delete each other's consumer in a loop. The safer follow-up is a janitor that deletes consumers whose node uuid is absent from the live `nodes` bucket.

Existing orphans on affected clusters need deleting manually; nothing will reclaim them.

## Testing

- `cargo check --workspace` clean; `cargo clippy -p infra --all-targets` clean for the touched file.
- `cargo test -p infra --lib db::nats::` — 32 pass, including 5 new: consumer-name stability across reconnects, subject-safety of the name, per-prefix uniqueness (including prefixes that truncate to the same label), non-panicking key decode for keys we did not write, and backoff growth/cap.