### PR TITLE
fix(lib): re-place toggle pill after an item reorder

### DIFF
--- a/web/src/lib/core/ToggleGroup/OToggleGroup.spec.ts
+++ b/web/src/lib/core/ToggleGroup/OToggleGroup.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
-import { h } from "vue";
+import { h, nextTick, ref } from "vue";
 import OToggleGroup from "./OToggleGroup.vue";
 import OToggleGroupItem from "./OToggleGroupItem.vue";
 
@@ -224,6 +224,88 @@ describe("OToggleGroup", () => {
 
       await dragged.trigger("dragend");
       expect(itemAt(wrapper, "a").classes()).not.toContain("opacity-40");
+    });
+  });
+
+  // --- Sliding selection indicator ---
+
+  describe("sliding indicator", () => {
+    const ITEM_WIDTH = 100;
+
+    /**
+     * jsdom lays nothing out: every rect is zero-sized and `offsetParent` is
+     * always null, so `measure()` would bail. Give the track and its items a
+     * synthetic box where each item's left edge is derived from its *current*
+     * position in the DOM — that is what makes a reorder observable here.
+     */
+    function stubGeometry(track: HTMLElement) {
+      const rect = (left: number, width: number) =>
+        ({
+          left,
+          top: 0,
+          width,
+          height: 20,
+          right: left + width,
+          bottom: 20,
+          x: left,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      track.getBoundingClientRect = () => rect(0, ITEM_WIDTH * 3);
+      for (const el of track.querySelectorAll<HTMLElement>("[data-otoggle-value]")) {
+        Object.defineProperty(el, "offsetParent", {
+          get: () => document.body,
+          configurable: true,
+        });
+        el.getBoundingClientRect = () => {
+          const order = Array.from(track.querySelectorAll<HTMLElement>("[data-otoggle-value]"));
+          return rect(order.indexOf(el) * ITEM_WIDTH, ITEM_WIDTH);
+        };
+      }
+    }
+
+    /** Lets Vue move the DOM node, the MutationObserver fire, and the raf settle. */
+    async function settle() {
+      await nextTick();
+      await Promise.resolve();
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    }
+
+    it("follows the active item when the items are reordered", async () => {
+      const order = ref(["a", "b", "c"]);
+      const wrapper = mount(
+        {
+          components: { OToggleGroup, OToggleGroupItem },
+          setup: () => ({ order }),
+          template: `
+            <OToggleGroup model-value="b">
+              <OToggleGroupItem v-for="value in order" :key="value" :value="value">
+                {{ value }}
+              </OToggleGroupItem>
+            </OToggleGroup>`,
+        },
+        { attachTo: document.body },
+      );
+
+      // The multi-root template above makes `wrapper.element` the VTU parent, so
+      // reach the ToggleGroupRoot (the indicator's offset parent) explicitly.
+      const track = wrapper.get("[data-variant]").element as HTMLElement;
+      stubGeometry(track);
+      const indicator = () => track.firstElementChild as HTMLElement;
+
+      // "b" dragged to the front — the pill must sit on it at index 0.
+      order.value = ["b", "a", "c"];
+      await settle();
+      expect(indicator().style.transform).toBe("translate(0px, 0px)");
+      expect(indicator().style.width).toBe(`${ITEM_WIDTH}px`);
+
+      // …and back to the end, without any selection change in between.
+      order.value = ["a", "c", "b"];
+      await settle();
+      expect(indicator().style.transform).toBe(`translate(${ITEM_WIDTH * 2}px, 0px)`);
+
+      wrapper.unmount();
     });
   });
 });

--- a/web/src/lib/core/ToggleGroup/OToggleGroup.vue
+++ b/web/src/lib/core/ToggleGroup/OToggleGroup.vue
@@ -51,6 +51,8 @@ const hasValidPosition = ref(false);
 const transitionOn = ref(false);
 
 let resizeObserver: ResizeObserver | null = null;
+let mutationObserver: MutationObserver | null = null;
+let settleRaf = 0;
 
 /**
  * Place the indicator over the active item.
@@ -95,6 +97,16 @@ const measure = (animated: boolean) => {
   };
 };
 
+/**
+ * Snap-measure now and again on the next frame: a mutation callback can sample
+ * layout mid-update, and a placement taken then would never self-correct.
+ */
+const measureSettled = () => {
+  measure(false);
+  cancelAnimationFrame(settleRaf);
+  settleRaf = requestAnimationFrame(() => measure(false));
+};
+
 // Slide when the selection changes …
 watch(
   () => props.modelValue,
@@ -116,11 +128,25 @@ onMounted(async () => {
     resizeObserver = new ResizeObserver(() => measure(false));
     resizeObserver.observe(track);
   }
+  // A drag-to-reorder (or an item added/removed) moves the active item without
+  // changing the track's size, so the ResizeObserver above never fires and the
+  // pill would keep the previous item's position/width while the active text
+  // colour follows the moved item. Watch the child list for that.
+  // Attributes are deliberately not observed: `data-state` flips on a real
+  // selection change, which the modelValue watcher already handles with a
+  // slide, and snapping here would cancel it.
+  if (track && typeof MutationObserver !== "undefined") {
+    mutationObserver = new MutationObserver(measureSettled);
+    mutationObserver.observe(track, { childList: true });
+  }
 });
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect();
   resizeObserver = null;
+  mutationObserver?.disconnect();
+  mutationObserver = null;
+  cancelAnimationFrame(settleRaf);
 });
 
 const indicatorClasses = computed(() => [


### PR DESCRIPTION
The sliding selection pill in OToggleGroup was re-measured only on a modelValue change or a track resize. A drag-to-reorder moves the active item but leaves the track exactly the same size, so neither trigger fired: the pill kept the previous item's position and width, landing under the wrong item and overlapping its neighbour, while the active text colour — being data-state driven — correctly followed the moved item. On the traces detail tab bar that read as the highlight and the colour coming apart.

Observe the track's childList and snap-measure on a change, mirroring OTabs, which already did this for its underline. Attributes are deliberately not observed: data-state flips on a real selection change, which the modelValue watcher handles with a slide, and snapping there would cancel it. Also covers items being added or removed, e.g. the traces Thread tab appearing for a trace with LLM spans.