### PR TITLE
test(logs): fix alpha1 unflattened drawer-close detach flake

### DIFF
--- a/tests/ui-testing/pages/logsPages/unflattened.js
+++ b/tests/ui-testing/pages/logsPages/unflattened.js
@@ -276,9 +276,21 @@ class UnflattenedPage {
             .locator('[data-test="logs-search-result-detail-dialog"] [data-test="log-detail-json-tab"]')
             .first();
         await jsonTab.waitFor({ state: 'visible', timeout: 10000 });
-        if ((await jsonTab.getAttribute('data-state')) !== 'active') {
-            await jsonTab.click();
+        // The JSON panel content can lag behind the tab activation on a slow
+        // (shared alpha) runner, so a single click + wait occasionally times
+        // out. Re-assert the tab and re-wait once before giving up.
+        for (let attempt = 0; attempt < 2; attempt++) {
+            if ((await jsonTab.getAttribute('data-state')) !== 'active') {
+                await jsonTab.click();
+            }
+            const rendered = await this.logDetailJsonContent
+                .waitFor({ state: 'visible', timeout: 10000 })
+                .then(() => true)
+                .catch(() => false);
+            if (rendered) return;
         }
+        // Last attempt with the original throwing behaviour so callers still see
+        // a clear failure if the panel genuinely never renders.
         await this.logDetailJsonContent.waitFor({ state: 'visible', timeout: 10000 });
     }
 

--- a/tests/ui-testing/playwright-tests/Logs/unflattened.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/unflattened.spec.js
@@ -279,9 +279,12 @@ test.describe("Unflattened testcases", () => {
     await pageManager.unflattenedPage.unflattenedTab.click();
     await page.waitForTimeout(500);
 
+    // Switching to the unflattened tab re-renders the drawer, so the close
+    // button node detaches mid-click ("element was detached from the DOM") and
+    // a bare .click() times out unrecoverably on CI. Use the resilient helper
+    // (Escape fallback + wait-for-hidden) instead.
     testLogger.info('Closing log detail dialog');
-    await pageManager.unflattenedPage.closeDialog.waitFor();
-    await pageManager.unflattenedPage.closeDialog.click();
+    await pageManager.unflattenedPage.closeLogDetailDrawerIfOpen();
 
     // Cleanup: Toggle Store Original Data back OFF
     testLogger.info('Cleanup: Toggling Store Original Data back OFF');
@@ -422,9 +425,12 @@ test.describe("Unflattened testcases", () => {
     await pageManager.unflattenedPage.unflattenedTab.click();
     await page.waitForTimeout(500);
 
+    // Switching to the unflattened tab re-renders the drawer, so the close
+    // button node detaches mid-click ("element was detached from the DOM") and
+    // a bare .click() times out unrecoverably on CI. Use the resilient helper
+    // (Escape fallback + wait-for-hidden) instead.
     testLogger.info('Closing log detail dialog');
-    await pageManager.unflattenedPage.closeDialog.waitFor();
-    await pageManager.unflattenedPage.closeDialog.click();
+    await pageManager.unflattenedPage.closeLogDetailDrawerIfOpen();
 
     testLogger.info('Toggling Store Original Data back OFF to clean up');
     await page.goto(`${process.env.ZO_BASE_URL}/web/streams?org_identifier=${getOrgIdentifier()}`);


### PR DESCRIPTION
## Problem

On the **alpha1 (cloud)** e2e run, the **Logs-Core** shard failed and did not recover across all 3 retries. The single hard failure was:

`Logs/unflattened.spec.js:220 › Unflattened testcases › stream to toggle store original data toggle and display o2 id`

### Root cause

After switching to the **unflattened** tab, the test closed the log-detail drawer with a bare `closeDialog.waitFor()` + `closeDialog.click()`. Switching that tab re-renders the drawer, so the close-button node **detaches mid-click** — Playwright logs `element was detached from the DOM, retrying` and the click hangs for the full 45s, failing every retry identically. It's a deterministic race, which is why retries never helped. The secondary retry-failure signature (JSON detail panel lagging behind tab activation) is the same drawer instability, wider on the slower shared alpha env.

## Fix

- Close the drawer via the file's existing resilient `closeLogDetailDrawerIfOpen()` helper (Escape fallback + wait-for-hidden) in **both** the failing test and its identical quick-mode sibling (`unflattened.spec.js` lines ~283 and ~426).
- Harden `openJsonDetailTab()` (`pages/logsPages/unflattened.js`) to re-assert the JSON tab and re-wait once when the panel content lags, then fall back to the original throwing wait so a genuine non-render still fails loudly.

Test-only change; no product code touched.

## Verification

Seeded the **Run E2E Tests on Alpha1 (Cloud)** workflow against this branch (`o2_opensource_repo=test/alpha1-unflatten-drawer-close-flake`, enterprise on `main`): [run 31067277452](https://github.com/openobserve/o2-enterprise/actions/runs/31067277452) — Logs-Core and the overall run passed green.