### PR TITLE
feat(llm): add annotation workflow storage schema

### DIFF
--- a/src/config/src/meta/self_reporting/llm_scores.rs
+++ b/src/config/src/meta/self_reporting/llm_scores.rs
@@ -92,6 +92,24 @@ pub struct LlmScoreRecord {
     pub score_config_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score_config_version: Option<String>,
+    /// Physical immutable Score Config row used for this Score. Queue reviews
+    /// use it to prove exact N/N rubric coverage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score_config_row_id: Option<String>,
+    /// Logical N/N grouping key for authoritative annotation-source Scores.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_submission_id: Option<String>,
+    /// Queue provenance for Workbench review Scores. Together with
+    /// `review_submission_id`, these fields make `_llm_scores` independently
+    /// queryable without a relational Review or Review Score table.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queue_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queue_item_id: Option<String>,
+    /// Distinct physical Score Config rows required for this complete N/N
+    /// review submission.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_submission_score_count: Option<i64>,
     pub source_type: LlmScoreDataSourceType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_stream: Option<String>,
@@ -109,8 +127,13 @@ pub struct LlmScoreRecord {
     pub job_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job_version: Option<i32>,
+    /// Justification for this individual Score dimension.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<String>,
+    /// Overall comment for the complete Review Submission. Annotation
+    /// projection repeats this value on each Score in the submission.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_submission_comments: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -144,6 +167,11 @@ impl LlmScoreRecord {
             scorer_version: Some(String::new()),
             score_config_id: Some(String::new()),
             score_config_version: Some(String::new()),
+            score_config_row_id: Some(String::new()),
+            review_submission_id: Some(String::new()),
+            queue_id: Some(String::new()),
+            queue_item_id: Some(String::new()),
+            review_submission_score_count: Some(0),
             source_type: LlmScoreDataSourceType::LlmJudge,
             source_stream: Some(String::new()),
             source_stream_type: Some(String::new()),
@@ -154,6 +182,7 @@ impl LlmScoreRecord {
             job_id: Some(String::new()),
             job_version: Some(0),
             reasoning: Some(String::new()),
+            review_submission_comments: Some(String::new()),
             metadata: Some(serde_json::json!({})),
             author: Some(String::new()),
             _timestamp: 0,
@@ -223,6 +252,11 @@ mod tests {
             scorer_version: Some("1".to_string()),
             score_config_id: Some("cfg-1".to_string()),
             score_config_version: Some("1".to_string()),
+            score_config_row_id: None,
+            review_submission_id: None,
+            queue_id: None,
+            queue_item_id: None,
+            review_submission_score_count: None,
             source_type,
             source_stream: Some("traces".to_string()),
             source_stream_type: Some("traces".to_string()),
@@ -233,6 +267,7 @@ mod tests {
             job_id: Some("job-1".to_string()),
             job_version: Some(1),
             reasoning: None,
+            review_submission_comments: None,
             metadata: None,
             author: None,
             _timestamp: timestamp,
@@ -265,6 +300,11 @@ mod tests {
             scorer_version: Some("1".to_string()),
             score_config_id: Some("cfg-entity-1".to_string()),
             score_config_version: Some("1".to_string()),
+            score_config_row_id: None,
+            review_submission_id: None,
+            queue_id: None,
+            queue_item_id: None,
+            review_submission_score_count: None,
             source_type: LlmScoreDataSourceType::LlmJudge,
             source_stream: Some("traces".to_string()),
             source_stream_type: Some("traces".to_string()),
@@ -275,6 +315,7 @@ mod tests {
             job_id: Some("job-1".to_string()),
             job_version: Some(1),
             reasoning: None,
+            review_submission_comments: None,
             metadata: None,
             author: None,
             _timestamp: 1700000000000,
@@ -293,6 +334,29 @@ mod tests {
         assert_eq!(back.source_stream_type, Some("traces".to_string()));
         assert_eq!(back.agent_name, Some("agent-a".to_string()));
         assert_eq!(back.agent_id, Some("agent-1".to_string()));
+    }
+
+    #[test]
+    fn annotation_score_keeps_dimension_reasoning_and_submission_comments_distinct() {
+        let mut record = test_score_record(
+            "annotation-score-1",
+            "org=org-1;submission=submission-1;config=cfg-1;target=span-1",
+            1,
+            1,
+            LlmScoreDataSourceType::Annotation,
+            0.9,
+        );
+        record.review_submission_id = Some("submission-1".to_string());
+        record.reasoning = Some("Reason for this dimension".to_string());
+        record.review_submission_comments = Some("Overall reviewer comment".to_string());
+
+        let json = serde_json::to_value(&record).unwrap();
+        assert_eq!(json["review_submission_id"], "submission-1");
+        assert_eq!(json["reasoning"], "Reason for this dimension");
+        assert_eq!(
+            json["review_submission_comments"],
+            "Overall reviewer comment"
+        );
     }
 
     #[test]
@@ -321,6 +385,11 @@ mod tests {
         assert!(obj.contains_key("score_config_id"));
         assert!(!obj.contains_key("score_config_entity_id"));
         assert!(obj.contains_key("score_config_version"));
+        assert!(obj.contains_key("score_config_row_id"));
+        assert!(obj.contains_key("review_submission_id"));
+        assert!(obj.contains_key("queue_id"));
+        assert!(obj.contains_key("queue_item_id"));
+        assert!(obj.contains_key("review_submission_score_count"));
         assert!(obj.contains_key("source_type"));
         assert!(obj.contains_key("source_stream"));
         assert!(obj.contains_key("source_stream_type"));
@@ -330,6 +399,7 @@ mod tests {
         assert!(!obj.contains_key("target_agent_id"));
         assert!(obj.contains_key("job_id"));
         assert!(obj.contains_key("reasoning"));
+        assert!(obj.contains_key("review_submission_comments"));
         assert!(obj.contains_key("metadata"));
         assert!(obj.contains_key("author"));
         assert!(obj.contains_key("_timestamp"));
@@ -361,6 +431,11 @@ mod tests {
             scorer_version: None,
             score_config_id: None,
             score_config_version: None,
+            score_config_row_id: None,
+            review_submission_id: None,
+            queue_id: None,
+            queue_item_id: None,
+            review_submission_score_count: None,
             source_type: LlmScoreDataSourceType::LlmJudge,
             source_stream: None,
             source_stream_type: None,
@@ -371,6 +446,7 @@ mod tests {
             job_id: None,
             job_version: None,
             reasoning: None,
+            review_submission_comments: None,
             metadata: None,
             author: None,
             _timestamp: 0,
@@ -386,9 +462,11 @@ mod tests {
         assert!(!obj.contains_key("value_boolean"));
         assert!(!obj.contains_key("scorer_id"));
         assert!(!obj.contains_key("score_config_id"));
+        assert!(!obj.contains_key("review_submission_id"));
         assert!(!obj.contains_key("agent_name"));
         assert!(!obj.contains_key("agent_id"));
         assert!(!obj.contains_key("reasoning"));
+        assert!(!obj.contains_key("review_submission_comments"));
         assert!(!obj.contains_key("author"));
     }
 

--- a/src/core/src/self_reporting/llm_scores_schema.rs
+++ b/src/core/src/self_reporting/llm_scores_schema.rs
@@ -147,6 +147,13 @@ mod tests {
         assert!(obj.contains_key("value_boolean"));
         assert!(obj.contains_key("data_type"));
         assert!(obj.contains_key("score_config_id"));
+        assert!(obj.contains_key("score_config_row_id"));
+        assert!(obj.contains_key("review_submission_id"));
+        assert!(obj.contains_key("queue_id"));
+        assert!(obj.contains_key("queue_item_id"));
+        assert!(obj.contains_key("review_submission_score_count"));
+        assert!(obj.contains_key("reasoning"));
+        assert!(obj.contains_key("review_submission_comments"));
         assert!(obj.contains_key("scorer_id"));
         assert!(obj.contains_key("source_stream_type"));
         assert!(!obj.contains_key("agent_name"));
@@ -163,5 +170,15 @@ mod tests {
         assert!(schema.field_with_name("value_numeric").is_ok());
         assert!(schema.field_with_name("value_categorical").is_ok());
         assert!(schema.field_with_name("value_boolean").is_ok());
+        assert!(schema.field_with_name("score_config_row_id").is_ok());
+        assert!(schema.field_with_name("review_submission_id").is_ok());
+        assert!(schema.field_with_name("queue_id").is_ok());
+        assert!(schema.field_with_name("queue_item_id").is_ok());
+        assert!(
+            schema
+                .field_with_name("review_submission_score_count")
+                .is_ok()
+        );
+        assert!(schema.field_with_name("review_submission_comments").is_ok());
     }
 }

--- a/src/infra/src/table/migration/m20260731_000001_create_llm_annotation_queue_tables.rs
+++ b/src/infra/src/table/migration/m20260731_000001_create_llm_annotation_queue_tables.rs
@@ -1,0 +1,427 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Mutable annotation Queue storage for LLM Observability Phase 2.5a.
+//!
+//! Queue target and binding mutations are published through the existing audit
+//! stream rather than stored in a Queue-specific audit table. Each binding
+//! points at one immutable physical Score Config version row. Queue-update and
+//! review-submit APIs must lock the Queue row and compare the exact submitted
+//! Score Config row-ID set with the current bindings in the same transaction;
+//! there is no separate rubric revision counter.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(create_annotation_queues_statement())
+            .await?;
+        manager
+            .create_table(create_queue_bindings_statement())
+            .await?;
+        manager.create_table(create_queue_items_statement()).await?;
+
+        for index in indexes() {
+            manager.create_index(index).await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(LlmAnnotationQueueItems::Table)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(LlmAnnotationQueueBindings::Table)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_table(Table::drop().table(LlmAnnotationQueues::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+fn create_annotation_queues_statement() -> TableCreateStatement {
+    Table::create()
+        .table(LlmAnnotationQueues::Table)
+        .if_not_exists()
+        .col(
+            ColumnDef::new(LlmAnnotationQueues::Id)
+                .string_len(27)
+                .not_null()
+                .primary_key(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueues::OrgId)
+                .string_len(256)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueues::Name)
+                .string_len(255)
+                .not_null(),
+        )
+        .col(ColumnDef::new(LlmAnnotationQueues::Description).text().null())
+        .col(
+            ColumnDef::new(LlmAnnotationQueues::TargetDatasetId)
+                .string_len(27)
+                .null(),
+        )
+        // Server-owned subset of session | trace | span, not a 2.5a form field.
+        .col(
+            ColumnDef::new(LlmAnnotationQueues::AllowedRefTypes)
+                .json()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueues::CreatedBy)
+                .string_len(256)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueues::CreatedAt)
+                .big_integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueues::UpdatedBy)
+                .string_len(256)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueues::UpdatedAt)
+                .big_integer()
+                .not_null(),
+        )
+        .to_owned()
+}
+
+fn create_queue_bindings_statement() -> TableCreateStatement {
+    Table::create()
+        .table(LlmAnnotationQueueBindings::Table)
+        .if_not_exists()
+        .col(
+            ColumnDef::new(LlmAnnotationQueueBindings::Id)
+                .string_len(27)
+                .not_null()
+                .primary_key(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueBindings::OrgId)
+                .string_len(256)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueBindings::QueueId)
+                .string_len(27)
+                .not_null(),
+        )
+        .col(
+            // score_configs.id is the physical ID of one immutable version;
+            // entity_id is the logical identity shared by all versions.
+            ColumnDef::new(LlmAnnotationQueueBindings::ScoreConfigRowId)
+                .string_len(27)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueBindings::CreatedAt)
+                .big_integer()
+                .not_null(),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_llm_queue_bindings_score_config_row")
+                .from(
+                    LlmAnnotationQueueBindings::Table,
+                    LlmAnnotationQueueBindings::ScoreConfigRowId,
+                )
+                .to(ScoreConfigs::Table, ScoreConfigs::Id)
+                .on_delete(ForeignKeyAction::Restrict),
+        )
+        .to_owned()
+}
+
+fn create_queue_items_statement() -> TableCreateStatement {
+    Table::create()
+        .table(LlmAnnotationQueueItems::Table)
+        .if_not_exists()
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::Id)
+                .string_len(27)
+                .not_null()
+                .primary_key(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::OrgId)
+                .string_len(256)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::QueueId)
+                .string_len(27)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::RefType)
+                .string_len(16)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::RefId)
+                .string_len(256)
+                .not_null(),
+        )
+        // Span-only context locator. Trace/session items leave ref_trace_id null.
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::RefTraceId)
+                .string_len(256)
+                .null(),
+        )
+        // Required for every scope as the lower bound for Workbench score searches.
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::RefTraceStartTime)
+                .big_integer()
+                .not_null(),
+        )
+        // pending | reviewed only. Archive is orthogonal via archived_at.
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::Status)
+                .string_len(16)
+                .not_null()
+                .default("pending"),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::ReviewedAt)
+                .big_integer()
+                .null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::ArchivedAt)
+                .big_integer()
+                .null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::CreatedAt)
+                .big_integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LlmAnnotationQueueItems::UpdatedAt)
+                .big_integer()
+                .not_null(),
+        )
+        .to_owned()
+}
+
+fn indexes() -> Vec<IndexCreateStatement> {
+    vec![
+        unique_index(
+            "uq_llm_annotation_queues_org_name",
+            LlmAnnotationQueues::Table,
+            [LlmAnnotationQueues::OrgId, LlmAnnotationQueues::Name],
+        ),
+        unique_index(
+            "uq_llm_queue_bindings_config",
+            LlmAnnotationQueueBindings::Table,
+            [
+                LlmAnnotationQueueBindings::QueueId,
+                LlmAnnotationQueueBindings::ScoreConfigRowId,
+            ],
+        ),
+        unique_index(
+            "uq_llm_queue_items_ref",
+            LlmAnnotationQueueItems::Table,
+            [
+                LlmAnnotationQueueItems::QueueId,
+                LlmAnnotationQueueItems::RefType,
+                LlmAnnotationQueueItems::RefId,
+            ],
+        ),
+        index(
+            "idx_llm_queue_items_status",
+            LlmAnnotationQueueItems::Table,
+            [
+                LlmAnnotationQueueItems::QueueId,
+                LlmAnnotationQueueItems::Status,
+                LlmAnnotationQueueItems::ArchivedAt,
+            ],
+        ),
+        index(
+            "idx_llm_queue_items_discovery",
+            LlmAnnotationQueueItems::Table,
+            [
+                LlmAnnotationQueueItems::OrgId,
+                LlmAnnotationQueueItems::RefType,
+                LlmAnnotationQueueItems::Status,
+                LlmAnnotationQueueItems::RefId,
+            ],
+        ),
+    ]
+}
+
+fn index<T, C, const N: usize>(name: &str, table: T, columns: [C; N]) -> IndexCreateStatement
+where
+    T: IntoIden + 'static,
+    C: IntoIden + 'static,
+{
+    let mut statement = Index::create();
+    statement.if_not_exists().name(name).table(table);
+    for column in columns {
+        statement.col(column);
+    }
+    statement.to_owned()
+}
+
+fn unique_index<T, C, const N: usize>(name: &str, table: T, columns: [C; N]) -> IndexCreateStatement
+where
+    T: IntoIden + 'static,
+    C: IntoIden + 'static,
+{
+    let mut statement = Index::create();
+    statement.if_not_exists().unique().name(name).table(table);
+    for column in columns {
+        statement.col(column);
+    }
+    statement.to_owned()
+}
+
+#[derive(DeriveIden)]
+enum LlmAnnotationQueues {
+    Table,
+    Id,
+    OrgId,
+    Name,
+    Description,
+    TargetDatasetId,
+    AllowedRefTypes,
+    CreatedBy,
+    CreatedAt,
+    UpdatedBy,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+enum LlmAnnotationQueueBindings {
+    Table,
+    Id,
+    OrgId,
+    QueueId,
+    ScoreConfigRowId,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum ScoreConfigs {
+    Table,
+    Id,
+}
+
+#[derive(DeriveIden)]
+enum LlmAnnotationQueueItems {
+    Table,
+    Id,
+    OrgId,
+    QueueId,
+    RefType,
+    RefId,
+    RefTraceId,
+    RefTraceStartTime,
+    Status,
+    ReviewedAt,
+    ArchivedAt,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_item_has_two_state_status_and_orthogonal_archive_timestamp() {
+        let sql = create_queue_items_statement().to_string(PostgresQueryBuilder);
+        assert!(sql.contains("\"status\" varchar(16) NOT NULL DEFAULT 'pending'"));
+        assert!(sql.contains("\"archived_at\" bigint NULL"));
+    }
+
+    #[test]
+    fn queue_has_no_rubric_revision_counter() {
+        let sql = create_annotation_queues_statement().to_string(PostgresQueryBuilder);
+        assert!(!sql.contains("\"rubric_revision\""));
+    }
+
+    #[test]
+    fn binding_references_one_physical_score_config_version_row() {
+        let sql = create_queue_bindings_statement().to_string(PostgresQueryBuilder);
+        assert!(sql.contains("\"score_config_row_id\" varchar(27) NOT NULL"));
+        assert!(!sql.contains("\"score_config_version\""));
+        assert!(sql.contains(
+            "FOREIGN KEY (\"score_config_row_id\") REFERENCES \"score_configs\" (\"id\")"
+        ));
+    }
+
+    #[test]
+    fn unique_indexes_enforce_queue_identities() {
+        let sql = indexes()
+            .into_iter()
+            .map(|index| index.to_string(PostgresQueryBuilder))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(sql.contains("uq_llm_annotation_queues_org_name"));
+        assert!(sql.contains("uq_llm_queue_bindings_config"));
+        assert!(sql.contains("uq_llm_queue_items_ref"));
+        assert_eq!(sql.matches("CREATE UNIQUE INDEX").count(), 3);
+    }
+
+    #[test]
+    fn discovery_index_covers_membership_filters_and_result() {
+        let sql = indexes()
+            .into_iter()
+            .map(|index| index.to_string(PostgresQueryBuilder))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(sql.contains("idx_llm_queue_items_discovery"));
+        assert!(sql.contains("(\"org_id\", \"ref_type\", \"status\", \"ref_id\")"));
+    }
+
+    #[test]
+    fn migration_creates_all_queue_tables() {
+        let tables = [
+            create_annotation_queues_statement().to_string(PostgresQueryBuilder),
+            create_queue_bindings_statement().to_string(PostgresQueryBuilder),
+            create_queue_items_statement().to_string(PostgresQueryBuilder),
+        ];
+        for expected in [
+            "llm_annotation_queues",
+            "llm_annotation_queue_bindings",
+            "llm_annotation_queue_items",
+        ] {
+            assert!(tables.iter().any(|sql| sql.contains(expected)));
+        }
+    }
+}

--- a/src/infra/src/table/migration/mod.rs
+++ b/src/infra/src/table/migration/mod.rs
@@ -154,6 +154,7 @@ mod m20260730_000001_add_alert_state_to_synthetics_monitors;
 mod m20260730_000002_create_incident_integrations;
 mod m20260730_000003_create_external_alerts;
 mod m20260730_000004_add_alert_kind_to_incident_alerts;
+mod m20260731_000001_create_llm_annotation_queue_tables;
 mod m20260802_000001_add_template_kind;
 mod m20260803_000001_add_destinations_to_incident_integrations;
 mod m20260803_000001_add_down_notified_at_to_synthetics_locations;
@@ -318,6 +319,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260730_000002_create_incident_integrations::Migration),
             Box::new(m20260730_000003_create_external_alerts::Migration),
             Box::new(m20260730_000004_add_alert_kind_to_incident_alerts::Migration),
+            Box::new(m20260731_000001_create_llm_annotation_queue_tables::Migration),
             Box::new(m20260802_000001_add_template_kind::Migration),
             Box::new(m20260803_000001_add_down_notified_at_to_synthetics_locations::Migration),
             Box::new(m20260803_000001_add_destinations_to_incident_integrations::Migration),


### PR DESCRIPTION
Add Queue, pinned binding, and QueueItem workflow storage for Phase 2.5a. QueueItems retain reference context plus eventual pending or reviewed state.

Keep human review values, reasoning, comments, reviewer identity, and immutable rubric provenance in the authoritative _llm_scores stream. Reserve queue, queue-item, physical-config, expected-count, and submission fields on each score event; no relational ReviewSubmission or ReviewScore table is created.

Queue mutations continue using the existing audit stream. The review service and eventual status reconciler are added by the annotation API layer later in this stack.

---
**Stack**:
- #13714
- #13713
- #13712
- #13711
- #13660
- #13649
- #13648
- #13634
- #13629
- #13623
- #13620
- #13608
- #13607
- #13597
- #13596
- #13595 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*