### PR TITLE
fix(folders): stop the move dialog offering the folder you are already in

### DIFF
--- a/web/src/components/common/sidebar/MoveAcrossFolders.spec.ts
+++ b/web/src/components/common/sidebar/MoveAcrossFolders.spec.ts
@@ -41,7 +41,7 @@ vi.mock("./SelectFolderDropDown.vue", () => ({
     name: "SelectFolderDropDown",
     template:
       "<div class='select-folder-dropdown' @folder-selected=\"$emit('folder-selected', $event)\"></div>",
-    props: ["type", "activeFolderId"],
+    props: ["type", "activeFolderId", "excludeFolderId"],
     emits: ["folder-selected"],
   },
 }));
@@ -513,14 +513,28 @@ describe("MoveAcrossFolders.vue", () => {
   });
 
   // Test 29: Initial selected folder setup
-  it("should initialize selected folder correctly from store", () => {
+  // The destination starts empty, NOT on the active folder. Seeding it there put
+  // the same folder name in both fields and read as "move this to where it
+  // already is"; the picker now excludes the active folder outright, so a seeded
+  // value would also name something the list cannot offer.
+  it("should initialize the destination empty rather than on the active folder", () => {
     wrapper = createWrapper({
       activeFolderId: "folder1",
       type: "alerts",
     });
 
-    expect(wrapper.vm.selectedFolder.label).toBe("Test Folder 1");
-    expect(wrapper.vm.selectedFolder.value).toBe("folder1");
+    expect(wrapper.vm.selectedFolder.label).toBe("");
+    expect(wrapper.vm.selectedFolder.value).toBe("");
+  });
+
+  it("should exclude the active folder from the destination picker", () => {
+    wrapper = createWrapper({
+      activeFolderId: "folder1",
+      type: "alerts",
+    });
+
+    const dropdown = wrapper.findComponent({ name: "SelectFolderDropDown" });
+    expect(dropdown.props("excludeFolderId")).toBe("folder1");
   });
 
   // Test 30: Form submission with empty moduleId
@@ -568,11 +582,11 @@ describe("MoveAcrossFolders.vue", () => {
   });
 
   // Test 34: Component exposes selectedFolder as a ref
-  it("should expose selectedFolder with correct initial value", () => {
+  it("should expose selectedFolder, unset until the author picks one", () => {
     wrapper = createWrapper({ activeFolderId: "folder1", type: "alerts" });
     expect(wrapper.vm.selectedFolder).toBeDefined();
-    expect(wrapper.vm.selectedFolder.value).toBe("folder1");
-    expect(wrapper.vm.selectedFolder.label).toBe("Test Folder 1");
+    expect(wrapper.vm.selectedFolder.value).toBe("");
+    expect(wrapper.vm.selectedFolder.label).toBe("");
   });
 
   // Test 35: onSubmit function existence
@@ -645,7 +659,11 @@ describe("MoveAcrossFolders.vue", () => {
   });
 
   // Test 40: primaryButtonDisabled with null selectedFolder value
-  it("should compute primaryButtonDisabled=false when selectedFolder value is null", async () => {
+  // Inverted deliberately. This asserted that a null destination ENABLES Move —
+  // which submits `dst_folder_id: null`. "Not the active folder" is not the same
+  // as "somewhere to move to", and the empty destination the dialog now opens in
+  // makes that state reachable on every open rather than only via a stray emit.
+  it("should keep Move disabled when the destination is empty or null", async () => {
     mockUseLoading.mockImplementation((fn: any) => ({
       execute: vi.fn().mockImplementation(async () => fn && (await fn())),
       isLoading: { value: false },
@@ -656,13 +674,15 @@ describe("MoveAcrossFolders.vue", () => {
       type: "alerts",
     });
 
-    // selectedFolder.value mutated to a non-matching object — drive via the public dropdown event
+    const drawer = wrapper.findComponent(ODialogStub);
+    // Unset on open — nothing has been chosen yet.
+    expect(drawer.props("primaryButtonDisabled")).toBe(true);
+
     const selectDropdown = wrapper.findComponent({ name: "SelectFolderDropDown" });
     await selectDropdown.vm.$emit("folder-selected", { value: null, label: "None" });
     await nextTick();
 
-    const drawer = wrapper.findComponent(ODialogStub);
-    expect(drawer.props("primaryButtonDisabled")).toBe(false);
+    expect(drawer.props("primaryButtonDisabled")).toBe(true);
   });
 
   // Test 41: Handles API error gracefully when move fails

--- a/web/src/components/common/sidebar/MoveAcrossFolders.vue
+++ b/web/src/components/common/sidebar/MoveAcrossFolders.vue
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :secondary-button-label="t('dashboard.cancel')"
     :primary-button-label="t('common.move')"
     :primary-button-loading="onSubmit.isLoading.value"
-    :primary-button-disabled="activeFolderId === selectedFolder.value"
+    :primary-button-disabled="!selectedFolder.value || activeFolderId === selectedFolder.value"
     @update:open="emit('update:open', $event)"
     @click:secondary="emit('update:open', false)"
     @click:primary="onSubmit.execute()"
@@ -41,11 +41,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       />
       <span>&nbsp;</span>
 
-      <!-- select folder or create new folder and select -->
+      <!-- select folder or create new folder and select.
+
+           `excludeFolderId` is what stops the destination opening on the folder
+           named directly above it as the CURRENT one: the same folder appeared
+           twice, reading as "move this to where it already is". Submit was
+           disabled in that state, so nothing could go wrong — the dialog simply
+           gave no clue why. -->
       <SelectFolderDropDown
         :type="type"
         @folder-selected="selectedFolder = $event"
         :activeFolderId="activeFolderId"
+        :excludeFolderId="activeFolderId"
       />
     </div>
   </ODialog>
@@ -91,14 +98,10 @@ export default defineComponent({
   emits: ["updated", "close", "update:open"],
   setup(props, { emit }) {
     const store: any = useStore();
-    //dropdown selected folder
-    const selectedFolder = ref({
-      label:
-        store.state.organizationData.foldersByType?.[props.type]?.find(
-          (item: any) => item.folderId === props.activeFolderId,
-        )?.name ?? "",
-      value: props.activeFolderId,
-    });
+    // Dropdown selected folder — deliberately empty, not the active folder.
+    // The picker excludes the active folder, so seeding it here would name a
+    // destination the list cannot offer and cannot be re-picked.
+    const selectedFolder = ref({ label: "", value: "" });
     const { t } = useI18n();
     const { showPositiveNotification, showErrorNotification } = useNotifications();
 

--- a/web/src/components/common/sidebar/SelectFolderDropDown.spec.ts
+++ b/web/src/components/common/sidebar/SelectFolderDropDown.spec.ts
@@ -233,6 +233,52 @@ describe("SelectFolderDropDown.vue", () => {
     });
   });
 
+  // Opt-in, and only a destination picker opts in. A move dialog naming the
+  // active folder as the destination showed the same folder name twice and read
+  // as "move this to where it already is".
+  describe("excludeFolderId", () => {
+    it("is unset by default, and then offers every folder", () => {
+      wrapper = createWrapper();
+      expect(wrapper.props("excludeFolderId")).toBeUndefined();
+      const values = (wrapper.vm as any).folderOptions.map((o: any) => o.value);
+      expect(values).toEqual(["default", "folder-1", "folder-2"]);
+    });
+
+    it("drops the excluded folder from the options", () => {
+      wrapper = createWrapper({ excludeFolderId: "folder-1" });
+      const values = (wrapper.vm as any).folderOptions.map((o: any) => o.value);
+      expect(values).toEqual(["default", "folder-2"]);
+    });
+
+    // The whole point: it must not open pointing at a folder the list refuses to
+    // show, so there is nothing to select until the author chooses.
+    it("opens with no selection when it would have seeded the excluded folder", () => {
+      wrapper = createWrapper({ activeFolderId: "folder-1", excludeFolderId: "folder-1" });
+      expect((wrapper.vm as any).selectedFolder).toBe("");
+    });
+
+    it("still seeds normally when the active folder is not the excluded one", () => {
+      wrapper = createWrapper({ activeFolderId: "folder-2", excludeFolderId: "folder-1" });
+      expect((wrapper.vm as any).selectedFolder).toBe("folder-2");
+    });
+
+    // Creating a folder from the + button reaches this component as a store list
+    // change. The re-seed on that watcher would otherwise clear the folder that
+    // was just created and selected.
+    it("keeps a still-offerable choice when the folder list changes", async () => {
+      wrapper = createWrapper({ activeFolderId: "folder-1", excludeFolderId: "folder-1" });
+      const vm = wrapper.vm as any;
+
+      vm.selectedFolder = "folder-2";
+      await nextTick();
+
+      setStoreFolders("alerts", [...MOCK_FOLDERS, { folderId: "folder-3", name: "Staging" }]);
+      await nextTick();
+
+      expect(vm.selectedFolder).toBe("folder-2");
+    });
+  });
+
   // ─── updateFolderList ────────────────────────────────────────────────────────
 
   describe("updateFolderList method", () => {

--- a/web/src/components/common/sidebar/SelectFolderDropDown.vue
+++ b/web/src/components/common/sidebar/SelectFolderDropDown.vue
@@ -20,12 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <OSelect
       v-model="selectedFolder"
       :label="t('dashboard.selectFolderLabel')"
-      :options="
-        store.state.organizationData.foldersByType[type]?.map((item: any) => ({
-          label: item.name,
-          value: item.folderId,
-        })) ?? []
-      "
+      :options="folderOptions"
+      :placeholder="excludeFolderId ? t('dashboard.selectFolderPlaceholder') : undefined"
       :data-test="`${type}-index-dropdown-stream_type`"
       labelKey="label"
       valueKey="value"
@@ -86,6 +82,21 @@ export default defineComponent({
         return typeof value === "string" || value === null;
       },
     },
+    /**
+     * A folder this picker must not offer — set by callers choosing a
+     * DESTINATION, where the folder the module already sits in is not a
+     * destination at all.
+     *
+     * Opt-in on purpose. Most callers here pick a folder to file something into
+     * and are right to open on the active one; only a move is choosing somewhere
+     * else. Leaving it unset keeps every one of those call sites exactly as it
+     * was — the filter and the blank initial selection both key off this prop.
+     */
+    excludeFolderId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
     type: {
       type: String,
       default: "alerts",
@@ -108,14 +119,25 @@ export default defineComponent({
     const route = useRoute();
     const showAddFolderDialog: any = ref(false);
 
+    const folderOptions = computed(() =>
+      (store.state.organizationData.foldersByType[props.type] ?? [])
+        // `!== undefined` is every folder, so an unset prop filters nothing.
+        .filter((item: any) => item.folderId !== props.excludeFolderId)
+        .map((item: any) => ({ label: item.name, value: item.folderId })),
+    );
+
     const getInitialFolderId = () => {
       // priority: activeFolderId > query.folder > default
-      return (
+      const resolved =
         store.state.organizationData.foldersByType[props.type]?.find(
           (item: any) =>
             item.folderId === (props.activeFolderId ?? route.query.folder ?? "default"),
-        )?.folderId ?? "default"
-      );
+        )?.folderId ?? "default";
+      // Opening already pointed at the excluded folder would show its name as the
+      // choice while the list cannot offer it — the state that made a move dialog
+      // read as "move this to where it already is". Start blank and make the
+      // caller's disabled-submit guard do the rest.
+      return resolved === props.excludeFolderId ? "" : resolved;
     };
 
     //dropdown selected folder index (holds primitive folderId string)
@@ -140,6 +162,15 @@ export default defineComponent({
     watch(
       () => store.state.organizationData.foldersByType[props.type],
       () => {
+        // A destination picker keeps a choice that is still offerable. Creating a
+        // folder from the + button lands here as a list change, and the re-seed
+        // below would clear the very folder that was just created and selected.
+        if (
+          props.excludeFolderId &&
+          folderOptions.value.some((option: any) => option.value === selectedFolder.value)
+        ) {
+          return;
+        }
         // refresh selected folder, on folders list change
         selectedFolder.value = getInitialFolderId();
       },
@@ -162,6 +193,7 @@ export default defineComponent({
       t,
       store,
       selectedFolder,
+      folderOptions,
       updateFolderList,
       showAddFolderDialog,
       computedStyle,

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -3108,6 +3108,7 @@
     "addFieldMessage": "Please add a field from the list",
     "currentFolderLabel": "Current Folder",
     "selectFolderLabel": "Select Folder",
+    "selectFolderPlaceholder": "Choose a destination folder",
     "selectDashboardLabel": "Select Dashboard",
     "selectTabLabel": "Select Tab",
     "layerType": "Layer Type",


### PR DESCRIPTION
## The bug

Selecting checks in Synthetic Monitoring and pressing **Move** opened a dialog reading:

```
Current Folder:  Foo
Select Folder:   Foo
```

The same folder name twice — which reads as "move this to where it already is".

Nothing could actually go wrong: `primary-button-disabled` already blocked a same-folder submit. The dialog simply gave no clue *why* Move was greyed out, because the destination it had chosen for you was the one destination it would not accept.

## Cause

`MoveAcrossFolders` seeded `selectedFolder` from `activeFolderId`, and `SelectFolderDropDown` listed every folder including that one.

## Fix

- `SelectFolderDropDown` gains an optional `excludeFolderId` prop: it filters that folder out of the options and refuses to seed the selection with it.
- `MoveAcrossFolders` passes `:excludeFolderId="activeFolderId"`, opens with no destination chosen, and additionally disables Move while the destination is empty — *"not the active folder"* is not the same as *"somewhere to move to"*.
- The folder-list watcher now keeps a still-offerable choice. Creating a folder from the **+** button arrives here as a store list change, and the re-seed would otherwise clear the folder just created and selected.

## Why the prop is opt-in

`SelectFolderDropDown` has six other consumers — ImportAlert, AlertList's clone dialog, CreateReport, AddSlo, SloList, and the synthetics *duplicate* dialog. Every one of those picks a folder to file something **into**, where opening on the active folder is correct.

Unset, the filter matches every folder (`!== undefined`) and the seeding is untouched, so those call sites are byte-for-byte unchanged.

## Scope

This dialog is shared, so the change reaches **alerts, pipelines, reports, SLOs and synthetics**. Behaviour is strictly narrowed: the option removed was already a guaranteed no-op behind the disabled-submit guard.

`MoveDashboardToAnotherFolder` uses a separate `SelectFolderDropdown` under `components/dashboards/` and has the same behaviour, but it is a different component tree and is deliberately left alone.

## Tests

5 new cases on the dropdown (default offers everything, excluded id dropped, blank start, normal seeding still works, choice survives a list change) and 1 on the dialog.

Three existing tests asserted the old seeding and are updated. **One deserves review:** `should compute primaryButtonDisabled=false when selectedFolder value is null` asserted that a *null* destination **enables** Move — executing that submits `dst_folder_id: null`. I read it as wrong rather than intentional and inverted it. If that null path is load-bearing somewhere I have not found, this is the thing to challenge.

## Verification

Run on this branch, based on `main`:

- `src/components/common/sidebar/` — 291 passed (6 files)
- Consumers: SyntheticMonitoring, AlertList, ImportAlert, MoveDashboardToAnotherFolder — 216 passed, 10 pre-existing skips
- `eslint` on all four changed files — clean
- `npm run lint:design:strict` — OK, no regressions
- `npm run type-check` — exit 0