### PR TITLE
test(e2e/alpha1): robustness — auth self-heal + service-graph wide window

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -10,7 +10,7 @@ import * as path from 'path';
 
 // Import testLogger for proper logging
 const testLogger = require('../../playwright-tests/utils/test-logger.js');
-const { getAuthHeaders, getOrgIdentifier, isCloudEnvironment } = require('../../playwright-tests/utils/cloud-auth.js');
+const { getAuthHeaders, getOrgIdentifier, isCloudEnvironment, authedRequest } = require('../../playwright-tests/utils/cloud-auth.js');
 const MonacoEditorHelper = require('../../playwright-tests/utils/MonacoEditorHelper.js');
 
 export class LogsPage {
@@ -844,7 +844,9 @@ export class LogsPage {
             await expect.poll(async () => {
                 pollCount++;
                 try {
-                    const response = await this.page.request.get(url, { headers: getAuthHeaders() });
+                    // authedRequest self-heals on 401/403 (refresh passcode / re-auth) so a
+                    // rotated-credential 401 from a concurrent shard doesn't stall the poll.
+                    const response = await authedRequest(this.page, 'get', url);
                     const status = response.status();
                     if (response.ok()) {
                         const data = await response.json();

--- a/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
+++ b/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
@@ -78,7 +78,7 @@ export class ServiceGraphPage {
    * Sets the stream filter in localStorage before navigating to ensure the correct stream is shown.
    * @param {string} streamName - Stream to filter by (default: 'default')
    */
-  async navigateToServiceGraphUrl(streamName = 'default') {
+  async navigateToServiceGraphUrl(streamName = 'default', period = '6h') {
     // Set stream filter in localStorage before navigation — the Vue component reads from here
     await this.page.evaluate((stream) => {
       localStorage.setItem('serviceGraph_streamFilter', stream);
@@ -86,9 +86,40 @@ export class ServiceGraphPage {
 
     const org = process.env['ORGNAME'] || 'default';
     const baseUrl = (process.env['ZO_BASE_URL'] || '').replace(/\/+$/, '');
-    const url = `${baseUrl}/web/traces?tab=service-graph&org_identifier=${org}`;
+    // Query a WIDE window (default 6h), not the page default of "Past 15 Minutes". The service
+    // graph is derived by a backend daemon that runs on a delay after trace ingestion, so with
+    // the 15m default the just-ingested topology often falls outside the window and the chart
+    // renders "No service graph data" (no chart element) — the alpha1 failure mode. The tab
+    // honours the `period` URL param (verified: label shows "Past 6 Hours").
+    const url = `${baseUrl}/web/traces?tab=service-graph&period=${period}&org_identifier=${org}`;
     await this.page.goto(url);
     await this.page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  }
+
+  /**
+   * Navigate to the service graph and wait until the chart actually renders, tolerating
+   * service-graph-daemon lag: if the page shows the empty "No service graph data" state,
+   * refresh and retry within the budget. Returns once the chart is visible; if it never
+   * renders the caller's own assertion still fails (non-masking).
+   * @param {string} streamName
+   * @param {object} [opts] { period, timeout }
+   */
+  async navigateToServiceGraphAndWaitForChart(streamName = 'default', opts = {}) {
+    const period = opts.period || '6h';
+    const timeout = opts.timeout || 90000;
+    await this.navigateToServiceGraphUrl(streamName, period);
+
+    const chart = this.page.locator(this.chartContainer);
+    const deadline = Date.now() + timeout;
+    // Date.now() is allowed here (test/page-object runtime, not a workflow script).
+    while (Date.now() < deadline) {
+      if (await chart.isVisible().catch(() => false)) return true;
+      // Empty-state → nudge the daemon result by refreshing, then wait a cycle.
+      await this.page.locator(this.refreshButton).click({ timeout: 5000 }).catch(() => {});
+      await this.page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      await chart.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+    }
+    return await chart.isVisible().catch(() => false);
   }
 
   async expectServiceGraphPageVisible() {

--- a/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
+++ b/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
@@ -77,6 +77,9 @@ export class ServiceGraphPage {
    * Navigate directly to service graph via URL (more reliable than click-based navigation).
    * Sets the stream filter in localStorage before navigating to ensure the correct stream is shown.
    * @param {string} streamName - Stream to filter by (default: 'default')
+   * @param {string} [period='6h'] - Relative time window passed via the `period` URL param.
+   *   Defaults to a WIDE 6h window (not the page default "Past 15 Minutes") so the
+   *   daemon-processed topology reliably falls inside the query window and the chart renders.
    */
   async navigateToServiceGraphUrl(streamName = 'default', period = '6h') {
     // Set stream filter in localStorage before navigation — the Vue component reads from here

--- a/tests/ui-testing/playwright-alpha1.config.js
+++ b/tests/ui-testing/playwright-alpha1.config.js
@@ -58,6 +58,21 @@ const CHROME_USE = {
   // multi-user splitting happens at the CI layer (each shard downloads its own
   // user's artifact into this path). See global-setup-alpha1.js AUTH_FILE.
   storageState: path.join(__dirname, 'playwright-tests/utils/auth/user.json'),
+  // Chromium launch flags for the EKS (Kubernetes) runners. --disable-dev-shm-usage
+  // is the critical one: containers default to a 64MB /dev/shm, which Chromium
+  // exhausts under parallel load (5 workers) on long/heavy shards — the renderer
+  // then crashes and the pod hits memory pressure, surfacing as "runner lost
+  // communication" (OOMKill/eviction) with a frozen step + 404 logs. Routing shared
+  // memory to /tmp (disk) instead is the standard fix. The sandbox/gpu flags are the
+  // usual container-safe defaults (no user namespaces / no GPU on the runners).
+  launchOptions: {
+    args: [
+      '--disable-dev-shm-usage',
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-gpu',
+    ],
+  },
 };
 
 module.exports = defineConfig({

--- a/tests/ui-testing/playwright-tests/utils/cloud-auth.js
+++ b/tests/ui-testing/playwright-tests/utils/cloud-auth.js
@@ -118,11 +118,15 @@ async function refreshCloudConfig(page) {
  * @param {import('@playwright/test').Page} page
  * @param {'get'|'post'|'put'|'delete'|'patch'} method
  * @param {string} url
- * @param {object} [options] extra page.request options (data, params, ...)
+ * @param {object} [options] extra page.request options (data, params, ...). Any options.headers
+ *   are MERGED over — not replaced with — the auth headers, so callers can add headers without
+ *   clobbering the Authorization header (which would defeat the 401 self-heal).
  * @param {number} [retries] max recovery attempts on 401/403
  */
 async function authedRequest(page, method, url, options = {}, retries = 1) {
-    let resp = await page.request[method](url, { headers: getAuthHeaders(), ...options });
+    const { headers: extraHeaders, ...rest } = options;
+    const buildOpts = () => ({ headers: { ...getAuthHeaders(), ...(extraHeaders || {}) }, ...rest });
+    let resp = await page.request[method](url, buildOpts());
     for (let i = 0; i < retries && (resp.status() === 401 || resp.status() === 403); i++) {
         let recovered = await refreshCloudConfig(page);
         if (!recovered) {
@@ -131,7 +135,8 @@ async function authedRequest(page, method, url, options = {}, retries = 1) {
             catch (e) { recovered = false; }
         }
         if (!recovered) break;
-        resp = await page.request[method](url, { headers: getAuthHeaders(), ...options });
+        // Rebuild opts so the refreshed passcode (getAuthHeaders) is picked up on retry.
+        resp = await page.request[method](url, buildOpts());
     }
     return resp;
 }

--- a/tests/ui-testing/playwright-tests/utils/cloud-auth.js
+++ b/tests/ui-testing/playwright-tests/utils/cloud-auth.js
@@ -71,4 +71,69 @@ function getOrgIdentifier() {
     return process.env['ORGNAME'];
 }
 
-module.exports = { getAuthHeaders, isCloudEnvironment, getCloudConfig, getOrgIdentifier };
+/**
+ * Drop the in-memory cloud-config cache so the next getCloudConfig()/getAuthHeaders()
+ * re-reads cloud-config.json from disk. Call after the file has been rewritten with a
+ * fresh passcode (refreshCloudConfig / re-auth).
+ */
+function resetCloudConfigCache() {
+    _cloudConfig = null;
+}
+
+/**
+ * Re-fetch this org's passcode using the page's LIVE browser session (cookie auth) and
+ * rewrite cloud-config.json. Cheap and non-disruptive (a background fetch — no navigation),
+ * so it's safe to call mid-test. Recovers the common cloud failure where the per-org passcode
+ * was rotated/invalidated by another shard sharing the org while the UI session is still alive.
+ * Returns true if a fresh passcode was obtained.
+ * @param {import('@playwright/test').Page} page
+ */
+async function refreshCloudConfig(page) {
+    if (!isCloudEnvironment()) return false;
+    try {
+        const orgId = getOrgIdentifier();
+        const pc = await page.evaluate(async (org) => {
+            const r = await fetch('/api/' + org + '/passcode');
+            return r.ok ? await r.json() : null;
+        }, orgId);
+        if (pc && pc.data && pc.data.passcode) {
+            const next = { ...(getCloudConfig() || {}), orgIdentifier: orgId, userEmail: pc.data.user, passcode: pc.data.passcode };
+            const configFile = path.join(__dirname, 'auth', 'cloud-config.json');
+            try { fs.writeFileSync(configFile, JSON.stringify(next, null, 2)); } catch (e) { /* fall through with in-memory value */ }
+            _cloudConfig = next;
+            const testLogger = require('./test-logger.js');
+            testLogger.info('[auth] Refreshed cloud passcode after 401');
+            return true;
+        }
+    } catch (e) {
+        // session may itself be dead — caller escalates to full re-auth
+    }
+    return false;
+}
+
+/**
+ * page.request wrapper that self-heals on 401/403: refreshes the passcode (and, if the
+ * session itself is dead, escalates to a full Dex re-login) then retries. Use for
+ * authenticated API calls so a transient/rotated-credential 401 doesn't fail the test.
+ * @param {import('@playwright/test').Page} page
+ * @param {'get'|'post'|'put'|'delete'|'patch'} method
+ * @param {string} url
+ * @param {object} [options] extra page.request options (data, params, ...)
+ * @param {number} [retries] max recovery attempts on 401/403
+ */
+async function authedRequest(page, method, url, options = {}, retries = 1) {
+    let resp = await page.request[method](url, { headers: getAuthHeaders(), ...options });
+    for (let i = 0; i < retries && (resp.status() === 401 || resp.status() === 403); i++) {
+        let recovered = await refreshCloudConfig(page);
+        if (!recovered) {
+            // Session itself is likely dead — lazy-require to avoid a circular import.
+            try { recovered = await require('./reauth-alpha1.js').reauthenticateAlpha1(page); }
+            catch (e) { recovered = false; }
+        }
+        if (!recovered) break;
+        resp = await page.request[method](url, { headers: getAuthHeaders(), ...options });
+    }
+    return resp;
+}
+
+module.exports = { getAuthHeaders, isCloudEnvironment, getCloudConfig, getOrgIdentifier, resetCloudConfigCache, refreshCloudConfig, authedRequest };

--- a/tests/ui-testing/playwright-tests/utils/enhanced-baseFixtures.js
+++ b/tests/ui-testing/playwright-tests/utils/enhanced-baseFixtures.js
@@ -146,13 +146,30 @@ async function navigateToBase(page) {
     await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
   }
   
-  const isAuthenticated = await verifyAuthentication(page);
-  
+  let isAuthenticated = await verifyAuthentication(page);
+
+  // Self-heal on cloud: the shared session token is minted once at the start of the run
+  // and reused by every shard, so on long runs (or when shards sharing an org contend on
+  // the same credential) it can expire/invalidate mid-run — surfacing as this auth check
+  // failing. Rather than fail the test, re-authenticate (fresh Dex login + org switch +
+  // passcode refresh) in this context and resume.
+  if (!isAuthenticated && isCloudEnvironment()) {
+    testLogger.warn('Auth check failed — attempting re-authentication and resume');
+    const { reauthenticateAlpha1 } = require('./reauth-alpha1.js');
+    const recovered = await reauthenticateAlpha1(page);
+    if (recovered) {
+      await page.goto(baseUrlWithOrg, { timeout: navTimeout });
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      isAuthenticated = await verifyAuthentication(page);
+    }
+  }
+
   if (!isAuthenticated) {
-    testLogger.error('User not authenticated - global setup might have failed');
+    testLogger.error('User not authenticated - global setup might have failed (re-auth also failed or unavailable)');
     throw new Error('User not authenticated. Global setup might have failed.');
   }
-  
+
   testLogger.info('Successfully navigated to base URL with authentication');
 }
 

--- a/tests/ui-testing/playwright-tests/utils/global-setup-alpha1.js
+++ b/tests/ui-testing/playwright-tests/utils/global-setup-alpha1.js
@@ -717,3 +717,8 @@ async function performGlobalIngestionWithFetch() {
 }
 
 module.exports = globalSetup;
+// Named helpers reused by mid-run re-authentication (reauth-alpha1.js). Attaching
+// them as properties keeps the default export the globalSetup function Playwright calls.
+module.exports.performDexLogin = performDexLogin;
+module.exports.switchOrgViaDropdown = switchOrgViaDropdown;
+module.exports.fetchCloudConfig = fetchCloudConfig;

--- a/tests/ui-testing/playwright-tests/utils/reauth-alpha1.js
+++ b/tests/ui-testing/playwright-tests/utils/reauth-alpha1.js
@@ -1,0 +1,58 @@
+const path = require('path');
+const testLogger = require('./test-logger.js');
+const { isCloudEnvironment, resetCloudConfigCache } = require('./cloud-auth.js');
+// Reuse the proven Dex login / org-switch / passcode-fetch helpers from global setup.
+const { performDexLogin, switchOrgViaDropdown, fetchCloudConfig } = require('./global-setup-alpha1.js');
+
+const AUTH_FILE = path.join(__dirname, 'auth', 'user.json');
+
+/**
+ * Mid-run recovery for Alpha1 (cloud) when the shared session/passcode has expired or been
+ * invalidated by another shard sharing the same org. Performs a fresh Dex login in the CURRENT
+ * browser context, re-selects ORGNAME, re-fetches the passcode, and persists the refreshed
+ * storageState + cloud-config so the rest of this worker's tests (and getAuthHeaders API calls)
+ * use the new credentials.
+ *
+ * NOTE: this navigates the page (a full login flow), so callers must treat it as a hard reset —
+ * it's meant to run at a test boundary (navigateToBase) or as a last-resort escalation after a
+ * cheaper passcode refresh has already failed.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<boolean>} true if re-authentication succeeded
+ */
+async function reauthenticateAlpha1(page) {
+    if (!isCloudEnvironment()) return false;
+
+    const baseUrl = (process.env.ZO_BASE_URL || '').replace(/\/$/, '');
+    const idx = (process.env.ALPHA1_USER_INDEX || '1').trim();
+    const email = (process.env[`ALPHA1_USER_EMAIL_${idx}`] || process.env.ALPHA1_USER_EMAIL || '').trim();
+    const password = (process.env.ALPHA1_USER_PASSWORD || '').trim();
+    if (!baseUrl || !email || !password) {
+        testLogger.warn('[reauth] Missing ZO_BASE_URL / ALPHA1 creds — cannot re-authenticate');
+        return false;
+    }
+
+    try {
+        testLogger.info(`[reauth] Session lost — re-authenticating Dex user ${idx} (${email})`);
+        await performDexLogin(page, baseUrl, email, password);
+
+        const targetOrg = process.env.ORGNAME;
+        if (targetOrg && targetOrg !== 'default') {
+            await switchOrgViaDropdown(page, targetOrg);
+        }
+
+        // Persist the refreshed session so later tests in this worker reuse it,
+        // and refresh the passcode used by getAuthHeaders() for API calls.
+        await page.context().storageState({ path: AUTH_FILE });
+        await fetchCloudConfig(page);
+        resetCloudConfigCache();
+
+        testLogger.info('[reauth] Re-authentication succeeded');
+        return true;
+    } catch (e) {
+        testLogger.error(`[reauth] Re-authentication failed: ${e.message}`);
+        return false;
+    }
+}
+
+module.exports = { reauthenticateAlpha1 };


### PR DESCRIPTION
## Alpha1 e2e robustness — self-healing auth + service-graph window

Builds on **#13621** (re-auth self-heal). Both branches share the slug `test/alpha1-e2e-robustness` is stacked on `test/alpha1-reauth-on-401`; review/merge #13621 first (or merge this, which contains it).

Root-caused against alpha1 runs 30892800970 / 30900015839 / 30902942856 (each investigated live via Playwright MCP).

### 1. Auth self-heal (from #13621, included here)
Shared cloud session + per-org passcode are minted once and reused all run; on long runs / org-contention they expire mid-run → `User not authenticated` (UI) and `HTTP 401 Unauthorized` (API). Now: `authedRequest` refreshes the passcode and retries on 401; `navigateToBase` re-authenticates and resumes instead of throwing. **Verified working** in run 30902942856 — the auth storm cleared (Metrics/SDR/Streams recovered, zero `User not authenticated`), and `[auth] Refreshed cloud passcode after 401` fired and recovered mid-run.

### 2. Service graph queries a wide window
All 9 `service-graph.spec.js` chart tests failed with `service-graph-chart` "element(s) not found" **despite** `beforeAll` confirming topology via API (25 nodes). **Reproduced live**: the service-graph tab defaults to **Past 15 Minutes** and shows *"No service graph data / 0 entities"* (no chart element) when the daemon-processed topology sits outside that window. The tab **honours the `period` URL param** (verified: label → "Past 6 Hours").
→ `navigateToServiceGraphUrl` now navigates with `period=6h`; added `navigateToServiceGraphAndWaitForChart()` (poll + refresh, tolerates daemon lag). Non-masking.

### Honest scope
- **Not included (can't validate locally / not test-code):**
  - **Pipelines ×5** (`Explore`/`update-pipeline` 45s timeout) — persistent across *every* run; pipeline/stream data unavailable. Env/data, needs CI-side repro.
  - **OTLP metrics ingestion 401** (a PromQL-prereq `beforeAll`) — a node-`fetch` ingest path with no page context to re-fetch the passcode; narrow, needs a small refactor to self-heal.
  - Singles: `logoManagement` (@enterprise `_meta`), `shareLink` (known race), `alerts-ui-operations:131` (#9484) — pre-existing flaky/env.
- Service-graph is **enterprise/feature-gated** (403 in my org), so its fix is evidence-reasoned + validated at the URL-param level, but final proof is the seeded CI run.
