### PR TITLE
ci: lint all Rust workspace targets

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -83,7 +83,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo --config net.git-fetch-with-cli=true clippy -- -D warnings
+        run: cargo --config net.git-fetch-with-cli=true clippy --workspace --all-targets -- -D warnings
 
   backend_unit_tests_postgres:
     needs: [check_changes]

--- a/src/api/search/src/traces/user.rs
+++ b/src/api/search/src/traces/user.rs
@@ -622,7 +622,6 @@ mod tests {
                 end_time: 2000,
                 gen_ai_usage_total_tokens: 150,
                 gen_ai_usage_cost: 0.01,
-                ..Default::default()
             },
         );
         trace_details.insert(
@@ -632,7 +631,6 @@ mod tests {
                 end_time: 3000,
                 gen_ai_usage_total_tokens: 300,
                 gen_ai_usage_cost: 0.02,
-                ..Default::default()
             },
         );
 
@@ -661,7 +659,6 @@ mod tests {
                 end_time: 200,
                 gen_ai_usage_total_tokens: 0,
                 gen_ai_usage_cost: 0.0,
-                ..Default::default()
             },
         );
         trace_details.insert(
@@ -671,7 +668,6 @@ mod tests {
                 end_time: 9000,
                 gen_ai_usage_total_tokens: 0,
                 gen_ai_usage_cost: 0.0,
-                ..Default::default()
             },
         );
 
@@ -709,7 +705,6 @@ mod tests {
                     end_time: start + 50,
                     gen_ai_usage_total_tokens: 0,
                     gen_ai_usage_cost: 0.0,
-                    ..Default::default()
                 },
             );
         }
@@ -737,7 +732,6 @@ mod tests {
             end_time: 2000,
             gen_ai_usage_total_tokens: 100,
             gen_ai_usage_cost: 0.05,
-            ..Default::default()
         }];
         let user = UserResponseItem::from_trace_details("user-1".to_string(), 1, &details);
         assert_eq!(user.user_id, "user-1");
@@ -756,14 +750,12 @@ mod tests {
                 end_time: 1500,
                 gen_ai_usage_total_tokens: 100,
                 gen_ai_usage_cost: 0.01,
-                ..Default::default()
             },
             TraceDetail {
                 start_time: 1000,
                 end_time: 3000,
                 gen_ai_usage_total_tokens: 200,
                 gen_ai_usage_cost: 0.02,
-                ..Default::default()
             },
         ];
         let user = UserResponseItem::from_trace_details("user-1".to_string(), 2, &details);

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -4349,7 +4349,7 @@ mod tests {
         let mut cfg = Config::default();
         cfg.nats.queue_max_size = 1;
         check_nats_config(&mut cfg).unwrap();
-        assert_eq!(cfg.nats.queue_max_size, 1 * 1024 * 1024);
+        assert_eq!(cfg.nats.queue_max_size, 1024 * 1024);
     }
 
     #[test]
