### PR TITLE
ci: use macos-latest-xlarge for darwin release builds (v0.92.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,12 @@ jobs:
             file_name: openobserve-${{ github.ref_name }}-linux-arm64
             file_ext: .tar.gz
           - arch: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-latest-xlarge
             features: "--features mimalloc"
             file_name: openobserve-${{ github.ref_name }}-darwin-amd64
             file_ext: .tar.gz
           - arch: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-latest-xlarge
             features: "--features mimalloc"
             file_name: openobserve-${{ github.ref_name }}-darwin-arm64
             file_ext: .tar.gz


### PR DESCRIPTION
## What
Backport to `branch-v0.92.0`: switch both darwin release builds (`x86_64-apple-darwin` and `aarch64-apple-darwin`) from `macos-latest` to `macos-latest-xlarge` in `release.yml`.

## Why
macOS builds on the default 3-core `macos-latest` runner were slow. `macos-latest-xlarge` is a beefier Apple Silicon runner. `macos-latest` is already arm64, so the x86_64 target remains a cross-compile exactly as today.

## Note
macOS *larger* runners bill per-minute at a premium (not free even on public repos). Intentional speed-for-cost trade.

## Related
- main: openobserve/openobserve#13692
- ENT v0.92.0 counterpart: openobserve/o2-enterprise#2374