### PR TITLE
feat(llm): add dataset item APIs

### DIFF
--- a/src/api/http/src/handler/http/router/mod.rs
+++ b/src/api/http/src/handler/http/router/mod.rs
@@ -1059,6 +1059,10 @@ pub fn service_routes() -> Router {
                         .post(annotation_queues::review_annotation_queue_item),
                 )
                 .route(
+                    "/{org_id}/annotation_queues/{queue_id}/items/{queue_item_id}/push_to_dataset",
+                    post(datasets::push_annotation_queue_item_to_dataset),
+                )
+                .route(
                     "/{org_id}/annotation_queues/{queue_id}/items/archive",
                     post(annotation_queues::archive_annotation_queue_items),
                 )
@@ -1071,6 +1075,18 @@ pub fn service_routes() -> Router {
                 .route(
                     "/{org_id}/datasets",
                     get(datasets::list_datasets).post(datasets::create_dataset),
+                )
+                .route(
+                    "/{org_id}/datasets/{dataset_id}/items/import",
+                    post(datasets::import_dataset_items),
+                )
+                .route(
+                    "/{org_id}/datasets/{dataset_id}/items",
+                    get(datasets::list_dataset_items).post(datasets::push_dataset_item),
+                )
+                .route(
+                    "/{org_id}/datasets/{dataset_id}/items/{item_id}",
+                    put(datasets::update_dataset_item).delete(datasets::delete_dataset_item),
                 )
                 .route(
                     "/{org_id}/datasets/{dataset_id}",

--- a/src/api/management/Cargo.toml
+++ b/src/api/management/Cargo.toml
@@ -60,6 +60,7 @@ bytes.workspace = true
 chrono.workspace = true
 common.workspace = true
 config.workspace = true
+csv.workspace = true
 db.workspace = true
 enrichment-data.workspace = true
 futures.workspace = true

--- a/src/api/management/src/models/datasets/mod.rs
+++ b/src/api/management/src/models/datasets/mod.rs
@@ -12,18 +12,22 @@
 //!
 //! - `POST /{org_id}/datasets/{dataset_id}/items` for manual or direct trace/span entry.
 //! - `POST /{org_id}/annotation_queues/{queue_id}/items/{queue_item_id}/push_to_dataset` for
-//!   explicit queue adjudication; the target Dataset and telemetry input are resolved server-side
-//!   from the Queue Item.
+//!   explicit queue adjudication; the caller selects the target Dataset while telemetry input is
+//!   resolved server-side from the Queue Item.
 //! - `POST /{org_id}/datasets/{dataset_id}/items/import` for multipart CSV import; malformed rows
 //!   are skipped and summarized.
 //!
 //! Stored source, logical/physical IDs, MVCC versions, actors, timestamps, and
 //! queue provenance are server-owned on every entry path.
 
-use openobserve_core::llm_evaluations::datasets::{CreateDataset, Dataset, UpdateDataset};
+use openobserve_core::llm_evaluations::datasets::{
+    CreateDataset, CreateDatasetItem, Dataset, DatasetItem, DatasetItemPage, DatasetItemSource,
+    ListDatasetItems, PushDatasetItemResult, PushQueueItemToDataset,
+    TelemetryDatasetItemRefType as ServiceRefType, UpdateDataset, UpdateDatasetItem,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -59,6 +63,30 @@ pub struct ListDatasetsResponseBody {
     pub list: Vec<DatasetResponseBody>,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
+#[serde(deny_unknown_fields)]
+pub struct ListDatasetItemsQuery {
+    /// Include the latest tombstone for deleted logical items. Defaults to false.
+    #[serde(rename = "includeDeleted", alias = "include_deleted")]
+    pub include_deleted: Option<bool>,
+    /// Zero-based result offset. Defaults to 0.
+    pub from: Option<usize>,
+    /// Page size from 1 through 100. Defaults to 20.
+    pub size: Option<usize>,
+}
+
+impl From<ListDatasetItemsQuery> for ListDatasetItems {
+    fn from(value: ListDatasetItemsQuery) -> Self {
+        let defaults = ListDatasetItems::default();
+        Self {
+            include_deleted: value.include_deleted.unwrap_or(defaults.include_deleted),
+            from: value.from.unwrap_or(defaults.from),
+            size: value.size.unwrap_or(defaults.size),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TelemetryDatasetItemRefType {
@@ -86,6 +114,12 @@ pub enum PushDatasetItemRequestBody {
         ref_type: TelemetryDatasetItemRefType,
         #[serde(rename = "refId")]
         ref_id: String,
+        /// Trace stream containing the immutable reference.
+        #[serde(rename = "sourceStream")]
+        source_stream: String,
+        /// Positive microsecond lower bound used to retrieve the reference.
+        #[serde(rename = "refTraceStartTime")]
+        ref_trace_start_time: i64,
         #[serde(rename = "expectedOutput")]
         expected_output: Value,
         #[serde(default)]
@@ -97,7 +131,20 @@ pub enum PushDatasetItemRequestBody {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdateDatasetItemRequestBody {
+    pub input: Value,
+    pub expected_output: Value,
+    #[serde(default)]
+    pub metadata: Option<Value>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PushAnnotationQueueItemToDatasetRequestBody {
+    /// User-selected destination Dataset.
+    pub dataset_id: String,
     /// Logical `_llm_scores` N/N submission selected as adjudication evidence.
     pub review_submission_id: String,
     /// Explicit human-finalized golden; never inferred from an ordinary score.
@@ -139,6 +186,16 @@ pub struct DatasetItemResponseBody {
     pub import_filename: Option<String>,
     pub updated_by: String,
     pub updated_at: i64,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListDatasetItemsResponseBody {
+    pub list: Vec<DatasetItemResponseBody>,
+    pub total: u64,
+    pub from: usize,
+    pub size: usize,
+    pub has_more: bool,
 }
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
@@ -199,9 +256,176 @@ impl From<Vec<Dataset>> for ListDatasetsResponseBody {
     }
 }
 
+impl From<TelemetryDatasetItemRefType> for ServiceRefType {
+    fn from(value: TelemetryDatasetItemRefType) -> Self {
+        match value {
+            TelemetryDatasetItemRefType::Trace => Self::Trace,
+            TelemetryDatasetItemRefType::Span => Self::Span,
+        }
+    }
+}
+
+impl From<PushDatasetItemRequestBody> for CreateDatasetItem {
+    fn from(value: PushDatasetItemRequestBody) -> Self {
+        match value {
+            PushDatasetItemRequestBody::Manual {
+                input,
+                expected_output,
+                metadata,
+                tags,
+            } => Self::Manual {
+                input,
+                expected_output,
+                metadata,
+                tags,
+            },
+            PushDatasetItemRequestBody::Telemetry {
+                ref_type,
+                ref_id,
+                source_stream,
+                ref_trace_start_time,
+                expected_output,
+                metadata,
+                tags,
+            } => Self::Telemetry {
+                ref_type: ref_type.into(),
+                ref_id,
+                source_stream,
+                ref_trace_start_time,
+                expected_output,
+                metadata,
+                tags,
+            },
+        }
+    }
+}
+
+impl From<UpdateDatasetItemRequestBody> for UpdateDatasetItem {
+    fn from(value: UpdateDatasetItemRequestBody) -> Self {
+        Self {
+            input: value.input,
+            expected_output: value.expected_output,
+            metadata: value.metadata,
+            tags: value.tags,
+        }
+    }
+}
+
+impl From<PushAnnotationQueueItemToDatasetRequestBody> for PushQueueItemToDataset {
+    fn from(value: PushAnnotationQueueItemToDatasetRequestBody) -> Self {
+        Self {
+            dataset_id: value.dataset_id,
+            review_submission_id: value.review_submission_id,
+            expected_output: value.expected_output,
+            metadata: value.metadata,
+            tags: value.tags,
+        }
+    }
+}
+
+impl From<DatasetItemSource> for DatasetItemSourceResponseBody {
+    fn from(value: DatasetItemSource) -> Self {
+        match value {
+            DatasetItemSource::Trace => Self::Trace,
+            DatasetItemSource::Annotation => Self::Annotation,
+            DatasetItemSource::Manual => Self::Manual,
+        }
+    }
+}
+
+impl From<DatasetItem> for DatasetItemResponseBody {
+    fn from(value: DatasetItem) -> Self {
+        Self {
+            row_id: value.row_id,
+            logical_id: value.logical_id,
+            org_id: value.org_id,
+            dataset_id: value.dataset_id,
+            input: value.input,
+            expected_output: value.expected_output,
+            global_version: value.global_version,
+            is_deleted: value.is_deleted,
+            source: value.source.into(),
+            source_ref: value.source_ref,
+            source_span_id: value.source_span_id,
+            metadata: value.metadata,
+            tags: value.tags,
+            queue_id: value.queue_id,
+            review_submission_id: value.review_submission_id,
+            adjudicated_by: value.adjudicated_by,
+            adjudicated_at: value.adjudicated_at,
+            import_filename: value.import_filename,
+            updated_by: value.updated_by,
+            updated_at: value.updated_at,
+        }
+    }
+}
+
+impl From<DatasetItemPage> for ListDatasetItemsResponseBody {
+    fn from(value: DatasetItemPage) -> Self {
+        Self {
+            list: value
+                .items
+                .into_iter()
+                .map(DatasetItemResponseBody::from)
+                .collect(),
+            total: value.total,
+            from: value.from,
+            size: value.size,
+            has_more: value.has_more,
+        }
+    }
+}
+
+impl From<PushDatasetItemResult> for PushDatasetItemResponseBody {
+    fn from(value: PushDatasetItemResult) -> Self {
+        Self {
+            created: value.created,
+            item: value.item.into(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod dataset_item_contract_tests {
     use super::*;
+
+    #[test]
+    fn list_query_defaults_to_live_current_items() {
+        let request: ListDatasetItems = ListDatasetItemsQuery::default().into();
+        assert!(!request.include_deleted);
+        assert_eq!(request.from, 0);
+        assert_eq!(request.size, 20);
+
+        let request: ListDatasetItems = serde_json::from_value::<ListDatasetItemsQuery>(
+            serde_json::json!({"includeDeleted": true, "from": 20, "size": 50}),
+        )
+        .unwrap()
+        .into();
+        assert!(request.include_deleted);
+        assert_eq!(request.from, 20);
+        assert_eq!(request.size, 50);
+    }
+
+    #[test]
+    fn update_accepts_only_replaceable_item_fields() {
+        let body: UpdateDatasetItemRequestBody = serde_json::from_value(serde_json::json!({
+            "input": "question",
+            "expectedOutput": "answer",
+            "metadata": {"difficulty": "hard"},
+            "tags": ["regression"]
+        }))
+        .unwrap();
+        let command: UpdateDatasetItem = body.into();
+        assert_eq!(command.expected_output, "answer");
+
+        let spoofed: Result<UpdateDatasetItemRequestBody, _> =
+            serde_json::from_value(serde_json::json!({
+                "input": "question",
+                "expectedOutput": "answer",
+                "source": "manual"
+            }));
+        assert!(spoofed.is_err());
+    }
 
     #[test]
     fn manual_entry_accepts_only_user_owned_golden_fields() {
@@ -233,6 +457,8 @@ mod dataset_item_contract_tests {
             "entryPoint": "telemetry",
             "refType": "trace",
             "refId": "trace-1",
+            "sourceStream": "default",
+            "refTraceStartTime": 1,
             "expectedOutput": "corrected answer"
         }))
         .unwrap();
@@ -249,6 +475,8 @@ mod dataset_item_contract_tests {
                 "entryPoint": "telemetry",
                 "refType": "session",
                 "refId": "session-1",
+                "sourceStream": "default",
+                "refTraceStartTime": 1,
                 "expectedOutput": "not supported"
             }));
         assert!(session.is_err());
@@ -258,6 +486,8 @@ mod dataset_item_contract_tests {
                 "entryPoint": "telemetry",
                 "refType": "trace",
                 "refId": "trace-1",
+                "sourceStream": "default",
+                "refTraceStartTime": 1,
                 "refTraceId": "trace-1",
                 "expectedOutput": "corrected answer"
             }));
@@ -265,22 +495,35 @@ mod dataset_item_contract_tests {
     }
 
     #[test]
-    fn queue_entry_exposes_adjudication_choice_but_not_provenance() {
+    fn queue_entry_exposes_destination_and_adjudication_choice_but_not_provenance() {
         let body: PushAnnotationQueueItemToDatasetRequestBody =
             serde_json::from_value(serde_json::json!({
+                "datasetId": "dataset-1",
                 "reviewSubmissionId": "submission-1",
                 "expectedOutput": {"answer": "final"},
                 "metadata": {"difficulty": "hard"}
             }))
             .unwrap();
+        assert_eq!(body.dataset_id, "dataset-1");
         assert_eq!(body.review_submission_id, "submission-1");
+
+        let service_input: PushQueueItemToDataset = body.into();
+        assert_eq!(service_input.dataset_id, "dataset-1");
 
         let spoofed: Result<PushAnnotationQueueItemToDatasetRequestBody, _> =
             serde_json::from_value(serde_json::json!({
+                "datasetId": "dataset-1",
                 "reviewSubmissionId": "submission-1",
                 "expectedOutput": "final",
                 "queueId": "other-queue"
             }));
         assert!(spoofed.is_err());
+
+        let missing_dataset: Result<PushAnnotationQueueItemToDatasetRequestBody, _> =
+            serde_json::from_value(serde_json::json!({
+                "reviewSubmissionId": "submission-1",
+                "expectedOutput": "final"
+            }));
+        assert!(missing_dataset.is_err());
     }
 }

--- a/src/api/management/src/request/datasets/mod.rs
+++ b/src/api/management/src/request/datasets/mod.rs
@@ -5,21 +5,29 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-use axum::{extract::Path, response::Response};
+use axum::{
+    extract::{Multipart, Path, Query},
+    response::Response,
+};
 use db::authz::{remove_ownership, set_ownership};
 use openobserve_api_common::extractors::Headers;
 use openobserve_core::{
     auth::{UserEmail, is_ofga_object_visible},
-    llm_evaluations::datasets::{self, DatasetError},
+    llm_evaluations::datasets::{self, DatasetError, ImportDatasetItem},
 };
 
 use crate::{
     common::meta::{authz::Authz, http::HttpResponse as MetaHttpResponse},
     models::datasets::{
-        CreateDatasetRequestBody, DatasetResponseBody, ListDatasetsResponseBody,
+        CreateDatasetRequestBody, DatasetItemResponseBody, DatasetResponseBody,
+        ImportDatasetItemsResponseBody, ListDatasetItemsQuery, ListDatasetItemsResponseBody,
+        ListDatasetsResponseBody, PushAnnotationQueueItemToDatasetRequestBody,
+        PushDatasetItemRequestBody, PushDatasetItemResponseBody, UpdateDatasetItemRequestBody,
         UpdateDatasetRequestBody,
     },
 };
+
+const MAX_DATASET_IMPORT_BYTES: usize = 10 * 1024 * 1024;
 
 fn dataset_error_response(value: DatasetError) -> Response {
     match value {
@@ -27,11 +35,70 @@ fn dataset_error_response(value: DatasetError) -> Response {
             log::error!("[Dataset] internal error: {err}");
             MetaHttpResponse::internal_error("Internal server error")
         }
-        DatasetError::MissingName => MetaHttpResponse::bad_request("Dataset name cannot be empty"),
+        error @ (DatasetError::ReviewLookup(_)
+        | DatasetError::VersionOverflow
+        | DatasetError::MalformedItem(_)) => {
+            log::error!("[Dataset] internal error: {error}");
+            MetaHttpResponse::internal_error("Internal server error")
+        }
+        error @ (DatasetError::MissingName
+        | DatasetError::MissingDatasetId
+        | DatasetError::MissingItemInput
+        | DatasetError::MissingExpectedOutput
+        | DatasetError::MissingSourceStream
+        | DatasetError::InvalidTraceStartTime
+        | DatasetError::InvalidPageSize
+        | DatasetError::InvalidTelemetryReference(_)
+        | DatasetError::UnsupportedQueueItemScope) => {
+            MetaHttpResponse::bad_request(error.to_string())
+        }
         DatasetError::NotFound => MetaHttpResponse::not_found("Dataset not found"),
+        DatasetError::ItemNotFound => MetaHttpResponse::not_found("Dataset Item not found"),
+        DatasetError::QueueNotFound => MetaHttpResponse::not_found("Annotation Queue not found"),
+        DatasetError::QueueItemNotFound => {
+            MetaHttpResponse::not_found("Annotation Queue Item not found")
+        }
+        DatasetError::ReviewSubmissionNotFound => {
+            MetaHttpResponse::not_found("Complete review submission not found")
+        }
         error @ (DatasetError::DuplicateName | DatasetError::InUse | DatasetError::NotEmpty) => {
             MetaHttpResponse::conflict(error)
         }
+        error @ (DatasetError::QueueItemNotReviewed | DatasetError::InconsistentReviewSource) => {
+            MetaHttpResponse::conflict(error)
+        }
+    }
+}
+
+/// ListDatasetItems
+#[utoipa::path(
+    get,
+    path = "/{org_id}/datasets/{dataset_id}/items",
+    context_path = "/api",
+    tag = "Datasets",
+    operation_id = "ListDatasetItems",
+    summary = "List the current Dataset Item snapshot",
+    description = "Returns the latest immutable row for every logical Dataset Item, excluding soft-deleted items unless include_deleted=true.",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("dataset_id" = String, Path, description = "Dataset ID"),
+        ListDatasetItemsQuery,
+    ),
+    responses(
+        (status = 200, body = inline(ListDatasetItemsResponseBody)),
+        (status = 400, description = "Invalid page size", body = ()),
+        (status = 404, description = "Dataset not found", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "Datasets", "operation": "list"}))),
+)]
+pub async fn list_dataset_items(
+    Path((org_id, dataset_id)): Path<(String, String)>,
+    Query(query): Query<ListDatasetItemsQuery>,
+) -> Response {
+    match datasets::list_items(&org_id, &dataset_id, query.into()).await {
+        Ok(page) => MetaHttpResponse::json(ListDatasetItemsResponseBody::from(page)),
+        Err(err) => dataset_error_response(err),
     }
 }
 
@@ -203,6 +270,331 @@ pub async fn delete_dataset(Path((org_id, dataset_id)): Path<(String, String)>) 
     }
 }
 
+/// PushDatasetItem
+#[utoipa::path(
+    post,
+    path = "/{org_id}/datasets/{dataset_id}/items",
+    context_path = "/api",
+    tag = "Datasets",
+    operation_id = "PushDatasetItem",
+    summary = "Add a manual or telemetry-backed Dataset Item",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("dataset_id" = String, Path, description = "Dataset ID"),
+    ),
+    request_body(content = inline(PushDatasetItemRequestBody), description = "Dataset Item payload"),
+    responses(
+        (status = 200, body = inline(PushDatasetItemResponseBody)),
+        (status = 400, description = "Bad Request", body = ()),
+        (status = 404, description = "Not Found", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "Datasets", "operation": "update"}))),
+)]
+pub async fn push_dataset_item(
+    Path((org_id, dataset_id)): Path<(String, String)>,
+    Headers(user): Headers<UserEmail>,
+    axum::Json(body): axum::Json<PushDatasetItemRequestBody>,
+) -> Response {
+    match datasets::push_item(&org_id, &dataset_id, &user.user_id, body.into()).await {
+        Ok(result) => MetaHttpResponse::json(PushDatasetItemResponseBody::from(result)),
+        Err(err) => dataset_error_response(err),
+    }
+}
+
+/// UpdateDatasetItem
+#[utoipa::path(
+    put,
+    path = "/{org_id}/datasets/{dataset_id}/items/{item_id}",
+    context_path = "/api",
+    tag = "Datasets",
+    operation_id = "UpdateDatasetItem",
+    summary = "Append a new Dataset Item version",
+    description = "Replaces the user-authored fields by appending an immutable row with the same logical Item ID and the next Dataset global version. Source provenance is preserved.",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("dataset_id" = String, Path, description = "Dataset ID"),
+        ("item_id" = String, Path, description = "Logical Dataset Item ID"),
+    ),
+    request_body(content = inline(UpdateDatasetItemRequestBody), description = "Replacement Dataset Item fields"),
+    responses(
+        (status = 200, body = inline(DatasetItemResponseBody)),
+        (status = 400, description = "Invalid Dataset Item", body = ()),
+        (status = 404, description = "Dataset or Dataset Item not found", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "Datasets", "operation": "update"}))),
+)]
+pub async fn update_dataset_item(
+    Path((org_id, dataset_id, item_id)): Path<(String, String, String)>,
+    Headers(user): Headers<UserEmail>,
+    axum::Json(body): axum::Json<UpdateDatasetItemRequestBody>,
+) -> Response {
+    match datasets::update_item(&org_id, &dataset_id, &item_id, &user.user_id, body.into()).await {
+        Ok(item) => MetaHttpResponse::json(DatasetItemResponseBody::from(item)),
+        Err(err) => dataset_error_response(err),
+    }
+}
+
+/// DeleteDatasetItem
+#[utoipa::path(
+    delete,
+    path = "/{org_id}/datasets/{dataset_id}/items/{item_id}",
+    context_path = "/api",
+    tag = "Datasets",
+    operation_id = "DeleteDatasetItem",
+    summary = "Soft-delete a Dataset Item",
+    description = "Appends an immutable tombstone with the same logical Item ID and the next Dataset global version.",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("dataset_id" = String, Path, description = "Dataset ID"),
+        ("item_id" = String, Path, description = "Logical Dataset Item ID"),
+    ),
+    responses(
+        (status = 200, body = inline(DatasetItemResponseBody)),
+        (status = 404, description = "Dataset or Dataset Item not found", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "Datasets", "operation": "delete"}))),
+)]
+pub async fn delete_dataset_item(
+    Path((org_id, dataset_id, item_id)): Path<(String, String, String)>,
+    Headers(user): Headers<UserEmail>,
+) -> Response {
+    match datasets::delete_item(&org_id, &dataset_id, &item_id, &user.user_id).await {
+        Ok(item) => MetaHttpResponse::json(DatasetItemResponseBody::from(item)),
+        Err(err) => dataset_error_response(err),
+    }
+}
+
+/// ImportDatasetItems
+#[utoipa::path(
+    post,
+    path = "/{org_id}/datasets/{dataset_id}/items/import",
+    context_path = "/api",
+    tag = "Datasets",
+    operation_id = "ImportDatasetItems",
+    summary = "Import Dataset Items from CSV",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("dataset_id" = String, Path, description = "Dataset ID"),
+    ),
+    responses(
+        (status = 200, body = inline(ImportDatasetItemsResponseBody)),
+        (status = 400, description = "Bad Request", body = ()),
+        (status = 404, description = "Not Found", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "Datasets", "operation": "update"}))),
+)]
+pub async fn import_dataset_items(
+    Path((org_id, dataset_id)): Path<(String, String)>,
+    Headers(user): Headers<UserEmail>,
+    mut multipart: Multipart,
+) -> Response {
+    let mut upload = None;
+    while let Ok(Some(field)) = multipart.next_field().await {
+        if field.name() != Some("file") {
+            continue;
+        }
+        if upload.is_some() {
+            return MetaHttpResponse::bad_request("Only one CSV file may be imported at a time");
+        }
+        let filename = field.file_name().unwrap_or("import.csv").to_string();
+        let bytes = match field.bytes().await {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return MetaHttpResponse::bad_request(format!(
+                    "Failed to read CSV upload: {error}"
+                ));
+            }
+        };
+        if bytes.len() > MAX_DATASET_IMPORT_BYTES {
+            return MetaHttpResponse::bad_request("CSV import exceeds the 10 MiB limit");
+        }
+        upload = Some((filename, bytes));
+    }
+
+    let Some((filename, bytes)) = upload else {
+        return MetaHttpResponse::bad_request("CSV file is required in multipart field 'file'");
+    };
+    let parsed = match parse_dataset_import_csv(&bytes) {
+        Ok(parsed) => parsed,
+        Err(error) => return MetaHttpResponse::bad_request(error),
+    };
+    match datasets::import_items(&org_id, &dataset_id, &user.user_id, &filename, parsed.items).await
+    {
+        Ok(imported_count) => MetaHttpResponse::json(ImportDatasetItemsResponseBody {
+            filename,
+            imported_count,
+            skipped_count: parsed.skipped_count,
+        }),
+        Err(err) => dataset_error_response(err),
+    }
+}
+
+/// PushAnnotationQueueItemToDataset
+#[utoipa::path(
+    post,
+    path = "/{org_id}/annotation_queues/{queue_id}/items/{queue_item_id}/push_to_dataset",
+    context_path = "/api",
+    tag = "Datasets",
+    operation_id = "PushAnnotationQueueItemToDataset",
+    summary = "Distill a reviewed Queue Item into a selected Dataset",
+    security(("Authorization" = [])),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("queue_id" = String, Path, description = "Annotation Queue ID"),
+        ("queue_item_id" = String, Path, description = "Annotation Queue Item ID"),
+    ),
+    request_body(
+        content = inline(PushAnnotationQueueItemToDatasetRequestBody),
+        description = "Selected Dataset and adjudicated Dataset Item payload"
+    ),
+    responses(
+        (status = 200, body = inline(PushDatasetItemResponseBody)),
+        (status = 400, description = "Bad Request", body = ()),
+        (status = 403, description = "Forbidden", body = ()),
+        (status = 404, description = "Not Found", body = ()),
+        (status = 409, description = "Conflict", body = ()),
+    ),
+    extensions(("x-o2-ratelimit" = json!({"module": "Datasets", "operation": "update"}))),
+)]
+pub async fn push_annotation_queue_item_to_dataset(
+    Path((org_id, queue_id, queue_item_id)): Path<(String, String, String)>,
+    Headers(user): Headers<UserEmail>,
+    axum::Json(body): axum::Json<PushAnnotationQueueItemToDatasetRequestBody>,
+) -> Response {
+    let dataset_id = body.dataset_id.trim().to_string();
+    if dataset_id.is_empty() {
+        return dataset_error_response(DatasetError::MissingDatasetId);
+    }
+    let permitted_datasets = match openobserve_api_common::auth::validator::list_objects_for_user(
+        &org_id,
+        &user.user_id,
+        "PUT",
+        "dataset",
+    )
+    .await
+    {
+        Ok(list) => list,
+        Err(err) => return MetaHttpResponse::forbidden(err.to_string()),
+    };
+    if !is_ofga_object_visible(
+        &org_id,
+        "dataset",
+        &dataset_id,
+        permitted_datasets.as_deref(),
+    ) {
+        return MetaHttpResponse::forbidden("Unauthorized Access");
+    }
+    match datasets::push_queue_item(
+        &org_id,
+        &queue_id,
+        &queue_item_id,
+        &user.user_id,
+        body.into(),
+    )
+    .await
+    {
+        Ok(result) => MetaHttpResponse::json(PushDatasetItemResponseBody::from(result)),
+        Err(err) => dataset_error_response(err),
+    }
+}
+
+struct ParsedDatasetImport {
+    items: Vec<ImportDatasetItem>,
+    skipped_count: u64,
+}
+
+fn parse_dataset_import_csv(bytes: &[u8]) -> Result<ParsedDatasetImport, String> {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .from_reader(bytes);
+    let headers = reader
+        .headers()
+        .map_err(|error| format!("Failed to parse CSV: {error}"))?
+        .clone();
+    if headers.is_empty() {
+        return Err("CSV file is empty".to_string());
+    }
+    let input_index = header_index(&headers, "input")
+        .ok_or_else(|| "CSV header must contain an 'input' column".to_string())?;
+    let expected_index = header_index(&headers, "expected_output")
+        .ok_or_else(|| "CSV header must contain an 'expected_output' column".to_string())?;
+    let tags_index = header_index(&headers, "tags");
+
+    let mut items = Vec::new();
+    let mut skipped_count = 0_u64;
+    for record in reader.records() {
+        let record = record.map_err(|error| format!("Failed to parse CSV: {error}"))?;
+        let input = record.get(input_index).unwrap_or("").trim();
+        let expected_output = record.get(expected_index).unwrap_or("").trim();
+        if input.is_empty() || expected_output.is_empty() {
+            skipped_count += 1;
+            continue;
+        }
+        let input = parse_json_or_string(input);
+        let expected_output = parse_json_or_string(expected_output);
+        if !non_empty_import_value(&input) || !non_empty_import_value(&expected_output) {
+            skipped_count += 1;
+            continue;
+        }
+        let tags = tags_index
+            .and_then(|index| record.get(index))
+            .map(parse_import_tags)
+            .unwrap_or_default();
+        items.push(ImportDatasetItem {
+            input,
+            expected_output,
+            tags,
+        });
+    }
+
+    Ok(ParsedDatasetImport {
+        items,
+        skipped_count,
+    })
+}
+
+fn header_index(headers: &csv::StringRecord, expected: &str) -> Option<usize> {
+    headers.iter().position(|header| {
+        header
+            .trim_start_matches('\u{feff}')
+            .trim()
+            .eq_ignore_ascii_case(expected)
+    })
+}
+
+fn parse_json_or_string(value: &str) -> serde_json::Value {
+    serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_string()))
+}
+
+fn non_empty_import_value(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Null => false,
+        serde_json::Value::String(value) => !value.trim().is_empty(),
+        serde_json::Value::Array(value) => !value.is_empty(),
+        serde_json::Value::Object(value) => !value.is_empty(),
+        serde_json::Value::Bool(_) | serde_json::Value::Number(_) => true,
+    }
+}
+
+fn parse_import_tags(value: &str) -> Vec<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Vec::new();
+    }
+    let tags = serde_json::from_str::<Vec<String>>(value)
+        .unwrap_or_else(|_| value.split('|').map(str::to_string).collect());
+    let mut seen = std::collections::HashSet::new();
+    tags.into_iter()
+        .map(|tag| tag.trim().to_string())
+        .filter(|tag| !tag.is_empty() && seen.insert(tag.clone()))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,5 +613,57 @@ mod tests {
                 .as_u16(),
             409
         );