@@ -4573,7 +4573,7 @@ mod tests {
         cfg.limit.ingest_allowed_upto = 1;
         cfg.limit.ingest_allowed_in_future = 2;
         check_limit_config(&mut cfg).unwrap();
-        assert_eq!(cfg.limit.ingest_allowed_upto_micro, 1 * 3600 * 1_000_000);
+        assert_eq!(cfg.limit.ingest_allowed_upto_micro, 3600 * 1_000_000);
         assert_eq!(
             cfg.limit.ingest_allowed_in_future_micro,
             2 * 3600 * 1_000_000

--- a/src/config/src/ider.rs
+++ b/src/config/src/ider.rs
@@ -447,11 +447,11 @@ mod tests {
 
         // Allow for some tolerance (within last hour and next hour)
         assert!(
-            timestamp >= now - 3600_000_000,
+            timestamp >= now - 3_600_000_000,
             "Timestamp should not be too far in past"
         );
         assert!(
-            timestamp <= now + 3600_000_000,
+            timestamp <= now + 3_600_000_000,
             "Timestamp should not be too far in future"
         );
 
@@ -465,8 +465,8 @@ mod tests {
 
         // Verify both formats give reasonable timestamps
         let standard_timestamp = standard_result.unwrap();
-        assert!(standard_timestamp >= now - 3600_000_000);
-        assert!(standard_timestamp <= now + 3600_000_000);
+        assert!(standard_timestamp >= now - 3_600_000_000);
+        assert!(standard_timestamp <= now + 3_600_000_000);
     }
 
     #[test]
@@ -582,7 +582,7 @@ mod tests {
         ];
         for (id, ts) in data {
             let id_ts = to_timestamp_millis(id);
-            let t = chrono::Utc.timestamp_nanos(id_ts * 1000_000);
+            let t = chrono::Utc.timestamp_nanos(id_ts * 1_000_000);
             let td = t.format("%Y-%m-%d").to_string();
             assert_eq!(td, ts.to_string());
         }

--- a/src/config/src/meta/alerts/alert.rs
+++ b/src/config/src/meta/alerts/alert.rs
@@ -436,7 +436,7 @@ mod tests {
         assert_eq!(alert.org_id, "");
         assert_eq!(alert.stream_type, StreamType::default());
         assert_eq!(alert.stream_name, "");
-        assert_eq!(alert.is_real_time, false);
+        assert!(!alert.is_real_time);
         assert_eq!(alert.query_condition, QueryCondition::default());
         assert_eq!(alert.trigger_condition, TriggerCondition::default());
         assert!(alert.destinations.is_empty());
@@ -444,7 +444,7 @@ mod tests {
         assert_eq!(alert.row_template, "");
         assert_eq!(alert.row_template_type, RowTemplateType::String);
         assert_eq!(alert.description, "");
-        assert_eq!(alert.enabled, false);
+        assert!(!alert.enabled);
         assert_eq!(alert.tz_offset, 0);
         assert_eq!(alert.last_triggered_at, None);
         assert_eq!(alert.last_satisfied_at, None);
@@ -755,7 +755,7 @@ mod tests {
             "tz_offset": 0
         }"#;
         let alert: Alert = serde_json::from_str(json).unwrap();
-        assert_eq!(alert.creates_incident, false);
+        assert!(!alert.creates_incident);
     }
 
     #[test]
@@ -945,8 +945,10 @@ mod tests {
     /// to raise it, lower it, and clear it back to unset.
     #[test]
     fn test_priority_is_mutable_including_back_to_unset() {
-        let mut alert = Alert::default();
-        alert.priority = Some(AlertPriority::P4);
+        let mut alert = Alert {
+            priority: Some(AlertPriority::P4),
+            ..Default::default()
+        };
         assert_eq!(alert.priority, Some(AlertPriority::P4));
 
         alert.priority = Some(AlertPriority::P1); // raised
@@ -962,8 +964,10 @@ mod tests {
 
     #[test]
     fn test_tags_are_mutable_including_back_to_empty() {
-        let mut alert = Alert::default();
-        alert.tags = vec!["prod".to_string()];
+        let mut alert = Alert {
+            tags: vec!["prod".to_string()],
+            ..Default::default()
+        };
         alert.tags.clear();
         let json = serde_json::to_value(&alert).unwrap();
         assert!(!json.as_object().unwrap().contains_key("tags"));

--- a/src/config/src/meta/alerts/grouping.rs
+++ b/src/config/src/meta/alerts/grouping.rs
@@ -1554,10 +1554,12 @@ mod tests {
     fn test_default_disappearance_multiplier_tolerates_a_missed_run() {
         // K must exceed 1: at K=1 a single slow evaluation resolves every group
         // and re-fires it on the next pass — an alert storm from a hiccup.
-        assert!(
-            DEFAULT_DISAPPEARANCE_K > 1,
-            "K=1 turns one missed evaluation into a full resolve/re-fire cycle"
-        );
+        const {
+            assert!(
+                DEFAULT_DISAPPEARANCE_K > 1,
+                "K=1 turns one missed evaluation into a full resolve/re-fire cycle"
+            );
+        }
         assert_eq!(DEFAULT_DISAPPEARANCE_K, 3);
     }
 

--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -2091,7 +2091,7 @@ mod test {
         // New York is west of UTC (negative offset)
         assert!(ny_offset < 0);
         // London is close to UTC (0 or +60 during BST)
-        assert!(london_offset >= 0 && london_offset <= 60);
+        assert!((0..=60).contains(&london_offset));
     }
 
     #[test]

--- a/src/config/src/meta/cluster.rs
+++ b/src/config/src/meta/cluster.rs
@@ -321,10 +321,12 @@ mod tests {
 
     #[test]
     fn test_node_is_ingester() {
-        let mut node = Node::default();
+        let mut node = Node {
+            role: vec![Role::All],
+            ..Default::default()
+        };
 
         // Test with All role
-        node.role = vec![Role::All];
         assert!(node.is_ingester());
 
         // Test with Ingester role
@@ -338,10 +340,12 @@ mod tests {
 
     #[test]
     fn test_node_is_querier() {
-        let mut node = Node::default();
+        let mut node = Node {
+            role: vec![Role::All],
+            ..Default::default()
+        };
 
         // Test with All role
-        node.role = vec![Role::All];
         assert!(node.is_querier());
 
         // Test with Querier role
@@ -355,10 +359,12 @@ mod tests {
 
     #[test]
     fn test_node_role_checks() {
-        let mut node = Node::default();
+        let mut node = Node {
+            role: vec![Role::Router],
+            ..Default::default()
+        };
 
         // Test router
-        node.role = vec![Role::Router];
         assert!(node.is_router());
         assert!(!node.is_compactor());
 
@@ -390,9 +396,11 @@ mod tests {
 
     #[test]
     fn test_node_is_single_role() {
-        let mut node = Node::default();
+        let mut node = Node {
+            role: vec![Role::Ingester],
+            ..Default::default()
+        };
 
-        node.role = vec![Role::Ingester];
         assert!(node.is_single_role());
 
         node.role = vec![Role::All];
@@ -407,11 +415,13 @@ mod tests {
 
     #[test]
     fn test_node_is_interactive_querier() {
-        let mut node = Node::default();
+        let mut node = Node {
+            role: vec![Role::Querier],
+            role_group: RoleGroup::None,
+            ..Default::default()
+        };
 
         // querier + no role group → interactive
-        node.role = vec![Role::Querier];
-        node.role_group = RoleGroup::None;
         assert!(node.is_interactive_querier());
 
         // querier + Interactive → interactive
@@ -430,11 +440,13 @@ mod tests {
 
     #[test]
     fn test_node_is_background_querier() {
-        let mut node = Node::default();
+        let mut node = Node {
+            role: vec![Role::Querier],
+            role_group: RoleGroup::None,
+            ..Default::default()
+        };
 
         // querier + no role group → background
-        node.role = vec![Role::Querier];
-        node.role_group = RoleGroup::None;
         assert!(node.is_background_querier());
 
         // querier + Background → background
@@ -453,10 +465,12 @@ mod tests {
 
     #[test]
     fn test_node_is_standalone() {
-        let mut node = Node::default();
+        let mut node = Node {
+            role: vec![Role::ActionServer],
+            ..Default::default()
+        };
 
         // ActionServer alone → standalone
-        node.role = vec![Role::ActionServer];
         assert!(node.is_standalone());
 
         // All role → NOT standalone (has external deps)
@@ -474,17 +488,19 @@ mod tests {
 
     #[test]
     fn test_node_is_same() {
-        let mut a = Node::default();
-        a.id = 1;
-        a.uuid = "uuid-1".to_string();
-        a.name = "node-1".to_string();
-        a.http_addr = "http://localhost:5080".to_string();
-        a.grpc_addr = "localhost:5081".to_string();
-        a.role = vec![Role::Ingester];
-        a.role_group = RoleGroup::None;
-        a.scheduled = true;
-        a.broadcasted = false;
-        a.status = NodeStatus::Online;
+        let a = Node {
+            id: 1,
+            uuid: "uuid-1".to_string(),
+            name: "node-1".to_string(),
+            http_addr: "http://localhost:5080".to_string(),
+            grpc_addr: "localhost:5081".to_string(),
+            role: vec![Role::Ingester],
+            role_group: RoleGroup::None,
+            scheduled: true,
+            broadcasted: false,
+            status: NodeStatus::Online,
+            ..Default::default()
+        };
 
         let b = a.clone();
         assert!(a.is_same(&b));

--- a/src/config/src/meta/dashboards/v8/mod.rs
+++ b/src/config/src/meta/dashboards/v8/mod.rs
@@ -1036,7 +1036,7 @@ mod tests {
         let s: AxisArgValueWrapper = serde_json::from_value(serde_json::json!("hello")).unwrap();
         assert!(matches!(s, AxisArgValueWrapper::String(_)));
 
-        let n: AxisArgValueWrapper = serde_json::from_value(serde_json::json!(3.14)).unwrap();
+        let n: AxisArgValueWrapper = serde_json::from_value(serde_json::json!(3.25)).unwrap();
         assert!(matches!(n, AxisArgValueWrapper::Number(_)));
     }
 

--- a/src/config/src/meta/enrichment_table.rs
+++ b/src/config/src/meta/enrichment_table.rs
@@ -201,9 +201,9 @@ mod tests {
         assert_eq!(job.total_bytes_fetched, 0);
         assert_eq!(job.total_records_processed, 0);
         assert_eq!(job.retry_count, 0);
-        assert_eq!(job.append_data, false);
+        assert!(!job.append_data);
         assert_eq!(job.last_byte_position, 0);
-        assert_eq!(job.supports_range, false);
+        assert!(!job.supports_range);
     }
 
     #[test]
@@ -300,7 +300,7 @@ mod tests {
             "url".to_string(),
             true,
         );
-        assert_eq!(job.append_data, true);
+        assert!(job.append_data);
     }
 
     #[test]

--- a/src/config/src/meta/otlp.rs
+++ b/src/config/src/meta/otlp.rs
@@ -44,7 +44,7 @@ mod tests {
     fn test_otlp_request_type_copy_clone() {
         let a = OtlpRequestType::HttpJson;
         let b = a;
-        let c = a.clone();
+        let c = a;
         assert_eq!(a, b);
         assert_eq!(a, c);
     }

--- a/src/config/src/meta/promql/grpc.rs
+++ b/src/config/src/meta/promql/grpc.rs
@@ -116,11 +116,11 @@ mod tests {
     fn test_sample_from_rpc() {
         let rpc = cluster_rpc::Sample {
             time: 1_700_000_000,
-            value: 3.14,
+            value: 3.25,
         };
         let sample = Sample::from(&rpc);
         assert_eq!(sample.timestamp, 1_700_000_000);
-        assert_eq!(sample.value, 3.14);
+        assert_eq!(sample.value, 3.25);
     }
 
     #[test]

--- a/src/config/src/meta/promql/value.rs
+++ b/src/config/src/meta/promql/value.rs
@@ -1030,7 +1030,7 @@ mod tests {
 
         use std::iter::zip;
         for (expect, got) in zip(expected, output.clone()) {
-            assert_eq!(expect.name, got.name, "{:?}", &output);
+            assert_eq!(expect.name, got.name, "{:?}", output);
         }
     }
 
@@ -1047,7 +1047,7 @@ mod tests {
 
         use std::iter::zip;
         for (expect, got) in zip(expected, output.clone()) {
-            assert_eq!(expect.name, got.name, "{:?}", &output);
+            assert_eq!(expect.name, got.name, "{:?}", output);
         }
     }
 
@@ -1062,10 +1062,10 @@ mod tests {
 
         use std::iter::zip;
         for (expect, got) in zip(expected.clone(), output_deleted.clone()) {
-            assert_eq!(expect.name, got.name, "{:?}", &output_deleted);
+            assert_eq!(expect.name, got.name, "{:?}", output_deleted);
         }
         for (expect, got) in zip(expected, output_kept.clone()) {
-            assert_eq!(expect.name, got.name, "{:?}", &output_kept);
+            assert_eq!(expect.name, got.name, "{:?}", output_kept);
         }
     }
 
@@ -1551,8 +1551,8 @@ mod tests {
 
     #[test]
     fn test_value_get_float() {
-        let val = Value::Float(3.14);
-        assert_eq!(val.get_float(), Some(3.14));
+        let val = Value::Float(3.25);
+        assert_eq!(val.get_float(), Some(3.25));
 
         assert!(Value::String("x".to_string()).get_float().is_none());
         assert!(Value::None.get_float().is_none());

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -2455,19 +2455,19 @@ mod tests {
 
     #[test]
     fn test_search_event_type_try_from() {
-        type SET = SearchEventType; // Saving line too long
-        assert_eq!(SET::try_from("ui").unwrap(), SET::UI);
-        assert_eq!(SET::try_from("dashboards").unwrap(), SET::Dashboards);
-        assert_eq!(SET::try_from("reports").unwrap(), SET::Reports);
-        assert_eq!(SET::try_from("alerts").unwrap(), SET::Alerts);
-        assert_eq!(SET::try_from("values").unwrap(), SET::Values);
-        assert_eq!(SET::try_from("_values").unwrap(), SET::Values);
-        assert_eq!(SET::try_from("other").unwrap(), SET::Other);
-        assert_eq!(SET::try_from("rum").unwrap(), SET::RUM);
-        assert_eq!(SET::try_from("derived_stream").unwrap(), SET::DerivedStream);
-        assert_eq!(SET::try_from("derivedstream").unwrap(), SET::DerivedStream);
-        assert_eq!(SET::try_from("search_job").unwrap(), SET::SearchJob);
-        assert_eq!(SET::try_from("searchjob").unwrap(), SET::SearchJob);
+        type Set = SearchEventType; // Saving line too long
+        assert_eq!(Set::try_from("ui").unwrap(), Set::UI);
+        assert_eq!(Set::try_from("dashboards").unwrap(), Set::Dashboards);
+        assert_eq!(Set::try_from("reports").unwrap(), Set::Reports);
+        assert_eq!(Set::try_from("alerts").unwrap(), Set::Alerts);
+        assert_eq!(Set::try_from("values").unwrap(), Set::Values);
+        assert_eq!(Set::try_from("_values").unwrap(), Set::Values);
+        assert_eq!(Set::try_from("other").unwrap(), Set::Other);
+        assert_eq!(Set::try_from("rum").unwrap(), Set::RUM);
+        assert_eq!(Set::try_from("derived_stream").unwrap(), Set::DerivedStream);
+        assert_eq!(Set::try_from("derivedstream").unwrap(), Set::DerivedStream);
+        assert_eq!(Set::try_from("search_job").unwrap(), Set::SearchJob);
+        assert_eq!(Set::try_from("searchjob").unwrap(), Set::SearchJob);
         assert!(SearchEventType::try_from("invalid").is_err());
     }
 
@@ -2749,29 +2749,27 @@ mod tests {
         // Find the chunk containing the oversized hit (id=11)
         let mut found_oversized_chunk = false;
         for chunk in &chunks[1..] {
-            if let ResponseChunk::Hits { hits } = chunk {
-                if hits.len() == 1 {
-                    if let Some(id) = hits[0].get("id").and_then(|v| v.as_u64()) {
-                        if id == 11 {
-                            // Verify this is indeed the oversized hit
-                            assert!(
-                                hits[0]
-                                    .get("oversized")
-                                    .and_then(|v| v.as_bool())
-                                    .unwrap_or(false),
-                                "Chunk with single hit should contain the oversized hit"
-                            );
-                            found_oversized_chunk = true;
+            if let ResponseChunk::Hits { hits } = chunk
+                && hits.len() == 1
+                && let Some(id) = hits[0].get("id").and_then(|v| v.as_u64())
+                && id == 11
+            {
+                // Verify this is indeed the oversized hit
+                assert!(
+                    hits[0]
+                        .get("oversized")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false),
+                    "Chunk with single hit should contain the oversized hit"
+                );
+                found_oversized_chunk = true;
 
-                            // Verify the oversized hit is sent alone (preserving order)
-                            assert_eq!(
-                                hits.len(),
-                                1,
-                                "Oversized hit should be sent alone in its own chunk"
-                            );
-                        }
-                    }
-                }
+                // Verify the oversized hit is sent alone (preserving order)
+                assert_eq!(
+                    hits.len(),
+                    1,
+                    "Oversized hit should be sent alone in its own chunk"
+                );
             }
         }
 
@@ -3631,21 +3629,23 @@ mod tests {
 
     #[test]
     fn test_response_skip_serializing_if_set_fields_present() {
-        let mut r = Response::default();
-        r.columns = vec!["col1".to_string()];
-        r.function_error = vec!["err".to_string()];
-        r.response_type = "json".to_string();
-        r.trace_id = "t1".to_string();
-        r.histogram_interval = Some(3600);
-        r.new_start_time = Some(1000);
-        r.new_end_time = Some(2000);
-        r.work_group = Some("wg".to_string());
-        r.order_by = Some(OrderBy::Desc);
-        r.converted_histogram_query = Some("SELECT ...".to_string());
-        r.histogram_breakdown_field = Some("level".to_string());
-        r.is_histogram_eligible = Some(true);
-        r.query_index = Some(3);
-        r.peak_memory_usage = Some(512.0);
+        let r = Response {
+            columns: vec!["col1".to_string()],
+            function_error: vec!["err".to_string()],
+            response_type: "json".to_string(),
+            trace_id: "t1".to_string(),
+            histogram_interval: Some(3600),
+            new_start_time: Some(1000),
+            new_end_time: Some(2000),
+            work_group: Some("wg".to_string()),
+            order_by: Some(OrderBy::Desc),
+            converted_histogram_query: Some("SELECT ...".to_string()),
+            histogram_breakdown_field: Some("level".to_string()),
+            is_histogram_eligible: Some(true),
+            query_index: Some(3),
+            peak_memory_usage: Some(512.0),
+            ..Default::default()
+        };
         let json = serde_json::to_value(&r).unwrap();
         let obj = json.as_object().unwrap();
         assert!(obj.contains_key("columns"));

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -1462,8 +1462,10 @@ mod tests {
         assert!(settings.index_fields_updated_at.is_empty());
 
         // the map survives a serialize -> parse round trip
-        let mut settings = StreamSettings::default();
-        settings.index_updated_at = 100;
+        let mut settings = StreamSettings {
+            index_updated_at: 100,
+            ..Default::default()
+        };
         settings
             .index_fields_updated_at
             .insert("trace_id".to_string(), 200);
@@ -2075,7 +2077,6 @@ mod tests {
             doc_time_min: 1000,
             doc_time_max: 2000,
             created_at: 100,
-            ..Default::default()
         };
         let b = StreamStats {
             file_num: 2,
@@ -2086,7 +2087,6 @@ mod tests {
             doc_time_min: 500,
             doc_time_max: 3000,
             created_at: 50,
-            ..Default::default()
         };
         a.merge(&b);
         assert_eq!(a.file_num, 5);

--- a/src/config/src/prebuilt_loader.rs
+++ b/src/config/src/prebuilt_loader.rs
@@ -794,17 +794,17 @@ mod tests {
         fs::write(config_path, test_config).unwrap();
 
         // Temporarily replace the main config path
-        if let Ok(config_str) = fs::read_to_string(config_path) {
-            if let Ok(config) = serde_json::from_str::<PrebuiltDestinationsConfig>(&config_str) {
-                let destinations: Vec<Destination> = config
-                    .destinations
-                    .into_iter()
-                    .filter_map(|dest| convert_to_destination(dest).ok())
-                    .collect();
+        if let Ok(config_str) = fs::read_to_string(config_path)
+            && let Ok(config) = serde_json::from_str::<PrebuiltDestinationsConfig>(&config_str)
+        {
+            let destinations: Vec<Destination> = config
+                .destinations
+                .into_iter()
+                .filter_map(|dest| convert_to_destination(dest).ok())
+                .collect();
 
-                assert_eq!(destinations.len(), 1);
-                assert_eq!(destinations[0].name, "Test Destination");
-            }
+            assert_eq!(destinations.len(), 1);
+            assert_eq!(destinations[0].name, "Test Destination");
         }
 
         // Clean up

--- a/src/config/src/stats.rs
+++ b/src/config/src/stats.rs
@@ -761,7 +761,7 @@ mod tests {
         assert_eq!(42i32.mem_size(), std::mem::size_of::<i32>());
         assert_eq!(42u8.mem_size(), std::mem::size_of::<u8>());
         assert_eq!(true.mem_size(), std::mem::size_of::<bool>());
-        assert_eq!(3.14f64.mem_size(), std::mem::size_of::<f64>());
+        assert_eq!(3.25f64.mem_size(), std::mem::size_of::<f64>());
     }
 
     #[test]

--- a/src/config/src/tantivy/query/ids_collector.rs
+++ b/src/config/src/tantivy/query/ids_collector.rs
@@ -94,7 +94,7 @@ mod tests {
 
         for i in 0..doc_count {
             let mut doc = TantivyDocument::default();
-            doc.add_text(body, &format!("document number {i}"));
+            doc.add_text(body, format!("document number {i}"));
             writer.add_document(doc).unwrap();
         }
         writer.commit().unwrap();

--- a/src/config/src/utils/base64.rs
+++ b/src/config/src/utils/base64.rs
@@ -197,7 +197,7 @@ mod tests {
         // Test with base64 that decodes to invalid UTF-8
         // This is tricky to create, but we can test the error path
         let invalid_utf8 = [0xFF, 0xFE, 0xFD];
-        let encoded = base64::engine::general_purpose::STANDARD.encode(&invalid_utf8);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(invalid_utf8);
 
         // This should fail when trying to convert to String
         assert!(decode(&encoded).is_err());

--- a/src/config/src/utils/json.rs
+++ b/src/config/src/utils/json.rs
@@ -285,8 +285,8 @@ mod tests {
         assert_eq!(get_float_value(&Value::String("invalid".to_string())), 0.0);
         assert_eq!(get_float_value(&Value::Number(Number::from(42))), 42.0);
         assert_eq!(
-            get_float_value(&Value::Number(Number::from_f64(3.14).unwrap())),
-            3.14
+            get_float_value(&Value::Number(Number::from_f64(3.25).unwrap())),
+            3.25
         );
         assert_eq!(get_float_value(&Value::Bool(true)), 1.0);
         assert_eq!(get_float_value(&Value::Bool(false)), 0.0);
@@ -298,7 +298,7 @@ mod tests {
         assert_eq!(get_int_value(&Value::String("invalid".to_string())), 0);
         assert_eq!(get_int_value(&Value::Number(Number::from(42))), 42);
         assert_eq!(
-            get_int_value(&Value::Number(Number::from_f64(3.14).unwrap())),
+            get_int_value(&Value::Number(Number::from_f64(3.25).unwrap())),
             3
         );
         assert_eq!(get_int_value(&Value::Bool(true)), 1);
@@ -311,7 +311,7 @@ mod tests {
         assert_eq!(get_uint_value(&Value::String("invalid".to_string())), 0);
         assert_eq!(get_uint_value(&Value::Number(Number::from(42u64))), 42);
         assert_eq!(
-            get_uint_value(&Value::Number(Number::from_f64(3.14).unwrap())),
+            get_uint_value(&Value::Number(Number::from_f64(3.25).unwrap())),
             3
         );
         assert_eq!(get_uint_value(&Value::Bool(true)), 1);
@@ -320,16 +320,16 @@ mod tests {
         assert_eq!(get_uint_value(&Value::Array(vec![])), 0);
 
         // Test get_bool_value
-        assert_eq!(get_bool_value(&Value::String("true".to_string())), true);
-        assert_eq!(get_bool_value(&Value::String("false".to_string())), false);
-        assert_eq!(get_bool_value(&Value::String("invalid".to_string())), false);
-        assert_eq!(get_bool_value(&Value::Number(Number::from(1))), true);
-        assert_eq!(get_bool_value(&Value::Number(Number::from(0))), false);
-        assert_eq!(get_bool_value(&Value::Number(Number::from(42))), true);
-        assert_eq!(get_bool_value(&Value::Bool(true)), true);
-        assert_eq!(get_bool_value(&Value::Bool(false)), false);
-        assert_eq!(get_bool_value(&Value::Null), false);
-        assert_eq!(get_bool_value(&Value::Array(vec![])), false);
+        assert!(get_bool_value(&Value::String("true".to_string())));
+        assert!(!get_bool_value(&Value::String("false".to_string())));
+        assert!(!get_bool_value(&Value::String("invalid".to_string())));
+        assert!(get_bool_value(&Value::Number(Number::from(1))));
+        assert!(!get_bool_value(&Value::Number(Number::from(0))));
+        assert!(get_bool_value(&Value::Number(Number::from(42))));
+        assert!(get_bool_value(&Value::Bool(true)));
+        assert!(!get_bool_value(&Value::Bool(false)));
+        assert!(!get_bool_value(&Value::Null));
+        assert!(!get_bool_value(&Value::Array(vec![])));
 
         // Test get_string_value
         assert_eq!(
@@ -338,8 +338,8 @@ mod tests {
         );
         assert_eq!(get_string_value(&Value::Number(Number::from(42))), "42");
         assert_eq!(
-            get_string_value(&Value::Number(Number::from_f64(3.14).unwrap())),
-            "3.14"
+            get_string_value(&Value::Number(Number::from_f64(3.25).unwrap())),
+            "3.25"
         );
         assert_eq!(get_string_value(&Value::Bool(true)), "true");
         assert_eq!(get_string_value(&Value::Bool(false)), "false");

--- a/src/config/src/utils/record_batch_ext.rs
+++ b/src/config/src/utils/record_batch_ext.rs
@@ -1803,9 +1803,9 @@ mod test {
             .as_any()
             .downcast_ref::<BooleanArray>()
             .unwrap();
-        assert_eq!(active_array.value(0), true);
-        assert_eq!(active_array.value(1), false);
-        assert_eq!(active_array.value(2), true);
+        assert!(active_array.value(0));
+        assert!(!active_array.value(1));
+        assert!(active_array.value(2));
     }
 
     // ── concat_batches ──────────────────────────────────────────────────────
@@ -2004,7 +2004,7 @@ mod test {
     fn test_format_recordbatch_float64_to_utf8() {
         let target = Arc::new(Schema::new(vec![Field::new("f", DataType::Utf8, true)]));
         let src_schema = Arc::new(Schema::new(vec![Field::new("f", DataType::Float64, true)]));
-        let arr: ArrayRef = Arc::new(Float64Array::from(vec![3.14_f64]));
+        let arr: ArrayRef = Arc::new(Float64Array::from(vec![3.25_f64]));
         let batch = RecordBatch::try_new(src_schema, vec![arr]).unwrap();
         let result = format_recordbatch_by_schema(target, batch);
         let col = result
@@ -2012,7 +2012,7 @@ mod test {
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
-        assert_eq!(col.value(0), "3.14");
+        assert_eq!(col.value(0), "3.25");
     }
 
     #[test]
@@ -2316,7 +2316,7 @@ mod test {
     fn test_convert_json_to_record_batch_float64() {
         let schema = Arc::new(Schema::new(vec![Field::new("f", DataType::Float64, true)]));
         let data = vec![
-            Arc::new(serde_json::json!({"f": 3.14})),
+            Arc::new(serde_json::json!({"f": 3.25})),
             Arc::new(serde_json::json!({"f": "2.71"})),
             Arc::new(serde_json::json!({"f": true})),
             Arc::new(serde_json::json!({"f": false})),
@@ -2329,7 +2329,7 @@ mod test {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert!((col.value(0) - 3.14).abs() < 1e-10);
+        assert!((col.value(0) - 3.25).abs() < 1e-10);
         assert!((col.value(1) - 2.71).abs() < 1e-10);
         assert!((col.value(2) - 1.0).abs() < f64::EPSILON);
         assert!((col.value(3) - 0.0).abs() < f64::EPSILON);
@@ -2698,7 +2698,7 @@ mod test {
             vrl::value::Value::Object(
                 [(
                     "v".into(),
-                    vrl::value::Value::Bytes(b"3.14".to_vec().into()),
+                    vrl::value::Value::Bytes(b"3.25".to_vec().into()),
                 )]
                 .into_iter()
                 .collect(),
@@ -2720,7 +2720,7 @@ mod test {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert!((col.value(0) - 3.14).abs() < 1e-10);
+        assert!((col.value(0) - 3.25).abs() < 1e-10);
         assert!((col.value(1) - 0.0).abs() < f64::EPSILON);
         assert!((col.value(2) - 0.0).abs() < f64::EPSILON);
     }

--- a/src/config/src/utils/schema.rs
+++ b/src/config/src/utils/schema.rs
@@ -616,7 +616,7 @@ mod tests {
     fn test_infer_json_schema_from_values_non_object_returns_error() {
         use serde_json::Value;
         // Passing a non-Object value (Array) should hit the `_` branch → error
-        let vals = vec![Value::Array(vec![Value::from(1), Value::from(2)])];
+        let vals = [Value::Array(vec![Value::from(1), Value::from(2)])];
         let result = infer_json_schema_from_values("test_stream", StreamType::Logs, vals.iter());
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -629,7 +629,7 @@ mod tests {
         // An object containing an array field hits `_` in infer_json_schema_from_object
         let mut obj = Map::new();
         obj.insert("items".to_string(), Value::Array(vec![Value::from(1)]));
-        let vals = vec![Value::Object(obj)];
+        let vals = [Value::Object(obj)];
         let result = infer_json_schema_from_values("test_stream", StreamType::Logs, vals.iter());
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();

--- a/src/config/src/utils/sort.rs
+++ b/src/config/src/utils/sort.rs
@@ -128,9 +128,9 @@ mod tests {
         let mut empty: [f64; 0] = [];
         empty.sort_by(sort_float);
 
-        let mut single = [3.14_f64];
+        let mut single = [3.25_f64];
         single.sort_by(sort_float);
-        assert_eq!(single[0], 3.14);
+        assert_eq!(single[0], 3.25);
     }
 
     #[test]

--- a/src/config/src/utils/sql/eligible_for_histogram.rs
+++ b/src/config/src/utils/sql/eligible_for_histogram.rs
@@ -58,8 +58,8 @@ mod tests {
         ];
         for query in queries.iter() {
             let (is_eligible, is_sub_query) = is_eligible_for_histogram(query, false).unwrap();
-            assert_eq!(is_eligible, true);
-            assert_eq!(is_sub_query, false);
+            assert!(is_eligible);
+            assert!(!is_sub_query);
         }
     }
 
@@ -72,11 +72,11 @@ mod tests {
         ];
         for query in queries.iter() {
             let (is_eligible, is_sub_query) = is_eligible_for_histogram(query, false).unwrap();
-            assert_eq!(is_eligible, false);
+            assert!(!is_eligible);
             if query.contains("SELECT * FROM (SELECT") {
-                assert_eq!(is_sub_query, true);
+                assert!(is_sub_query);
             } else {
-                assert_eq!(is_sub_query, false);
+                assert!(!is_sub_query);
             }
         }
     }

--- a/src/config/src/utils/sql/visitors/union.rs
+++ b/src/config/src/utils/sql/visitors/union.rs
@@ -107,7 +107,7 @@ mod tests {
         let is_not_union_all = is_multi_search_eligible_for_histogram(sql1).unwrap();
         let is_union_all = is_multi_search_eligible_for_histogram(sql2).unwrap();
 
-        assert_eq!(is_not_union_all, false);
-        assert_eq!(is_union_all, true);
+        assert!(!is_not_union_all);
+        assert!(is_union_all);
     }
 }

--- a/src/config/src/utils/sysinfo/cpu.rs
+++ b/src/config/src/utils/sysinfo/cpu.rs
@@ -67,7 +67,7 @@ mod tests {
     fn test_sysinfo_get_cpu_usage() {
         let usage = get_cpu_usage();
         assert!(
-            usage >= 0.0 && usage <= 100.0,
+            (0.0..=100.0).contains(&usage),
             "CPU usage should be between 0 and 100, got {}",
             usage
         );

--- a/src/core/src/alerts/scheduler/handlers.rs
+++ b/src/core/src/alerts/scheduler/handlers.rs
@@ -4534,6 +4534,171 @@ async fn check_deletion_status(job_id: &str) -> Result<String, anyhow::Error> {
     Ok(status_str.to_string())
 }
 
+/// One SLI ingest pass (`alerts_2.md` §6b.4a, §6b.9).
+///
+/// The failure policy is the part worth reading: a failed pass writes no
+/// slice, so coverage falls and the SLO eventually freezes. It does NOT write
+/// zeros. Zeros would report a search outage as 100% downtime and page
+/// everyone, which is the opposite of what an absence of measurement means.
+async fn handle_slo_triggers(mut trigger: db::scheduler::Trigger) -> Result<(), anyhow::Error> {
+    use config::utils::time::{now_micros, second_micros};
+
+    let slo_id = trigger.module_key.clone();
+    let cfg = config::get_config();
+
+    // Turned off at runtime: keep the trigger alive so it resumes on restart
+    // rather than silently losing its schedule.
+    if !cfg.slo.enabled {
+        trigger.next_run_at = now_micros() + second_micros(300);
+        trigger.status = db::scheduler::TriggerStatus::Waiting;
+        db::scheduler::update_trigger(trigger, true, "").await?;
+        return Ok(());
+    }
+
+    let db = infra::db::ORM_CLIENT
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
+    let slo = infra::table::slos::get(db, &trigger.org, &slo_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    // Not found locally may be a super-cluster race (the trigger row arrived
+    // before the SLO synced). Reschedule rather than delete — the trigger is
+    // cleaned up by the delete path, not here.
+    let Some(slo) = slo else {
+        log::warn!(
+            "[slo] definition not found locally for id={slo_id} org={} — rescheduling +60s",
+            trigger.org
+        );
+        trigger.next_run_at = now_micros() + second_micros(60);
+        trigger.status = db::scheduler::TriggerStatus::Waiting;
+        db::scheduler::update_trigger(trigger, true, "").await?;
+        return Ok(());
+    };
+
+    if !slo.enabled {
+        trigger.next_run_at = now_micros() + second_micros(slo.definition.slice_interval_secs);
+        trigger.status = db::scheduler::TriggerStatus::Waiting;
+        db::scheduler::update_trigger(trigger.clone(), true, "").await?;
+        publish_slo_pass(&trigger, &slo_id, RunOutcome::Skipped, None);
+        return Ok(());
+    }
+
+    let now_secs = now_micros() / 1_000_000;
+    let started = now_micros();
+    let (outcome, error) = match crate::slo::job::run_pass(&slo, now_secs).await {
+        Ok(o) => {
+            log::debug!("[slo] pass for {slo_id}: {o:?}");
+            (RunOutcome::Succeeded, None)
+        }
+        Err(e) => {
+            // Deliberately not propagated: the scheduler would retry, and a
+            // retry storm against a failing search helps nobody. Coverage
+            // falling is the designed response.
+            log::error!("[slo] pass failed for {slo_id} org={}: {e}", trigger.org);
+            (RunOutcome::NotifyFailed, Some(e.to_string()))
+        }
+    };
+
+    trigger.next_run_at = crate::slo::job::next_run_at(slo.definition.slice_interval_secs);
+    trigger.status = db::scheduler::TriggerStatus::Waiting;
+    let published = trigger.clone();
+    db::scheduler::update_trigger(trigger, true, "").await?;
+    publish_slo_pass_timed(&published, &slo_id, outcome, error, started);
+    Ok(())
+}
+
+/// One backfill chunk. Its own module so a bulk historical scan never shares a
+/// concurrency budget with latency-sensitive incremental passes (§6b.9).
+async fn handle_slo_backfill_triggers(
+    mut trigger: db::scheduler::Trigger,
+) -> Result<(), anyhow::Error> {
+    use config::utils::time::{now_micros, second_micros};
+
+    let slo_id = trigger.module_key.clone();
+    let cfg = config::get_config();
+    if !cfg.slo.enabled {
+        trigger.next_run_at = now_micros() + second_micros(300);
+        trigger.status = db::scheduler::TriggerStatus::Waiting;
+        db::scheduler::update_trigger(trigger, true, "").await?;
+        return Ok(());
+    }
+
+    let db = infra::db::ORM_CLIENT
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
+    let Some(slo) = infra::table::slos::get(db, &trigger.org, &slo_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?
+    else {
+        // The SLO is gone, so its backfill has nothing to fill.
+        db::scheduler::delete(
+            &trigger.org,
+            db::scheduler::TriggerModule::SloBackfill,
+            &slo_id,
+        )
+        .await?;
+        return Ok(());
+    };
+
+    match crate::slo::backfill::run_chunk(&slo).await {
+        Ok(crate::slo::backfill::ChunkOutcome::Done) => {
+            log::info!("[slo] backfill complete for {slo_id}");
+            db::scheduler::delete(
+                &trigger.org,
+                db::scheduler::TriggerModule::SloBackfill,
+                &slo_id,
+            )
+            .await?;
+            return Ok(());
+        }
+        Ok(crate::slo::backfill::ChunkOutcome::More) => {}
+        Err(e) => {
+            log::error!("[slo] backfill chunk failed for {slo_id}: {e}");
+        }
+    }
+
+    // Paced: chunks are bulk scans, and running them back-to-back would use
+    // the whole lane even though the lane exists to bound exactly that.
+    trigger.next_run_at = now_micros() + second_micros(30);
+    trigger.status = db::scheduler::TriggerStatus::Waiting;
+    db::scheduler::update_trigger(trigger, true, "").await?;
+    Ok(())
+}
+
+fn publish_slo_pass(
+    trigger: &db::scheduler::Trigger,
+    slo_id: &str,
+    outcome: RunOutcome,
+    error: Option<String>,
+) {
+    publish_slo_pass_timed(trigger, slo_id, outcome, error, now_micros());
+}
+
+fn publish_slo_pass_timed(
+    trigger: &db::scheduler::Trigger,
+    slo_id: &str,
+    outcome: RunOutcome,
+    error: Option<String>,
+    started: i64,
+) {
+    usage_reporting::publish_triggers_usage(TriggerData {
+        _timestamp: now_micros(),
+        org: trigger.org.clone(),
+        module: TriggerDataType::Slo,
+        key: slo_id.to_string(),
+        next_run_at: trigger.next_run_at,
+        is_realtime: false,
+        is_silenced: false,
+        status: outcome,
+        start_time: started,
+        end_time: now_micros(),
+        retries: trigger.retries,
+        error,
+        ..Default::default()
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use config::meta::stream::StreamType;
@@ -5241,169 +5406,4 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].stream_name.as_str(), "output-stream");
     }
-}
-
-/// One SLI ingest pass (`alerts_2.md` §6b.4a, §6b.9).
-///
-/// The failure policy is the part worth reading: a failed pass writes no
-/// slice, so coverage falls and the SLO eventually freezes. It does NOT write
-/// zeros. Zeros would report a search outage as 100% downtime and page
-/// everyone, which is the opposite of what an absence of measurement means.
-async fn handle_slo_triggers(mut trigger: db::scheduler::Trigger) -> Result<(), anyhow::Error> {
-    use config::utils::time::{now_micros, second_micros};
-
-    let slo_id = trigger.module_key.clone();
-    let cfg = config::get_config();
-
-    // Turned off at runtime: keep the trigger alive so it resumes on restart
-    // rather than silently losing its schedule.
-    if !cfg.slo.enabled {
-        trigger.next_run_at = now_micros() + second_micros(300);
-        trigger.status = db::scheduler::TriggerStatus::Waiting;
-        db::scheduler::update_trigger(trigger, true, "").await?;
-        return Ok(());
-    }
-
-    let db = infra::db::ORM_CLIENT
-        .get()
-        .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
-    let slo = infra::table::slos::get(db, &trigger.org, &slo_id)
-        .await
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-
-    // Not found locally may be a super-cluster race (the trigger row arrived
-    // before the SLO synced). Reschedule rather than delete — the trigger is
-    // cleaned up by the delete path, not here.
-    let Some(slo) = slo else {
-        log::warn!(
-            "[slo] definition not found locally for id={slo_id} org={} — rescheduling +60s",
-            trigger.org
-        );
-        trigger.next_run_at = now_micros() + second_micros(60);
-        trigger.status = db::scheduler::TriggerStatus::Waiting;
-        db::scheduler::update_trigger(trigger, true, "").await?;
-        return Ok(());
-    };
-
-    if !slo.enabled {
-        trigger.next_run_at = now_micros() + second_micros(slo.definition.slice_interval_secs);
-        trigger.status = db::scheduler::TriggerStatus::Waiting;
-        db::scheduler::update_trigger(trigger.clone(), true, "").await?;
-        publish_slo_pass(&trigger, &slo_id, RunOutcome::Skipped, None);
-        return Ok(());
-    }
-
-    let now_secs = now_micros() / 1_000_000;
-    let started = now_micros();
-    let (outcome, error) = match crate::slo::job::run_pass(&slo, now_secs).await {
-        Ok(o) => {
-            log::debug!("[slo] pass for {slo_id}: {o:?}");
-            (RunOutcome::Succeeded, None)
-        }
-        Err(e) => {
-            // Deliberately not propagated: the scheduler would retry, and a
-            // retry storm against a failing search helps nobody. Coverage
-            // falling is the designed response.
-            log::error!("[slo] pass failed for {slo_id} org={}: {e}", trigger.org);
-            (RunOutcome::NotifyFailed, Some(e.to_string()))
-        }
-    };
-
-    trigger.next_run_at = crate::slo::job::next_run_at(slo.definition.slice_interval_secs);
-    trigger.status = db::scheduler::TriggerStatus::Waiting;
-    let published = trigger.clone();
-    db::scheduler::update_trigger(trigger, true, "").await?;
-    publish_slo_pass_timed(&published, &slo_id, outcome, error, started);
-    Ok(())
-}
-
-/// One backfill chunk. Its own module so a bulk historical scan never shares a
-/// concurrency budget with latency-sensitive incremental passes (§6b.9).
-async fn handle_slo_backfill_triggers(
-    mut trigger: db::scheduler::Trigger,
-) -> Result<(), anyhow::Error> {
-    use config::utils::time::{now_micros, second_micros};
-
-    let slo_id = trigger.module_key.clone();
-    let cfg = config::get_config();
-    if !cfg.slo.enabled {
-        trigger.next_run_at = now_micros() + second_micros(300);
-        trigger.status = db::scheduler::TriggerStatus::Waiting;
-        db::scheduler::update_trigger(trigger, true, "").await?;
-        return Ok(());
-    }
-
-    let db = infra::db::ORM_CLIENT
-        .get()
-        .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
-    let Some(slo) = infra::table::slos::get(db, &trigger.org, &slo_id)
-        .await
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?
-    else {
-        // The SLO is gone, so its backfill has nothing to fill.
-        db::scheduler::delete(
-            &trigger.org,
-            db::scheduler::TriggerModule::SloBackfill,
-            &slo_id,
-        )
-        .await?;
-        return Ok(());
-    };
-
-    match crate::slo::backfill::run_chunk(&slo).await {
-        Ok(crate::slo::backfill::ChunkOutcome::Done) => {
-            log::info!("[slo] backfill complete for {slo_id}");
-            db::scheduler::delete(
-                &trigger.org,
-                db::scheduler::TriggerModule::SloBackfill,
-                &slo_id,
-            )
-            .await?;
-            return Ok(());
-        }
-        Ok(crate::slo::backfill::ChunkOutcome::More) => {}
-        Err(e) => {
-            log::error!("[slo] backfill chunk failed for {slo_id}: {e}");
-        }
-    }
-
-    // Paced: chunks are bulk scans, and running them back-to-back would use
-    // the whole lane even though the lane exists to bound exactly that.
-    trigger.next_run_at = now_micros() + second_micros(30);
-    trigger.status = db::scheduler::TriggerStatus::Waiting;
-    db::scheduler::update_trigger(trigger, true, "").await?;
-    Ok(())
-}
-
-fn publish_slo_pass(
-    trigger: &db::scheduler::Trigger,
-    slo_id: &str,
-    outcome: RunOutcome,
-    error: Option<String>,
-) {
-    publish_slo_pass_timed(trigger, slo_id, outcome, error, now_micros());
-}
-
-fn publish_slo_pass_timed(
-    trigger: &db::scheduler::Trigger,
-    slo_id: &str,
-    outcome: RunOutcome,
-    error: Option<String>,
-    started: i64,
-) {
-    usage_reporting::publish_triggers_usage(TriggerData {
-        _timestamp: now_micros(),
-        org: trigger.org.clone(),
-        module: TriggerDataType::Slo,
-        key: slo_id.to_string(),
-        next_run_at: trigger.next_run_at,
-        is_realtime: false,
-        is_silenced: false,
-        status: outcome,
-        start_time: started,
-        end_time: now_micros(),
-        retries: trigger.retries,
-        error,
-        ..Default::default()
-    });
 }

--- a/src/core/src/metrics/native_histogram.rs
+++ b/src/core/src/metrics/native_histogram.rs
@@ -504,7 +504,7 @@ mod tests {
         assert_eq!(format_le(8.0), "8");
         assert_eq!(format_le(0.5946035575013605), "0.5946");
         assert_eq!(format_le(0.022097086912079608), "0.0221");
-        assert_eq!(format_le(-0.7071067811865476), "-0.7071");
+        assert_eq!(format_le(-std::f64::consts::FRAC_1_SQRT_2), "-0.7071");
         assert_eq!(format_le(f64::INFINITY), "inf");
         assert_eq!(format_le(0.00001), "0.00001");
         // finest schema stays collision-free

--- a/src/flight/src/encoder.rs
+++ b/src/flight/src/encoder.rs
@@ -745,7 +745,7 @@ mod tests {
         let values: ArrayRef = Arc::new(StringViewArray::from(
             (0..200_usize).map(|i| format!("v{i}")).collect::<Vec<_>>(),
         ));
-        let offsets = OffsetBuffer::from_lengths(std::iter::repeat(2).take(100));
+        let offsets = OffsetBuffer::from_lengths(std::iter::repeat_n(2, 100));
         let list_col: ArrayRef = Arc::new(ListArray::new(item_field, offsets, values, None));
         let batch = RecordBatch::try_new(schema, vec![list_col]).unwrap();
         assert_large_splits_slice_does_not(batch, 5);
@@ -761,7 +761,7 @@ mod tests {
         let values: ArrayRef = Arc::new(StringArray::from(
             (0..200_usize).map(|i| format!("w{i}")).collect::<Vec<_>>(),
         ));
-        let offsets = OffsetBuffer::from_lengths(std::iter::repeat(2).take(100));
+        let offsets = OffsetBuffer::from_lengths(std::iter::repeat_n(2, 100));
         let list_col: ArrayRef = Arc::new(ListArray::new(item_field, offsets, values, None));
         let batch = RecordBatch::try_new(schema, vec![list_col]).unwrap();
         assert_large_splits_slice_does_not(batch, 5);

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -1178,7 +1178,7 @@ mod tests {
         let file_key = "files/default/logs/disk/2022/10/03/10/6982652937134804993_2_1.parquet";
         let content = Bytes::from("Some text");
         let data_size = content.len();
-        let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
+        let (file_key, tmp_file) = write_tmp_file(file_key, content.clone()).await.unwrap();
 
         file_data
             .set(&file_key, &tmp_file, data_size)
@@ -1202,7 +1202,7 @@ mod tests {
         let file_key2 = "files/default/logs/disk/2022/10/03/10/6982652937134804993_3_2.parquet";
         let content = Bytes::from("Some text");
         let data_size = content.len();
-        let (file_key1, tmp_file) = write_tmp_file(&file_key1, content.clone()).await.unwrap();
+        let (file_key1, tmp_file) = write_tmp_file(file_key1, content.clone()).await.unwrap();
         // set one key
         file_data
             .set(&file_key1, &tmp_file, data_size)
@@ -1210,7 +1210,7 @@ mod tests {
             .unwrap();
         assert!(file_data.exist(&file_key1).await);
         // set another key, will release first key
-        let (file_key2, tmp_file) = write_tmp_file(&file_key2, content.clone()).await.unwrap();
+        let (file_key2, tmp_file) = write_tmp_file(file_key2, content.clone()).await.unwrap();
         file_data
             .set(&file_key2, &tmp_file, data_size)
             .await
@@ -1250,7 +1250,7 @@ mod tests {
         let file_key = "files/default/logs/disk/2022/10/03/10/6982652937134804993_5_1.parquet";
         let content = Bytes::from("Some text");
         let data_size = content.len();
-        let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
+        let (file_key, tmp_file) = write_tmp_file(file_key, content.clone()).await.unwrap();
 
         file_data
             .set(&file_key, &tmp_file, data_size)
@@ -1274,7 +1274,7 @@ mod tests {
         let file_key2 = "files/default/logs/disk/2022/10/03/10/6982652937134804993_6_2.parquet";
         let content = Bytes::from("Some text");
         let data_size = content.len();
-        let (file_key1, tmp_file) = write_tmp_file(&file_key1, content.clone()).await.unwrap();
+        let (file_key1, tmp_file) = write_tmp_file(file_key1, content.clone()).await.unwrap();
         // set one key
         file_data
             .set(&file_key1, &tmp_file, data_size)
@@ -1282,7 +1282,7 @@ mod tests {
             .unwrap();
         assert!(file_data.exist(&file_key1).await);
         // set another key, will release first key
-        let (file_key2, tmp_file) = write_tmp_file(&file_key2, content.clone()).await.unwrap();
+        let (file_key2, tmp_file) = write_tmp_file(file_key2, content.clone()).await.unwrap();
         file_data
             .set(&file_key2, &tmp_file, data_size)
             .await
@@ -1309,7 +1309,7 @@ mod tests {
         let file_key = "files/default/logs/disk/2022/10/03/10/6982652937134804993_7_1.parquet";
         let content = Bytes::from("Some text");
         let data_size = content.len();
-        let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
+        let (file_key, tmp_file) = write_tmp_file(file_key, content.clone()).await.unwrap();
 
         file_data
             .set(&file_key, &tmp_file, data_size)
@@ -1550,16 +1550,8 @@ mod tests {
 
         // Used size and length should not decrease significantly (may change due to concurrent
         // tests) Allow some variance due to cache operations (GC, additions)
-        let used_diff = if used2 > used1 {
-            used2 - used1
-        } else {
-            used1 - used2
-        };
-        let len_diff = if len2 > len1 {
-            len2 - len1
-        } else {
-            len1 - len2
-        };
+        let used_diff = used2.abs_diff(used1);
+        let len_diff = len2.abs_diff(len1);
         assert!(used_diff < 10000 || used1 == 0 || used2 == 0); // Allow reasonable variance
         assert!(len_diff < 100 || len1 == 0 || len2 == 0); // Allow reasonable variance
     }

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -89,61 +89,6 @@ fn is_sqlite_cantopen_fresh_install(msg: &str, db_file_exists: bool) -> bool {
     msg.contains("unable to open database file") && !db_file_exists
 }
 
-#[cfg(test)]
-mod schema_version_tests {
-    use super::*;
-
-    #[test]
-    fn test_missing_version_key_is_fresh_install() {
-        let e = errors::Error::DbError(errors::DbError::KeyNotExists("/meta/kv/version".into()));
-        assert!(is_db_schema_version_missing(&e));
-    }
-
-    #[test]
-    fn test_missing_meta_table_is_fresh_install() {
-        // sqlite and postgres Db::get() wrap the table-missing error into
-        // DBOperError with the sqlx message text
-        let e = errors::Error::DbError(errors::DbError::DBOperError(
-            "error returned from database: (code: 1) no such table: meta".to_string(),
-            "/meta/kv/version".to_string(),
-        ));
-        assert!(is_db_schema_version_missing(&e));
-        let e = errors::Error::DbError(errors::DbError::DBOperError(
-            "error returned from database: relation \"meta\" does not exist".to_string(),
-            "/meta/kv/version".to_string(),
-        ));
-        assert!(is_db_schema_version_missing(&e));
-    }
-
-    #[test]
-    fn test_sqlite_cantopen_fresh_install_depends_on_db_file() {
-        let msg = "error returned from database: (code: 14) unable to open database file";
-        // fresh install: the metadata file does not exist yet
-        assert!(is_sqlite_cantopen_fresh_install(msg, false));
-        // existing file: permission/disk problem, must keep failing startup
-        assert!(!is_sqlite_cantopen_fresh_install(msg, true));
-        assert!(!is_sqlite_cantopen_fresh_install(
-            "connection refused",
-            false
-        ));
-    }
-
-    #[test]
-    fn test_other_errors_are_not_fresh_install() {
-        let e = errors::Error::Message("connection refused".to_string());
-        assert!(!is_db_schema_version_missing(&e));
-        let e = errors::Error::SqlxError(sqlx::Error::PoolTimedOut);
-        assert!(!is_db_schema_version_missing(&e));
-        // a db-level operation error that is not table-missing must not be
-        // treated as a fresh install
-        let e = errors::Error::DbError(errors::DbError::DBOperError(
-            "connection reset by peer".to_string(),
-            "/meta/kv/version".to_string(),
-        ));
-        assert!(!is_db_schema_version_missing(&e));
-    }
-}
-
 pub async fn set_db_schema_version() -> Result<(), anyhow::Error> {
     let db = db::get_db().await;
     let s = config::DB_SCHEMA_VERSION.to_string();
@@ -210,4 +155,59 @@ pub async fn init() -> Result<(), anyhow::Error> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod schema_version_tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_version_key_is_fresh_install() {
+        let e = errors::Error::DbError(errors::DbError::KeyNotExists("/meta/kv/version".into()));
+        assert!(is_db_schema_version_missing(&e));
+    }
+
+    #[test]
+    fn test_missing_meta_table_is_fresh_install() {
+        // sqlite and postgres Db::get() wrap the table-missing error into
+        // DBOperError with the sqlx message text
+        let e = errors::Error::DbError(errors::DbError::DBOperError(
+            "error returned from database: (code: 1) no such table: meta".to_string(),
+            "/meta/kv/version".to_string(),
+        ));
+        assert!(is_db_schema_version_missing(&e));
+        let e = errors::Error::DbError(errors::DbError::DBOperError(
+            "error returned from database: relation \"meta\" does not exist".to_string(),
+            "/meta/kv/version".to_string(),
+        ));
+        assert!(is_db_schema_version_missing(&e));
+    }
+
+    #[test]
+    fn test_sqlite_cantopen_fresh_install_depends_on_db_file() {
+        let msg = "error returned from database: (code: 14) unable to open database file";
+        // fresh install: the metadata file does not exist yet
+        assert!(is_sqlite_cantopen_fresh_install(msg, false));
+        // existing file: permission/disk problem, must keep failing startup
+        assert!(!is_sqlite_cantopen_fresh_install(msg, true));
+        assert!(!is_sqlite_cantopen_fresh_install(
+            "connection refused",
+            false
+        ));
+    }
+
+    #[test]
+    fn test_other_errors_are_not_fresh_install() {
+        let e = errors::Error::Message("connection refused".to_string());
+        assert!(!is_db_schema_version_missing(&e));
+        let e = errors::Error::SqlxError(sqlx::Error::PoolTimedOut);
+        assert!(!is_db_schema_version_missing(&e));
+        // a db-level operation error that is not table-missing must not be
+        // treated as a fresh install
+        let e = errors::Error::DbError(errors::DbError::DBOperError(
+            "connection reset by peer".to_string(),
+            "/meta/kv/version".to_string(),
+        ));
+        assert!(!is_db_schema_version_missing(&e));
+    }
 }

--- a/src/infra/src/pipeline/postgres.rs
+++ b/src/infra/src/pipeline/postgres.rs
@@ -397,13 +397,11 @@ mod tests {
 
     #[test]
     fn test_postgres_pipeline_table_new() {
-        let t = PostgresPipelineTable::new();
-        drop(t);
+        let _table = PostgresPipelineTable::new();
     }
 
     #[test]
     fn test_postgres_pipeline_table_default() {
-        let t = PostgresPipelineTable::default();
-        drop(t);
+        let _table = PostgresPipelineTable::default();
     }
 }

--- a/src/infra/src/pipeline/sqlite.rs
+++ b/src/infra/src/pipeline/sqlite.rs
@@ -409,13 +409,11 @@ mod tests {
 
     #[test]
     fn test_sqlite_pipeline_table_new() {
-        let t = SqlitePipelineTable::new();
-        drop(t);
+        let _table = SqlitePipelineTable::new();
     }
 
     #[test]
     fn test_sqlite_pipeline_table_default() {
-        let t = SqlitePipelineTable::default();
-        drop(t);
+        let _table = SqlitePipelineTable::default();
     }
 }

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -940,14 +940,12 @@ mod tests {
 
     #[test]
     fn test_postgres_scheduler_new() {
-        let s = PostgresScheduler::new();
-        drop(s);
+        let _scheduler = PostgresScheduler::new();
     }
 
     #[test]
     fn test_postgres_scheduler_default() {
-        let s = PostgresScheduler::default();
-        drop(s);
+        let _scheduler = PostgresScheduler::default();
     }
 
     #[test]

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -609,13 +609,11 @@ mod tests {
 
     #[test]
     fn test_sqlite_scheduler_new() {
-        let s = SqliteScheduler::new();
-        drop(s);
+        let _scheduler = SqliteScheduler::new();
     }
 
     #[test]
     fn test_sqlite_scheduler_default() {
-        let s = SqliteScheduler::default();
-        drop(s);
+        let _scheduler = SqliteScheduler::default();
     }
 }

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -146,13 +146,11 @@ mod tests {
 
     #[test]
     fn test_postgres_schema_history_new() {
-        let s = PostgresSchemaHistory::new();
-        drop(s);
+        let _history = PostgresSchemaHistory::new();
     }
 
     #[test]
     fn test_postgres_schema_history_default() {
-        let s = PostgresSchemaHistory::default();
-        drop(s);
+        let _history = PostgresSchemaHistory::default();
     }
 }

--- a/src/infra/src/schema/history/sqlite.rs
+++ b/src/infra/src/schema/history/sqlite.rs
@@ -141,13 +141,11 @@ mod tests {
 
     #[test]
     fn test_sqlite_schema_history_new() {
-        let s = SqliteSchemaHistory::new();
-        drop(s);
+        let _history = SqliteSchemaHistory::new();
     }
 
     #[test]
     fn test_sqlite_schema_history_default() {
-        let s = SqliteSchemaHistory::default();
-        drop(s);
+        let _history = SqliteSchemaHistory::default();
     }
 }

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -1160,8 +1160,10 @@ mod tests {
         assert!(fields.is_empty());
 
         // Test with Some settings
-        let mut settings = StreamSettings::default();
-        settings.defined_schema_fields = vec!["field1".to_string(), "field2".to_string()];
+        let settings = StreamSettings {
+            defined_schema_fields: vec!["field1".to_string(), "field2".to_string()],
+            ..Default::default()
+        };
         let fields = get_stream_setting_defined_schema_fields(&Some(settings));
         assert_eq!(fields.len(), 2);
         assert!(fields.contains(&"field1".to_string()));
@@ -1171,10 +1173,12 @@ mod tests {
     #[test]
     fn test_get_stream_setting_fts_fields_with_settings() {
         // Test with custom FTS fields
-        let mut settings = StreamSettings::default();
-        settings.full_text_search_keys = vec!["custom_field".to_string()];
-        settings.index_original_data = true;
-        settings.index_all_values = true;
+        let settings = StreamSettings {
+            full_text_search_keys: vec!["custom_field".to_string()],
+            index_original_data: true,
+            index_all_values: true,
+            ..Default::default()
+        };
 
         let fields = get_stream_setting_fts_fields(&Some(settings));
         assert!(fields.contains(&"custom_field".to_string()));
@@ -1193,8 +1197,10 @@ mod tests {
         assert!(!fields.is_empty()); // Should have default fields
 
         // Test with custom index fields
-        let mut settings = StreamSettings::default();
-        settings.index_fields = vec!["index_field1".to_string(), "index_field2".to_string()];
+        let settings = StreamSettings {
+            index_fields: vec!["index_field1".to_string(), "index_field2".to_string()],
+            ..Default::default()
+        };
         let fields = get_stream_setting_index_fields(&Some(settings));
         assert!(fields.contains(&"index_field1".to_string()));
         assert!(fields.contains(&"index_field2".to_string()));
@@ -1212,8 +1218,10 @@ mod tests {
         assert_eq!(fields, BLOOM_FILTER_DEFAULT_FIELDS.clone());
 
         // Test with custom bloom filter fields
-        let mut settings = StreamSettings::default();
-        settings.bloom_filter_fields = vec!["bloom_field".to_string()];
+        let settings = StreamSettings {
+            bloom_filter_fields: vec!["bloom_field".to_string()],
+            ..Default::default()
+        };
         let fields = get_stream_setting_bloom_filter_fields(&Some(settings));
         assert!(fields.contains(&"bloom_field".to_string()));
 
@@ -1226,12 +1234,14 @@ mod tests {
     fn test_get_stream_setting_index_updated_at_for_fields() {
         let base_time = BASE_TIME.timestamp_micros();
         let created_at = 1_700_000_000_000_000;
-        let mut settings = StreamSettings::default();
-        settings.index_updated_at = 1_750_000_000_000_000;
-        settings
+        let mut stream_settings = StreamSettings {
+            index_updated_at: 1_750_000_000_000_000,
+            ..Default::default()
+        };
+        stream_settings
             .index_fields_updated_at
             .insert("user_id".to_string(), 1_760_000_000_000_000);
-        let settings = Some(settings);
+        let settings = Some(stream_settings.clone());
 
         // no referenced fields -> no cutoff
         let fields = Vec::new();
@@ -1267,11 +1277,10 @@ mod tests {
         assert_eq!(result, created_at);
 
         // default-enabled index fields always resolve to BASE_TIME, even with an entry
-        let mut settings = settings.unwrap();
-        settings
+        stream_settings
             .index_fields_updated_at
             .insert("trace_id".to_string(), 1_760_000_000_000_000);
-        let settings = Some(settings);
+        let settings = Some(stream_settings);
         let fields = vec!["trace_id".to_string()];
         let result =
             get_stream_setting_index_updated_at_for_fields(&settings, Some(created_at), &fields);

--- a/src/infra/src/table/anomaly_detection/config.rs
+++ b/src/infra/src/table/anomaly_detection/config.rs
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(active.anomaly_id.unwrap(), "anom-all");
         assert_eq!(active.org_id.unwrap(), "org-all");
         assert_eq!(active.stream_name.unwrap(), "default");
-        assert_eq!(active.enabled.unwrap(), true);
+        assert!(active.enabled.unwrap());
         assert_eq!(active.threshold.unwrap(), 95);
     }
 }

--- a/src/infra/src/table/backfill_jobs.rs
+++ b/src/infra/src/table/backfill_jobs.rs
@@ -143,53 +143,6 @@ pub async fn delete_by_org(org: &str) -> Result<(), errors::Error> {
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn make_model() -> Model {
-        Model {
-            id: "job-1".to_string(),
-            org: "myorg".to_string(),
-            pipeline_id: "pipe-1".to_string(),
-            start_time: 1000,
-            end_time: 2000,
-            chunk_period_minutes: Some(30),
-            delay_between_chunks_secs: Some(5),
-            delete_before_backfill: true,
-            created_at: 1000,
-            enabled: true,
-        }
-    }
-
-    #[test]
-    fn test_backfill_job_from_model() {
-        let model = make_model();
-        let job = BackfillJob::from(model);
-        assert_eq!(job.id, "job-1");
-        assert_eq!(job.org, "myorg");
-        assert_eq!(job.pipeline_id, "pipe-1");
-        assert_eq!(job.start_time, 1000);
-        assert_eq!(job.end_time, 2000);
-        assert_eq!(job.chunk_period_minutes, Some(30));
-        assert_eq!(job.delay_between_chunks_secs, Some(5));
-        assert!(job.delete_before_backfill);
-        assert!(job.enabled);
-    }
-
-    #[test]
-    fn test_backfill_job_from_model_optional_fields() {
-        let mut model = make_model();
-        model.chunk_period_minutes = None;
-        model.delay_between_chunks_secs = None;
-        model.delete_before_backfill = false;
-        let job = BackfillJob::from(model);
-        assert!(job.chunk_period_minutes.is_none());
-        assert!(job.delay_between_chunks_secs.is_none());
-        assert!(!job.delete_before_backfill);
-    }
-}
-
 pub async fn update(job: &BackfillJob) -> Result<(), errors::Error> {
     let _lock = get_lock().await;
 
@@ -248,5 +201,52 @@ pub async fn update_enabled(org: &str, job_id: &str, enabled: bool) -> Result<()
         }
         Ok(None) => orm_err!("backfill job not found"),
         Err(e) => orm_err!(format!("find backfill job error: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_model() -> Model {
+        Model {
+            id: "job-1".to_string(),
+            org: "myorg".to_string(),
+            pipeline_id: "pipe-1".to_string(),
+            start_time: 1000,
+            end_time: 2000,
+            chunk_period_minutes: Some(30),
+            delay_between_chunks_secs: Some(5),
+            delete_before_backfill: true,
+            created_at: 1000,
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn test_backfill_job_from_model() {
+        let model = make_model();
+        let job = BackfillJob::from(model);
+        assert_eq!(job.id, "job-1");
+        assert_eq!(job.org, "myorg");
+        assert_eq!(job.pipeline_id, "pipe-1");
+        assert_eq!(job.start_time, 1000);
+        assert_eq!(job.end_time, 2000);
+        assert_eq!(job.chunk_period_minutes, Some(30));
+        assert_eq!(job.delay_between_chunks_secs, Some(5));
+        assert!(job.delete_before_backfill);
+        assert!(job.enabled);
+    }
+
+    #[test]
+    fn test_backfill_job_from_model_optional_fields() {
+        let mut model = make_model();
+        model.chunk_period_minutes = None;
+        model.delay_between_chunks_secs = None;
+        model.delete_before_backfill = false;
+        let job = BackfillJob::from(model);
+        assert!(job.chunk_period_minutes.is_none());
+        assert!(job.delay_between_chunks_secs.is_none());
+        assert!(!job.delete_before_backfill);
     }
 }

--- a/src/infra/src/table/entity/alert_dedup_state.rs
+++ b/src/infra/src/table/entity/alert_dedup_state.rs
@@ -69,11 +69,11 @@ mod tests {
             fingerprint: "test_fingerprint_123".to_string(),
             alert_id: "alert_id_456".to_string(),
             org_id: "org_123".to_string(),
-            first_seen_at: 1234567890_000000,
-            last_seen_at: 1234567890_000000,
+            first_seen_at: 1_234_567_890_000_000,
+            last_seen_at: 1_234_567_890_000_000,
             occurrence_count: 1,
             notification_sent: false,
-            created_at: 1234567890_000000,
+            created_at: 1_234_567_890_000_000,
         };
 
         assert_eq!(model.fingerprint, "test_fingerprint_123");

--- a/src/infra/src/table/migration/m20241217_155000_populate_alerts_table.rs
+++ b/src/infra/src/table/migration/m20241217_155000_populate_alerts_table.rs
@@ -1395,7 +1395,7 @@ mod tests {
 
         let ser_condition: alerts_table_ser::Condition = meta_condition.into();
         assert_eq!(ser_condition.column, "status");
-        assert_eq!(ser_condition.ignore_case, true);
+        assert!(ser_condition.ignore_case);
 
         let value_str = ser_condition.value.as_str().unwrap();
         assert_eq!(value_str, "active");
@@ -1419,7 +1419,7 @@ mod tests {
         let ser_agg: alerts_table_ser::Aggregation = meta_agg.into();
         assert_eq!(ser_agg.group_by.as_ref().unwrap().len(), 2);
         assert_eq!(ser_agg.having.column, "count");
-        assert_eq!(ser_agg.having.ignore_case, false);
+        assert!(!ser_agg.having.ignore_case);
     }
 
     #[test]

--- a/src/infra/src/table/ratelimit.rs
+++ b/src/infra/src/table/ratelimit.rs
@@ -682,10 +682,10 @@ mod tests {
         // Test update
         let result = Entity::update_many()
             .col_expr(Column::Org, Expr::value(&rule.org))
-            .col_expr(Column::RuleType, Expr::value(&rule.rule_type.unwrap()))
-            .col_expr(Column::UserRole, Expr::value(&rule.user_role.unwrap()))
+            .col_expr(Column::RuleType, Expr::value(rule.rule_type.unwrap()))
+            .col_expr(Column::UserRole, Expr::value(rule.user_role.unwrap()))
             .col_expr(Column::Threshold, Expr::value(rule.threshold))
-            .filter(Column::RuleId.eq(&rule.rule_id.unwrap()))
+            .filter(Column::RuleId.eq(rule.rule_id.unwrap()))
             .exec(&db)
             .await;
 
@@ -736,15 +736,15 @@ mod tests {
     #[test]
     fn test_ratelimit_rule_type() {
         assert!(matches!(
-            RatelimitRuleType::try_from("exact"),
-            Ok(RatelimitRuleType::Exact)
+            RatelimitRuleType::from("exact"),
+            RatelimitRuleType::Exact
         ));
         assert!(matches!(
-            RatelimitRuleType::try_from("regex"),
-            Ok(RatelimitRuleType::Regex)
+            RatelimitRuleType::from("regex"),
+            RatelimitRuleType::Regex
         ));
         assert_eq!(
-            RatelimitRuleType::try_from("invalid").unwrap().to_string(),
+            RatelimitRuleType::from("invalid").to_string(),
             RatelimitRuleType::Exact.to_string()
         );
         assert_eq!(RatelimitRuleType::Exact.to_string(), "exact");

--- a/src/infra/src/table/re_pattern.rs
+++ b/src/infra/src/table/re_pattern.rs
@@ -66,52 +66,6 @@ impl PatternEntry {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_pattern_entry_new_sets_all_fields() {
-        let entry = PatternEntry::new("myorg", "pat1", "a description", r"\d+", "alice");
-        assert_eq!(entry.org, "myorg");
-        assert_eq!(entry.name, "pat1");
-        assert_eq!(entry.description, "a description");
-        assert_eq!(entry.pattern, r"\d+");
-        assert_eq!(entry.created_by, "alice");
-        assert!(!entry.id.is_empty());
-    }
-
-    #[test]
-    fn test_pattern_entry_new_timestamps_equal_at_creation() {
-        let entry = PatternEntry::new("org", "name", "desc", "pat", "user");
-        assert_eq!(entry.created_at, entry.updated_at);
-        assert!(entry.created_at > 0);
-    }
-
-    #[test]
-    fn test_pattern_entry_from_model_maps_all_fields() {
-        let model = Model {
-            id: "id-1".to_string(),
-            org: "myorg".to_string(),
-            name: "email".to_string(),
-            description: "match emails".to_string(),
-            created_by: "admin".to_string(),
-            created_at: 1_000_000,
-            updated_at: 2_000_000,
-            pattern: r"\S+@\S+\.\S+".to_string(),
-        };
-        let entry = PatternEntry::from(model);
-        assert_eq!(entry.id, "id-1");
-        assert_eq!(entry.org, "myorg");
-        assert_eq!(entry.name, "email");
-        assert_eq!(entry.description, "match emails");
-        assert_eq!(entry.created_by, "admin");
-        assert_eq!(entry.created_at, 1_000_000);
-        assert_eq!(entry.updated_at, 2_000_000);
-        assert_eq!(entry.pattern, r"\S+@\S+\.\S+");
-    }
-}
-
 pub async fn add(entry: PatternEntry) -> Result<(), errors::Error> {
     let record = ActiveModel {
         id: Set(entry.id),
@@ -239,4 +193,50 @@ pub async fn delete_by_org(org: &str) -> Result<(), errors::Error> {
         .exec(client)
         .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pattern_entry_new_sets_all_fields() {
+        let entry = PatternEntry::new("myorg", "pat1", "a description", r"\d+", "alice");
+        assert_eq!(entry.org, "myorg");
+        assert_eq!(entry.name, "pat1");
+        assert_eq!(entry.description, "a description");
+        assert_eq!(entry.pattern, r"\d+");
+        assert_eq!(entry.created_by, "alice");
+        assert!(!entry.id.is_empty());
+    }
+
+    #[test]
+    fn test_pattern_entry_new_timestamps_equal_at_creation() {
+        let entry = PatternEntry::new("org", "name", "desc", "pat", "user");
+        assert_eq!(entry.created_at, entry.updated_at);
+        assert!(entry.created_at > 0);
+    }
+
+    #[test]
+    fn test_pattern_entry_from_model_maps_all_fields() {
+        let model = Model {
+            id: "id-1".to_string(),
+            org: "myorg".to_string(),
+            name: "email".to_string(),
+            description: "match emails".to_string(),
+            created_by: "admin".to_string(),
+            created_at: 1_000_000,
+            updated_at: 2_000_000,
+            pattern: r"\S+@\S+\.\S+".to_string(),
+        };
+        let entry = PatternEntry::from(model);
+        assert_eq!(entry.id, "id-1");
+        assert_eq!(entry.org, "myorg");
+        assert_eq!(entry.name, "email");
+        assert_eq!(entry.description, "match emails");
+        assert_eq!(entry.created_by, "admin");
+        assert_eq!(entry.created_at, 1_000_000);
+        assert_eq!(entry.updated_at, 2_000_000);
+        assert_eq!(entry.pattern, r"\S+@\S+\.\S+");
+    }
 }

--- a/src/ingester/src/immutable.rs
+++ b/src/ingester/src/immutable.rs
@@ -386,16 +386,8 @@ mod tests {
         assert_eq!(total1, total2);
 
         // Used size and length may change due to concurrent tests, but should not vary wildly
-        let used_diff = if used2 > used1 {
-            used2 - used1
-        } else {
-            used1 - used2
-        };
-        let len_diff = if len2 > len1 {
-            len2 - len1
-        } else {
-            len1 - len2
-        };
+        let used_diff = used2.abs_diff(used1);
+        let len_diff = len2.abs_diff(len1);
         assert!(used_diff < 100000 || used1 == 0 || used2 == 0);
         assert!(len_diff < 100 || len1 == 0 || len2 == 0);
     }
@@ -420,16 +412,8 @@ mod tests {
         assert_eq!(total1, total2);
 
         // Used size and length may change due to concurrent tests, but should not vary wildly
-        let used_diff = if used2 > used1 {
-            used2 - used1
-        } else {
-            used1 - used2
-        };
-        let len_diff = if len2 > len1 {
-            len2 - len1
-        } else {
-            len1 - len2
-        };
+        let used_diff = used2.abs_diff(used1);
+        let len_diff = len2.abs_diff(len1);
         assert!(used_diff < 100000 || used1 == 0 || used2 == 0);
         assert!(len_diff < 100 || len1 == 0 || len2 == 0);
     }

--- a/src/report_server/src/report.rs
+++ b/src/report_server/src/report.rs
@@ -686,7 +686,7 @@ mod tests {
 
     #[test]
     fn test_dashboard_variables_generation() {
-        let variables = vec![
+        let variables = [
             ReportDashboardVariable {
                 key: "env".to_string(),
                 value: "prod".to_string(),

--- a/src/search/src/datafusion/exec.rs
+++ b/src/search/src/datafusion/exec.rs
@@ -1074,7 +1074,7 @@ mod tests {
     }
 
     #[test]
-    fn catalog_functions_documents_what_only_the_SERVER_can_supply() {
+    fn catalog_functions_documents_what_only_the_server_can_supply() {
         // Deliberately NOT asserting docs for the O2 UDFs. The frontend catalog
         // carries its own prose for those and wins on merge (it also owns which
         // arguments are columns), so a server-side doc for `match_all` would

--- a/src/search_service/src/streaming/execution.rs
+++ b/src/search_service/src/streaming/execution.rs
@@ -1102,10 +1102,11 @@ mod tests {
     use super::*;
 
     fn slice_with(n: usize) -> Response {
-        let mut r = Response::default();
-        r.hits = (0..n).map(|i| serde_json::json!({ "i": i })).collect();
-        r.total = n;
-        r
+        Response {
+            hits: (0..n).map(|i| serde_json::json!({ "i": i })).collect(),
+            total: n,
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -1134,7 +1135,7 @@ mod tests {
         let total: usize = slices.iter().map(|s| s.hits.len()).sum();
         assert_eq!(total, 10_000, "must fill the budget exactly");
         for (i, s) in slices.iter().enumerate() {
-            assert!(s.hits.len() > 0, "slice {i} was dropped entirely");
+            assert!(!s.hits.is_empty(), "slice {i} was dropped entirely");
         }
     }
 

--- a/src/wal/src/errors.rs
+++ b/src/wal/src/errors.rs
@@ -175,7 +175,7 @@ mod tests {
     #[test]
     fn test_file_sync_display() {
         let err = Error::FileSync {
-            source: io::Error::new(io::ErrorKind::Other, "sync failed"),
+            source: io::Error::other("sync failed"),
             path: PathBuf::from("/tmp/sync.wal"),
         };
         let display = format!("{err}");


### PR DESCRIPTION
## Summary

- run Clippy against every workspace member and target in the unit-test CI
- fix the existing test-target Clippy findings, including the non-snake-case test name
- keep warnings as hard failures so `unit_tests_summary` can be used as the required check

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p search --lib catalog_functions_documents_what_only_the_server_can_supply`
- `cargo test -p config --lib` — 2967 passed, 2 ignored
- `cargo test -p infra --lib` — 1243 passed, 35 ignored; the full parallel run also exposed two pre-existing local-only failures: an environment-sensitive default-index-field assertion and a shared mock database initialization race. The ratelimit test passes in isolation.