### PR TITLE
fix(correlation): P0/P1 fixes from service-streams correlation review

### DIFF
--- a/src/api/management/src/request/service_streams/mod.rs
+++ b/src/api/management/src/request/service_streams/mod.rs
@@ -490,12 +490,30 @@ pub async fn reset_services(
         {
             return MetaHttpResponse::forbidden("Unauthorized Access");
         }
-        match infra::table::service_streams::delete_all(&org_id).await {
-            Ok(deleted_count) => MetaHttpResponse::json(serde_json::json!({
-                "deleted_count": deleted_count,
-                "message": format!("Successfully deleted {} discovered service(s) for org '{}'", deleted_count, org_id),
-                "note": "Services will be automatically re-discovered as new telemetry data arrives. This typically begins within minutes of the next data ingestion."
-            })),
+        // Go through the enterprise storage layer so the local cache is cleared and the
+        // reset is replicated to the super-cluster.
+        match o2_enterprise::enterprise::service_streams::storage::ServiceStorage::delete_all(
+            &org_id,
+        )
+        .await
+        {
+            Ok(deleted_count) => {
+                // Org-scope reload: other nodes wholesale-replace their org cache from
+                // the now-empty DB. Without this the pre-reset rows are served forever
+                // (the cache has no TTL) (F6).
+                if let Err(e) =
+                    infra::coordinator::service_streams::emit_reload_event(&org_id).await
+                {
+                    log::warn!(
+                        "[ServiceStreams] _reset: failed to emit reload event for org '{org_id}': {e}"
+                    );
+                }
+                MetaHttpResponse::json(serde_json::json!({
+                    "deleted_count": deleted_count,
+                    "message": format!("Successfully deleted {} discovered service(s) for org '{}'", deleted_count, org_id),
+                    "note": "Services will be automatically re-discovered as new telemetry data arrives. This typically begins within minutes of the next data ingestion."
+                }))
+            }
             Err(e) => MetaHttpResponse::internal_error(format!("Failed to reset services: {e}")),
         }
     }

--- a/src/api/management/src/request/service_streams/mod.rs
+++ b/src/api/management/src/request/service_streams/mod.rs
@@ -418,6 +418,10 @@ pub async fn save_identity_config(
         }
     }
 
+    // Captured before the write so we can find sets that disappeared or changed shape (F10).
+    #[cfg(feature = "enterprise")]
+    let old_config = db::system_settings::get_service_identity_config(&org_id).await;
+
     let value = match serde_json::to_value(&body) {
         Ok(v) => v,
         Err(e) => return MetaHttpResponse::internal_error(format!("Serialization error: {e}")),
@@ -426,7 +430,7 @@ pub async fn save_identity_config(
     let setting = SystemSetting {
         id: None,
         scope: SettingScope::Org,
-        org_id: Some(org_id),
+        org_id: Some(org_id.clone()),
         user_id: None,
         setting_key: "service_identity".to_string(),
         setting_category: Some("service_streams".to_string()),
@@ -439,7 +443,31 @@ pub async fn save_identity_config(
     };
 
     match infra::table::system_settings::set(&setting).await {
-        Ok(_) => MetaHttpResponse::json(serde_json::json!({"message": "saved"})),
+        Ok(_) => {
+            #[cfg(feature = "enterprise")]
+            {
+                // F10: rows filed under removed/changed sets would otherwise match every
+                // request for their service (anchor rule) until the 24h stale job fires.
+                for set_id in config::meta::correlation::obsolete_set_ids(&old_config, &body) {
+                    if let Err(e) =
+                        infra::table::service_streams::delete_by_set_id(&org_id, &set_id).await
+                    {
+                        log::warn!(
+                            "[ServiceStreams] save_identity_config: failed to delete rows for obsolete set '{set_id}' in org '{org_id}': {e}"
+                        );
+                    }
+                }
+                o2_enterprise::enterprise::service_streams::cache::clear_org_cache(&org_id).await;
+                if let Err(e) =
+                    infra::coordinator::service_streams::emit_reload_event(&org_id).await
+                {
+                    log::warn!(
+                        "[ServiceStreams] save_identity_config: failed to emit reload event for org '{org_id}': {e}"
+                    );
+                }
+            }
+            MetaHttpResponse::json(serde_json::json!({"message": "saved"}))
+        }
         Err(e) => MetaHttpResponse::internal_error(format!("Failed to save config: {e}")),
     }
 }

--- a/src/api/search/src/traces/mod.rs
+++ b/src/api/search/src/traces/mod.rs
@@ -427,6 +427,14 @@ pub async fn get_latest_traces(
             );
         }
     };
+    // F2: the filter is a raw, user-supplied WHERE fragment. Validate it parses as a
+    // single well-formed boolean expression before splicing, so statement smuggling
+    // and comment-truncated payloads never reach the planner.
+    if !filter.is_empty()
+        && let Err(e) = config::utils::sql::validate_where_fragment(&filter)
+    {
+        return MetaHttpResponse::bad_request(format!("invalid filter: {e}"));
+    }
     let query_sql = if filter.is_empty() {
         format!("{query_sql} GROUP BY trace_id ORDER BY {sql_order_expr}")
     } else {
@@ -979,6 +987,16 @@ pub async fn get_latest_traces_stream(
         Some(v) => v.to_string(),
         None => "".to_string(),
     };
+    // F2: validate the raw filter here, in the HTTP handler, so a bad fragment is a
+    // 400 rather than an error frame mid-stream. This is stricter than the `--`/`;`
+    // stripping done in process_latest_traces_stream (which silently mangles the
+    // fragment instead of rejecting it), and that stripping only ever makes the
+    // spliced string a subset of what is validated here.
+    if !filter.is_empty()
+        && let Err(e) = config::utils::sql::validate_where_fragment(&filter)
+    {
+        return MetaHttpResponse::bad_request(format!("invalid filter: {e}"));
+    }
 
     let from = query
         .get("from")

--- a/src/config/src/meta/correlation.rs
+++ b/src/config/src/meta/correlation.rs
@@ -266,9 +266,9 @@ impl ServiceIdentityConfig {
                 return Err(format!("duplicate set id '{}'", set.id));
             }
         }
