### PR TITLE
fix: collapse apt-get layers and clean cache in Dockerfile and Dockerfile.amd64

### DIFF
--- a/deploy/build/Dockerfile
+++ b/deploy/build/Dockerfile
@@ -22,9 +22,11 @@ RUN cargo build --release
 
 # FROM gcr.io/distroless/cc as runtime
 FROM public.ecr.aws/debian/debian:trixie-slim AS runtime
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools
-RUN update-ca-certificates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates curl htop iftop sysstat procps lsof net-tools && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=builder /openobserve/target/release/openobserve /
 RUN ["/openobserve", "init-dir", "-p", "/data/"]
 CMD ["/openobserve"]

--- a/deploy/build/Dockerfile.amd64
+++ b/deploy/build/Dockerfile.amd64
@@ -28,9 +28,11 @@ RUN --mount=type=cache,target=/root/.cache/sccache cargo build --release --featu
 RUN mv /openobserve/target/x86_64-unknown-linux-gnu/release/openobserve /openobserve/target/release/openobserve
 
 FROM public.ecr.aws/debian/debian:trixie-slim AS runtime
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools sqlite3
-RUN update-ca-certificates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates curl htop iftop sysstat procps lsof net-tools sqlite3 && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=builder /openobserve/target/release/openobserve /
 RUN ["/openobserve", "init-dir", "-p", "/data/"]
 CMD ["/openobserve"]


### PR DESCRIPTION
## Summary

Fixes three Dockerfile best practice issues in `Dockerfile` and `Dockerfile.amd64` runtime stages. `Dockerfile.pr` already follows the correct pattern — this brings the other two files in line with it.

## Why

**Split `RUN` apt-get layers (cache invalidation bug):**
The runtime stage ran `apt-get update` and `apt-get install` in separate `RUN` instructions. Docker caches each layer independently, so `apt-get update` can be cached while `apt-get install` runs fresh — resulting in stale package indexes and potentially inconsistent installs. This is [explicitly called out](https://docs.docker.com/build/building/best-practices/#apt-get) in Docker's official best practices.

**Missing `--no-install-recommends`:**
The second `apt-get install` was missing `--no-install-recommends`, pulling in unnecessary recommended packages and bloating the image.

**apt cache left in image:**
No `rm -rf /var/lib/apt/lists/*` after the install, leaving the package index cache in the final image unnecessarily.

## What changed

Both `Dockerfile` and `Dockerfile.amd64` runtime stages: collapsed three separate `RUN` instructions into one, added `--no-install-recommends`, and added `rm -rf /var/lib/apt/lists/*` to clean the apt cache.

**Before:**
```dockerfile
RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools
RUN update-ca-certificates
```

**After:**
```dockerfile
RUN apt-get update && \
    apt-get install -y --no-install-recommends \
      ca-certificates curl htop iftop sysstat procps lsof net-tools && \
    update-ca-certificates && \
    rm -rf /var/lib/apt/lists/*
```

No changes to installed packages, build stages, base images, or any other files.