### PR TITLE
fix(alerts): bring External Alert Sources page up to the listing standard

### DIFF
--- a/.claude/skills/ui-architect/SKILL.md
+++ b/.claude/skills/ui-architect/SKILL.md
@@ -292,6 +292,10 @@ considering the UI done:
 - [ ] `data-test` on every interactive and key output element, pattern
       `<module>-<filename>-<descriptor>` (see the project FE rules).
 - [ ] New component uses `<script setup lang="ts">`, no `// @ts-nocheck`.
+- [ ] **Comments are one or two lines** — the *why* of a non-obvious choice, not
+      a re-telling of the code or the history of the PR that added it (no ticket
+      ids, "review finding", "as discussed"). Same in specs. See
+      [conventions § Comments stay short](references/conventions.md).
 - [ ] `cd web && npm run lint && npm run type-check` pass.
 
 ## When a rule can't be satisfied

--- a/.claude/skills/ui-architect/references/conventions.md
+++ b/.claude/skills/ui-architect/references/conventions.md
@@ -146,6 +146,26 @@ or duplicate styles for dark mode around an O2 component. If something looks
 wrong in dark mode, the fix is a token value in `dark.css`, not a per-component
 conditional.
 
+### Comments stay short
+
+**One or two lines.** A comment carries the *why* behind a non-obvious choice —
+not a re-telling of the code, and not the history of the PR that added it.
+
+```vue
+<!-- good -->
+<!-- OSelect fills its container, so the width lives on the wrapper. -->
+
+<!-- bad — a paragraph, half of it review archaeology -->
+<!-- Bounded elastic column: absorbs leftover width but stays inside the
+     horizontal-scroll container instead of stretching to fit its longest
+     value. Matches the recipe used by Nodes.vue, PipelinesList.vue, etc.
+     (tag 02 review finding) -->
+```
+
+Drop ticket ids, "review finding", "as discussed", "previously we…", and any
+line that just narrates the next statement. Same rule in `.spec.ts` files: one
+line on why a setup is unusual, not a paragraph defending it.
+
 ### No component fits? Build a reusable one — don't assemble raw classes
 
 When you need a UI element and **no existing component matches it**, the answer

--- a/web/src/components/alerts/AddExternalAlertSource.schema.ts
+++ b/web/src/components/alerts/AddExternalAlertSource.schema.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Add/Edit Alert Source drawer. Destinations are optional — an empty list
+// falls back to the org default (the list page flags that row).
+
+import { z } from "zod";
+
+export const makeAlertSourceSchema = (
+  t: (_key: string, _params?: Record<string, unknown>) => string,
+) =>
+  z.object({
+    name: z
+      .string()
+      .trim()
+      .min(1, t("common.nameRequired"))
+      .max(256, t("common.nameMaxLength", { max: 256 })),
+    destinations: z.array(z.string()).default([]),
+  });
+
+export type AlertSourceForm = z.infer<ReturnType<typeof makeAlertSourceSchema>>;
+
+export const alertSourceDefaults = (
+  integration?: { name: string; destinations: string[] } | undefined,
+): AlertSourceForm => ({
+  name: integration?.name ?? "",
+  destinations: [...(integration?.destinations ?? [])],
+});

--- a/web/src/components/alerts/AddExternalAlertSource.spec.ts
+++ b/web/src/components/alerts/AddExternalAlertSource.spec.ts
@@ -15,22 +15,12 @@ vi.mock("@/services/alert_destination", () => ({
   default: { list: vi.fn() },
 }));
 
-// ODrawer renders its body via <Teleport>, which JSDOM/VTU's wrapper.find()
-// and wrapper.html() cannot traverse from the mounted component's own root
-// (they only serialize its own subtree, not other document.body content the
-// teleport lands in) — matches the codebase's own AddRegexPattern.spec.ts
-// pattern for the same underlying component.
+// ODrawer teleports its body, which wrapper.find()/html() can't traverse.
+// Same stub the codebase uses in AddRegexPattern.spec.ts.
 const ODrawerStub = {
   name: "ODrawer",
   inheritAttrs: false,
-  props: [
-    "open",
-    "title",
-    "size",
-    "primaryButtonLabel",
-    "secondaryButtonLabel",
-    "primaryButtonDisabled",
-  ],
+  props: ["open", "title", "size", "formId", "primaryButtonLabel", "secondaryButtonLabel"],
   emits: ["update:open", "click:primary", "click:secondary"],
   template: `<div data-test="o-drawer-stub" :data-open="String(open)"><slot /></div>`,
 };
