### PR TITLE
test(alpha1): split shard logins across multiple Dex users

### DIFF
--- a/tests/ui-testing/playwright-alpha1.config.js
+++ b/tests/ui-testing/playwright-alpha1.config.js
@@ -54,7 +54,9 @@ const CHROME_USE = {
   ...devices['Desktop Chrome'],
   viewport: { width: 1500, height: 1024 },
   permissions: ['clipboard-read', 'clipboard-write'],
-  // Reuse auth state from global setup (Dex email login)
+  // Reuse auth state from global setup (Dex email login). Filename is canonical;
+  // multi-user splitting happens at the CI layer (each shard downloads its own
+  // user's artifact into this path). See global-setup-alpha1.js AUTH_FILE.
   storageState: path.join(__dirname, 'playwright-tests/utils/auth/user.json'),
 };
 

--- a/tests/ui-testing/playwright-tests/auth-warm.spec.js
+++ b/tests/ui-testing/playwright-tests/auth-warm.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+const testLogger = require('./utils/test-logger.js');
+
+/**
+ * Auth-warm spec — mints a shared-auth artifact WITHOUT running the heavy
+ * org-wide cleanup.
+ *
+ * The alpha1 barrier (pre_test_cleanup job) splits its Dex logins across multiple
+ * users (ALPHA1_USER_INDEX). User 1 runs cleanup.spec.js (which also mints its
+ * artifact via globalSetup); users 2..N have no cleanup to do, so they run THIS
+ * spec instead. globalSetup already performed the Dex login and wrote
+ * user<N>.json / cloud-config<N>.json before this test executes — all this test
+ * does is confirm the session loads, so the job fails loudly if login didn't take.
+ *
+ * Runs with SKIP_INGESTION=true in the barrier (no per-shard ingestion here).
+ */
+test.describe('Alpha1 auth warm-up', () => {
+  test('minted session is usable', {
+    tag: ['@auth-warm', '@all']
+  }, async ({ page, baseURL }) => {
+    const userIndex = (process.env.ALPHA1_USER_INDEX || '1').trim();
+    testLogger.info(`[alpha1] auth-warm: verifying minted session for user index ${userIndex}`);
+
+    await page.goto(`${baseURL}/web/`, { timeout: 60000, waitUntil: 'domcontentloaded' });
+
+    // If the saved session were invalid we'd be bounced to Dex/login here.
+    const url = page.url();
+    expect(url, `expected an authenticated app URL, got ${url}`).not.toContain('dex');
+    expect(url, `expected an authenticated app URL, got ${url}`).not.toMatch(/\/web\/login$/);
+
+    // Home menu item is only present once the SPA has an authenticated session.
+    await expect(page.locator('[data-test="menu-link-\\/-item"]')).toBeVisible({ timeout: 30000 });
+    testLogger.info(`[alpha1] auth-warm: session for user index ${userIndex} is valid`);
+  });
+});

--- a/tests/ui-testing/playwright-tests/utils/global-setup-alpha1.js
+++ b/tests/ui-testing/playwright-tests/utils/global-setup-alpha1.js
@@ -4,7 +4,14 @@ const fs = require('fs');
 const testLogger = require('./test-logger.js');
 const logsdata = require('../../../test-data/logs_data.json');
 
-// Auth storage paths
+// Auth storage paths. Filenames stay canonical (user.json / cloud-config.json)
+// because ~20 spec files and shared utils (cloud-auth.js, enhanced-baseFixtures.js)
+// read these exact paths. Multi-user splitting (ALPHA1_USER_INDEX, 1|2|3) is
+// achieved at the CI layer instead: each shard runs on its own runner and
+// downloads only ITS user's artifact into this dir, so the canonical file always
+// holds the right user's session. USER_INDEX here only selects which Dex user to
+// log in as (email resolution below).
+const USER_INDEX = (process.env.ALPHA1_USER_INDEX || '1').trim();
 const AUTH_DIR = path.join(__dirname, 'auth');
 const AUTH_FILE = path.join(AUTH_DIR, 'user.json');
 const CLOUD_CONFIG_FILE = path.join(AUTH_DIR, 'cloud-config.json');
@@ -28,11 +35,17 @@ async function globalSetup() {
   if (!baseUrl) {
     throw new Error('ZO_BASE_URL must be set');
   }
-  const userEmail = (process.env.ALPHA1_USER_EMAIL || '').trim();
+  // Resolve this shard's Dex user by index: ALPHA1_USER_EMAIL_<N> when provided,
+  // else fall back to the base ALPHA1_USER_EMAIL. This keeps the workflow safe to
+  // roll out incrementally — if _2/_3 aren't set yet, every shard just uses user 1.
+  // Password is shared across all users (single ALPHA1_USER_PASSWORD secret).
+  const userEmail = (process.env[`ALPHA1_USER_EMAIL_${USER_INDEX}`]
+    || process.env.ALPHA1_USER_EMAIL || '').trim();
   const userPassword = (process.env.ALPHA1_USER_PASSWORD || '').trim();
   if (!userEmail || !userPassword) {
     throw new Error('ALPHA1_USER_EMAIL and ALPHA1_USER_PASSWORD must be set');
   }
+  testLogger.info(`[alpha1] Using Dex user index ${USER_INDEX} (${userEmail})`);
 
   // Check if shared auth state exists (downloaded from cleanup job artifact)
   // If valid, skip the entire Dex login flow — just verify and ingest


### PR DESCRIPTION
## What
Lets alpha1 shards log in as **different Dex users** instead of all hammering the cloud env as one user. Paired with **openobserve/o2-enterprise#2333** (the workflow wiring).

## Why
- **Load distribution** — spreads API/session load across users if the env rate-limits per user.
- **Blast radius** — one user's account/session issue stops ~1/3 of shards, not all.
- Test **data isolation is unchanged** (still per-org); this is purely about the login user.

## Changes (OSS)
- `global-setup-alpha1.js` — new `ALPHA1_USER_INDEX` (1|2|3) selects the Dex user: email resolves from `ALPHA1_USER_EMAIL_<N>`, **falling back to `ALPHA1_USER_EMAIL`** when the indexed secret isn't set (safe incremental rollout). Password shared (`ALPHA1_USER_PASSWORD`).
- Auth **filenames stay canonical** (`user.json` / `cloud-config.json`) — ~20 specs + shared utils read those exact paths. The per-user split happens at the CI layer (each shard downloads only its user's artifact into the canonical path), so no spec changes needed.
- New `auth-warm.spec.js` — a login-only spec the barrier uses to mint auth artifacts for users 2..N **without** running the heavy org-wide cleanup.

## Default behaviour
With no index set, everything resolves to user 1 — identical to today.

## Enterprise PR
openobserve/o2-enterprise#2333