### PR TITLE
fix(ci): downgrade custom-labels for musl build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,9 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "custom-labels"
-version = "0.4.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4121f4f539659ad975da5bc6702b7d7d6de59ff1bbaec328dfe7dd5058052ef2"
+checksum = "a750ea4bdb7dbf9584b5d5c668bfa3835f88275781a947b5ea0212945bbdd41f"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
## Summary

- downgrade `custom-labels` from 0.4.6 to 0.4.5 in `Cargo.lock`
- restore the version used by v0.92.0-rc2 to avoid the musl release linker failure

## Context

The x86_64 musl release job fails while linking `customlabels.o` because it contains unresolved glibc `__memcpy_chk` references. `custom-labels` 0.4.6 enabled C++ mode in its build script, which selects the workflow-provided `musl-g++` symlink to the host glibc `g++`.

Failed job: https://github.com/openobserve/openobserve/actions/runs/30970715681/job/92194205390

## Verification

- `cargo metadata --locked --offline --no-deps --format-version 1`
- `cargo tree -i custom-labels --locked --offline --edges normal` resolves `custom-labels v0.4.5`
- `git diff --check`