### PR TITLE
fix: logs page freezes when wrap is enabled

### DIFF
--- a/web/src/lib/core/Table/OTable.vue
+++ b/web/src/lib/core/Table/OTable.vue
@@ -921,7 +921,9 @@ const computedTableWidth = computed<string | undefined>(() => {
 // virtualizer for nothing — a real per-row scroll tax on long lists. Skip it.
 const hasVariableRowHeight = computed(() => expansion.isEnabled.value || !!props.wrap);
 function measureElement(el: any) {
-  if (el && props.virtualScroll && hasVariableRowHeight.value) {
+  // Not in dynamic mode: `measureRowElement` measures each row there, and measure()
+  // wipes the whole size cache — per row mount that loops until the tab locks up.
+  if (el && props.virtualScroll && hasVariableRowHeight.value && !useDynamicRowHeight.value) {
     virtualMeasure();
   }
 }

--- a/web/src/lib/core/Table/OTable.wrapMeasure.spec.ts
+++ b/web/src/lib/core/Table/OTable.wrapMeasure.spec.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 OpenObserve Inc.
+
+import { describe, expect, it, afterEach, beforeAll, beforeEach, vi } from "vitest";
+import { mount, config, type VueWrapper } from "@vue/test-utils";
+import { createI18n } from "vue-i18n";
+import { ref } from "vue";
+
+const i18n = createI18n({ legacy: false, locale: "en", messages: { en: {} } });
+beforeAll(() => {
+  config.global.plugins.unshift([i18n as any]);
+});
+
+// jsdom has no layout, so the real virtualizer yields 0 virtual items and the
+// measurement wiring never renders — stub it with a fixed window of rows.
+const measureSpy = vi.fn();
+const measureElementSpy = vi.fn();
+
+vi.mock("@tanstack/vue-virtual", () => ({
+  useVirtualizer: () =>
+    ref({
+      getVirtualItems: () =>
+        Array.from({ length: 5 }, (_, i) => ({
+          index: i,
+          key: i,
+          start: i * 20,
+          end: (i + 1) * 20,
+          size: 20,
+          lane: 0,
+        })),
+      getTotalSize: () => 100,
+      measure: measureSpy,
+      measureElement: measureElementSpy,
+      scrollToIndex: vi.fn(),
+    }),
+}));
+
+import OTable from "./OTable.vue";
+import type { OTableColumnDef } from "./OTable.types";
+
+const columns: OTableColumnDef<any>[] = [
+  { id: "name", accessorKey: "name", header: "Name" },
+  { id: "value", accessorKey: "value", header: "Value", meta: { autoWidth: true } },
+];
+
+const data = Array.from({ length: 20 }, (_, i) => ({
+  id: i,
+  name: `row-${i}`,
+  value: "long value ".repeat(30),
+}));
+
+function mountTable(props: Record<string, unknown> = {}) {
+  return mount(OTable, {
+    props: {
+      data,
+      columns,
+      rowKey: "id",
+      virtualScroll: true,
+      rowHeight: 20,
+      pagination: "none",
+      sorting: "none",
+      ...props,
+    },
+  });
+}
+
+describe("OTable virtual measurement", () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    measureSpy.mockClear();
+    measureElementSpy.mockClear();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it("should not call the global measure() when wrap makes rows variable-height", () => {
+    // Wiping the size cache per row mount re-renders the body, which mounts more
+    // rows — the loop that froze the logs page.
+    wrapper = mountTable({ wrap: true, expansion: "multiple" });
+    expect(measureSpy).not.toHaveBeenCalled();
+  });
+
+  it("should measure each wrapped row individually", () => {
+    wrapper = mountTable({ wrap: true, expansion: "multiple" });
+    expect(measureElementSpy).toHaveBeenCalled();
+  });
+
+  it("should stamp data-index on wrapped rows so the virtualizer can measure them", () => {
+    wrapper = mountTable({ wrap: true });
+    const rows = wrapper.findAll("tbody tr[data-index]");
+    expect(rows.length).toBe(5);
+  });
+
+  it("should still call the global measure() for expandable rows when wrap is off", () => {
+    wrapper = mountTable({ wrap: false, expansion: "multiple" });
+    expect(measureSpy).toHaveBeenCalled();
+  });
+
+  it("should not call the global measure() for fixed-height rows", () => {
+    wrapper = mountTable({ wrap: false, expansion: "none" });
+    expect(measureSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Every virtual row called the virtualizer's global measure() from onMounted whenever row heights could vary, which includes wrap mode. measure() throws away the entire itemSizeCache, so with wrap on each mounting row wiped all measured heights, the rows fell back to the estimate, the ResizeObserver reported the real (taller) heights, offsets shifted, more rows mounted, and the cycle repeated — "Maximum recursive updates exceeded in <OTable>" plus ResizeObserver loops until the tab locked up.

Fixed-height mode converges instantly (the re-measure returns the same constant), which is why only wrap froze.

Skip the global measure() in dynamic-row-height mode: measureRowElement already hands each <tr> to the virtualizer, which measures and observes it individually. The expanded-row path (wrap off) is unchanged.

Measured on a 1000-row table with the logs table's props, scrolling one viewport with wrap on: 1 rAF frame in 3s and a 4260ms worst frame gap before, 179 frames and 51ms after — matching wrap-off (180 frames / 42ms).