### PR TITLE
feat(llm): add stream-backed annotation APIs

### DIFF
--- a/src/api/http/src/handler/http/router/mod.rs
+++ b/src/api/http/src/handler/http/router/mod.rs
@@ -54,9 +54,9 @@ use {
         config::get_config as get_o2_config,
     },
     openobserve_api_management::request::{
-        actions, ai, annotation_queues, anomaly_detection, datasets, domain_management, eval_jobs,
-        gen_ai, keys, license, providers, score_configs, scorers, service_streams, synthetics,
-        workflows,
+        actions, ai, annotation_queues, annotations, anomaly_detection, datasets,
+        domain_management, eval_jobs, gen_ai, keys, license, providers, score_configs, scorers,
+        service_streams, synthetics, workflows,
     },
     openobserve_api_pipelines::request::re_pattern,
     openobserve_api_search::search::patterns,
@@ -1050,6 +1050,15 @@ pub fn service_routes() -> Router {
                         .delete(annotation_queues::clear_annotation_queue_items),
                 )
                 .route(
+                    "/{org_id}/annotation_queues/{queue_id}/items/{queue_item_id}",
+                    get(annotation_queues::get_annotation_queue_item),
+                )
+                .route(
+                    "/{org_id}/annotation_queues/{queue_id}/items/{queue_item_id}/reviews",
+                    get(annotation_queues::list_annotation_queue_item_reviews)
+                        .post(annotation_queues::review_annotation_queue_item),
+                )
+                .route(
                     "/{org_id}/annotation_queues/{queue_id}/items/archive",
                     post(annotation_queues::archive_annotation_queue_items),
                 )
@@ -1069,6 +1078,9 @@ pub fn service_routes() -> Router {
                         .put(datasets::update_dataset)
                         .delete(datasets::delete_dataset),
                 )
+
+                // On-demand human annotation from Discovery
+                .route("/{org_id}/annotations", post(annotations::annotate_target))
 
                 // LLM Providers (Online Eval Phase 2)
                 .route("/{org_id}/providers", get(providers::list_providers).post(providers::create_provider))

