### PR TITLE
ci: fix weekly npm update type-check failure and rename branch/PR

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -34,25 +34,51 @@ jobs:
 
       - name: Create update branch
         run: |
-          BRANCH_NAME="automated/npm-update-$(date +%Y%m%d)"
+          BRANCH_NAME="chore/npm-update-$(date +%Y%m%d)"
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
-      - name: Check for outdated packages
+      - name: Install current dependencies
+        run: |
+          cd web
+          # Install from the lockfile first so `npm outdated`/ncu report accurate
+          # "current" versions, and so the toolchain exists for the later checks.
+          npm ci
+
+      - name: Check for available updates
         id: check_updates
         run: |
           cd web
-          echo "Checking for outdated packages..."
-          npm outdated --json > outdated.json || true
 
-          if [ -s outdated.json ] && [ "$(cat outdated.json)" != "{}" ]; then
+          # Snapshot the pre-update manifest so the PR body can show old → new.
+          cp package.json "$RUNNER_TEMP/package.json.before"
+
+          # IMPORTANT: --target minor keeps upgrades inside the current major.
+          # Unrestricted major bumps break the build toolchain (e.g. typescript
+          # 5.x -> 7.x drops the `./lib/tsc` export that vue-tsc still requires).
+          # Major upgrades stay a deliberate, manual decision.
+          npx --yes npm-check-updates --target minor --peer --jsonUpgraded \
+            > "$RUNNER_TEMP/upgrades.json"
+
+          if ! jq -e 'type == "object"' "$RUNNER_TEMP/upgrades.json" > /dev/null; then
+            echo "npm-check-updates did not return valid JSON:"
+            cat "$RUNNER_TEMP/upgrades.json"
+            exit 1
+          fi
+
+          if [ "$(jq 'length' "$RUNNER_TEMP/upgrades.json")" -gt 0 ]; then
             echo "has_updates=true" >> $GITHUB_OUTPUT
-            echo "Found outdated packages:"
-            cat outdated.json | jq '.'
+            echo "Packages to upgrade:"
+            jq '.' "$RUNNER_TEMP/upgrades.json"
           else
             echo "has_updates=false" >> $GITHUB_OUTPUT
-            echo "No outdated packages found"
+            echo "No in-major updates available"
           fi
+
+          # Informational only: majors deliberately held back, surfaced in the PR
+          # body so reviewers know what still needs a manual upgrade.
+          npx --yes npm-check-updates --target latest --jsonUpgraded \
+            > "$RUNNER_TEMP/majors.json" || echo '{}' > "$RUNNER_TEMP/majors.json"
 
       - name: Update dependencies
         if: steps.check_updates.outputs.has_updates == 'true'
@@ -60,14 +86,10 @@ jobs:
           cd web
           echo "Updating dependencies..."
 
-          # Update all dependencies to their latest versions
-          # This will update both package.json and package-lock.json
-          npm update --save
+          # Apply the same in-major upgrades that were just reported.
+          npx --yes npm-check-updates -u --target minor --peer
 
-          # Also check for major version updates and update them
-          npx npm-check-updates -u
-
-          # Install to ensure package-lock.json is updated
+          # Resolve the new ranges and regenerate package-lock.json
           npm install
 
           echo "Dependencies updated successfully"
@@ -99,16 +121,29 @@ jobs:
         if: steps.check_updates.outputs.has_updates == 'true'
         id: summary
         run: |
-          cd web
+          # Map of package -> previous range, from the pre-update manifest.
+          BEFORE=$(jq -c '(.dependencies // {}) + (.devDependencies // {})' \
+            "$RUNNER_TEMP/package.json.before")
 
-          # Get the list of updated packages
-          UPDATED_PACKAGES=$(cat outdated.json | jq -r 'to_entries[] | "- **\(.key)**: \(.value.current) → \(.value.latest)"')
+          UPDATED_PACKAGES=$(jq -r --argjson before "$BEFORE" \
+            'to_entries[] | "- **\(.key)**: \($before[.key] // "n/a") → \(.value)"' \
+            "$RUNNER_TEMP/upgrades.json")
 