@@ -41,8 +31,7 @@ function buildWrapper(open = true, editingIntegration: any = undefined) {
   const store = createStore({
     state: {
       selectedOrganization: { identifier: "myorg" },
-      // CopyContent (rendered once a source is created) reads these directly
-      // in setup() — omitting them throws and silently aborts that subtree.
+      // CopyContent reads these in setup(); omitting them aborts that subtree.
       userInfo: { email: "admin@example.com" },
       organizationData: { organizationPasscode: "passcode" },
       zoConfig: {},
@@ -76,21 +65,15 @@ describe("AddExternalAlertSource", () => {
   });
 
   afterEach(() => {
-    // Each mounted component leaves a running setInterval (startPolling) or a
-    // pending mounted()-hook promise (fetchDestinationOptions) behind if not
-    // explicitly unmounted — under fake timers those linger into the next
-    // test's scheduler flush and produce stale-DOM failures unrelated to that
-    // test's own logic.
+    // Unmount explicitly: a leaked poll timer or pending fetch leaks into the
+    // next test's flush under fake timers.
     mountedWrappers.forEach((w) => w.unmount());
     mountedWrappers = [];
     vi.useRealTimers();
   });
 
   it("fetches destination options for the alert module when opened", async () => {
-    // Mounted with open=false first, matching how the parent list actually
-    // instantiates the drawer — fetchDestinationOptions only fires off the
-    // `open` watcher, not mounted(), so it must be exercised via a real
-    // false→true transition rather than always-open.
+    // Opens false→true: the fetch fires off the `open` watcher, not mounted().
     const wrapper = buildWrapper(false);
     expect(destinationService.list).not.toHaveBeenCalled();
     await wrapper.setProps({ open: true });
@@ -107,9 +90,7 @@ describe("AddExternalAlertSource", () => {
       data: { id: "int-1", token: "o2iat_abc", name: "grafana-staging" },
     });
     const wrapper = buildWrapper();
-    (wrapper.vm as any).form.name = "grafana-staging";
-    (wrapper.vm as any).form.destinations = ["sre-pages"];
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "grafana-staging", destinations: ["sre-pages"] });
     expect(alertSources.create).toHaveBeenCalledWith("myorg", {
       name: "grafana-staging",
       source_type: "auto",
@@ -120,8 +101,7 @@ describe("AddExternalAlertSource", () => {
 
   it("does not call create when name is empty", async () => {
     const wrapper = buildWrapper();
-    (wrapper.vm as any).form.name = "";
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "   ", destinations: [] });
     expect(alertSources.create).not.toHaveBeenCalled();
   });
 
@@ -137,13 +117,16 @@ describe("AddExternalAlertSource", () => {
       data: { id: "int-1", token: "o2iat_abc", name: "grafana-staging" },
     });
     const wrapper = buildWrapper();
-    (wrapper.vm as any).form.name = "grafana-staging";
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "grafana-staging", destinations: [] });
     expect((wrapper.vm as any).created).toBe(true);
     await wrapper.setProps({ open: false });
     await wrapper.setProps({ open: true });
     expect((wrapper.vm as any).created).toBe(false);
-    expect((wrapper.vm as any).form.name).toBe("");
+    expect((wrapper.vm as any).defaultValues).toEqual({ name: "", destinations: [] });
+    expect(
+      (wrapper.find('[data-test="add-alert-source-name-input"] input').element as HTMLInputElement)
+        .value,
+    ).toBe("");
   });
 
   it("renders a usable name input and destinations select in the DOM", async () => {
@@ -151,8 +134,35 @@ describe("AddExternalAlertSource", () => {
     const nameInput = wrapper.find('[data-test="add-alert-source-name-input"] input');
     expect(nameInput.exists()).toBe(true);
     await nameInput.setValue("my-source");
-    expect((wrapper.vm as any).form.name).toBe("my-source");
+    expect((nameInput.element as HTMLInputElement).value).toBe("my-source");
     expect(wrapper.find('[data-test="add-alert-source-destinations-select"]').exists()).toBe(true);
+  });
+
+  it("creates the source when the drawer's form is submitted, without a manual click handler", async () => {
+    (alertSources.create as any).mockResolvedValue({
+      data: { id: "int-1", token: "o2iat_abc", name: "grafana-staging" },
+    });
+    const wrapper = buildWrapper();
+    await flushPromises();
+    await wrapper
+      .find('[data-test="add-alert-source-name-input"] input')
+      .setValue("grafana-staging");
+    await wrapper.find("form#add-alert-source-form").trigger("submit");
+    await vi.waitFor(() =>
+      expect(alertSources.create).toHaveBeenCalledWith("myorg", {
+        name: "grafana-staging",
+        source_type: "auto",
+        destinations: [],
+      }),
+    );
+  });
+
+  it("does not submit an empty name — the schema blocks the create call", async () => {
+    const wrapper = buildWrapper();
+    await flushPromises();
+    await wrapper.find("form#add-alert-source-form").trigger("submit");
+    await flushPromises();
+    expect(alertSources.create).not.toHaveBeenCalled();
   });
 
   it("shows all 3 setup steps together before the source is created, not just step 1", async () => {
@@ -161,8 +171,7 @@ describe("AddExternalAlertSource", () => {
     expect(html).toContain("alert_sources.setupStep1Title");
     expect(html).toContain("alert_sources.setupStep2Title");
     expect(html).toContain("alert_sources.setupStep3Title");
-    // Step 2/3 show a placeholder instead of the real snippet/status pill
-    // until the source is actually created.
+    // Steps 2/3 show a placeholder until the source is created.
     expect(wrapper.find('[data-test="add-alert-source-step2-placeholder"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="add-alert-source-created-snippet"]').exists()).toBe(false);
   });
@@ -185,23 +194,15 @@ describe("AddExternalAlertSource", () => {
     });
     (alertSources.listSenders as any).mockResolvedValue({ data: { senders: [] } });
     const wrapper = buildWrapper();
-    // setValue() dispatches a real input event — direct `wrapper.vm.form.name =
-    // ...` mutation doesn't reliably resync the rendered tree with fake timers
-    // active, leaving `wrapper.find()`/`wrapper.html()` reading a stale
-    // snapshot even though component state is already correct.
     await wrapper
       .find('[data-test="add-alert-source-name-input"] input')
       .setValue("grafana-staging");
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "grafana-staging", destinations: [] });
     await flushPromises();
     await vi.runOnlyPendingTimersAsync();
     await flushPromises();
-    // Under the global ODrawerStub + fake timers combination, the rendered
-    // tree has repeatedly proven stale relative to already-correct reactive
-    // state (created/waitingForEvent) even after $nextTick/$forceUpdate — a
-    // VTU/stub-slot quirk, not app logic. Assert on state directly, which is
-    // the actual behavior under test; DOM branch selection is covered by the
-    // "renders a usable name input" test exercising the same v-if unaffected.
+    // The stub's slot tree renders stale under fake timers (a VTU quirk), so
+    // assert on state; the DOM branch is covered by the name-input test.
     expect((wrapper.vm as any).created).toBe(true);
     expect((wrapper.vm as any).waitingForEvent).toBe(true);
     expect((wrapper.vm as any).createdIntegration?.id).toBe("int-1");
@@ -212,8 +213,7 @@ describe("AddExternalAlertSource", () => {
       data: { id: "int-1", token: "o2iat_abc", name: "grafana-staging" },
     });
     const wrapper = buildWrapper();
-    (wrapper.vm as any).form.name = "grafana-staging";
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "grafana-staging", destinations: [] });
     const snippet = (wrapper.vm as any).createdCurlSnippet as string;
     expect(snippet.startsWith("curl ")).toBe(true);
     expect(snippet).not.toContain("#");
@@ -224,8 +224,7 @@ describe("AddExternalAlertSource", () => {
       data: { id: "int-1", token: "o2iat_abc", name: "grafana-staging" },
     });
     const wrapper = buildWrapper();
-    (wrapper.vm as any).form.name = "grafana-staging";
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "grafana-staging", destinations: [] });
     const snippet = (wrapper.vm as any).createdCurlSnippet as string;
     const bodyMatch = snippet.match(/-d '(.+)'$/);
     expect(bodyMatch).not.toBeNull();
@@ -244,8 +243,7 @@ describe("AddExternalAlertSource", () => {
       .mockResolvedValueOnce({ data: { senders: [] } })
       .mockResolvedValue({ data: { senders: [{ detected_source: "grafana" }] } });
     const wrapper = buildWrapper();
-    (wrapper.vm as any).form.name = "grafana-staging";
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "grafana-staging", destinations: [] });
     await vi.advanceTimersByTimeAsync(3000);
     await wrapper.vm.$nextTick();
     expect((wrapper.vm as any).waitingForEvent).toBe(false);
@@ -263,7 +261,7 @@ describe("AddExternalAlertSource", () => {
     await wrapper
       .find('[data-test="add-alert-source-name-input"] input')
       .setValue("grafana-staging");
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "grafana-staging", destinations: [] });
     await flushPromises();
     await vi.runOnlyPendingTimersAsync();
     await flushPromises();
@@ -276,8 +274,7 @@ describe("AddExternalAlertSource", () => {
       data: { id: "int-1", token: "o2iat_abc", name: "grafana-staging" },
     });
     const wrapper = buildWrapper();
-    (wrapper.vm as any).form.name = "grafana-staging";
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "grafana-staging", destinations: [] });
     expect((wrapper.vm as any).pollTimer).toBeDefined();
     wrapper.unmount();
     expect((wrapper.vm as any).pollTimer).toBeUndefined();
@@ -288,8 +285,7 @@ describe("AddExternalAlertSource", () => {
       data: { id: "int-1", token: "o2iat_abc", name: "grafana-staging" },
     });
     const wrapper = buildWrapper();
-    (wrapper.vm as any).form.name = "grafana-staging";
-    await (wrapper.vm as any).submit();
+    await (wrapper.vm as any).submit({ name: "grafana-staging", destinations: [] });
     expect((wrapper.vm as any).pollTimer).toBeDefined();
     await wrapper.setProps({ open: false });
     expect((wrapper.vm as any).pollTimer).toBeUndefined();
