### PR TITLE
docs: fix occured typo in alert and folder doc comments

### DIFF
--- a/src/core/src/alerts/alert.rs
+++ b/src/core/src/alerts/alert.rs
@@ -232,12 +232,12 @@ pub enum AlertError {
     #[error("Error resolving stream names in SQL query: {0}")]
     ResolveStreamNameError(#[source] anyhow::Error),
 
-    /// An error occured trying to get the list of permitted alerts in
+    /// An error occurred trying to get the list of permitted alerts in
     /// enterprise mode because no user_id was provided.
     #[error("user_id required to get permitted alerts in enterprise mode")]
     PermittedAlertsMissingUser,
 
-    /// An error occured trying to get the list of permitted alerts in
+    /// An error occurred trying to get the list of permitted alerts in
     /// enterprise mode using the validator.
     #[error("PermittedAlertsValidator# {0}")]
     PermittedAlertsValidator(String),

--- a/src/db/src/folders.rs
+++ b/src/db/src/folders.rs
@@ -80,12 +80,12 @@ pub enum FolderError {
     #[error("Folder not found")]
     NotFound,
 
-    /// An error occured trying to get the list of permitted folders in
+    /// An error occurred trying to get the list of permitted folders in
     /// enterprise mode because no user_id was provided.
     #[error("user_id required to get permitted folders in enterprise mode")]
     PermittedFoldersMissingUser,
 
-    /// An error occured trying to get the list of permitted folders in
+    /// An error occurred trying to get the list of permitted folders in
     /// enterprise mode using the validator.
     #[error("PermittedFoldersValidator# {0}")]
     PermittedFoldersValidator(String),


### PR DESCRIPTION
`occured` should be `occurred`. Four occurrences, all in rustdoc comments on error variants:

- `src/core/src/alerts/alert.rs:235,240`
- `src/db/src/folders.rs:83,88`

No identifiers, error messages or code paths change.

The remaining two hits in the tree are in `src/config/src/utils/async_walkdir/`, which is a vendored copy of the `async_walkdir` crate and carries its upstream copyright headers, so I left those untouched.
