### PR TITLE
feat(llm): expose discovery API

### DIFF
--- a/src/api/http/src/handler/http/router/mod.rs
+++ b/src/api/http/src/handler/http/router/mod.rs
@@ -54,7 +54,7 @@ use {
         config::get_config as get_o2_config,
     },
     openobserve_api_management::request::{
-        actions, ai, annotation_queues, annotations, anomaly_detection, datasets,
+        actions, ai, annotation_queues, annotations, anomaly_detection, datasets, discovery,
         domain_management, eval_jobs, gen_ai, keys, license, providers, score_configs, scorers,
         service_streams, synthetics, workflows,
     },
@@ -1081,6 +1081,9 @@ pub fn service_routes() -> Router {
 
                 // On-demand human annotation from Discovery
                 .route("/{org_id}/annotations", post(annotations::annotate_target))
+
+                // LLM score-based Discovery
+                .route("/{org_id}/discovery", get(discovery::list_discovery_items))
 
                 // LLM Providers (Online Eval Phase 2)
                 .route("/{org_id}/providers", get(providers::list_providers).post(providers::create_provider))

--- a/src/api/management/src/models/discovery.rs
+++ b/src/api/management/src/models/discovery.rs
@@ -1,0 +1,267 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use config::meta::self_reporting::llm_scores::LlmScoreTargetScope;
+use openobserve_core::llm_evaluations::discovery::{
+    DiscoveryItem, DiscoveryPage, DiscoveryQueueMembership, DiscoveryQueueStatusFilter,
+    DiscoveryScopeTotals, ListDiscoveryItems,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
+#[derive(Clone, Debug, Deserialize, IntoParams)]
+#[serde(deny_unknown_fields)]
+#[into_params(parameter_in = Query)]
+pub struct ListDiscoveryItemsQuery {
+    /// Target scope: `span`, `trace`, or `session`.
+    #[param(value_type = String, example = "trace")]
+    pub scope: LlmScoreTargetScope,
+    /// Queue membership filter. Defaults to `not_enqueued`; also supports
+    /// `enqueued`, `pending`, `reviewed`, and `all`.
+    pub queue_status: Option<String>,
+    /// Inclusive target timestamp lower bound, in microseconds.
+    pub start_time: i64,
+    /// Exclusive target timestamp upper bound, in microseconds.
+    pub end_time: i64,
+    /// Zero-based result offset. Defaults to 0.
+    pub from: Option<usize>,
+    /// Page size from 1 through 100. Defaults to 20.
+    pub size: Option<usize>,
+}
+
+impl TryFrom<ListDiscoveryItemsQuery> for ListDiscoveryItems {
+    type Error = openobserve_core::llm_evaluations::discovery::DiscoveryError;
+
+    fn try_from(value: ListDiscoveryItemsQuery) -> Result<Self, Self::Error> {
+        Ok(Self {
+            scope: value.scope,
+            queue_status: value
+                .queue_status
+                .as_deref()
+                .map(DiscoveryQueueStatusFilter::try_from)
+                .transpose()?
+                .unwrap_or_default(),
+            start_time: value.start_time,
+            end_time: value.end_time,
+            from: value.from.unwrap_or(0),
+            size: value.size.unwrap_or(20),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryItemResponseBody {
+    pub scope: String,
+    pub target_id: String,
+    pub trace_id: Option<String>,
+    pub session_id: Option<String>,
+    pub ref_timestamp: i64,
+    pub source_stream: Option<String>,
+    /// Derived quality: `issue` for one unhealthy dimension and `multiple` for
+    /// two or more unhealthy dimensions.
+    pub quality: String,
+    pub issue_count: usize,
+    /// Scope-specific display fields hydrated from the target trace stream.
+    pub context: Option<serde_json::Value>,
+    /// Visible Annotation Queue memberships for this target.
+    pub queues: Vec<DiscoveryQueueMembershipResponseBody>,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryQueueMembershipResponseBody {
+    pub queue_id: String,
+    pub queue_name: Option<String>,
+    /// Queue workflow status: `pending` or `reviewed`.
+    pub status: String,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryScopeTotalsResponseBody {
+    pub span: usize,
+    pub trace: usize,
+    pub session: usize,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListDiscoveryItemsResponseBody {
+    pub list: Vec<DiscoveryItemResponseBody>,
+    pub total: usize,
+    pub scope_totals: DiscoveryScopeTotalsResponseBody,
+    pub from: usize,
+    pub size: usize,
+    pub has_more: bool,
+}
+
+impl From<DiscoveryItem> for DiscoveryItemResponseBody {
+    fn from(value: DiscoveryItem) -> Self {
+        Self {
+            scope: value.scope.to_string(),
+            target_id: value.target_id,
+            trace_id: value.trace_id,
+            session_id: value.session_id,
+            ref_timestamp: value.ref_timestamp,
+            source_stream: value.source_stream,
+            quality: value.quality.as_str().to_string(),
+            issue_count: value.issue_count,
+            context: value.context,
+            queues: value
+                .queues
+                .into_iter()
+                .map(DiscoveryQueueMembershipResponseBody::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<DiscoveryQueueMembership> for DiscoveryQueueMembershipResponseBody {
+    fn from(value: DiscoveryQueueMembership) -> Self {
+        Self {
+            queue_id: value.queue_id,
+            queue_name: value.queue_name,
+            status: value.status,
+        }
+    }
+}
+
+impl From<DiscoveryScopeTotals> for DiscoveryScopeTotalsResponseBody {
+    fn from(value: DiscoveryScopeTotals) -> Self {
+        Self {
+            span: value.span,
+            trace: value.trace,
+            session: value.session,
+        }
+    }
+}
+
+impl From<DiscoveryPage> for ListDiscoveryItemsResponseBody {
+    fn from(value: DiscoveryPage) -> Self {
+        Self {
+            list: value
+                .items
+                .into_iter()
+                .map(DiscoveryItemResponseBody::from)
+                .collect(),
+            total: value.total,
+            scope_totals: value.scope_totals.into(),
+            from: value.from,
+            size: value.size,
+            has_more: value.has_more,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openobserve_core::llm_evaluations::discovery::{
+        DiscoveryQuality, DiscoveryQueueMembership, DiscoveryScopeTotals,
+    };
+
+    use super::*;
+
+    #[test]
+    fn query_defaults_to_not_enqueued_and_standard_pagination() {
+        let request = ListDiscoveryItems::try_from(ListDiscoveryItemsQuery {
+            scope: LlmScoreTargetScope::Trace,
+            queue_status: None,
+            start_time: 10,
+            end_time: 20,
+            from: None,
+            size: None,
+        })
+        .unwrap();
+
+        assert_eq!(
+            request.queue_status,
+            DiscoveryQueueStatusFilter::NotEnqueued
+        );
+        assert_eq!(request.from, 0);
+        assert_eq!(request.size, 20);
+    }
+
+    #[test]
+    fn query_rejects_unknown_queue_status() {
+        let result = ListDiscoveryItems::try_from(ListDiscoveryItemsQuery {
+            scope: LlmScoreTargetScope::Span,
+            queue_status: Some("open".to_string()),
+            start_time: 10,
+            end_time: 20,
+            from: None,
+            size: None,
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn response_serializes_context_and_all_scope_totals() {
+        let response = ListDiscoveryItemsResponseBody::from(DiscoveryPage {
+            items: vec![DiscoveryItem {
+                scope: LlmScoreTargetScope::Trace,
+                target_id: "trace-1".to_string(),
+                trace_id: Some("trace-1".to_string()),
+                session_id: None,
+                ref_timestamp: 123,
+                source_stream: Some("traces".to_string()),
+                quality: DiscoveryQuality::Issue,
+                issue_count: 1,
+                context: Some(serde_json::json!({
+                    "input": "question",
+                    "serviceName": "api",
+                    "operationName": "chat",
+                    "spanKind": "INTERNAL",
+                })),
+                queues: vec![
+                    DiscoveryQueueMembership {
+                        queue_id: "queue-1".to_string(),
+                        queue_name: Some("Safety review".to_string()),
+                        status: "pending".to_string(),
+                    },
+                    DiscoveryQueueMembership {
+                        queue_id: "queue-2".to_string(),
+                        queue_name: Some("Completed review".to_string()),
+                        status: "reviewed".to_string(),
+                    },
+                ],
+            }],
+            total: 42,
+            scope_totals: DiscoveryScopeTotals {
+                span: 216,
+                trace: 42,
+                session: 11,
+            },
+            from: 0,
+            size: 20,
+            has_more: true,
+        });
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(value["scopeTotals"]["span"], 216);
+        assert_eq!(value["scopeTotals"]["trace"], 42);
+        assert_eq!(value["scopeTotals"]["session"], 11);
+        assert_eq!(value["list"][0]["context"]["input"], "question");
+        assert_eq!(value["list"][0]["queues"][0]["queueId"], "queue-1");
+        assert_eq!(value["list"][0]["queues"][0]["queueName"], "Safety review");
+        assert_eq!(value["list"][0]["queues"][1]["status"], "reviewed");
+        assert!(value["list"][0].get("traceDetails").is_none());
+        assert!(value["list"][0]["context"].get("output").is_none());
+        assert_eq!(value["from"], 0);
+        assert_eq!(value["size"], 20);
+        assert_eq!(value["hasMore"], true);
+    }
+}

--- a/src/api/management/src/models/mod.rs
+++ b/src/api/management/src/models/mod.rs
@@ -28,6 +28,8 @@ pub mod dashboards;
 pub mod datasets;
 pub mod destinations;
 #[cfg(feature = "enterprise")]
+pub mod discovery;
+#[cfg(feature = "enterprise")]
 pub mod eval_jobs;
 pub mod folders;
 #[cfg(feature = "enterprise")]

--- a/src/api/management/src/request/discovery.rs
+++ b/src/api/management/src/request/discovery.rs
@@ -1,0 +1,209 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use axum::{
+    extract::{Path, Query},
+    response::Response,
+};
+use openobserve_api_common::extractors::Headers;
+use openobserve_core::{
+    auth::UserEmail,
+    http::map_error_to_http_response,
+    llm_evaluations::discovery::{self, DiscoveryError, ListDiscoveryItems},
+};
+
+use crate::{
+    common::meta::http::HttpResponse as MetaHttpResponse,
+    models::discovery::{ListDiscoveryItemsQuery, ListDiscoveryItemsResponseBody},
+};
+
+fn discovery_error_response(error: DiscoveryError) -> Response {
+    match error {
+        error @ (DiscoveryError::InvalidQueueStatus(_)
+        | DiscoveryError::InvalidTimeRange
+        | DiscoveryError::InvalidPageSize) => MetaHttpResponse::bad_request(error),
+        DiscoveryError::Infra(error) => {
+            log::error!("[Discovery] score-config database error: {error}");
+            MetaHttpResponse::internal_error("Internal server error")
+        }
+        DiscoveryError::Database(error) => {
+            log::error!("[Discovery] queue database error: {error}");
+            MetaHttpResponse::internal_error("Internal server error")
+        }
+        DiscoveryError::Search(error) => {
+            log::error!("[Discovery] {error}");
+            match error.downcast_ref::<infra::errors::Error>() {
+                Some(error) => map_error_to_http_response(error, None),
+                None => MetaHttpResponse::internal_error("Discovery query failed"),
+            }
+        }
+        error @ DiscoveryError::MalformedSearchResponse(_) => {
+            log::error!("[Discovery] {error}");
+            MetaHttpResponse::internal_error("Discovery query failed")
+        }
+    }
+}
+
+fn visible_queue_ids(
+    org_id: &str,
+    permitted_objects: Option<Vec<String>>,
+) -> Option<HashSet<String>> {
+    let permitted_objects = permitted_objects?;
+    if permitted_objects.contains(&format!("annotation_queue:_all_{org_id}")) {
+        return None;
+    }
+
+    Some(
+        permitted_objects
+            .into_iter()
+            .filter_map(|object| object.strip_prefix("annotation_queue:").map(str::to_string))
+            .collect(),
+    )
+}
+
+/// ListDiscoveryItems
+#[utoipa::path(
+    get,
+    path = "/{org_id}/discovery",
+    context_path = "/api",
+    tag = "Discovery",
+    operation_id = "ListDiscoveryItems",
+    summary = "List unhealthy scored LLM targets",
+    description = "Resolves the latest score evaluation and score dimension, applies the current active Score Config thresholds, derives issue or multiple quality, applies visible queue memberships, returns exact totals for every native scope, pages the requested scope, and hydrates scope-specific context for that page.",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ListDiscoveryItemsQuery,
+    ),
+    responses(
+        (status = 200, body = inline(ListDiscoveryItemsResponseBody)),
+        (status = 400, description = "Invalid discovery request or search query", content_type = "application/json", body = MetaHttpResponse),
+        (status = 403, description = "Unable to resolve visible Annotation Queues", content_type = "application/json", body = MetaHttpResponse),
+        (status = 408, description = "Discovery query timed out", content_type = "application/json", body = MetaHttpResponse),
+        (status = 429, description = "Discovery query cancelled or rate limited", content_type = "application/json", body = MetaHttpResponse),
+        (status = 500, description = "Discovery query failed", content_type = "application/json", body = MetaHttpResponse),
+        (status = 503, description = "Discovery query service unavailable", content_type = "application/json", body = MetaHttpResponse),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "Discovery", "operation": "list"}))),
+)]
+pub async fn list_discovery_items(
+    Path(org_id): Path<String>,
+    Headers(user): Headers<UserEmail>,
+    Query(query): Query<ListDiscoveryItemsQuery>,
+) -> Response {
+    let request = match ListDiscoveryItems::try_from(query) {
+        Ok(request) => request,
+        Err(error) => return discovery_error_response(error),
+    };
+
+    let permitted_objects = match openobserve_api_common::auth::validator::list_objects_for_user(
+        &org_id,
+        &user.user_id,
+        "GET",
+        "annotation_queue",
+    )
+    .await
+    {
+        Ok(list) => list,
+        Err(error) => return MetaHttpResponse::forbidden(error.to_string()),
+    };
+    let visible_queue_ids = visible_queue_ids(&org_id, permitted_objects);
+
+    match discovery::list(&org_id, request, visible_queue_ids.as_ref()).await {
+        Ok(page) => MetaHttpResponse::json(ListDiscoveryItemsResponseBody::from(page)),
+        Err(error) => discovery_error_response(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use infra::errors::{Error as InfraError, ErrorCodes};
+
+    use super::*;
+
+    #[test]
+    fn maps_client_errors_to_bad_request() {
+        assert_eq!(
+            discovery_error_response(DiscoveryError::InvalidQueueStatus("open".to_string()))
+                .status()
+                .as_u16(),
+            400
+        );
+        assert_eq!(
+            discovery_error_response(DiscoveryError::InvalidTimeRange)
+                .status()
+                .as_u16(),
+            400
+        );
+    }
+
+    #[test]
+    fn resolves_explicit_and_organization_wide_queue_visibility() {
+        assert_eq!(
+            visible_queue_ids(
+                "org-1",
+                Some(vec![
+                    "annotation_queue:queue-1".to_string(),
+                    "dataset:dataset-1".to_string(),
+                ]),
+            ),
+            Some(HashSet::from(["queue-1".to_string()]))
+        );
+        assert_eq!(
+            visible_queue_ids(
+                "org-1",
+                Some(vec!["annotation_queue:_all_org-1".to_string()]),
+            ),
+            None
+        );
+        assert_eq!(visible_queue_ids("org-1", None), None);
+    }
+
+    #[tokio::test]
+    async fn forwards_structured_search_errors() {
+        let response = discovery_error_response(DiscoveryError::Search(anyhow::anyhow!(
+            InfraError::ErrorCode(ErrorCodes::SearchTimeout("query timed out".to_string())),
+        )));
+
+        assert_eq!(response.status().as_u16(), 408);
+        assert_eq!(response.headers().get("X-Error-Message").unwrap(), "20010");
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: MetaHttpResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body.code, 20010);
+        assert_eq!(body.message, "Search query timed out");
+        assert_eq!(body.error_detail.as_deref(), Some("query timed out"));
+    }
+
+    #[tokio::test]
+    async fn hides_unstructured_search_errors() {
+        let response = discovery_error_response(DiscoveryError::Search(anyhow::anyhow!(
+            "executor failed with private details"
+        )));
+
+        assert_eq!(response.status().as_u16(), 500);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: MetaHttpResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body.code, 500);
+        assert_eq!(body.message, "Discovery query failed");
+    }
+}

--- a/src/api/management/src/request/mod.rs
+++ b/src/api/management/src/request/mod.rs
@@ -32,6 +32,8 @@ pub mod dashboards;
 #[cfg(feature = "enterprise")]
 pub mod datasets;
 #[cfg(feature = "enterprise")]
+pub mod discovery;
+#[cfg(feature = "enterprise")]
 pub mod domain_management;
 #[cfg(feature = "enterprise")]
 pub mod eval_jobs;

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -52,7 +52,7 @@ pub type RwAHashSet<K> = tokio::sync::RwLock<HashSet<K>>;
 pub type RwBTreeMap<K, V> = tokio::sync::RwLock<BTreeMap<K, V>>;
 
 // for DDL commands and migrations
-pub const DB_SCHEMA_VERSION: u64 = 65;
+pub const DB_SCHEMA_VERSION: u64 = 67;
 pub const DB_SCHEMA_KEY: &str = "/db_schema_version/";
 
 // global version variables

--- a/src/core/src/llm_evaluations/mod.rs
+++ b/src/core/src/llm_evaluations/mod.rs
@@ -17,6 +17,6 @@ pub mod eval_jobs;
 pub mod evaluator_trace_exporter;
 
 pub use o2_enterprise::enterprise::llm_evaluations::{
-    annotation_queues, annotations, datasets, evaluator_trace, prepared_scorers, score_configs,
-    score_writer, scorers,
+    annotation_queues, annotations, datasets, discovery, evaluator_trace, prepared_scorers,
+    score_configs, score_writer, scorers,
 };


### PR DESCRIPTION
Add the scope and queue-status filter contract for Discovery results. Register the organization endpoint and return the paginated scored-target projection.

---
**Stack**:
- #13714
- #13713
- #13712
- #13711
- #13660
- #13649
- #13648
- #13634
- #13629
- #13623
- #13620 ⬅
- #13608
- #13607
- #13597
- #13596
- #13595
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*