+        assert_eq!(
+            dataset_error_response(DatasetError::InvalidPageSize)
+                .status()
+                .as_u16(),
+            400
+        );
+        assert_eq!(
+            dataset_error_response(DatasetError::ItemNotFound)
+                .status()
+                .as_u16(),
+            404
+        );
+    }
+
+    #[test]
+    fn csv_import_accepts_quoted_json_and_skips_missing_goldens() {
+        let parsed = parse_dataset_import_csv(
+            br#"input,expected_output,tags
+"{""question"":""refund?""}","{""answer"":""30 days""}","[""policy"",""reviewed""]"
+missing,,bad
+"plain, question",plain answer,manual|seed
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.skipped_count, 1);
+        assert_eq!(
+            parsed.items[0].input,
+            serde_json::json!({"question": "refund?"})
+        );
+        assert_eq!(parsed.items[0].tags, ["policy", "reviewed"]);
+        assert_eq!(parsed.items[1].input, "plain, question");
+        assert_eq!(parsed.items[1].tags, ["manual", "seed"]);
+    }
+
+    #[test]
+    fn csv_import_requires_both_headers_and_valid_utf8() {
+        assert!(parse_dataset_import_csv(b"input\nquestion\n").is_err());
+        assert!(parse_dataset_import_csv(&[b'i', b'n', b'p', b'u', b't', b',', 0xff]).is_err());
+    }
+
+    #[test]
+    fn csv_import_supports_newlines_and_escaped_quotes_in_fields() {
+        let parsed = parse_dataset_import_csv(
+            b"input,expected_output\n\"line 1\nline 2\",\"say \"\"hi\"\"\"\n",
+        )
+        .unwrap();
+
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.items[0].input, "line 1\nline 2");
+        assert_eq!(parsed.items[0].expected_output, "say \"hi\"");
     }
 }


### PR DESCRIPTION
Expose backend-only Dataset Item entry points for manual and telemetry goldens, CSV import with per-row skip summaries, and reviewed Annotation Queue distillation. Requests keep provenance server-owned, require non-empty inputs and expected outputs, and return idempotent creation state for trace and annotation retries.

---
**Stack**:
- #13714
- #13713
- #13712
- #13711
- #13660
- #13649
- #13648
- #13634
- #13629 ⬅
- #13623
- #13620
- #13608
- #13607
- #13597
- #13596
- #13595
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*