-        if self.tracked_alias_ids.is_empty() {
-            return Err("tracked_alias_ids requires at least 1 alias group ID".into());
-        }
+        // tracked_alias_ids may be empty: ingest tracking is the UNION of this list and
+        // every set's distinguish_by, and >=1 set is enforced above — sets alone are
+        // a complete config (custom set dims need not be re-listed here).
         if self.tracked_alias_ids.len() > MAX_TRACKED_ALIASES {
             return Err(format!(
                 "tracked_alias_ids cannot exceed {} entries",
@@ -873,5 +873,22 @@ mod tests {
         let old = mk(&["k8s-cluster", "k8s-namespace"]);
         let new = mk(&["k8s-namespace", "k8s-cluster"]);
         assert_eq!(obsolete_set_ids(&old, &new), vec!["k8s".to_string()]);
+    }
+
+    #[test]
+    fn test_validate_allows_empty_tracked_alias_ids_with_sets() {
+        // tracked_ids at ingest are the UNION of tracked_alias_ids and every set's
+        // distinguish_by, and validate() already requires >=1 set — so an empty
+        // tracked_alias_ids list is a fully functional config and must not be rejected.
+        let cfg = ServiceIdentityConfig {
+            sets: vec![IdentitySet {
+                id: "custom".into(),
+                label: "Custom".into(),
+                distinguish_by: vec!["region".into(), "version".into()],
+            }],
+            tracked_alias_ids: vec![],
+            service_optional: false,
+        };
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/src/config/src/meta/correlation.rs
+++ b/src/config/src/meta/correlation.rs
@@ -149,8 +149,9 @@ const MAX_TRACKED_ALIASES: usize = 30;
 ///
 /// The `id` is the semantic category slug (e.g. "k8s", "aws", "gcp", "azure").
 /// At processing time the system tries ALL configured sets against each record and
-/// picks the one whose `distinguish_by` fields yield the most non-empty values
-/// (best-coverage wins; ties broken by first-in-list).
+/// ranks them by coverage of the record's non-empty dimensions: a fully-covered set
+/// wins first, then the highest covered ratio, then the highest raw count; ties are
+/// broken by declaration order (first-in-list). See `resolve_best_set_by_coverage`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, PartialEq)]
 pub struct IdentitySet {
     /// Semantic category slug: "k8s", "aws", "gcp", "azure", or a custom slug.
@@ -205,8 +206,10 @@ impl IdentitySet {
 /// Contains 1–5 identity sets. Service name is always derived from the "service"
 /// semantic group — hardcoded, not configurable.
 ///
-/// At processing time each record is matched against ALL sets; the set whose
-/// `distinguish_by` fields yield the most non-empty values wins (best coverage).
+/// At processing time each record is matched against ALL sets and ranked by
+/// coverage of the record's non-empty dimensions: full coverage > highest ratio >
+/// highest count, ties broken by declaration order. The same ranking is used on the
+/// correlation read path so ingest files records under the set reads will select.
 /// If no set has any coverage the record is skipped.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct ServiceIdentityConfig {
@@ -280,30 +283,71 @@ impl ServiceIdentityConfig {
 
     /// Pick the best-matching identity set for `dims` using best-coverage resolution.
     ///
-    /// For each set, counts how many `distinguish_by` fields have non-empty values
-    /// in `dims`. Returns the set with the highest count. Ties are broken by
-    /// first-in-list wins. Returns `None` if no set has any coverage (all counts == 0).
+    /// Only non-empty values in `dims` count as available. Ranking is delegated to
+    /// [`resolve_best_set_by_coverage`] — full coverage > highest ratio > highest
+    /// count, ties broken by declaration order. Returns `None` if no set has any
+    /// coverage.
     pub fn resolve_best_set<'a>(
         &'a self,
         dims: &std::collections::HashMap<String, String>,
     ) -> Option<&'a IdentitySet> {
-        let mut best: Option<(&IdentitySet, usize)> = None;
-        for set in &self.sets {
-            let count = set
-                .distinguish_by
-                .iter()
-                .filter(|k| dims.get(k.as_str()).map(|v| !v.is_empty()).unwrap_or(false))
-                .count();
-            if count > 0 {
-                match best {
-                    None => best = Some((set, count)),
-                    Some((_, best_count)) if count > best_count => best = Some((set, count)),
-                    _ => {}
-                }
-            }
-        }
-        best.map(|(set, _)| set)
+        let available: std::collections::HashSet<&str> = dims
+            .iter()
+            .filter(|(_, v)| !v.is_empty())
+            .map(|(k, _)| k.as_str())
+            .collect();
+        resolve_best_set_by_coverage(&self.sets, &available).map(|(set, _)| set)
     }
+}
+
+/// Coverage of one identity set against a request's available dimension keys.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SetCoverage {
+    pub is_full: bool,
+    pub ratio: f64,
+    pub count: usize,
+}
+
+impl SetCoverage {
+    fn rank(&self) -> (bool, f64, usize) {
+        (self.is_full, self.ratio, self.count)
+    }
+}
+
+/// Shared ingest/read ranking: full coverage > highest ratio > highest count;
+/// ties broken by declaration order (strict `>` keeps the earlier set).
+/// Raw-count ranking is WRONG here — a 3/5 partial beating a 2/2 full set files
+/// records under a set the read side will never select (cross-workload pollution).
+pub fn resolve_best_set_by_coverage<'a>(
+    sets: &'a [IdentitySet],
+    available: &std::collections::HashSet<&str>,
+) -> Option<(&'a IdentitySet, SetCoverage)> {
+    let mut best: Option<(&IdentitySet, SetCoverage)> = None;
+    for set in sets {
+        if set.distinguish_by.is_empty() {
+            continue;
+        }
+        let total = set.distinguish_by.len();
+        let count = set
+            .distinguish_by
+            .iter()
+            .filter(|f| available.contains(f.as_str()))
+            .count();
+        if count == 0 {
+            continue;
+        }
+        let cov = SetCoverage {
+            is_full: count == total,
+            ratio: count as f64 / total as f64,
+            count,
+        };
+        match &best {
+            None => best = Some((set, cov)),
+            Some((_, b)) if cov.rank() > b.rank() => best = Some((set, cov)),
+            _ => {}
+        }
+    }
+    best
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -497,9 +541,14 @@ mod tests {
         dims.insert("k8s-namespace".to_string(), "app".to_string());
         dims.insert("aws-region".to_string(), "us-east-1".to_string());
 
-        // k8s has 2 matches, aws has 1 — k8s wins
+        // F8: k8s is 2/3 (partial), aws is 1/1 (full) — full coverage wins over raw
+        // count, matching the correlation read path's ranking.
         let best = cfg.resolve_best_set(&dims).unwrap();
-        assert_eq!(best.id, "k8s");
+        assert_eq!(best.id, "aws");
+
+        // Without the aws dimension, k8s is the only set with any coverage.
+        dims.remove("aws-region");
+        assert_eq!(cfg.resolve_best_set(&dims).unwrap().id, "k8s");
     }
 
     #[test]
@@ -571,6 +620,64 @@ mod tests {
 
         let best = cfg.resolve_best_set(&k8s_dims).unwrap();
         assert_eq!(best.id, "k8s");
+    }
+
+    #[test]
+    fn test_resolve_best_set_prefers_full_coverage_over_raw_count() {
+        // F8: a fully-covered 2-field set must beat a 3/5 partial set at ingest,
+        // matching the read-side ranking (is_full, ratio, count).
+        let cfg = ServiceIdentityConfig {
+            sets: vec![
+                make_set("big", "Big", &["a", "b", "c", "d", "e"]),
+                make_set("small", "Small", &["x", "y"]),
+            ],
+            tracked_alias_ids: vec!["a".into()],
+            service_optional: false,
+        };
+        let dims: std::collections::HashMap<String, String> = [
+            ("a", "1"),
+            ("b", "1"),
+            ("c", "1"), // big: 3/5 partial
+            ("x", "1"),
+            ("y", "1"), // small: 2/2 full
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+        assert_eq!(cfg.resolve_best_set(&dims).unwrap().id, "small");
+    }
+
+    #[test]
+    fn test_resolve_best_set_ties_broken_by_declaration_order() {
+        let cfg = ServiceIdentityConfig {
+            sets: vec![
+                make_set("first", "F", &["a"]),
+                make_set("second", "S", &["b"]),
+            ],
+            tracked_alias_ids: vec!["a".into()],
+            service_optional: false,
+        };
+        let dims: std::collections::HashMap<String, String> = [("a", "1"), ("b", "1")]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        assert_eq!(cfg.resolve_best_set(&dims).unwrap().id, "first");
+    }
+
+    #[test]
+    fn test_resolve_best_set_by_coverage_reports_coverage() {
+        let sets = vec![
+            make_set("k8s", "Kubernetes", &["k8s-cluster", "k8s-namespace"]),
+            make_set("aws", "AWS", &["aws-region"]),
+        ];
+        let available: std::collections::HashSet<&str> =
+            ["k8s-cluster", "aws-region"].into_iter().collect();
+        let (set, cov) = resolve_best_set_by_coverage(&sets, &available).unwrap();
+        // aws is fully covered (1/1); k8s is only 1/2 → aws wins on is_full
+        assert_eq!(set.id, "aws");
+        assert!(cov.is_full);
+        assert_eq!(cov.count, 1);
+        assert_eq!(cov.ratio, 1.0);
     }
 
     // ========== IncidentGroupingConfig::validate() Tests ==========

--- a/src/config/src/meta/correlation.rs
+++ b/src/config/src/meta/correlation.rs
@@ -350,6 +350,23 @@ pub fn resolve_best_set_by_coverage<'a>(
     best
 }
 
+/// Set IDs whose stored service rows are stale after a config change: sets that were
+/// removed, plus sets whose `distinguish_by` changed (their rows' disambiguation was
+/// keyed to the old field list). Rows under these IDs linger and pollute correlation
+/// unions until aged out (F10) — callers should delete them and emit a reload event.
+pub fn obsolete_set_ids(old: &ServiceIdentityConfig, new: &ServiceIdentityConfig) -> Vec<String> {
+    old.sets
+        .iter()
+        .filter(
+            |old_set| match new.sets.iter().find(|s| s.id == old_set.id) {
+                None => true,
+                Some(new_set) => new_set.distinguish_by != old_set.distinguish_by,
+            },
+        )
+        .map(|s| s.id.clone())
+        .collect()
+}
+
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct IncidentGroupingConfig {
     pub group_by: Vec<String>,
@@ -797,5 +814,64 @@ mod tests {
     #[test]
     fn test_default_upgrade_window() {
         assert_eq!(default_upgrade_window(), 30);
+    }
+
+    #[test]
+    fn test_obsolete_set_ids_removed_and_changed() {
+        let mk = |id: &str, fields: &[&str]| IdentitySet {
+            id: id.into(),
+            label: id.into(),
+            distinguish_by: fields.iter().map(|s| s.to_string()).collect(),
+        };
+        let old = ServiceIdentityConfig {
+            sets: vec![
+                mk("k8s", &["k8s-cluster", "k8s-namespace"]),
+                mk("aws", &["aws-region"]),
+                mk("keep", &["environment"]),
+            ],
+            tracked_alias_ids: vec!["environment".into()],
+            service_optional: false,
+        };
+        let new = ServiceIdentityConfig {
+            sets: vec![mk("k8s", &["k8s-cluster"]), mk("keep", &["environment"])],
+            tracked_alias_ids: vec!["environment".into()],
+            service_optional: false,
+        };
+        let mut ids = obsolete_set_ids(&old, &new);
+        ids.sort();
+        // "aws" removed; "k8s" distinguish_by changed; "keep" untouched
+        assert_eq!(ids, vec!["aws".to_string(), "k8s".to_string()]);
+    }
+
+    #[test]
+    fn test_obsolete_set_ids_unchanged_config_is_empty() {
+        let cfg = ServiceIdentityConfig {
+            sets: vec![IdentitySet {
+                id: "k8s".into(),
+                label: "Kubernetes".into(),
+                distinguish_by: vec!["k8s-cluster".into(), "k8s-namespace".into()],
+            }],
+            tracked_alias_ids: vec!["environment".into()],
+            service_optional: false,
+        };
+        assert!(obsolete_set_ids(&cfg, &cfg).is_empty());
+    }
+
+    #[test]
+    fn test_obsolete_set_ids_field_reorder_is_obsolete() {
+        // Order of distinguish_by decides the disambiguation key layout, so a reorder
+        // invalidates stored rows just like a membership change.
+        let mk = |fields: &[&str]| ServiceIdentityConfig {
+            sets: vec![IdentitySet {
+                id: "k8s".into(),
+                label: "Kubernetes".into(),
+                distinguish_by: fields.iter().map(|s| s.to_string()).collect(),
+            }],
+            tracked_alias_ids: vec![],
+            service_optional: false,
+        };
+        let old = mk(&["k8s-cluster", "k8s-namespace"]);
+        let new = mk(&["k8s-namespace", "k8s-cluster"]);
+        assert_eq!(obsolete_set_ids(&old, &new), vec!["k8s".to_string()]);
     }
 }

--- a/src/config/src/meta/service_streams.rs
+++ b/src/config/src/meta/service_streams.rs
@@ -44,6 +44,12 @@ pub struct StreamInfo {
     /// Example: {"namespace": "production", "cluster": "us-east-1"}
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub filters: HashMap<String, String>,
+
+    /// Identity dimensions that could not be resolved to a queryable field on
+    /// this stream's schema and were therefore omitted from `filters`.
+    /// Consumers should warn: queries on this stream are wider than the chips imply.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dropped_dimensions: Vec<String>,
 }
 
 impl std::hash::Hash for StreamInfo {
@@ -67,6 +73,7 @@ impl StreamInfo {
             stream_name,
             stream_type: StreamType::default(),
             filters: HashMap::new(),
+            dropped_dimensions: Vec::new(),
         }
     }
 
@@ -76,6 +83,7 @@ impl StreamInfo {
             stream_name,
             stream_type,
             filters: HashMap::new(),
+            dropped_dimensions: Vec::new(),
         }
     }
 
@@ -85,6 +93,7 @@ impl StreamInfo {
             stream_name,
             stream_type: StreamType::default(),
             filters,
+            dropped_dimensions: Vec::new(),
         }
     }
 
@@ -98,6 +107,7 @@ impl StreamInfo {
             stream_name,
             stream_type,
             filters,
+            dropped_dimensions: Vec::new(),
         }
     }
 
@@ -451,6 +461,24 @@ impl CardinalityClass {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_stream_info_dropped_dimensions_serde() {
+        // Old payloads without the field must deserialize (default = empty)
+        let old: StreamInfo =
+            serde_json::from_str(r#"{"stream_name":"s1","stream_type":"logs"}"#).unwrap();
+        assert!(old.dropped_dimensions.is_empty());
+
+        // Empty vec must be skipped on serialization (backward-compatible wire format)
+        let ser = serde_json::to_string(&old).unwrap();
+        assert!(!ser.contains("dropped_dimensions"));
+
+        // Populated vec round-trips
+        let mut s = StreamInfo::new("s2".to_string());
+        s.dropped_dimensions = vec!["k8s-cluster".to_string()];
+        let round: StreamInfo = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert_eq!(round.dropped_dimensions, vec!["k8s-cluster".to_string()]);
+    }
 
     #[test]
     fn test_stream_info_with_type() {

--- a/src/config/src/utils/sql/mod.rs
+++ b/src/config/src/utils/sql/mod.rs
@@ -21,6 +21,7 @@ mod simple_aggregate_query;
 mod simple_distinct_query;
 mod timestamp_selected;
 mod visitors;
+mod where_fragment;
 
 pub use complex_query::{is_complex_query, is_complex_query_stmt};
 pub use eligible_for_histogram::is_eligible_for_histogram;
@@ -29,6 +30,7 @@ pub use simple_aggregate_query::is_simple_aggregate_query;
 pub use simple_distinct_query::is_simple_distinct_query;
 pub use timestamp_selected::is_timestamp_selected;
 pub use visitors::TimestampVisitor;
+pub use where_fragment::validate_where_fragment;
 
 pub const AGGREGATE_UDF_LIST: [&str; 17] = [
     "min",

--- a/src/config/src/utils/sql/where_fragment.rs
+++ b/src/config/src/utils/sql/where_fragment.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use sqlparser::{dialect::GenericDialect, parser::Parser};
+
+/// Validate that `filter` is a single well-formed SQL boolean expression suitable
+/// for splicing into a WHERE clause. Rejects empty input, multi-statement payloads,
+/// and fragments that only parse because a comment (`--`, `/*`) swallowed the
+/// closing context. Defense-in-depth for endpoints that accept raw filter fragments
+/// (traces latest/latest_stream) — clients must still escape values.
+///
+/// It intentionally does NOT reject tautologies (`a='x' OR 1=1` is valid SQL); the
+/// client-side escaping is the real fix, this is the backstop for direct API callers.
+pub fn validate_where_fragment(filter: &str) -> Result<(), String> {
+    if filter.trim().is_empty() {
+        return Err("filter must not be empty".to_string());
+    }
+    let probe = format!("SELECT 1 FROM t WHERE ({filter})");
+    let dialect = GenericDialect {};
+    match Parser::parse_sql(&dialect, &probe) {
+        Ok(statements) if statements.len() == 1 => Ok(()),
+        Ok(_) => Err("filter must be a single expression".to_string()),
+        Err(e) => Err(format!("invalid filter expression: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_where_fragment() {
+        // Well-formed fragments pass
+        assert!(validate_where_fragment("service_name='api' AND duration > 100").is_ok());
+        assert!(validate_where_fragment("\"k8s_pod_name\" = 'checkout.service'").is_ok());
+        // Statement smuggling / truncation / garbage fail
+        assert!(validate_where_fragment("1=1; DROP TABLE t").is_err());
+        // A trailing comment swallows the wrapper's closing paren -> unclosed paren
+        assert!(validate_where_fragment("a='x' --").is_err());
+        assert!(validate_where_fragment("a='x' /*").is_err());
+        assert!(validate_where_fragment("a='x").is_err()); // unterminated literal
+        assert!(validate_where_fragment("").is_err());
+        assert!(validate_where_fragment("   ").is_err());
+        // Set-operation smuggling is rejected too (the wrapper paren is still open)
+        assert!(validate_where_fragment("a='x' UNION SELECT 1").is_err());
+    }
+
+    #[test]
+    fn test_validate_where_fragment_balanced_breakout_is_accepted() {
+        // Documented limitation: a payload that BALANCES the wrapper paren itself and
+        // comments out the tail still parses as one statement, so it is accepted.
+        // That is intended: the fragment is still a single boolean expression spliced
+        // into one WHERE clause (here a tautology), not a second statement. Tautologies
+        // are deliberately out of scope for this backstop — the client-side escaping
+        // is what prevents them. What this validator guarantees is that no additional
+        // statement and no truncated/garbage SQL reaches the planner.
+        assert!(validate_where_fragment("a='x') OR 1=1 --").is_ok());
+        // ...but the same shape cannot smuggle a second statement:
+        assert!(validate_where_fragment("a='x') ; DROP TABLE t --").is_err());
+    }
+}

--- a/src/infra/src/table/service_streams.rs
+++ b/src/infra/src/table/service_streams.rs
@@ -178,7 +178,15 @@ fn normalize_json_object(v: serde_json::Value) -> serde_json::Value {
     }
 }
 
-pub async fn put(org_id: &str, mut record: ServiceRecord) -> Result<(), errors::Error> {
+/// Upsert a service record.
+///
+/// Returns the `disambiguation` JSON of every orphaned (lower-specificity) row that was
+/// deleted as part of this put, so callers can evict the matching cache keys (F19).
+/// Empty on a plain insert.
+pub async fn put(
+    org_id: &str,
+    mut record: ServiceRecord,
+) -> Result<Vec<serde_json::Value>, errors::Error> {
     // Normalize disambiguation to sorted-key JSON so that text comparisons in SQLite
     // are stable regardless of insertion order of the original object.
     record.disambiguation = normalize_json_object(record.disambiguation);
@@ -240,7 +248,7 @@ pub async fn put(org_id: &str, mut record: ServiceRecord) -> Result<(), errors::
             &incoming_map,
             &kept_id,
         )
-        .await?;
+        .await
     } else {
         // No exact match. Check if an existing row can be upgraded:
         // A row is upgradeable if its disambiguation is a subset of the incoming one
@@ -332,7 +340,7 @@ pub async fn put(org_id: &str, mut record: ServiceRecord) -> Result<(), errors::
                 richer_map,
                 &kept_id,
             )
-            .await?;
+            .await
         } else {
             let active_model = ActiveModel {
                 id: Set(record.id),
@@ -352,14 +360,18 @@ pub async fn put(org_id: &str, mut record: ServiceRecord) -> Result<(), errors::
                 .exec(client)
                 .await
                 .map_err(|e| Error::DbError(DbError::SeaORMError(e.to_string())))?;
+
+            // Plain insert: nothing was orphaned.
+            Ok(Vec::new())
         }
     }
-
-    Ok(())
 }
 
 /// Delete rows for `service_name` that are strict subsets of `richer_map`, excluding `keep_id`.
 /// Called after a successful put/upgrade to clean up orphaned lower-specificity rows.
+///
+/// Returns the `disambiguation` JSON of each deleted row so callers can evict the
+/// corresponding cache entries (F19).
 async fn delete_subset_orphans(
     client: &sea_orm::DatabaseConnection,
     org_id: &str,
@@ -367,7 +379,7 @@ async fn delete_subset_orphans(
     set_id: &str,
     richer_map: &std::collections::HashMap<String, String>,
     keep_id: &str,
-) -> Result<(), errors::Error> {
+) -> Result<Vec<serde_json::Value>, errors::Error> {
     let candidates = Entity::find()
         .filter(Column::OrgId.eq(org_id))
         .filter(Column::ServiceName.eq(service_name))
@@ -376,6 +388,7 @@ async fn delete_subset_orphans(
         .await
         .map_err(|e| errors::Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
 
+    let mut deleted: Vec<serde_json::Value> = Vec::new();
     for row in candidates {
         if row.id == keep_id {
             continue;
@@ -394,13 +407,15 @@ async fn delete_subset_orphans(
             .iter()
             .all(|(k, v)| richer_map.get(k).map(|rv| rv == v).unwrap_or(false));
         if is_subset && row_map.len() < richer_map.len() {
+            let disambiguation = row.disambiguation.clone();
             Entity::delete_by_id(row.id)
                 .exec(client)
                 .await
                 .map_err(|e| errors::Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+            deleted.push(disambiguation);
         }
     }
-    Ok(())
+    Ok(deleted)
 }
 
 fn union_stream_array(existing: &serde_json::Value, new: &serde_json::Value) -> serde_json::Value {

--- a/src/super_cluster_queue/src/service_streams.rs
+++ b/src/super_cluster_queue/src/service_streams.rs
@@ -40,7 +40,9 @@ pub(crate) async fn process_msg(msg: ServiceStreamsMessage) -> Result<()> {
                 record.service_name
             );
             let org_id = record.org_id.clone();
-            service_streams::put(&org_id, *record).await?;
+            // Orphan disambiguations are irrelevant here: the put event below makes this
+            // cluster's nodes reload the org's services wholesale (F19).
+            let _orphans = service_streams::put(&org_id, *record).await?;
             infra::coordinator::service_streams::emit_put_event(&org_id).await?;
         }
         ServiceStreamsMessage::Delete {

--- a/src/super_cluster_queue/src/service_streams.rs
+++ b/src/super_cluster_queue/src/service_streams.rs
@@ -53,7 +53,9 @@ pub(crate) async fn process_msg(msg: ServiceStreamsMessage) -> Result<()> {
                 service_key
             );
             service_streams::delete_all(&org_id).await?;
-            infra::coordinator::service_streams::emit_delete_event(&org_id, &service_key).await?;
+            // Org-scope reload: the delete wiped the whole org's rows, so a per-service
+            // delete event would evict only one cache key on this cluster's nodes (F6).
+            infra::coordinator::service_streams::emit_reload_event(&org_id).await?;
         }
     }
     Ok(())

--- a/web/src/components/alerts/IncidentDetailDrawer.vue
+++ b/web/src/components/alerts/IncidentDetailDrawer.vue
@@ -1140,6 +1140,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     :source-stream="'incidents'"
                     :source-type="'incidents'"
                     :available-dimensions="availableDimensions"
+                    :semantic-groups="semanticGroups"
                     :fts-fields="ftsFields"
                     :time-range="telemetryTimeRange"
                     :hide-view-related-button="true"
@@ -3390,6 +3391,7 @@ export default defineComponent({
       telemetryTimeRange,
       actualMatchedDimensions,
       availableDimensions,
+      semanticGroups,
       ftsFields,
       incidentContextData,
       affectedServicesCount,

--- a/web/src/components/settings/ServiceIdentitySetup.vue
+++ b/web/src/components/settings/ServiceIdentitySetup.vue
@@ -3103,14 +3103,6 @@ async function saveConfig() {
       return;
     }
 
-    if (trackedAliasIds.value.length === 0) {
-      toast({
-        variant: "warning",
-        message: t("settings.serviceIdentitySetup.selectAtLeastOneTrackedAlias"),
-      });
-      return;
-    }
-
     // "service" is always tracked implicitly by the backend; strip it to avoid 400.
     // Also drop orphan ids that no longer correspond to any known group (e.g. the
     // group was deleted from Field Mappings after being added to tracked aliases).

--- a/web/src/composables/useCorrelatedLogs.spec.ts
+++ b/web/src/composables/useCorrelatedLogs.spec.ts
@@ -252,7 +252,6 @@ describe("useCorrelatedLogs", () => {
       expect(composable.currentFilters.value.service).toBe("updated-api");
       expect(composable.currentFilters.value.region).toBe("us-east");
     });
-
   });
 
   describe("Dimension Helpers", () => {

--- a/web/src/composables/useCorrelatedLogs.spec.ts
+++ b/web/src/composables/useCorrelatedLogs.spec.ts
@@ -253,36 +253,6 @@ describe("useCorrelatedLogs", () => {
       expect(composable.currentFilters.value.region).toBe("us-east");
     });
 
-    it("should remove filter", async () => {
-      const composable = useCorrelatedLogs(props);
-
-      composable.removeFilter("region");
-      await nextTick();
-
-      expect(composable.currentFilters.value.region).toBeUndefined();
-    });
-
-    it("should reset filters to matched dimensions only", async () => {
-      mockFetchQueryDataWithHttpStream.mockImplementation((_params: any, callbacks: any) => {
-        callbacks.complete(null);
-        return Promise.resolve();
-      });
-
-      const composable = useCorrelatedLogs(props);
-
-      // Modify filters
-      composable.updateFilter("service", "modified");
-      composable.updateFilter("newKey", "newValue");
-
-      // Reset - should only keep matched dimensions, not additional ones
-      composable.resetFilters();
-      await nextTick();
-
-      expect(composable.currentFilters.value).toEqual({
-        service: "api",
-        environment: "prod",
-      });
-    });
   });
 
   describe("Dimension Helpers", () => {

--- a/web/src/composables/useCorrelatedLogs.ts
+++ b/web/src/composables/useCorrelatedLogs.ts
@@ -17,9 +17,13 @@ import type { I18nText } from "@/types/i18n";
 
 import { ref, computed, watch, onUnmounted } from "vue";
 import { useStore } from "vuex";
-import type { StreamInfo } from "@/services/service_streams";
+import type { StreamInfo, FieldAlias } from "@/services/service_streams";
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
-import { buildSqlCondition } from "@/utils/telemetryCorrelation";
+import {
+  buildSqlCondition,
+  applyFilterOverlay,
+  buildFieldToGroupIdMap,
+} from "@/utils/telemetryCorrelation";
 import { generateTraceContext } from "@/utils/zincutils";
 import useHttpStreamingSearch from "@/composables/useStreamingSearch";
 
@@ -43,6 +47,13 @@ export interface CorrelatedLogsProps {
   sourceStream: string;
   sourceType: string;
   availableDimensions?: Record<string, any>;
+  /**
+   * Semantic field groups for the org. Used to resolve a filter edit made on one
+   * stream's field name onto every other correlated stream's alias for the same
+   * semantic group (F35). Without it, edits only apply to streams that spell the
+   * field exactly the same way as the chip.
+   */
+  semanticGroups?: FieldAlias[];
   ftsFields?: string[];
   timeRange: TimeRange;
   hideViewRelatedButton?: boolean;
@@ -141,17 +152,22 @@ export function useCorrelatedLogs(props: CorrelatedLogsProps) {
   const buildSQLQueries = (): string[] => {
     const queries: string[] = [];
 
+    // Built once per call: chip keys come from whichever stream sourced them, so
+    // an edit must be resolved onto each stream's own alias for the same group.
+    const fieldToGroupId = buildFieldToGroupIdMap(props.semanticGroups ?? []);
+
     for (const streamInfo of props.logStreams) {
       const conditions: string[] = [];
 
-      // Merge stream's base filters with user overrides from currentFilters.
-      // currentFilters keys are raw field names (same namespace as streamInfo.filters),
-      // so a key present in both takes the user-modified value.
+      // Merge the stream's base filters with the user's overrides from
+      // currentFilters, matching on exact field name first and falling back to
+      // the shared semantic group (F35).
       const baseFilters = streamInfo.filters ?? {};
-      const effectiveFilters: Record<string, string> = { ...baseFilters };
-      for (const [k, v] of Object.entries(currentFilters.value)) {
-        if (k in baseFilters) effectiveFilters[k] = v;
-      }
+      const effectiveFilters = applyFilterOverlay(
+        baseFilters,
+        currentFilters.value,
+        fieldToGroupId,
+      );
 
       for (const [field, value] of Object.entries(effectiveFilters)) {
         if (value === SELECT_ALL_VALUE) continue;
@@ -331,27 +347,6 @@ export function useCorrelatedLogs(props: CorrelatedLogsProps) {
   };
 
   /**
-   * Remove a filter dimension
-   */
-  const removeFilter = (key: string) => {
-    const updatedFilters = { ...currentFilters.value };
-    delete updatedFilters[key];
-    currentFilters.value = updatedFilters;
-
-    currentPage.value = 1;
-    fetchCorrelatedLogs();
-  };
-
-  /**
-   * Reset filters to the initial per-stream filter values from _correlate
-   */
-  const resetFilters = () => {
-    currentFilters.value = { ...props.matchedDimensions };
-    currentPage.value = 1;
-    fetchCorrelatedLogs();
-  };
-
-  /**
    * Update time range
    */
   const updateTimeRange = (startTime: number, endTime: number) => {
@@ -445,8 +440,6 @@ export function useCorrelatedLogs(props: CorrelatedLogsProps) {
     goToPage,
     updateFilter,
     updateFilters,
-    removeFilter,
-    resetFilters,
     updateTimeRange,
     refresh,
     isMatchedDimension,

--- a/web/src/composables/useCorrelatedLogs.ts
+++ b/web/src/composables/useCorrelatedLogs.ts
@@ -19,6 +19,7 @@ import { ref, computed, watch, onUnmounted } from "vue";
 import { useStore } from "vuex";
 import type { StreamInfo } from "@/services/service_streams";
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
+import { buildSqlCondition } from "@/utils/telemetryCorrelation";
 import { generateTraceContext } from "@/utils/zincutils";
 import useHttpStreamingSearch from "@/composables/useStreamingSearch";
 
@@ -157,9 +158,7 @@ export function useCorrelatedLogs(props: CorrelatedLogsProps) {
         if (field.startsWith("_")) continue;
         if (value === null || value === undefined || value === "") continue;
 
-        const quotedField = `"${field.replace(/"/g, '""')}"`;
-        const escapedValue = String(value).replace(/'/g, "''");
-        conditions.push(`${quotedField} = '${escapedValue}'`);
+        conditions.push(buildSqlCondition(field, String(value)));
       }
 
       // Always quote stream name to match dashboard behavior

--- a/web/src/composables/useMetricsCorrelationDashboard.spec.ts
+++ b/web/src/composables/useMetricsCorrelationDashboard.spec.ts
@@ -72,7 +72,7 @@ describe("useMetricsCorrelationDashboard", () => {
       expect(panel.queryType).toBe("sql");
       expect(panel.queries).toHaveLength(1);
       expect(panel.queries[0].query).toContain('FROM "cpu_usage"');
-      expect(panel.queries[0].query).toContain("service = 'api'");
+      expect(panel.queries[0].query).toContain("\"service\" = 'api'");
       expect(panel.queries[0].query).toContain("\"k8s-cluster\" = 'prod'");
     });
 
@@ -99,7 +99,7 @@ describe("useMetricsCorrelationDashboard", () => {
       const query = dashboard.tabs[0].panels[0].queries[0].query;
 
       // Single quotes should be escaped
-      expect(query).toContain("description = 'it''s a test'");
+      expect(query).toContain("\"description\" = 'it''s a test'");
     });
 
     it("should position panels in 3-column grid", () => {
@@ -272,8 +272,8 @@ describe("useMetricsCorrelationDashboard", () => {
       // Should only use matched dimension values from API filters
       const query = dashboard!.tabs[0].panels[0].queries[0].query;
       expect(query).toContain('FROM "default"');
-      expect(query).toContain("service_name = 'api'");
-      expect(query).toContain("env = 'prod'");
+      expect(query).toContain("\"service_name\" = 'api'");
+      expect(query).toContain("\"env\" = 'prod'");
       expect(query).not.toContain("host = 'server01'"); // Not in API filters
     });
 
@@ -351,7 +351,7 @@ describe("useMetricsCorrelationDashboard", () => {
 
       const query = dashboard!.tabs[0].panels[0].queries[0].query;
       // Should only include service_name (string, non-internal) in WHERE clause
-      expect(query).toContain("service_name = 'api'");
+      expect(query).toContain("\"service_name\" = 'api'");
       expect(query).not.toContain("port");
       expect(query).not.toContain("enabled");
       // _timestamp appears in ORDER BY, not in WHERE clause (which is correct)
@@ -387,8 +387,9 @@ describe("useMetricsCorrelationDashboard", () => {
       // Fields with hyphens should be quoted
       expect(query).toContain("\"k8s-cluster\" = 'prod'");
       expect(query).toContain("\"k8s-namespace\" = 'default'");
-      // Regular field names should not be quoted
-      expect(query).toContain("service = 'api'");
+      // Regular field names are quoted too — every identifier goes through
+      // quoteSqlIdentifier so escaping can never be forgotten (F2/F38)
+      expect(query).toContain("\"service\" = 'api'");
     });
 
     it("should set table_dynamic_columns for logs panel", () => {

--- a/web/src/composables/useMetricsCorrelationDashboard.spec.ts
+++ b/web/src/composables/useMetricsCorrelationDashboard.spec.ts
@@ -528,4 +528,58 @@ describe("useMetricsCorrelationDashboard", () => {
       expect(dashboard.defaultDatetimeDuration.endTime).toBe(1234567990000000);
     });
   });
+
+  describe("subject overrides (F31)", () => {
+    const semanticGroups = [
+      {
+        id: "k8s-namespace",
+        fields: ["k8s_namespace_name", "service_k8s_namespace_name"],
+      },
+    ] as MetricsCorrelationConfig["semanticGroups"];
+
+    const buildConfig = (
+      overrides: Partial<MetricsCorrelationConfig>,
+    ): MetricsCorrelationConfig => ({
+      serviceName: "api",
+      matchedDimensions: { "k8s-namespace": "staging" },
+      metricStreams: [],
+      orgIdentifier: "test-org",
+      timeRange: { startTime: 1000000000000000, endTime: 1000000900000000 },
+      semanticGroups,
+      ...overrides,
+    });
+
+    it("replaces the stream's own alias rather than ANDing both aliases", () => {
+      const metricStreams: StreamInfo[] = [
+        { stream_name: "cpu", filters: { service_k8s_namespace_name: "prod" } },
+      ];
+
+      const dashboard = composable.generateDashboard(
+        metricStreams,
+        buildConfig({
+          metricSchemas: {
+            cpu: { schema: [{ name: "k8s_namespace_name" }, { name: "value" }] },
+          },
+        }),
+      );
+
+      const query = dashboard.tabs[0].panels[0].queries[0].query;
+      expect(query).toContain(`"k8s_namespace_name" = 'staging'`);
+      expect(query).not.toContain("service_k8s_namespace_name");
+    });
+
+    it("does not guess a field name when the stream schema is unavailable", () => {
+      const metricStreams: StreamInfo[] = [
+        { stream_name: "cpu", filters: { service_k8s_namespace_name: "prod" } },
+      ];
+
+      // No metricSchemas entry -> schema unknown. Guessing an alias here used to
+      // emit a WHERE on a nonexistent column and kill the panel.
+      const dashboard = composable.generateDashboard(metricStreams, buildConfig({}));
+
+      const query = dashboard.tabs[0].panels[0].queries[0].query;
+      expect(query).toContain(`"service_k8s_namespace_name" = 'prod'`);
+      expect(query).not.toContain("'staging'");
+    });
+  });
 });

--- a/web/src/composables/useMetricsCorrelationDashboard.ts
+++ b/web/src/composables/useMetricsCorrelationDashboard.ts
@@ -15,7 +15,11 @@
 
 import type { StreamInfo, FieldAlias } from "@/services/service_streams";
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
-import { buildSqlCondition } from "@/utils/telemetryCorrelation";
+import {
+  buildFieldToGroupIdMap,
+  buildSqlCondition,
+  mergeSubjectOverrides,
+} from "@/utils/telemetryCorrelation";
 
 export interface MetricsCorrelationConfig {
   serviceName: string;
@@ -136,20 +140,26 @@ export function useMetricsCorrelationDashboard() {
     for (const [semanticId, value] of Object.entries(config.matchedDimensions)) {
       if (!value || value === SELECT_ALL_VALUE) continue;
       const group = semanticGroups.find((g) => g.id === semanticId);
-      if (!group) continue; // not a semantic ID key — skip (raw field names handled below)
-      // Find the first alias field that appears in this stream's schema.
-      // Fallback when schema is unavailable: prefer the field whose name matches
-      // the group ID (dashes → underscores), e.g. "k8s-node-name" → "k8s_node_name".
-      const groupIdAsField = semanticId.replace(/-/g, "_");
-      const fallback = group.fields.find((f) => f === groupIdAsField) ?? group.fields[0];
-      const hit = streamSchema.size > 0 ? group.fields.find((f) => streamSchema.has(f)) : fallback;
+      if (!group) continue; // not a semantic ID key — raw field names handled below
+      // F31: only override when the stream schema is loaded AND contains the field.
+      // Guessing a field name here produced `WHERE guessed = 'x' AND real = 'x'`
+      // (nonexistent guess → "No field named …" kills the panel).
+      if (streamSchema.size === 0) continue;
+      const hit = group.fields.find((f) => streamSchema.has(f));
       if (hit) subjectOverrides[hit] = value;
     }
 
     // Build WHERE clause from stream filters merged with active subject overrides.
+    // Overrides REPLACE the stream's own alias of the same semantic group (F31) —
+    // a plain spread would AND two aliases of one concept together and match nothing.
     // Quote field names that contain special characters (hyphens, dots, etc.)
     // Skip filters with SELECT_ALL_VALUE (wildcard - means match all values)
-    const effectiveFilters = { ...(stream.filters ?? {}), ...subjectOverrides };
+    const fieldToGroupId = buildFieldToGroupIdMap(semanticGroups);
+    const effectiveFilters = mergeSubjectOverrides(
+      stream.filters ?? {},
+      subjectOverrides,
+      fieldToGroupId,
+    );
 
     const whereConditions = Object.entries(effectiveFilters)
       .filter(([, value]) => {

--- a/web/src/composables/useMetricsCorrelationDashboard.ts
+++ b/web/src/composables/useMetricsCorrelationDashboard.ts
@@ -15,6 +15,7 @@
 
 import type { StreamInfo, FieldAlias } from "@/services/service_streams";
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
+import { buildSqlCondition } from "@/utils/telemetryCorrelation";
 
 export interface MetricsCorrelationConfig {
   serviceName: string;
@@ -159,9 +160,7 @@ export function useMetricsCorrelationDashboard() {
         return !skip;
       })
       .map(([field, value]) => {
-        const quotedField = /[^a-zA-Z0-9_]/.test(field) ? `"${field.replace(/"/g, '""')}"` : field;
-        const escapedValue = value.replace(/'/g, "''");
-        return `${quotedField} = '${escapedValue}'`;
+        return buildSqlCondition(field, value);
       })
       .join(" AND ");
 
@@ -349,9 +348,7 @@ ORDER BY x_axis_1`;
         return typeof value === "string" && !field.startsWith("_") && value !== SELECT_ALL_VALUE;
       })
       .map(([field, value]) => {
-        const quotedField = /[^a-zA-Z0-9_]/.test(field) ? `"${field.replace(/"/g, '""')}"` : field;
-        const escapedValue = value.replace(/'/g, "''");
-        return `${quotedField} = '${escapedValue}'`;
+        return buildSqlCondition(field, value);
       })
       .join(" AND ");
 

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -8363,7 +8363,6 @@
   },
   "correlation": {
     "unstableDimensionNote": "Unstable dimension - changes on pod restart. Default: All values.",
-    "droppedDimensionsWarning": "Some filters could not be applied to every stream ({dims}) — results may include data outside the selected scope.",
     "streamsSelectedCount": "{selected} of {total} selected",
     "importSemanticGroupsTitle": "Import Semantic Groups",
     "importSemanticGroupsSubtitle": "Upload JSON file to import semantic field groups",

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -8363,6 +8363,7 @@
   },
   "correlation": {
     "unstableDimensionNote": "Unstable dimension - changes on pod restart. Default: All values.",
+    "droppedDimensionsWarning": "Some filters could not be applied to every stream ({dims}) — results may include data outside the selected scope.",
     "streamsSelectedCount": "{selected} of {total} selected",
     "importSemanticGroupsTitle": "Import Semantic Groups",
     "importSemanticGroupsSubtitle": "Upload JSON file to import semantic field groups",

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -7328,7 +7328,7 @@
       "noFieldsConfiguredYet": "No fields configured yet",
       "workloadDetection": "Workload Detection",
       "workloadDetectedUsingFields": "Workload detected using fields",
-      "workloadTrackedHelp": "Only these field alias groups are used for workload detection and recommendations. Fields not in this list will not influence service discovery results. Cannot be empty.",
+      "workloadTrackedHelp": "Only these field alias groups are used for workload detection and recommendations. Fields not in this list will not influence service discovery results. Optional — dimensions listed in identity sets are always tracked.",
       "goToFieldAliases": "Go to Field Aliases",
       "toConfigureFieldMappings": "to configure individual field mappings.",
       "selectAliasGroup": "Select alias group",
@@ -7355,7 +7355,6 @@
       "uniqueValuesDetected": "{n} unique values detected",
       "locations": "locations",
       "recommendedConfigApplied": "Recommended configuration applied. Click \"Save Configuration\" to save.",
-      "selectAtLeastOneTrackedAlias": "Select at least one tracked alias group.",
       "cardinalityClassLabel": " ({cardinality} cardinality)",
       "fieldCardinalityTooltip": "{count} unique values{classLabel} — fewer values = better for grouping"
     },

--- a/web/src/plugins/correlation/CorrelatedLogsTable.spec.ts
+++ b/web/src/plugins/correlation/CorrelatedLogsTable.spec.ts
@@ -39,7 +39,6 @@ vi.mock("@/composables/useCorrelatedLogs", () => ({
     fetchCorrelatedLogs: vi.fn(),
     updateFilter: vi.fn(),
     updateFilters: vi.fn(),
-    resetFilters: vi.fn(),
     refresh: vi.fn(),
     isMatchedDimension: vi.fn(() => false),
     isAdditionalDimension: vi.fn(() => false),

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.spec.ts
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.spec.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { createI18n } from "vue-i18n";
 import TelemetryCorrelationDashboard from "./TelemetryCorrelationDashboard.vue";
+import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import store from "@/test/unit/helpers/store";
 import { nextTick } from "vue";
 
@@ -150,6 +151,8 @@ const mockTranslations = {
   "correlation.tracesFromService": "Traces from {service}",
   "correlation.viewInTraces": "View in Traces",
   "correlation.selectMetrics": "Select Metrics",
+  "correlation.droppedDimensionsWarning":
+    "Some filters could not be applied to every stream ({dims}) — results may include data outside the selected scope.",
   "common.logs": "Logs",
   "common.apply": "Apply",
   "common.refresh": "Refresh",
@@ -946,6 +949,63 @@ describe("TelemetryCorrelationDashboard.vue", () => {
       await nextTick();
 
       expect(wrapper.vm.showMetricSelector).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // droppedDimensions banner (F14)
+  // -------------------------------------------------------------------------
+  describe("droppedDimensions banner (F14)", () => {
+    const bannerSelector = "[data-test='correlation-dropped-dimensions-warning']";
+
+    it("should not render the banner when no stream has dropped_dimensions", () => {
+      wrapper = createWrapper();
+      expect(wrapper.find(bannerSelector).exists()).toBe(false);
+      expect(wrapper.vm.droppedDimensions).toEqual([]);
+    });
+
+    it("should dedupe and sort dropped semantic IDs across log/metric/trace streams", () => {
+      wrapper = createWrapper({
+        logStreams: [
+          {
+            stream_name: "default",
+            stream_type: "logs",
+            dropped_dimensions: ["k8s-cluster", "environment"],
+          },
+        ],
+        traceStreams: [
+          {
+            stream_name: "traces",
+            stream_type: "traces",
+            dropped_dimensions: ["k8s-cluster"],
+          },
+        ],
+      });
+      // semanticGroups mock is empty -> raw IDs are the fallback labels
+      expect(wrapper.vm.droppedDimensions).toEqual(["environment", "k8s-cluster"]);
+      const banner = wrapper.find(bannerSelector);
+      expect(banner.exists()).toBe(true);
+      expect(banner.text()).toContain("environment, k8s-cluster");
+    });
+
+    it("should resolve semantic group IDs to display labels, falling back to raw IDs", () => {
+      (useServiceCorrelation as any).mockReturnValueOnce({
+        semanticGroups: {
+          value: [{ id: "k8s-cluster", display: "K8s Cluster", fields: [] }],
+        },
+        loadSemanticGroups: vi.fn(),
+      });
+      wrapper = createWrapper({
+        logStreams: [
+          {
+            stream_name: "default",
+            stream_type: "logs",
+            dropped_dimensions: ["k8s-cluster", "environment"],
+          },
+        ],
+      });
+      expect(wrapper.vm.droppedDimensions).toEqual(["K8s Cluster", "environment"]);
+      expect(wrapper.find(bannerSelector).text()).toContain("K8s Cluster, environment");
     });
   });
 });

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.spec.ts
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.spec.ts
@@ -757,8 +757,30 @@ describe("TelemetryCorrelationDashboard.vue", () => {
       await wrapper.vm.fetchTracesByDimensions();
 
       const callArg = mockFetchQueryDataWithHttpStream.mock.calls[0][0];
-      expect(callArg.queryReq.filter).toContain("service='api'");
-      expect(callArg.queryReq.filter).toContain("env='prod'");
+      // Identifiers and values are escaped via buildSqlCondition (F2/F38)
+      expect(callArg.queryReq.filter).toContain("\"service\" = 'api'");
+      expect(callArg.queryReq.filter).toContain("\"env\" = 'prod'");
+    });
+
+    it("should escape single quotes in trace filter values", async () => {
+      mockFetchQueryDataWithHttpStream.mockImplementation((_payload: any, handlers: any) => {
+        handlers.complete();
+      });
+
+      wrapper = createWrapper({
+        traceStreams: [
+          {
+            stream_name: "traces",
+            stream_type: "traces",
+            filters: { service: "a' OR 1=1 --" },
+          },
+        ],
+      });
+
+      await wrapper.vm.fetchTracesByDimensions();
+
+      const callArg = mockFetchQueryDataWithHttpStream.mock.calls[0][0];
+      expect(callArg.queryReq.filter).toBe("\"service\" = 'a'' OR 1=1 --'");
     });
 
     it("should accumulate and return hits from streaming data callback", async () => {

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.spec.ts
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.spec.ts
@@ -151,8 +151,6 @@ const mockTranslations = {
   "correlation.tracesFromService": "Traces from {service}",
   "correlation.viewInTraces": "View in Traces",
   "correlation.selectMetrics": "Select Metrics",
-  "correlation.droppedDimensionsWarning":
-    "Some filters could not be applied to every stream ({dims}) — results may include data outside the selected scope.",
   "common.logs": "Logs",
   "common.apply": "Apply",
   "common.refresh": "Refresh",
@@ -952,60 +950,4 @@ describe("TelemetryCorrelationDashboard.vue", () => {
     });
   });
 
-  // -------------------------------------------------------------------------
-  // droppedDimensions banner (F14)
-  // -------------------------------------------------------------------------
-  describe("droppedDimensions banner (F14)", () => {
-    const bannerSelector = "[data-test='correlation-dropped-dimensions-warning']";
-
-    it("should not render the banner when no stream has dropped_dimensions", () => {
-      wrapper = createWrapper();
-      expect(wrapper.find(bannerSelector).exists()).toBe(false);
-      expect(wrapper.vm.droppedDimensions).toEqual([]);
-    });
-
-    it("should dedupe and sort dropped semantic IDs across log/metric/trace streams", () => {
-      wrapper = createWrapper({
-        logStreams: [
-          {
-            stream_name: "default",
-            stream_type: "logs",
-            dropped_dimensions: ["k8s-cluster", "environment"],
-          },
-        ],
-        traceStreams: [
-          {
-            stream_name: "traces",
-            stream_type: "traces",
-            dropped_dimensions: ["k8s-cluster"],
-          },
-        ],
-      });
-      // semanticGroups mock is empty -> raw IDs are the fallback labels
-      expect(wrapper.vm.droppedDimensions).toEqual(["environment", "k8s-cluster"]);
-      const banner = wrapper.find(bannerSelector);
-      expect(banner.exists()).toBe(true);
-      expect(banner.text()).toContain("environment, k8s-cluster");
-    });
-
-    it("should resolve semantic group IDs to display labels, falling back to raw IDs", () => {
-      (useServiceCorrelation as any).mockReturnValueOnce({
-        semanticGroups: {
-          value: [{ id: "k8s-cluster", display: "K8s Cluster", fields: [] }],
-        },
-        loadSemanticGroups: vi.fn(),
-      });
-      wrapper = createWrapper({
-        logStreams: [
-          {
-            stream_name: "default",
-            stream_type: "logs",
-            dropped_dimensions: ["k8s-cluster", "environment"],
-          },
-        ],
-      });
-      expect(wrapper.vm.droppedDimensions).toEqual(["K8s Cluster", "environment"]);
-      expect(wrapper.find(bannerSelector).text()).toContain("K8s Cluster, environment");
-    });
-  });
 });

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.spec.ts
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.spec.ts
@@ -949,5 +949,4 @@ describe("TelemetryCorrelationDashboard.vue", () => {
       expect(wrapper.vm.showMetricSelector).toBe(false);
     });
   });
-
 });

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
@@ -81,6 +81,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :get-subject-button-label="getSubjectButtonLabel"
     />
 
+    <!-- F14: warn that some streams' queries are wider than the chips imply -->
+    <div
+      v-if="droppedDimensions.length"
+      class="border-status-warning-text bg-status-warning-bg text-status-warning-text rounded-default mx-4 mt-2 flex items-center gap-2 border px-4 py-2 text-sm"
+      data-test="correlation-dropped-dimensions-warning"
+    >
+      <OIcon name="warning" size="sm" class="shrink-0" />
+      <span>
+        {{ t("correlation.droppedDimensionsWarning", { dims: droppedDimensions.join(", ") }) }}
+      </span>
+    </div>
+
     <!-- Tabs (only in dialog mode, hidden in embedded-tabs mode) -->
     <div class="px-page-edge">
       <OTabs v-if="!isEmbeddedTabs" v-model="activeTab" dense bordered align="left">
@@ -536,6 +548,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       overflow-mode="responsive"
       :get-subject-button-label="getSubjectButtonLabel"
     />
+
+    <!-- F14: warn that some streams' queries are wider than the chips imply -->
+    <div
+      v-if="droppedDimensions.length"
+      class="border-status-warning-text bg-status-warning-bg text-status-warning-text rounded-default mx-4 my-2 flex items-center gap-2 border px-4 py-2 text-sm"
+      data-test="correlation-dropped-dimensions-warning"
+    >
+      <OIcon name="warning" size="sm" class="shrink-0" />
+      <span>
+        {{ t("correlation.droppedDimensionsWarning", { dims: droppedDimensions.join(", ") }) }}
+      </span>
+    </div>
 
     <!-- Tab Panels (no tabs in embedded mode, controlled by parent) -->
     <OCard
@@ -1256,6 +1280,25 @@ const sortedTraceStreams = computed<StreamInfo[]>(() =>
     ),
   ),
 );
+
+// F14: dimensions the backend dropped from at least one stream's filters
+// (no queryable schema field) — those streams' queries are WIDER than the
+// chips imply. Values are semantic group IDs; resolve each to its
+// human-readable display label, falling back to the raw ID if no group matches.
+const droppedDimensions = computed<string[]>(() => {
+  const dropped = new Set<string>();
+  const streams: Array<{ dropped_dimensions?: string[] }> = [
+    ...(props.logStreams ?? []),
+    ...(props.metricStreams ?? []),
+    ...(props.traceStreams ?? []),
+  ];
+  for (const s of streams) {
+    for (const d of s.dropped_dimensions ?? []) dropped.add(d);
+  }
+  return Array.from(dropped)
+    .map((id) => semanticGroups.value.find((g) => g.id === id)?.display ?? id)
+    .sort();
+});
 
 // Check if embedded tabs mode
 const isEmbeddedTabs = computed(() => props.mode === "embedded-tabs");

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
@@ -1070,7 +1070,11 @@ import {
 import type { StreamInfo } from "@/services/service_streams";
 import { enrichStreamsWithOverlap, sortStreamsByOverlap } from "@/utils/streamTimeOverlap";
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
-import { buildSqlCondition } from "@/utils/telemetryCorrelation";
+import {
+  buildSqlCondition,
+  buildFieldToGroupIdMap,
+  applyDimensionEditsToFilters,
+} from "@/utils/telemetryCorrelation";
 import streamService from "@/services/stream";
 import searchService from "@/services/search";
 import { b64EncodeUnicode, getUUID, timestampToTimezoneDate } from "@/utils/zincutils";
@@ -2104,35 +2108,22 @@ const applyDimensionChanges = () => {
   // Copy pending to active
   activeDimensions.value = { ...pendingDimensions.value };
 
-  // Build field_name -> dimension_id mapping from semantic groups
-  // This is the same approach as applyUnstableDimensionDefaults
-  const fieldToDimensionId = new Map<string, string>();
-  for (const group of semanticGroups.value) {
-    for (const field of group.fields) {
-      fieldToDimensionId.set(field, group.id);
-    }
-  }
+  // Build field_name -> dimension_id mapping from semantic groups.
+  // Uses the shared builder so lookups are case-insensitive and honour the
+  // backend's declaration-order priority when a field appears in two groups.
+  const fieldToDimensionId = buildFieldToGroupIdMap(semanticGroups.value);
 
-  // Update metric stream filters with new dimension values
-  // Use semantic groups to map filter field names to dimension IDs
-  selectedMetricStreams.value = selectedMetricStreams.value.map((stream) => {
-    const updatedFilters = { ...(stream.filters ?? {}) };
-
-    // For each filter in the stream, find its semantic dimension ID
-    // and update with the new value from activeDimensions
-    for (const [filterKey] of Object.entries(stream.filters ?? {})) {
-      const dimensionId = fieldToDimensionId.get(filterKey);
-      if (dimensionId && activeDimensions.value[dimensionId] !== undefined) {
-        const newValue = activeDimensions.value[dimensionId];
-        updatedFilters[filterKey] = newValue;
-      }
-    }
-
-    return {
-      ...stream,
-      filters: updatedFilters,
-    };
-  });
+  // Update metric stream filters with new dimension values.
+  // activeDimensions is raw-field-keyed in the dialog path and
+  // semantic-ID-keyed in the drawer path — the helper accepts both (F36).
+  selectedMetricStreams.value = selectedMetricStreams.value.map((stream) => ({
+    ...stream,
+    filters: applyDimensionEditsToFilters(
+      stream.filters ?? {},
+      activeDimensions.value,
+      fieldToDimensionId,
+    ),
+  }));
 
   // Note: For logs, the filters are built from config.matchedDimensions in the composable
   // which we're already updating via activeDimensions

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
@@ -1070,6 +1070,7 @@ import {
 import type { StreamInfo } from "@/services/service_streams";
 import { enrichStreamsWithOverlap, sortStreamsByOverlap } from "@/utils/streamTimeOverlap";
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
+import { buildSqlCondition } from "@/utils/telemetryCorrelation";
 import streamService from "@/services/stream";
 import searchService from "@/services/search";
 import { b64EncodeUnicode, getUUID, timestampToTimezoneDate } from "@/utils/zincutils";
@@ -2739,7 +2740,7 @@ const fetchTracesByDimensions = (): Promise<any[]> => {
   const filterParts: string[] = [];
   if (traceStreamInfo.filters) {
     for (const [fieldName, value] of Object.entries(traceStreamInfo.filters)) {
-      filterParts.push(`${fieldName}='${value}'`);
+      filterParts.push(buildSqlCondition(fieldName, value));
     }
   }
   const filter = filterParts.join(" AND ");
@@ -2863,7 +2864,7 @@ const openTracesPage = () => {
 
   if (traceStreamInfo?.filters) {
     for (const [fieldName, value] of Object.entries(traceStreamInfo.filters)) {
-      filterParts.push(`${fieldName}='${value}'`);
+      filterParts.push(buildSqlCondition(fieldName, value));
     }
   }
 

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
@@ -81,18 +81,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :get-subject-button-label="getSubjectButtonLabel"
     />
 
-    <!-- F14: warn that some streams' queries are wider than the chips imply -->
-    <div
-      v-if="droppedDimensions.length"
-      class="border-status-warning-text bg-status-warning-bg text-status-warning-text rounded-default mx-4 mt-2 flex items-center gap-2 border px-4 py-2 text-sm"
-      data-test="correlation-dropped-dimensions-warning"
-    >
-      <OIcon name="warning" size="sm" class="shrink-0" />
-      <span>
-        {{ t("correlation.droppedDimensionsWarning", { dims: droppedDimensions.join(", ") }) }}
-      </span>
-    </div>
-
     <!-- Tabs (only in dialog mode, hidden in embedded-tabs mode) -->
     <div class="px-page-edge">
       <OTabs v-if="!isEmbeddedTabs" v-model="activeTab" dense bordered align="left">
@@ -548,18 +536,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       overflow-mode="responsive"
       :get-subject-button-label="getSubjectButtonLabel"
     />
-
-    <!-- F14: warn that some streams' queries are wider than the chips imply -->
-    <div
-      v-if="droppedDimensions.length"
-      class="border-status-warning-text bg-status-warning-bg text-status-warning-text rounded-default mx-4 my-2 flex items-center gap-2 border px-4 py-2 text-sm"
-      data-test="correlation-dropped-dimensions-warning"
-    >
-      <OIcon name="warning" size="sm" class="shrink-0" />
-      <span>
-        {{ t("correlation.droppedDimensionsWarning", { dims: droppedDimensions.join(", ") }) }}
-      </span>
-    </div>
 
     <!-- Tab Panels (no tabs in embedded mode, controlled by parent) -->
     <OCard
@@ -1280,25 +1256,6 @@ const sortedTraceStreams = computed<StreamInfo[]>(() =>
     ),
   ),
 );
-
-// F14: dimensions the backend dropped from at least one stream's filters
-// (no queryable schema field) — those streams' queries are WIDER than the
-// chips imply. Values are semantic group IDs; resolve each to its
-// human-readable display label, falling back to the raw ID if no group matches.
-const droppedDimensions = computed<string[]>(() => {
-  const dropped = new Set<string>();
-  const streams: Array<{ dropped_dimensions?: string[] }> = [
-    ...(props.logStreams ?? []),
-    ...(props.metricStreams ?? []),
-    ...(props.traceStreams ?? []),
-  ];
-  for (const s of streams) {
-    for (const d of s.dropped_dimensions ?? []) dropped.add(d);
-  }
-  return Array.from(dropped)
-    .map((id) => semanticGroups.value.find((g) => g.id === id)?.display ?? id)
-    .sort();
-});
 
 // Check if embedded tabs mode
 const isEmbeddedTabs = computed(() => props.mode === "embedded-tabs");

--- a/web/src/plugins/logs/DetailTable.vue
+++ b/web/src/plugins/logs/DetailTable.vue
@@ -262,6 +262,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :source-stream="correlationProps.sourceStream"
             :source-type="correlationProps.sourceType"
             :available-dimensions="correlationProps.availableDimensions"
+            :semantic-groups="correlationProps.semanticGroups"
             :fts-fields="correlationProps.ftsFields"
             :time-range="correlationProps.timeRange"
             :hide-view-related-button="true"

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -1770,6 +1770,9 @@ export default defineComponent({
           sourceType: "logs",
           // Use log stream filters and log record as availableDimensions for field name resolution and traceId extraction
           availableDimensions: { ...logFilters, ...context.fields },
+          // Lets filter edits resolve across streams that alias the same
+          // semantic group under different field names (F35).
+          semanticGroups: semanticGroups.value,
           ftsFields: ftsFields, // Full text search fields for trace_id extraction from log body
           timeRange: {
             startTime: startTimeMicros,

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -744,6 +744,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :source-stream="correlationProps.sourceStream"
             :source-type="correlationProps.sourceType"
             :available-dimensions="correlationProps.availableDimensions"
+            :semantic-groups="correlationProps.semanticGroups"
             :fts-fields="correlationProps.ftsFields"
             :time-range="correlationProps.timeRange"
             :hide-view-related-button="true"
@@ -1766,6 +1767,9 @@ export default defineComponent({
             sourceType: "traces",
             // Use log stream filters and log record as availableDimensions for field name resolution and traceId extraction
             availableDimensions: { ...logFilters, ...context.fields },
+            // Lets filter edits resolve across streams that alias the same
+            // semantic group under different field names (F35).
+            semanticGroups: semanticGroups.value,
             ftsFields: [],
             timeRange: {
               startTime: spanStartUs - bufferUs,

--- a/web/src/services/service_streams.ts
+++ b/web/src/services/service_streams.ts
@@ -50,6 +50,8 @@ export interface StreamInfo {
   stream_name: string;
   stream_type: string;
   filters?: Record<string, string>; // omitted by backend when empty (skip_serializing_if)
+  /** Identity dimensions the backend could not resolve on this stream's schema (query is wider than chips imply). */
+  dropped_dimensions?: string[];
 }
 
 export interface RelatedStreams {

--- a/web/src/utils/telemetryCorrelation.spec.ts
+++ b/web/src/utils/telemetryCorrelation.spec.ts
@@ -22,6 +22,7 @@ import {
   buildSqlCondition,
   applyFilterOverlay,
   applyDimensionEditsToFilters,
+  mergeSubjectOverrides,
 } from "./telemetryCorrelation";
 import type { ServiceIdentityConfig, FieldAlias } from "@/services/service_streams";
 
@@ -465,6 +466,74 @@ describe("telemetryCorrelation", () => {
       const result = applyDimensionEditsToFilters(filters, { "k8s-namespace": "b" }, f2d);
       expect(filters).toEqual({ k8s_namespace_name: "a" });
       expect(result).not.toBe(filters);
+    });
+  });
+
+  describe("mergeSubjectOverrides", () => {
+    const groups = new Map<string, string>([
+      ["k8s_namespace_name", "k8s-namespace"],
+      ["service_k8s_namespace_name", "k8s-namespace"],
+      ["k8s_pod_name", "k8s-pod"],
+    ]);
+
+    it("replaces the same-group backend key instead of adding a duplicate (F31)", () => {
+      expect(
+        mergeSubjectOverrides(
+          { service_k8s_namespace_name: "prod" }, // backend-resolved key
+          { k8s_namespace_name: "staging" }, // schema-resolved override, different alias
+          groups,
+        ),
+      ).toEqual({ k8s_namespace_name: "staging" }); // ONE condition, not two
+    });
+
+    it("overwrites in place when keys match", () => {
+      expect(
+        mergeSubjectOverrides({ k8s_namespace_name: "a" }, { k8s_namespace_name: "b" }, groups),
+      ).toEqual({ k8s_namespace_name: "b" });
+    });
+
+    it("adds an override whose group is not present in the filters", () => {
+      expect(mergeSubjectOverrides({ k8s_pod_name: "p" }, { k8s_namespace_name: "n" }, groups)).toEqual(
+        { k8s_pod_name: "p", k8s_namespace_name: "n" },
+      );
+    });
+
+    it("leaves filters of other groups untouched while replacing one group", () => {
+      expect(
+        mergeSubjectOverrides(
+          { service_k8s_namespace_name: "prod", k8s_pod_name: "p" },
+          { k8s_namespace_name: "staging" },
+          groups,
+        ),
+      ).toEqual({ k8s_pod_name: "p", k8s_namespace_name: "staging" });
+    });
+
+    it("matches the existing filter key case-insensitively", () => {
+      expect(
+        mergeSubjectOverrides(
+          { SERVICE_K8S_NAMESPACE_NAME: "prod" },
+          { k8s_namespace_name: "staging" },
+          groups,
+        ),
+      ).toEqual({ k8s_namespace_name: "staging" });
+    });
+
+    it("adds an ungrouped override without disturbing existing filters", () => {
+      expect(mergeSubjectOverrides({ a: "1" }, { unknown_field: "2" }, groups)).toEqual({
+        a: "1",
+        unknown_field: "2",
+      });
+    });
+
+    it("returns a copy and does not mutate the input filters", () => {
+      const filters = { service_k8s_namespace_name: "prod" };
+      const result = mergeSubjectOverrides(filters, { k8s_namespace_name: "staging" }, groups);
+      expect(filters).toEqual({ service_k8s_namespace_name: "prod" });
+      expect(result).not.toBe(filters);
+    });
+
+    it("passes filters through untouched with no overrides", () => {
+      expect(mergeSubjectOverrides({ a: "1" }, {}, groups)).toEqual({ a: "1" });
     });
   });
 });

--- a/web/src/utils/telemetryCorrelation.spec.ts
+++ b/web/src/utils/telemetryCorrelation.spec.ts
@@ -20,6 +20,7 @@ import {
   quoteSqlIdentifier,
   quoteSqlLiteral,
   buildSqlCondition,
+  applyFilterOverlay,
 } from "./telemetryCorrelation";
 import type { ServiceIdentityConfig, FieldAlias } from "@/services/service_streams";
 
@@ -326,6 +327,67 @@ describe("telemetryCorrelation", () => {
     it("coerces non-string inputs before escaping", () => {
       expect(quoteSqlLiteral(42 as unknown as string)).toBe("'42'");
       expect(quoteSqlIdentifier(7 as unknown as string)).toBe('"7"');
+    });
+  });
+
+  describe("applyFilterOverlay", () => {
+    const groups = new Map<string, string>([
+      ["k8s_namespace_name", "k8s-namespace"],
+      ["service_k8s_namespace_name", "k8s-namespace"],
+    ]);
+
+    it("applies exact-key overrides", () => {
+      expect(
+        applyFilterOverlay({ k8s_namespace_name: "a" }, { k8s_namespace_name: "b" }, groups),
+      ).toEqual({ k8s_namespace_name: "b" });
+    });
+
+    it("resolves an override to the stream's own alias for the same group (F35)", () => {
+      // Chip key came from stream A ("k8s_namespace_name"); stream B uses the other alias.
+      expect(
+        applyFilterOverlay({ service_k8s_namespace_name: "a" }, { k8s_namespace_name: "b" }, groups),
+      ).toEqual({ service_k8s_namespace_name: "b" });
+    });
+
+    it("ignores overrides with no group and no matching base key", () => {
+      expect(applyFilterOverlay({ x: "1" }, { unrelated: "z" }, groups)).toEqual({ x: "1" });
+    });
+
+    it("ignores a grouped override when the stream has no field in that group", () => {
+      expect(applyFilterOverlay({ x: "1" }, { k8s_namespace_name: "b" }, groups)).toEqual({
+        x: "1",
+      });
+    });
+
+    it("resolves group aliases case-insensitively", () => {
+      expect(
+        applyFilterOverlay(
+          { SERVICE_K8S_NAMESPACE_NAME: "a" },
+          { K8S_NAMESPACE_NAME: "b" },
+          groups,
+        ),
+      ).toEqual({ SERVICE_K8S_NAMESPACE_NAME: "b" });
+    });
+
+    it("prefers the exact key when the base has both the exact key and a group sibling", () => {
+      expect(
+        applyFilterOverlay(
+          { k8s_namespace_name: "a", service_k8s_namespace_name: "a2" },
+          { k8s_namespace_name: "b" },
+          groups,
+        ),
+      ).toEqual({ k8s_namespace_name: "b", service_k8s_namespace_name: "a2" });
+    });
+
+    it("returns a copy and does not mutate the base filters", () => {
+      const base = { k8s_namespace_name: "a" };
+      const result = applyFilterOverlay(base, { k8s_namespace_name: "b" }, groups);
+      expect(base).toEqual({ k8s_namespace_name: "a" });
+      expect(result).not.toBe(base);
+    });
+
+    it("passes base filters through untouched with an empty group map", () => {
+      expect(applyFilterOverlay({ a: "1" }, { a: "2", b: "3" }, new Map())).toEqual({ a: "2" });
     });
   });
 });

--- a/web/src/utils/telemetryCorrelation.spec.ts
+++ b/web/src/utils/telemetryCorrelation.spec.ts
@@ -14,7 +14,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { filterDimensionsForCorrelation, buildFieldToGroupIdMap } from "./telemetryCorrelation";
+import {
+  filterDimensionsForCorrelation,
+  buildFieldToGroupIdMap,
+  quoteSqlIdentifier,
+  quoteSqlLiteral,
+  buildSqlCondition,
+} from "./telemetryCorrelation";
 import type { ServiceIdentityConfig, FieldAlias } from "@/services/service_streams";
 
 describe("telemetryCorrelation", () => {
@@ -295,6 +301,31 @@ describe("telemetryCorrelation", () => {
         service: "my-service",
         "k8s-cluster": "prod-cluster",
       });
+    });
+  });
+
+  describe("sql escaping helpers", () => {
+    it("quotes identifiers and doubles embedded double quotes", () => {
+      expect(quoteSqlIdentifier("k8s_pod_name")).toBe('"k8s_pod_name"');
+      expect(quoteSqlIdentifier('bad"field')).toBe('"bad""field"');
+    });
+
+    it("quotes literals and doubles embedded single quotes", () => {
+      expect(quoteSqlLiteral("prod")).toBe("'prod'");
+      expect(quoteSqlLiteral("a' OR 1=1 --")).toBe("'a'' OR 1=1 --'");
+    });
+
+    it("builds a fully escaped condition", () => {
+      expect(buildSqlCondition("svc", "a'b")).toBe("\"svc\" = 'a''b'");
+    });
+
+    it("always quotes identifiers, including ones with special characters", () => {
+      expect(buildSqlCondition("k8s-pod.name", "web-1")).toBe("\"k8s-pod.name\" = 'web-1'");
+    });
+
+    it("coerces non-string inputs before escaping", () => {
+      expect(quoteSqlLiteral(42 as unknown as string)).toBe("'42'");
+      expect(quoteSqlIdentifier(7 as unknown as string)).toBe('"7"');
     });
   });
 });

--- a/web/src/utils/telemetryCorrelation.spec.ts
+++ b/web/src/utils/telemetryCorrelation.spec.ts
@@ -21,6 +21,7 @@ import {
   quoteSqlLiteral,
   buildSqlCondition,
   applyFilterOverlay,
+  applyDimensionEditsToFilters,
 } from "./telemetryCorrelation";
 import type { ServiceIdentityConfig, FieldAlias } from "@/services/service_streams";
 
@@ -388,6 +389,82 @@ describe("telemetryCorrelation", () => {
 
     it("passes base filters through untouched with an empty group map", () => {
       expect(applyFilterOverlay({ a: "1" }, { a: "2", b: "3" }, new Map())).toEqual({ a: "2" });
+    });
+  });
+
+  describe("applyDimensionEditsToFilters", () => {
+    const f2d = new Map<string, string>([
+      ["k8s_namespace_name", "k8s-namespace"],
+      ["service_k8s_namespace_name", "k8s-namespace"],
+    ]);
+
+    it("applies semantic-ID-keyed edits (IncidentDetailDrawer path)", () => {
+      expect(
+        applyDimensionEditsToFilters({ k8s_namespace_name: "a" }, { "k8s-namespace": "b" }, f2d),
+      ).toEqual({ k8s_namespace_name: "b" });
+    });
+
+    it("applies raw-field-keyed edits (SearchResult dialog path — F36)", () => {
+      expect(
+        applyDimensionEditsToFilters(
+          { k8s_namespace_name: "a" },
+          { k8s_namespace_name: "b" },
+          f2d,
+        ),
+      ).toEqual({ k8s_namespace_name: "b" });
+    });
+
+    it("resolves a raw-field-keyed edit to the stream's own alias for the same group", () => {
+      // The dimension bar was seeded from a log stream's field name; the metric
+      // stream spells the same concept differently.
+      expect(
+        applyDimensionEditsToFilters(
+          { service_k8s_namespace_name: "a" },
+          { k8s_namespace_name: "b" },
+          f2d,
+        ),
+      ).toEqual({ service_k8s_namespace_name: "b" });
+    });
+
+    it("prefers the raw-field edit over the semantic-ID edit for the same filter", () => {
+      expect(
+        applyDimensionEditsToFilters(
+          { k8s_namespace_name: "a" },
+          { k8s_namespace_name: "raw", "k8s-namespace": "semantic" },
+          f2d,
+        ),
+      ).toEqual({ k8s_namespace_name: "raw" });
+    });
+
+    it("leaves filters without an edit untouched", () => {
+      expect(applyDimensionEditsToFilters({ x: "1" }, { "k8s-namespace": "b" }, f2d)).toEqual({
+        x: "1",
+      });
+    });
+
+    it("resolves filter keys case-insensitively", () => {
+      expect(
+        applyDimensionEditsToFilters({ K8S_NAMESPACE_NAME: "a" }, { "k8s-namespace": "b" }, f2d),
+      ).toEqual({ K8S_NAMESPACE_NAME: "b" });
+    });
+
+    it("keeps an empty-string edit (clearing a value is a real edit)", () => {
+      expect(
+        applyDimensionEditsToFilters({ k8s_namespace_name: "a" }, { k8s_namespace_name: "" }, f2d),
+      ).toEqual({ k8s_namespace_name: "" });
+    });
+
+    it("never adds a filter key the stream does not already have", () => {
+      expect(
+        applyDimensionEditsToFilters({ x: "1" }, { k8s_namespace_name: "b", other: "c" }, f2d),
+      ).toEqual({ x: "1" });
+    });
+
+    it("returns a copy and does not mutate the input filters", () => {
+      const filters = { k8s_namespace_name: "a" };
+      const result = applyDimensionEditsToFilters(filters, { "k8s-namespace": "b" }, f2d);
+      expect(filters).toEqual({ k8s_namespace_name: "a" });
+      expect(result).not.toBe(filters);
     });
   });
 });

--- a/web/src/utils/telemetryCorrelation.spec.ts
+++ b/web/src/utils/telemetryCorrelation.spec.ts
@@ -347,7 +347,11 @@ describe("telemetryCorrelation", () => {
     it("resolves an override to the stream's own alias for the same group (F35)", () => {
       // Chip key came from stream A ("k8s_namespace_name"); stream B uses the other alias.
       expect(
-        applyFilterOverlay({ service_k8s_namespace_name: "a" }, { k8s_namespace_name: "b" }, groups),
+        applyFilterOverlay(
+          { service_k8s_namespace_name: "a" },
+          { k8s_namespace_name: "b" },
+          groups,
+        ),
       ).toEqual({ service_k8s_namespace_name: "b" });
     });
 
@@ -407,11 +411,7 @@ describe("telemetryCorrelation", () => {
 
     it("applies raw-field-keyed edits (SearchResult dialog path — F36)", () => {
       expect(
-        applyDimensionEditsToFilters(
-          { k8s_namespace_name: "a" },
-          { k8s_namespace_name: "b" },
-          f2d,
-        ),
+        applyDimensionEditsToFilters({ k8s_namespace_name: "a" }, { k8s_namespace_name: "b" }, f2d),
       ).toEqual({ k8s_namespace_name: "b" });
     });
 
@@ -493,9 +493,9 @@ describe("telemetryCorrelation", () => {
     });
 
     it("adds an override whose group is not present in the filters", () => {
-      expect(mergeSubjectOverrides({ k8s_pod_name: "p" }, { k8s_namespace_name: "n" }, groups)).toEqual(
-        { k8s_pod_name: "p", k8s_namespace_name: "n" },
-      );
+      expect(
+        mergeSubjectOverrides({ k8s_pod_name: "p" }, { k8s_namespace_name: "n" }, groups),
+      ).toEqual({ k8s_pod_name: "p", k8s_namespace_name: "n" });
     });
 
     it("leaves filters of other groups untouched while replacing one group", () => {

--- a/web/src/utils/telemetryCorrelation.ts
+++ b/web/src/utils/telemetryCorrelation.ts
@@ -203,6 +203,45 @@ export function applyDimensionEditsToFilters(
 }
 
 /**
+ * Merge schema-verified subject overrides into ONE stream's filters (F31).
+ *
+ * The backend resolves a stream's filters using its own alias for a semantic
+ * group; the subject override is resolved against the stream schema and may
+ * land on a different alias of the SAME group. A plain spread therefore UNIONS
+ * the two aliases into `WHERE old_alias = 'prod' AND new_alias = 'staging'`,
+ * which matches nothing. Replace the same-group key instead of adding to it.
+ *
+ * An override whose group has no counterpart in `filters` is added — it was
+ * resolved against the stream schema, so the column is known to exist.
+ *
+ * @param filters - the stream's own filters, keyed by its raw field names
+ * @param overrides - schema-verified field name -> value
+ * @param fieldToGroupId - lowercased field name -> semantic group ID (see buildFieldToGroupIdMap)
+ */
+export function mergeSubjectOverrides(
+  filters: Record<string, string>,
+  overrides: Record<string, string>,
+  fieldToGroupId: Map<string, string>,
+): Record<string, string> {
+  const effective: Record<string, string> = { ...filters };
+
+  for (const [hit, value] of Object.entries(overrides)) {
+    const groupId = fieldToGroupId.get(hit.toLowerCase());
+    const existingKey = Object.keys(effective).find(
+      (key) =>
+        key === hit ||
+        (groupId !== undefined && fieldToGroupId.get(key.toLowerCase()) === groupId),
+    );
+    if (existingKey !== undefined && existingKey !== hit) {
+      delete effective[existingKey];
+    }
+    effective[hit] = value;
+  }
+
+  return effective;
+}
+
+/**
  * Filter dimensions to only include fields that are actually used for disambiguation
  *
  * This implements the same logic as the backend to determine which dimensions are relevant

--- a/web/src/utils/telemetryCorrelation.ts
+++ b/web/src/utils/telemetryCorrelation.ts
@@ -155,6 +155,54 @@ export function applyFilterOverlay(
 }
 
 /**
+ * Apply dimension-bar edits to ONE stream's filters (F36).
+ *
+ * `activeDimensions` is raw-field-keyed when the bar was seeded from stream
+ * filters (SearchResult / TraceDetailsSidebar dialog path) and
+ * semantic-ID-keyed when seeded from `matched_dimensions`
+ * (IncidentDetailDrawer path) — the component cannot tell which, so look up
+ * BOTH key spaces, raw field first.
+ *
+ * Only existing filter keys are updated: adding a key would emit a WHERE
+ * condition on a column the stream does not have.
+ *
+ * @param filters - the stream's own filters, keyed by its raw field names
+ * @param activeDimensions - edited values, keyed by raw field name OR semantic group ID
+ * @param fieldToDimensionId - lowercased field name -> semantic group ID (see buildFieldToGroupIdMap)
+ */
+export function applyDimensionEditsToFilters(
+  filters: Record<string, string>,
+  activeDimensions: Record<string, string>,
+  fieldToDimensionId: Map<string, string>,
+): Record<string, string> {
+  const updated: Record<string, string> = { ...filters };
+
+  for (const filterKey of Object.keys(filters)) {
+    const dimensionId = fieldToDimensionId.get(filterKey.toLowerCase());
+
+    // Raw-field key wins over the semantic-ID key. When the bar was seeded from
+    // a different stream's alias, fall back to any edit whose key resolves to
+    // the same semantic group.
+    let newValue = activeDimensions[filterKey];
+    if (newValue === undefined && dimensionId !== undefined) {
+      newValue = activeDimensions[dimensionId];
+    }
+    if (newValue === undefined && dimensionId !== undefined) {
+      const aliasKey = Object.keys(activeDimensions).find(
+        (key) => fieldToDimensionId.get(key.toLowerCase()) === dimensionId,
+      );
+      if (aliasKey !== undefined) newValue = activeDimensions[aliasKey];
+    }
+
+    if (newValue !== undefined) {
+      updated[filterKey] = newValue;
+    }
+  }
+
+  return updated;
+}
+
+/**
  * Filter dimensions to only include fields that are actually used for disambiguation
  *
  * This implements the same logic as the backend to determine which dimensions are relevant

--- a/web/src/utils/telemetryCorrelation.ts
+++ b/web/src/utils/telemetryCorrelation.ts
@@ -229,8 +229,7 @@ export function mergeSubjectOverrides(
     const groupId = fieldToGroupId.get(hit.toLowerCase());
     const existingKey = Object.keys(effective).find(
       (key) =>
-        key === hit ||
-        (groupId !== undefined && fieldToGroupId.get(key.toLowerCase()) === groupId),
+        key === hit || (groupId !== undefined && fieldToGroupId.get(key.toLowerCase()) === groupId),
     );
     if (existingKey !== undefined && existingKey !== hit) {
       delete effective[existingKey];

--- a/web/src/utils/telemetryCorrelation.ts
+++ b/web/src/utils/telemetryCorrelation.ts
@@ -168,6 +168,23 @@ export function filterDimensionsForCorrelation(
 }
 
 /**
+ * SQL escaping for correlation query builders. Values originate from
+ * telemetry labels (user-controlled data) — every builder MUST route
+ * field/value interpolation through these helpers (F2).
+ */
+export function quoteSqlIdentifier(field: string): string {
+  return `"${String(field).replace(/"/g, '""')}"`;
+}
+
+export function quoteSqlLiteral(value: string): string {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+export function buildSqlCondition(field: string, value: string): string {
+  return `${quoteSqlIdentifier(field)} = ${quoteSqlLiteral(value)}`;
+}
+
+/**
  * Build WHERE clause conditions using exact field names from StreamInfo.filters
  *
  * Uses the exact field names returned by the _correlate API instead of semantic variations.
@@ -181,9 +198,7 @@ function buildExactDimensionConditions(filters: Record<string, string>): string[
     if (value === SELECT_ALL_VALUE) {
       continue;
     }
-    // Escape single quotes in value
-    const escapedValue = value.replace(/'/g, "''");
-    conditions.push(`${fieldName} = '${escapedValue}'`);
+    conditions.push(buildSqlCondition(fieldName, value));
   }
 
   return conditions;

--- a/web/src/utils/telemetryCorrelation.ts
+++ b/web/src/utils/telemetryCorrelation.ts
@@ -112,6 +112,49 @@ export function buildFieldToGroupIdMap(semanticGroups: FieldAlias[]): Map<string
 }
 
 /**
+ * Overlay user filter edits onto ONE stream's base filters (F35).
+ *
+ * Chip keys are raw field names harvested from a single stream, but every
+ * correlated stream carries its own alias for the same semantic group (e.g.
+ * a log stream's `k8s_namespace_name` vs a trace stream's
+ * `service_k8s_namespace_name`). Requiring literal key identity silently drops
+ * the user's edit for every stream that spells the field differently, so the
+ * override is resolved through the semantic group when the exact key is absent.
+ *
+ * Precedence: an exact key match always wins; only then do we fall back to the
+ * group. Overrides that match neither are dropped — adding them would emit a
+ * WHERE condition on a column the stream does not have.
+ *
+ * @param baseFilters - the stream's own filters, keyed by its raw field names
+ * @param overrides - user-edited values, keyed by whichever stream's field names the chips came from
+ * @param fieldToGroupId - lowercased field name -> semantic group ID (see buildFieldToGroupIdMap)
+ */
+export function applyFilterOverlay(
+  baseFilters: Record<string, string>,
+  overrides: Record<string, string>,
+  fieldToGroupId: Map<string, string>,
+): Record<string, string> {
+  const effective: Record<string, string> = { ...baseFilters };
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (key in baseFilters) {
+      effective[key] = value;
+      continue;
+    }
+
+    const groupId = fieldToGroupId.get(key.toLowerCase());
+    if (!groupId) continue;
+
+    const target = Object.keys(baseFilters).find(
+      (baseKey) => fieldToGroupId.get(baseKey.toLowerCase()) === groupId,
+    );
+    if (target) effective[target] = value;
+  }
+
+  return effective;
+}
+
+/**
  * Filter dimensions to only include fields that are actually used for disambiguation
  *
  * This implements the same logic as the backend to determine which dimensions are relevant


### PR DESCRIPTION
## Summary

OSS half of the correlation P0/P1 fix set from the line-by-line review (`docs/ak_review/correlation-line-by-line-review-2026-08-06.md`). Companion enterprise PR: same branch name in o2-enterprise (required for CI manifest pairing).

### Fixes (by review finding)

| Finding | Fix |
|---|---|
| **F14** | `StreamInfo.dropped_dimensions` contract field (`#[serde(default, skip_serializing_if)]`, backward-compatible wire format) + TS type |
| **F8** | Shared coverage-based identity-set ranking (`resolve_best_set_by_coverage`) in `config::meta::correlation` — full coverage > ratio > count, declaration-order ties; ingest and read now rank identically |
| **F10** | `save_identity_config` purges rows of removed/changed sets (`obsolete_set_ids`) + cache clear + org reload event |
| **F6** | `_reset` routes through enterprise `ServiceStorage::delete_all` (cache clear + super-cluster replication) and emits an org-scope reload; super-cluster Delete consumer emits org reload instead of per-service delete |
| **F19** | `infra::table::service_streams::put`/`delete_subset_orphans` return deleted orphan disambiguations so callers can evict cache keys |
| **F2** | `config::utils::sql::validate_where_fragment` (sqlparser) applied to the `filter` param at both `traces/latest*` interpolation sites — statement smuggling and comment-truncation payloads → 400 |
| **F2/F38** | FE: shared `quoteSqlIdentifier`/`quoteSqlLiteral`/`buildSqlCondition` adopted by all six SQL builders (two trace paths were fully unescaped) |
| **F35** | `applyFilterOverlay`: filter edits resolve per-stream via semantic groups instead of literal key identity; dead `removeFilter`/`resetFilters` removed; `semanticGroups` threaded to `CorrelatedLogsTable` parents |
| **F36** | `applyDimensionEditsToFilters`: dimension-bar edits work in both key spaces (raw-field and semantic-ID), case-insensitive shared field→group map |
| **F31** | `mergeSubjectOverrides`: subject overrides replace the same-group key (never union two aliases into contradictory WHERE), schema-less field guessing removed |
| F14 (FE) | Warning banner shipped, then removed by reviewer decision (`dropped_dimensions` stays in the API) |

### Verification

- `cargo test -p config` correlation/service_streams/sql: 121 tests green; enterprise-feature and OSS-only cfg builds both compile
- FE: 263 vitest tests green across the correlation suites; vue-tsc clean
- **Live-verified** against a local build (fresh DB): 19/19 API checks (raw-value emission, set filing, obsolete-set purge, reset cache invalidation, orphan eviction, filter validation) plus browser checks (escaped SQL on the wire: `"environment" = 'Prod-EU'`)

Deliberately out of scope (per review decision): F15, F17/F37, F9.
