### PR TITLE
chore: bundle the SIL OFL 1.1 license for the vendored Geist fonts

### DIFF
--- a/web/serve.json
+++ b/web/serve.json
@@ -6,7 +6,7 @@
         "headers": [
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; connect-src 'self' http://localhost:5080;  script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; block-all-mixed-content;"
+            "value": "default-src 'self'; connect-src 'self' http://localhost:5080;  script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; block-all-mixed-content;"
 
           }
         ]

--- a/web/src/styles/fonts/OFL.txt
+++ b/web/src/styles/fonts/OFL.txt
@@ -1,0 +1,93 @@
+Copyright 2024 The Geist Project Authors (https://github.com/vercel/geist-font)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/web/src/styles/fonts/README.md
+++ b/web/src/styles/fonts/README.md
@@ -1,0 +1,36 @@
+# Bundled fonts
+
+Both families are vendored rather than loaded from a CDN, and both are compiled
+into the OpenObserve binary along with the rest of `web/dist`.
+
+| File                       | Family     | Version | Upstream                             |
+| -------------------------- | ---------- | ------- | ------------------------------------ |
+| `Geist-Variable.woff2`     | Geist      | 1.800   | https://github.com/vercel/geist-font |
+| `GeistMono-Variable.woff2` | Geist Mono | 1.700   | https://github.com/vercel/geist-font |
+
+## License
+
+SIL Open Font License 1.1 — full text in [`OFL.txt`](./OFL.txt), copied verbatim
+from upstream. Redistributing the fonts (which every release does) requires that
+copyright notice and license to travel with them, so `OFL.txt` must stay next to
+the `.woff2` files.
+
+Vite only emits assets that something imports, so `vite.config.ts` copies
+`OFL.txt` to `dist/fonts/OFL.txt` via the `font-license` plugin — that is what
+puts it inside the binary alongside the fonts.
+
+Geist declares **no Reserved Font Name**, so a renamed derivative would be
+permitted — we ship the fonts unmodified.
+
+## Re-vendoring
+
+Copy the two variable `.woff2` files from an upstream release and refresh
+`OFL.txt` and the versions above:
+
+```
+packages/next/dist/fonts/geist-sans/Geist-Variable.woff2
+packages/next/dist/fonts/geist-mono/GeistMono-Variable.woff2
+```
+
+The `@font-face` rules that consume them live in
+`web/src/lib/styles/tokens/base.css`.

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -81,6 +81,22 @@ const enterpriseResolverPlugin = {
   },
 };
 
+// The Geist fonts are vendored and get compiled into the OpenObserve binary
+// with the rest of dist/, and the OFL requires its text to travel with them.
+// Vite only emits assets that are imported, so the license is copied explicitly.
+const fontLicensePlugin = {
+  name: "font-license",
+  apply: "build" as const,
+  generateBundle() {
+    const src = path.resolve(__dirname, "src/styles/fonts/OFL.txt");
+    (this as any).emitFile({
+      type: "asset",
+      fileName: "fonts/OFL.txt",
+      source: fs.readFileSync(src, "utf8"),
+    });
+  },
+};
+
 function monacoEditorTestResolver() {
   return {
     name: "monaco-editor-test-resolver",
@@ -180,12 +196,13 @@ export default defineConfig(({ mode }) => {
       port: 8081,
       // headers: {
       //   "Content-Security-Policy":
-      //     "default-src 'self'; connect-src 'self' http://localhost:5080;  script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;img-src 'self' data:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; block-all-mixed-content;",
+      //     "default-src 'self'; connect-src 'self' http://localhost:5080;  script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:;img-src 'self' data:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; block-all-mixed-content;",
       // },
     },
     base: "./",
     plugins: [
       vue(),
+      fontLicensePlugin,
       debugFilterPlugin,
       process.env.VITE_COVERAGE === "true" &&
         istanbul({


### PR DESCRIPTION
Geist and Geist Mono are vendored under web/src/styles/fonts/ and, like the rest of web/dist, are compiled into the binary by rust-embed. Both are licensed under the SIL Open Font License 1.1, which requires the copyright notice and license text to be redistributed with the fonts. Neither was present.

- OFL.txt, copied verbatim from vercel/geist-font, next to the .woff2 files.
- A font-license Vite plugin copying it to dist/fonts/OFL.txt, since Vite only emits assets something imports and the license has to reach the binary too.
- README.md recording family, version, upstream and how to re-vendor.

DejaVu Sans (src/core/src/alerts/notifications/chart/font/) already ships its license and needs no change.

Also drops the fonts.googleapis.com / fonts.gstatic.com allowances from the serve.json CSP and its commented twin in vite.config.ts — dead since 9e9c8c713d moved the fonts local.