### PR TITLE
test(alerts): heal Move-across-folders selection-wipe flake

### DIFF
--- a/tests/ui-testing/pages/alertsPages/alertBulkOperations.js
+++ b/tests/ui-testing/pages/alertsPages/alertBulkOperations.js
@@ -132,121 +132,83 @@ export class AlertBulkOperations {
     /**
      * Move all alerts in current folder to another folder
      * @param {string} targetFolderName - Target folder name
+     * @param {object} [options]
+     * @param {string} [options.expectAlertName] - Name of an alert expected in the SOURCE folder.
+     *   When provided, we wait for THAT row to render before selecting — this proves the source
+     *   folder's own data has loaded (see race note below) and that we are not looking at a stale
+     *   table left over from the previous folder.
      */
-    async moveAllAlertsToFolder(targetFolderName) {
-        // Select all alerts using the header checkbox
+    async moveAllAlertsToFolder(targetFolderName, options = {}) {
+        const { expectAlertName } = options;
         const headerCheckbox = this.page.locator(this.locators.headerCheckbox).first();
-        await headerCheckbox.waitFor({ state: 'visible', timeout: 10000 });
-        // Wait for at least one alert ROW first — after navigating to the folder the OTable can
-        // still be loading, and clicking select-all over an empty table selects nothing so the
-        // (selection-gated) move-across-folders button never appears (alerts-e2e-flow:160 flake).
-        await this.page.locator('[data-test^="o2-table-row-"]').first()
-            .waitFor({ state: 'visible', timeout: 15000 });
-        await headerCheckbox.click();
-        testLogger.info('Clicked select all checkbox');
-
-        // Verify pagination text is visible with fallback — the text may be delayed
-        // when checking the current folder before the move operation completes.
-        // Use a soft check with retry: wait up to 5 s for the pagination summary,
-        // but don't block forever if the UI renders it slightly later.
-        try {
-            await expect(this.page.getByText(/Showing \d+ - \d+ of/)).toBeVisible({ timeout: 5000 });
-        } catch (e) {
-            testLogger.warn('Pagination text not immediately visible, continuing — header checkbox was checked');
-        }
-
-        // Wait for Vue reactivity to propagate the selection
-        await this.page.waitForTimeout(500);
-
-        // Click move across folders button with retry — header checkbox may not
-        // always propagate `selectedAlerts` on first attempt due to Vue reactivity timing.
         const moveBtn = this.page.locator(this.locators.moveAcrossFoldersButton);
-        for (let attempt = 1; attempt <= 3; attempt++) {
-            if (await moveBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-                break;
-            }
-            testLogger.warn('Move button not visible after header checkbox, re-clicking select-all', { attempt });
-            const headerCheckbox = this.page.locator(this.locators.headerCheckbox).first();
-            if (!(await headerCheckbox.isChecked())) {
-                await headerCheckbox.click({ force: true });
-            }
-            await this.page.waitForTimeout(1000);
-        }
-        await moveBtn.waitFor({ state: 'visible', timeout: 10000 });
+        await headerCheckbox.waitFor({ state: 'visible', timeout: 10000 });
 
-        // Dismiss any visible toasts before clicking the move button.
-        // Toasts (e.g. "Please select stream type" error from clone validation, or "Folder
-        // added successfully" from ensureFolderExists) render in the Notifications region and
-        // intercept pointer events at the button's position. Error toasts linger 30s by default
-        // (and their timers are paused in headless mode). Loop until all are gone.
+        // ROOT CAUSE (alerts-e2e-flow:160 "Move drawer failed to open"):
+        // AlertList.vue's getAlertsFn() runs `selectedAlerts.value = []` at the START of every
+        // folder fetch. Switching to a freshly-created (uncached) folder kicks off that async
+        // fetch, but navigateToFolder returns as soon as the tab is active + a table is on screen
+        // — so clicking select-all can fire BEFORE the fetch resolves, and when it resolves it
+        // WIPES the selection. The move-across-folders button is `v-if="selectedAlerts.length > 0"`
+        // so it vanishes ("Move button disappeared before click attempt"). A CACHED folder serves
+        // synchronously with no wipe — which is exactly why this historically failed attempt 1 and
+        // passed attempt 2 (retry warmed the cache), and became permanent under parallel load
+        // (slow listByFolderId => the wipe always lands after select-all). networkidle does not
+        // catch it because streaming/websocket keeps connections open.
+        // Fix: wait until the source folder's OWN data has settled (loading gone + the expected row
+        // rendered) so the wipe has already happened, THEN select and confirm the selection sticks.
+
+        // 1) Let the folder's load finish (getAlertsFn resolved) — best-effort, non-blocking.
+        await this.page.locator('[data-test="alert-list-loading-alert"]')
+            .waitFor({ state: 'hidden', timeout: 20000 }).catch(() => {});
+
+        // 2) Wait for the source folder's own rows to render. Prefer the specific expected alert
+        //    (proves right folder + settled data); fall back to any row when no name is given.
+        if (expectAlertName) {
+            await this.page.locator('[data-test^="o2-table-row-"]')
+                .filter({ hasText: expectAlertName }).first()
+                .waitFor({ state: 'visible', timeout: 20000 });
+        } else {
+            await this.page.locator('[data-test^="o2-table-row-"]').first()
+                .waitFor({ state: 'visible', timeout: 20000 });
+        }
+
         const toastDismissBtn = this.page.locator('button[aria-label="Dismiss notification"]');
-        let toastCount = await toastDismissBtn.count().catch(() => 0);
-        if (toastCount > 0) {
-            testLogger.warn('Dismissing visible toast(s) before move operation', { count: toastCount });
-            while (toastCount > 0) {
-                await toastDismissBtn.first().click({ force: true }).catch(() => {});
-                await this.page.waitForTimeout(150);
-                toastCount = await toastDismissBtn.count().catch(() => 0);
-            }
-            await this.page.waitForTimeout(500);
-        }
-
         const moveDrawer = this.page.locator('[data-test="dashboard-move-to-another-folder-dialog"]');
         const scopedFolderDropdown = moveDrawer.locator(this.locators.folderDropdown);
 
-        // Retry opening the drawer and wait for an interactive child control.
-        // Uses force:true on all attempts to bypass any residual toast overlay.
-        // Re-selects alerts before each attempt because Vue may clear selectedAlerts
-        // during the previous attempt's timeout period (v-if hides the button when empty).
-        let drawerReady = false;
-        let lastOpenError;
-
-        for (let attempt = 1; attempt <= 3; attempt++) {
-            try {
-                // Ensure move button is still visible — selectedAlerts may have been cleared.
-                const isMoveVisible = await moveBtn.isVisible({ timeout: 2000 }).catch(() => false);
-                if (!isMoveVisible) {
-                    testLogger.warn('Move button disappeared before click attempt — re-selecting alerts', { attempt });
-                    const hdrChk = this.page.locator(this.locators.headerCheckbox).first();
-                    await hdrChk.waitFor({ state: 'visible', timeout: 5000 });
-                    if (!(await hdrChk.isChecked().catch(() => false))) {
-                        await hdrChk.click({ force: true });
-                    }
-                    await moveBtn.waitFor({ state: 'visible', timeout: 10000 });
-                }
-
-                await moveBtn.click({ force: true, timeout: 5000 });
-
-                await moveDrawer.waitFor({ state: 'visible', timeout: 7000 });
-                await scopedFolderDropdown.waitFor({ state: 'visible', timeout: 7000 });
-                drawerReady = true;
-                break;
-            } catch (e) {
-                lastOpenError = e;
-                testLogger.warn('Move drawer did not become ready, retrying move action', {
-                    attempt,
-                    error: e.message,
-                });
-                // Only press Escape if the drawer actually opened — pressing it when
-                // the drawer is not visible would disrupt other UI state.
-                const isDrawerOpen = await moveDrawer.isVisible({ timeout: 300 }).catch(() => false);
-                if (isDrawerOpen) {
-                    await this.page.keyboard.press('Escape').catch(() => {});
-                }
-                // Dismiss any toasts that may have appeared during this attempt.
-                let dc = await toastDismissBtn.count().catch(() => 0);
-                while (dc > 0) {
-                    await toastDismissBtn.first().click({ force: true }).catch(() => {});
-                    await this.page.waitForTimeout(150);
-                    dc = await toastDismissBtn.count().catch(() => 0);
-                }
-                await this.page.waitForTimeout(800);
+        // 3) ATOMIC open: (re)select-all → click move → confirm the drawer opened — as ONE retried
+        //    block. A late getAlertsFn resolve can still wipe selectedAlerts AFTER select-all
+        //    (hiding the move button, which is v-if="selectedAlerts.length > 0"), so a fixed
+        //    stability window is not enough. Instead we retry the WHOLE open until the drawer is
+        //    up: the drawer is driven by its own `showMoveAlertDialog` ref and captures the
+        //    selection at click time, so once it opens a later wipe cannot close it. Each
+        //    iteration re-selects if the button vanished, so the operation only needs ONE click
+        //    to land while the selection is valid — which it eventually does once the folder is
+        //    cached and no further fetch fires. Also dismisses toasts that intercept the click.
+        await expect(async () => {
+            // Already open (from a prior iteration whose success check hadn't settled)? Done.
+            if (await moveDrawer.isVisible().catch(() => false)
+                && await scopedFolderDropdown.isVisible().catch(() => false)) {
+                return;
             }
-        }
-
-        if (!drawerReady) {
-            throw new Error(`Move drawer failed to open after retries: ${lastOpenError?.message || 'unknown error'}`);
-        }
+            // Toasts (folder-added, clone-validation errors) render over the button and eat clicks.
+            let dc = await toastDismissBtn.count().catch(() => 0);
+            while (dc > 0) {
+                await toastDismissBtn.first().click({ force: true }).catch(() => {});
+                await this.page.waitForTimeout(150);
+                dc = await toastDismissBtn.count().catch(() => 0);
+            }
+            // Ensure the selection is present (re-tick if a fetch wiped it).
+            if (!(await headerCheckbox.isChecked().catch(() => false))) {
+                await headerCheckbox.click({ force: true });
+            }
+            await expect(moveBtn).toBeVisible({ timeout: 3000 });
+            await moveBtn.click({ force: true, timeout: 5000 });
+            await expect(moveDrawer).toBeVisible({ timeout: 5000 });
+            await expect(scopedFolderDropdown).toBeVisible({ timeout: 5000 });
+        }).toPass({ timeout: 60000 });
+        testLogger.info('Move drawer opened with a valid selection');
 
         await scopedFolderDropdown.click();
         await this.page.waitForTimeout(2000);

--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -782,8 +782,8 @@ export class AlertsPage {
         return this.bulkOperations.pauseAllSelectedAlerts();
     }
 
-    async moveAllAlertsToFolder(targetFolderName) {
-        return this.bulkOperations.moveAllAlertsToFolder(targetFolderName);
+    async moveAllAlertsToFolder(targetFolderName, options = {}) {
+        return this.bulkOperations.moveAllAlertsToFolder(targetFolderName, options);
     }
 
     async deleteAllAlertsInFolder() {

--- a/tests/ui-testing/playwright-tests/Alerts/alerts-e2e-flow.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alerts-e2e-flow.spec.js
@@ -204,7 +204,7 @@ test.describe("Alerts E2E Flow", () => {
     // ===== Move Alert to Target Folder =====
     await pm.alertsPage.navigateToFolder(sourceFolderName);
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
-    await pm.alertsPage.moveAllAlertsToFolder(targetFolderName);
+    await pm.alertsPage.moveAllAlertsToFolder(targetFolderName, { expectAlertName: alertName });
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
     testLogger.info('Moved all alerts to target folder', { targetFolderName });
 

--- a/tests/ui-testing/playwright-tests/Alerts/alerts-ui-operations.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alerts-ui-operations.spec.js
@@ -262,7 +262,7 @@ test.describe("Alerts UI Operations", () => {
     await pm.alertsPage.ensureFolderExists(targetFolderName, 'Test Folder for Moving Alerts');
     // Navigate back to source folder — ensureFolderExists may navigate away via createFolder
     await pm.alertsPage.navigateToFolder(folderName);
-    await pm.alertsPage.moveAllAlertsToFolder(targetFolderName);
+    await pm.alertsPage.moveAllAlertsToFolder(targetFolderName, { expectAlertName: alertName });
 
     // Verify in target folder
     await pm.dashboardFolder.searchFolder(folderName);


### PR DESCRIPTION
## What

Heals the recurring flake in `alerts-e2e-flow.spec.js:160` — **E2E: Alert Folder Management - Move, Search, Verify** — which fails with *"Move drawer failed to open after retries"* (the `alert-list-move-across-folders-btn` never becomes visible). Also hardens the sibling caller in `alerts-ui-operations.spec.js`.

**Test-only change. No `web/` product code is touched.**

## Root cause

`AlertList.vue`'s `getAlertsFn()` runs `selectedAlerts.value = []` at the **start of every folder fetch**. The move / export / pause buttons are `v-if="selectedAlerts.length > 0"`.

- Switching to a freshly-created (**uncached**) folder kicks off an async `listByFolderId` fetch.
- `navigateToFolder` returns as soon as the folder tab is active and a table is on screen — so `select-all` can fire **before** that fetch resolves.
- When it resolves it **wipes the selection** → the move button disappears → the drawer never opens.
- **Cached** folders serve synchronously with no wipe.

This precisely explains the observed signature:
- **Always failed attempt 1** (folder uncached), **passed attempt 2** (retry warmed the cache).
- **Failed all 3 attempts under parallel load** — the slower API guarantees the wipe lands after `select-all` every time.

`networkidle` doesn't catch it because streaming/websocket (`ZO_STREAMING_ENABLED=true`) keeps connections open.

## The fix (`pages/alertsPages/alertBulkOperations.js`)

1. Before selecting, wait for the source folder's **own** row to render (`expectAlertName`) — this proves the fetch resolved (wipe already happened) and that we're on the right folder, not a stale table. Falls back to "any row" when no name is passed (backward compatible).
2. Retry **select-all → click Move → assert drawer open** as **one atomic `expect(...).toPass()`**. A fixed stability window isn't enough (a second fetch can resolve later and wipe). The drawer is driven by its own `showMoveAlertDialog` ref and captures the selection **at click time**, so once open a later wipe cannot close it — the click just needs to land while the selection is valid, which it always eventually does once the folder is cached.

Both spec callers now pass `{ expectAlertName: alertName }`.

## Validation

Ran against the alpha cloud env on the exact failing scenario (freshly-created uncached source folder, `--workers=1 --retries=0`):

- 1 initial run → **passed**
- `--repeat-each=3` → **3/3 passed**

`Move drawer opened with a valid selection` → `Moved all alerts to target folder` on every run.

## Note

Not related to the concurrent Traces service-graph failures on alpha — those are a separate main-vs-RC route skew (#13659 not in the deployed RC build) and resolve on deploying latest `main`.