### PR TITLE
test(e2e): fix Alpha1 shard failures (Alerts SSRF, sanity time-range, lazy Monaco, traces settle)

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -3340,6 +3340,25 @@ export class LogsPage {
         }, this.queryEditor);
     }
 
+    /**
+     * Read the query-editor text, polling until it is populated. Monaco is lazy-loaded and
+     * prefills its model asynchronously (e.g. after a saved view is applied on a fresh page
+     * load), so a one-shot read can catch an empty editor and return "". Poll instead: return
+     * the text once it is non-empty (or contains `expectedSubstring` when given). If the editor
+     * never populates, expect.poll throws on timeout — so a genuine prefill failure still fails
+     * the test rather than being masked.
+     * @param {string} [expectedSubstring] substring that must be present before returning
+     * @param {number} [timeout] max time to wait for the editor to populate, ms
+     */
+    async getQueryEditorTextWhenReady(expectedSubstring = '', timeout = 15000) {
+        let last = '';
+        await expect.poll(async () => {
+            last = (await this.getQueryEditorText()) || '';
+            return expectedSubstring ? last.includes(expectedSubstring) : last.trim().length > 0;
+        }, { timeout, intervals: [300, 500, 800, 1200] }).toBe(true);
+        return last;
+    }
+
     async clickLogTableColumnSource() {
         // Open the first result row's detail/search-around. With the FTS
         // default-column feature the first cell may be the generic "source"

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -1529,6 +1529,11 @@ export class LogsPage {
         await this.page.locator('[data-test="date-time-relative-15-m-btn"]').click();
     }
 
+    async setDateTimeToPast1Hour() {
+        await this.page.locator(this.dateTimeButton).click();
+        await this.page.locator(this.relative1HourButton).click();
+    }
+
     async setAbsoluteDate(year, month, day, currentMonth, currentYear) {
         await this.page.locator(this.dateTimeButton).click();
         await this.page.locator(this.absoluteTab).click();

--- a/tests/ui-testing/playwright-tests/Alerts/alerts-advanced.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alerts-advanced.spec.js
@@ -21,10 +21,14 @@ const TEST_STREAM = 'e2e_automate';
 // Test timeout constants (in milliseconds)
 const NETWORK_IDLE_TIMEOUT_MS = 30000;
 
-// Self-contained notification sink — this instance's own ingest, replacing the previous
-// external webhook placeholder (no third-party dependency or rate limit). These tests only
-// need a destination that SAVES; delivery is not asserted here.
-const notificationSinkUrl = () => `${process.env.ZO_BASE_URL}/api/${getOrgIdentifier()}/alerts_notify_sink/_json`;
+// Notification sink URL for the destinations these tests create. These tests only need a
+// destination that SAVES; delivery is never triggered or asserted here.
+// NOTE: must be a PUBLIC host. Pointing at this instance's own ingest (ZO_BASE_URL) fails on
+// cloud/alpha, where ZO_BASE_URL resolves to a private IP and the backend's SSRF guard rejects
+// the save ("Destination URL blocked by SSRF guard: private IP ... not allowed"), leaving the
+// form open forever. example.com is IANA-reserved for documentation: it resolves to a public IP
+// (passes the SSRF guard) and is never actually delivered to (no third-party dependency / rate limit).
+const notificationSinkUrl = () => 'https://example.com/webhook';
 
 test.describe("Alerts Advanced Coverage Tests", () => {
     let pm;

--- a/tests/ui-testing/playwright-tests/GeneralTests/sanity.spec.js
+++ b/tests/ui-testing/playwright-tests/GeneralTests/sanity.spec.js
@@ -49,7 +49,18 @@ test.describe("Sanity Test Cases", () => {
     } catch (error) {
       testLogger.warn('Stream selection failed, continuing test', { error: error.message });
     }
-    
+
+    // Query over the last hour, not the default "Past 15 Minutes". On shared/cloud envs
+    // ingestion to e2e_automate is bursty, so the last 15 min is frequently EMPTY — the
+    // result-summary/pagination tests then find no rows and time out on the result table.
+    // The last hour reliably contains data, making these tests deterministic.
+    try {
+      await pm.logsPage.setDateTimeToPast1Hour();
+      testLogger.info('Time range set to Past 1 Hour');
+    } catch (error) {
+      testLogger.warn('Setting time range failed, continuing test', { error: error.message });
+    }
+
     testLogger.info('Test setup completed');
   });
 

--- a/tests/ui-testing/playwright-tests/Logs/monaco-query-prefill.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/monaco-query-prefill.spec.js
@@ -191,10 +191,12 @@ test.describe("Monaco Editor Query Pre-fill Tests", () => {
 
     // Click the saved view to apply
     await pm.logsPage.clickSavedViewByName(savedViewName);
-    await page.waitForTimeout(2000);
 
-    // Step 10: Verify Monaco editor contains the saved query
-    const editorContent = await pm.logsPage.getQueryEditorText();
+    // Step 10: Verify Monaco editor contains the saved query. Monaco is lazy-loaded and
+    // prefills asynchronously after the saved view is applied, so poll the editor value
+    // until the query lands instead of reading once after a fixed wait (which caught an
+    // empty editor on CI). Still fails if the editor never populates.
+    const editorContent = await pm.logsPage.getQueryEditorTextWhenReady('SELECT', 20000);
     testLogger.info('Editor content after applying saved view', { content: editorContent });
 
     // Verify query structure is preserved

--- a/tests/ui-testing/playwright-tests/Traces/tracesSearch.spec.js
+++ b/tests/ui-testing/playwright-tests/Traces/tracesSearch.spec.js
@@ -226,13 +226,17 @@ test.describe("Traces Search testcases", () => {
       // Verify the search bar is still functional
       await pm.tracesPage.expectSearchBarVisible();
 
-      // Verify we can see either results or a proper message
-      const hasResults = await pm.tracesPage.hasTraceResults();
-      const hasNoResults = await pm.tracesPage.isNoResultsVisible();
-
-      // At least one state should be present
-      const validState = hasResults || hasNoResults;
-      expect(validState).toBeTruthy();
+      // Verify we can see either results or a proper message. The trace search settles
+      // asynchronously, so a single read of both checks can catch the in-between state
+      // where neither has rendered yet (both false) — the CI failure here. Poll until one
+      // terminal state appears; if neither ever does, the poll still times out and fails.
+      let hasResults = false, hasNoResults = false;
+      await expect.poll(async () => {
+        hasResults = await pm.tracesPage.hasTraceResults();
+        if (hasResults) return true;
+        hasNoResults = await pm.tracesPage.isNoResultsVisible();
+        return hasResults || hasNoResults;
+      }, { timeout: 20000, intervals: [500, 1000, 1500, 2000] }).toBe(true);
       testLogger.info(`Stream selected state verified: hasResults=${hasResults}, hasNoResults=${hasNoResults}`);
     } else {
       // Neither state is visible - this might be a different UI state or error


### PR DESCRIPTION
## Alpha1 (Cloud) E2E — shard-by-shard failure fixes

Fixes real, root-caused failures from Alpha1 run [30876689608](https://github.com/openobserve/o2-enterprise/actions/runs/30876689608) (5 red shards, 16 hard failures). Each root cause was reproduced live against alpha via Playwright MCP. **8 of 16 hard failures are fixed here in code**; the remaining 8 are environment/data-timing driven (backend instability during the run's 04:15–04:18 ingest window) and need a re-run, not a code change.

### Fixes

| Shard | Fix | Root cause |
|---|---|---|
| **Alerts** (4) | `alerts-advanced.spec.js` destination URL → `https://example.com/webhook` | The self-host URL `${ZO_BASE_URL}/…/alerts_notify_sink/_json` resolves to a **private IP** on cloud, so the backend **SSRF guard rejects the save** → the New Destination form never closes → `createDestination()` times out, failing all 4 Alerts-Advanced tests. Verified live: private-IP URL is blocked, `example.com` (public, IANA-reserved, never delivered to) saves and closes the form. |
| **GeneralTests** (2 + 2 flaky) | sanity `beforeEach` → `setDateTimeToPast1Hour()` (+ new `logsPage` helper) | The result-summary/pagination tests query the default **Past 15 Minutes**. `e2e_automate` ingestion is bursty on shared/cloud envs — **0 rows in 15m vs 7,850 in 1h** (confirmed via API) — so the result table never renders. This is exactly the failed-vs-flaky split seen on the run. |
| **Logs-Features** (1) | `monaco-query-prefill.spec.js` → poll `getQueryEditorTextWhenReady()` | Lazy Monaco prefills its model asynchronously after a saved view is applied on a fresh page load. A one-shot read after a fixed 2s caught an empty editor (`Received: ""`). Now polls until the query lands. Non-masking: if it never prefills, the poll still times out and the test fails. |
| **Traces** (1 of 2) | `tracesSearch.spec.js` → poll for a settled results/no-results state | The "no stream selected state" test read `hasTraceResults()`/`isNoResultsVisible()` once each; the async search settle left both momentarily false. Now polls until one terminal state renders. |

### Not changed (deliberately)

- **Traces `traceQueryEditor.spec.js:151`** — the detail-tree check already waits 10s; its failure means the error-trace detail didn't open, which needs error-trace data in-window to validate. Weakening the assertion would mask real behavior.
- **GeneralTests `enrichment.spec.js:101`, `logoManagement.spec.js:18`** — ran during the backend-instability window and can't be reproduced live. `[name='home']` is **not** stale (present live) and `_meta` access is fine for the test user. Env/timing.
- **Pipelines (all 5)** — UI-click timeouts (`…-update-pipeline` / `Explore` button not found) because pipeline creation / stream data was unavailable while the backend returned *"No online node" / "Proxy request" / "Expected N records, got 0"*. Same selectors 42 passing tests in the shard use. Env-driven → re-run to confirm.

### Validation
- All fixes reproduced/verified live on alpha via Playwright MCP (`e2etest1@o2-qa.com`, `auto_org_1`).
- All 4 edited specs parse and list (`playwright test --list`).
- Full local runs are blocked by an unrelated issue: the Dex login UI changed (new "Continue with Email" flow) so `global-setup.js` can't authenticate locally; CI uses the shared-auth artifact. (Worth a separate fix.)
