### PR TITLE
fix: propagate send error correctly

### DIFF
--- a/src/core/src/alerts/alert.rs
+++ b/src/core/src/alerts/alert.rs
@@ -1702,7 +1702,13 @@ async fn send_http_notification(endpoint: &Endpoint, msg: String) -> Result<Stri
         req = req.header("Content-type", "application/json");
     }
 
-    let resp = req.body(msg.clone()).send().await?;
+    let resp = match req.body(msg.clone()).send().await {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!("error sending request to {} with error {e:?}", endpoint.url);
+            return Err(anyhow::anyhow!("error sending request : {e:?}"));
+        }
+    };
     let resp_status = resp.status();
     let resp_body = resp.text().await?;
 


### PR DESCRIPTION
Currently if the destination notification fails at connect stage itself, it logs the error just as error sending request, with no other information. This PR instead captures the error, and logs the debug fmt which looks like
```
reqwest::Error { kind: Request, url: "https://localhost:5001/", source: hyper_util::client::legacy::Error(Connect, Custom { kind: Other, error: Custom { kind: InvalidData, error: InvalidMessage(InvalidContentType) } }) }
```

Which provides more info to debug the issue.