### PR TITLE
test(traces): heal service-graph Metrics-tab correlation detection

### DIFF
--- a/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
+++ b/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
@@ -59,7 +59,19 @@ export class ServiceGraphPage {
     this.metricsTab = '[data-test="service-graph-node-panel-tab-metrics"]';
     this.metricsPanel = '[data-test="service-graph-side-panel-metrics"]';
     this.metricsLoadingIndicator = '[data-test="service-graph-side-panel-metrics-loading"]';
-    this.metricsDashboard = '[data-test="service-graph-side-panel-metrics-dashboard"]';
+    // The metrics-tab CONTENT is what we wait on — NOT the panel wrapper. Two hooks that look
+    // usable are not:
+    //   • service-graph-side-panel-metrics is on an OTabPanel whose data-test is swallowed by
+    //     <Transition>, so it never reaches the DOM;
+    //   • service-graph-side-panel-metrics-dashboard is passed to <TelemetryCorrelationDashboard>,
+    //     which has multiple top-level roots (a Vue FRAGMENT) so Vue 3 drops the fallthrough attr.
+    // The reliable, currently-shipping "correlation view rendered" signal is the correlation event
+    // header (renders whenever the metrics tab resolves to a correlation object, with or without
+    // metric streams — this env seeds only traces, so zero-stream is the common case).
+    this.metricsCorrelationHeader = '[data-test^="correlation-event-header-"]';
+    // "Rendered WITH metric data" = real per-metric-stream rows (data-dependent; used only for the
+    // happy-path assertion, never required for the tab to count as resolved).
+    this.metricsStreamItem = '[data-test="telemetry-correlation-metric-stream-item"]';
     this.metricsError = '[data-test="service-graph-side-panel-metrics-error"]';
     this.metricsEmpty = '[data-test="service-graph-side-panel-metrics-empty"]';
 
@@ -400,26 +412,34 @@ export class ServiceGraphPage {
   // ===== TELEMETRY CORRELATION =====
 
   /**
-   * Click the Metrics tab in the side panel and wait for correlation data to load.
-   * Returns true if metrics dashboard rendered, false if error/empty state shown.
+   * Click the Metrics tab in the side panel and wait for the correlation view to RESOLVE.
+   * Deploy-independent: gates only on real, currently-shipping elements (the metrics panel and its
+   * loading spinner) — NOT on the dashboard's data-test, which the fragment-root component drops
+   * (see this.metricsStreamItem). Throws if the panel never renders (a genuinely broken tab).
+   * @returns {Promise<boolean>} true if real metric-stream rows rendered (data present); false for
+   *   a resolved-but-streamless view (zero-stream dashboard / empty / error) — all acceptable.
    */
   async clickMetricsTabAndWait() {
     await this.page.locator(this.metricsTab).click();
 
-    // Wait for loading spinner to appear and disappear
-    const panel = this.page.locator(this.metricsPanel);
-    await panel.locator(this.metricsLoadingIndicator).waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
-    await panel.locator(this.metricsLoadingIndicator).waitFor({ state: 'hidden', timeout: 30000 }).catch(() => {});
+    // Wait until the metrics tab RESOLVES into a rendered content state — the correlation view
+    // (header) OR a terminal empty/error state. We race real content elements (never the swallowed
+    // panel wrapper); if none appears within the window the race rejects and the caller fails,
+    // which is the correct outcome for a genuinely broken/hung tab.
+    await Promise.race([
+      this.page.locator(this.metricsCorrelationHeader).first().waitFor({ state: 'visible', timeout: 30000 }),
+      this.page.locator(this.metricsError).first().waitFor({ state: 'visible', timeout: 30000 }),
+      this.page.locator(this.metricsEmpty).first().waitFor({ state: 'visible', timeout: 30000 }),
+    ]);
 
-    // Check if the metrics dashboard rendered
-    return await this.page.locator(this.metricsDashboard)
-      .waitFor({ state: 'visible', timeout: 5000 })
-      .then(() => true)
-      .catch(() => false);
+    // Report whether real metric-stream rows rendered (.first() — the selector matches every row,
+    // so an unscoped locator would trip Playwright strict mode).
+    return await this.page.locator(this.metricsStreamItem).first()
+      .isVisible({ timeout: 2000 }).catch(() => false);
   }
 
-  async expectMetricsDashboardVisible() {
-    await expect(this.page.locator(this.metricsDashboard)).toBeVisible({ timeout: 5000 });
+  async expectMetricsStreamsVisible() {
+    await expect(this.page.locator(this.metricsStreamItem).first()).toBeVisible({ timeout: 8000 });
   }
 
   async isMetricsErrorVisible() {

--- a/tests/ui-testing/playwright-tests/Traces/service-graph.spec.js
+++ b/tests/ui-testing/playwright-tests/Traces/service-graph.spec.js
@@ -329,26 +329,21 @@ test.describe("Service Graph testcases", { tag: '@enterprise' }, () => {
     await pm.serviceGraphPage.expectSidePanelVisible();
     testLogger.info('Side panel opened for api-gateway');
 
-    // Click Metrics tab and wait for correlation data to load
-    const metricsLoaded = await pm.serviceGraphPage.clickMetricsTabAndWait();
-    testLogger.info(`Metrics tab result: metricsLoaded=${metricsLoaded}`);
+    // Click Metrics tab and wait for the correlation view to RESOLVE. clickMetricsTabAndWait throws
+    // if the metrics panel never renders (a broken tab); it returns whether real metric-stream rows
+    // appeared. Distinguishing dashboard-with-data vs zero-stream vs empty vs error is
+    // data-dependent (this env seeds only traces, so correlation often yields zero metric streams)
+    // and NOT asserted — the smoke check is that the Metrics tab loads and resolves without hanging.
+    const streamsPresent = await pm.serviceGraphPage.clickMetricsTabAndWait();
+    testLogger.info(`Metrics tab resolved: streamsPresent=${streamsPresent}`);
 
-    if (metricsLoaded) {
-      // Happy path: metrics correlation dashboard rendered
-      testLogger.info('Metrics correlation dashboard rendered successfully');
-
-      await pm.serviceGraphPage.expectMetricsDashboardVisible();
-      testLogger.info('Metrics dashboard visible in side panel');
+    if (streamsPresent) {
+      // Happy path: correlated metric streams rendered — assert they're visible.
+      await pm.serviceGraphPage.expectMetricsStreamsVisible();
+      testLogger.info('Metrics correlation streams visible in side panel');
     } else {
-      // Expected fallback: no metrics data available or correlation failed
-      // Check for error or empty state
-      testLogger.info('Metrics dashboard did not load — checking for error/empty state');
-
-      const hasError = await pm.serviceGraphPage.isMetricsErrorVisible();
-      const hasEmpty = await pm.serviceGraphPage.isMetricsEmptyVisible();
-
-      expect(hasError || hasEmpty).toBeTruthy();
-      testLogger.info(`Metrics tab fallback state: error=${hasError}, empty=${hasEmpty}`);
+      // Resolved to a streamless view (zero-stream dashboard / empty / error) — acceptable.
+      testLogger.info('Metrics tab resolved with no correlated streams (acceptable for this data set)');
     }
 
     await pm.serviceGraphPage.closeSidePanel();


### PR DESCRIPTION
## What

Fixes the one remaining alpha1 Traces failure after the service-graph route deploy: **`service-graph.spec.js` → P1: Show telemetry correlation from node panel via Metrics tab**. Test-only, no product change.

## Root cause

The test asserted on two hooks that never reach the DOM:

- `service-graph-side-panel-metrics` sits on an `OTabPanel` whose `data-test` is **swallowed by `<Transition>`**.
- `service-graph-side-panel-metrics-dashboard` is passed to `<TelemetryCorrelationDashboard>`, which has **multiple top-level roots** (dialog `ODrawer` / embedded `div` / `ODialog`) → it renders a **Vue fragment**, and Vue 3 **drops fallthrough attrs on fragment roots**, so the `data-test` is never applied.

On alpha (which seeds only traces, no metrics), the correlation returns a **zero-stream dashboard object**: the dashboard branch renders (so the parent empty-state is suppressed), but there are no stream rows and the dashboard hook doesn't exist → the test's `else` branch `expect(hasError || hasEmpty)` fails. The test only ever passed before when correlation happened to return *empty*; it broke as soon as real correlation data appeared.

Confirmed live on the deployed build: after clicking Metrics, the panel wrapper `data-test` is absent, while the correlation view's real content (`correlation-event-header-*`, metric selector) renders fine.

## Fix

Wait on the correlation view's **real rendered content** — the correlation event header, or a terminal empty/error state — instead of the swallowed/dropped wrappers, and assert only that the Metrics tab **resolves** (the helper throws if nothing renders, catching a genuinely broken tab). Metric-stream rows are asserted only on the happy path when data is present.

Deploy-independent: every element it waits on ships on the current build (verified), so it won't reintroduce the main-vs-deployed skew.

## Validation

`--workers=1 --retries=0` against alpha on the previously-failing test:
- 1 run → passed
- `--repeat-each=2` → 2/2 passed

`Metrics tab resolved: streamsPresent=false → resolved with no correlated streams (acceptable) → Test PASSED`

## Context

The other 9 service-graph failures were the missing `/traces/service-graph` route (#13659) and cleared on deploying latest `main`. Sibling fixes from the same alpha1 triage: openobserve#13672 (alerts move flake), o2-enterprise#2370 (per-org cleanup).