### PR TITLE
chore(deps): remove unused proc-macro-error2 patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15102,8 +15102,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "git+https://github.com/hengfeiyang/proc-macro-error-2?branch=main#9170a9d18fef904daf611c95256d90e0b86f0890"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -652,5 +652,4 @@ datafusion-pruning = { git = "https://github.com/openobserve/datafusion", rev = 
 datafusion-session = { git = "https://github.com/openobserve/datafusion", rev = "869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b" }
 datafusion-sql = { git = "https://github.com/openobserve/datafusion", rev = "869ec1a70482e1a26c4ac2fde3e9fd5545c33d7b" }
 object_store = { git = "https://github.com/openobserve/arrow-rs-object-store", branch = "openobserve-v0.13.2" }
-proc-macro-error2 = { git = "https://github.com/hengfeiyang/proc-macro-error-2", branch = "main" }
 tantivy = { git = "https://github.com/openobserve/tantivy", branch = "perf/openobserve" }


### PR DESCRIPTION
## Summary

- remove the crates.io patch for proc-macro-error2, which is no longer present in the resolved dependency graph
- remove the generated patch.unused entry from Cargo.lock
- keep the OSS manifest and enterprise mirror cleanup aligned
- companion Enterprise PR: openobserve/o2-enterprise#2369

## Testing

- cargo metadata --locked --all-features
- verified proc-macro-error2 is absent from the resolved package set
- git diff --check