### PR TITLE
fix: Fix/traces view logs url restore

### DIFF
--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -7467,6 +7467,7 @@
     "RedMetrics": "RED Metrics",
     "loadingStream": "Loading Stream...",
     "noLogsAvailableForService": "No Logs available for this service",
+    "noCorrelatedLogsFound": "No correlated logs found for this span",
     "noData": {
       "title": "Start sending traces to OpenObserve",
       "description": "No trace streams found in this organization yet. Instrument your services and traces will appear here automatically.",

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
@@ -771,10 +771,29 @@ describe("ServiceGraphNodeSidePanel", () => {
           path: "/logs",
           query: expect.objectContaining({
             stream_type: "logs",
-            stream_value: "k8s-logs",
+            // `stream` (not `stream_value`) — restoreUrlQueryParams only reads `stream`,
+            // and `type` routes the Logs page through its trace-explorer restore branch.
+            stream: "k8s-logs",
+            type: "trace_explorer",
           }),
         }),
       );
+    });
+
+    it("should clear the logs isInitialized flag so the URL params win over the previous session", async () => {
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+
+      const viewRelatedLogsBtn = wrapper.find(
+        '[data-test="service-graph-node-panel-view-related-logs-btn"]',
+      );
+      await viewRelatedLogsBtn.trigger("click");
+      await flushPromises();
+
+      // Without this the Logs page restores its stored session and silently drops
+      // the stream, time range and filter carried in the pushed URL.
+      expect(dispatchSpy).toHaveBeenCalledWith("logs/setIsInitialized", false);
+
+      dispatchSpy.mockRestore();
     });
 
     it("should NOT show a warning notification when a valid log stream is found", async () => {

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -2399,11 +2399,20 @@ export default defineComponent({
         sql_mode: "false",
         query: b64EncodeUnicode(filterQuery),
         org_identifier: org,
+        // The Logs route is keep-alive, so a repeat visit only runs onActivated —
+        // which restores the URL params solely on the trace-explorer branch.
+        type: "trace_explorer",
       };
 
       if (streamName) {
-        queryParams.stream_value = streamName;
+        queryParams.stream = streamName;
       }
+
+      // The Logs page keeps `isInitialized` in the store across unmounts, and while
+      // it is set it restores the previous session from the store instead of reading
+      // these params — dropping the stream, time range and filter. Clearing it makes
+      // the URL the source of truth, same as the trace-details "View Logs" button.
+      store.dispatch("logs/setIsInitialized", false);
 
       router.push({
         path: "/logs",

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -2707,8 +2707,15 @@ export default defineComponent({
       updateSelectedSpan(spanId);
 
       const correlationData = searchObj.data.traceDetails.correlationProps;
-      if (correlationData) {
+      if (correlationData?.logStreams?.length) {
         navigateToCorrelatedLogs(correlationData);
+      } else {
+        // The sidebar owns the correlation lookup; when it produced nothing there
+        // is no log stream to open, so tell the user rather than doing nothing.
+        toast({
+          variant: "warning",
+          message: t("traces.noCorrelatedLogsFound"),
+        });
       }
     };
 

--- a/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
+++ b/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
@@ -23,11 +23,17 @@ const {
   mockBuildQueryDetails,
   mockNavigateToLogs,
   mockNavigateToCorrelatedLogs,
+  mockToast,
 } = vi.hoisted(() => ({
   mockLoadSemanticGroups: vi.fn().mockResolvedValue([]),
   mockBuildQueryDetails: vi.fn().mockReturnValue({}),
   mockNavigateToLogs: vi.fn(),
   mockNavigateToCorrelatedLogs: vi.fn(),
+  mockToast: vi.fn(),
+}));
+
+vi.mock("@/lib/feedback/Toast/useToast", () => ({
+  toast: mockToast,
 }));
 
 vi.mock("@/utils/traces/convertTraceData", () => ({
@@ -439,16 +445,24 @@ describe("TraceDetailsSidebar", async () => {
       });
     });
 
-    describe("when isEnterprise is true but correlationProps is null (fallback path)", () => {
+    describe("when isEnterprise is true but no correlation was found", () => {
       beforeEach(() => {
         config.isEnterprise = "true";
-        // correlationProps is null — correlation data hasn't been loaded yet
+        // Remount with a streamName so loadCorrelation() runs the real lookup
+        // instead of bailing out on a missing stream. findRelatedTelemetry is
+        // mocked to resolve null, i.e. the lookup succeeds with nothing correlated.
+        viewLogsWrapper.unmount();
+        viewLogsWrapper = mountSidebar({
+          parentMode: "standalone",
+          streamName: "default",
+        });
         viewLogsWrapper.vm.correlationProps = null;
+        mockToast.mockClear();
         dispatchSpy = vi.spyOn(mockStore, "dispatch").mockResolvedValue(undefined);
         pushSpy = vi.spyOn(router, "push").mockResolvedValue(undefined);
       });
 
-      it("should fall back to buildQueryDetails and navigateToLogs when correlationProps is null", async () => {
+      it("should toast a warning instead of navigating when nothing is correlated", async () => {
         const viewLogsBtn = viewLogsWrapper.find(
           '[data-test="trace-details-sidebar-header-toolbar-view-logs-btn"]',
         );
@@ -457,11 +471,16 @@ describe("TraceDetailsSidebar", async () => {
         await viewLogsBtn.trigger("click");
         await flushPromises();
 
-        expect(mockBuildQueryDetails).toHaveBeenCalledWith(mockSpan);
-        expect(mockNavigateToLogs).toHaveBeenCalled();
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: "warning",
+            message: "No correlated logs found for this span",
+          }),
+        );
+        expect(pushSpy).not.toHaveBeenCalled();
       });
 
-      it("should not call navigateToCorrelatedLogs when correlationProps is null", async () => {
+      it("should not call navigateToCorrelatedLogs when nothing is correlated", async () => {
         const viewLogsBtn = viewLogsWrapper.find(
           '[data-test="trace-details-sidebar-header-toolbar-view-logs-btn"]',
         );
@@ -469,6 +488,26 @@ describe("TraceDetailsSidebar", async () => {
         await flushPromises();
 
         expect(mockNavigateToCorrelatedLogs).not.toHaveBeenCalled();
+      });
+
+      it("should toast the lookup failure reason when correlation could not be loaded", async () => {
+        // No streamName — loadCorrelation() bails out and records why.
+        viewLogsWrapper.unmount();
+        viewLogsWrapper = mountSidebar({ parentMode: "standalone" });
+        mockToast.mockClear();
+
+        const viewLogsBtn = viewLogsWrapper.find(
+          '[data-test="trace-details-sidebar-header-toolbar-view-logs-btn"]',
+        );
+        await viewLogsBtn.trigger("click");
+        await flushPromises();
+
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: "warning",
+            message: "Missing span or stream name",
+          }),
+        );
       });
     });
 

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -831,7 +831,7 @@ import { toggleFullscreen as domToggleFullScreen } from "@/utils/dom";
 import { defineComponent, onBeforeMount, ref, watch, type Ref, type PropType, inject } from "vue";
 import { useStore } from "vuex";
 import useTheme from "@/composables/useTheme";
-import { useI18nTyped } from "@/types/i18n";
+import { useI18nTyped, raw } from "@/types/i18n";
 import { computed } from "vue";
 import { formatTimeWithSuffix, convertTimeFromNsToUs, getImageURL } from "@/utils/zincutils";
 import useTraces from "@/composables/useTraces";
@@ -1439,9 +1439,23 @@ export default defineComponent({
       },
     );
 
-    const viewSpanLogs = () => {
-      if (config.isEnterprise === "true" && correlationProps.value) {
-        navigateToCorrelatedLogs(correlationProps.value);
+    const viewSpanLogs = async () => {
+      if (config.isEnterprise === "true") {
+        await loadCorrelation();
+        if (correlationProps.value?.logStreams?.length) {
+          navigateToCorrelatedLogs(correlationProps.value);
+        } else {
+          // Nothing correlated to this span — say so instead of navigating to an
+          // empty Logs page. A failed lookup reports its own reason; a successful
+          // lookup that found nothing gets the plain "no correlated logs" wording.
+          toast({
+            variant: "warning",
+            message:
+              correlationFailed.value && correlationError.value
+                ? raw(correlationError.value)
+                : t("traces.noCorrelatedLogsFound"),
+          });
+        }
       } else {
         const queryDetails = buildQueryDetails(props.span);
         navigateToLogs(queryDetails);
@@ -1539,6 +1553,9 @@ export default defineComponent({
     // Correlation state
     const correlationLoading = ref(false);
     const correlationError = ref<string | null>(null);
+    // True when the lookup itself failed (request error, missing span/stream) as
+    // opposed to succeeding with nothing correlated — the two need different wording.
+    const correlationFailed = ref(false);
     const correlationProps = ref<any>(null);
     const { findRelatedTelemetry, loadSemanticGroups, semanticGroups } = useServiceCorrelation();
 
@@ -1635,17 +1652,20 @@ export default defineComponent({
       // Gate correlation feature behind enterprise check to avoid 403 errors
       if (config.isEnterprise !== "true") {
         correlationError.value = t("traces.traceDetailsSidebar.enterpriseLicenseRequired");
+        correlationFailed.value = true;
         return;
       }
 
       if (!props.span || !props.streamName) {
         console.warn("[TraceDetailsSidebar] Cannot load correlation: missing span or stream name");
         correlationError.value = t("traces.traceDetailsSidebar.missingSpanOrStream");
+        correlationFailed.value = true;
         return;
       }
 
       correlationLoading.value = true;
       correlationError.value = null;
+      correlationFailed.value = false;
 
       try {
         try {
@@ -1758,6 +1778,7 @@ export default defineComponent({
       } catch (err: any) {
         console.error("[TraceDetailsSidebar] Correlation failed:", err);
         correlationError.value = err.message || t("correlation.failedToLoad");
+        correlationFailed.value = true;
       } finally {
         correlationLoading.value = false;
       }
@@ -1769,6 +1790,7 @@ export default defineComponent({
       () => {
         correlationProps.value = null;
         correlationError.value = null;
+        correlationFailed.value = false;
 
         // Load correlation proactively so View Logs button has data
         if (props.serviceStreamsEnabled) {


### PR DESCRIPTION
Two reports, same visible failure — clicking a "View Logs" affordance in Traces either did nothing at all, or landed on the Logs page with no stream selected, no filter, and the previous session's results still showing:

Span-level "View Logs" in the trace-detail sidebar (enterprise).
"View Related Logs" on a service-graph node.
**Root cause**
Both trace back to one contract on the Logs side, hit by two different callers.

The shared contract. restoreUrlQueryParams bails out entirely when the stream param is absent ([useLogs.ts:343](vscode-webview://1natcp3amfqrfqrsn6p0sf7iek84lktqhb8p7td2pk978hr7cg9s/web/src/composables/useLogs.ts#L343)):


if (!queryParams.stream && queryParams.sql_mode !== "true") { return; }
That returns before applying the query, the time range and the stream — so a missing stream doesn't degrade the navigation, it discards all of it. Two further gates decide whether that function runs at all: setupLogsTab() only restores when logs.isInitialized is false, and on a keep-alive repeat visit handleActivation() restores only on the type === "trace_explorer" branch.

Trigger A — span "View Logs" (commit a7cbf9cfdd). viewSpanLogs read correlationProps.value without awaiting loadCorrelation(). Correlation is loaded lazily, so on a fast click that value was still null, and navigateToCorrelatedLogs(null) threw on correlationProps.logStreams — the button appeared dead. When the lookup did resolve but matched nothing, logStreams was [], so the stream param came out empty and the Logs page discarded everything per the contract above. The tree-view handler had the same gap with a different failure mode: if (correlationData) returned silently.

Trigger B — service graph "View Related Logs" (commit 1b02f512a1). The stream was pushed under the wrong key — stream_value instead of stream — so the early return fired every time. Two restore-path gaps compounded it: isInitialized was left set (and isRouteChanged() clears it only on a stream or org change, not a filter change), so setupLogsTab() skipped the restore and re-showed the stored session; and the URL didn't carry type=trace_explorer, so the keep-alive onActivated path had no branch that would read it.

**Fix applied**
a7cbf9cfdd — fix(traces): warn when no correlated logs found

viewSpanLogs now awaits loadCorrelation() before reading the result.
Navigation is gated on correlationProps?.logStreams?.length — an empty correlation result no longer navigates to an empty Logs page.
When there's nothing to open, the user gets a toast instead of silence. A new correlationFailed ref separates "the lookup failed" (surface its own reason) from "the lookup succeeded and matched nothing" (traces.noCorrelatedLogsFound) — needed because correlationError is set in both cases.
handleTreeViewCorrelatedLogs gets the same non-empty check and toast, replacing the silent return.
Two sidebar specs that asserted the old navigateToLogs fallback now assert the toast.
1b02f512a1 — fix(traces): restore logs URL params from service graph

stream_value → stream, so the restore no longer early-returns.
Added type: "trace_explorer" so the keep-alive onActivated path restores on repeat visits.
Explicit store.dispatch("logs/setIsInitialized", false) so the URL is the source of truth rather than the stored session.
Spec coverage for both paths in ServiceGraphNodeSidePanel.spec.ts.