### PR TITLE
fix: add env to completely skip ssrf checks (v91)

### DIFF
--- a/src/common/utils/ssrf_guard.rs
+++ b/src/common/utils/ssrf_guard.rs
@@ -27,58 +27,72 @@ mod tests {
 
     #[test]
     fn test_validate_safe_urls() {
-        assert!(SsrfGuard::validate_url("https://hooks.slack.com/services/xyz").is_ok());
-        assert!(SsrfGuard::validate_url("https://example.com/webhook").is_ok());
-        assert!(SsrfGuard::validate_url("http://example.com/webhook").is_ok());
+        assert!(
+            SsrfGuard::validate_url_with_config("https://hooks.slack.com/services/xyz").is_ok()
+        );
+        assert!(SsrfGuard::validate_url_with_config("https://example.com/webhook").is_ok());
+        assert!(SsrfGuard::validate_url_with_config("http://example.com/webhook").is_ok());
     }
 
     #[test]
     fn test_block_private_ipv4() {
-        assert!(SsrfGuard::validate_url("http://10.0.0.1/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://10.255.255.255/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://172.16.0.1/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://172.31.255.255/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://192.168.0.1/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://192.168.255.255/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://10.0.0.1/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://10.255.255.255/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://172.16.0.1/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://172.31.255.255/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://192.168.0.1/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://192.168.255.255/webhook").is_err());
     }
 
     #[test]
     fn test_block_localhost() {
-        assert!(SsrfGuard::validate_url("http://localhost/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://localhost:8080/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://127.0.0.1/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://[::1]/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://localhost/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://localhost:8080/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://127.0.0.1/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://[::1]/webhook").is_err());
     }
 
     #[test]
     fn test_block_metadata_endpoints() {
-        assert!(SsrfGuard::validate_url("http://169.254.169.254/latest/meta-data/").is_err());
         assert!(
-            SsrfGuard::validate_url("http://metadata.google.internal/computeMetadata/v1/").is_err()
+            SsrfGuard::validate_url_with_config("http://169.254.169.254/latest/meta-data/")
+                .is_err()
         );
-        assert!(SsrfGuard::validate_url("http://metadata/computeMetadata/v1/").is_err());
+        assert!(
+            SsrfGuard::validate_url_with_config(
+                "http://metadata.google.internal/computeMetadata/v1/"
+            )
+            .is_err()
+        );
+        assert!(
+            SsrfGuard::validate_url_with_config("http://metadata/computeMetadata/v1/").is_err()
+        );
     }
 
     #[test]
     fn test_block_unsupported_protocols() {
-        assert!(SsrfGuard::validate_url("ftp://example.com/webhook").is_err());
-        assert!(SsrfGuard::validate_url("file:///etc/passwd").is_err());
-        assert!(SsrfGuard::validate_url("gopher://example.com").is_err());
+        assert!(SsrfGuard::validate_url_with_config("ftp://example.com/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("file:///etc/passwd").is_err());
+        assert!(SsrfGuard::validate_url_with_config("gopher://example.com").is_err());
     }
 
     #[test]
     fn test_block_ipv6_special_ranges() {
-        assert!(SsrfGuard::validate_url("http://[fe80::1]/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://[fc00::1]/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://[fd00::1]/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://[2001:db8::1]/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://[fe80::1]/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://[fc00::1]/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://[fd00::1]/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://[2001:db8::1]/webhook").is_err());
     }
 
     #[test]
     fn test_block_ipv4_mapped_ipv6() {
-        assert!(SsrfGuard::validate_url("http://[::ffff:127.0.0.1]/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://[::ffff:10.0.0.1]/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://[::ffff:192.168.1.1]/webhook").is_err());
-        assert!(SsrfGuard::validate_url("http://[::ffff:169.254.169.254]/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://[::ffff:127.0.0.1]/webhook").is_err());
+        assert!(SsrfGuard::validate_url_with_config("http://[::ffff:10.0.0.1]/webhook").is_err());
+        assert!(
+            SsrfGuard::validate_url_with_config("http://[::ffff:192.168.1.1]/webhook").is_err()
+        );
+        assert!(
+            SsrfGuard::validate_url_with_config("http://[::ffff:169.254.169.254]/webhook").is_err()
+        );
     }
 }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -928,6 +928,9 @@ pub struct Common {
     /// server legitimately needs to send notifications to itself.
     #[env_config(name = "ZO_SSRF_ALLOW_LOOPBACK", default = false)]
     pub ssrf_allow_loopback: bool,
+    // This will completely skip ssrf checks, not just localhost
+    #[env_config(name = "ZO_SKIP_SSRF_CHECKS", default = false)]
+    pub skip_ssrf_checks: bool,
     #[env_config(name = "ZO_BASE_URI", default = "")] // /abc
     pub base_uri: String,
     #[env_config(name = "ZO_DATA_DIR", default = "./data/openobserve/")]

--- a/src/config/src/utils/ssrf_guard.rs
+++ b/src/config/src/utils/ssrf_guard.rs
@@ -31,14 +31,11 @@ pub struct SsrfGuard;
 impl SsrfGuard {
     pub fn validate_url_with_config(url: &str) -> Result<(), String> {
         let allow_loopback = crate::get_config().common.ssrf_allow_loopback;
-        Self::validate_url_inner(url, allow_loopback)
+        let skip_ssrf = crate::get_config().common.skip_ssrf_checks;
+        Self::validate_url_inner(url, allow_loopback, skip_ssrf)
     }
 
-    pub fn validate_url(url: &str) -> Result<(), String> {
-        Self::validate_url_inner(url, false)
-    }
-
-    fn validate_url_inner(url: &str, allow_loopback: bool) -> Result<(), String> {
+    fn validate_url_inner(url: &str, allow_loopback: bool, skip_ssrf: bool) -> Result<(), String> {
         let parsed = url::Url::parse(url).map_err(|e| format!("Invalid URL: {}", e))?;
 
         if parsed.scheme() != "http" && parsed.scheme() != "https" {
@@ -51,6 +48,10 @@ impl SsrfGuard {
         let host = parsed
             .host_str()
             .ok_or_else(|| "URL must have a valid host".to_string())?;
+
+        if skip_ssrf {
+            return Ok(());
+        }
 
         // Strip IPv6 brackets so IpAddr can parse the literal.
         let unbracketed_host = if host.starts_with('[') && host.ends_with(']') {
@@ -117,6 +118,10 @@ impl SsrfGuard {
     /// hostname string passed the pre-flight check.
     pub fn check_ip_with_config(ip: &IpAddr) -> Result<(), String> {
         let allow_loopback = crate::get_config().common.ssrf_allow_loopback;
+        let skip_ssrf = crate::get_config().common.skip_ssrf_checks;
+        if skip_ssrf {
+            return Ok(());
+        }
         Self::check_ip_inner(ip, allow_loopback)
     }
 
@@ -136,14 +141,15 @@ impl SsrfGuard {
     /// bypass that the sync validator can't see.
     pub async fn validate_url_with_config_async(url: &str) -> Result<(), String> {
         let allow_loopback = crate::get_config().common.ssrf_allow_loopback;
+        let skip_ssrf = crate::get_config().common.skip_ssrf_checks;
         // When loopback is explicitly allowed we're in a dev/test environment;
         // skip SSRF validation entirely so test fixtures with placeholder URLs
         // (e.g. "DEMO") and unresolvable hostnames don't get rejected at save time.
         // Production keeps ZO_SSRF_ALLOW_LOOPBACK=false and remains strict.
-        if allow_loopback {
+        if allow_loopback || skip_ssrf {
             return Ok(());
         }
-        Self::validate_url_inner(url, allow_loopback)?;
+        Self::validate_url_inner(url, allow_loopback, skip_ssrf)?;
 
         let parsed = url::Url::parse(url).map_err(|e| format!("Invalid URL: {}", e))?;
         let Some(host) = parsed.host_str() else {


### PR DESCRIPTION
cherry pick of https://github.com/openobserve/openobserve/pull/13682