--- a/src/api/management/src/models/annotation_queues/mod.rs
+++ b/src/api/management/src/models/annotation_queues/mod.rs
@@ -5,13 +5,19 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
+use config::meta::self_reporting::llm_scores::{
+    LlmScoreDataSourceType, LlmScoreDataType, LlmScoreRecord,
+};
 use infra::table::score_configs::ScoreConfigDataType;
 use openobserve_core::llm_evaluations::annotation_queues::{
-    AnnotationQueue, AnnotationQueueItem, AnnotationQueueItemSelection, CreateAnnotationQueue,
-    EnqueueAnnotationQueueItem, PinnedScoreConfig, UpdateAnnotationQueue,
+    AnnotationQueue, AnnotationQueueItem, AnnotationQueueItemContent, AnnotationQueueItemDetail,
+    AnnotationQueueItemSelection, CreateAnnotationQueue, CreateQueueReview,
+    EnqueueAnnotationQueueItem, PinnedScoreConfig, QueueReviewSubmission, UpdateAnnotationQueue,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
+
+use super::annotations::{AnnotationScoreRequestBody, AnnotationTargetMetadataRequestBody};
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -71,6 +77,8 @@ pub struct ListAnnotationQueuesResponseBody {
 #[into_params(parameter_in = Query)]
 #[serde(deny_unknown_fields)]
 pub struct ListAnnotationQueueItemsQuery {
+    /// Return memberships from one Annotation Queue only.
+    pub queue_id: Option<String>,
     /// Queue workflow status. Supported values are `pending` and `reviewed`.
     pub queue_status: Option<String>,
     /// Item scope. Supported values are `span`, `trace`, and `session`.
@@ -96,6 +104,28 @@ pub struct EnqueueAnnotationQueueItemRequestBody {
 pub struct AnnotationQueueItemSelectionRequestBody {
     /// Queue Item IDs selected for this bulk action.
     pub item_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReviewAnnotationQueueItemRequestBody {
+    /// Client-generated idempotency key shared by all N Score events. Reuse it
+    /// only when retrying the identical logical submission.
+    pub submission_id: String,
+    pub source_stream: String,
+    pub scores: Vec<AnnotationScoreRequestBody>,
+    #[serde(default)]
+    pub comments: Option<String>,
+    #[serde(default)]
+    pub target_metadata: Option<AnnotationTargetMetadataRequestBody>,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListQueueReviewsResponseBody {
+    pub list: Vec<QueueReviewSubmission>,
 }
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
@@ -132,6 +162,42 @@ pub struct AnnotationQueueItemResponseBody {
 #[serde(rename_all = "camelCase")]
 pub struct ListAnnotationQueueItemsResponseBody {
     pub list: Vec<AnnotationQueueItemResponseBody>,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AnnotationQueueItemContentResponseBody {
+    pub input: Option<serde_json::Value>,
+    pub output: Option<serde_json::Value>,
+    pub trace: Vec<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AnnotationQueueMachineScoreResponseBody {
+    pub id: String,
+    pub name: String,
+    pub value_numeric: Option<f64>,
+    pub value_categorical: Option<String>,
+    pub value_boolean: Option<bool>,
+    pub data_type: String,
+    pub source_type: String,
+    pub source_stream: Option<String>,
+    pub scorer_id: Option<String>,
+    pub scorer_version: Option<String>,
+    pub score_config_id: Option<String>,
+    pub score_config_version: Option<String>,
+    pub reasoning: Option<String>,
+    pub timestamp: i64,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AnnotationQueueItemDetailResponseBody {
+    pub item: AnnotationQueueItemResponseBody,
+    pub source_stream: String,
+    pub content: AnnotationQueueItemContentResponseBody,
+    pub machine_scores: Vec<AnnotationQueueMachineScoreResponseBody>,
 }
 
 impl From<CreateAnnotationQueueRequestBody> for CreateAnnotationQueue {
@@ -172,6 +238,19 @@ impl From<AnnotationQueueItemSelectionRequestBody> for AnnotationQueueItemSelect
     fn from(value: AnnotationQueueItemSelectionRequestBody) -> Self {
         Self {
             item_ids: value.item_ids,
+        }
+    }
+}
+
+impl From<ReviewAnnotationQueueItemRequestBody> for CreateQueueReview {
+    fn from(value: ReviewAnnotationQueueItemRequestBody) -> Self {
+        Self {
+            submission_id: value.submission_id,
+            source_stream: value.source_stream,
+            scores: value.scores.into_iter().map(Into::into).collect(),
+            comments: value.comments,
+            target_metadata: value.target_metadata.unwrap_or_default().into(),
+            metadata: value.metadata,
         }
     }
 }
@@ -237,6 +316,61 @@ impl From<AnnotationQueueItem> for AnnotationQueueItemResponseBody {
             archived_at: value.archived_at,
             created_at: value.created_at,
             updated_at: value.updated_at,
+        }
+    }
+}
+
+impl From<AnnotationQueueItemContent> for AnnotationQueueItemContentResponseBody {
+    fn from(value: AnnotationQueueItemContent) -> Self {
+        Self {
+            input: value.input,
+            output: value.output,
+            trace: value.trace,
+        }
+    }
+}
+
+impl From<LlmScoreRecord> for AnnotationQueueMachineScoreResponseBody {
+    fn from(value: LlmScoreRecord) -> Self {
+        let data_type = match value.data_type {
+            LlmScoreDataType::Numeric => "numeric",
+            LlmScoreDataType::Categorical => "categorical",
+            LlmScoreDataType::Boolean => "boolean",
+        };
+        let source_type = match value.source_type {
+            LlmScoreDataSourceType::LlmJudge => "llm_judge",
+            LlmScoreDataSourceType::Code => "code",
+            LlmScoreDataSourceType::Remote => "remote",
+            LlmScoreDataSourceType::Annotation => "annotation",
+            LlmScoreDataSourceType::Feedback => "feedback",
+            LlmScoreDataSourceType::Experiment => "experiment",
+        };
+        Self {
+            id: value.id,
+            name: value.name,
+            value_numeric: value.value_numeric,
+            value_categorical: value.value_categorical,
+            value_boolean: value.value_boolean,
+            data_type: data_type.to_string(),
+            source_type: source_type.to_string(),
+            source_stream: value.source_stream,
+            scorer_id: value.scorer_id,
+            scorer_version: value.scorer_version,
+            score_config_id: value.score_config_id,
+            score_config_version: value.score_config_version,
+            reasoning: value.reasoning,
+            timestamp: value._timestamp,
+        }
+    }
+}
+
+impl From<AnnotationQueueItemDetail> for AnnotationQueueItemDetailResponseBody {
+    fn from(value: AnnotationQueueItemDetail) -> Self {
+        Self {
+            item: value.item.into(),
+            source_stream: value.source_stream,
+            content: value.content.into(),
+            machine_scores: value.machine_scores.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -308,6 +442,50 @@ mod tests {
         assert_eq!(response.list[0].ref_id, response.list[1].ref_id);
         assert_ne!(response.list[0].queue_id, response.list[1].queue_id);
         assert_ne!(response.list[0].status, response.list[1].status);
+    }
+
+    #[test]
+    fn queue_item_detail_serializes_content_and_machine_scores() {
+        let detail = AnnotationQueueItemDetail {
+            item: AnnotationQueueItem {
+                id: "item-1".to_string(),
+                org_id: "org-1".to_string(),
+                queue_id: "queue-1".to_string(),
+                queue_name: Some("Review".to_string()),
+                ref_type: "trace".to_string(),
+                ref_id: "trace-1".to_string(),
+                ref_trace_id: None,
+                ref_trace_start_time: 100,
+                status: "pending".to_string(),
+                reviewed_at: None,
+                archived_at: None,
+                created_at: 1,
+                updated_at: 2,
+            },
+            source_stream: "traces".to_string(),
+            content: AnnotationQueueItemContent {
+                input: Some(serde_json::json!({"question": "hello"})),
+                output: Some(serde_json::json!({"answer": "hi"})),
+                trace: vec![serde_json::json!({"trace_id": "trace-1"})],
+            },
+            machine_scores: vec![LlmScoreRecord {
+                id: "score-1".to_string(),
+                name: "faithfulness".to_string(),
+                value_numeric: Some(0.9),
+                data_type: LlmScoreDataType::Numeric,
+                source_type: LlmScoreDataSourceType::LlmJudge,
+                source_stream: Some("traces".to_string()),
+                _timestamp: 200,
+                ..LlmScoreRecord::default()
+            }],
+        };
+        let value =
+            serde_json::to_value(AnnotationQueueItemDetailResponseBody::from(detail)).unwrap();
+        assert_eq!(value["item"]["refTraceStartTime"], 100);
+        assert_eq!(value["sourceStream"], "traces");
+        assert_eq!(value["content"]["input"]["question"], "hello");
+        assert_eq!(value["machineScores"][0]["sourceType"], "llm_judge");
+        assert_eq!(value["machineScores"][0]["valueNumeric"], 0.9);
     }
 
     #[test]

--- a/src/api/management/src/models/annotations.rs
+++ b/src/api/management/src/models/annotations.rs
@@ -1,0 +1,186 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use config::meta::self_reporting::llm_scores::LlmScoreTargetScope;
+use openobserve_core::llm_evaluations::annotations::{
+    AnnotationScoreInput, AnnotationTargetMetadata, CreateAnnotation, PreparedAnnotation,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnnotationScoreRequestBody {
+    /// Physical row ID of the immutable Score Config version selected by the user.
+    pub score_config_row_id: String,
+    /// A number, string, or boolean matching the selected Score Config data type.
+    pub value: serde_json::Value,
+    #[serde(default)]
+    pub reasoning: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnnotationTargetMetadataRequestBody {
+    #[serde(default)]
+    pub agent_name: Option<String>,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub agent_env: Option<String>,
+    #[serde(default)]
+    pub agent_version: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnnotateRequestBody {
+    /// Evaluated target scope: span, trace, or session.
+    #[schema(value_type = String)]
+    pub scope: LlmScoreTargetScope,
+    /// Span ID, trace ID, or session ID according to `scope`.
+    pub target_id: String,
+    /// Required for span annotations; optional context for trace annotations.
+    #[serde(default)]
+    pub trace_id: Option<String>,
+    /// Optional parent context for span/trace annotations.
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Original evaluated object's timestamp in microseconds.
+    pub ref_timestamp: i64,
+    /// Trace stream containing the evaluated target.
+    pub source_stream: String,
+    pub scores: Vec<AnnotationScoreRequestBody>,
+    /// Agent identity copied from the selected target when available.
+    #[serde(default)]
+    pub target_metadata: Option<AnnotationTargetMetadataRequestBody>,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AnnotateResponseBody {
+    pub annotation_id: String,
+    pub score_ids: Vec<String>,
+    pub annotated_at: i64,
+}
+
+impl From<AnnotationScoreRequestBody> for AnnotationScoreInput {
+    fn from(value: AnnotationScoreRequestBody) -> Self {
+        Self {
+            score_config_row_id: value.score_config_row_id,
+            value: value.value,
+            reasoning: value.reasoning,
+            metadata: value.metadata,
+        }
+    }
+}
+
+impl From<AnnotateRequestBody> for CreateAnnotation {
+    fn from(value: AnnotateRequestBody) -> Self {
+        Self {
+            scope: value.scope,
+            target_id: value.target_id,
+            trace_id: value.trace_id,
+            session_id: value.session_id,
+            ref_timestamp: value.ref_timestamp,
+            source_stream: value.source_stream,
+            scores: value
+                .scores
+                .into_iter()
+                .map(AnnotationScoreInput::from)
+                .collect(),
+            target_metadata: value.target_metadata.unwrap_or_default().into(),
+            metadata: value.metadata,
+            review: None,
+        }
+    }
+}
+
+impl From<AnnotationTargetMetadataRequestBody> for AnnotationTargetMetadata {
+    fn from(value: AnnotationTargetMetadataRequestBody) -> Self {
+        Self {
+            agent_name: value.agent_name,
+            agent_id: value.agent_id,
+            agent_env: value.agent_env,
+            agent_version: value.agent_version,
+        }
+    }
+}
+
+impl From<&PreparedAnnotation> for AnnotateResponseBody {
+    fn from(value: &PreparedAnnotation) -> Self {
+        Self {
+            annotation_id: value.id.clone(),
+            score_ids: value
+                .records
+                .iter()
+                .map(|record| record.id.clone())
+                .collect(),
+            annotated_at: value.annotated_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_rejects_unknown_fields() {
+        let result: Result<AnnotateRequestBody, _> = serde_json::from_value(serde_json::json!({
+            "scope": "trace",
+            "targetId": "trace-1",
+            "refTimestamp": 1,
+            "sourceStream": "default",
+            "scores": [],
+            "queueId": "not-applicable"
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn request_uses_target_scope_enum_and_agent_metadata() {
+        let body: AnnotateRequestBody = serde_json::from_value(serde_json::json!({
+            "scope": "session",
+            "targetId": "session-1",
+            "refTimestamp": 1,
+            "sourceStream": "default",
+            "scores": [],
+            "targetMetadata": {
+                "agentId": "agent-1",
+                "agentEnv": "production",
+                "agentVersion": "1.2.3"
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(body.scope, LlmScoreTargetScope::Session);
+        let input: CreateAnnotation = body.into();
+        assert_eq!(input.target_metadata.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(
+            input.target_metadata.agent_env.as_deref(),
+            Some("production")
+        );
+        assert_eq!(
+            input.target_metadata.agent_version.as_deref(),
+            Some("1.2.3")
+        );
+    }
+}

--- a/src/api/management/src/models/mod.rs
+++ b/src/api/management/src/models/mod.rs
@@ -19,6 +19,8 @@ pub mod ai;
 pub mod alerts;
 #[cfg(feature = "enterprise")]
 pub mod annotation_queues;
+#[cfg(feature = "enterprise")]
+pub mod annotations;
 #[cfg(feature = "cloud")]
 pub mod billings;
 pub mod dashboards;

--- a/src/api/management/src/request/annotation_queues/mod.rs
+++ b/src/api/management/src/request/annotation_queues/mod.rs
@@ -16,17 +16,22 @@ use openobserve_core::{
     llm_evaluations::annotation_queues::{
         self, AnnotationQueueError, ListAnnotationQueueItemsFilter,
     },
+    self_reporting::llm_scores_writer,
 };
 
 use crate::{
     common::meta::{authz::Authz, http::HttpResponse as MetaHttpResponse},
-    models::annotation_queues::{
-        AnnotationQueueItemResponseBody, AnnotationQueueItemSelectionRequestBody,
-        AnnotationQueueResponseBody, ArchiveAnnotationQueueItemsResponseBody,
-        ClearAnnotationQueueItemsResponseBody, CreateAnnotationQueueRequestBody,
-        EnqueueAnnotationQueueItemRequestBody, ListAnnotationQueueItemsQuery,
-        ListAnnotationQueueItemsResponseBody, ListAnnotationQueuesResponseBody,
-        UpdateAnnotationQueueRequestBody,
+    models::{
+        annotation_queues::{
+            AnnotationQueueItemDetailResponseBody, AnnotationQueueItemResponseBody,
+            AnnotationQueueItemSelectionRequestBody, AnnotationQueueResponseBody,
+            ArchiveAnnotationQueueItemsResponseBody, ClearAnnotationQueueItemsResponseBody,
+            CreateAnnotationQueueRequestBody, EnqueueAnnotationQueueItemRequestBody,
+            ListAnnotationQueueItemsQuery, ListAnnotationQueueItemsResponseBody,
+            ListAnnotationQueuesResponseBody, ListQueueReviewsResponseBody,
+            ReviewAnnotationQueueItemRequestBody, UpdateAnnotationQueueRequestBody,
+        },
+        annotations::AnnotateResponseBody,
     },
 };
 
@@ -36,17 +41,47 @@ fn annotation_queue_error_response(value: AnnotationQueueError) -> Response {
             log::error!("[AnnotationQueue] internal error: {err}");
             MetaHttpResponse::internal_error("Internal server error")
         }
+        AnnotationQueueError::Publish(err) => {
+            log::error!("[AnnotationQueue] failed to publish review Scores: {err}");
+            MetaHttpResponse::internal_error("Failed to publish review Scores")
+        }
+        AnnotationQueueError::Search(err) => {
+            log::error!("[AnnotationQueue] failed to query Workbench Scores: {err}");
+            MetaHttpResponse::internal_error("Failed to query Workbench Scores")
+        }
+        AnnotationQueueError::MalformedReviewScore(err) => {
+            log::error!("[AnnotationQueue] malformed review Score: {err}");
+            MetaHttpResponse::internal_error("Malformed review Score")
+        }
+        AnnotationQueueError::MalformedMachineScore(err) => {
+            log::error!("[AnnotationQueue] malformed machine Score: {err}");
+            MetaHttpResponse::internal_error("Malformed machine Score")
+        }
+        AnnotationQueueError::QueueItemSourceStreamNotFound => {
+            log::error!("[AnnotationQueue] Queue Item has no machine Score source stream");
+            MetaHttpResponse::internal_error("Queue Item source stream not found")
+        }
+        AnnotationQueueError::AmbiguousQueueItemSourceStream => {
+            log::error!("[AnnotationQueue] Queue Item resolves to multiple source streams");
+            MetaHttpResponse::internal_error("Queue Item source stream is ambiguous")
+        }
+        AnnotationQueueError::Hydration(err) => {
+            log::error!("[AnnotationQueue] failed to hydrate Queue Item: {err}");
+            MetaHttpResponse::internal_error("Failed to hydrate Queue Item")
+        }
         error @ (AnnotationQueueError::MissingName
         | AnnotationQueueError::MissingScoreConfigs
         | AnnotationQueueError::DuplicateScoreConfigRowIds
         | AnnotationQueueError::TargetDatasetNotFound
         | AnnotationQueueError::InvalidQueueItemStatus(_)
         | AnnotationQueueError::InvalidQueueItemScope(_)
+        | AnnotationQueueError::InvalidQueueId
         | AnnotationQueueError::InvalidQueueItemReference(_)
         | AnnotationQueueError::QueueItemRefTypeNotAllowed(_)
         | AnnotationQueueError::MissingQueueItemIds
         | AnnotationQueueError::InvalidQueueItemIds
-        | AnnotationQueueError::DuplicateQueueItemIds) => MetaHttpResponse::bad_request(error),
+        | AnnotationQueueError::DuplicateQueueItemIds
+        | AnnotationQueueError::Annotation(_)) => MetaHttpResponse::bad_request(error),
         error @ AnnotationQueueError::InvalidScoreConfigRowIds(_) => {
             MetaHttpResponse::bad_request(error)
         }
@@ -54,9 +89,13 @@ fn annotation_queue_error_response(value: AnnotationQueueError) -> Response {
             MetaHttpResponse::bad_request(error)
         }
         AnnotationQueueError::NotFound => MetaHttpResponse::not_found("Annotation Queue not found"),
-        error @ (AnnotationQueueError::DuplicateName | AnnotationQueueError::StaleBindings) => {
-            MetaHttpResponse::conflict(error)
+        AnnotationQueueError::QueueItemNotFound => {
+            MetaHttpResponse::not_found("Annotation Queue Item not found")
         }
+        error @ (AnnotationQueueError::DuplicateName
+        | AnnotationQueueError::StaleBindings
+        | AnnotationQueueError::ArchivedQueueItem
+        | AnnotationQueueError::QueueItemAlreadyQueued) => MetaHttpResponse::conflict(error),
     }
 }
 
@@ -68,7 +107,7 @@ fn annotation_queue_error_response(value: AnnotationQueueError) -> Response {
     tag = "AnnotationQueues",
     operation_id = "EnqueueAnnotationQueueItem",
     summary = "Add a discovered item to an Annotation Queue",
-    description = "Idempotently adds a discovered span, trace, or session to one Annotation Queue. Re-enqueuing the same reference returns the existing QueueItem.",
+    description = "Adds a discovered span, trace, or session to one Annotation Queue. Returns a conflict when the same reference is already in the Queue.",
     security(("Authorization" = [])),
     params(
         ("org_id" = String, Path, description = "Organization name"),
@@ -79,6 +118,7 @@ fn annotation_queue_error_response(value: AnnotationQueueError) -> Response {
         (status = 200, body = inline(AnnotationQueueItemResponseBody)),
         (status = 400, description = "Bad Request", body = ()),
         (status = 404, description = "Annotation Queue not found", body = ()),
+        (status = 409, description = "Item is already queued in this Annotation Queue", body = ()),
     ),
     extensions(("x-o2-ratelimit" = json!({"module": "AnnotationQueues", "operation": "create"}))),
 )]
@@ -92,6 +132,113 @@ pub async fn enqueue_annotation_queue_item(
     }
 }
 
+/// GetAnnotationQueueItem
+#[utoipa::path(
+    get,
+    path = "/{org_id}/annotation_queues/{queue_id}/items/{queue_item_id}",
+    context_path = "/api",
+    tag = "AnnotationQueues",
+    operation_id = "GetAnnotationQueueItem",
+    summary = "Get one hydrated Annotation Queue Item",
+    description = "Uses the Queue Item's stored trace start time through now to load its latest machine Scores, resolve the source trace stream, and hydrate its business input, output, and trace context.",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("queue_id" = String, Path, description = "Annotation Queue ID"),
+        ("queue_item_id" = String, Path, description = "Annotation Queue Item ID"),
+    ),
+    responses(
+        (status = 200, body = inline(AnnotationQueueItemDetailResponseBody)),
+        (status = 404, description = "Queue or Queue Item not found", body = ()),
+        (status = 500, description = "Score lookup or source hydration failed", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "AnnotationQueues", "operation": "get"}))),
+)]
+pub async fn get_annotation_queue_item(
+    Path((org_id, queue_id, queue_item_id)): Path<(String, String, String)>,
+) -> Response {
+    match annotation_queues::get_item_detail(&org_id, &queue_id, &queue_item_id).await {
+        Ok(item) => MetaHttpResponse::json(AnnotationQueueItemDetailResponseBody::from(item)),
+        Err(err) => annotation_queue_error_response(err),
+    }
+}
+
+/// ReviewAnnotationQueueItem
+#[utoipa::path(
+    post,
+    path = "/{org_id}/annotation_queues/{queue_id}/items/{queue_item_id}/reviews",
+    context_path = "/api",
+    tag = "AnnotationQueues",
+    operation_id = "ReviewAnnotationQueueItem",
+    summary = "Submit one complete N/N Workbench review",
+    description = "Validates exact pinned Score Config coverage, writes the immutable review to _llm_scores, and then advances the QueueItem workflow projection to reviewed.",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("queue_id" = String, Path, description = "Annotation Queue ID"),
+        ("queue_item_id" = String, Path, description = "Annotation Queue Item ID"),
+    ),
+    request_body(content = inline(ReviewAnnotationQueueItemRequestBody), description = "Complete N/N review"),
+    responses(
+        (status = 200, body = inline(AnnotateResponseBody)),
+        (status = 400, description = "Incomplete or invalid review", body = ()),
+        (status = 404, description = "Queue or Queue Item not found", body = ()),
+        (status = 409, description = "Stale bindings or archived Queue Item", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "AnnotationQueues", "operation": "update"}))),
+)]
+pub async fn review_annotation_queue_item(
+    Path((org_id, queue_id, queue_item_id)): Path<(String, String, String)>,
+    Headers(user): Headers<UserEmail>,
+    axum::Json(body): axum::Json<ReviewAnnotationQueueItemRequestBody>,
+) -> Response {
+    match annotation_queues::submit_review(
+        &org_id,
+        &queue_id,
+        &queue_item_id,
+        &user.user_id,
+        body.into(),
+        |publish_org_id, records| async move {
+            llm_scores_writer::publish(&publish_org_id, &records).await
+        },
+    )
+    .await
+    {
+        Ok(prepared) => MetaHttpResponse::json(AnnotateResponseBody::from(&prepared)),
+        Err(err) => annotation_queue_error_response(err),
+    }
+}
+
+/// ListAnnotationQueueItemReviews
+#[utoipa::path(
+    get,
+    path = "/{org_id}/annotation_queues/{queue_id}/items/{queue_item_id}/reviews",
+    context_path = "/api",
+    tag = "AnnotationQueues",
+    operation_id = "ListAnnotationQueueItemReviews",
+    summary = "List complete Workbench reviews from _llm_scores",
+    description = "Reads the authoritative annotation Score events, collapses idempotent retries, groups them by review submission ID, and omits incomplete N/N groups.",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("queue_id" = String, Path, description = "Annotation Queue ID"),
+        ("queue_item_id" = String, Path, description = "Annotation Queue Item ID"),
+    ),
+    responses(
+        (status = 200, description = "Complete review submissions"),
+        (status = 404, description = "Queue or Queue Item not found", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "AnnotationQueues", "operation": "list"}))),
+)]
+pub async fn list_annotation_queue_item_reviews(
+    Path((org_id, queue_id, queue_item_id)): Path<(String, String, String)>,
+) -> Response {
+    match annotation_queues::list_reviews(&org_id, &queue_id, &queue_item_id).await {
+        Ok(list) => MetaHttpResponse::json(ListQueueReviewsResponseBody { list }),
+        Err(err) => annotation_queue_error_response(err),
+    }
+}
+
 /// ArchiveAnnotationQueueItems
 #[utoipa::path(
     post,
@@ -100,7 +247,7 @@ pub async fn enqueue_annotation_queue_item(
     tag = "AnnotationQueues",
     operation_id = "ArchiveAnnotationQueueItems",
     summary = "Archive selected Annotation Queue Items",
-    description = "Soft-removes selected Queue Items from the active workflow by setting archivedAt. Existing review submissions and analytics scores are retained.",
+    description = "Soft-removes selected Queue Items from the active workflow by setting archivedAt. Existing review Scores in _llm_scores are retained.",
     security(("Authorization" = [])),
     params(
         ("org_id" = String, Path, description = "Organization name"),
@@ -134,7 +281,7 @@ pub async fn archive_annotation_queue_items(
     tag = "AnnotationQueues",
     operation_id = "ClearAnnotationQueueItems",
     summary = "Clear selected Annotation Queue Items",
-    description = "Permanently removes selected QueueItem workflow rows. Existing immutable review submissions and analytics scores are retained.",
+    description = "Permanently removes selected QueueItem workflow rows. Existing immutable review Scores in _llm_scores are retained.",
     security(("Authorization" = [])),
     params(
         ("org_id" = String, Path, description = "Organization name"),
@@ -185,7 +332,11 @@ pub async fn list_annotation_queue_items(
     Headers(user): Headers<UserEmail>,
     Query(query): Query<ListAnnotationQueueItemsQuery>,
 ) -> Response {
-    let filter = match ListAnnotationQueueItemsFilter::try_from((query.queue_status, query.scope)) {
+    let filter = match ListAnnotationQueueItemsFilter::try_from((
+        query.queue_id,
+        query.queue_status,
+        query.scope,
+    )) {
         Ok(filter) => filter,
         Err(err) => return annotation_queue_error_response(err),
     };
@@ -428,6 +579,12 @@ mod tests {
         );
         assert_eq!(
             annotation_queue_error_response(AnnotationQueueError::StaleBindings)
+                .status()
+                .as_u16(),
+            409
+        );
+        assert_eq!(
+            annotation_queue_error_response(AnnotationQueueError::QueueItemAlreadyQueued)
                 .status()
                 .as_u16(),
             409

--- a/src/api/management/src/request/annotations.rs
+++ b/src/api/management/src/request/annotations.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use axum::{extract::Path, response::Response};
+use openobserve_api_common::extractors::Headers;
+use openobserve_core::{
+    auth::{UserEmail, is_ofga_object_visible},
+    llm_evaluations::annotations::{self, AnnotationError},
+    self_reporting::llm_scores_writer,
+};
+
+use crate::{
+    common::meta::http::HttpResponse as MetaHttpResponse,
+    models::annotations::{AnnotateRequestBody, AnnotateResponseBody},
+};
+
+fn annotation_error_response(value: AnnotationError) -> Response {
+    match value {
+        AnnotationError::Database(err) => {
+            log::error!("[Annotation] internal error: {err}");
+            MetaHttpResponse::internal_error("Internal server error")
+        }
+        error => MetaHttpResponse::bad_request(error),
+    }
+}
+
+/// AnnotateTarget
+#[utoipa::path(
+    post,
+    path = "/{org_id}/annotations",
+    context_path = "/api",
+    tag = "Annotations",
+    operation_id = "AnnotateTarget",
+    summary = "Annotate a span, trace, or session",
+    description = "Validates values against immutable Score Config versions and writes one annotation-source event per Score to the _llm_scores stream.",
+    security(("Authorization" = [])),
+    params(("org_id" = String, Path, description = "Organization name")),
+    request_body(content = inline(AnnotateRequestBody), description = "Target and typed Score values"),
+    responses(
+        (status = 200, body = inline(AnnotateResponseBody)),
+        (status = 400, description = "Invalid target, Score Config, or Score value", body = ()),
+        (status = 403, description = "A selected Score Config is not visible", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "Annotations", "operation": "create"}))),
+)]
+pub async fn annotate_target(
+    Path(org_id): Path<String>,
+    Headers(user): Headers<UserEmail>,
+    axum::Json(body): axum::Json<AnnotateRequestBody>,
+) -> Response {
+    let prepared = match annotations::prepare(&org_id, &user.user_id, body.into()).await {
+        Ok(prepared) => prepared,
+        Err(err) => return annotation_error_response(err),
+    };
+
+    let permitted_objects = match openobserve_api_common::auth::validator::list_objects_for_user(
+        &org_id,
+        &user.user_id,
+        "GET",
+        "score_config",
+    )
+    .await
+    {
+        Ok(list) => list,
+        Err(err) => return MetaHttpResponse::forbidden(err.to_string()),
+    };
+    if prepared.records.iter().any(|record| {
+        record.score_config_id.as_deref().is_none_or(|config_id| {
+            !is_ofga_object_visible(
+                &org_id,
+                "score_config",
+                config_id,
+                permitted_objects.as_deref(),
+            )
+        })
+    }) {
+        return MetaHttpResponse::forbidden(
+            "One or more selected Score Configs are not accessible",
+        );
+    }
+
+    let response = AnnotateResponseBody::from(&prepared);
+    if let Err(err) = llm_scores_writer::publish(&org_id, &prepared.records).await {
+        log::error!("[Annotation] failed to publish Scores for {org_id}: {err}");
+        return MetaHttpResponse::internal_error("Failed to publish annotation Scores");
+    }
+
+    MetaHttpResponse::json(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_errors_are_bad_requests() {
+        let response = annotation_error_response(AnnotationError::MissingTargetId);
+        assert_eq!(response.status().as_u16(), 400);
+    }
+}

--- a/src/api/management/src/request/mod.rs
+++ b/src/api/management/src/request/mod.rs
@@ -22,6 +22,8 @@ pub mod alerts;
 #[cfg(feature = "enterprise")]
 pub mod annotation_queues;
 #[cfg(feature = "enterprise")]
+pub mod annotations;
+#[cfg(feature = "enterprise")]
 pub mod anomaly_detection;
 pub mod authz;
 #[cfg(feature = "cloud")]

--- a/src/config/src/meta/self_reporting/llm_scores.rs
+++ b/src/config/src/meta/self_reporting/llm_scores.rs
@@ -13,7 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, btree_map::Entry};
+use std::{
+    collections::{BTreeMap, btree_map::Entry},
+    fmt,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -47,12 +50,80 @@ pub enum LlmScoreDataType {
     Boolean,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LlmScoreTargetScope {
     Span,
     Trace,
     Session,
+}
+
+impl fmt::Display for LlmScoreTargetScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Span => "span",
+            Self::Trace => "trace",
+            Self::Session => "session",
+        })
+    }
+}
+
+impl From<LlmScoreTargetScope> for LlmScoreDataLevel {
+    fn from(value: LlmScoreTargetScope) -> Self {
+        match value {
+            LlmScoreTargetScope::Span => Self::Span,
+            LlmScoreTargetScope::Trace => Self::Trace,
+            LlmScoreTargetScope::Session => Self::Session,
+        }
+    }
+}
+
+/// Producer identity used to build the read-side deduplication key.
+#[derive(Clone, Copy, Debug)]
+pub enum LlmScoreEvaluationSource<'a> {
+    Automated {
+        job_id: &'a str,
+        scorer_id: &'a str,
+    },
+    Annotation {
+        annotation_id: &'a str,
+        score_config_id: &'a str,
+    },
+}
+
+/// Build the stable JSON identity used to select the latest Score from one
+/// producer for one target. Automated producer IDs come from the evaluation
+/// job; annotation and Score Config IDs are generated or resolved server-side.
+/// The JSON is stored as a string because SQL and OpenTelemetry consume the key
+/// as a scalar.
+pub fn evaluation_key(
+    org_id: &str,
+    source: LlmScoreEvaluationSource<'_>,
+    target_scope: LlmScoreTargetScope,
+    target_id: &str,
+) -> String {
+    match source {
+        LlmScoreEvaluationSource::Automated { job_id, scorer_id } => serde_json::json!({
+            "orgId": org_id,
+            "source": "automated",
+            "jobId": job_id,
+            "scorerId": scorer_id,
+            "scope": target_scope,
+            "targetId": target_id,
+        }),
+        LlmScoreEvaluationSource::Annotation {
+            annotation_id,
+            score_config_id,
+        } => serde_json::json!({
+            "orgId": org_id,
+            "source": "annotation",
+            "annotationId": annotation_id,
+            "scoreConfigId": score_config_id,
+            "scope": target_scope,
+            "targetId": target_id,
+        }),
+    }
+    .to_string()
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -67,6 +138,10 @@ pub struct LlmScoreRecord {
     pub target_id: String,
     pub evaluation_key: String,
     pub score_version: i64,
+    /// Timestamp of the evaluated span, trace, or session. This stays distinct
+    /// from `_timestamp`, which records when the Score itself was written.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ref_timestamp: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub span_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -110,6 +185,10 @@ pub struct LlmScoreRecord {
     /// review submission.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub review_submission_score_count: Option<i64>,
+    /// Overall comment for the complete Review Submission. Annotation
+    /// projection repeats this value on each Score in the submission.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_submission_comments: Option<String>,
     pub source_type: LlmScoreDataSourceType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_stream: Option<String>,
@@ -130,10 +209,6 @@ pub struct LlmScoreRecord {
     /// Justification for this individual Score dimension.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<String>,
-    /// Overall comment for the complete Review Submission. Annotation
-    /// projection repeats this value on each Score in the submission.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub review_submission_comments: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -141,8 +216,8 @@ pub struct LlmScoreRecord {
     pub _timestamp: i64,
 }
 
-impl LlmScoreRecord {
-    pub fn init_for_reflection() -> Self {
+impl Default for LlmScoreRecord {
+    fn default() -> Self {
         Self {
             id: String::new(),
             task_id: String::new(),
@@ -153,16 +228,55 @@ impl LlmScoreRecord {
             target_id: String::new(),
             evaluation_key: String::new(),
             score_version: 0,
+            ref_timestamp: None,
+            span_id: None,
+            trace_id: None,
+            session_id: None,
+            experiment_id: None,
+            level: LlmScoreDataLevel::Span,
+            name: String::new(),
+            value_numeric: None,
+            value_categorical: None,
+            value_boolean: None,
+            data_type: LlmScoreDataType::Numeric,
+            scorer_id: None,
+            scorer_version: None,
+            score_config_id: None,
+            score_config_version: None,
+            score_config_row_id: None,
+            review_submission_id: None,
+            queue_id: None,
+            queue_item_id: None,
+            review_submission_score_count: None,
+            review_submission_comments: None,
+            source_type: LlmScoreDataSourceType::LlmJudge,
+            source_stream: None,
+            source_stream_type: None,
+            agent_name: None,
+            agent_id: None,
+            agent_env: None,
+            agent_version: None,
+            job_id: None,
+            job_version: None,
+            reasoning: None,
+            metadata: None,
+            author: None,
+            _timestamp: 0,
+        }
+    }
+}
+
+impl LlmScoreRecord {
+    pub fn init_for_reflection() -> Self {
+        Self {
+            ref_timestamp: Some(0),
             span_id: Some(String::new()),
             trace_id: Some(String::new()),
             session_id: Some(String::new()),
             experiment_id: Some(String::new()),
-            level: LlmScoreDataLevel::Span,
-            name: String::new(),
             value_numeric: Some(0.0),
             value_categorical: Some(String::new()),
             value_boolean: Some(false),
-            data_type: LlmScoreDataType::Numeric,
             scorer_id: Some(String::new()),
             scorer_version: Some(String::new()),
             score_config_id: Some(String::new()),
@@ -172,20 +286,17 @@ impl LlmScoreRecord {
             queue_id: Some(String::new()),
             queue_item_id: Some(String::new()),
             review_submission_score_count: Some(0),
-            source_type: LlmScoreDataSourceType::LlmJudge,
+            review_submission_comments: Some(String::new()),
             source_stream: Some(String::new()),
             source_stream_type: Some(String::new()),
-            agent_name: None,
-            agent_id: None,
             agent_env: Some(String::new()),
             agent_version: Some(String::new()),
             job_id: Some(String::new()),
             job_version: Some(0),
             reasoning: Some(String::new()),
-            review_submission_comments: Some(String::new()),
             metadata: Some(serde_json::json!({})),
             author: Some(String::new()),
-            _timestamp: 0,
+            ..Self::default()
         }
     }
 
@@ -238,6 +349,7 @@ mod tests {
             target_id: "span-1".to_string(),
             evaluation_key: evaluation_key.to_string(),
             score_version,
+            ref_timestamp: None,
             span_id: Some("span-1".to_string()),
             trace_id: Some("trace-1".to_string()),
             session_id: None,
@@ -257,6 +369,7 @@ mod tests {
             queue_id: None,
             queue_item_id: None,
             review_submission_score_count: None,
+            review_submission_comments: None,
             source_type,
             source_stream: Some("traces".to_string()),
             source_stream_type: Some("traces".to_string()),
@@ -267,7 +380,6 @@ mod tests {
             job_id: Some("job-1".to_string()),
             job_version: Some(1),
             reasoning: None,
-            review_submission_comments: None,
             metadata: None,
             author: None,
             _timestamp: timestamp,
@@ -277,6 +389,7 @@ mod tests {
     #[test]
     fn test_llm_score_record_round_trip() {
         let record = LlmScoreRecord {
+            ref_timestamp: Some(1699999999000),
             id: "s-1".to_string(),
             task_id: "task-1".to_string(),
             eval_run_id: "run-1".to_string(),
@@ -284,27 +397,26 @@ mod tests {
             org_id: "org-1".to_string(),
             target_scope: LlmScoreTargetScope::Span,
             target_id: "span-1".to_string(),
-            evaluation_key: "org=org-1;job=job-1;scorer=sc-1;scope=span;target=span-1".to_string(),
+            evaluation_key: serde_json::json!({
+                "orgId": "org-1",
+                "source": "automated",
+                "jobId": "job-1",
+                "scorerId": "sc-1",
+                "scope": "span",
+                "targetId": "span-1",
+            })
+            .to_string(),
             score_version: 1700000000000,
             span_id: Some("span-1".to_string()),
             trace_id: Some("trace-1".to_string()),
-            session_id: None,
-            experiment_id: None,
             level: LlmScoreDataLevel::Span,
             name: "faithfulness".to_string(),
             value_numeric: Some(0.95),
-            value_categorical: None,
-            value_boolean: None,
             data_type: LlmScoreDataType::Numeric,
             scorer_id: Some("sc-1".to_string()),
             scorer_version: Some("1".to_string()),
             score_config_id: Some("cfg-entity-1".to_string()),
             score_config_version: Some("1".to_string()),
-            score_config_row_id: None,
-            review_submission_id: None,
-            queue_id: None,
-            queue_item_id: None,
-            review_submission_score_count: None,
             source_type: LlmScoreDataSourceType::LlmJudge,
             source_stream: Some("traces".to_string()),
             source_stream_type: Some("traces".to_string()),
@@ -314,11 +426,8 @@ mod tests {
             agent_version: Some("1.2.0".to_string()),
             job_id: Some("job-1".to_string()),
             job_version: Some(1),
-            reasoning: None,
-            review_submission_comments: None,
-            metadata: None,
-            author: None,
             _timestamp: 1700000000000,
+            ..LlmScoreRecord::default()
         };
         let json = serde_json::to_string(&record).unwrap();
         let back: LlmScoreRecord = serde_json::from_str(&json).unwrap();
@@ -327,6 +436,7 @@ mod tests {
         assert_eq!(back.target_scope, LlmScoreTargetScope::Span);
         assert_eq!(back.target_id, "span-1");
         assert_eq!(back.score_version, 1700000000000);
+        assert_eq!(back.ref_timestamp, Some(1699999999000));
         assert_eq!(back.span_id, Some("span-1".to_string()));
         assert_eq!(back.value_numeric, Some(0.95));
         assert_eq!(back.level, LlmScoreDataLevel::Span);
@@ -370,6 +480,7 @@ mod tests {
         assert!(obj.contains_key("target_id"));
         assert!(obj.contains_key("evaluation_key"));
         assert!(obj.contains_key("score_version"));
+        assert!(obj.contains_key("ref_timestamp"));
         assert!(obj.contains_key("span_id"));
         assert!(obj.contains_key("trace_id"));
         assert!(obj.contains_key("session_id"));
@@ -415,45 +526,23 @@ mod tests {
             org_id: "org-1".to_string(),
             target_scope: LlmScoreTargetScope::Trace,
             target_id: "trace-1".to_string(),
-            evaluation_key: "org=org-1;job=;scorer=;scope=trace;target=trace-1".to_string(),
-            score_version: 0,
-            span_id: None,
-            trace_id: None,
-            session_id: None,
-            experiment_id: None,
+            evaluation_key: serde_json::json!({
+                "orgId": "org-1",
+                "source": "automated",
+                "jobId": "",
+                "scorerId": "",
+                "scope": "trace",
+                "targetId": "trace-1",
+            })
+            .to_string(),
             level: LlmScoreDataLevel::Trace,
             name: "test".to_string(),
-            value_numeric: None,
-            value_categorical: None,
-            value_boolean: None,
-            data_type: LlmScoreDataType::Numeric,
-            scorer_id: None,
-            scorer_version: None,
-            score_config_id: None,
-            score_config_version: None,
-            score_config_row_id: None,
-            review_submission_id: None,
-            queue_id: None,
-            queue_item_id: None,
-            review_submission_score_count: None,
-            source_type: LlmScoreDataSourceType::LlmJudge,
-            source_stream: None,
-            source_stream_type: None,
-            agent_name: None,
-            agent_id: None,
-            agent_env: None,
-            agent_version: None,
-            job_id: None,
-            job_version: None,
-            reasoning: None,
-            review_submission_comments: None,
-            metadata: None,
-            author: None,
-            _timestamp: 0,
+            ..LlmScoreRecord::default()
         };
         let json = serde_json::to_value(&record).unwrap();
         let obj = json.as_object().unwrap();
         assert!(!obj.contains_key("span_id"));
+        assert!(!obj.contains_key("ref_timestamp"));
         assert!(!obj.contains_key("trace_id"));
         assert!(!obj.contains_key("session_id"));
         assert!(!obj.contains_key("experiment_id"));
@@ -589,5 +678,69 @@ mod tests {
             serde_json::to_string(&LlmScoreDataType::Boolean).unwrap(),
             "\"boolean\""
         );
+    }
+
+    #[test]
+    fn target_scope_display_matches_stream_values() {
+        assert_eq!(LlmScoreTargetScope::Span.to_string(), "span");
+        assert_eq!(LlmScoreTargetScope::Trace.to_string(), "trace");
+        assert_eq!(LlmScoreTargetScope::Session.to_string(), "session");
+    }
+
+    #[test]
+    fn evaluation_keys_are_structured_json() {
+        let automated = evaluation_key(
+            "org=1",
+            LlmScoreEvaluationSource::Automated {
+                job_id: "job;1",
+                scorer_id: "scorer%1",
+            },
+            LlmScoreTargetScope::Span,
+            "span=1;2",
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&automated).unwrap(),
+            serde_json::json!({
+                "orgId": "org=1",
+                "source": "automated",
+                "jobId": "job;1",
+                "scorerId": "scorer%1",
+                "scope": "span",
+                "targetId": "span=1;2",
+            })
+        );
+
+        let annotation = evaluation_key(
+            "org-1",
+            LlmScoreEvaluationSource::Annotation {
+                annotation_id: "annotation-1",
+                score_config_id: "config-1",
+            },
+            LlmScoreTargetScope::Trace,
+            "trace-1",
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&annotation).unwrap(),
+            serde_json::json!({
+                "orgId": "org-1",
+                "source": "annotation",
+                "annotationId": "annotation-1",
+                "scoreConfigId": "config-1",
+                "scope": "trace",
+                "targetId": "trace-1",
+            })
+        );
+    }
+
+    #[test]
+    fn score_record_default_is_safe_for_selective_construction() {
+        let record = LlmScoreRecord::default();
+        assert!(record.id.is_empty());
+        assert_eq!(record.target_scope, LlmScoreTargetScope::Span);
+        assert_eq!(record.level, LlmScoreDataLevel::Span);
+        assert_eq!(record.data_type, LlmScoreDataType::Numeric);
+        assert!(record.scorer_id.is_none());
+        assert!(record.agent_id.is_none());
+        assert!(record.ref_timestamp.is_none());
     }
 }

--- a/src/core/src/llm_evaluations/mod.rs
+++ b/src/core/src/llm_evaluations/mod.rs
@@ -17,6 +17,6 @@ pub mod eval_jobs;
 pub mod evaluator_trace_exporter;
 
 pub use o2_enterprise::enterprise::llm_evaluations::{
-    annotation_queues, datasets, evaluator_trace, prepared_scorers, score_configs, score_writer,
-    scorers,
+    annotation_queues, annotations, datasets, evaluator_trace, prepared_scorers, score_configs,
+    score_writer, scorers,
 };

--- a/src/core/src/self_reporting/llm_scores_schema.rs
+++ b/src/core/src/self_reporting/llm_scores_schema.rs
@@ -135,6 +135,7 @@ mod tests {
         assert!(obj.contains_key("target_id"));
         assert!(obj.contains_key("evaluation_key"));
         assert!(obj.contains_key("score_version"));
+        assert!(obj.contains_key("ref_timestamp"));
         assert!(obj.contains_key("job_version"));
         assert!(obj.contains_key("span_id"));
         assert!(obj.contains_key("trace_id"));
@@ -170,6 +171,7 @@ mod tests {
         assert!(schema.field_with_name("value_numeric").is_ok());
         assert!(schema.field_with_name("value_categorical").is_ok());
         assert!(schema.field_with_name("value_boolean").is_ok());
+        assert!(schema.field_with_name("ref_timestamp").is_ok());
         assert!(schema.field_with_name("score_config_row_id").is_ok());
         assert!(schema.field_with_name("review_submission_id").is_ok());
         assert!(schema.field_with_name("queue_id").is_ok());

--- a/src/core/src/self_reporting/llm_scores_writer.rs
+++ b/src/core/src/self_reporting/llm_scores_writer.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Publishes typed Score records to the reserved `_llm_scores` stream.
+
+use anyhow::Result;
+use config::meta::{
+    self_reporting::llm_scores::{LLM_SCORES_STREAM, LlmScoreRecord},
+    stream::{StreamParams, StreamType},
+};
+
+/// Publish a complete annotation batch as one internal ingestion request.
+pub async fn publish(org_id: &str, records: &[LlmScoreRecord]) -> Result<()> {
+    if records.is_empty() {
+        return Ok(());
+    }
+
+    super::llm_scores_schema::ensure_llm_scores_stream_initialized(org_id).await?;
+    let values = records
+        .iter()
+        .map(config::utils::json::to_value)
+        .collect::<Result<Vec<_>, _>>()?;
+    let stream = StreamParams::new(org_id, LLM_SCORES_STREAM, StreamType::Logs);
+
+    super::ingestion::ingest_reporting_data(values, stream).await
+}

--- a/src/core/src/self_reporting/mod.rs
+++ b/src/core/src/self_reporting/mod.rs
@@ -20,6 +20,8 @@ pub mod evaluator_schema;
 mod ingestion;
 #[cfg(feature = "enterprise")]
 pub mod llm_scores_schema;
+#[cfg(feature = "enterprise")]
+pub mod llm_scores_writer;
 pub(crate) mod persistence;
 pub mod search;
 mod triggers_schema;

--- a/src/jobs/src/job/llm_review_reconciliation.rs
+++ b/src/jobs/src/job/llm_review_reconciliation.rs
@@ -1,0 +1,66 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+//! Repairs the eventual-consistency gap between authoritative `_llm_scores`
+//! review ingestion and the PostgreSQL QueueItem workflow projection.
+
+use config::{cluster::LOCAL_NODE, spawn_pausable_job};
+
+const RECONCILE_BATCH_SIZE: u64 = 1_000;
+
+pub fn run() {
+    if !LOCAL_NODE.is_alert_manager() {
+        log::debug!("[LLM_REVIEW_RECONCILIATION] not an alert_manager node, skipping");
+        return;
+    }
+    if !o2_enterprise::enterprise::common::config::get_config()
+        .llm_eval_config
+        .enabled
+    {
+        log::debug!("[LLM_REVIEW_RECONCILIATION] LLM evaluations disabled, skipping");
+        return;
+    }
+
+    spawn_pausable_job!(
+        "llm_review_reconciliation",
+        o2_enterprise::enterprise::common::config::get_config()
+            .llm_eval_config
+            .review_reconcile_interval_secs,
+        {
+            let is_leader = match infra::cluster::get_cached_online_nodes().await {
+                Some(mut nodes) => {
+                    nodes.retain(|node| node.is_alert_manager());
+                    nodes.sort_by(|left, right| left.uuid.cmp(&right.uuid));
+                    nodes
+                        .first()
+                        .is_none_or(|leader| leader.uuid == LOCAL_NODE.uuid)
+                }
+                None => true,
+            };
+            if !is_leader {
+                log::debug!("[LLM_REVIEW_RECONCILIATION] not leader, skipping this pass");
+                continue;
+            }
+
+            match o2_enterprise::enterprise::llm_evaluations::annotation_queues::reconcile_pending_reviews(
+                RECONCILE_BATCH_SIZE,
+            )
+            .await
+            {
+                Ok(0) => log::debug!(
+                    "[LLM_REVIEW_RECONCILIATION] no QueueItems required repair"
+                ),
+                Ok(repaired) => log::info!(
+                    "[LLM_REVIEW_RECONCILIATION] repaired {repaired} QueueItem(s)"
+                ),
+                Err(error) => log::error!(
+                    "[LLM_REVIEW_RECONCILIATION] reconciliation failed: {error}"
+                ),
+            }
+        }
+    );
+}

--- a/src/jobs/src/job/mod.rs
+++ b/src/jobs/src/job/mod.rs
@@ -39,6 +39,8 @@ pub(crate) mod files;
 mod flatten_compactor;
 #[cfg(feature = "enterprise")]
 mod incidents;
+#[cfg(feature = "enterprise")]
+mod llm_review_reconciliation;
 pub mod metrics;
 mod mmdb_downloader;
 #[cfg(feature = "enterprise")]
@@ -1086,6 +1088,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
     // climbs past what its window can hold. Also releases expired budget
     // residuals (S-14c).
     slo_maintenance::run();
+    // `_llm_scores` is authoritative for Workbench reviews. Repair the narrow
+    // failure window where ingestion succeeded but QueueItem status did not.
+    #[cfg(feature = "enterprise")]
+    llm_review_reconciliation::run();
 
     if LOCAL_NODE.is_compactor() {
         tokio::task::spawn(file_list_dump::run());


### PR DESCRIPTION
Add inline manual annotation and Annotation Queue review endpoints backed by the authoritative _llm_scores stream.

Queue submissions validate exact pinned N/N coverage, publish deterministic score events carrying Queue and QueueItem provenance, expose only complete retry-deduplicated groups from the stored trace-start bound, and advance QueueItem state only after ingestion succeeds.

Add a leader-only, configurable, pausable reconciliation job that keyset-scans pending items and repairs the narrow failure window where stream ingestion succeeded but the PostgreSQL status update did not.

---
**Stack**:
- #13714
- #13713
- #13712
- #13711
- #13660
- #13649
- #13648
- #13634
- #13629
- #13623
- #13620
- #13608 ⬅
- #13607
- #13597
- #13596
- #13595
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*