-          # Create PR body
-          cat > /tmp/pr_body.md <<EOF
+          # Drop entries whose "latest" is the same version the minor pass already
+          # applied — those are not held back.
+          HELD_BACK=$(jq -r --argjson before "$BEFORE" \
+            --slurpfile minor "$RUNNER_TEMP/upgrades.json" \
+            'to_entries[] | select($minor[0][.key] != .value)
+             | "- **\(.key)**: \($before[.key] // "n/a") → \(.value)"' \
+            "$RUNNER_TEMP/majors.json")
+          if [ -z "$HELD_BACK" ]; then
+            HELD_BACK="_None — every dependency is on its latest major._"
+          fi
+
+          cat > "$RUNNER_TEMP/pr_body.md" <<EOF
           ## 📦 Weekly NPM Dependencies Update
 
-          This automated PR updates npm packages to their latest versions.
+          This automated PR updates \`web/\` npm packages within their current major versions.
 
           ### Updated Packages
 
@@ -120,9 +155,16 @@ jobs:
           - ✅ Unit tests passed
           - ✅ Build successful
 
+          ### Major Upgrades Available (not applied)
+
+          Majors are intentionally excluded — they routinely break the build toolchain
+          (e.g. \`typescript\` 7.x drops the \`./lib/tsc\` export that \`vue-tsc\` requires).
+          Upgrade these deliberately in a dedicated PR:
+
+          $HELD_BACK
+
           ### Notes
 
-          - All dependencies have been updated to their latest compatible versions
           - \`package-lock.json\` has been regenerated
           - All tests passed successfully
 
@@ -138,24 +180,22 @@ jobs:
       - name: Commit changes
         if: steps.check_updates.outputs.has_updates == 'true'
         run: |
-          cd web
-
-          # Check if there are changes to commit
-          if [[ -n $(git status --porcelain) ]]; then
-            git add package.json package-lock.json
-            git commit -m "chore: update npm dependencies ($(date +%Y-%m-%d))
-
-            - Updated packages to their latest versions
-            - Regenerated package-lock.json
-            - All tests passing
-
-            🤖 Automated update by GitHub Actions"
+          # Scope the check to the manifest files so stray build artifacts never
+          # trigger an empty dependency PR.
+          if git diff --quiet -- web/package.json web/package-lock.json; then
+            echo "No dependency changes to commit"
+            echo "changes_committed=false" >> $GITHUB_ENV
+          else
+            git add web/package.json web/package-lock.json
+            git commit \
+              -m "chore(deps): update web npm dependencies ($(date +%Y-%m-%d))" \
+              -m "- Updated packages to their latest in-major versions" \
+              -m "- Regenerated package-lock.json" \
+              -m "- Type check, unit tests and build all passing" \
+              -m "🤖 Automated update by GitHub Actions"
 
             git push origin "$BRANCH_NAME"
             echo "changes_committed=true" >> $GITHUB_ENV
-          else
-            echo "No changes to commit"
-            echo "changes_committed=false" >> $GITHUB_ENV
           fi
 
       - name: Create Pull Request
@@ -164,8 +204,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr create \
-            --title "chore: Weekly NPM dependencies update ($(date +%Y-%m-%d))" \
-            --body-file /tmp/pr_body.md \
+            --title "chore(deps): update web npm dependencies ($(date +%Y-%m-%d))" \
+            --body-file "$RUNNER_TEMP/pr_body.md" \
             --base main \
             --head "$BRANCH_NAME" \
             --label "dependencies" \
@@ -174,4 +214,4 @@ jobs:
       - name: No updates needed
         if: steps.check_updates.outputs.has_updates == 'false'
         run: |
-          echo "✅ All npm packages are up to date. No PR needed."
+          echo "✅ All npm packages are up to date within their current majors. No PR needed."

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -13,8 +13,10 @@ permissions:
 jobs:
   update-dependencies:
     name: Update NPM Dependencies
-    runs-on:
-      labels: ubicloud-standard-8
+    # This job only bumps the manifest and opens the PR. Type check, unit tests
+    # and build all run as normal PR checks on the resulting pull request, so
+    # nothing here needs to install node_modules or compile anything.
+    runs-on: ubuntu-latest
 
     steps:
       - name: Clone the current repo
@@ -38,13 +40,6 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
-      - name: Install current dependencies
-        run: |
-          cd web
-          # Install from the lockfile first so `npm outdated`/ncu report accurate
-          # "current" versions, and so the toolchain exists for the later checks.
-          npm ci
-
       - name: Check for available updates
         id: check_updates
         run: |
@@ -53,11 +48,7 @@ jobs:
           # Snapshot the pre-update manifest so the PR body can show old → new.
           cp package.json "$RUNNER_TEMP/package.json.before"
 
-          # IMPORTANT: --target minor keeps upgrades inside the current major.
-          # Unrestricted major bumps break the build toolchain (e.g. typescript
-          # 5.x -> 7.x drops the `./lib/tsc` export that vue-tsc still requires).
-          # Major upgrades stay a deliberate, manual decision.
-          npx --yes npm-check-updates --target minor --peer --jsonUpgraded \
+          npx --yes npm-check-updates --target latest --peer --jsonUpgraded \
             > "$RUNNER_TEMP/upgrades.json"
 
           if ! jq -e 'type == "object"' "$RUNNER_TEMP/upgrades.json" > /dev/null; then
@@ -72,13 +63,8 @@ jobs:
             jq '.' "$RUNNER_TEMP/upgrades.json"
           else
             echo "has_updates=false" >> $GITHUB_OUTPUT
-            echo "No in-major updates available"
+            echo "No updates available"
           fi
-
-          # Informational only: majors deliberately held back, surfaced in the PR
-          # body so reviewers know what still needs a manual upgrade.
-          npx --yes npm-check-updates --target latest --jsonUpgraded \
-            > "$RUNNER_TEMP/majors.json" || echo '{}' > "$RUNNER_TEMP/majors.json"
 
       - name: Update dependencies
         if: steps.check_updates.outputs.has_updates == 'true'
@@ -86,36 +72,14 @@ jobs:
           cd web
           echo "Updating dependencies..."
 
-          # Apply the same in-major upgrades that were just reported.
-          npx --yes npm-check-updates -u --target minor --peer
+          # Apply the same upgrades that were just reported.
+          npx --yes npm-check-updates -u --target latest --peer
 
-          # Resolve the new ranges and regenerate package-lock.json
-          npm install
+          # Regenerate package-lock.json only — node_modules is never needed
+          # here, and skipping the install keeps this job to well under a minute.
+          npm install --package-lock-only
 
           echo "Dependencies updated successfully"
-
-      - name: Run type check
-        if: steps.check_updates.outputs.has_updates == 'true'
-        run: |
-          cd web
-          echo "Running type check..."
-          npm run type-check
-
-      - name: Run unit tests
-        if: steps.check_updates.outputs.has_updates == 'true'
-        run: |
-          cd web
-          echo "Running unit tests..."
-          npm run test:unit:coverage
-
-      - name: Build project
-        if: steps.check_updates.outputs.has_updates == 'true'
-        env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
-        run: |
-          cd web
-          echo "Building project..."
-          npm run build
 
       - name: Generate update summary
         if: steps.check_updates.outputs.has_updates == 'true'
@@ -129,46 +93,22 @@ jobs:
             'to_entries[] | "- **\(.key)**: \($before[.key] // "n/a") → \(.value)"' \
             "$RUNNER_TEMP/upgrades.json")
 
-          # Drop entries whose "latest" is the same version the minor pass already
-          # applied — those are not held back.
-          HELD_BACK=$(jq -r --argjson before "$BEFORE" \
-            --slurpfile minor "$RUNNER_TEMP/upgrades.json" \
-            'to_entries[] | select($minor[0][.key] != .value)
-             | "- **\(.key)**: \($before[.key] // "n/a") → \(.value)"' \
-            "$RUNNER_TEMP/majors.json")
-          if [ -z "$HELD_BACK" ]; then
-            HELD_BACK="_None — every dependency is on its latest major._"
-          fi
-
           cat > "$RUNNER_TEMP/pr_body.md" <<EOF
           ## 📦 Weekly NPM Dependencies Update
 
-          This automated PR updates \`web/\` npm packages within their current major versions.
+          This automated PR updates \`web/\` npm packages to their latest versions
+          and regenerates \`package-lock.json\`.
 
           ### Updated Packages
 
           $UPDATED_PACKAGES
 
-          ### Testing Results
+          ### Validation
 
-          - ✅ Type check passed
-          - ✅ Unit tests passed
-          - ✅ Build successful
-
-          ### Major Upgrades Available (not applied)
-
-          Majors are intentionally excluded — they routinely break the build toolchain
-          (e.g. \`typescript\` 7.x drops the \`./lib/tsc\` export that \`vue-tsc\` requires).
-          Upgrade these deliberately in a dedicated PR:
-
-          $HELD_BACK
-
-          ### Notes
-
-          - \`package-lock.json\` has been regenerated
-          - All tests passed successfully
-
-          Please review the changes and merge if everything looks good.
+          This workflow does **not** run any checks — type check, unit tests and
+          build all run as normal PR checks below. Review the results there before
+          merging; a red check usually means one of the upgrades above needs to be
+          pinned back or accompanied by a code change.
 
           ---
 
@@ -180,7 +120,7 @@ jobs:
       - name: Commit changes
         if: steps.check_updates.outputs.has_updates == 'true'
         run: |
-          # Scope the check to the manifest files so stray build artifacts never
+          # Scope the check to the manifest files so stray artifacts never
           # trigger an empty dependency PR.
           if git diff --quiet -- web/package.json web/package-lock.json; then
             echo "No dependency changes to commit"
@@ -189,9 +129,8 @@ jobs:
             git add web/package.json web/package-lock.json
             git commit \
               -m "chore(deps): update web npm dependencies ($(date +%Y-%m-%d))" \
-              -m "- Updated packages to their latest in-major versions" \
+              -m "- Updated packages to their latest versions" \
               -m "- Regenerated package-lock.json" \
-              -m "- Type check, unit tests and build all passing" \
               -m "🤖 Automated update by GitHub Actions"
 
             git push origin "$BRANCH_NAME"
@@ -214,4 +153,4 @@ jobs:
       - name: No updates needed
         if: steps.check_updates.outputs.has_updates == 'false'
         run: |
-          echo "✅ All npm packages are up to date within their current majors. No PR needed."
+          echo "✅ All npm packages are up to date. No PR needed."

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -139,7 +139,19 @@ jobs:
               -m "- Regenerated package-lock.json" \
               -m "🤖 Automated update by GitHub Actions"
 
-            git push origin "$BRANCH_NAME"
+            # The branch name is date-stamped, so a second run on the same day
+            # (a re-run, or a manual dispatch after the scheduled one) finds the
+            # earlier run's branch already on the remote. This branch is entirely
+            # machine-owned and rebuilt from main every run, so replacing it is
+            # correct — a plain push would just fail non-fast-forward.
+            if git ls-remote --exit-code --heads origin "$BRANCH_NAME" > /dev/null 2>&1; then
+              echo "Branch $BRANCH_NAME already exists on the remote — replacing it"
+              git fetch origin "+refs/heads/$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME"
+              git push --force-with-lease origin "$BRANCH_NAME"
+            else
+              git push origin "$BRANCH_NAME"
+            fi
+
             echo "changes_committed=true" >> $GITHUB_ENV
           fi
 
@@ -149,13 +161,27 @@ jobs:
           # Same PAT as the checkout — the PR author is whoever owns this token.
           GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
         run: |
-          PR_URL=$(gh pr create \
-            --title "chore(deps): update web npm dependencies ($(date +%Y-%m-%d))" \
-            --body-file "$RUNNER_TEMP/pr_body.md" \
-            --base main \
-            --head "$BRANCH_NAME")
+          TITLE="chore(deps): update web npm dependencies ($(date +%Y-%m-%d))"
 
-          echo "Opened $PR_URL"
+          # If an earlier run today already opened a PR for this branch, the
+          # force-push above updated it in place — `gh pr create` would fail with
+          # "a pull request for branch ... already exists". Refresh it instead.
+          PR_URL=$(gh pr list --head "$BRANCH_NAME" --state open \
+            --json url --jq '.[0].url // empty')
+
+          if [ -n "$PR_URL" ]; then
+            gh pr edit "$PR_URL" \
+              --title "$TITLE" \
+              --body-file "$RUNNER_TEMP/pr_body.md"
+            echo "Refreshed existing $PR_URL"
+          else
+            PR_URL=$(gh pr create \
+              --title "$TITLE" \
+              --body-file "$RUNNER_TEMP/pr_body.md" \
+              --base main \
+              --head "$BRANCH_NAME")
+            echo "Opened $PR_URL"
+          fi
 
           # Labels and assignee are applied separately and best-effort. Passing
           # them to `gh pr create` makes a single bad value abort the whole

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # A PAT, not GITHUB_TOKEN. Pushes made with GITHUB_TOKEN do not start
+          # workflow runs, so the resulting PR would sit there with zero checks —
+          # and the whole point of this job is to hand verification to PR CI.
+          token: ${{ secrets.ORG_ADMIN_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -31,8 +35,10 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Commit as Bhargav rather than the bot, so the commit and the PR share
+          # one author and the PR shows up under his own filters.
+          git config user.name "Bhargav"
+          git config user.email "551527+bjp232004@users.noreply.github.com"
 
       - name: Create update branch
         run: |
@@ -140,15 +146,25 @@ jobs:
       - name: Create Pull Request
         if: steps.check_updates.outputs.has_updates == 'true' && env.changes_committed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Same PAT as the checkout — the PR author is whoever owns this token.
+          GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
         run: |
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "chore(deps): update web npm dependencies ($(date +%Y-%m-%d))" \
             --body-file "$RUNNER_TEMP/pr_body.md" \
             --base main \
-            --head "$BRANCH_NAME" \
-            --label "dependencies" \
-            --label "automated"
+            --head "$BRANCH_NAME")
+
+          echo "Opened $PR_URL"
+
+          # Labels and assignee are applied separately and best-effort. Passing
+          # them to `gh pr create` makes a single bad value abort the whole
+          # command, leaving the already-pushed branch behind with no PR at all.
+          gh pr edit "$PR_URL" \
+            --add-assignee "bjp232004" \
+            --add-label "dependencies" \
+            --add-label "auto-generated" \
+            || echo "::warning::Could not apply assignee/labels to $PR_URL"
 
       - name: No updates needed
         if: steps.check_updates.outputs.has_updates == 'false'

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -35,10 +35,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          # Commit as Bhargav rather than the bot, so the commit and the PR share
+          # Commit as one of the user rather than the bot, so the commit and the PR share
           # one author and the PR shows up under his own filters.
-          git config user.name "Bhargav"
-          git config user.email "551527+bjp232004@users.noreply.github.com"
 
       - name: Create update branch
         run: |

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -17,11 +17,16 @@ on:
         required: false
         default: ''
 
-# Cancel an in-progress run if a newer push to the same ref arrives, so we don't
-# pay for superseded translation runs.
+# Serialise runs on the same ref, but never cancel one that is already working.
+# `cancel-in-progress: true` was actively harmful here: en-US.json lands on main
+# more often than a backlog run takes, so every run was killed by the next merge
+# and its API spend thrown away (20 of the last 40 runs ended `cancelled`, none on
+# main ever succeeded). GitHub keeps at most one running + one pending run per
+# group, so queueing cannot pile up, and the work is incremental — a queued run
+# picks up exactly what its predecessor did not finish.
 concurrency:
   group: update-translations-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   update-translations:
@@ -41,6 +46,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Check out the branch TIP, not the triggering commit. The job is a
+          # reconciliation against .translation_state.json rather than a diff of
+          # one commit, so a run that waited in the concurrency queue must start
+          # from the newest main — which already contains the translations its
+          # predecessor merged. Pinning to github.sha would make it redo that work.
+          ref: ${{ github.ref_name }}
 
       - name: Verify DeepSeek API key secret is configured
         env:
@@ -82,6 +93,14 @@ jobs:
 
       - name: Check for translation changes
         id: check_changes
+        # `always()` because partial progress is still worth shipping. The script
+        # exits non-zero when ANY string failed validation (main.py), and it is
+        # cancellable mid-run — under the default `success()` this step and the PR
+        # steps were skipped, so multi-hour runs that had already written most
+        # locale files produced nothing and the next run repeated the work.
+        # Locale files are written atomically per locale, so whatever is on disk
+        # here is complete, valid JSON.
+        if: always()
         # Use `git status --porcelain` (not `git diff`) so brand-new untracked
         # files — e.g. a freshly created .translation_state.json or a new locale
         # file — are detected, not just modifications to already-tracked files.
@@ -103,7 +122,7 @@ jobs:
       # (Settings → Actions → General → Workflow permissions).
       - name: Create pull request with translation updates
         id: cpr
-        if: steps.check_changes.outputs.changes == 'true'
+        if: always() && steps.check_changes.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -135,7 +154,7 @@ jobs:
       # that user. Store that account's PAT in the TRANSLATIONS_APPROVE_TOKEN
       # secret. PR number is passed via env (never interpolated into the shell body).
       - name: Approve the translation PR
-        if: steps.check_changes.outputs.changes == 'true' && steps.cpr.outputs.pull-request-number
+        if: always() && steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.TRANSLATIONS_APPROVE_TOKEN }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
@@ -150,7 +169,7 @@ jobs:
       # merge_group checks) trigger correctly. Merge method must match the repo's
       # merge-queue configuration — change --squash if the queue uses merge/rebase.
       - name: Enable auto-merge (merge queue)
-        if: steps.check_changes.outputs.changes == 'true' && steps.cpr.outputs.pull-request-number
+        if: always() && steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.TRANSLATIONS_APPROVE_TOKEN }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
@@ -160,13 +179,18 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          SCRIPT_OUTCOME: ${{ steps.run_translation.outcome }}
+          HAS_CHANGES: ${{ steps.check_changes.outputs.changes }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          if [ "${{ steps.run_translation.outcome }}" != "success" ]; then
-            echo "❌ Translation script did not complete successfully (outcome: ${{ steps.run_translation.outcome }}). See the 'Run translation script' step logs."
-            exit 0
-          fi
-          if [ "${{ steps.check_changes.outputs.changes }}" == "true" ]; then
-            echo "✅ Translations updated — PR #${{ steps.cpr.outputs.pull-request-number }} created/updated (branch: chore/update-translations), labeled 'translations,e2e', approved, and set to auto-merge into the merge queue."
+          if [ "$HAS_CHANGES" == "true" ] && [ -n "$PR_NUMBER" ]; then
+            echo "✅ PR #$PR_NUMBER created/updated (branch: chore/update-translations), labeled 'translations,e2e', approved, and set to auto-merge into the merge queue."
+          elif [ "$HAS_CHANGES" == "true" ]; then
+            echo "⚠️  Translation changes exist on disk but no PR was opened — see the 'Create pull request' step."
           else
             echo "ℹ️  No new or modified keys — translations already up to date."
+          fi
+          if [ "$SCRIPT_OUTCOME" != "success" ]; then
+            echo "❌ Translation script outcome: $SCRIPT_OUTCOME — some strings failed or the run was interrupted. Any completed locales are included in the PR above; the rest retry on the next run. See the 'Run translation script' logs."
           fi

--- a/scripts/translations/README.md
+++ b/scripts/translations/README.md
@@ -5,32 +5,42 @@ OpenAI-compatible API.
 
 ## Overview
 
-This system automatically translates the English locale file (`en-US.json`) into multiple languages **during the build process**. It intelligently preserves existing translations and only translates new keys, making it safe to run repeatedly.
+This system automatically translates the English locale file (`en-US.json`) into multiple languages. It intelligently preserves existing translations and only translates new keys, making it safe to run repeatedly.
 
 ## 🚀 How It Works
 
-**Automatic workflow triggered by `en-US.json` changes:**
+**Automatic workflow triggered when `en-US.json` lands on `main`:**
 
-1. **Developer updates `en-US.json`** and pushes to any branch (main, develop, feature branches)
-2. **GitHub Action detects the change** and automatically triggers
+1. **Developer updates `en-US.json`** and merges the change to `main`
+2. **GitHub Actions detects it** via the workflow's `paths:` filter — pushes that don't touch `en-US.json` never start a run at all
 3. **Translation script runs** using DeepSeek to update all language files
-4. **Changes are committed** back to the same branch automatically
+4. **A PR is opened** (`chore/update-translations`), auto-approved and set to auto-merge
 5. **Build workflows use updated files** - all subsequent builds have fresh translations
 
 This means **translations are always up-to-date** without any manual intervention!
 
 ## Supported Languages
 
-- 🇹🇷 Turkish (tr)
-- 🇨🇳 Chinese (zh)
-- 🇫🇷 French (fr)
-- 🇪🇸 Spanish (es)
-- 🇩🇪 German (de)
-- 🇮🇹 Italian (it)
-- 🇵🇹 Portuguese (pt)
-- 🇯🇵 Japanese (ja)
-- 🇰🇷 Korean (ko)
-- 🇳🇱 Dutch (nl)
+The list lives in `LANGUAGE_NAMES` in `translator.py` — that dict is the single
+source of truth for both the locale codes and the language names used in the prompt.
+
+- 🇹🇷 Turkish (tr-TR)
+- 🇨🇳 Simplified Chinese (zh-CN)
+- 🇹🇼 Traditional Chinese (zh-TW)
+- 🇫🇷 French (fr-FR)
+- 🇪🇸 Spanish (es-ES)
+- 🇩🇪 German (de-DE)
+- 🇮🇹 Italian (it-IT)
+- 🇵🇹 Portuguese (pt-PT)
+- 🇯🇵 Japanese (ja-JP)
+- 🇰🇷 Korean (ko-KR)
+- 🇳🇱 Dutch (nl-NL)
+- 🇷🇺 Russian (ru-RU)
+- 🇵🇱 Polish (pl-PL)
+- 🇻🇳 Vietnamese (vi-VN)
+
+RTL languages (Arabic, Persian) are deliberately excluded until the web app has
+`dir="rtl"` support — see the note in `translator.py`.
 
 ## How It Works
 
@@ -69,6 +79,7 @@ export DEEPSEEK_API_KEY=your_api_key
 export DEEPSEEK_MODEL=deepseek-v4-flash        # model id
 export DEEPSEEK_BASE_URL=https://api.deepseek.com
 export TRANSLATION_BATCH_SIZE=50               # strings per API call
+export TRANSLATION_CONCURRENCY=4               # batches in flight per locale (1 = serial)
 ```
 
 ### Running Translations
@@ -95,13 +106,26 @@ python3 main.py fr-FR es-ES de-DE
 
 The workflow (`.github/workflows/update-translations.yml`) automatically runs when:
 
-- **Trigger**: Any push that modifies `web/src/locales/languages/en-US.json`
-- **Branches**: **All branches** (`**`)
+- **Trigger**: A push to `main` that modifies `web/src/locales/languages/en-US.json`
+- **Branches**: **`main` only** (plus manual `workflow_dispatch`)
 - **Action**:
   1. Runs Python translation script
   2. Updates all language JSON files
-  3. Commits changes back to the same branch
-  4. Subsequent builds use the updated files
+  3. Opens PR `chore/update-translations`, approves it, enables auto-merge
+  4. Subsequent builds use the updated files once that PR merges
+
+### Run lifecycle guarantees
+
+Two properties of the workflow matter when you are reading a run:
+
+- **Runs are never cancelled by a newer push.** The concurrency group uses
+  `cancel-in-progress: false`, so at most one run works at a time and at most one
+  waits. A queued run checks out the branch *tip*, so it picks up whatever its
+  predecessor already merged instead of redoing it.
+- **Partial progress is always shipped.** Locale files are written atomically, one
+  locale at a time, and the PR steps run under `if: always()`. A run that fails
+  validation on some strings — or is cancelled manually — still opens a PR with the
+  locales it finished. Anything unfinished simply stays pending for the next run.
 
 ### Setup Requirements
 
@@ -123,33 +147,32 @@ error if this secret is missing.
 
 ```mermaid
 graph TD
-    A[Push Code to Branch] --> B[Update Translations Workflow]
-    B --> C{en-US.json Changed?}
-    C -->|Yes| D[Run Translation Script]
-    C -->|No| E[Skip Translation]
-    D --> F[Commit Updated Languages]
-    E --> G[Mark Complete]
-    F --> G
-    G --> H[Build Workflows Start]
-    H --> I[Build with Latest Translations]
+    A[Push to main] --> C{en-US.json in the diff?}
+    C -->|No| E[No run is created at all]
+    C -->|Yes| D[Run translation script]
+    D --> F{Any new/changed keys<br/>vs .translation_state.json?}
+    F -->|No| G[Done - already up to date]
+    F -->|Yes| H[Translate pending keys only]
+    H --> I[Open/update PR chore/update-translations]
+    I --> J[Auto-approve + auto-merge]
+    J --> K[Build workflows use latest translations]
 ```
 
 **Workflow Execution Order:**
 
-1. **Push code** → `update-translations.yml` runs
-2. Checks if `en-US.json` changed
-   - If YES: Translates and commits back to branch
-   - If NO: Skips (fast, ~10 seconds)
-3. **If translations were committed** → New push event
-4. **Build workflows trigger** on the new commit → Use updated translations
+1. **Merge to `main`** → GitHub's `paths:` filter decides whether a run is created
+2. Script reconciles `en-US.json` against `.translation_state.json`
+   - New / changed keys: translated
+   - Everything else: kept, never re-sent to the API
+3. **If any file changed** → PR opened, approved, auto-merged
+4. **Build workflows** pick up the translations once that PR lands
 
 **Key Features:**
-- ✅ **Always runs** - Checks every push for en-US.json changes
-- ✅ **Smart detection** - Only translates if en-US.json actually changed
-- ✅ **Non-blocking** - Quick skip if no translation needed
-- ✅ **Auto-commit** - Updates committed back to same branch
-- ✅ **Natural flow** - Translation commit triggers builds automatically
-- ✅ **Works everywhere** - All branches (main, develop, feature branches)
+- ✅ **Cheap trigger** - a push without `en-US.json` changes creates no run at all
+- ✅ **Smart detection** - only new or modified keys are translated
+- ✅ **Never re-billed per branch** - runs on `main` only, so each string is translated once, when it lands
+- ✅ **Crash/cancel safe** - completed locales are still shipped in a PR
+- ✅ **Reviewable** - lands as a normal PR rather than a direct push to a protected branch
 
 ### Manual Workflow Trigger
 
@@ -159,7 +182,11 @@ You can also run translations manually:
 2. Select **Update Translations** workflow
 3. Click **Run workflow**
 4. (Optional) Specify specific languages: `fr-FR es-ES de-DE`
-5. Translations will be committed to the current branch
+5. Translations are opened as a PR against the branch you ran it from
+
+> Note: a subset run (specific languages) intentionally does **not** advance
+> `.translation_state.json` — see [Change detection](#change-detection-translation_statejson).
+> Use it to unblock or backfill one language; run all languages to persist state.
 
 ## File Structure
 
@@ -181,40 +208,44 @@ web/src/locales/languages/
 ├── pt-PT.json           # Portuguese translations
 ├── ja-JP.json           # Japanese translations
 ├── ko-KR.json           # Korean translations
-└── nl-NL.json           # Dutch translations
+├── nl-NL.json           # Dutch translations
+├── zh-TW.json           # Traditional Chinese translations
+├── ru-RU.json           # Russian translations
+├── pl-PL.json           # Polish translations
+└── vi-VN.json           # Vietnamese translations
 ```
 
 ## Adding New Languages
 
-1. Add language code to `get_supported_languages()` in `translator.py`
-2. Update the README to reflect the new language
-3. Run the translation script
+1. Add the locale code and language name to `LANGUAGE_NAMES` in `translator.py`
+   (`get_supported_languages()` is derived from it)
+2. Wire the locale into the web app's locale registry (`web/src/locales/`)
+3. Update the README to reflect the new language
+4. Run the translation script
 
 ## Troubleshooting
 
-### Workflow Not Detecting en-US.json Changes
+### No Run Was Created for My en-US.json Change
 
-**Symptom:** You changed `en-US.json` but workflow says "en-US.json not modified"
+**Symptom:** You changed `en-US.json` but no **Update Translations** run appears.
 
-**Solution 1 - Check workflow logs:**
-1. Go to **Actions** → **Update Translations** → Click the run
-2. Look at "Check if en-US.json was modified" step
-3. It shows debug info: event type, before/after SHAs, and changed files
+The trigger is a `paths:` filter on **pushes to `main`** — GitHub evaluates it
+before any job exists, so a non-matching push produces no run at all (this is
+intended: it is what stops feature branches from re-translating the same strings).
 
-**Solution 2 - Debug detection:**
+Check, in order:
+
 ```bash
-# Locally check what git sees
-git show --name-only --pretty="" HEAD
-# Should show web/src/locales/languages/en-US.json
+# 1. Is your change actually on main yet? The workflow does not run on branches.
+git log origin/main --oneline -1 -- web/src/locales/languages/en-US.json
 
-# Check last push
-git diff HEAD~1 --name-only
+# 2. Did the merged commit really touch the source file?
+git show --name-only --pretty="" <sha> | grep en-US.json
 ```
 
-**Root cause:** The detection uses `git diff` to compare commits. If:
-- Multiple commits in one push → Uses `github.event.before` and `github.sha`
-- First commit on branch → Uses `git show HEAD`
-- Manual trigger → Uses `git show HEAD`
+If the file is on `main` and a run exists but produced no PR, the keys were already
+recorded in `.translation_state.json` — nothing was pending. Confirm with a local
+run: `python3 main.py` prints `Translating: <locale> (N strings pending)`.
 
 ### API Key Error
 ```
@@ -238,11 +269,12 @@ ModuleNotFoundError: No module named 'openai'
 
 **Symptom:** Build doesn't have the latest translations
 
-**Solution:** Check if translation workflow ran and committed:
-1. Go to **Actions** → Find the **Update Translations** run
-2. Check if it detected en-US.json changes and committed translations
-3. If translations were committed, the commit should trigger a new build
-4. The new build will have updated translations
+**Solution:** Translations reach `main` through a PR, not a direct push — so check
+that the PR actually merged:
+1. Go to **Actions** → find the latest **Update Translations** run → read its Summary
+2. If it opened a PR, check that `chore/update-translations` merged (auto-merge can
+   stall on a failing required check, leaving the translations sitting in the PR)
+3. Builds started before that PR merged will still carry the old strings
 
 ## Workflow Example
 
@@ -267,7 +299,7 @@ ModuleNotFoundError: No module named 'openai'
 3. **Workflow automatically (on `main` only):**
    - Triggers because `web/src/locales/languages/en-US.json` changed
    - Runs translation script
-   - Translates only the **new or modified** keys to all 10 languages
+   - Translates only the **new or modified** keys to all 14 languages
    - Commits updated `fr-FR.json`, `es-ES.json`, etc. plus `.translation_state.json`
 
 4. **Build workflows:**
@@ -288,8 +320,14 @@ English source each translated value was derived from. On every run the script:
 - **Keeps** already-translated text whose source is unchanged — it is never re-sent to
   the API, and English is never "translated" to English.
 - **Prunes** keys that were removed from `en-US.json`.
-- **Bootstraps** safely: the first run after this file is introduced adopts existing
-  translations as-is (no costly full re-translation, no overwriting manual fixes).
+- **Bootstraps** safely: a key that already has a translation but no recorded hash is
+  adopted as-is (no costly full re-translation, no overwriting manual fixes). This is
+  also what lets a partially-completed run heal: once its locale files merge, those
+  new keys are adopted rather than translated again.
+
+State is only rewritten on a **full run** (every supported language), because a key's
+hash is recorded only when the translation is present in *every* locale. A subset run
+(`python3 main.py fr-FR`) translates correctly but deliberately leaves state untouched.
 
 Commit `.translation_state.json` together with the translation files — it is the
 source of truth that keeps subsequent runs incremental.
@@ -304,16 +342,18 @@ source of truth that keeps subsequent runs incremental.
 
 ## Cost Considerations
 
-Translation is billed per token by DeepSeek. The whole `en-US.json` is ~205k
-characters (~8,300 strings); a full 10-language rebuild is a one-time cost, and
-day-to-day runs only translate the handful of new/changed keys per `en-US.json`
-merge.
+Translation is billed per token by DeepSeek. The whole `en-US.json` is ~10,700
+strings; a full 14-language rebuild is a one-time cost, and day-to-day runs only
+translate the handful of new/changed keys per `en-US.json` merge.
 
 ### Cost Optimization:
 - ✅ Only **new or modified** keys are translated (unchanged text is never re-sent)
 - ✅ Strings are sent in **batches** (`TRANSLATION_BATCH_SIZE`, default 50) to cut request overhead
 - ✅ Runs on **`main` only**, and only when `en-US.json` changes (no per-branch re-billing)
-- ✅ Superseded runs are cancelled (`concurrency` with `cancel-in-progress`)
+- ✅ Batches run **concurrently** (`TRANSLATION_CONCURRENCY`, default 4) so a run finishes
+  and records its state instead of being overtaken by the next merge
+- ✅ Runs are **never cancelled mid-flight**, and partial progress is committed — work
+  already paid for is never discarded
 - ✅ Failed API calls / placeholder-mismatched outputs are retried next run, not silently kept
 
 ## Alternative Translation Services

--- a/scripts/translations/README.md
+++ b/scripts/translations/README.md
@@ -60,13 +60,6 @@ RTL languages (Arabic, Persian) are deliberately excluded until the web app has
 ### Setup
 
 ```bash
-# From the web directory
-npm run translate:setup
-```
-
-Or manually:
-
-```bash
 cd scripts/translations
 pip3 install -r requirements.txt
 ```
@@ -86,10 +79,6 @@ export TRANSLATION_CONCURRENCY=4               # batches in flight per locale (1
 
 Translate all languages:
 ```bash
-# From the web directory
-npm run translate
-
-# Or directly
 cd scripts/translations
 python3 main.py
 ```
@@ -257,7 +246,7 @@ DEEPSEEK_API_KEY is not set — cannot reach the translation service.
 ```
 ModuleNotFoundError: No module named 'openai'
 ```
-**Solution**: Run `npm run translate:setup` or `pip3 install -r requirements.txt`
+**Solution**: Run `pip3 install -r requirements.txt` from `scripts/translations`
 
 ### Translation Quality Issues
 - Machine translations are not perfect

--- a/scripts/translations/main.py
+++ b/scripts/translations/main.py
@@ -16,9 +16,9 @@ Environment:
     DEEPSEEK_API_KEY   Required. API key for https://api.deepseek.com.
     DEEPSEEK_MODEL     Model id (default "deepseek-v4-flash").
     TRANSLATION_BATCH_SIZE  Strings per API call (default 50).
+    TRANSLATION_CONCURRENCY Batches in flight per locale (default 4; 1 = serial).
 """
 
-import json
 import sys
 
 from translator import (
@@ -33,6 +33,7 @@ from translator import (
     new_counters,
     save_state,
     translate_pending,
+    write_json,
 )
 
 
@@ -75,8 +76,9 @@ def main():
         translated = translate_pending(pending, locale) if pending else {}
 
         target = build_locale(source, existing, state, translated, counters)
-        with open(get_language_file_path(locale), "w", encoding="utf-8") as f:
-            f.write(json.dumps(target, indent=2, ensure_ascii=False) + "\n")
+        # Flushed per locale (atomically), so a run that is cancelled or dies part
+        # way through still leaves every completed locale on disk for CI to commit.
+        write_json(get_language_file_path(locale), target)
         locale_targets[locale] = target
 
     # Advance shared state only on a full run, where every supported locale was

--- a/scripts/translations/translator.py
+++ b/scripts/translations/translator.py
@@ -16,22 +16,27 @@ Decision per key (per locale):
   * key removed from en-US.json               -> pruned from the target file
 
 Pending leaves are translated in batches (many strings per API call) to keep the
-request count and cost low. Each item is validated independently — a string whose
-translation drops/alters an interpolation placeholder (e.g. `{count}`) is rejected
-and left un-advanced so it retries on the next run, exactly like a hard API failure.
+request count and cost low, and several batches are in flight at once so a large
+backlog finishes in minutes rather than hours. Each item is validated
+independently — a string whose translation drops/alters an interpolation
+placeholder (e.g. `{count}`) is rejected and left un-advanced so it retries on the
+next run, exactly like a hard API failure.
 
 Environment:
     DEEPSEEK_API_KEY   Required. API key for https://api.deepseek.com.
     DEEPSEEK_MODEL     Model id (default "deepseek-v4-flash").
     DEEPSEEK_BASE_URL  API base URL (default "https://api.deepseek.com").
     TRANSLATION_BATCH_SIZE  Strings per API call (default 50).
+    TRANSLATION_CONCURRENCY Batches in flight per locale (default 4; 1 = serial).
 """
 
 import json
 import os
 import re
 import hashlib
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from openai import OpenAI
 
@@ -69,6 +74,9 @@ LANGUAGE_NAMES = {
 _PLACEHOLDER = re.compile(r"{[^{}]*}|%[sd]|@:[\w.]+")
 
 _client = None
+# Batches are translated concurrently (see translate_pending), so the lazy client
+# construction below must be race-free.
+_client_lock = threading.Lock()
 
 
 class TranslationError(Exception):
@@ -123,9 +131,23 @@ def load_state():
     return load_json(get_state_file_path(), {})
 
 
+def write_json(path, data, sort_keys=False):
+    """Write `data` as pretty JSON to `path` atomically.
+
+    Written to a sibling temp file and renamed, so an interrupted run (the job is
+    cancellable mid-write, and CI now commits whatever progress exists) can never
+    leave a truncated / half-written locale file behind to be committed.
+    """
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=sort_keys) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
 def save_state(state):
-    with open(get_state_file_path(), "w", encoding="utf-8") as f:
-        f.write(json.dumps(state, indent=2, ensure_ascii=False, sort_keys=True) + "\n")
+    write_json(get_state_file_path(), state, sort_keys=True)
 
 
 def new_counters():
@@ -141,23 +163,27 @@ def _get_client():
     """Lazily construct the DeepSeek (OpenAI-compatible) client.
 
     Constructed on first use so that dry passes / imports don't require the API
-    key to be present (e.g. when only counting pending work).
+    key to be present (e.g. when only counting pending work). The client itself is
+    thread-safe and shared by every worker; only its construction is locked.
     """
     global _client
     if _client is None:
-        api_key = os.environ.get("DEEPSEEK_API_KEY")
-        if not api_key:
-            raise TranslationError(
-                "DEEPSEEK_API_KEY is not set — cannot reach the translation service."
-            )
-        _client = OpenAI(
-            api_key=api_key,
-            base_url=os.environ.get("DEEPSEEK_BASE_URL", "https://api.deepseek.com"),
-            # Cap per-request time so a single hung/slow call can't stall the whole
-            # run for the SDK's 600s default. Our own retry/split loop then recovers.
-            timeout=float(os.environ.get("DEEPSEEK_TIMEOUT", "60")),
-            max_retries=2,
-        )
+        with _client_lock:
+            if _client is None:
+                api_key = os.environ.get("DEEPSEEK_API_KEY")
+                if not api_key:
+                    raise TranslationError(
+                        "DEEPSEEK_API_KEY is not set — cannot reach the translation service."
+                    )
+                _client = OpenAI(
+                    api_key=api_key,
+                    base_url=os.environ.get("DEEPSEEK_BASE_URL", "https://api.deepseek.com"),
+                    # Cap per-request time so a single hung/slow call can't stall the
+                    # whole run for the SDK's 600s default. Our own retry/split loop
+                    # then recovers.
+                    timeout=float(os.environ.get("DEEPSEEK_TIMEOUT", "60")),
+                    max_retries=2,
+                )
     return _client
 
 
@@ -456,14 +482,38 @@ def translate_pending(pending, locale):
             flat.append((uidx, 0, value))
 
     total = len(flat)
+    chunks = [flat[start : start + batch_size] for start in range(0, total, batch_size)]
+
+    # Batches are independent, so translate several concurrently. Sequentially a
+    # backlog run is ~880 API calls and takes hours — longer than the gap between
+    # two en-US.json merges to main, so the run was always superseded before it
+    # could open a PR. Concurrency is what lets a full run actually land.
+    workers = max(1, int(os.environ.get("TRANSLATION_CONCURRENCY", "4")))
+    batch_results = [None] * len(chunks)
     done = 0
-    for start in range(0, total, batch_size):
-        chunk = flat[start : start + batch_size]
-        results = translate_batch([s for _, _, s in chunk], locale)
+
+    if workers == 1 or len(chunks) <= 1:
+        for i, chunk in enumerate(chunks):
+            batch_results[i] = translate_batch([s for _, _, s in chunk], locale)
+            done += len(chunk)
+            print(f"    {locale}: {done}/{total} strings translated", flush=True)
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(translate_batch, [s for _, _, s in chunk], locale): i
+                for i, chunk in enumerate(chunks)
+            }
+            # Results are stored by index, so out-of-order completion cannot
+            # misalign a translation with its source string.
+            for fut in as_completed(futures):
+                i = futures[fut]
+                batch_results[i] = fut.result()
+                done += len(chunks[i])
+                print(f"    {locale}: {done}/{total} strings translated", flush=True)
+
+    for chunk, results in zip(chunks, batch_results):
         for (uidx, eidx, src), out in zip(chunk, results):
             units[uidx][2][eidx] = _validate(src, out)  # None on failure/mismatch
-        done += len(chunk)
-        print(f"    {locale}: {done}/{total} strings translated")
 
     translated = {}
     for path, kind, slots in units:


### PR DESCRIPTION
Restrict npm-check-updates to in-major upgrades (--target minor --peer). Unrestricted major bumps pushed typescript from 5.9.x to 7.0.x, which drops the ./lib/tsc export that vue-tsc still resolves, failing the type check with ERR_PACKAGE_PATH_NOT_EXPORTED. Majors held back are now listed in the PR body so they stay visible for a deliberate manual upgrade.

Rename the branch to chore/npm-update-<date> and the PR title to chore(deps): update web npm dependencies, matching the repo convention used by update-translations.yml instead of the automated/ prefix.

Also fix along the way:
- npm ci before checking for updates, so reported current versions are real
- gate has_updates on ncu output instead of npm outdated, so the job no longer runs a full build cycle only to find nothing to commit
- write scratch files to RUNNER_TEMP so an untracked outdated.json cannot make the commit step think dependencies changed
- scope the change check to web/package.json and web/package-lock.json
- split the commit message into separate -m flags to drop YAML indentation