### PR TITLE
test(e2e/alpha1): re-authorize & resume on session expiry / 401 (stop needing re-runs)

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -10,7 +10,7 @@ import * as path from 'path';
 
 // Import testLogger for proper logging
 const testLogger = require('../../playwright-tests/utils/test-logger.js');
-const { getAuthHeaders, getOrgIdentifier, isCloudEnvironment } = require('../../playwright-tests/utils/cloud-auth.js');
+const { getAuthHeaders, getOrgIdentifier, isCloudEnvironment, authedRequest } = require('../../playwright-tests/utils/cloud-auth.js');
 const MonacoEditorHelper = require('../../playwright-tests/utils/MonacoEditorHelper.js');
 
 export class LogsPage {
@@ -844,7 +844,9 @@ export class LogsPage {
             await expect.poll(async () => {
                 pollCount++;
                 try {
-                    const response = await this.page.request.get(url, { headers: getAuthHeaders() });
+                    // authedRequest self-heals on 401/403 (refresh passcode / re-auth) so a
+                    // rotated-credential 401 from a concurrent shard doesn't stall the poll.
+                    const response = await authedRequest(this.page, 'get', url);
                     const status = response.status();
                     if (response.ok()) {
                         const data = await response.json();

--- a/tests/ui-testing/playwright-tests/utils/cloud-auth.js
+++ b/tests/ui-testing/playwright-tests/utils/cloud-auth.js
@@ -71,4 +71,69 @@ function getOrgIdentifier() {
     return process.env['ORGNAME'];
 }
 
-module.exports = { getAuthHeaders, isCloudEnvironment, getCloudConfig, getOrgIdentifier };
+/**
+ * Drop the in-memory cloud-config cache so the next getCloudConfig()/getAuthHeaders()
+ * re-reads cloud-config.json from disk. Call after the file has been rewritten with a
+ * fresh passcode (refreshCloudConfig / re-auth).
+ */
+function resetCloudConfigCache() {
+    _cloudConfig = null;
+}
+
+/**
+ * Re-fetch this org's passcode using the page's LIVE browser session (cookie auth) and
+ * rewrite cloud-config.json. Cheap and non-disruptive (a background fetch — no navigation),
+ * so it's safe to call mid-test. Recovers the common cloud failure where the per-org passcode
+ * was rotated/invalidated by another shard sharing the org while the UI session is still alive.
+ * Returns true if a fresh passcode was obtained.
+ * @param {import('@playwright/test').Page} page
+ */
+async function refreshCloudConfig(page) {
+    if (!isCloudEnvironment()) return false;
+    try {
+        const orgId = getOrgIdentifier();
+        const pc = await page.evaluate(async (org) => {
+            const r = await fetch('/api/' + org + '/passcode');
+            return r.ok ? await r.json() : null;
+        }, orgId);
+        if (pc && pc.data && pc.data.passcode) {
+            const next = { ...(getCloudConfig() || {}), orgIdentifier: orgId, userEmail: pc.data.user, passcode: pc.data.passcode };
+            const configFile = path.join(__dirname, 'auth', 'cloud-config.json');
+            try { fs.writeFileSync(configFile, JSON.stringify(next, null, 2)); } catch (e) { /* fall through with in-memory value */ }
+            _cloudConfig = next;
+            const testLogger = require('./test-logger.js');
+            testLogger.info('[auth] Refreshed cloud passcode after 401');
+            return true;
+        }
+    } catch (e) {
+        // session may itself be dead — caller escalates to full re-auth
+    }
+    return false;
+}
+
+/**
+ * page.request wrapper that self-heals on 401/403: refreshes the passcode (and, if the
+ * session itself is dead, escalates to a full Dex re-login) then retries. Use for
+ * authenticated API calls so a transient/rotated-credential 401 doesn't fail the test.
+ * @param {import('@playwright/test').Page} page
+ * @param {'get'|'post'|'put'|'delete'|'patch'} method
+ * @param {string} url
+ * @param {object} [options] extra page.request options (data, params, ...)
+ * @param {number} [retries] max recovery attempts on 401/403
+ */
+async function authedRequest(page, method, url, options = {}, retries = 1) {
+    let resp = await page.request[method](url, { headers: getAuthHeaders(), ...options });
+    for (let i = 0; i < retries && (resp.status() === 401 || resp.status() === 403); i++) {
+        let recovered = await refreshCloudConfig(page);
+        if (!recovered) {
+            // Session itself is likely dead — lazy-require to avoid a circular import.
+            try { recovered = await require('./reauth-alpha1.js').reauthenticateAlpha1(page); }
+            catch (e) { recovered = false; }
+        }
+        if (!recovered) break;
+        resp = await page.request[method](url, { headers: getAuthHeaders(), ...options });
+    }
+    return resp;
+}
+
+module.exports = { getAuthHeaders, isCloudEnvironment, getCloudConfig, getOrgIdentifier, resetCloudConfigCache, refreshCloudConfig, authedRequest };

--- a/tests/ui-testing/playwright-tests/utils/enhanced-baseFixtures.js
+++ b/tests/ui-testing/playwright-tests/utils/enhanced-baseFixtures.js
@@ -146,13 +146,30 @@ async function navigateToBase(page) {
     await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
   }
   
-  const isAuthenticated = await verifyAuthentication(page);
-  
+  let isAuthenticated = await verifyAuthentication(page);
+
+  // Self-heal on cloud: the shared session token is minted once at the start of the run
+  // and reused by every shard, so on long runs (or when shards sharing an org contend on
+  // the same credential) it can expire/invalidate mid-run — surfacing as this auth check
+  // failing. Rather than fail the test, re-authenticate (fresh Dex login + org switch +
+  // passcode refresh) in this context and resume.
+  if (!isAuthenticated && isCloudEnvironment()) {
+    testLogger.warn('Auth check failed — attempting re-authentication and resume');
+    const { reauthenticateAlpha1 } = require('./reauth-alpha1.js');
+    const recovered = await reauthenticateAlpha1(page);
+    if (recovered) {
+      await page.goto(baseUrlWithOrg, { timeout: navTimeout });
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      isAuthenticated = await verifyAuthentication(page);
+    }
+  }
+
   if (!isAuthenticated) {
-    testLogger.error('User not authenticated - global setup might have failed');
+    testLogger.error('User not authenticated - global setup might have failed (re-auth also failed or unavailable)');
     throw new Error('User not authenticated. Global setup might have failed.');
   }
-  
+
   testLogger.info('Successfully navigated to base URL with authentication');
 }
 

--- a/tests/ui-testing/playwright-tests/utils/global-setup-alpha1.js
+++ b/tests/ui-testing/playwright-tests/utils/global-setup-alpha1.js
@@ -717,3 +717,8 @@ async function performGlobalIngestionWithFetch() {
 }
 
 module.exports = globalSetup;
+// Named helpers reused by mid-run re-authentication (reauth-alpha1.js). Attaching
+// them as properties keeps the default export the globalSetup function Playwright calls.
+module.exports.performDexLogin = performDexLogin;
+module.exports.switchOrgViaDropdown = switchOrgViaDropdown;
+module.exports.fetchCloudConfig = fetchCloudConfig;

--- a/tests/ui-testing/playwright-tests/utils/reauth-alpha1.js
+++ b/tests/ui-testing/playwright-tests/utils/reauth-alpha1.js
@@ -1,0 +1,58 @@
+const path = require('path');
+const testLogger = require('./test-logger.js');
+const { isCloudEnvironment, resetCloudConfigCache } = require('./cloud-auth.js');
+// Reuse the proven Dex login / org-switch / passcode-fetch helpers from global setup.
+const { performDexLogin, switchOrgViaDropdown, fetchCloudConfig } = require('./global-setup-alpha1.js');
+
+const AUTH_FILE = path.join(__dirname, 'auth', 'user.json');
+
+/**
+ * Mid-run recovery for Alpha1 (cloud) when the shared session/passcode has expired or been
+ * invalidated by another shard sharing the same org. Performs a fresh Dex login in the CURRENT
+ * browser context, re-selects ORGNAME, re-fetches the passcode, and persists the refreshed
+ * storageState + cloud-config so the rest of this worker's tests (and getAuthHeaders API calls)
+ * use the new credentials.
+ *
+ * NOTE: this navigates the page (a full login flow), so callers must treat it as a hard reset —
+ * it's meant to run at a test boundary (navigateToBase) or as a last-resort escalation after a
+ * cheaper passcode refresh has already failed.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<boolean>} true if re-authentication succeeded
+ */
+async function reauthenticateAlpha1(page) {
+    if (!isCloudEnvironment()) return false;
+
+    const baseUrl = (process.env.ZO_BASE_URL || '').replace(/\/$/, '');
+    const idx = (process.env.ALPHA1_USER_INDEX || '1').trim();
+    const email = (process.env[`ALPHA1_USER_EMAIL_${idx}`] || process.env.ALPHA1_USER_EMAIL || '').trim();
+    const password = (process.env.ALPHA1_USER_PASSWORD || '').trim();
+    if (!baseUrl || !email || !password) {
+        testLogger.warn('[reauth] Missing ZO_BASE_URL / ALPHA1 creds — cannot re-authenticate');
+        return false;
+    }
+
+    try {
+        testLogger.info(`[reauth] Session lost — re-authenticating Dex user ${idx} (${email})`);
+        await performDexLogin(page, baseUrl, email, password);
+
+        const targetOrg = process.env.ORGNAME;
+        if (targetOrg && targetOrg !== 'default') {
+            await switchOrgViaDropdown(page, targetOrg);
+        }
+
+        // Persist the refreshed session so later tests in this worker reuse it,
+        // and refresh the passcode used by getAuthHeaders() for API calls.
+        await page.context().storageState({ path: AUTH_FILE });
+        await fetchCloudConfig(page);
+        resetCloudConfigCache();
+
+        testLogger.info('[reauth] Re-authentication succeeded');
+        return true;
+    } catch (e) {
+        testLogger.error(`[reauth] Re-authentication failed: ${e.message}`);
+        return false;
+    }
+}
+
+module.exports = { reauthenticateAlpha1 };


### PR DESCRIPTION
## Self-heal Alpha1 e2e on auth expiry / 401 (no more "re-run to pass")

### Problem
Alpha1 mints the shared cloud session + per-org passcode **once** (pre-test-cleanup) and every shard reuses it for the whole run. On long runs — and whenever shards sharing an org contend on the same per-org passcode — that credential expires/rotates **mid-run**, and tests fail with:

- `Error: User not authenticated. Global setup might have failed.` (UI session dead)
- `HTTP 401, body=Unauthorized Access` (API calls, e.g. `waitForStreamAvailable`)

Observed across runs [30892800970](https://github.com/openobserve/o2-enterprise/actions/runs/30892800970) and [30900015839](https://github.com/openobserve/o2-enterprise/actions/runs/30900015839): 401s are **scattered and self-recovering** (not a clean TTL cliff), interleaved with passing tests — the fingerprint of shared-credential contention. There was **no re-auth path** anywhere: auth was minted once, cached, and reused forever; a 401 just failed the test. Reducing parallelism doesn't fix it (later batches run *further* from mint time, and batching isn't org-aware).

### Fix — re-authorize and resume
- **`cloud-auth.js`**
  - `refreshCloudConfig(page)` — re-fetches the org passcode via the **live browser session** (background fetch, no navigation) and rewrites `cloud-config.json`; `resetCloudConfigCache()` drops the in-memory cache.
  - `authedRequest(page, method, url, …)` — wraps `page.request` and, on 401/403, refreshes the passcode and retries; escalates to a full re-login only if the session itself is dead.
- **`reauth-alpha1.js`** (new) — `reauthenticateAlpha1(page)` does a fresh Dex login + org switch + passcode refresh in the current context and persists `storageState` (reuses the proven `global-setup-alpha1` helpers, now exported).
- **`enhanced-baseFixtures.navigateToBase`** — on cloud, if the auth check fails, re-authenticate and resume instead of throwing.
- **`logsPage.waitForStreamAvailable`** — uses `authedRequest` so a rotated-credential 401 self-heals instead of stalling the poll.

All new behaviour is gated on `isCloudEnvironment()` — **no change for self-hosted**.

### Scope note
This is entirely OSS test-framework code (no ENT change). Per your call, org-sharing across 2 shards is left as-is — re-auth makes the contention self-healing rather than fatal. Seeding an Alpha1 run from this branch (OSS) to validate.