@@ -315,16 +311,23 @@ describe("AddExternalAlertSource", () => {
       const wrapper = buildWrapper(false, EXISTING_INTEGRATION);
       await wrapper.setProps({ open: true });
       expect((wrapper.vm as any).isEditMode).toBe(true);
-      expect((wrapper.vm as any).form.name).toBe("default");
-      expect((wrapper.vm as any).form.destinations).toEqual(["sre-pages"]);
+      expect((wrapper.vm as any).defaultValues).toEqual({
+        name: "default",
+        destinations: ["sre-pages"],
+      });
+      expect(
+        (
+          wrapper.find('[data-test="add-alert-source-name-input"] input')
+            .element as HTMLInputElement
+        ).value,
+      ).toBe("default");
     });
 
     it("submitEdit calls update with only the changed fields, then emits updated and closes", async () => {
       (alertSources.update as any).mockResolvedValue({ data: {} });
       const wrapper = buildWrapper(false, EXISTING_INTEGRATION);
       await wrapper.setProps({ open: true });
-      (wrapper.vm as any).form.name = "renamed";
-      await (wrapper.vm as any).submitEdit();
+      await (wrapper.vm as any).submitEdit({ name: "renamed", destinations: ["sre-pages"] });
       expect(alertSources.update).toHaveBeenCalledWith("myorg", "int-1", { name: "renamed" });
       expect(wrapper.emitted("updated")).toBeTruthy();
       expect(wrapper.emitted("update:open")?.at(-1)).toEqual([false]);
@@ -334,8 +337,10 @@ describe("AddExternalAlertSource", () => {
       (alertSources.update as any).mockResolvedValue({ data: {} });
       const wrapper = buildWrapper(false, EXISTING_INTEGRATION);
       await wrapper.setProps({ open: true });
-      (wrapper.vm as any).form.destinations = ["sre-pages", "email-oncall"];
-      await (wrapper.vm as any).submitEdit();
+      await (wrapper.vm as any).submitEdit({
+        name: "default",
+        destinations: ["sre-pages", "email-oncall"],
+      });
       expect(alertSources.update).toHaveBeenCalledWith("myorg", "int-1", {
         destinations: ["sre-pages", "email-oncall"],
       });
@@ -344,17 +349,15 @@ describe("AddExternalAlertSource", () => {
     it("submitEdit does nothing when the name is blank", async () => {
       const wrapper = buildWrapper(false, EXISTING_INTEGRATION);
       await wrapper.setProps({ open: true });
-      (wrapper.vm as any).form.name = "   ";
-      await (wrapper.vm as any).submitEdit();
+      await (wrapper.vm as any).submitEdit({ name: "   ", destinations: ["sre-pages"] });
       expect(alertSources.update).not.toHaveBeenCalled();
     });
 
-    it("onPrimaryClick routes to submitEdit instead of create when in edit mode", async () => {
+    it("onSubmit routes to update instead of create when in edit mode", async () => {
       (alertSources.update as any).mockResolvedValue({ data: {} });
       const wrapper = buildWrapper(false, EXISTING_INTEGRATION);
       await wrapper.setProps({ open: true });
-      (wrapper.vm as any).form.name = "renamed";
-      await (wrapper.vm as any).onPrimaryClick();
+      await (wrapper.vm as any).onSubmit({ name: "renamed", destinations: ["sre-pages"] });
       expect(alertSources.create).not.toHaveBeenCalled();
       expect(alertSources.update).toHaveBeenCalledWith("myorg", "int-1", { name: "renamed" });
     });

--- a/web/src/components/alerts/AddExternalAlertSource.vue
+++ b/web/src/components/alerts/AddExternalAlertSource.vue
@@ -20,66 +20,74 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     @update:open="onDrawerOpenChange"
     :title="isEditMode ? t('alert_sources.editTitle') : t('alert_sources.addTitle')"
     size="lg"
+    :form-id="created ? undefined : FORM_ID"
     :primary-button-label="created ? t('alert_sources.done') : t('alert_sources.save')"
     :secondary-button-label="created ? undefined : t('alert_sources.cancel')"
-    :primary-button-disabled="!created && !form.name.trim()"
-    :primary-button-loading="saving"
     data-test="add-alert-source-drawer"
     @click:primary="onPrimaryClick"
     @click:secondary="cancel"
   >
     <div class="flex flex-col gap-4">
-      <OInput
-        v-model="form.name"
-        :disabled="created"
-        :label="t('alert_sources.name')"
-        :help-text="t('alert_sources.nameHint')"
-        data-test="add-alert-source-name-input"
-      />
-      <div class="flex flex-col gap-1">
-        <p class="text-text-secondary text-xs">{{ t("alert_sources.incidentDestination") }}</p>
-        <div class="flex items-center">
-          <OSelect
-            v-model="form.destinations"
-            multiple
-            searchable
-            :disabled="created"
-            class="max-w-[18.75rem] min-w-[11.25rem]"
-            :options="destinationOptions"
-            :placeholder="t('alert_sources.incidentDestinationPlaceholder')"
-            data-test="add-alert-source-destinations-select"
-          >
-            <template #empty>{{ t("alerts.alertSettings.noDestinationsAvailable") }}</template>
-          </OSelect>
-          <OButton
-            variant="ghost"
-            size="icon-circle-sm"
-            class="ml-1"
-            :disabled="created"
-            :title="t('alerts.alertSettings.refreshDestinations')"
-            data-test="add-alert-source-refresh-destinations-btn"
-            @click="fetchDestinationOptions"
-          >
-            <OIcon name="refresh" size="sm" />
-          </OButton>
-          <OButton
-            variant="outline"
-            size="sm"
-            class="ml-2"
-            :disabled="created"
-            data-test="add-alert-source-create-destination-btn"
-            @click="routeToCreateDestination"
-          >
-            {{ t("alerts.alertSettings.addNewDestination") }}
-          </OButton>
+      <!-- `formKey` remounts OForm on open so defaults re-read the edit target. -->
+      <OForm
+        :id="FORM_ID"
+        :key="formKey"
+        :schema="schema"
+        :default-values="defaultValues"
+        class="flex flex-col gap-5"
+        @submit="onSubmit"
+      >
+        <OFormInput
+          name="name"
+          :disabled="created"
+          :label="t('alert_sources.name')"
+          :help-text="t('alert_sources.nameHint')"
+          required
+          data-test="add-alert-source-name-input"
+        />
+        <div class="flex flex-col gap-1">
+          <div class="flex items-end gap-2">
+            <!-- OSelect fills its container, so the width lives on the wrapper. -->
+            <div class="w-72">
+              <OFormSelect
+                name="destinations"
+                multiple
+                searchable
+                :disabled="created"
+                :label="t('alert_sources.incidentDestination')"
+                :options="destinationOptions"
+                :placeholder="t('alert_sources.incidentDestinationPlaceholder')"
+                data-test="add-alert-source-destinations-select"
+              >
+                <template #empty>{{ t("alerts.alertSettings.noDestinationsAvailable") }}</template>
+              </OFormSelect>
+            </div>
+            <OButton
+              variant="ghost"
+              size="icon-circle-sm"
+              :disabled="created"
+              :title="t('alerts.alertSettings.refreshDestinations')"
+              data-test="add-alert-source-refresh-destinations-btn"
+              @click="fetchDestinationOptions"
+            >
+              <OIcon name="refresh" size="sm" />
+            </OButton>
+            <OButton
+              variant="outline"
+              size="sm"
+              :disabled="created"
+              data-test="add-alert-source-create-destination-btn"
+              @click="routeToCreateDestination"
+            >
+              {{ t("alerts.alertSettings.addNewDestination") }}
+            </OButton>
+          </div>
+          <p class="text-text-secondary text-xs">{{ t("alert_sources.incidentDestinationHint") }}</p>
         </div>
-        <p class="text-text-secondary text-xs">{{ t("alert_sources.incidentDestinationHint") }}</p>
-      </div>
+      </OForm>
 
-      <!-- All 3 setup steps render together from the start (matches the
-           ingestion setup cards' OStepper `expanded` checklist pattern) —
-           steps 2/3 just show a "save first" placeholder until the source
-           exists, instead of being hidden entirely. -->
+      <!-- All 3 steps show from the start; 2 and 3 hold a "save first"
+           placeholder until the source exists. -->
       <OStepper v-if="!isEditMode" :model-value="activeStep" expanded orientation="vertical">
         <OStep :name="1" :title="t('alert_sources.setupStep1Title')" :done="created">
           <p class="text-text-secondary text-sm">{{ t("alert_sources.setupStep1Body") }}</p>
@@ -139,8 +147,9 @@ import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import ODrawer from "@/lib/overlay/Drawer/ODrawer.vue";
-import OInput from "@/lib/forms/Input/OInput.vue";
-import OSelect from "@/lib/forms/Select/OSelect.vue";
+import OForm from "@/lib/forms/Form/OForm.vue";
+import OFormInput from "@/lib/forms/Input/OFormInput.vue";
+import OFormSelect from "@/lib/forms/Select/OFormSelect.vue";
 import OButton from "@/lib/core/Button/OButton.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OTag from "@/lib/core/Badge/OTag.vue";
@@ -151,27 +160,41 @@ import alertSources from "@/services/alert_sources";
 import destinationService from "@/services/alert_destination";
 import { toast } from "@/lib/feedback/Toast/useToast";
 import { getEndPoint, getIngestionURL } from "@/utils/zincutils";
+import {
+  makeAlertSourceSchema,
+  alertSourceDefaults,
+  type AlertSourceForm,
+} from "./AddExternalAlertSource.schema";
 import type { AlertSourceIntegration } from "@/ts/interfaces/alertSources";
 
-// Polls the senders endpoint until the first event arrives, so the admin sees
-// wiring confirmed live instead of having to manually refresh the source
-// list — closes the "no feedback loop" gap flagged in the design review.
+// Polls senders until the first event arrives, so wiring is confirmed live.
 const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 120000;
 
+// Links ODrawer's Save button to the nested OForm (submit + spinner).
+const FORM_ID = "add-alert-source-form";
+
 export default defineComponent({
   name: "AddExternalAlertSource",
-  components: { ODrawer, OInput, OSelect, OButton, OIcon, OTag, OStepper, OStep, CopyContent },
+  components: {
+    ODrawer,
+    OForm,
+    OFormInput,
+    OFormSelect,
+    OButton,
+    OIcon,
+    OTag,
+    OStepper,
+    OStep,
+    CopyContent,
+  },
   props: {
     open: {
       type: Boolean,
       default: false,
     },
-    // When set, the drawer opens pre-filled with this integration's current
-    // name/destinations and Save patches them in place instead of creating a
-    // new source — one row-level "Edit" action covering all editable fields,
-    // matching the list ⇄ editor convention used by Destinations/Templates
-    // rather than separate per-field popovers.
+    // When set, the drawer pre-fills from this integration and Save patches
+    // it in place instead of creating a new source.
     editingIntegration: {
       type: Object as () => AlertSourceIntegration | undefined,
       default: undefined,
@@ -182,19 +205,20 @@ export default defineComponent({
     const store = useStore();
     const { t } = useI18n();
     const router = useRouter();
-    return { store, t, router };
+    const schema = makeAlertSourceSchema(t);
+    return { store, t, router, schema, FORM_ID };
   },
   data() {
     return {
-      form: { name: "", destinations: [] as string[] },
       destinationOptions: [] as Array<{ label: string; value: string }>,
+      defaultValues: alertSourceDefaults(),
+      formKey: 0,
       created: false,
       createdIntegration: undefined as AlertSourceIntegration | undefined,
       waitingForEvent: true,
       detectedFormat: "",
       pollTimer: undefined as ReturnType<typeof setInterval> | undefined,
       pollDeadline: 0,
-      saving: false,
     };
   },
   computed: {
@@ -204,10 +228,7 @@ export default defineComponent({
     isEditMode(): boolean {
       return !!this.editingIntegration;
     },
-    // Drives OStepper's required modelValue: highlights step 1 until the
-    // source is created, step 2 while waiting for the first event, step 3
-    // once connected. Steps are still shown together (expanded mode) — this
-    // only controls which one reads as "active".
+    // OStepper's modelValue — which step reads as active (all stay visible).
     activeStep(): number {
       if (!this.created) return 1;
       return this.waitingForEvent ? 2 : 3;
@@ -229,13 +250,8 @@ export default defineComponent({
       const ingestionURL = getIngestionURL();
       const base = getEndPoint(ingestionURL).url;
       const url = `${base}/api/v2/${this.orgIdentifier}/incidents/events`;
-      // No leading "# curl" comment line here — unlike createdUrlSnippet,
-      // this whole block is meant to be pasted straight into a shell and
-      // run as-is, so it must contain nothing but valid shell syntax.
-      // Body is the minimal payload the generic-format detector accepts
-      // (status: firing/resolved + a labels object) — see
-      // core/src/alerts/external_alerts/detect.rs — an empty `{}` body
-      // fails with "unrecognized payload format".
+      // Pasted straight into a shell, so: no comment lines. The body is the
+      // minimal payload detect.rs accepts — an empty `{}` is rejected.
       return [
         `curl -X POST '${url}' \\`,
         `  -H 'Authorization: Bearer ${this.createdIntegration.token}' \\`,
@@ -244,11 +260,8 @@ export default defineComponent({
       ].join("\n");
     },
     connectedLabel(): string {
-      // Built from a plain (non-interpolated) t() call + string concatenation
-      // rather than t(key, { format }) — vue-i18n's named-interpolation path
-      // throws on a missing/renamed key instead of warning-and-falling-back
-      // the way a plain t() call does, which previously could take down this
-      // whole branch's render.
+      // Plain t() + concatenation: named interpolation THROWS on a missing
+      // key, which would take down this whole branch's render.
       return `${this.t("alert_sources.connectedPrefix")} ${this.detectedFormat}`;
     },
   },
@@ -267,12 +280,8 @@ export default defineComponent({
   },
   methods: {
     resetForm() {
-      this.form = this.editingIntegration
-        ? {
-            name: this.editingIntegration.name,
-            destinations: [...this.editingIntegration.destinations],
-          }
-        : { name: "", destinations: [] };
+      this.defaultValues = alertSourceDefaults(this.editingIntegration);
+      this.formKey += 1;
       this.created = false;
       this.createdIntegration = undefined;
       this.waitingForEvent = true;
@@ -292,10 +301,8 @@ export default defineComponent({
         toast({ variant: "error", message: this.t("alert_sources.destinationsLoadError") });
       }
     },
-    // Matches AlertSettings.vue's routeToCreateDestination — destinations are
-    // a full resource (webhook/email/etc config), so creation always happens
-    // on the real Destinations page, not inline. Opens in a new tab; the
-    // admin returns and clicks refresh to pick up the new destination.
+    // Destinations are a full resource, so they're created on their own page
+    // (new tab) — matches AlertSettings.vue.
     routeToCreateDestination() {
       const url = this.router.resolve({
         name: "alertDestinations",
@@ -306,22 +313,22 @@ export default defineComponent({
       }).href;
       window.open(url, "_blank");
     },
+    // ODrawer only emits click:primary without a form-id — i.e. the "Done"
+    // button. Save/Update go through the form's own submit.
     onPrimaryClick() {
-      if (this.created) {
-        this.onDrawerOpenChange(false);
-      } else if (this.isEditMode) {
-        this.submitEdit();
-      } else {
-        this.submit();
-      }
+      if (this.created) this.onDrawerOpenChange(false);
     },
-    async submit() {
-      if (!this.form.name.trim()) return;
+    onSubmit(values: AlertSourceForm) {
+      return this.isEditMode ? this.submitEdit(values) : this.submit(values);
+    },
+    async submit(values: AlertSourceForm) {
+      const name = values.name.trim();
+      if (!name) return;
       try {
         const res = await alertSources.create(this.orgIdentifier, {
-          name: this.form.name,
+          name,
           source_type: "auto",
-          destinations: this.form.destinations,
+          destinations: values.destinations,
         });
         this.createdIntegration = res.data;
         this.created = true;
@@ -332,19 +339,18 @@ export default defineComponent({
         toast({ variant: "error", message: this.t("alert_sources.error") });
       }
     },
-    async submitEdit() {
-      if (!this.editingIntegration || !this.form.name.trim()) return;
-      this.saving = true;
+    async submitEdit(values: AlertSourceForm) {
+      const name = values.name.trim();
+      if (!this.editingIntegration || !name) return;
       try {
-        const name = this.form.name.trim();
         const nameChanged = name !== this.editingIntegration.name;
         const destinationsChanged =
-          JSON.stringify([...this.form.destinations].sort()) !==
+          JSON.stringify([...values.destinations].sort()) !==
           JSON.stringify([...this.editingIntegration.destinations].sort());
         if (nameChanged || destinationsChanged) {
           await alertSources.update(this.orgIdentifier, this.editingIntegration.id, {
             ...(nameChanged ? { name } : {}),
-            ...(destinationsChanged ? { destinations: this.form.destinations } : {}),
+            ...(destinationsChanged ? { destinations: values.destinations } : {}),
           });
         }
         toast({ variant: "success", message: this.t("alert_sources.updatedSuccess") });
@@ -352,8 +358,6 @@ export default defineComponent({
         this.onDrawerOpenChange(false);
       } catch (e) {
         toast({ variant: "error", message: this.t("alert_sources.error") });
-      } finally {
-        this.saving = false;
       }
     },
     startPolling() {
@@ -384,8 +388,7 @@ export default defineComponent({
           this.stopPolling();
         }
       } catch (e) {
-        // Transient poll failures don't need a toast — the pill just stays
-        // "waiting" and the next tick tries again.
+        // Transient failures just leave the pill "waiting" for the next tick.
       }
     },
     onDrawerOpenChange(value: boolean) {

--- a/web/src/components/alerts/AddExternalAlertSource.vue
+++ b/web/src/components/alerts/AddExternalAlertSource.vue
@@ -82,7 +82,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               {{ t("alerts.alertSettings.addNewDestination") }}
             </OButton>
           </div>
-          <p class="text-text-secondary text-xs">{{ t("alert_sources.incidentDestinationHint") }}</p>
+          <p class="text-text-secondary text-xs">
+            {{ t("alert_sources.incidentDestinationHint") }}
+          </p>
         </div>
       </OForm>
 

--- a/web/src/components/alerts/ExternalAlertSourcesList.spec.ts
+++ b/web/src/components/alerts/ExternalAlertSourcesList.spec.ts
@@ -57,6 +57,17 @@ function buildWrapper() {
   });
 }
 
+// OTable holds its skeleton briefly after `loading` flips false, so
+// flushPromises() alone still sees skeleton rows instead of real cells.
+async function mountAndSettle() {
+  const wrapper = buildWrapper();
+  await flushPromises();
+  await vi.waitFor(() =>
+    expect(wrapper.find('[data-test="o2-table-skeleton-body"]').exists()).toBe(false),
+  );
+  return wrapper;
+}
+
 describe("ExternalAlertSourcesList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -80,16 +91,14 @@ describe("ExternalAlertSourcesList", () => {
     // Setup snippets that need the real URL only render inside the Add
     // Source drawer once a source is freshly created (not on the list page
     // itself), so the table text should never contain an unmasked token.
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     const table = wrapper.find('[data-test="alert-sources-advanced-table"]');
     expect(table.text()).not.toContain("abcd1234efgh5678");
     expect(table.text()).toContain("****");
   });
 
   it("reveals the full token when reveal is toggled", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     await (wrapper.vm as any).toggleRevealFor(DEFAULT_SOURCE);
     await flushPromises();
     expect(wrapper.text()).toContain("o2iat_abcd1234efgh5678");
@@ -97,23 +106,20 @@ describe("ExternalAlertSourcesList", () => {
 
   it("copies the full URL via copyToClipboard", async () => {
     const { copyToClipboard } = await import("@/utils/clipboard");
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     await (wrapper.vm as any).copyUrlFor(DEFAULT_SOURCE);
     expect(copyToClipboard).toHaveBeenCalledWith(`http://localhost:5080${DEFAULT_SOURCE.url}`);
   });
 
   it("copies just the bare token via copyToClipboard, not the full URL", async () => {
     const { copyToClipboard } = await import("@/utils/clipboard");
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     await (wrapper.vm as any).copyTokenFor(DEFAULT_SOURCE);
     expect(copyToClipboard).toHaveBeenCalledWith(DEFAULT_SOURCE.token);
   });
 
   it("shows 'not_connected' status when no senders exist", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect((wrapper.vm as any).sourceStatuses).toEqual([]);
   });
 
@@ -135,8 +141,7 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect((wrapper.vm as any).sourceStatuses.length).toBe(1);
     expect((wrapper.vm as any).sourceStatuses[0].displayName).toBe("grafana");
     expect((wrapper.vm as any).sourceStatuses[0].resolveWiringHint).toBe(true);
@@ -171,8 +176,7 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     const rows = (wrapper.vm as any).tableRows;
     expect(rows.map((r: any) => r.displayName)).toEqual(["solarwinds", "elasticsearch"]);
     expect(rows.every((r: any) => r.sharesDefaultToken)).toBe(true);
@@ -198,15 +202,13 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect((wrapper.vm as any).sourceStatuses[0].displayName).toBe("solarwinds");
     expect(wrapper.text()).toContain("solarwinds");
   });
 
   it("calls setEnabled with the inverse of current enabled state", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     (alertSources.setEnabled as any).mockResolvedValue({ data: {} });
     await (wrapper.vm as any).toggleEnabledFor(DEFAULT_SOURCE);
     expect(alertSources.setEnabled).toHaveBeenCalledWith("myorg", "int-1", false);
@@ -221,8 +223,7 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect((wrapper.vm as any).additionalIntegrations.length).toBe(1);
     expect((wrapper.vm as any).additionalIntegrations[0].name).toBe("grafana-staging");
   });
@@ -243,8 +244,7 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect(wrapper.text()).toContain("staging1234efgh5678".slice(-4));
     expect(wrapper.text()).not.toContain("o2iat_staging1234efgh5678");
     (wrapper.vm as any).toggleRevealFor({ id: "int-2" });
@@ -271,8 +271,7 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     (wrapper.vm as any).copyUrlFor({
       id: "int-2",
       url: "/api/v2/myorg/incidents/events/o2iat_staging1234efgh5678",
@@ -291,8 +290,7 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    await mountAndSettle();
     expect(alertSources.listSenders).toHaveBeenCalledWith("myorg", "int-1");
     expect(alertSources.listSenders).toHaveBeenCalledWith("myorg", "int-2");
   });
@@ -328,8 +326,7 @@ describe("ExternalAlertSourcesList", () => {
       }
       return Promise.resolve({ data: { senders: [] } });
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect((wrapper.vm as any).additionalStatusById["int-2"]).toBe("receiving");
     expect((wrapper.vm as any).additionalStatusById["int-1"]).toBeUndefined();
   });
@@ -343,8 +340,7 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     const rows = (wrapper.vm as any).tableRows;
     const defaultRow = rows.find((r: any) => r.integration?.id === "int-1");
     const additionalRow = rows.find((r: any) => r.integration?.id === "int-2");
@@ -353,8 +349,7 @@ describe("ExternalAlertSourcesList", () => {
   });
 
   it("confirmDelete sets the delete target and opens the confirm dialog", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     const target = { id: "int-2", name: "grafana-staging" };
     (wrapper.vm as any).confirmDelete(target);
     expect((wrapper.vm as any).deleteTarget).toEqual(target);
@@ -362,8 +357,7 @@ describe("ExternalAlertSourcesList", () => {
   });
 
   it("doDelete calls alertSources.delete with the target id and refreshes the list", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     (alertSources.delete as any).mockResolvedValue({ data: {} });
     (wrapper.vm as any).confirmDelete({ id: "int-2", name: "grafana-staging" });
     await (wrapper.vm as any).doDelete();
@@ -372,24 +366,21 @@ describe("ExternalAlertSourcesList", () => {
   });
 
   it("doDelete does nothing when there is no delete target", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     (wrapper.vm as any).deleteTarget = undefined;
     await (wrapper.vm as any).doDelete();
     expect(alertSources.delete).not.toHaveBeenCalled();
   });
 
   it("openEditFor opens the drawer targeting the clicked integration", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     (wrapper.vm as any).openEditFor(DEFAULT_SOURCE);
     expect((wrapper.vm as any).showAddDrawer).toBe(true);
     expect((wrapper.vm as any).editTargetIntegration).toEqual(DEFAULT_SOURCE);
   });
 
   it("openAddDrawer opens the drawer with no edit target (create mode)", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     (wrapper.vm as any).editTargetIntegration = DEFAULT_SOURCE;
     (wrapper.vm as any).openAddDrawer();
     expect((wrapper.vm as any).showAddDrawer).toBe(true);
@@ -397,8 +388,7 @@ describe("ExternalAlertSourcesList", () => {
   });
 
   it("refreshes the list when the drawer emits 'updated'", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     const addDrawer = wrapper.findComponent({ name: "AddExternalAlertSource" });
     addDrawer.vm.$emit("updated");
     await flushPromises();
@@ -406,8 +396,7 @@ describe("ExternalAlertSourcesList", () => {
   });
 
   it("clicking Add source opens the AddExternalAlertSource drawer", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect((wrapper.vm as any).showAddDrawer).toBe(false);
     await wrapper.find('[data-test="alert-sources-add-btn"]').trigger("click");
     expect((wrapper.vm as any).showAddDrawer).toBe(true);
@@ -418,14 +407,12 @@ describe("ExternalAlertSourcesList", () => {
     (alertSources.list as any).mockResolvedValue({
       data: { integrations: [{ ...DEFAULT_SOURCE, destinations: ["sre-pages", "email-oncall"] }] },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect(wrapper.text()).toContain("sre-pages, email-oncall");
   });
 
   it("flags a source with no incident destination configured", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect(wrapper.find('[data-test="alert-sources-no-destination-tag"]').exists()).toBe(true);
   });
 
@@ -433,8 +420,7 @@ describe("ExternalAlertSourcesList", () => {
     (alertSources.list as any).mockResolvedValue({
       data: { integrations: [{ ...DEFAULT_SOURCE, destinations: ["sre-pages"] }] },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect(wrapper.find('[data-test="alert-sources-no-destination-tag"]').exists()).toBe(false);
   });
 
@@ -460,8 +446,7 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect(wrapper.find('[data-test="alert-sources-never-resolves-icon"]').exists()).toBe(true);
     // No page-level banner — the explanation lives in the icon's tooltip, so
     // there's no unbounded banner list even with many misconfigured sources.
@@ -488,8 +473,7 @@ describe("ExternalAlertSourcesList", () => {
         ],
       },
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect(wrapper.find('[data-test="alert-sources-never-resolves-icon"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="alert-sources-never-resolves-tag"]').exists()).toBe(false);
   });
@@ -525,18 +509,108 @@ describe("ExternalAlertSourcesList", () => {
       }
       return Promise.resolve({ data: { senders: [] } });
     });
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect((wrapper.vm as any).additionalResolveWiringHintById["int-2"]).toBe(true);
     expect(wrapper.find('[data-test="alert-sources-never-resolves-icon"]').exists()).toBe(true);
   });
 
   it("renders just the table on the list page — no webhook URL/setup-snippet blocks (those live in the Add Source drawer)", async () => {
-    const wrapper = buildWrapper();
-    await flushPromises();
+    const wrapper = await mountAndSettle();
     expect(wrapper.find('[data-test="alert-sources-setup-type-tabs"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="alert-sources-setup-snippet"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="alert-sources-url-cell"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="alert-sources-advanced-table"]').exists()).toBe(true);
+  });
+
+  describe("toolbar", () => {
+    const TWO_SOURCES = {
+      data: {
+        integrations: [
+          DEFAULT_SOURCE,
+          {
+            ...DEFAULT_SOURCE,
+            id: "int-2",
+            name: "grafana-staging",
+            destinations: ["sre-pages"],
+            token: "o2iat_staging1234efgh5678",
+            url: "/api/v2/myorg/incidents/events/o2iat_staging1234efgh5678",
+          },
+        ],
+      },
+    };
+
+    it("filters rows by name from the search box", async () => {
+      (alertSources.list as any).mockResolvedValue(TWO_SOURCES);
+      const wrapper = await mountAndSettle();
+      expect((wrapper.vm as any).visibleRows.length).toBe(2);
+      await wrapper
+        .find('[data-test="alert-sources-search-input"] input')
+        .setValue("grafana-staging");
+      expect((wrapper.vm as any).visibleRows.map((r: any) => r.displayName)).toEqual([
+        "grafana-staging",
+      ]);
+    });
+
+    it("filters rows by incident destination name too", async () => {
+      (alertSources.list as any).mockResolvedValue(TWO_SOURCES);
+      const wrapper = await mountAndSettle();
+      await wrapper.find('[data-test="alert-sources-search-input"] input').setValue("sre-pages");
+      expect((wrapper.vm as any).visibleRows.map((r: any) => r.displayName)).toEqual([
+        "grafana-staging",
+      ]);
+    });
+
+    it("refetches integrations and senders when the toolbar refresh button is clicked", async () => {
+      const wrapper = await mountAndSettle();
+      (alertSources.list as any).mockClear();
+      (alertSources.listSenders as any).mockClear();
+      await wrapper.find('[data-test="alert-sources-refresh-btn"]').trigger("click");
+      await flushPromises();
+      expect(alertSources.list).toHaveBeenCalledWith("myorg");
+      expect(alertSources.listSenders).toHaveBeenCalledWith("myorg", "int-1");
+    });
+
+    it("shows the empty state when no alert sources exist", async () => {
+      (alertSources.list as any).mockResolvedValue({ data: { integrations: [] } });
+      const wrapper = await mountAndSettle();
+      expect((wrapper.vm as any).visibleRows.length).toBe(0);
+      expect(wrapper.find('[data-test="alert-sources-empty-state"]').exists()).toBe(true);
+    });
+
+    it("clears the search when the filtered empty state asks for it", async () => {
+      (alertSources.list as any).mockResolvedValue(TWO_SOURCES);
+      const wrapper = await mountAndSettle();
+      await wrapper.find('[data-test="alert-sources-search-input"] input').setValue("no-such-name");
+      expect((wrapper.vm as any).visibleRows.length).toBe(0);
+      (wrapper.vm as any).onEmptyAction("clear-filters");
+      await flushPromises();
+      expect((wrapper.vm as any).filterQuery).toBe("");
+      expect((wrapper.vm as any).visibleRows.length).toBe(2);
+    });
+
+    it("shows the row count with its noun in the footer", async () => {
+      (alertSources.list as any).mockResolvedValue(TWO_SOURCES);
+      const wrapper = await mountAndSettle();
+      expect(wrapper.find('[data-test="o2-table-pagination-bottom"]').text()).toContain(
+        "2 alert_sources.header",
+      );
+    });
+
+    it("gives every non-action column a resize handle, including Name↔Status", async () => {
+      const wrapper = await mountAndSettle();
+      for (const id of ["name", "status", "destination", "last_event", "url"]) {
+        const th = wrapper.find(`[data-test="o2-table-th-${id}"]`);
+        expect(th.exists()).toBe(true);
+        expect(th.find(".resizer").exists()).toBe(true);
+      }
+    });
+
+    it("opens the add drawer from the empty state's create action", async () => {
+      (alertSources.list as any).mockResolvedValue({ data: { integrations: [] } });
+      const wrapper = await mountAndSettle();
+      (wrapper.vm as any).onEmptyAction("create");
+      expect((wrapper.vm as any).showAddDrawer).toBe(true);
+      expect((wrapper.vm as any).editTargetIntegration).toBeUndefined();
+    });
   });
 });

--- a/web/src/components/alerts/ExternalAlertSourcesList.vue
+++ b/web/src/components/alerts/ExternalAlertSourcesList.vue
@@ -20,18 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :subtitle="t('alert_sources.subtitle')"
     title-data-test="alert-sources-list-title"
     icon="webhook"
-    scroll
-    pad-y
+    bleed
   >
     <template #actions>
-      <OButton
-        variant="outline"
-        size="icon-sm"
-        icon-left="refresh"
-        :loading="loading"
-        data-test="alert-sources-refresh-btn"
-        @click="fetchAll"
-      />
       <OButton
         variant="primary"
         size="sm"
@@ -50,21 +41,61 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       @updated="fetchAll"
     />
 
-    <div class="flex flex-col gap-3 text-sm">
-      <div v-if="defaultSource">
+    <div class="min-h-0 w-full flex-1 overflow-hidden">
+      <div class="bg-card-glass-bg h-full">
         <OTable
-          :data="tableRows"
+          :frame="false"
+          :data="visibleRows"
           :columns="advancedColumns"
           row-key="rowKey"
+          :loading="loading"
           pagination="client"
-          :page-size="10"
+          :page-size="20"
+          :page-size-options="[10, 20, 50, 100]"
           :row-class="noDestinationRowClass"
+          :footer-title="t('alert_sources.header')"
           wrap
           horizontal-scroll
           :default-columns="false"
           :enable-column-resize="true"
+          :persist-columns="true"
+          table-id="alerts-external-sources"
+          :show-global-filter="false"
           data-test="alert-sources-advanced-table"
         >
+          <template #toolbar>
+            <OSearchInput
+              v-model="filterQuery"
+              class="flex-1"
+              :placeholder="t('alert_sources.searchPlaceholder')"
+              data-test="alert-sources-search-input"
+            />
+          </template>
+          <template #toolbar-trailing>
+            <OButton
+              variant="outline"
+              size="icon-sm"
+              icon-left="refresh"
+              :loading="loading"
+              data-test="alert-sources-refresh-btn"
+              @click="fetchAll"
+            >
+              <OTooltip
+                side="bottom"
+                :content="t('alert_sources.refresh')"
+                shortcut-id="alertSourcesRefresh"
+              />
+            </OButton>
+          </template>
+          <template #empty>
+            <OEmptyState
+              size="hero"
+              preset="no-alert-sources"
+              :filtered="!!filterQuery"
+              data-test="alert-sources-empty-state"
+              @action="onEmptyAction"
+            />
+          </template>
           <template #cell-name="{ row }">
             <div class="flex min-w-0 flex-col">
               <div class="flex min-w-0 items-center gap-2">
@@ -96,10 +127,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <OTag v-else variant="default-outline">
                 {{ t("alert_sources.statusNotConnected") }}
               </OTag>
-              <!-- resolveWiringHint can co-occur with "Receiving"/"Stale" (the
-                   source is actively sending, it just never sends a resolved
-                   event) — surface it as a standalone icon+tooltip in that
-                   case instead of only via the fallback tag above. -->
+              <!-- The hint can co-occur with Receiving/Stale, so it also needs
+                   a standalone icon beside the status tag. -->
               <OIcon
                 v-if="row.resolveWiringHint && row.status !== 'not_connected'"
                 name="flag"
@@ -125,9 +154,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <OTag
               v-else-if="row.integration"
               variant="error-soft"
+              dot
               data-test="alert-sources-no-destination-tag"
             >
-              ⚠ {{ t("alert_sources.noDestinationSet") }}
+              {{ t("alert_sources.noDestinationSet") }}
             </OTag>
             <span v-else class="text-text-secondary">—</span>
           </template>
@@ -249,7 +279,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, getCurrentInstance } from "vue";
 import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 import OPageLayout from "@/lib/core/PageLayout/OPageLayout.vue";
@@ -257,15 +287,20 @@ import OButton from "@/lib/core/Button/OButton.vue";
 import OTag from "@/lib/core/Badge/OTag.vue";
 import OTable from "@/lib/core/Table/OTable.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
+import OSearchInput from "@/lib/forms/SearchInput/OSearchInput.vue";
+import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
 import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import AddExternalAlertSource from "./AddExternalAlertSource.vue";
 import alertSources from "@/services/alert_sources";
+import { useShortcuts } from "@/lib/vue-shortcut-manager";
+import { focusSearchInput, isInputFocused } from "@/utils/keyboardShortcuts";
 import { getAlertSourceStatus } from "@/utils/alertSourceStatus";
 import { formatTimeAgoUs } from "@/utils/synthetics/format";
 import { copyToClipboard } from "@/utils/clipboard";
 import { toast } from "@/lib/feedback/Toast/useToast";
 import { getEndPoint, getIngestionURL } from "@/utils/zincutils";
+import { COL } from "@/lib/core/Table/OTable.types";
 import type { AlertSourceIntegration } from "@/ts/interfaces/alertSources";
 
 interface SourceStatusRow {
@@ -277,6 +312,20 @@ interface SourceStatusRow {
   lastReceivedAt: number;
 }
 
+/** A table row: an additional integration, or a sender under the default
+ *  source (those share the default's URL/token, so `integration` is unset). */
+interface SourceTableRow {
+  rowKey: string;
+  displayName: string;
+  nameCaption: string;
+  status: "receiving" | "stale" | "not_connected";
+  integration: AlertSourceIntegration | undefined;
+  sharesDefaultToken: boolean;
+  destinations: string[];
+  resolveWiringHint: boolean;
+  lastEventLabel: string;
+}
+
 export default defineComponent({
   name: "ExternalAlertSourcesList",
   components: {
@@ -285,6 +334,8 @@ export default defineComponent({
     OTag,
     OTable,
     OIcon,
+    OSearchInput,
+    OEmptyState,
     OTooltip,
     ConfirmDialog,
     AddExternalAlertSource,
@@ -292,11 +343,36 @@ export default defineComponent({
   setup() {
     const store = useStore();
     const { t } = useI18n();
+
+    // useShortcuts must run in setup(); the proxy reaches this Options-API
+    // component's own methods.
+    const instance = getCurrentInstance();
+    const vm = () => instance?.proxy as any;
+    useShortcuts([
+      {
+        id: "alertSourcesAdd",
+        handler: () => {
+          if (!isInputFocused()) vm()?.openAddDrawer();
+        },
+      },
+      {
+        id: "alertSourcesRefresh",
+        handler: () => {
+          if (!isInputFocused()) vm()?.fetchAll();
+        },
+      },
+      {
+        id: "alertSourcesFocusSearch",
+        handler: () => focusSearchInput("alert-sources-search-input"),
+      },
+    ]);
+
     return { store, t };
   },
   data() {
     return {
       loading: false,
+      filterQuery: "",
       showAddDrawer: false,
       editTargetIntegration: undefined as AlertSourceIntegration | undefined,
       integrations: [] as AlertSourceIntegration[],
@@ -309,27 +385,28 @@ export default defineComponent({
       additionalStatusById: {} as Record<string, "receiving" | "stale" | "not_connected">,
       additionalResolveWiringHintById: {} as Record<string, boolean>,
       additionalLastReceivedAtById: {} as Record<string, number | undefined>,
-      // table-fixed layout (default-columns=false below) is required for `wrap`
-      // to actually confine wrapped text to its own column — table-auto lets
-      // wrapped/long content bleed into neighboring columns instead. Matches
-      // the size/flex recipe used by Nodes.vue, PipelinesList.vue, etc.
+      // default-columns=false (table-fixed) is what keeps `wrap`ped text inside
+      // its own column instead of bleeding into the next one.
       advancedColumns: [
         {
           id: "name",
           header: this.t("alert_sources.name"),
           accessorKey: "displayName",
           sortable: true,
+          resizable: true,
+          hideable: true,
+          size: COL.name,
           minSize: 160,
-          // Bounded elastic column: absorbs leftover width but stays inside
-          // the horizontal-scroll container instead of stretching to fit its
-          // longest value — the other sized columns get their minWidth
-          // enforced (and the row scrolls) only when horizontalScroll is on.
-          meta: { align: "left", autoWidth: true, fillRemaining: true },
+          // `flex`, not `autoWidth`: both absorb leftover width, but autoWidth
+          // columns are never resizable (no Name│Status drag handle).
+          meta: { align: "left", flex: true },
         },
         {
           id: "status",
           header: this.t("alert_sources.statusColumnHeader"),
           accessorKey: "rowKey",
+          resizable: true,
+          hideable: true,
           size: 150,
           meta: { align: "left" },
         },
@@ -337,6 +414,8 @@ export default defineComponent({
           id: "destination",
           header: this.t("alert_sources.incidentDestination"),
           accessorKey: "rowKey",
+          resizable: true,
+          hideable: true,
           size: 200,
           meta: { align: "left" },
         },
@@ -344,6 +423,8 @@ export default defineComponent({
           id: "last_event",
           header: this.t("alert_sources.lastEvent"),
           accessorKey: "rowKey",
+          resizable: true,
+          hideable: true,
           size: 100,
           meta: { align: "left" },
         },
@@ -351,6 +432,8 @@ export default defineComponent({
           id: "url",
           header: this.t("alert_sources.urlHeader"),
           accessorKey: "rowKey",
+          resizable: true,
+          hideable: true,
           size: 420,
           minSize: 420,
           meta: { align: "left" },
@@ -361,6 +444,7 @@ export default defineComponent({
           isAction: true,
           pinned: "right",
           size: 150,
+          meta: { align: "center", actionCount: 4 },
         },
       ] as any[],
     };
@@ -379,28 +463,8 @@ export default defineComponent({
       const ingestionURL = getIngestionURL();
       return getEndPoint(ingestionURL).url;
     },
-    tableRows(): Array<{
-      rowKey: string;
-      displayName: string;
-      nameCaption: string;
-      status: "receiving" | "stale" | "not_connected";
-      integration: AlertSourceIntegration | undefined;
-      sharesDefaultToken: boolean;
-      destinations: string[];
-      resolveWiringHint: boolean;
-      lastEventLabel: string;
-    }> {
-      const rows: Array<{
-        rowKey: string;
-        displayName: string;
-        nameCaption: string;
-        status: "receiving" | "stale" | "not_connected";
-        integration: AlertSourceIntegration | undefined;
-        sharesDefaultToken: boolean;
-        destinations: string[];
-        resolveWiringHint: boolean;
-        lastEventLabel: string;
-      }> = [];
+    tableRows(): SourceTableRow[] {
+      const rows: SourceTableRow[] = [];
 
       if (this.defaultSource) {
         if (this.sourceStatuses.length === 0) {
@@ -422,8 +486,7 @@ export default defineComponent({
               displayName: s.displayName,
               nameCaption: "",
               status: s.status,
-              // Only the first sender row carries the shared URL/token controls
-              // to avoid repeating identical actions per sender.
+              // Only the first sender row carries the shared URL/token actions.
               integration: idx === 0 ? this.defaultSource : undefined,
               sharesDefaultToken: true,
               destinations: this.defaultSource!.destinations,
@@ -450,6 +513,16 @@ export default defineComponent({
       }
 
       return rows;
+    },
+    // Client-side search — the list is fetched whole anyway.
+    visibleRows(): SourceTableRow[] {
+      const term = this.filterQuery.trim().toLowerCase();
+      if (!term) return this.tableRows;
+      return this.tableRows.filter(
+        (row) =>
+          row.displayName.toLowerCase().includes(term) ||
+          row.destinations.some((d) => d.toLowerCase().includes(term)),
+      );
     },
   },
   mounted() {
@@ -610,13 +683,16 @@ export default defineComponent({
       this.editTargetIntegration = integration;
       this.showAddDrawer = true;
     },
-    // Highlights a row with no incident destination configured — matches the
-    // mockup's tinted row for "impossible to miss" (tag 02 review finding).
-    noDestinationRowClass(row: {
-      destinations: string[];
-      integration: AlertSourceIntegration | undefined;
-    }): string {
+    // Tints rows that have no incident destination configured.
+    noDestinationRowClass(row: SourceTableRow): string {
       return row.integration && row.destinations.length === 0 ? "bg-banner-error-soft-bg" : "";
+    },
+    onEmptyAction(id: string) {
+      if (id === "clear-filters") {
+        this.filterQuery = "";
+        return;
+      }
+      this.openAddDrawer();
     },
   },
 });

--- a/web/src/components/alerts/ExternalAlertSourcesList.vue
+++ b/web/src/components/alerts/ExternalAlertSourcesList.vue
@@ -687,7 +687,8 @@ export default defineComponent({
     noDestinationRowClass(row: SourceTableRow): string {
       return row.integration && row.destinations.length === 0 ? "bg-banner-error-soft-bg" : "";
     },
-    onEmptyAction(id: string) {
+    // `id` is optional: OEmptyState's simple-button mode emits no id.
+    onEmptyAction(id?: string) {
       if (id === "clear-filters") {
         this.filterQuery = "";
         return;

--- a/web/src/lib/core/EmptyState/presets.ts
+++ b/web/src/lib/core/EmptyState/presets.ts
@@ -487,6 +487,20 @@ export const emptyStatePresets = {
       },
     ],
   },
+  "no-alert-sources": {
+    illustration: "alert",
+    variant: "create",
+    titleKey: "emptyState.noAlertSources.title",
+    descriptionKey: "emptyState.noAlertSources.description",
+    actions: [
+      {
+        id: "create",
+        icon: "add",
+        titleKey: "emptyState.noAlertSources.action",
+        descriptionKey: "emptyState.noAlertSources.actionDesc",
+      },
+    ],
+  },
   "no-pipeline-destinations": {
     illustration: "pipeline",
     variant: "create",
@@ -788,6 +802,7 @@ export const presetNouns: Partial<Record<EmptyStatePresetName, string>> = {
   "no-ingestion-tokens": "emptyState.nouns.ingestionTokens",
   "no-organizations": "emptyState.nouns.organizations",
   "no-alert-destinations": "emptyState.nouns.alertDestinations",
+  "no-alert-sources": "emptyState.nouns.alertSources",
   "no-pipeline-destinations": "emptyState.nouns.pipelineDestinations",
   "no-alert-templates": "emptyState.nouns.alertTemplates",
   "no-eval-templates": "emptyState.nouns.evalTemplates",

--- a/web/src/lib/vue-shortcut-manager/shortcutRegistry.ts
+++ b/web/src/lib/vue-shortcut-manager/shortcutRegistry.ts
@@ -91,6 +91,7 @@ export const SHORTCUT_MODULES: ShortcutModule[] = [
     pages: [
       "shortcuts.pages.alerts",
       "shortcuts.pages.alertDestinations",
+      "shortcuts.pages.alertSources",
       "shortcuts.pages.alertTemplates",
       "shortcuts.pages.alertIncidents",
     ],
@@ -438,6 +439,21 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
         display: "del / ⌫",
         descriptionKey: "shortcuts.actions.tableRowDelete",
       },
+    ],
+  },
+
+  // ── Alert Sources ───────────────────────────────────────────────────────
+  {
+    pageKey: "shortcuts.pages.alertSources",
+    scope: "alert-sources",
+    shortcuts: [
+      { id: "alertSourcesAdd", key: "n", descriptionKey: "shortcuts.actions.alertSourcesAdd" },
+      {
+        id: "alertSourcesRefresh",
+        key: "r",
+        descriptionKey: "shortcuts.actions.alertSourcesRefresh",
+      },
+      { id: "alertSourcesFocusSearch", key: "/", descriptionKey: "shortcuts.actions.focusSearch" },
     ],
   },
 

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -91,6 +91,12 @@
       "import": "Import destination",
       "importDesc": "Import from a JSON file"
     },
+    "noAlertSources": {
+      "title": "No alert sources yet",
+      "description": "Alert sources give external tools — Grafana, Alertmanager, or any webhook — a URL to send alerts to, so they become Incidents here.",
+      "action": "New alert source",
+      "actionDesc": "Create a webhook URL and token"
+    },
     "noPipelineDestinations": {
       "title": "No destinations yet",
       "description": "External targets for pipeline output — HTTP endpoints and remote write targets.",
@@ -344,6 +350,7 @@
       "ingestionTokens": "ingestion tokens",
       "organizations": "organizations",
       "alertDestinations": "destinations",
+      "alertSources": "alert sources",
       "pipelineDestinations": "destinations",
       "alertTemplates": "templates",
       "evalTemplates": "evaluation templates",
@@ -5525,6 +5532,7 @@
     "rejectedCount": "Rejected",
     "resolveHintMessage": "Receiving alerts but no resolved events seen yet — check your source's resolve/recovery settings so incidents can auto-resolve.",
     "refresh": "Refresh",
+    "searchPlaceholder": "Search alert sources",
     "advancedSectionTitle": "Advanced: additional sources",
     "advancedSectionDesc": "Only needed if you want a second, separate webhook URL — for example, to keep one team's alerts deduplicated apart from another's. Most setups only need the default source above.",
     "add": "Add source",
@@ -10822,6 +10830,7 @@
       "iamGroups": "IAM — Groups",
       "iamServiceAccounts": "IAM — Service Accounts",
       "alertDestinations": "Alerts — Destinations",
+      "alertSources": "Alerts — External Sources",
       "alertTemplates": "Alerts — Templates",
       "panelEditor": "Panel Editor",
       "traceDetail": "Trace Detail",
@@ -10912,6 +10921,8 @@
       "iamServiceAccountsRefresh": "Refresh list",
       "alertDestinationsAdd": "Add new destination",
       "alertDestinationsRefresh": "Refresh list",
+      "alertSourcesAdd": "Add new alert source",
+      "alertSourcesRefresh": "Refresh list",
       "alertTemplatesAdd": "Add new template",
       "alertTemplatesRefresh": "Refresh list",
       "logsSearchHistory": "Open search history",


### PR DESCRIPTION
## What

Brings the **External Alert Sources** page in line with the house listing-page standard (`ui-architect` skill + `page-recipes`), following the patterns already used by `SyntheticsTokens.vue` and `AlertsDestinationList.vue`.

### List page — `ExternalAlertSourcesList.vue`

- **Layout**: `OPageLayout scroll pad-y` → `bleed` + the full-height flush chain, so the table scrolls internally instead of the whole page.
- **Toolbar** (all three were missing): search box in `#toolbar`, refresh moved from the page header into `#toolbar-trailing`, and the column show/hide toggle (via `persist-columns` + `table-id` + `hideable` columns).
- **Empty state**: the table was hidden entirely behind `v-if="defaultSource"`, so a fresh org saw a blank page. It now always renders, with one `OEmptyState` (new `no-alert-sources` preset) that swaps to "no results / clear filters" via `:filtered`.
- `:loading` bound (no skeleton before), footer row count via `:footer-title`, and `n` / `r` / `/` shortcuts registered + bound.
- **Name column resize**: it used `meta.autoWidth`, which `useTableCore` marks `enableResizing: false`, so the Name│Status boundary had no drag handle. Switched to `meta.flex` (same recipe as the synthetics `MonitorTable`) — still absorbs leftover width, but resizable.
- Removed a hardcoded `⚠` glyph from the no-destination tag.

### Add/Edit drawer — `AddExternalAlertSource.vue`

- Converted the hand-rolled `form` object + disabled-Save validation to `OForm` + a colocated zod schema, with fields addressed by `name=` only and wired to the drawer footer via `form-id`. Save is no longer disabled on invalid and the manual `saving` flag is gone.
- `form-id` is dropped once the source exists, so the "Done" button closes instead of resubmitting.
- Select width moved to a wrapper (`OSelect` self-applies `w-full`) and its hand-rolled `<p>` label became the `label` prop.

## Testing

- `ExternalAlertSourcesList.spec.ts` — 38 pass (8 new: search filtering, empty state, clear-filters, footer count, resize handles). Binding `:loading` made DOM assertions hit OTable's minimum-hold skeleton, so they now go through a `mountAndSettle()` helper.
- `AddExternalAlertSource.spec.ts` — 22 pass, rewritten off `vm.form` onto the validated-values API, plus two tests that submit the real `<form>` end-to-end.
- Full `src/components/alerts/` suite green (1997 tests). `npm run type-check`, ESLint and `lint:design:strict` all clean.
