### PR TITLE
docs: add PROTOC_INCLUDE env var note for Linux in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,11 @@ unzip protoc-21.12-linux-x86_64.zip -d protoc
 sudo cp protoc/bin/protoc /usr/local/bin/
 sudo cp -r protoc/include/google /usr/local/include/
 
+# Set environment variable for protobuf include path (Linux)
+export PROTOC_INCLUDE=/usr/local/include
+# Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.) to make it permanent
+# You could also set it in your .env file
+
 # Windows
 curl -L -o protoc-21.12-win64.zip https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip
 unzip protoc-21.12-win64.zip -d protoc


### PR DESCRIPTION
## Summary

Adds a `PROTOC_INCLUDE` environment variable note for Linux in the protoc installation instructions, mirroring the same guidance already present for macOS.

## Why

The macOS section of `CONTRIBUTING.md` already documents:

```bash
export PROTOC_INCLUDE=/opt/homebrew/include
# Add this to your shell profile (~/.zshrc, ~/.bashrc, etc.) to make it permanent
```

The Linux section has no equivalent. On some Linux setups, `prost-build` fails to locate protobuf include files without `PROTOC_INCLUDE` being set explicitly, which can be confusing for new contributors.

## What changed

- Added 4 lines to the Linux section of the protoc install instructions, matching the existing macOS guidance pattern
- No changes to any code, CI, build scripts, or version pins