### PR TITLE
fix(web): hide LLM Model Pricing settings on OSS builds

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,7 +49,6 @@ env:
   # Allow alert destinations to target localhost so the test validation stream
   # (http://localhost:5080/api/.../..._json) is not blocked by the SSRF guard.
   ZO_SSRF_ALLOW_LOOPBACK: true
-  ZO_MODEL_PRICING_ENABLED: true
 
 jobs:
   check_changes:

--- a/tests/ui-testing/ci-matrix/ci_matrix.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix.json
@@ -17,7 +17,6 @@
       "ingestionTokens.spec.js",
       "landingPage.spec.js",
       "languageTranslation.spec.js",
-      "model-pricing.spec.js",
       "edition-features.spec.js",
       "logsqueries.sql-comments.spec.js",
       "iam-form-validation.spec.js",

--- a/tests/ui-testing/pages/generalPages/settingsFormValidationPage.js
+++ b/tests/ui-testing/pages/generalPages/settingsFormValidationPage.js
@@ -359,17 +359,25 @@ export class SettingsFormValidationPage {
 
     /**
      * Navigate to Settings and open the Model Pricing section.
-     * The section is expected to be on the General or AI settings tab.
+     * LLM Model Pricing is an ENTERPRISE/CLOUD-only feature — the tab/route only
+     * mounts on the enterprise (or cloud) build. Probe positively for the
+     * model-pricing tab and return a boolean so callers can gate the suite to a
+     * clean SKIP on the OSS binary (mirrors navigateToDomainManagement).
      */
     async navigateToModelPricing() {
         await this.navigateToSettings(this.page);
-        const modelPricingTab = this.page.locator('[data-test="model-pricing-tab"]');
-        await modelPricingTab.waitFor({ state: 'visible', timeout: 10000 });
-        await modelPricingTab.click();
-        const addBtn = this.page.locator('[data-test="model-pricing-add-btn"]');
-        await addBtn.waitFor({ state: 'visible', timeout: 10000 });
-        await addBtn.click();
-        await this.page.locator(this.modelPricingSaveBtn).waitFor({ state: 'visible', timeout: 10000 });
+        try {
+            const modelPricingTab = this.page.locator('[data-test="model-pricing-tab"]');
+            await modelPricingTab.waitFor({ state: 'visible', timeout: 10000 });
+            await modelPricingTab.click();
+            const addBtn = this.page.locator('[data-test="model-pricing-add-btn"]');
+            await addBtn.waitFor({ state: 'visible', timeout: 10000 });
+            await addBtn.click();
+            await this.page.locator(this.modelPricingSaveBtn).waitFor({ state: 'visible', timeout: 10000 });
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     async clearModelPricingName() {

--- a/tests/ui-testing/playwright-tests/GeneralTests/settings-form-validation.spec.js
+++ b/tests/ui-testing/playwright-tests/GeneralTests/settings-form-validation.spec.js
@@ -289,8 +289,11 @@ test.describe("Settings DomainManagement form validation", {
 });
 
 // ── ModelPricingEditor form validation ────────────────────────────────────────
+// LLM Model Pricing is enterprise/cloud-only — absent in the OSS build.
 
-test.describe("Settings ModelPricingEditor form validation", () => {
+test.describe("Settings ModelPricingEditor form validation", {
+    tag: '@enterprise'
+}, () => {
     test.describe.configure({ mode: 'serial' });
     let pm;
 
@@ -298,7 +301,16 @@ test.describe("Settings ModelPricingEditor form validation", () => {
         testLogger.testStart(testInfo.title, testInfo.file);
         await navigateToBase(page);
         pm = new PageManager(page);
-        await pm.settingsFormValidation.navigateToModelPricing();
+        // Model Pricing is enterprise/cloud-only — gate to a clean SKIP on OSS.
+        if (featureAvailable['settings-model-pricing'] === false) {
+            test.skip(true, 'LLM Model Pricing is an enterprise/cloud-only feature — absent in the OSS build');
+            return;
+        }
+        featureAvailable['settings-model-pricing'] = await pm.settingsFormValidation.navigateToModelPricing();
+        if (!featureAvailable['settings-model-pricing']) {
+            test.skip(true, 'LLM Model Pricing is an enterprise/cloud-only feature — absent in the OSS build');
+            return;
+        }
         testLogger.info('Navigated to Settings > Model Pricing');
     });
 

--- a/web/src/components/settings/index.vue
+++ b/web/src/components/settings/index.vue
@@ -270,7 +270,7 @@ export default defineComponent({
           description: t("settings.modelPricingDesc"),
           icon: "paid",
           to: { name: "modelPricing", query: { org_identifier: org } },
-          visible: !!z.model_pricing_enabled,
+          visible: (isEnt || isCloud) && !!z.model_pricing_enabled,
           dataTest: "model-pricing-tab",
           group: "Data & AI",
         },

--- a/web/src/composables/shared/useManagementRoutes.spec.ts
+++ b/web/src/composables/shared/useManagementRoutes.spec.ts
@@ -220,23 +220,35 @@ describe("useManagementRoutes", () => {
     });
 
     it("should have correct path for each base child route", () => {
+      // model_pricing / model_pricing/edit are no longer base children — they moved
+      // into the enterprise/cloud block (Model Pricing is enterprise/cloud-only).
       const expectedPaths = [
         "general",
         "organization",
         "alert_destinations",
-        "model_pricing",
-        "model_pricing/edit",
         "templates",
+        "alert_sources",
       ];
-      const actualPaths = routes[0].children.slice(0, 6).map((child: any) => child.path);
+      const actualPaths = routes[0].children.slice(0, 5).map((child: any) => child.path);
       expect(actualPaths).toEqual(expectedPaths);
+    });
+
+    it("should NOT have modelPricing route in OSS builds", () => {
+      const modelPricingRoute = routes[0].children.find(
+        (child: any) => child.name === "modelPricing",
+      );
+      expect(modelPricingRoute).toBeUndefined();
+      const modelPricingEditor = routes[0].children.find(
+        (child: any) => child.name === "modelPricingEditor",
+      );
+      expect(modelPricingEditor).toBeUndefined();
     });
 
     it("should have unique names for each named base child route", () => {
       // Redirect-only children are deliberately unnamed — their name belongs to
       // the /alerts/* route they point at.
       const names = routes[0].children
-        .slice(0, 6)
+        .slice(0, 5)
         .filter((child: any) => !child.redirect)
         .map((child: any) => child.name);
       const uniqueNames = [...new Set(names)];
@@ -269,6 +281,20 @@ describe("useManagementRoutes", () => {
       const cipherRoute = routes[0].children.find((child: any) => child.name === "cipherKeys");
       expect(cipherRoute).toBeDefined();
       expect(cipherRoute.path).toBe("cipher_keys");
+    });
+
+    it("should have modelPricing route (+ editor) when enterprise", () => {
+      const routes = useManagementRoutes();
+      const modelPricingRoute = routes[0].children.find(
+        (child: any) => child.name === "modelPricing",
+      );
+      expect(modelPricingRoute).toBeDefined();
+      expect(modelPricingRoute.path).toBe("model_pricing");
+      const modelPricingEditor = routes[0].children.find(
+        (child: any) => child.name === "modelPricingEditor",
+      );
+      expect(modelPricingEditor).toBeDefined();
+      expect(modelPricingEditor.path).toBe("model_pricing/edit");
     });
 
     it("should have pipelineDestinations route when enterprise", () => {
@@ -447,7 +473,7 @@ describe("useManagementRoutes", () => {
 
     it("should have exactly 20 children routes when enterprise is enabled", () => {
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(20); // 7 base (incl. alert_sources redirect) + llmProviders + genAiAgentMapping + 11 enterprise
+      expect(routes[0].children).toHaveLength(20); // 5 base (incl. alert_sources redirect) + modelPricing (+ editor) + llmProviders + genAiAgentMapping + 11 enterprise
     });
   });
 
@@ -510,7 +536,7 @@ describe("useManagementRoutes", () => {
 
     it("should have exactly 10 children routes when cloud is enabled", () => {
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(10); // 7 base (incl. alert_sources redirect) + llmProviders + genAiAgentMapping + 1 cloud
+      expect(routes[0].children).toHaveLength(10); // 5 base (incl. alert_sources redirect) + modelPricing (+ editor) + llmProviders + genAiAgentMapping + 1 cloud
     });
   });
 
@@ -527,7 +553,7 @@ describe("useManagementRoutes", () => {
 
     it("should have exactly 21 children routes when both enterprise and cloud are enabled", () => {
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(21); // 7 base (incl. alert_sources redirect) + llmProviders + genAiAgentMapping + 11 enterprise + 1 cloud
+      expect(routes[0].children).toHaveLength(21); // 5 base (incl. alert_sources redirect) + modelPricing (+ editor) + llmProviders + genAiAgentMapping + 11 enterprise + 1 cloud
     });
 
     it("should have all enterprise routes when both are enabled", () => {
@@ -627,63 +653,63 @@ describe("useManagementRoutes", () => {
       config.isEnterprise = "false";
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
+      expect(routes[0].children).toHaveLength(5); // model_pricing (+ editor), gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
     });
 
     it("should handle isCloud as string 'false'", () => {
       config.isEnterprise = "false";
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
+      expect(routes[0].children).toHaveLength(5); // model_pricing (+ editor), gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
     });
 
     it("should handle isEnterprise as undefined", () => {
       (config as any).isEnterprise = undefined;
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
+      expect(routes[0].children).toHaveLength(5); // model_pricing (+ editor), gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
     });
 
     it("should handle isCloud as undefined", () => {
       config.isEnterprise = "false";
       (config as any).isCloud = undefined;
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
+      expect(routes[0].children).toHaveLength(5); // model_pricing (+ editor), gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
     });
 
     it("should handle both config values as undefined", () => {
       (config as any).isEnterprise = undefined;
       (config as any).isCloud = undefined;
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
+      expect(routes[0].children).toHaveLength(5); // model_pricing (+ editor), gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
     });
 
     it("should handle isEnterprise as non-string truthy value", () => {
       (config as any).isEnterprise = true;
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present, since config comparison is strict "true"
+      expect(routes[0].children).toHaveLength(5); // model_pricing (+ editor), gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present, since config comparison is strict "true"
     });
 
     it("should handle isCloud as non-string truthy value", () => {
       config.isEnterprise = "false";
       (config as any).isCloud = true;
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present, since config comparison is strict "true"
+      expect(routes[0].children).toHaveLength(5); // model_pricing (+ editor), gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present, since config comparison is strict "true"
     });
 
     it("should handle empty string for isEnterprise", () => {
       config.isEnterprise = "";
       config.isCloud = "false";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
+      expect(routes[0].children).toHaveLength(5); // model_pricing (+ editor), gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
     });
 
     it("should handle empty string for isCloud", () => {
       config.isEnterprise = "false";
       config.isCloud = "";
       const routes = useManagementRoutes();
-      expect(routes[0].children).toHaveLength(7); // gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
+      expect(routes[0].children).toHaveLength(5); // model_pricing (+ editor), gen_ai_agent_mapping and llm_providers are enterprise/cloud-only; alert_sources redirect is always present
     });
 
     it("should return the same structure on multiple calls", () => {

--- a/web/src/composables/shared/useManagementRoutes.ts
+++ b/web/src/composables/shared/useManagementRoutes.ts
@@ -48,29 +48,6 @@ const useManagementRoutes = () => {
           path: "alert_destinations",
           redirect: (to: any) => ({ name: "alertDestinations", query: to.query }),
         },
-        {
-          path: "model_pricing",
-          name: "modelPricing",
-          meta: {
-            keepAlive: true,
-            title: "LLM Model Pricing",
-          },
-          component: () => import("@/components/settings/ModelPricingList.vue"),
-          beforeEnter(to: any, from: any, next: any) {
-            routeGuard(to, from, next);
-          },
-        },
-        {
-          path: "model_pricing/edit",
-          name: "modelPricingEditor",
-          meta: {
-            title: "Model Pricing Editor",
-          },
-          component: () => import("@/components/settings/ModelPricingEditor.vue"),
-          beforeEnter(to: any, from: any, next: any) {
-            routeGuard(to, from, next);
-          },
-        },
         // Alert templates moved to /alert-templates (Reliability). Redirect kept
         // for the same reason as alert_destinations above, query included.
         {
@@ -88,11 +65,34 @@ const useManagementRoutes = () => {
       ],
     },
   ];
-  // LLM Providers and GenAI Agent Mapping (used by the AI Observability /
-  // Online Evals flows) are enterprise/cloud-only features — the backend routes
-  // only exist behind the enterprise feature flag, so they must not be exposed
-  // in OSS builds.
+  // LLM Model Pricing, LLM Providers and GenAI Agent Mapping (used by the AI
+  // Observability / Online Evals flows) are enterprise/cloud-only features — the
+  // backend routes only exist behind the enterprise feature flag, so they must
+  // not be exposed in OSS builds.
   if (config.isEnterprise == "true" || config.isCloud == "true") {
+    routes[0].children.push({
+      path: "model_pricing",
+      name: "modelPricing",
+      meta: {
+        keepAlive: true,
+        title: "LLM Model Pricing",
+      },
+      component: () => import("@/components/settings/ModelPricingList.vue"),
+      beforeEnter(to: any, from: any, next: any) {
+        routeGuard(to, from, next);
+      },
+    });
+    routes[0].children.push({
+      path: "model_pricing/edit",
+      name: "modelPricingEditor",
+      meta: {
+        title: "Model Pricing Editor",
+      },
+      component: () => import("@/components/settings/ModelPricingEditor.vue"),
+      beforeEnter(to: any, from: any, next: any) {
+        routeGuard(to, from, next);
+      },
+    });
     routes[0].children.push({
       path: "llm_providers",
       name: "llmProviders",

--- a/web/src/lib/core/Navbar/navGroups.ts
+++ b/web/src/lib/core/Navbar/navGroups.ts
@@ -32,7 +32,7 @@ export const GATE_PREDICATES: Record<string, (c: NavGateContext) => boolean> = {
   enterpriseMeta: (c) => c.isEnterprise && c.isMeta,
   cloudMeta: (c) => c.isCloud && c.isMeta,
   storage: (c) => c.isEnterprise && (!c.isCloud || c.orgStorage),
-  modelPricing: (c) => c.modelPricing,
+  modelPricing: (c) => (c.isEnterprise || c.isCloud) && c.modelPricing,
   correlation: (c) => c.isEnterprise && c.serviceStreams,
   llmProviders: (c) => (c.isEnterprise || c.isCloud) && c.onlineEvals,
   // IAM (isEnt = enterprise OR cloud)


### PR DESCRIPTION
## What

Hide **LLM Model Pricing** on OSS builds and make it an enterprise/cloud-only feature, end to end (UI + e2e coverage). Paired with o2-enterprise PR on branch `fix/hide-llm-model-pricing-oss`.

## Why

Model Pricing was surfaced on OSS (settings rail + navbar flyout), gated only on the `model_pricing_enabled` backend flag with **no** enterprise/cloud check — unlike its sibling AI feature **LLM Providers** (`(isEnterprise || isCloud) && online_evals_enabled`). Product decision: it should not appear on OSS. This brings it in line with that sibling.

## Changes

**Web (hide on OSS)**
- `web/src/components/settings/index.vue` — settings rail item now `visible: (isEnt || isCloud) && !!z.model_pricing_enabled`.
- `web/src/lib/core/Navbar/navGroups.ts` — `modelPricing` gate predicate now requires enterprise/cloud (mirrors `llmProviders`), so the collapsed-navbar flyout matches the rail.
- `web/src/composables/shared/useManagementRoutes.ts` — `model_pricing` + `model_pricing/edit` routes registered only inside the `isEnterprise || isCloud` block (defense-in-depth; matches `llm_providers`), so the route isn't reachable by direct URL on OSS.

**E2E (move coverage to ENT)**
- `tests/ui-testing/ci-matrix/ci_matrix.json` — drop `model-pricing.spec.js` from the OSS `GeneralTests` shard. It's added back on ENT via the enterprise overlay (`ci_matrix.ent.json`, in the paired ENT PR), so the merged ENT matrix runs it exactly once (verified with `build-ci-matrix.js`).
- `.github/workflows/playwright.yml` — remove `ZO_MODEL_PRICING_ENABLED: true` (OSS no longer exercises the feature; ENT `playwright.yml` keeps it).
- `tests/ui-testing/playwright-tests/GeneralTests/settings-form-validation.spec.js` — gate the *ModelPricingEditor* describe block to a clean SKIP on OSS, mirroring the existing Domain Management / Org Storage / Correlation blocks.
- `tests/ui-testing/pages/generalPages/settingsFormValidationPage.js` — `navigateToModelPricing()` now returns a boolean so the suite can detect the OSS build and skip (mirrors `navigateToDomainManagement()`).

## Not changed (deliberately)

The backend `ZO_MODEL_PRICING_ENABLED` default (`true`, [config.rs](src/config/src/config.rs)) is **left as-is**. It lives in the shared config crate used by both editions, so flipping it to `false` would also regress real ENT/Cloud deployments (feature off by default). The UI gate already ensures the page never shows on OSS regardless of the flag. Making the backend itself enterprise-only would be a separate, backend-owned change.

## Behavior

| Build | Model Pricing UI | e2e |
|-------|------------------|-----|
| OSS | Hidden | `model-pricing.spec.js` not run; settings-form-validation block SKIPPED |
| Enterprise / Cloud | Shown (if flag set) — unchanged | `model-pricing.spec.js` runs (via ENT overlay) |