### PR TITLE
test(reports): heal reports-regression timezone spec (edit-prefill race + toast selector)

### DIFF
--- a/tests/ui-testing/pages/reportsPages/reportsPage.js
+++ b/tests/ui-testing/pages/reportsPages/reportsPage.js
@@ -240,7 +240,22 @@ export class ReportsPage {
   }
 
   async createReportContinueButtonStep1() {
-    await this.continueButtonStep1.click({ force: true });
+    // Advance step 1 (dashboard) -> step 2 (schedule). On the EDIT flow the
+    // step-1 fields (folder/dashboard/tabs) are prefilled asynchronously via
+    // form.reset() after the report GET resolves; goToStep() validates those
+    // fields before advancing, so a single Continue click that lands before the
+    // prefill is applied fails validation and silently stays on step 1 (the
+    // schedule toggle never renders — the create/edit flow then times out looking
+    // for it). Retry the click until the schedule step is actually reached.
+    await expect(async () => {
+      if (await this.continueButtonStep1.isVisible().catch(() => false)) {
+        await this.continueButtonStep1.click({ force: true });
+      }
+      await expect(this.scheduleLaterBtn).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 20000, intervals: [500, 1000, 2000] });
+    // Preserve the original post-advance settle: downstream step-2 interactions
+    // (the scheduleLater toggle, the step-2 Continue) can be swallowed if driven
+    // before the freshly-mounted step has settled.
     await this.page.waitForTimeout(3000);
   }
 

--- a/tests/ui-testing/playwright-tests/RegressionSet/Reports/reports-regression-bugs.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Reports/reports-regression-bugs.spec.js
@@ -84,38 +84,24 @@ test.describe("Reports Regression Bug Fixes", () => {
         'Schedule Later button should be visible').toBeVisible({ timeout: 5000 });
       await pm.reportsPage.createReportScheduleLater();
 
-      const TEST_START_TIME = '10:30';
-      const TEST_START_HOUR = 10;
+      const TEST_START_HOUR = 10; // matches the 10:30 set by createReportDateTime()
 
-      // Start Date is REQUIRED + format-checked on the Schedule Later tab
-      // (CreateReport.schema date/time rule). ODate is a Reka segmented field
-      // (no native <input>) whose locale defaults to "en" → en-US segment order
-      // MONTH / DAY / YEAR. Focus the leftmost (month) segment, then type in
-      // M/D/Y order so Reka auto-advances and emits ISO YYYY-MM-DD (2027-12-29).
-      const startDateField = page.locator('[data-test="add-report-schedule-start-date-field-group"]');
-      await startDateField.click({ force: true });
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('ArrowLeft'); // 3 segments -> 2 lefts reaches month from any start
-      await page.keyboard.type('12');   // month
-      await page.keyboard.type('29');   // day
-      await page.keyboard.type('2027'); // year
-      await page.keyboard.press('Escape');
-
-      // OTime wraps a hidden <input type="time"> inside the role="group" div.
-      // Fill with force:true since the native input is visually hidden.
-      const startTimeInput = page.locator('[data-test="add-report-schedule-start-time-field"] input[type="time"]');
-      await expect(startTimeInput, 'Start Time input should exist').toHaveCount(1, { timeout: 5000 });
-      await startTimeInput.fill(TEST_START_TIME, { force: true });
-      testLogger.info(`Set start time to: "${TEST_START_TIME}"`);
+      // Set Start Date (2027-12-29) + Start Time (10:30) via the shared POM helper
+      // (same entry the reportsScheduleLater suite uses) so `date`/`time` are
+      // well-formed and the zod save is not blocked.
+      await pm.reportsPage.createReportDateTime();
+      testLogger.info('Set start date/time (2027-12-29 10:30)');
 
       await pm.reportsPage.createReportZone();
       testLogger.info('Set timezone to UTC');
 
-      // Save with schedule
+      // Save with schedule. The success feedback is an OToast success variant
+      // (role="status"); only error/warning toasts render role="alert", so assert
+      // on the success toast, not getByRole('alert').
       await expect(pm.reportsPage.saveButton, 'Save button should be visible').toBeVisible({ timeout: 5000 });
       await pm.reportsPage.saveButton.click({ force: true });
-      await expect(page.getByRole('alert').first(),
-        'Save success alert should appear').toBeVisible({ timeout: 15000 });
+      await expect(pm.reportsPage.toastSuccess.first(),
+        'Save success toast should appear').toBeVisible({ timeout: 15000 });
       testLogger.info('Saved report with schedule configured');
 
       // Re-open to verify time has NOT shifted (the bug: each save shifts by TZ offset)


### PR DESCRIPTION
## What

Heals the Reports regression spec `reports-regression-bugs.spec.js` → *"Report save should not shift timestamp by timezone offset"* (@bug-11231), which was failing deterministically (all 4 retries) in both the OSS and ENT **Playwright Regression** runs:

- OSS: https://github.com/openobserve/openobserve/actions/runs/31364820545
- ENT: https://github.com/openobserve/o2-enterprise/actions/runs/31364817885

This is **test-only** — the product is unaffected (the historical #11231 fix and normal report save both work; a save actually succeeds in the failing run).

## Root cause (two independent defects)

1. **Wrong success-toast selector (deterministic line-118 failure).** The save assertion used `page.getByRole('alert')`. `OToast` renders the **success** variant with `role="status"` — only **error/warning** toasts get `role="alert"` ([`OToast.vue`](https://github.com/openobserve/openobserve/blob/main/web/src/lib/feedback/Toast/OToast.vue) `rootRole`). So the assertion could never match a successful save and timed out. → now asserts on the success toast `[data-test-variant="success"]`, consistent with the rest of the file.

2. **Edit-prefill race (line-84 failure, the one captured in the trace).** On the edit flow, step-1 `Continue` could fire before the async edit prefill (`form.reset()` after the report GET) populated folder/dashboard/tabs. `goToStep()` then failed validation and silently stayed on step 1, so the schedule toggle never rendered and the test timed out looking for it. → `createReportContinueButtonStep1()` now retries the click until the schedule step is actually reached, **keeping** the original post-advance settle so downstream step-2 interactions (schedule-later toggle, step-2 Continue) don't race.

Also dedups the spec's inline date/time entry through the existing `createReportDateTime()` helper (logic unchanged).

## Verification (local, `localhost:5080`)

| Suite | Result |
|---|---|
| `reports-regression-bugs.spec.js` (target) | ✅ stable across repeated runs (1 + 3× repeat-each) |
| `reportsScheduleLater.spec.js` | ✅ 6/6 |
| `reportsScheduleNow.spec.js` + `reportCsvMediaType.spec.js` | ✅ 13/13 |

The two changed page-object methods are shared with the sibling Reports specs above; all pass, confirming no regression.

## Scope

The spec lives in OSS `tests/` and is tree-merged into the ENT regression run, so this single OSS change fixes both pipelines. No ENT repo change required; the ENT regression will be re-triggered against this branch.
