### PR TITLE
feat(traces): restore in-page Service Graph / Service Catalog tabs alongside standalone routes

### DIFF
--- a/tests/ui-testing/pages/tracesPages/tracesPage.js
+++ b/tests/ui-testing/pages/tracesPages/tracesPage.js
@@ -31,6 +31,7 @@ export class TracesPage {
     this.servicesCatalogTable = '[data-test="services-catalog-table"]';
     this.servicesCatalogEmpty = '[data-test="services-catalog-empty"]';
     this.servicesCatalogRefreshButton = '[data-test="services-catalog-refresh-btn"]';
+    this.servicesCatalogDateTimePicker = '[data-test="services-catalog-date-time-picker"]';
     // No-data state inside the graph panel (OEmptyState rendered by
     // ServiceGraphNoDataState.vue within the graph container).
     this.serviceGraphEmptyState = '[data-test="service-graph-container"] [data-test="o2-empty-state"]';
@@ -78,6 +79,8 @@ export class TracesPage {
     // Service Graph (Enterprise)
     this.serviceGraphChart = '[data-test="service-graph-chart"]';
     this.serviceGraphRefreshButton = '[data-test="service-graph-refresh-btn"]';
+    // Standalone Service Graph page (rail-flyout route /traces/service-graph).
+    this.serviceGraphPage = '[data-test="service-graph-page"]';
 
     // ===== ANALYZE DIMENSIONS SELECTORS (VERIFIED against Vue source) =====
     // TracesMetricsDashboard.vue: data-test="insights-button"
@@ -444,6 +447,45 @@ export class TracesPage {
 
   async expectServiceGraphVisible() {
     await expect(this.page.locator(this.serviceGraphChart)).toBeVisible({ timeout: 10000 });
+  }
+
+  // In-page Service Graph tab view: the chart when topology data exists, else
+  // the no-data state (this suite does not seed the service-graph daemon).
+  async expectServiceGraphViewVisible() {
+    await expect(
+      this.page
+        .locator(this.serviceGraphChart)
+        .or(this.page.locator(this.serviceGraphEmptyState))
+        .first()
+    ).toBeVisible({ timeout: 15000 });
+  }
+
+  // In-page Services Catalog tab view: the table when data exists, else empty.
+  async expectServicesCatalogVisible() {
+    await expect(
+      this.page
+        .locator(this.servicesCatalogTable)
+        .or(this.page.locator(this.servicesCatalogEmpty))
+        .first()
+    ).toBeVisible({ timeout: 15000 });
+  }
+
+  // The catalog toolbar's date-time picker reflects the shared search period.
+  async expectServicesCatalogTimeRange(text) {
+    await expect(this.page.locator(this.servicesCatalogDateTimePicker))
+      .toContainText(text, { timeout: 10000 });
+  }
+
+  // The services-catalog toolbar tab is the active mode (data-state="on").
+  async expectServicesCatalogTabActive() {
+    await expect(this.page.locator(this.servicesCatalogTabToggle))
+      .toHaveAttribute('data-state', 'on', { timeout: 10000 });
+  }
+
+  // Standalone Service Graph page rendered from the rail flyout route.
+  async expectStandaloneServiceGraphPageVisible() {
+    await expect(this.page.locator(this.serviceGraphPage))
+      .toBeVisible({ timeout: 10000 });
   }
 
   async refreshServiceGraph() {

--- a/tests/ui-testing/pages/tracesPages/tracesPage.js
+++ b/tests/ui-testing/pages/tracesPages/tracesPage.js
@@ -16,11 +16,24 @@ export class TracesPage {
     // Source: web/src/plugins/traces/SearchBar.vue
     this.searchToggle = '[data-test="traces-search-mode-traces-btn"]';
     this.spansToggle = '[data-test="traces-search-mode-spans-btn"]';
-    // Service Graph and Services are their own routes now, reached from the
-    // Traces rail tile's hover flyout — not tabs on the Traces page.
+    // Service Graph and Services are reachable two ways with different
+    // semantics: (a) the Traces rail tile's hover flyout navigates to the
+    // standalone routes (/traces/service-graph, /traces/services), and
+    // (b) toolbar tabs on the Traces page switch the view IN-PAGE — the URL
+    // stays on /traces and gains ?tab=. Keep both paths covered.
     this.tracesRailTile = '[data-test="nav-group-traces"]';
     this.serviceMapsNavItem = '[data-test="nav-group-item-serviceGraph"]';
     this.servicesCatalogNavItem = '[data-test="nav-group-item-servicesCatalog"]';
+    this.serviceGraphTabToggle = '[data-test="traces-service-graph-toggle"]';
+    this.servicesCatalogTabToggle = '[data-test="traces-search-mode-services-catalog-btn"]';
+    // Inline-safe selectors (defined in the inner components, so they work for
+    // both the in-page tabs and the standalone pages).
+    this.servicesCatalogTable = '[data-test="services-catalog-table"]';
+    this.servicesCatalogEmpty = '[data-test="services-catalog-empty"]';
+    this.servicesCatalogRefreshButton = '[data-test="services-catalog-refresh-btn"]';
+    // No-data state inside the graph panel (OEmptyState rendered by
+    // ServiceGraphNoDataState.vue within the graph container).
+    this.serviceGraphEmptyState = '[data-test="service-graph-container"] [data-test="o2-empty-state"]';
 
     // Search Bar - Controls
     this.showMetricsToggle = '[data-test="traces-search-bar-show-metrics-toggle-btn"]';
@@ -395,6 +408,34 @@ export class TracesPage {
     await this.page.locator(this.serviceMapsNavItem).click();
     await this.page.waitForURL(/\/traces\/service-graph/, { timeout: 10000 }).catch(() => {});
     await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+  }
+
+  // In-page toolbar tab on the Traces page (NOT the rail flyout) — clicking it
+  // switches the view inline; the URL stays on /traces and gains
+  // ?tab=service-graph. Waits for the inline graph view: the chart when
+  // topology data exists, or the no-data state otherwise (topology needs the
+  // service-graph daemon, which this suite does not seed).
+  async navigateToServiceGraphViaTab() {
+    await this.page.locator(this.serviceGraphTabToggle).click();
+    await this.page.waitForURL(/\/traces\?.*tab=service-graph/, { timeout: 10000 });
+    await this.page
+      .locator(this.serviceGraphChart)
+      .or(this.page.locator(this.serviceGraphEmptyState))
+      .first()
+      .waitFor({ state: 'visible', timeout: 15000 });
+  }
+
+  // In-page toolbar tab on the Traces page (NOT the rail flyout) — clicking it
+  // switches the view inline; the URL stays on /traces and gains
+  // ?tab=services-catalog. Waits for the inline catalog (table or empty state).
+  async navigateToServicesViaTab() {
+    await this.page.locator(this.servicesCatalogTabToggle).click();
+    await this.page.waitForURL(/\/traces\?.*tab=services-catalog/, { timeout: 10000 });
+    await this.page
+      .locator(this.servicesCatalogTable)
+      .or(this.page.locator(this.servicesCatalogEmpty))
+      .first()
+      .waitFor({ state: 'visible', timeout: 15000 });
   }
 
   async switchToSearchView() {

--- a/tests/ui-testing/playwright-tests/Traces/traces-toolbar-tabs.spec.js
+++ b/tests/ui-testing/playwright-tests/Traces/traces-toolbar-tabs.spec.js
@@ -44,11 +44,7 @@ test.describe("Traces toolbar tabs (in-page)", () => {
     // Inline graph view renders (selectors live in ServiceGraph.vue, so they
     // work in-page): the chart when topology data exists, else the no-data
     // state — this suite doesn't seed the service-graph daemon's topology.
-    const graphView = page
-      .locator('[data-test="service-graph-chart"]')
-      .or(page.locator('[data-test="service-graph-container"] [data-test="o2-empty-state"]'))
-      .first();
-    await expect(graphView).toBeVisible({ timeout: 15000 });
+    await pm.tracesPage.expectServiceGraphViewVisible();
     testLogger.info('Service Graph rendered inline from toolbar tab');
   });
 
@@ -62,11 +58,7 @@ test.describe("Traces toolbar tabs (in-page)", () => {
     expect(page.url()).toMatch(/\/traces\?.*tab=services-catalog/);
     expect(page.url()).not.toMatch(/\/traces\/services(\?|$)/);
     // Inline catalog renders — table with data, or the empty state
-    const catalog = page
-      .locator('[data-test="services-catalog-table"]')
-      .or(page.locator('[data-test="services-catalog-empty"]'))
-      .first();
-    await expect(catalog).toBeVisible({ timeout: 15000 });
+    await pm.tracesPage.expectServicesCatalogVisible();
     testLogger.info('Services Catalog rendered inline from toolbar tab');
   });
 
@@ -82,8 +74,7 @@ test.describe("Traces toolbar tabs (in-page)", () => {
 
     // All per-mode DateTime instances bind to the same searchObj.data.datetime,
     // so the chosen period carries into the catalog toolbar implicitly.
-    await expect(page.locator('[data-test="services-catalog-date-time-picker"]'))
-      .toContainText('Past 30 Minutes', { timeout: 10000 });
+    await pm.tracesPage.expectServicesCatalogTimeRange('Past 30 Minutes');
 
     // Reload — mandatory: a warm in-app visit does NOT re-run
     // restoreUrlQueryParams (pre-#13659-faithful); only a cold load proves the
@@ -92,13 +83,8 @@ test.describe("Traces toolbar tabs (in-page)", () => {
     await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
 
     // The catalog tab is active again after the cold load
-    await expect(page.locator('[data-test="traces-search-mode-services-catalog-btn"]'))
-      .toHaveAttribute('data-state', 'on', { timeout: 10000 });
-    const catalog = page
-      .locator('[data-test="services-catalog-table"]')
-      .or(page.locator('[data-test="services-catalog-empty"]'))
-      .first();
-    await expect(catalog).toBeVisible({ timeout: 15000 });
+    await pm.tracesPage.expectServicesCatalogTabActive();
+    await pm.tracesPage.expectServicesCatalogVisible();
     testLogger.info('Catalog tab restored from ?tab= after reload');
   });
 
@@ -111,7 +97,7 @@ test.describe("Traces toolbar tabs (in-page)", () => {
 
     // The flyout path IS the standalone route — proving the dual semantics coexist
     expect(page.url()).toMatch(/\/traces\/service-graph/);
-    await expect(page.locator('[data-test="service-graph-page"]')).toBeVisible({ timeout: 10000 });
+    await pm.tracesPage.expectStandaloneServiceGraphPageVisible();
     testLogger.info('Standalone Service Graph page rendered from flyout');
   });
 });

--- a/tests/ui-testing/playwright-tests/Traces/traces-toolbar-tabs.spec.js
+++ b/tests/ui-testing/playwright-tests/Traces/traces-toolbar-tabs.spec.js
@@ -1,0 +1,117 @@
+// traces-toolbar-tabs.spec.js
+// E2E tests for the IN-PAGE Service Graph / Services Catalog tabs on the
+// Traces page toolbar. Clicking a tab switches the view inline — the URL stays
+// on /traces and gains ?tab=service-graph / ?tab=services-catalog, and the
+// shared search context (stream, time range) carries implicitly. The rail
+// flyout is a separate access path that navigates to the standalone routes
+// (/traces/service-graph, /traces/services) — dual semantics, both covered.
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+test.describe("Traces toolbar tabs (in-page)", () => {
+  test.describe.configure({ mode: 'serial' });
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    await pm.tracesPage.navigateToTraces();
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    testLogger.info('Test setup completed for traces toolbar tabs');
+  });
+
+  test.afterEach(async ({ }, testInfo) => {
+    testLogger.testEnd(testInfo.title, testInfo.status);
+  });
+
+  test("P1: Service Graph tab switches the view in-page (?tab=service-graph)", {
+    tag: ['@traces', '@tracesToolbarTabs', '@enterprise', '@P1', '@all']
+  }, async ({ page }) => {
+    testLogger.info('=== Clicking Service Graph toolbar tab ===');
+
+    await pm.tracesPage.navigateToServiceGraphViaTab();
+
+    // URL stays on /traces with ?tab= — NOT the standalone route
+    expect(page.url()).toMatch(/\/traces\?.*tab=service-graph/);
+    expect(page.url()).not.toMatch(/\/traces\/service-graph/);
+    // Inline graph view renders (selectors live in ServiceGraph.vue, so they
+    // work in-page): the chart when topology data exists, else the no-data
+    // state — this suite doesn't seed the service-graph daemon's topology.
+    const graphView = page
+      .locator('[data-test="service-graph-chart"]')
+      .or(page.locator('[data-test="service-graph-container"] [data-test="o2-empty-state"]'))
+      .first();
+    await expect(graphView).toBeVisible({ timeout: 15000 });
+    testLogger.info('Service Graph rendered inline from toolbar tab');
+  });
+
+  test("P1: Services Catalog tab switches the view in-page (?tab=services-catalog)", {
+    tag: ['@traces', '@tracesToolbarTabs', '@P1', '@all']
+  }, async ({ page }) => {
+    testLogger.info('=== Clicking Services Catalog toolbar tab ===');
+
+    await pm.tracesPage.navigateToServicesViaTab();
+
+    expect(page.url()).toMatch(/\/traces\?.*tab=services-catalog/);
+    expect(page.url()).not.toMatch(/\/traces\/services(\?|$)/);
+    // Inline catalog renders — table with data, or the empty state
+    const catalog = page
+      .locator('[data-test="services-catalog-table"]')
+      .or(page.locator('[data-test="services-catalog-empty"]'))
+      .first();
+    await expect(catalog).toBeVisible({ timeout: 15000 });
+    testLogger.info('Services Catalog rendered inline from toolbar tab');
+  });
+
+  test("P1: Search context carries into the catalog tab and ?tab= survives reload", {
+    tag: ['@traces', '@tracesToolbarTabs', '@P1', '@all']
+  }, async ({ page }) => {
+    testLogger.info('=== Setting non-default period on Traces, then switching to catalog tab ===');
+
+    // Non-default relative period (default is 15m)
+    await pm.tracesPage.setTimeRange('30m');
+
+    await pm.tracesPage.navigateToServicesViaTab();
+
+    // All per-mode DateTime instances bind to the same searchObj.data.datetime,
+    // so the chosen period carries into the catalog toolbar implicitly.
+    await expect(page.locator('[data-test="services-catalog-date-time-picker"]'))
+      .toContainText('Past 30 Minutes', { timeout: 10000 });
+
+    // Reload — mandatory: a warm in-app visit does NOT re-run
+    // restoreUrlQueryParams (pre-#13659-faithful); only a cold load proves the
+    // old ?tab= bookmark behavior.
+    await page.reload();
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+
+    // The catalog tab is active again after the cold load
+    await expect(page.locator('[data-test="traces-search-mode-services-catalog-btn"]'))
+      .toHaveAttribute('data-state', 'on', { timeout: 10000 });
+    const catalog = page
+      .locator('[data-test="services-catalog-table"]')
+      .or(page.locator('[data-test="services-catalog-empty"]'))
+      .first();
+    await expect(catalog).toBeVisible({ timeout: 15000 });
+    testLogger.info('Catalog tab restored from ?tab= after reload');
+  });
+
+  test("P1: Rail flyout still navigates to the standalone Service Graph route", {
+    tag: ['@traces', '@tracesToolbarTabs', '@enterprise', '@P1', '@all']
+  }, async ({ page }) => {
+    testLogger.info('=== Opening rail flyout and clicking Service Graph ===');
+
+    await pm.tracesPage.switchToServiceMaps();
+
+    // The flyout path IS the standalone route — proving the dual semantics coexist
+    expect(page.url()).toMatch(/\/traces\/service-graph/);
+    await expect(page.locator('[data-test="service-graph-page"]')).toBeVisible({ timeout: 10000 });
+    testLogger.info('Standalone Service Graph page rendered from flyout');
+  });
+});

--- a/tests/ui-testing/playwright-tests/utils/global-setup.js
+++ b/tests/ui-testing/playwright-tests/utils/global-setup.js
@@ -89,9 +89,10 @@ async function globalSetup() {
     // Wait for login to complete — look for navigation or success indicators.
     await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
 
-    // Verify login success by checking for the home menu item — the home
-    // route is "/" so the resulting data-test contains a literal slash.
-    await page.locator('[data-test="menu-link-/-item"]').waitFor({
+    // Verify login success by checking for the main nav rail — the current
+    // rail no longer renders per-route `menu-link-*` items (see #13659, which
+    // made the same fix in enhanced-baseFixtures.js).
+    await page.locator('[data-test="navbar-main-nav"]').waitFor({
       state: 'visible',
       timeout: 10000,
     });

--- a/web/src/composables/shared/router.ts
+++ b/web/src/composables/shared/router.ts
@@ -292,7 +292,7 @@ const useRoutes = () => {
       component: ServicesCatalogView,
       meta: {
         keepAlive: true,
-        title: "Services",
+        title: "Service Catalog",
       },
       beforeEnter(to: any, from: any, next: any) {
         routeGuard(to, from, next);

--- a/web/src/lib/core/Navbar/ONavGroup.spec.ts
+++ b/web/src/lib/core/Navbar/ONavGroup.spec.ts
@@ -294,4 +294,105 @@ describe("ONavGroup", () => {
       expect(activeNames(wrapper)).toEqual(["alertDetail"]);
     });
   });
+
+  // Traces: Service Graph / Service Catalog are standalone routes, but the same
+  // views also render in-page on /traces?tab=… — `activeOnTab` makes the flyout
+  // highlight follow what the user is looking at on either path.
+  describe("tab-alias active state (activeOnTab)", () => {
+    const tracesChildren: SubnavChild[] = [
+      { titleKey: "menu.traces", icon: "account-tree", name: "traces" },
+      {
+        titleKey: "menu.serviceGraph",
+        icon: "share",
+        name: "serviceGraph",
+        activeOnTab: { name: "traces", tab: "service-graph" },
+      },
+      {
+        titleKey: "menu.services",
+        icon: "menu-book",
+        name: "servicesCatalog",
+        activeOnTab: { name: "traces", tab: "services-catalog" },
+      },
+    ];
+
+    function makeTracesRouter() {
+      return createRouter({
+        history: createMemoryHistory(),
+        routes: [
+          { path: "/", name: "home", component: { template: "<div />" } },
+          { path: "/traces", name: "traces", component: { template: "<div />" } },
+          {
+            path: "/traces/service-graph",
+            name: "serviceGraph",
+            component: { template: "<div />" },
+          },
+          {
+            path: "/traces/services",
+            name: "servicesCatalog",
+            component: { template: "<div />" },
+          },
+        ],
+      });
+    }
+
+    async function mountAt(path: string) {
+      const router = makeTracesRouter();
+      router.push(path);
+      await router.isReady();
+      const w = mount(ONavGroup, {
+        props: {
+          groupKey: "traces",
+          title: "Traces",
+          icon: "account-tree",
+          children: tracesChildren,
+          parentItem: {
+            link: "/traces",
+            title: "Traces",
+            icon: "account-tree",
+            name: "traces",
+          },
+        },
+        global: {
+          plugins: [router, store, i18n],
+          stubs: { MenuLink: menuLinkStub, OIcon: oIconStub, teleport: true },
+        },
+      });
+      await w.trigger("mouseenter");
+      vi.advanceTimersByTime(OPEN_DELAY);
+      await flushPromises();
+      return w;
+    }
+
+    function activeNames(w: VueWrapper): string[] {
+      return w
+        .findAll('[data-test^="nav-group-item-"]')
+        .filter((el) => el.attributes("aria-current") === "page")
+        .map((el) => el.attributes("data-test")!.replace("nav-group-item-", ""));
+    }
+
+    it("marks Traces on plain /traces", async () => {
+      wrapper = await mountAt("/traces");
+      expect(activeNames(wrapper)).toEqual(["traces"]);
+    });
+
+    it("marks Service Graph, not Traces, on /traces?tab=service-graph", async () => {
+      wrapper = await mountAt("/traces?tab=service-graph");
+      expect(activeNames(wrapper)).toEqual(["serviceGraph"]);
+    });
+
+    it("marks Service Catalog, not Traces, on /traces?tab=services-catalog", async () => {
+      wrapper = await mountAt("/traces?tab=services-catalog");
+      expect(activeNames(wrapper)).toEqual(["servicesCatalog"]);
+    });
+
+    it("marks Traces on the in-page granularity tabs (?tab=spans)", async () => {
+      wrapper = await mountAt("/traces?tab=spans");
+      expect(activeNames(wrapper)).toEqual(["traces"]);
+    });
+
+    it("marks Service Graph on its standalone route", async () => {
+      wrapper = await mountAt("/traces/service-graph");
+      expect(activeNames(wrapper)).toEqual(["serviceGraph"]);
+    });
+  });
 });

--- a/web/src/lib/core/Navbar/ONavGroup.vue
+++ b/web/src/lib/core/Navbar/ONavGroup.vue
@@ -181,6 +181,17 @@ function childPath(name: string): string | null {
 const activeChild = computed<SubnavChild | null>(() => {
   const route = router.currentRoute.value;
 
+  // A tab-alias match wins over everything: the child's own route is elsewhere,
+  // but the CURRENT route is showing its view via a query tab (e.g.
+  // /traces?tab=service-graph renders the Service Graph in-page). Checked
+  // before the exact-name pass so the aliased route's own child (Traces)
+  // doesn't claim the highlight.
+  const tabAlias = props.children.find(
+    (c) =>
+      c.activeOnTab && route.name === c.activeOnTab.name && route.query.tab === c.activeOnTab.tab,
+  );
+  if (tabAlias) return tabAlias;
+
   const exact = props.children.find(
     (c) => route.name === c.name && (!c.tab || route.query.tab === c.tab),
   );

--- a/web/src/lib/core/Navbar/ONavbar.types.ts
+++ b/web/src/lib/core/Navbar/ONavbar.types.ts
@@ -57,6 +57,14 @@ export interface SubnavChild {
   category?: string;
   /** Query `tab` for routes that switch sub-views via a query param (AI evals). */
   tab?: string;
+  /**
+   * Also mark this child active when ANOTHER route shows the same view via a
+   * query tab. Traces: Service Graph / Service Catalog are standalone routes
+   * (what this child navigates to) but the same views also render in-page on
+   * `/traces?tab=…` — the flyout highlight should follow what the user is
+   * looking at, matching every other submenu's behavior.
+   */
+  activeOnTab?: { name: string; tab: string };
   /** Group children only: include only when this top-level item is present. */
   requires?: string;
   /**

--- a/web/src/lib/core/Navbar/navGroups.ts
+++ b/web/src/lib/core/Navbar/navGroups.ts
@@ -215,8 +215,11 @@ export const NAV_GROUPS: NavGroupDef[] = [
  * in-page SectionRail is the place to switch sections. Re-add an entry here
  * (mirroring the page's SectionRail) to restore a hover flyout.
  *
- * Traces: each child is its own route. Spans is deliberately absent — it is a
- * view-granularity toggle inside the Traces search page (it shares the
+ * Traces: each flyout child is its own standalone route. The Traces page also
+ * offers Service Graph / Services Catalog as toolbar tabs (SearchBar.vue) that
+ * switch views in-page (`?tab=`) — dual access paths with different semantics.
+ * Spans is deliberately absent — it is
+ * a view-granularity toggle inside the Traces search page (it shares the
  * query/stream/time context), not a destination. Service Graph carries the
  * `enterprise` gate its route guard applies, so the rail never offers a link
  * that would redirect straight back to Traces.
@@ -229,8 +232,14 @@ export const NAV_SUBNAV: Record<string, SubnavChild[]> = {
       icon: "share",
       name: "serviceGraph",
       gate: "enterprise",
+      activeOnTab: { name: "traces", tab: "service-graph" },
     },
-    { titleKey: "menu.services", icon: "menu-book", name: "servicesCatalog" },
+    {
+      titleKey: "menu.services",
+      icon: "menu-book",
+      name: "servicesCatalog",
+      activeOnTab: { name: "traces", tab: "services-catalog" },
+    },
   ],
 };
 

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -1025,7 +1025,7 @@
     "search": "Logs",
     "traces": "Traces",
     "serviceGraph": "Service Graph",
-    "services": "Services",
+    "services": "Service Catalog",
     "aiObservability": "AI",
     "aiAssistant": "AI Assistant",
     "signOut": "Sign Out",

--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -21,6 +21,7 @@ import i18n from "@/locales";
 import store from "@/test/unit/helpers/store";
 import router from "@/test/unit/helpers/router";
 import * as useDurationPercentilesModule from "@/composables/useDurationPercentiles";
+import { buildViewTracesFilter } from "@/plugins/traces/viewTracesHandoff";
 
 // Create DOM node for mounting
 const node = document.createElement("div");
@@ -152,7 +153,7 @@ const mockSearchObj = {
     showQuery: true,
     showHistogram: true,
     sqlMode: false,
-    searchMode: "traces" as "traces" | "spans" | "service-graph",
+    searchMode: "traces" as "traces" | "spans" | "service-graph" | "services-catalog",
     resultGrid: {
       rowsPerPage: 25,
       sortBy: "start_time" as string,
@@ -393,6 +394,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -415,6 +417,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -444,6 +447,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -479,6 +483,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -498,6 +503,119 @@ describe("Index.vue (Main Traces Page)", () => {
         }),
       );
     });
+
+    it("should switch to service-graph tab from ?tab= on enterprise", async () => {
+      routerCurrentRouteSpy.mockReturnValue({
+        value: {
+          query: { tab: "service-graph" },
+          name: "traces",
+          path: "/traces",
+        },
+      } as any);
+
+      wrapper = mount(Index, {
+        attachTo: node,
+        global: {
+          plugins: [i18n, router],
+          provide: { store: store },
+          stubs: {
+            "search-bar": true,
+            "index-list": true,
+            "search-result": true,
+            "service-graph": true,
+            "services-catalog": true,
+            SanitizedHtmlRenderer: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // onBeforeMount sets searchMode from URL; activeTab computed reflects it
+      expect(mockSearchObj.meta.searchMode).toBe("service-graph");
+      expect(wrapper.vm.activeTab).toBe("service-graph");
+    });
+  });
+
+  describe("In-page tab rendering", () => {
+    const mountIndex = () =>
+      mount(Index, {
+        attachTo: node,
+        global: {
+          plugins: [i18n, router],
+          provide: { store: store },
+          stubs: {
+            "search-bar": true,
+            "index-list": true,
+            "search-result": true,
+            "service-graph": true,
+            "services-catalog": true,
+            SanitizedHtmlRenderer: true,
+          },
+        },
+      });
+
+    it("should render the ServiceGraph stub inline in service-graph mode (enterprise)", async () => {
+      mockSearchObj.meta.searchMode = "service-graph";
+      wrapper = mountIndex();
+      await flushPromises();
+
+      expect(wrapper.findComponent({ name: "service-graph" }).exists()).toBe(true);
+      expect(wrapper.findComponent({ name: "services-catalog" }).exists()).toBe(false);
+    });
+
+    it("should render the ServicesCatalog stub inline in services-catalog mode", async () => {
+      mockSearchObj.meta.searchMode = "services-catalog";
+      wrapper = mountIndex();
+      await flushPromises();
+
+      expect(wrapper.findComponent({ name: "services-catalog" }).exists()).toBe(true);
+      expect(wrapper.findComponent({ name: "service-graph" }).exists()).toBe(false);
+    });
+
+    it("should apply the built filter and switch mode on view-traces from the graph", async () => {
+      mockSearchObj.meta.searchMode = "service-graph";
+      wrapper = mountIndex();
+      await flushPromises();
+
+      const payload = {
+        serviceName: "cart-service",
+        operationName: "GET /cart",
+        mode: "traces",
+        stream: "default",
+      };
+      const graphEl = wrapper.findComponent({ name: "service-graph" });
+      expect(graphEl.exists()).toBe(true);
+      await graphEl.vm.$emit("view-traces", payload);
+      await flushPromises();
+
+      expect(mockSearchObj.data.editorValue).toBe(buildViewTracesFilter(payload));
+      expect(mockSearchObj.data.editorValue).toBe(
+        "service_name = 'cart-service' AND operation_name = 'GET /cart'",
+      );
+      expect(mockSearchObj.meta.searchMode).toBe("traces");
+      expect(mockSearchObj.data.stream.selectedStream).toEqual({
+        label: "default",
+        value: "default",
+      });
+    });
+
+    it("should hydrate the handoff ?filter= into the editor on mount", async () => {
+      routerCurrentRouteSpy.mockReturnValue({
+        value: {
+          query: { filter: "service_name = 'checkout'" },
+          name: "traces",
+          path: "/traces",
+        },
+      } as any);
+      mockSearchObj.meta.sqlMode = true;
+
+      wrapper = mountIndex();
+      await flushPromises();
+
+      expect(mockSearchObj.data.editorValue).toBe("service_name = 'checkout'");
+      expect(mockSearchObj.meta.sqlMode).toBe(false);
+    });
   });
 
   describe("Stream Selection", () => {
@@ -512,6 +630,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -547,6 +666,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -577,6 +697,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -611,6 +732,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -632,6 +754,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -663,6 +786,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -694,6 +818,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -720,6 +845,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -750,6 +876,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -775,6 +902,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -805,6 +933,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -847,6 +976,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -880,6 +1010,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -910,6 +1041,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -949,6 +1081,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1070,6 +1203,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1100,6 +1234,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1126,6 +1261,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1147,6 +1283,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1169,6 +1306,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1190,6 +1328,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1229,6 +1368,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1255,6 +1395,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1280,6 +1421,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1305,6 +1447,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1332,6 +1475,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1425,6 +1569,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1469,6 +1614,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1507,6 +1653,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1550,6 +1697,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1606,6 +1754,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1636,6 +1785,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1669,6 +1819,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1704,6 +1855,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1745,6 +1897,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1815,6 +1968,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1923,6 +2077,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -1977,6 +2132,7 @@ describe("Index.vue (Main Traces Page)", () => {
               "index-list": true,
               "search-result": true,
               "service-graph": true,
+              "services-catalog": true,
               SanitizedHtmlRenderer: true,
             },
           },
@@ -2167,6 +2323,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -2200,6 +2357,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -2237,6 +2395,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -2279,6 +2438,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },
@@ -2310,6 +2470,7 @@ describe("Index.vue (Main Traces Page)", () => {
             "index-list": true,
             "search-result": true,
             "service-graph": true,
+            "services-catalog": true,
             SanitizedHtmlRenderer: true,
           },
         },

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -23,8 +23,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   >
     <div id="tracesSecondLevel" class="h-full">
       <OSplitter
-        class="traces-horizontal-splitter h-full"
+        :class="[
+          'traces-horizontal-splitter h-full',
+          activeTab === 'service-graph' || activeTab === 'services-catalog'
+            ? 'hide-splitter-separator'
+            : '',
+        ]"
         v-model="splitterModel"
+        :disable="activeTab === 'service-graph' || activeTab === 'services-catalog'"
         :horizontal="true"
         unit="px"
         :limits="[85, 400]"
@@ -34,7 +40,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           marginBottom: '-0.3125rem',
           zIndex: '10',
         }"
-        before-class="z-auto overflow-visible"
+        :before-class="
+          activeTab === 'service-graph' || activeTab === 'services-catalog'
+            ? 'z-auto overflow-visible max-h-[3.125rem]!'
+            : 'z-auto overflow-visible'
+        "
         @update:model-value="onSplitterUpdate"
       >
         <template v-slot:before>
@@ -48,20 +58,50 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               ref="searchBarRef"
               :fieldValues="fieldValues"
               :isLoading="searchObj.loading"
+              :activeTab="activeTab"
               class="bg-card-glass-bg"
               @searchdata="searchData"
               @onChangeTimezone="refreshTimezone"
+              @update:activeTab="activeTab = $event"
               @error-only-toggled="onErrorOnlyToggled"
               @filters-reset="onFiltersReset"
               @cancel-query="cancelSearch"
               @update:searchMode="onSearchModeChange"
+              @service-graph-refresh="serviceGraphRef?.refresh()"
+              @services-catalog-refresh="servicesCatalogRef?.loadServicesCatalog()"
             />
           </div>
         </template>
         <template v-slot:after>
           <div class="h-full overflow-hidden">
-            <!-- Search results (Spans / Traces) -->
+            <!-- Service Graph Tab Content -->
             <div
+              v-if="activeTab === 'service-graph' && config.isEnterprise == 'true'"
+              class="h-full overflow-hidden"
+            >
+              <ServiceGraph
+                ref="serviceGraphRef"
+                class="h-full"
+                @view-traces="handleServiceGraphViewTraces"
+                @request:stream-change="onChildStreamChangeRequest"
+                @jump-to-stream-data="onJumpToPanelStreamData"
+              />
+            </div>
+
+            <!-- Services Catalog Tab Content -->
+            <div v-if="activeTab === 'services-catalog'" class="h-full overflow-hidden">
+              <ServicesCatalog
+                ref="servicesCatalogRef"
+                class="h-full"
+                @view-traces="handleServicesCatalogViewTraces"
+                @request:stream-change="onChildStreamChangeRequest"
+                @jump-to-stream-data="onJumpToPanelStreamData"
+              />
+            </div>
+
+            <!-- Search Tab Content -->
+            <div
+              v-if="activeTab === 'search'"
               id="tracesThirdLevel"
               class="traces-search-result-container relative-position h-full"
             >
@@ -281,6 +321,7 @@ import {
   getUUID,
   generateTraceContext,
 } from "@/utils/zincutils";
+import { buildViewTracesFilter, normalizeViewTracesPayload } from "./viewTracesHandoff";
 import { chartColor } from "@/utils/chartTheme";
 import useHttpStreaming from "@/composables/useStreamingSearch";
 import segment from "@/services/segment_analytics";
@@ -329,7 +370,15 @@ const SearchResult = defineAsyncComponent(() => import("./SearchResult.vue"));
 const SanitizedHtmlRenderer = defineAsyncComponent(
   () => import("@/components/SanitizedHtmlRenderer.vue"),
 );
+const ServiceGraph = defineAsyncComponent(() => import("./ServiceGraph.vue"));
+const ServicesCatalog = defineAsyncComponent(() => import("./ServicesCatalog.vue"));
+
 const store = useStore();
+const activeTab = computed(() => {
+  if (searchObj.meta.searchMode === "service-graph") return "service-graph";
+  if (searchObj.meta.searchMode === "services-catalog") return "services-catalog";
+  return "search";
+});
 const router = useRouter();
 const { t } = useI18nTyped();
 // Bubbles AI-chat requests up to MainLayout, which opens the O2AIChat panel.
@@ -364,6 +413,8 @@ correlationFilters.watchQuery();
 let refreshIntervalID = 0;
 const searchResultRef = ref(null);
 const searchBarRef = ref(null);
+const serviceGraphRef = ref<any>(null);
+const servicesCatalogRef = ref<any>(null);
 const splitterModel = ref(90);
 const fieldValues = ref({});
 const { showErrorNotification } = useNotifications();
@@ -1514,10 +1565,14 @@ function restoreUrlQueryParams() {
     searchObj.data.editorValue = b64DecodeUnicode(queryParams.query);
   }
 
-  // Service Graph / Services Catalog are their own routes now; the only tab
-  // values this page still owns are its two search granularities.
   const tab = typeof queryParams.tab === "string" ? queryParams.tab : undefined;
-  if (tab === "traces" || tab === "spans") {
+  if (
+    tab !== undefined &&
+    (["service-graph", "traces", "spans", "services-catalog"] as const).includes(
+      tab as "service-graph" | "traces" | "spans" | "services-catalog",
+    )
+  ) {
+    if (tab === "service-graph" && config.isEnterprise !== "true") return;
     searchObj.meta.searchMode = tab as TraceSearchMode;
   }
 
@@ -1605,9 +1660,10 @@ const onErrorOnlyToggled = (value: boolean) => {
   }
 };
 
-// Handler for the Spans / Traces granularity toggle
-const onSearchModeChange = (mode: "traces" | "spans") => {
+// Handler for Search Mode toggle (Service Graph / Traces / Spans / Services Catalog)
+const onSearchModeChange = (mode: "traces" | "spans" | "service-graph" | "services-catalog") => {
   searchObj.meta.searchMode = mode;
+  if (mode === "service-graph" || mode === "services-catalog") return;
   if (
     mode === "traces" &&
     searchObj.meta.resultGrid.sortBy !== "start_time" &&
@@ -1914,6 +1970,8 @@ const searchData = () => {
     return;
   }
 
+  if (activeTab.value === "service-graph" || activeTab.value === "services-catalog") return;
+
   // Clear brush selections when running query
   // The filters are now part of the query, so brush selections should be cleared
   searchObj.meta.metricsRangeFilters.clear();
@@ -2067,6 +2125,63 @@ watch(
 // Auto-run in live mode is driven by explicit triggers at each user-intent
 // handler (filter add/remove, manual date change, redirect, metrics brush), not
 // by watching `searchObj.data.query`.
+
+// Handler for service graph view traces event
+const handleServiceGraphViewTraces = (data: any) => {
+  // Switch to search tab
+  searchObj.meta.searchMode = data.mode;
+
+  // Set the selected stream in dropdown
+  if (data.stream) {
+    searchObj.data.stream.selectedStream = {
+      label: data.stream,
+      value: data.stream,
+    };
+  }
+
+  // Set the filter query (just the WHERE condition, no SELECT or ORDER BY).
+  // buildViewTracesFilter returns "" when the payload names no service, which
+  // preserves the pre-existing "only filter when a service is named" guard.
+  const filterQuery = buildViewTracesFilter(data);
+  if (filterQuery) {
+    searchObj.data.editorValue = filterQuery;
+    searchObj.meta.sqlMode = false; // Traces doesn't use SQL mode
+  }
+
+  // Set the time range
+  if (data.timeRange) {
+    searchObj.data.datetime = {
+      startTime: data.timeRange.startTime,
+      endTime: data.timeRange.endTime,
+      relativeTimePeriod: null,
+      type: "absolute",
+    };
+  }
+
+  // Run the query
+  nextTick(() => {
+    runQueryFn();
+  });
+};
+
+/**
+ * Handler for the services catalog `view-traces` event.
+ *
+ * Normalizes the payload (which may be a plain service name string for backward
+ * compatibility, or a full object with `serviceName`, `serviceType`,
+ * `resourceFilter`, etc.) and delegates to {@link handleServiceGraphViewTraces}
+ * to populate the search bar and run the filtered traces query.
+ *
+ * @param data - Service name string (legacy) or structured filter object.
+ *               Structured objects may include `serviceName`, `serviceType`,
+ *               `operationName`, `nodeName`, `podName`, `callerService`,
+ *               `resourceFilter`, `errorsOnly`, `minDurationMicros`,
+ *               `maxDurationMicros`, `mode`, and `stream`.
+ */
+const handleServicesCatalogViewTraces = (data: string | Record<string, any>) => {
+  // Normalize plain string to object then delegate to the full handler
+  handleServiceGraphViewTraces(normalizeViewTracesPayload(data));
+};
 
 /**
  * Hydrate a handoff from the standalone Service Graph / Services Catalog routes.

--- a/web/src/plugins/traces/SearchBar.spec.ts
+++ b/web/src/plugins/traces/SearchBar.spec.ts
@@ -392,19 +392,132 @@ describe("SearchBar", () => {
       await flushPromises();
 
       // OToggleGroup replaces the old .button-group.logs-visualize-toggle div.
-      // Only the two search granularities remain — Service Graph and Services
-      // Catalog are their own routes now, reached from the left-rail flyout.
+      // All four modes render as in-page tabs — Service Graph and Services
+      // Catalog switch views inline on the Traces page (`?tab=`).
       expect(wrapper.find(".o-toggle-group-stub").exists()).toBe(true);
       expect(wrapper.find('[data-test="traces-search-mode-spans-btn"]').exists()).toBe(true);
       expect(wrapper.find('[data-test="traces-search-mode-traces-btn"]').exists()).toBe(true);
-      expect(wrapper.find('[data-test="traces-service-graph-toggle"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="traces-service-graph-toggle"]').exists()).toBe(true);
       expect(wrapper.find('[data-test="traces-search-mode-services-catalog-btn"]').exists()).toBe(
-        false,
+        true,
       );
     });
   });
 
   // -------------------------------------------------------------------------
+  describe("search mode toggle emits (update:searchMode)", () => {
+    it("should emit update:searchMode with 'service-graph' when the service-graph button is clicked", async () => {
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      const sgBtn = wrapper.find('[data-test="traces-service-graph-toggle"]');
+      expect(sgBtn.exists()).toBe(true);
+      await sgBtn.trigger("click");
+
+      expect(wrapper.emitted("update:searchMode")).toBeTruthy();
+      expect(wrapper.emitted("update:searchMode")![0]).toEqual(["service-graph"]);
+    });
+
+    it("should emit update:searchMode with 'services-catalog' when the services-catalog button is clicked", async () => {
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      const scBtn = wrapper.find('[data-test="traces-search-mode-services-catalog-btn"]');
+      expect(scBtn.exists()).toBe(true);
+      await scBtn.trigger("click");
+
+      expect(wrapper.emitted("update:searchMode")).toBeTruthy();
+      expect(wrapper.emitted("update:searchMode")![0]).toEqual(["services-catalog"]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe("searchMode conditional rendering", () => {
+    it("should show search controls when searchMode is 'traces'", async () => {
+      searchObjInstance.meta.searchMode = "traces";
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      expect(wrapper.find('[data-test="traces-search-bar-reset-filters-btn"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="logs-search-bar-date-time-dropdown"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="logs-search-bar-refresh-btn"]').exists()).toBe(true);
+    });
+
+    it("should hide search controls when searchMode is 'service-graph'", async () => {
+      searchObjInstance.meta.searchMode = "service-graph";
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      expect(wrapper.find('[data-test="traces-search-bar-reset-filters-btn"]').exists()).toBe(
+        false,
+      );
+      expect(wrapper.find('[data-test="logs-search-bar-date-time-dropdown"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="logs-search-bar-refresh-btn"]').exists()).toBe(false);
+    });
+
+    it("should hide search controls when searchMode is 'services-catalog'", async () => {
+      searchObjInstance.meta.searchMode = "services-catalog";
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      expect(wrapper.find('[data-test="traces-search-bar-reset-filters-btn"]').exists()).toBe(
+        false,
+      );
+      expect(wrapper.find('[data-test="logs-search-bar-date-time-dropdown"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="logs-search-bar-refresh-btn"]').exists()).toBe(false);
+    });
+
+    it("should re-show controls when searchMode changes back to 'traces'", async () => {
+      searchObjInstance.meta.searchMode = "service-graph";
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      expect(wrapper.find('[data-test="logs-search-bar-refresh-btn"]').exists()).toBe(false);
+
+      searchObjInstance.meta.searchMode = "traces";
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-test="logs-search-bar-refresh-btn"]').exists()).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe("per-mode toolbars", () => {
+    it("should show the Service Graph toolbar (DateTime, refresh, view toggles) in service-graph mode", async () => {
+      searchObjInstance.meta.searchMode = "service-graph";
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      expect(wrapper.find('[data-test="service-graph-date-time-picker"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="service-graph-refresh-btn"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="service-graph-tree-view-btn"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="service-graph-graph-view-btn"]').exists()).toBe(true);
+      // Services Catalog toolbar is not co-mounted
+      expect(wrapper.find('[data-test="services-catalog-date-time-picker"]').exists()).toBe(false);
+    });
+
+    it("should show the Services Catalog toolbar (DateTime) in services-catalog mode", async () => {
+      searchObjInstance.meta.searchMode = "services-catalog";
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      expect(wrapper.find('[data-test="services-catalog-date-time-picker"]').exists()).toBe(true);
+      // Service Graph toolbar is not co-mounted
+      expect(wrapper.find('[data-test="service-graph-date-time-picker"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="service-graph-refresh-btn"]').exists()).toBe(false);
+    });
+
+    it("should emit service-graph-refresh when the graph refresh button is clicked", async () => {
+      searchObjInstance.meta.searchMode = "service-graph";
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      await wrapper.find('[data-test="service-graph-refresh-btn"]').trigger("click");
+
+      expect(wrapper.emitted("service-graph-refresh")).toBeTruthy();
+    });
+  });
+
   // -------------------------------------------------------------------------
   describe("search mode toggle (update:searchMode)", () => {
     it("should emit update:searchMode with 'traces' when Traces button is clicked", async () => {
@@ -452,6 +565,19 @@ describe("SearchBar", () => {
       expect(wrapper.find('[data-test="traces-search-mode-spans-btn"]').classes()).toContain(
         "selected",
       );
+      expect(wrapper.find('[data-test="traces-search-mode-traces-btn"]').classes()).not.toContain(
+        "selected",
+      );
+    });
+
+    it("should apply 'selected' class to Services Catalog button when searchMode is 'services-catalog'", async () => {
+      searchObjInstance.meta.searchMode = "services-catalog";
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      expect(
+        wrapper.find('[data-test="traces-search-mode-services-catalog-btn"]').classes(),
+      ).toContain("selected");
       expect(wrapper.find('[data-test="traces-search-mode-traces-btn"]').classes()).not.toContain(
         "selected",
       );

--- a/web/src/plugins/traces/SearchBar.vue
+++ b/web/src/plugins/traces/SearchBar.vue
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         ref="toolbarLeftRef"
         class="flex min-w-0 flex-1 flex-row items-center gap-1.5 overflow-hidden"
       >
-        <!-- Search granularity toggle: Spans / Traces -->
+        <!-- Unified View Toggle: Service Graph / Traces / Spans -->
         <OToggleGroup
           :model-value="searchObj.meta.searchMode"
           @update:model-value="$emit('update:searchMode', $event)"
@@ -44,33 +44,60 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <template #icon-left><OIcon name="account-tree" size="sm" class="shrink-0" /></template>
             <span v-if="!shouldHideToggleText">{{ t("traces.tracesTab") }}</span>
           </OToggleGroupItem>
+          <OToggleGroupItem
+            v-if="config.isEnterprise == 'true'"
+            data-test="traces-service-graph-toggle"
+            value="service-graph"
+            size="sm"
+            :tooltip="shouldHideToggleText ? t('traces.serviceGraphTab') : undefined"
+          >
+            <template #icon-left><OIcon name="share" size="sm" class="shrink-0" /></template>
+            <span v-if="!shouldHideToggleText">{{ t("traces.serviceGraphTab") }}</span>
+          </OToggleGroupItem>
+          <OToggleGroupItem
+            data-test="traces-search-mode-services-catalog-btn"
+            value="services-catalog"
+            size="sm"
+            :tooltip="shouldHideToggleText ? t('traces.servicesCatalog.tabLabel') : undefined"
+          >
+            <template #icon-left><OIcon name="menu-book" size="sm" class="shrink-0" /></template>
+            <span v-if="!shouldHideToggleText">{{ t("traces.servicesCatalog.tabLabel") }}</span>
+          </OToggleGroupItem>
         </OToggleGroup>
 
-        <!-- Reset: icon+text at wide widths, icon-only when narrow -->
-        <OButton
-          data-test="traces-search-bar-reset-filters-btn"
-          variant="outline"
-          size="xs"
-          @click="resetFilters"
+        <!-- Show search controls only when not on Service Graph or Services Catalog -->
+        <template
+          v-if="
+            searchObj.meta.searchMode !== 'service-graph' &&
+            searchObj.meta.searchMode !== 'services-catalog'
+          "
         >
-          <template #icon-left>
-            <OIcon name="restart-alt" size="sm" class="shrink-0" />
-          </template>
-          <span v-if="!shouldHideResetText">{{ t("common.reset") }}</span>
-        </OButton>
+          <!-- Reset: icon+text at wide widths, icon-only when narrow -->
+          <OButton
+            data-test="traces-search-bar-reset-filters-btn"
+            variant="outline"
+            size="xs"
+            @click="resetFilters"
+          >
+            <template #icon-left>
+              <OIcon name="restart-alt" size="sm" class="shrink-0" />
+            </template>
+            <span v-if="!shouldHideResetText">{{ t("common.reset") }}</span>
+          </OButton>
 
-        <div
-          class="border-button-outline-border rounded-default hover:bg-button-outline-hover-bg flex cursor-pointer items-center justify-center border px-1.5 py-1 transition-all duration-200"
-        >
-          <OSwitch
-            data-test="traces-search-bar-show-metrics-toggle-btn"
-            v-model="searchObj.meta.showHistogram"
-            class="o2-toggle-button-xs flex items-center justify-center pr-1"
-            size="lg"
-          />
-          <OIcon name="bar-chart" size="sm" class="shrink-0" />
-          <OTooltip :content="t('traces.RedMetrics')" />
-        </div>
+          <div
+            class="border-button-outline-border rounded-default hover:bg-button-outline-hover-bg flex cursor-pointer items-center justify-center border px-1.5 py-1 transition-all duration-200"
+          >
+            <OSwitch
+              data-test="traces-search-bar-show-metrics-toggle-btn"
+              v-model="searchObj.meta.showHistogram"
+              class="o2-toggle-button-xs flex items-center justify-center pr-1"
+              size="lg"
+            />
+            <OIcon name="bar-chart" size="sm" class="shrink-0" />
+            <OTooltip :content="t('traces.RedMetrics')" />
+          </div>
+        </template>
 
         <!-- More menu: Syntax Guide — always last.
              Sessions + LLM Insights were removed from Traces; they now
@@ -96,7 +123,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
       <!-- Right toolbar — persistent wrapper so toolbarRightRef is always observable -->
       <div ref="toolbarRightRef" class="flex flex-shrink-0 items-center">
-        <div class="flex items-center gap-1.5">
+        <div
+          v-if="
+            searchObj.meta.searchMode !== 'service-graph' &&
+            searchObj.meta.searchMode !== 'services-catalog'
+          "
+          class="flex items-center gap-1.5"
+        >
           <DateTime
             ref="dateTimeRef"
             auto-apply
@@ -213,10 +246,89 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             shortcut-id="tracesCopyUrl"
           />
         </div>
+
+        <!-- Service Graph right toolbar: DateTime, Refresh, Tree/Graph tabs, Layout -->
+        <div v-if="searchObj.meta.searchMode === 'service-graph'" class="ml-auto">
+          <div class="flex items-center gap-2">
+            <DateTime
+              ref="dateTimeRef"
+              auto-apply
+              :default-type="searchObj.data.datetime.type"
+              :default-absolute-time="{
+                startTime: searchObj.data.datetime.startTime,
+                endTime: searchObj.data.datetime.endTime,
+              }"
+              :default-relative-time="searchObj.data.datetime.relativeTimePeriod"
+              data-test="service-graph-date-time-picker"
+              class="h-8!"
+              @on:date-change="updateDateTime"
+            />
+            <OButton
+              data-test="service-graph-refresh-btn"
+              variant="outline"
+              size="icon-toolbar"
+              class="min-w-[1.875rem]!"
+              @click="$emit('service-graph-refresh')"
+            >
+              <OIcon name="refresh" size="sm" />
+              <OTooltip :content="t('common.refresh')" />
+            </OButton>
+            <OToggleGroup
+              :model-value="searchObj.meta.serviceGraphVisualizationType"
+              @update:model-value="onServiceGraphVisualizationChange($event)"
+            >
+              <OToggleGroupItem data-test="service-graph-tree-view-btn" value="tree" size="sm">
+                <template #icon-left>
+                  <OIcon name="git-branch" size="sm" />
+                </template>
+                {{ t("traces.treeView") }}
+              </OToggleGroupItem>
+              <OToggleGroupItem data-test="service-graph-graph-view-btn" value="graph" size="sm">
+                <template #icon-left><OIcon name="share" size="sm" class="shrink-0" /></template>
+                {{ t("traces.graphView") }}
+              </OToggleGroupItem>
+            </OToggleGroup>
+            <OSelect
+              v-model="searchObj.meta.serviceGraphLayoutType"
+              :options="serviceGraphLayoutOptions"
+              :searchable="false"
+              class="h-8! min-h-8! w-[7.5rem]"
+              :disabled="searchObj.meta.serviceGraphVisualizationType === 'graph'"
+              @update:model-value="onServiceGraphLayoutChange"
+            />
+          </div>
+        </div>
+
+        <!-- Services Catalog right toolbar: DateTime, Refresh -->
+        <div v-if="searchObj.meta.searchMode === 'services-catalog'" class="ml-auto">
+          <div class="flex items-center gap-2">
+            <DateTime
+              ref="dateTimeRef"
+              auto-apply
+              menu-align="end"
+              :default-type="searchObj.data.datetime.type"
+              :default-absolute-time="{
+                startTime: searchObj.data.datetime.startTime,
+                endTime: searchObj.data.datetime.endTime,
+              }"
+              :default-relative-time="searchObj.data.datetime.relativeTimePeriod"
+              data-test="services-catalog-date-time-picker"
+              class="mr-1.5 h-8!"
+              @on:date-change="updateDateTime"
+            />
+          </div>
+        </div>
       </div>
       <!-- /toolbarRightRef wrapper -->
     </div>
-    <div v-if="searchObj.meta.showQuery" class="border-border-default flex min-h-0 flex-1 border-b">
+    <div
+      v-if="
+        searchObj.meta.searchMode !== 'service-graph' &&
+        searchObj.meta.searchMode !== 'services-catalog' &&
+        searchObj.meta.showQuery
+      "
+      class="border-border-default flex min-h-0 flex-1 border-b"
+    >
       <div class="relative flex h-full w-full flex-col overflow-hidden">
         <CodeQueryEditor
           ref="queryEditorRef"
@@ -269,6 +381,7 @@ import OIcon from "@/lib/core/Icon/OIcon.vue";
 import ODropdown from "@/lib/overlay/Dropdown/ODropdown.vue";
 import ODropdownItem from "@/lib/overlay/Dropdown/ODropdownItem.vue";
 import OSwitch from "@/lib/forms/Switch/OSwitch.vue";
+import OSelect from "@/lib/forms/Select/OSelect.vue";
 import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
 import OSeparator from "@/lib/core/Separator/OSeparator.vue";
 import useTraces from "@/composables/useTraces";
@@ -302,6 +415,7 @@ export default defineComponent({
     ODropdown,
     ODropdownItem,
     OSwitch,
+    OSelect,
     OTooltip,
     CodeQueryEditor: defineAsyncComponent(() => import("@/components/CodeQueryEditor.vue")),
     SyntaxGuide,
@@ -313,6 +427,8 @@ export default defineComponent({
     "error-only-toggled",
     "filters-reset",
     "onChangeTimezone",
+    "service-graph-refresh",
+    "services-catalog-refresh",
   ],
   props: {
     fieldValues: {
@@ -712,6 +828,35 @@ export default defineComponent({
       dateTimeRef.value?.setDateType("absolute");
     };
 
+    // Service Graph toolbar controls
+    const serviceGraphVisualizationTabs = [
+      { label: t("traces.treeView"), value: "tree" },
+      { label: t("traces.graphView"), value: "graph" },
+    ];
+
+    const serviceGraphLayoutOptions = computed(() => {
+      if (searchObj.meta.serviceGraphVisualizationType === "graph") {
+        return [{ label: t("traces.layoutForce"), value: "force" }];
+      }
+      return [
+        { label: t("traces.layoutHorizontal"), value: "horizontal" },
+        { label: t("traces.layoutVertical"), value: "vertical" },
+      ];
+    });
+
+    const onServiceGraphVisualizationChange = (type: "tree" | "graph") => {
+      searchObj.meta.serviceGraphVisualizationType = type;
+      localStorage.setItem("serviceGraph_visualizationType", type);
+      const newLayout = type === "tree" ? "horizontal" : "force";
+      searchObj.meta.serviceGraphLayoutType = newLayout;
+      localStorage.setItem("serviceGraph_layoutType", newLayout);
+    };
+
+    const onServiceGraphLayoutChange = (type: string) => {
+      searchObj.meta.serviceGraphLayoutType = type;
+      localStorage.setItem("serviceGraph_layoutType", type);
+    };
+
     const _traceStreamFields = computed(() => searchObj.data.stream.selectedStreamFields ?? []);
     const _traceFieldValues = computed(() => props.fieldValues ?? {});
     const _traceSqlMode = computed(() => false);
@@ -761,6 +906,10 @@ export default defineComponent({
       config,
       applyFilters,
       removeFilterByField,
+      serviceGraphVisualizationTabs,
+      serviceGraphLayoutOptions,
+      onServiceGraphVisualizationChange,
+      onServiceGraphLayoutChange,
       toggleLiveMode,
       traceEditorPlaceholder,
       toolbarLeftRef,


### PR DESCRIPTION
## What

#13659 converted Service Graph and Services Catalog from in-page tabs on the Traces page into standalone routes reached from the nav-rail flyout. This PR restores the in-page tabs as a **second access path** — both now coexist, with distinct semantics:

| Path | Semantics |
|---|---|
| Toolbar tabs on `/traces` | In-page view switch (`?tab=service-graph` / `?tab=services-catalog`), shares the page's stream + time context — the pre-#13659 UX, including old `?tab=` bookmarks |
| Nav-rail flyout | Navigates to the standalone routes `/traces/service-graph`, `/traces/services` — unchanged from #13659 |

Both paths render the same inner components (`ServiceGraph.vue`, `ServicesCatalog.vue`); only toolbar chrome differs.

## How

A guided **reverse-apply of #13659's diff to `Index.vue` + `SearchBar.vue` only** (verified byte-identical to the pre-PR files — both were untouched on main since), with four deliberate adaptations:

- **Re-added `applyHandoffFilter`** + its two hook call sites, which the revert would have deleted — the standalone pages' "View Traces" handoff (`?filter=` landing) depends on it. Covered by a new unit regression test and verified live.
- The restored in-page `view-traces` handlers call `viewTracesHandoff.ts` (`buildViewTracesFilter` / `normalizeViewTracesPayload`) instead of resurrecting the inline filter builders that #13659 extracted from them — no re-duplication.
- **Fixed a latent pre-#13659 bug**: the graph tab's refresh button called `serviceGraphRef?.loadServiceGraph()`, which was never in `ServiceGraph.vue`'s `expose()` — now `refresh()`.
- **Flyout highlight now follows the visible view** on both paths: new `SubnavChild.activeOnTab` alias marks the Service Graph / Service Catalog flyout items active when `/traces?tab=…` shows their view in-page. Previously the same view highlighted different flyout items depending on how you reached it — the only submenu that deviated.

Also:
- Renamed the "Services" submenu / page header / route title to **"Service Catalog"**, matching the toolbar tab label (single `menu.services` locale value covers all).
- `global-setup.js` login verification moved to `navbar-main-nav` — the same stale-selector fix #13659 applied to `enhanced-baseFixtures.js`; suites fail setup on main without it.

## Tests

| Suite | Result |
|---|---|
| Unit: `SearchBar` 69, `Index` 76, `ONavGroup` 18 (5 new `activeOnTab` cases), `viewTracesHandoff` 21, `navGroups` 28 | all pass (233 total, 2 pre-existing skips) |
| E2E (new) `Traces/traces-toolbar-tabs.spec.js` — in-page tab switches, shared-datetime carry, `?tab=` bookmark reload, flyout→standalone-route coexistence | 4/4 vs live enterprise build |
| E2E `Traces/service-catalog.spec.js` (standalone-route regression) | 18 pass |
| `type-check`, `eslint` (0 errors), `prettier`, `lint:design:strict` | clean |

Not run: `Traces/service-graph.spec.js` — its `beforeAll` ingests via `ZO_BASE_URL`, which requires a single-origin instance (CI); the dev vite+backend split can't satisfy it. Nothing in this PR touches `ServiceGraph.vue` or the standalone views.

## Notes for review

- `Index.vue` / `SearchBar.vue` restored regions are intentionally verbatim pre-#13659 (including its 16 pre-existing lint *warnings*) — deviations are limited to the four adaptations above, so the diff-vs-pre-PR is auditable.
- Two known-inert quirks restored deliberately, not bugs to fix here: `hide-splitter-separator` has no CSS rule (was a no-op pre-#13659 too), and `@update:activeTab` writes to a getter-only computed.