### PR TITLE
fix: accept org ingestion tokens for OTLP gRPC (#13627)

### DIFF
--- a/src/api/grpc/src/handler/grpc/auth/mod.rs
+++ b/src/api/grpc/src/handler/grpc/auth/mod.rs
@@ -13,14 +13,31 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use common::infra::config::ROOT_USER;
+use common::infra::config::{ORG_INGESTION_TOKENS, ROOT_USER};
 use config::meta::cluster::get_internal_grpc_token;
 use db::{org_users::get_cached_user_org, user::is_root_user};
 use http_auth_basic::Credentials;
+use infra::table::org_ingestion_tokens::ORG_INGESTION_TOKEN_PREFIX;
 use openobserve_core::auth::get_hash;
 use tonic::{Request, Status, metadata::MetadataValue};
 
 pub fn check_auth(req: Request<()>) -> Result<Request<()>, Status> {
+    check_auth_inner(req, false)
+}
+
+/// Authenticate external OTLP ingestion requests.
+///
+/// Org-level ingestion tokens are deliberately accepted only by the OTLP
+/// logs, metrics, and traces services. Internal cluster RPCs continue to use
+/// [`check_auth`], so an ingestion token cannot authorize query or node APIs.
+pub fn check_otlp_auth(req: Request<()>) -> Result<Request<()>, Status> {
+    check_auth_inner(req, true)
+}
+
+fn check_auth_inner(
+    req: Request<()>,
+    allow_org_ingestion_token: bool,
+) -> Result<Request<()>, Status> {
     let cfg = config::get_config();
     let metadata = req.metadata();
     if !metadata.contains_key(&cfg.grpc.org_header_key) && !metadata.contains_key("authorization") {
@@ -69,6 +86,19 @@ pub fn check_auth(req: Request<()>) -> Result<Request<()>, Status> {
         };
 
         let user_id = credentials.user_id;
+        if allow_org_ingestion_token && credentials.password.starts_with(ORG_INGESTION_TOKEN_PREFIX)
+        {
+            let org_id = org_id.unwrap().to_str().unwrap();
+            let cache_key = db::org_ingestion_tokens::cache_key(org_id, &credentials.password);
+            if ORG_INGESTION_TOKENS.contains_key(&cache_key) {
+                let mut req = req;
+                let user_id_metadata = MetadataValue::try_from(&user_id).unwrap();
+                req.metadata_mut().append("user_id", user_id_metadata);
+                return Ok(req);
+            }
+            return Err(Status::unauthenticated("No valid auth token[5]"));
+        }
+
         let user = if is_root_user(&user_id) {
             ROOT_USER.get("root").unwrap().to_owned()
         } else if let Some(user) = get_cached_user_org(org_id.unwrap().to_str().unwrap(), &user_id)
@@ -101,7 +131,7 @@ pub fn check_auth(req: Request<()>) -> Result<Request<()>, Status> {
 
 #[cfg(test)]
 mod tests {
-    use common::infra::config::ORG_USERS;
+    use common::infra::config::{ORG_INGESTION_TOKENS, ORG_USERS};
     use config::{
         cache_instance_id, get_config,
         meta::user::{User, UserRole},
@@ -222,5 +252,60 @@ mod tests {
 
         let res = check_auth(request);
         assert!(res.is_err())
+    }
+
+    fn org_token_request(org_id: &str, encoded_credentials: &str) -> tonic::Request<()> {
+        let mut request = tonic::Request::new(());
+        request.metadata_mut().insert(
+            "authorization",
+            format!("basic {encoded_credentials}").parse().unwrap(),
+        );
+        request
+            .metadata_mut()
+            .insert("organization", org_id.parse().unwrap());
+        request
+    }
+
+    #[test]
+    fn test_otlp_auth_accepts_org_ingestion_token() {
+        let cache_key = db::org_ingestion_tokens::cache_key("default", "o2oi_valid_token");
+        ORG_INGESTION_TOKENS.insert(cache_key.clone(), "collector-token".to_string());
+
+        let request = org_token_request(
+            "default",
+            "Y29sbGVjdG9yQGV4YW1wbGUuY29tOm8yb2lfdmFsaWRfdG9rZW4=",
+        );
+        let request = check_otlp_auth(request).unwrap();
+
+        assert_eq!(
+            request.metadata().get("user_id").unwrap().to_str().unwrap(),
+            "collector@example.com"
+        );
+        ORG_INGESTION_TOKENS.remove(&cache_key);
+    }
+
+    #[test]
+    fn test_internal_auth_rejects_org_ingestion_token() {
+        let cache_key = db::org_ingestion_tokens::cache_key("default", "o2oi_internal_token");
+        ORG_INGESTION_TOKENS.insert(cache_key.clone(), "collector-token".to_string());
+
+        let request = org_token_request(
+            "default",
+            "Y29sbGVjdG9yQGV4YW1wbGUuY29tOm8yb2lfaW50ZXJuYWxfdG9rZW4=",
+        );
+
+        assert!(check_auth(request).is_err());
+        ORG_INGESTION_TOKENS.remove(&cache_key);
+    }
+
+    #[test]
+    fn test_otlp_auth_rejects_missing_org_ingestion_token() {
+        let request = org_token_request(
+            "default",
+            "Y29sbGVjdG9yQGV4YW1wbGUuY29tOm8yb2lfbWlzc2luZ190b2tlbg==",
+        );
+
+        let status = check_otlp_auth(request).unwrap_err();
+        assert_eq!(status.code(), tonic::Code::Unauthenticated);
     }
 }

--- a/src/api/grpc/src/server.rs
+++ b/src/api/grpc/src/server.rs
@@ -33,12 +33,13 @@ use search_service::SEARCH_SERVER;
 use tokio::sync::oneshot;
 use tonic::{
     codec::CompressionEncoding,
+    service::interceptor::InterceptedService,
     transport::{Identity, ServerTlsConfig},
 };
 
 use crate::{
     handler::grpc::{
-        auth::check_auth,
+        auth::{check_auth, check_otlp_auth},
         flight::FlightServiceImpl,
         request::{
             event::Eventer,
@@ -141,6 +142,19 @@ async fn run_common(
         .max_decoding_message_size(cfg.grpc.max_message_size * 1024 * 1024)
         .max_encoding_message_size(cfg.grpc.max_message_size * 1024 * 1024);
 
+    let event_svc = authenticated(event_svc);
+    let search_svc = authenticated(search_svc);
+    let metrics_svc = authenticated(metrics_svc);
+    let metrics_ingest_svc = otlp_authenticated(metrics_ingest_svc);
+    let trace_svc = otlp_authenticated(trace_svc);
+    let logs_svc = otlp_authenticated(logs_svc);
+    let query_cache_svc = authenticated(query_cache_svc);
+    let ingest_svc = authenticated(ingest_svc);
+    let streams_svc = authenticated(streams_svc);
+    let flight_svc = authenticated(flight_svc);
+    let node_svc = authenticated(node_svc);
+    let cluster_info_svc = authenticated(cluster_info_svc);
+
     log::info!(
         "starting gRPC server {} at {}",
         if cfg.grpc.tls_enabled { "with TLS" } else { "" },
@@ -148,9 +162,8 @@ async fn run_common(
     );
     init_tx.send(()).ok();
 
-    let builder = server_builder()?;
+    let mut builder = server_builder()?;
     let ret = builder
-        .layer(tonic::service::InterceptorLayer::new(check_auth))
         .add_service(event_svc)
         .add_service(search_svc)
         .add_service(metrics_svc)
@@ -199,6 +212,10 @@ async fn run_router(
         .max_decoding_message_size(cfg.grpc.max_message_size * 1024 * 1024)
         .max_encoding_message_size(cfg.grpc.max_message_size * 1024 * 1024);
 
+    let logs_svc = otlp_authenticated(logs_svc);
+    let metrics_svc = otlp_authenticated(metrics_svc);
+    let traces_svc = otlp_authenticated(traces_svc);
+
     log::info!(
         "starting gRPC server {} at {}",
         if cfg.grpc.tls_enabled { "with TLS" } else { "" },
@@ -206,9 +223,8 @@ async fn run_router(
     );
     init_tx.send(()).ok();
 
-    let builder = server_builder()?;
+    let mut builder = server_builder()?;
     let ret = builder
-        .layer(tonic::service::InterceptorLayer::new(check_auth))
         .add_service(logs_svc)
         .add_service(metrics_svc)
         .add_service(traces_svc)
@@ -223,6 +239,16 @@ async fn run_router(
 
     stopped_tx.send(()).ok();
     Ok(())
+}
+
+type AuthInterceptor = fn(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>;
+
+fn authenticated<S>(service: S) -> InterceptedService<S, AuthInterceptor> {
+    InterceptedService::new(service, check_auth)
+}
+
+fn otlp_authenticated<S>(service: S) -> InterceptedService<S, AuthInterceptor> {
+    InterceptedService::new(service, check_otlp_auth)
 }
 
 fn server_builder() -> Result<tonic::transport::Server, anyhow::Error> {


### PR DESCRIPTION
## Summary

- accept organization ingestion tokens (`o2oi_`) for OTLP gRPC logs, metrics, and traces
- keep internal cluster, search, node, and other non-OTLP gRPC services on the existing authentication path
- add coverage for accepted, missing, and internal-RPC token cases

## Root cause

The HTTP ingestion authentication path validates organization ingestion tokens, but the global gRPC interceptor only recognized internal gRPC tokens and user credentials. As a result, the same organization token succeeded over HTTP OTLP and failed over gRPC OTLP with `Unauthenticated: No valid auth token[5]`.

This change assigns the organization-token-aware interceptor only to external OTLP services. Internal RPCs continue using the original interceptor, preserving the existing security boundary.

## Testing

- `cargo test --release -p openobserve-api-grpc handler::grpc::auth::tests --lib` (6 passed)
- `cargo build --release --bin openobserve`
- live local E2E on latest `main`: created a real organization ingestion token, exported an OTLP log over gRPC, then searched the stream and verified the expected record (`total=1`)

Fixes #12540