### PR TITLE
fix(traces): scope "View Logs" correlated query to the clicked span

### DIFF
--- a/web/src/composables/useTraces.spec.ts
+++ b/web/src/composables/useTraces.spec.ts
@@ -37,6 +37,16 @@ vi.mock("vue-router", () => ({
   })),
 }));
 
+// The span/trace id column names are org-configurable. Kept as one stable
+// mutable object so tests can repoint them and prove the query builders read
+// settings rather than hardcoding the defaults.
+const { mockOrgSettings } = vi.hoisted(() => ({
+  mockOrgSettings: {
+    span_id_field_name: "span_id",
+    trace_id_field_name: "trace_id",
+  } as Record<string, string | undefined>,
+}));
+
 vi.mock("vuex", async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -46,10 +56,7 @@ vi.mock("vuex", async (importOriginal) => {
         selectedOrganization: { identifier: "test-org" },
         zoConfig: { timestamp_column: "_timestamp", sql_reserved_keywords: [] },
         organizationData: {
-          organizationSettings: {
-            span_id_field_name: "span_id",
-            trace_id_field_name: "trace_id",
-          },
+          organizationSettings: mockOrgSettings,
         },
       },
       dispatch: vi.fn(),
@@ -163,6 +170,8 @@ describe("useTraces", () => {
     });
     mockSemanticGroups.value = [];
     mockLoadSemanticGroups.mockImplementation(async () => mockSemanticGroups.value);
+    mockOrgSettings.span_id_field_name = "span_id";
+    mockOrgSettings.trace_id_field_name = "trace_id";
     // Reset shared singleton state before each test
     const { resetSearchObj } = useTraces();
     resetSearchObj();
@@ -524,6 +533,48 @@ describe("useTraces", () => {
       expect(String(details.query)).toContain("b64std:");
     });
 
+    it("names the id columns from the org's configured field names", () => {
+      mockOrgSettings.span_id_field_name = "custom_span_col";
+      mockOrgSettings.trace_id_field_name = "custom_trace_col";
+      const { searchObj, buildQueryDetails, resetSearchObj } = useTraces();
+      resetSearchObj();
+      searchObj.data.traceDetails.selectedLogStreams = ["my-logs"] as any;
+      searchObj.data.traceDetails.selectedTrace = {
+        trace_id: "trace-xyz",
+        trace_start_time: 0,
+        trace_end_time: 0,
+      };
+
+      const details = buildQueryDetails({ spanId: "s1", start_time: 1000, end_time: 2000 }, true);
+
+      expect(String(details.query).replace(/^b64std:/, "")).toBe(
+        "custom_span_col='s1' AND custom_trace_col='trace-xyz'",
+      );
+    });
+
+    // Regression: the field names were previously interpolated as
+    // String(settings.span_id_field_name) with no fallback, so an org missing
+    // the setting produced a column literally named "undefined".
+    it("falls back to span_id/trace_id instead of an 'undefined' column", () => {
+      mockOrgSettings.span_id_field_name = undefined;
+      mockOrgSettings.trace_id_field_name = undefined;
+      const { searchObj, buildQueryDetails, resetSearchObj } = useTraces();
+      resetSearchObj();
+      searchObj.data.traceDetails.selectedLogStreams = ["my-logs"] as any;
+      searchObj.data.traceDetails.selectedTrace = {
+        trace_id: "trace-xyz",
+        trace_start_time: 0,
+        trace_end_time: 0,
+      };
+
+      const query = String(
+        buildQueryDetails({ spanId: "s1", start_time: 1000, end_time: 2000 }, true).query,
+      ).replace(/^b64std:/, "");
+
+      expect(query).not.toContain("undefined");
+      expect(query).toBe("span_id='s1' AND trace_id='trace-xyz'");
+    });
+
     it("joins multiple log streams with comma", () => {
       const { searchObj, buildQueryDetails, resetSearchObj } = useTraces();
       resetSearchObj();
@@ -646,6 +697,28 @@ describe("useTraces", () => {
 
       // The exact trace id wins over the stream's alias for the same group.
       expect(pushedQuery()).toBe("trace_id = 'trace-4'");
+    });
+
+    it("names the id columns from the org's configured field names", async () => {
+      mockOrgSettings.span_id_field_name = "custom_span_col";
+      mockOrgSettings.trace_id_field_name = "custom_trace_col";
+      const { navigateToCorrelatedLogs } = useTraces();
+      selectSpan("span-5", "trace-5");
+
+      await navigateToCorrelatedLogs(correlationProps());
+
+      expect(pushedQuery()).toBe("custom_span_col = 'span-5' and custom_trace_col = 'trace-5'");
+    });
+
+    it("falls back to span_id/trace_id when the org settings are absent", async () => {
+      mockOrgSettings.span_id_field_name = undefined;
+      mockOrgSettings.trace_id_field_name = undefined;
+      const { navigateToCorrelatedLogs } = useTraces();
+      selectSpan("span-6", "trace-6");
+
+      await navigateToCorrelatedLogs(correlationProps());
+
+      expect(pushedQuery()).toBe("span_id = 'span-6' and trace_id = 'trace-6'");
     });
   });
 

--- a/web/src/composables/useTraces.spec.ts
+++ b/web/src/composables/useTraces.spec.ts
@@ -90,6 +90,20 @@ vi.mock("@/utils/traces/traceColors", () => ({
   getSpanColorHex: vi.fn((index: number) => `#color-${index}`),
 }));
 
+// navigateToCorrelatedLogs resolves field names through the org's semantic
+// groups; tests drive that lookup by setting mockSemanticGroups.
+const { mockLoadSemanticGroups, mockSemanticGroups } = vi.hoisted(() => {
+  const mockSemanticGroups = { value: [] as any[] };
+  const mockLoadSemanticGroups = vi.fn(async () => mockSemanticGroups.value);
+  return { mockLoadSemanticGroups, mockSemanticGroups };
+});
+
+vi.mock("@/composables/useServiceCorrelation", () => ({
+  useServiceCorrelation: vi.fn(() => ({
+    loadSemanticGroups: mockLoadSemanticGroups,
+  })),
+}));
+
 // Mock serviceColorRegistry so the singleton internal registry does not
 // leak state between tests.  The composable imports
 //   `import { getOrSetServiceColor as registryGetOrSetServiceColor }`
@@ -147,6 +161,8 @@ describe("useTraces", () => {
       }
       return localTraceFilterStore;
     });
+    mockSemanticGroups.value = [];
+    mockLoadSemanticGroups.mockImplementation(async () => mockSemanticGroups.value);
     // Reset shared singleton state before each test
     const { resetSearchObj } = useTraces();
     resetSearchObj();
@@ -558,6 +574,78 @@ describe("useTraces", () => {
       expect(callArg.query.stream).toBe("my-stream");
       expect(callArg.query.org_identifier).toBe("my-org");
       expect(callArg.query.query).toBe("encoded");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // navigateToCorrelatedLogs
+  // -------------------------------------------------------------------------
+  describe("navigateToCorrelatedLogs", () => {
+    const correlationProps = (filters: Record<string, string> = {}) => ({
+      logStreams: [{ stream_name: "app-logs", filters }],
+      timeRange: { startTime: 1000, endTime: 2000 },
+    });
+
+    // b64EncodeUnicode is mocked as `b64uni:<input>`, so the pushed query param
+    // carries the raw WHERE clause.
+    const pushedQuery = () =>
+      String(mockRouterPush.mock.calls[0][0].query.query).replace(/^b64uni:/, "");
+
+    const selectSpan = (spanId: string | null, traceId: string | null) => {
+      const { searchObj } = useTraces();
+      searchObj.data.traceDetails.selectedSpanId = spanId;
+      searchObj.data.traceDetails.selectedTrace = traceId
+        ? { trace_id: traceId, trace_start_time: 0, trace_end_time: 0 }
+        : null;
+    };
+
+    it("appends span_id and trace_id conditions to the stream filter conditions", async () => {
+      const { navigateToCorrelatedLogs } = useTraces();
+      selectSpan("span-1", "trace-1");
+
+      await navigateToCorrelatedLogs(correlationProps({ k8s_namespace_name: "prod" }));
+
+      expect(pushedQuery()).toBe(
+        "k8s_namespace_name = 'prod' and span_id = 'span-1' and trace_id = 'trace-1'",
+      );
+    });
+
+    it("adds the id conditions when the correlated stream has no filters", async () => {
+      const { navigateToCorrelatedLogs } = useTraces();
+      selectSpan("span-2", "trace-2");
+
+      await navigateToCorrelatedLogs(correlationProps());
+
+      expect(pushedQuery()).toBe("span_id = 'span-2' and trace_id = 'trace-2'");
+    });
+
+    it("omits each id condition when its value is unavailable", async () => {
+      const { navigateToCorrelatedLogs } = useTraces();
+      selectSpan(null, "trace-3");
+
+      await navigateToCorrelatedLogs(correlationProps());
+
+      expect(pushedQuery()).toBe("trace_id = 'trace-3'");
+    });
+
+    it("escapes single quotes in id values", async () => {
+      const { navigateToCorrelatedLogs } = useTraces();
+      selectSpan("sp'an", null);
+
+      await navigateToCorrelatedLogs(correlationProps());
+
+      expect(pushedQuery()).toBe("span_id = 'sp''an'");
+    });
+
+    it("emits one condition when an id field shares a semantic group with a stream filter", async () => {
+      mockSemanticGroups.value = [{ id: "trace-id", fields: ["traceId", "trace_id"] }];
+      const { navigateToCorrelatedLogs } = useTraces();
+      selectSpan(null, "trace-4");
+
+      await navigateToCorrelatedLogs(correlationProps({ traceId: "stale-value" }));
+
+      // The exact trace id wins over the stream's alias for the same group.
+      expect(pushedQuery()).toBe("trace_id = 'trace-4'");
     });
   });
 

--- a/web/src/composables/useTraces.ts
+++ b/web/src/composables/useTraces.ts
@@ -263,8 +263,7 @@ const useTraces = () => {
     const key = `${identifier}_${searchObj.data.stream.selectedStream.value}`;
     // storage ref .value is typed {} at this boundary; narrow to the stored map shape
     const stored = useLocalTraceFilterField()?.value as
-      | Record<string, Record<string, string[]>>
-      | undefined;
+      Record<string, Record<string, string[]>> | undefined;
     const saved: Record<string, string[]> | undefined = stored?.[key];
 
     const fields: string[] = saved?.[searchMode]?.length

--- a/web/src/composables/useTraces.ts
+++ b/web/src/composables/useTraces.ts
@@ -21,7 +21,7 @@ import { copyToClipboard } from "@/utils/clipboard";
 import type { TranslateFn } from "@/types/i18n";
 import { getOrSetServiceColor as registryGetOrSetServiceColor } from "@/utils/traces/serviceColorRegistry";
 import { quoteSqlIdentifierIfNeeded } from "@/utils/query/sqlIdentifiers";
-import { buildFieldToGroupIdMap } from "@/utils/telemetryCorrelation";
+import { buildFieldToGroupIdMap, quoteSqlLiteral } from "@/utils/telemetryCorrelation";
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
 import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import type { TraceSearchMode } from "@/ts/interfaces/traces/trace.types";
@@ -263,7 +263,8 @@ const useTraces = () => {
     const key = `${identifier}_${searchObj.data.stream.selectedStream.value}`;
     // storage ref .value is typed {} at this boundary; narrow to the stored map shape
     const stored = useLocalTraceFilterField()?.value as
-      Record<string, Record<string, string[]>> | undefined;
+      | Record<string, Record<string, string[]>>
+      | undefined;
     const saved: Record<string, string[]> | undefined = stored?.[key];
 
     const fields: string[] = saved?.[searchMode]?.length
@@ -332,17 +333,25 @@ const useTraces = () => {
     });
   };
 
+  // The columns carrying span/trace ids are org-configurable. Both log
+  // navigations — the plain one and the correlated one — resolve them here so
+  // they cannot drift apart. Defaults mirror stores/index.ts.
+  const getSpanIdField = () =>
+    store.state.organizationData?.organizationSettings?.span_id_field_name || "span_id";
+  const getTraceIdField = () =>
+    store.state.organizationData?.organizationSettings?.trace_id_field_name || "trace_id";
+
   // Function to build query details for navigation
   const buildQueryDetails = (span: any, isSpan: boolean = true) => {
-    const spanIdField = store.state.organizationData?.organizationSettings?.span_id_field_name;
-    const traceIdField = store.state.organizationData?.organizationSettings?.trace_id_field_name;
+    const spanIdField = getSpanIdField();
+    const traceIdField = getTraceIdField();
     const traceId = searchObj.data.traceDetails.selectedTrace?.trace_id;
 
     let query: string = isSpan
-      ? `${quoteSqlIdentifierIfNeeded(String(spanIdField))}='${span.spanId || span.span_id}' ${
-          traceId ? `AND ${quoteSqlIdentifierIfNeeded(String(traceIdField))}='${traceId}'` : ""
+      ? `${quoteSqlIdentifierIfNeeded(spanIdField)}='${span.spanId || span.span_id}' ${
+          traceId ? `AND ${quoteSqlIdentifierIfNeeded(traceIdField)}='${traceId}'` : ""
         }`
-      : `${quoteSqlIdentifierIfNeeded(String(traceIdField))}='${traceId}'`;
+      : `${quoteSqlIdentifierIfNeeded(traceIdField)}='${traceId}'`;
 
     if (query) query = b64EncodeStandard(query) as string;
 
@@ -471,23 +480,43 @@ const useTraces = () => {
   };
 
   const navigateToCorrelatedLogs = async (correlationProps: any) => {
+    // Conditions are keyed by semantic group, not by field name, so that two
+    // streams aliasing one dimension (k8s_namespace_name vs
+    // service_k8s_namespace_name) collapse into a single condition.
     const conditions = new Map<string, string>();
-    const usedGroups = new Set<string>();
 
     const semanticGroups = await loadSemanticGroups();
     const fieldToGroupId = buildFieldToGroupIdMap(semanticGroups);
+
+    const groupIdFor = (field: string) => fieldToGroupId.get(field.toLowerCase()) ?? field;
+    const setCondition = (field: string, value: string) =>
+      conditions.set(
+        groupIdFor(field),
+        `${quoteSqlIdentifierIfNeeded(field)} = ${quoteSqlLiteral(value)}`,
+      );
 
     for (const streamInfo of correlationProps.logStreams) {
       const filters = streamInfo.filters ?? {};
       for (const [field, value] of Object.entries(filters)) {
         if (!value || value === SELECT_ALL_VALUE || field.startsWith("_")) continue;
-        const groupId = fieldToGroupId.get(field.toLowerCase()) ?? field;
-        if (usedGroups.has(groupId)) continue;
-        usedGroups.add(groupId);
-
-        const escapedValue = String(value).replace(/'/g, "''");
-        conditions.set(groupId, `${quoteSqlIdentifierIfNeeded(field)} = '${escapedValue}'`);
+        // First stream to claim a group wins.
+        if (conditions.has(groupIdFor(field))) continue;
+        setCondition(field, String(value));
       }
+    }
+
+    // Narrow the correlated logs down to the span the user clicked "View Logs"
+    // on. Field names come from org settings and values from the current
+    // selection, same as buildQueryDetails(). These deliberately overwrite a
+    // stream filter on the same group — an exact id is the more specific match.
+    const idFilters: Array<[string, string | null | undefined]> = [
+      [getSpanIdField(), searchObj.data.traceDetails.selectedSpanId],
+      [getTraceIdField(), searchObj.data.traceDetails.selectedTrace?.trace_id],
+    ];
+
+    for (const [field, value] of idFilters) {
+      if (!value) continue;
+      setCondition(field, value);
     }
 
     const queryString = Array.from(conditions.values()).join(" and ");


### PR DESCRIPTION
## Problem

In enterprise, the span sidebar's **View Logs** goes through `navigateToCorrelatedLogs()`, which built its WHERE clause purely from the per-stream `filters` returned by `_correlate`. The result was a service/namespace-wide log query with no reference to the span the user actually clicked.

The OSS path (`buildQueryDetails`) pins both `span_id` and `trace_id`. The enterprise path did not.

## Change

Append `span_id` and `trace_id` conditions in `navigateToCorrelatedLogs()`:

- **Field names** from the org's `span_id_field_name` / `trace_id_field_name` settings
- **Values** from `searchObj.data.traceDetails.selectedSpanId` and `selectedTrace?.trace_id` — the same sources `buildQueryDetails` reads, and `selectedSpanId` is what drives the sidebar's `:span` prop, so it always matches the clicked span
- Each condition is missing-value guarded and routed through the existing semantic-group keying, so an id field that is also a tracked dimension yields one condition rather than two — with the exact id winning over a stream's alias

## Deduplication

The new code would otherwise have been a third copy of logic already present twice, so:

- Extracted `getSpanIdField()` / `getTraceIdField()`; `buildQueryDetails` and `navigateToCorrelatedLogs` now share them. This also fixes a latent bug — `buildQueryDetails` did `String(spanIdField)` with no fallback, emitting a column literally named `undefined` when the org setting was absent. Defaults now mirror `stores/index.ts`.
- Extracted `groupIdFor()` / `setCondition()` so the stream-filter loop and the id loop share one implementation.
- Dropped the `usedGroups` Set — every `add()` was paired with a `conditions.set()` on the same key, making `usedGroups.has(x)` always equivalent to `conditions.has(x)`.
- Replaced the hand-rolled `String(v).replace(/'/g, "''")` with `quoteSqlLiteral()` from `utils/telemetryCorrelation` (byte-identical output). Deliberately *not* `buildSqlCondition()` — it wraps identifiers via `quoteSqlIdentifier` (always quotes), which would change emitted SQL from `field = 'v'` to `"field" = 'v'`.

