### PR TITLE
test(sentinel): complete POM compliance — Dashboards + Correlation (follow-up to #13727)

### DIFF
--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -4405,4 +4405,85 @@ export class AlertsPage {
     getErrorMessageBanner() {
         return this.page.locator('[class*="error"], [data-test*="error"]');
     }
+
+    // ==================== ALERT FORM (from-dashboard-panel) LOCATORS ====================
+
+    /** Pre-filled alert name input on the add-alert form */
+    getAlertNameInput() {
+        return this.page.locator(this.locators.alertNameInput);
+    }
+
+    /** Wizard "Continue" button */
+    getContinueButton() {
+        return this.page.getByRole("button", { name: "Continue" });
+    }
+
+    /** Threshold operator select control (Step 4 settings) */
+    getThresholdOperatorSelect() {
+        return this.page.locator('[data-test="alert-threshold-operator-select"]');
+    }
+
+    /** Threshold operator option by exact text (e.g. ">=") */
+    getThresholdOperatorOption(text) {
+        return this.page.getByText(text, { exact: true });
+    }
+
+    /**
+     * Threshold value input. The data-test may sit on the native <input> or on
+     * its root div, so match both forms.
+     */
+    getThresholdValueInput() {
+        return this.page.locator(
+            'input[data-test="alert-threshold-value-input"], [data-test="alert-threshold-value-input"] input'
+        );
+    }
+
+    /** Destination select control */
+    getDestinationsSelect() {
+        return this.page.locator(this.locators.alertDestinationsSelect);
+    }
+
+    /** Destination option by name */
+    getDestinationOption(destinationName) {
+        return this.page.locator(
+            `[data-test="alert-destination-option-${destinationName}"]`
+        );
+    }
+
+    /** Add-alert submit button */
+    getAddAlertSubmitButton() {
+        return this.page.locator(this.locators.alertSubmitButton);
+    }
+
+    /** Toast message filtered by text */
+    getToastMessageByText(text) {
+        return this.page
+            .locator(this.locators.oToastMessage)
+            .filter({ hasText: text });
+    }
+
+    /** Alert list search input */
+    getAlertListSearchInput() {
+        return this.page.locator(this.locators.alertSearchInput);
+    }
+
+    /** Alert list table rows */
+    getAlertTableRows() {
+        return this.page.locator("table tbody tr");
+    }
+
+    /** Context/kebab menu "Delete" option by exact text */
+    getDeleteMenuOption() {
+        return this.page.getByText("Delete", { exact: true });
+    }
+
+    /** Generic dialog primary (confirm) button */
+    getDialogPrimaryButton() {
+        return this.page.locator('[data-test="o-dialog-primary-btn"]');
+    }
+
+    /** "Alert deleted" toast text */
+    getAlertDeletedText() {
+        return this.page.getByText(this.locators.alertDeletedMessage);
+    }
 }

--- a/tests/ui-testing/pages/dashboardPages/dashboard-chart.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-chart.js
@@ -22,6 +22,7 @@ export default class ChartTypeSelector {
     this.sqlQueryTypeBtn = page.locator('[data-test="dashboard-sql-query-type"]');
     this.customQueryTypeBtn = page.locator('[data-test="dashboard-custom-query-type"]');
     this.builderQueryTypeBtn = page.locator('[data-test="dashboard-builder-query-type"]');
+    this.promqlQueryTypeBtn = page.locator('[data-test="dashboard-promql-query-type"]');
 
     // Custom query editor
     this.queryEditor = page.locator('[data-test="dashboard-panel-query-editor"]');
@@ -30,6 +31,32 @@ export default class ChartTypeSelector {
     this.jsonFieldRenderer = page.locator('[data-test="json-field-renderer"]');
     this.jsonKey = page.locator('[data-test="json-key"]');
     this.jsonValue = page.locator('[data-test="json-value"]');
+
+    // VRL function editor (toggle + editor) shown in the panel query bar
+    this.vrlToggleBtn = page.locator('[data-test="logs-search-bar-show-query-toggle-btn"]');
+    this.vrlFunctionEditor = page.locator('[data-test="dashboard-vrl-function-editor"]');
+
+    // Field layout containers (X / Y / Breakdown) and the +P (add-to-pivot) button
+    this.xLayout = page.locator('[data-test="dashboard-x-layout"]');
+    this.yLayout = page.locator('[data-test="dashboard-y-layout"]');
+    this.breakdownLayout = page.locator('[data-test="dashboard-b-layout"]');
+    this.pivotAddBtn = page.locator('[data-test="dashboard-add-p-data"]');
+  }
+
+  // Returns the field-list row for a given field name
+  getFieldListRow(fieldName) {
+    return this.page.locator(`[data-test="o-field-list-row-${fieldName}"]`);
+  }
+
+  // Returns the nth breakdown (pivot) field chip (1-based index in the data-test)
+  getBreakdownItem(index) {
+    return this.page.locator(`[data-test="dashboard-b-item-breakdown_${index}"]`);
+  }
+
+  // Returns a field-section label by its visible text (e.g. "First Column",
+  // "Row Fields", "Add 0 or 1 field here"), used to assert layout-mode labels.
+  getFieldSectionLabel(text) {
+    return this.page.getByText(text);
   }
 
   // Chart Type select

--- a/tests/ui-testing/pages/dashboardPages/dashboard-chart.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-chart.js
@@ -589,6 +589,35 @@ export default class ChartTypeSelector {
   }
 
   /**
+   * Click the SQL query-type toggle button
+   */
+  async clickSqlQueryType() {
+    await this.sqlQueryTypeBtn.click();
+  }
+
+  /**
+   * Click the Custom query-type toggle button
+   */
+  async clickCustomQueryType() {
+    await this.customQueryTypeBtn.click();
+  }
+
+  /**
+   * Focus the panel query editor by clicking its Monaco code region
+   */
+  async clickQueryEditorCode() {
+    await this.queryEditor.getByRole('code').click();
+  }
+
+  /**
+   * Fill the panel query editor's hidden input area with a query string
+   * @param {string} query - The SQL query to fill
+   */
+  async fillQueryEditorInputArea(query) {
+    await this.queryEditor.locator(".inputarea").fill(query);
+  }
+
+  /**
    * Wait for a field to appear in the field list (e.g. after SQL parsing).
    * @param {string} fieldName - The field name to wait for
    * @param {number} timeout - Max wait time in ms (default 10000)

--- a/tests/ui-testing/pages/dashboardPages/dashboard-chart.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-chart.js
@@ -41,11 +41,65 @@ export default class ChartTypeSelector {
     this.yLayout = page.locator('[data-test="dashboard-y-layout"]');
     this.breakdownLayout = page.locator('[data-test="dashboard-b-layout"]');
     this.pivotAddBtn = page.locator('[data-test="dashboard-add-p-data"]');
+
+    // Geomap chart canvas (rendered inside #chart-map)
+    this.mapCanvas = page.locator("#chart-map canvas");
+
+    // HTML chart editor + rendered output
+    this.htmlEditor = page.locator('[data-test="dashboard-html-editor"]');
+    this.htmlRenderer = page.locator('[data-test="html-renderer"]');
+  }
+
+  // Click the geomap chart canvas at a given pixel position
+  async clickMapCanvas(position) {
+    await this.mapCanvas.click({ position });
+  }
+
+  // Enter HTML code into the HTML chart Monaco editor
+  async fillHtmlEditor(html) {
+    await this.htmlEditor.locator(".monaco-editor").click();
+    await this.htmlEditor.locator(".inputarea").fill(html);
+  }
+
+  // Rendered HTML output: heading by accessible name
+  getHtmlHeading(name) {
+    return this.page.getByRole("heading", { name });
+  }
+
+  // Rendered HTML output: element containing given text
+  getHtmlRendererText(text) {
+    return this.htmlRenderer.getByText(text);
+  }
+
+  // Rendered HTML output: any <script> tags (should be sanitized away)
+  getHtmlRendererScripts() {
+    return this.htmlRenderer.locator("script");
   }
 
   // Returns the field-list row for a given field name
   getFieldListRow(fieldName) {
     return this.page.locator(`[data-test="o-field-list-row-${fieldName}"]`);
+  }
+
+  // Field-list search input (the OInput field itself)
+  getFieldSearchInput() {
+    return this.page.locator('[data-test="o-field-list-search-field"]');
+  }
+
+  // Returns the "selected chart type" indicator item (e.g. pie, donut)
+  getSelectedChartItem(chartType) {
+    return this.page.locator(`[data-test="selected-chart-${chartType}-item"]`);
+  }
+
+  // Sankey builder layout areas
+  getSankeySourceLayout() {
+    return this.page.locator('[data-test="dashboard-source-layout"]');
+  }
+  getSankeyTargetLayout() {
+    return this.page.locator('[data-test="dashboard-target-layout"]');
+  }
+  getSankeyValueLayout() {
+    return this.page.locator('[data-test="dashboard-value-layout"]');
   }
 
   // Returns the nth breakdown (pivot) field chip (1-based index in the data-test)

--- a/tests/ui-testing/pages/dashboardPages/dashboard-create.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-create.js
@@ -27,6 +27,11 @@ export default class DashboardCreate {
     );
   }
 
+  // Wait for the "add panel" button on an empty dashboard to be visible
+  async waitForAddPanelIfEmptyVisible() {
+    await this.addPanelIfEmptyBtn.waitFor({ state: "visible" });
+  }
+
   // Wait for the default folder tab on the dashboard list to be visible
   async waitForDefaultFolderTabVisible() {
     await this.defaultFolderTab.waitFor({ state: "visible" });

--- a/tests/ui-testing/pages/dashboardPages/dashboard-create.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-create.js
@@ -36,8 +36,20 @@ export default class DashboardCreate {
   }
 
   // Wait for the "add panel" button on an empty dashboard to be visible
-  async waitForAddPanelIfEmptyVisible() {
-    await this.addPanelIfEmptyBtn.waitFor({ state: "visible" });
+  async waitForAddPanelIfEmptyVisible(timeout) {
+    await this.addPanelIfEmptyBtn.waitFor({ state: "visible", timeout });
+  }
+
+  // Wait for the dashboard search input to be visible
+  async waitForSearchVisible(timeout = 30000) {
+    await this.searchDash.waitFor({ state: "visible", timeout });
+  }
+
+  // Wait for the dashboard list table to be visible
+  async waitForDashboardTableVisible(timeout = 10000) {
+    await this.page
+      .locator('[data-test="dashboard-table"]')
+      .waitFor({ state: "visible", timeout });
   }
 
   // Wait for the default folder tab on the dashboard list to be visible

--- a/tests/ui-testing/pages/dashboardPages/dashboard-create.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-create.js
@@ -25,6 +25,14 @@ export default class DashboardCreate {
     this.defaultFolderTab = this.page.locator(
       'button[data-test="dashboard-folder-tab-default"]'
     );
+    this.defaultDashboardTab = this.page.locator(
+      '[data-test="dashboard-tab-default"]'
+    );
+  }
+
+  // Wait for the default tab inside an opened dashboard to be visible
+  async waitForDefaultDashboardTabVisible() {
+    await this.defaultDashboardTab.waitFor({ state: "visible" });
   }
 
   // Wait for the "add panel" button on an empty dashboard to be visible

--- a/tests/ui-testing/pages/dashboardPages/dashboard-drilldown.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-drilldown.js
@@ -31,6 +31,19 @@ export default class DashboardDrilldownPage {
     this.confirmButton = page.locator(
       '[data-test="dashboard-drilldown-popup"] [data-test="o-dialog-primary-btn"]'
     );
+    // Unscoped primary dialog button (matches the spec's page-level confirm click).
+    this.dialogPrimaryButton = page.locator('[data-test="o-dialog-primary-btn"]');
+
+    // Drilldown popup — variable mapping + passAllVariables toggle
+    this.addVariableButton = page.locator('[data-test="dashboard-drilldown-add-variable"]');
+    this.passAllVariablesToggle = page.locator('[data-test="dashboard-drilldown-pass-all-variables"]');
+    // The variable-mapping OCombobox rows in DrilldownPopUp have no data-test —
+    // match by placeholder, scoped to the popup.
+    this.variableNameInput = this.popup.getByPlaceholder('Name').first();
+    this.variableValueInput = this.popup.getByPlaceholder('Value').first();
+
+    // Dashboard view — first table panel
+    this.panelTable = page.locator('[data-test="dashboard-panel-table"]').first();
 
     // Dashboard view — drilldown trigger overlay
     this.drilldownMenu = page.locator('[data-test="drilldown-menu"]');
@@ -49,6 +62,25 @@ export default class DashboardDrilldownPage {
 
   generateUniqueDrilldownName(prefix = "u") {
     return `${prefix}_${Date.now()}`;
+  }
+
+  /**
+   * Get an ARIA-role listbox option by its (exact) accessible name.
+   * Used for the folder / dashboard / tab OSelect dropdowns which render
+   * role="option" items.
+   * @param {string} name - Exact option label
+   * @returns {import('@playwright/test').Locator}
+   */
+  optionByRole(name) {
+    return this.page.getByRole("option", { name, exact: true });
+  }
+
+  /**
+   * Get the first ARIA-role listbox option (used when any option is acceptable).
+   * @returns {import('@playwright/test').Locator}
+   */
+  firstOptionByRole() {
+    return this.page.getByRole("option").first();
   }
 
   /**

--- a/tests/ui-testing/pages/dashboardPages/dashboard-filter.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-filter.js
@@ -251,6 +251,37 @@ export default class DashboardFilter {
     }
   }
 
+  // Open a condition's list-tab OSelect, search for a value and pick the
+  // matching option (by data-test-value). Mirrors the maps filter flow:
+  // label -> list-tab OSelect -> search -> option.
+  async applyListConditionBySearch(index, fieldName, searchValue, optionValue) {
+    const idx = String(index);
+
+    const conditionLabel = this.page.locator(
+      `[data-test="dashboard-add-condition-label-${idx}-${fieldName}"]`
+    );
+    await conditionLabel.click();
+
+    const conditionList = this.page.locator(
+      '[data-test="dashboard-add-condition-list-tab"]'
+    );
+    await conditionList.click();
+
+    // Fill the search input inside the OSelect popover
+    const conditionSearch = this.page.locator(
+      '[data-test="dashboard-add-condition-list-tab-search"]'
+    );
+    await conditionSearch.waitFor({ state: "visible", timeout: 5000 });
+    await conditionSearch.fill(searchValue);
+
+    // Select the matching option via data-test-value
+    const optionLocator = this.page.locator(
+      `[data-test="dashboard-add-condition-list-tab-option"][data-test-value="${optionValue}"]`
+    );
+    await optionLocator.waitFor({ state: "visible", timeout: 5000 });
+    await optionLocator.click();
+  }
+
   // Add filter condition with dynamic ,Group inside group filter
   async addGroupFilterCondition(index, newFieldName, operator, value) {
     const idx = String(index);

--- a/tests/ui-testing/pages/dashboardPages/dashboard-filter.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-filter.js
@@ -3,6 +3,78 @@ export default class DashboardFilter {
     this.page = page;
   }
 
+  // Click the "add condition" (+) button in the filter builder
+  async clickAddConditionBtn() {
+    await this.page.locator('[data-test="dashboard-add-condition-add"]').click();
+  }
+
+  // Click the "Add Group" menu option
+  async clickAddGroupOption() {
+    await this.page.getByText("Add Group").click();
+  }
+
+  // Click the last "Add Group" menu option (for nested groups)
+  async clickAddGroupOptionLast() {
+    await this.page.getByText("Add Group").last().click();
+  }
+
+  // Click the nth "Add Group" div (legacy nested-group flow)
+  async clickAddGroupDivByNth(n) {
+    await this.page.locator("div").filter({ hasText: "Add Group" }).nth(n).click();
+  }
+
+  // Click the "add condition" (+) button within a row matched by text/regex
+  async clickAddConditionWithinRowText(text) {
+    await this.page
+      .locator("div")
+      .filter({ hasText: text })
+      .locator('[data-test="dashboard-add-condition-add"]')
+      .click();
+  }
+
+  // Group container locator by group index
+  getGroup(groupIndex) {
+    return this.page.locator(
+      `[data-test="dashboard-group"][style*="--group-index: ${groupIndex}"]`
+    );
+  }
+
+  // Wait for a filter group (by index) to be visible
+  async waitForGroupVisible(groupIndex) {
+    await this.getGroup(groupIndex).waitFor({ state: "visible" });
+  }
+
+  // Click the "add condition" (+) button inside a specific group
+  async clickAddConditionInGroup(groupIndex) {
+    await this.getGroup(groupIndex)
+      .locator('[data-test="dashboard-add-condition-add"]')
+      .click();
+  }
+
+  // Click the remove-condition (trash) button
+  async clickRemoveCondition() {
+    await this.page.locator('[data-test="dashboard-add-condition-remove"]').click();
+  }
+
+  // Filter-condition label locator by index + field name
+  getAddConditionLabel(index, fieldName) {
+    return this.page.locator(
+      `[data-test="dashboard-add-condition-label-${index}-${fieldName}"]`
+    );
+  }
+
+  // Click the logical operator toggle (AND/OR) at a given condition index
+  async clickLogicalOperator(index) {
+    await this.page
+      .locator(`[data-test="dashboard-add-condition-logical-operator-${index}"]`)
+      .click();
+  }
+
+  // Select an operator option by its accessible name (e.g. "OR")
+  async selectOperatorOption(name) {
+    await this.page.getByRole("option", { name }).click();
+  }
+
   /**
    * Helper method to select a field from the StreamFieldSelect dropdown
    * @param {string} fieldName - The field name to select

--- a/tests/ui-testing/pages/dashboardPages/dashboard-legends-copy.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-legends-copy.js
@@ -42,6 +42,16 @@ export default class DashboardLegendsCopy {
     return this.showLegendsBtn.first();
   }
 
+  /** Returns the legends popup container locator */
+  getLegendsPopup() {
+    return this.legendsPopup;
+  }
+
+  /** Returns the raw legend-item locator (all items, unfiltered) */
+  getLegendItems() {
+    return this.page.locator('[data-test^="dashboard-legend-item-"]');
+  }
+
   /**
    * Hover over a panel to reveal the toolbar, then click Show Legends.
    * Works both in dashboard view (PanelContainer) and edit panel (AddPanel).

--- a/tests/ui-testing/pages/dashboardPages/dashboard-multi-sql.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-multi-sql.js
@@ -94,6 +94,26 @@ export default class DashboardMultiSQL {
     return this.page.locator('[data-test="panel-x-alias-inconsistency-warning"]');
   }
 
+  /**
+   * Locator for the x-alias-inconsistency warning nested inside a given axis
+   * layout section (used to assert the warning is NOT rendered inside a layout).
+   * @param {string} layoutDataTest - data-test of the layout wrapper
+   */
+  xAliasWarningInLayout(layoutDataTest) {
+    return this.page.locator(
+      `[data-test="${layoutDataTest}"] [data-test="panel-x-alias-inconsistency-warning"]`,
+    );
+  }
+
+  /**
+   * Locator for the "SQL" mode subtitle label shown in the query editor header.
+   */
+  get sqlModeSubtitle() {
+    return this.page.locator(
+      '.text-subtitle2.text-weight-bold:has-text("SQL")',
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Actions
   // ---------------------------------------------------------------------------

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-actions.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-actions.js
@@ -17,6 +17,7 @@ export default class DashboardactionPage {
     this.dashboardTable = page.locator('[data-test="dashboard-panel-table"]');
     this.chartRenderer = page.locator('[data-test="dashboard-panel-table"], [data-test="chart-renderer"]');
     this.chartRendererCanvas = page.locator('[data-test="chart-renderer"]');
+    this.chartRendererCanvasEl = page.locator('[data-test="chart-renderer"] canvas');
     this.noDataElement = page.locator('[data-test="no-data"]');
     this.dashboardSearchInput = page.locator('[data-test="dashboard-search"]');
     this.discardPanelBtn = page.locator('[data-test="dashboard-panel-discard"]');
@@ -102,6 +103,11 @@ export default class DashboardactionPage {
   // Get chart-renderer canvas locator
   getChartRendererCanvas() {
     return this.chartRendererCanvas;
+  }
+
+  // Get the inner <canvas> element inside the chart-renderer
+  getChartRendererCanvasElement() {
+    return this.chartRendererCanvasEl;
   }
 
   // Get dashboard-error locator

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-actions.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-actions.js
@@ -57,6 +57,12 @@ export default class DashboardactionPage {
     return this.errorToast;
   }
 
+  // Generic visible-text locator for query-output / error-message assertions
+  // (accepts a string or RegExp). Chain .first() as needed.
+  getVisibleText(text) {
+    return this.page.getByText(text);
+  }
+
   // Returns the inline panel-name validation error locator for assertions
   getPanelNameError() {
     return this.panelNameError;
@@ -129,6 +135,11 @@ export default class DashboardactionPage {
     await this.panelNameTrigger.click();
     await this.panelNameInput.waitFor({ state: "visible" });
     await this.panelNameInput.fill(panelName);
+  }
+
+  // Save panel button locator (for callers that only need a raw click)
+  getPanelSaveBtn() {
+    return this.panelSaveBtn;
   }
 
   // Save panel button

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-actions.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-actions.js
@@ -28,6 +28,10 @@ export default class DashboardactionPage {
     this.panelNameError = page.locator('[data-test="dashboard-panel-name-error"]');
     // TanStack table data rows / cells (source data-tests in TenstackTable.vue)
     this.tableDataRow = page.locator('[data-test="dashboard-panel-table"] [data-test^="o2-table-row-"]');
+    // Rendered table header cells (thead th) and the prefixed per-column header
+    // cells (data-test="o2-table-th-<colId>") used for sort / pivot-total checks.
+    this.tableHeaderCells = page.locator('[data-test="dashboard-panel-table"] thead tr th');
+    this.tableThCells = page.locator('[data-test^="o2-table-th-"]');
 
     // Rendered chart bar + the per-panel edit dropdown/menu, used to reopen a
     // saved panel in edit mode from the dashboard view.
@@ -193,6 +197,13 @@ export default class DashboardactionPage {
   }
 
   //Dashboard panel actions(Edit, Layout, Duplicate, Inspector, Move, Delete)
+
+  // Returns the per-panel edit dropdown locator (data-test keyed by panel name)
+  getEditPanelDropdown(panelName) {
+    return this.page.locator(
+      `[data-test="dashboard-edit-panel-${panelName}-dropdown"]`
+    );
+  }
 
   async selectPanelAction(panelName, action) {
     const actionDataTestIds = {

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-actions.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-actions.js
@@ -28,6 +28,23 @@ export default class DashboardactionPage {
     this.panelNameError = page.locator('[data-test="dashboard-panel-name-error"]');
     // TanStack table data rows / cells (source data-tests in TenstackTable.vue)
     this.tableDataRow = page.locator('[data-test="dashboard-panel-table"] [data-test^="o2-table-row-"]');
+
+    // Rendered chart bar + the per-panel edit dropdown/menu, used to reopen a
+    // saved panel in edit mode from the dashboard view.
+    this.panelBar = page.locator('[data-test="dashboard-panel-bar"]');
+    this.editPanelDropdownAny = page.locator('[data-test*="dashboard-edit-panel"][data-test$="-dropdown"]');
+    this.editPanelMenuItem = page.locator('[data-test="dashboard-edit-panel"]');
+  }
+
+  /**
+   * Reopen the first rendered panel in edit mode: hover its bar to reveal the
+   * hover-actions dropdown, open it, and click Edit. Encapsulates the
+   * hover → dropdown → edit chain the config specs use to verify persistence.
+   */
+  async openFirstPanelEditor() {
+    await this.panelBar.first().hover();
+    await this.editPanelDropdownAny.first().click();
+    await this.editPanelMenuItem.click();
   }
 
   // Returns the error toast locator for assertions

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-configs.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-configs.js
@@ -24,6 +24,9 @@ export default class DashboardPanelConfigs {
     this.description = page.locator(
       '[data-test="dashboard-config-description"]'
     );
+    this.descriptionField = page.locator(
+      '[data-test="dashboard-config-description-field"]'
+    );
     this.axisWidth = page.locator('[data-test="dashboard-config-axis-width"]');
     this.showSymbols = page.locator(
       '[data-test="dashboard-config-show_symbol"]'
@@ -329,6 +332,11 @@ export default class DashboardPanelConfigs {
   // dropdown trigger to open.
   async legendPosition(position) {
     await this._clickVirtualOption("dashboard-config-legend-position", position);
+  }
+
+  // Return the panel description input field locator
+  getDescriptionField() {
+    return this.descriptionField;
   }
 
   // Select unit

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-configs.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-configs.js
@@ -70,8 +70,16 @@ export default class DashboardPanelConfigs {
     this.wrapcell = page.locator(
       '[data-test="dashboard-config-wrap-table-cells"]'
     );
+    // The underlying toggle button (carries aria-checked), distinct from the
+    // wrapcell label/container above used by selectWrapCell().
+    this.wrapCellBtn = page.locator(
+      '[data-test="dashboard-config-wrap-table-cells-btn"]'
+    );
     this.transpose = page.locator(
       '[data-test="dashboard-config-table_transpose"]'
+    );
+    this.transposeBtn = page.locator(
+      '[data-test="dashboard-config-table_transpose-btn"]'
     );
     this.dynamicColumn = page.locator(
       '[data-test="dashboard-config-table_dynamic_columns"]'
@@ -120,8 +128,13 @@ export default class DashboardPanelConfigs {
     this.rowsPerPageField = page.locator('[data-test="dashboard-config-rows-per-page-field"]');
     this.rowsPerPageInfo = page.locator('[data-test="dashboard-config-rows-per-page-info"]');
     this.tablePagination = page.locator('[data-test="dashboard-table-pagination"]');
+    // Pagination container scoped inside the rendered panel table (distinct from the
+    // unscoped tablePagination, which can also match a PromQL legend bottom slot).
+    this.tablePaginationInTable = page.locator('[data-test="dashboard-panel-table"] [data-test="dashboard-table-pagination"]');
     this.tableRowsPerPageLabel = page.locator('[data-test="dashboard-table-rows-per-page-label"]');
     this.tableRowCount = page.locator('[data-test="dashboard-table-row-count"]');
+    // Generic role=tooltip (e.g. rows-per-page info icon hover tooltip)
+    this.infoTooltip = page.locator('[role="tooltip"]');
 
     //Metric Text
     this.bgColor = page.locator('[data-test="dashboard-config-color-mode"]');

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-configs.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-configs.js
@@ -185,6 +185,85 @@ export default class DashboardPanelConfigs {
     this.colorBySeriesCancelBtn = page.locator(
       '[data-test="color-by-series-popup-dialog"] [data-test="o-dialog-close-btn"]'
     );
+
+    // ===== Config-panel elements referenced directly by the config-* spec suite =====
+    // (relocated from the specs so no raw page.locator lives in the tests)
+
+    // Line style
+    this.showSymbolTrigger = page.locator('[data-test="dashboard-config-show_symbol-trigger"]');
+    this.lineInterpolationTrigger = page.locator('[data-test="dashboard-config-line_interpolation-trigger"]');
+
+    // Trellis
+    this.trellisTrigger = page.locator('[data-test="dashboard-trellis-chart-trigger"]');
+    this.trellisNumColumns = page.locator('[data-test="trellis-chart-num-of-columns"]');
+    this.trellisGroupByYAxis = page.locator('[data-test="dashboard-config-trellis-group-by-y-axis"]');
+
+    // General settings
+    this.customUnit = page.locator('[data-test="dashboard-config-custom-unit"]');
+    this.noValueReplacementWrapper = page.locator('[data-test="dashboard-config-no-value-replacement"]');
+
+    // Axis settings
+    this.showGridlines = page.locator('[data-test="dashboard-config-show-gridlines"]');
+    this.labelPositionTrigger = page.locator('[data-test="dashboard-config-label-position-trigger"]');
+    this.axisLabelRotate = page.locator('[data-test="dashboard-config-axis-label-rotate"]');
+    this.axisLabelTruncate = page.locator('[data-test="dashboard-config-axis-label-truncate"]');
+
+    // Legends
+    this.showLegend = page.locator('[data-test="dashboard-config-show-legend"]');
+    this.legendsScrollable = page.locator('[data-test="dashboard-config-legends-scrollable"]');
+    this.legendWidth = page.locator('[data-test="dashboard-config-legend-width"]');
+    this.legendHeight = page.locator('[data-test="dashboard-config-legend-height"]');
+    this.legendWidthUnitActive = page.locator('[data-test="dashboard-config-legend-width-unit-active"]');
+    this.legendWidthUnitInactive = page.locator('[data-test="dashboard-config-legend-width-unit-inactive"]');
+    this.legendHeightUnitActive = page.locator('[data-test="dashboard-config-legend-height-unit-active"]');
+    this.legendHeightUnitInactive = page.locator('[data-test="dashboard-config-legend-height-unit-inactive"]');
+
+    // Gauge & Maps
+    this.geomapRenderer = page.locator('[data-test="dashboard-geomap-renderer"]');
+    this.mapSymbolFixed = page.locator('[data-test="dashboard-config-map-symbol-fixed"]');
+    this.symbolTrigger = page.locator('[data-test="dashboard-config-symbol-trigger"]');
+    this.layerTypeTrigger = page.locator('[data-test="dashboard-config-layer-type-trigger"]');
+    this.mapTypeTrigger = page.locator('[data-test="dashboard-config-map-type-trigger"]');
+
+    // Advanced settings
+    this.timeShiftRemoveButtons = page.locator('[data-test^="dashboard-addpanel-config-time-shift-remove-"]');
+    this.topResults = page.locator('[data-test="dashboard-config-top_results"]');
+    this.topResultsOthers = page.locator('[data-test="dashboard-config-top_results_others"]');
+    this.chartAlign = page.locator('[data-test="dashboard-config-chart-align"]');
+    this.chartAlignOptions = page.locator('[data-test="dashboard-config-chart-align-option"]');
+    this.sparklineType = page.locator('[data-test="dashboard-config-sparkline-type"]');
+    this.sparklineLayout = page.locator('[data-test="dashboard-config-sparkline-layout"]');
+    this.sparklineLineWidthInput = page.locator('[data-test="dashboard-config-sparkline-line-width"]');
+    this.sparklineFillOpacity = page.locator('[data-test="dashboard-config-sparkline-fill-opacity"]');
+    this.panelSchemaRendererError = page.locator('[data-test="panel-schema-renderer-error-message"]');
+
+    // Mark line
+    this.marklineAddBtn = page.locator('[data-test="dashboard-addpanel-config-markline-add-btn"]');
+
+    // PromQL settings
+    this.stepValue = page.locator('[data-test="dashboard-config-step-value"]');
+    this.promqlLegendInfo = page.locator('[data-test="dashboard-config-promql-legend-info"]');
+    this.aggregation = page.locator('[data-test="dashboard-config-aggregation"]');
+    this.promqlTableMode = page.locator('[data-test="dashboard-config-promql-table-mode"]');
+    this.promqlTableModeTrigger = page.locator('[data-test="dashboard-config-promql-table-mode-trigger"]');
+    this.stickyFirstColumn = page.locator('[data-test="dashboard-config-sticky-first-column"]');
+    this.tableAggregations = page.locator('[data-test="dashboard-config-table-aggregations"]');
+    this.tableAggregationsTrigger = page.locator('[data-test="dashboard-config-table-aggregations-trigger"]');
+    this.visibleColumns = page.locator('[data-test="dashboard-config-visible-columns"]');
+    this.visibleColumnsTrigger = page.locator('[data-test="dashboard-config-visible-columns-trigger"]');
+    this.visibleColumnsSearch = page.locator('[data-test="dashboard-config-visible-columns-search"]');
+    this.hiddenColumns = page.locator('[data-test="dashboard-config-hidden-columns"]');
+    this.hiddenColumnsTrigger = page.locator('[data-test="dashboard-config-hidden-columns-trigger"]');
+    this.hiddenColumnsSearch = page.locator('[data-test="dashboard-config-hidden-columns-search"]');
+    this.stickyColumns = page.locator('[data-test="dashboard-config-sticky-columns"]');
+    this.stickyColumnsTrigger = page.locator('[data-test="dashboard-config-sticky-columns-trigger"]');
+    this.stickyColumnsSearch = page.locator('[data-test="dashboard-config-sticky-columns-search"]');
+    this.geoLatLabel = page.locator('[data-test="dashboard-config-geo-lat-label"]');
+    this.geoLonLabel = page.locator('[data-test="dashboard-config-geo-lon-label"]');
+    this.geoWeightLabel = page.locator('[data-test="dashboard-config-geo-weight-label"]');
+    this.mapsNameLabel = page.locator('[data-test="dashboard-config-maps-name-label"]');
+    this.promqlLegend = page.locator('[data-test="dashboard-config-promql-legend"]');
+    this.addQueryBtn = page.locator('[data-test*="query-tab-add"]');
   }
   async _clickVirtualOption(dataTestParent, label) {
     const option = this.page.locator(
@@ -1405,6 +1484,82 @@ export default class DashboardPanelConfigs {
    */
   async isPivotColTotalsEnabled() {
     return this.getToggleState(this.pivotColTotals);
+  }
+
+  // ========== Parameterized locator getters for the config-* spec suite ==========
+
+  /** Legend type (Scroll/Plain) OSelect option by label. */
+  getLegendsScrollableOption(label) {
+    return this.page.locator(
+      `[data-test="dashboard-config-legends-scrollable-option"][data-test-label="${label}"]`
+    );
+  }
+
+  /** Map type OSelect option by label (shared: geomap-maps + PromQL maps). */
+  getMapTypeOption(label) {
+    return this.page.locator(
+      `[data-test="dashboard-config-map-type-option"][data-test-label="${label}"]`
+    );
+  }
+
+  /** PromQL aggregation OSelect option by full label (e.g. "Max (maximum value)"). */
+  getAggregationOption(label) {
+    return this.page.locator(
+      `[data-test="dashboard-config-aggregation-option"][data-test-label="${label}"]`
+    );
+  }
+
+  /** PromQL table-mode OSelect option by label (e.g. "Aggregate"). */
+  getPromqlTableModeOption(label) {
+    return this.page.locator(
+      `[data-test="dashboard-config-promql-table-mode-option"][data-test-label="${label}"]`
+    );
+  }
+
+  /** PromQL table-aggregations OSelect option by label. */
+  getTableAggregationsOption(label) {
+    return this.page.locator(
+      `[data-test="dashboard-config-table-aggregations-option"][data-test-label="${label}"]`
+    );
+  }
+
+  /** Config-panel per-query tab by index (multi-query PromQL). */
+  getConfigQueryTab(index) {
+    return this.page.locator(`[data-test="dashboard-config-query-tab-${index}"]`);
+  }
+
+  // ---- Mark line rows (index-based) ----
+
+  /** Mark line type OSelect wrapper for row `index`. */
+  getMarklineTypeSelect(index) {
+    return this.page.locator(`[data-test="dashboard-config-markline-type-${index}"]`);
+  }
+
+  /** Mark line type OSelect trigger for row `index` (carries data-test-selected-value). */
+  getMarklineTypeTrigger(index) {
+    return this.page.locator(`[data-test="dashboard-config-markline-type-${index}-trigger"]`);
+  }
+
+  /** Mark line type OSelect option by label for row `index`. */
+  getMarklineTypeOption(index, label) {
+    return this.page.locator(
+      `[data-test="dashboard-config-markline-type-${index}-option"][data-test-label="${label}"]`
+    );
+  }
+
+  /** Mark line value input wrapper for row `index`. */
+  getMarklineValue(index) {
+    return this.page.locator(`[data-test="dashboard-config-markline-value-${index}"]`);
+  }
+
+  /** Mark line name input wrapper for row `index`. */
+  getMarklineName(index) {
+    return this.page.locator(`[data-test="dashboard-config-markline-name-${index}"]`);
+  }
+
+  /** Mark line per-row remove button for row `index`. */
+  getMarklineRemoveBtn(index) {
+    return this.page.locator(`[data-test="dashboard-addpanel-config-markline-remove-${index}"]`);
   }
 
 }

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-configs.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-configs.js
@@ -87,6 +87,10 @@ export default class DashboardPanelConfigs {
     this.dynamicColumn = page.locator(
       '[data-test="dashboard-config-table_dynamic_columns"]'
     );
+    // The inner toggle button (carries aria-checked) for dynamic columns config
+    this.dynamicColumnBtn = page.locator(
+      '[data-test="dashboard-config-table_dynamic_columns-btn"]'
+    );
     this.valueMapping = page.locator(
       '[data-test="dashboard-addpanel-config-value-mapping-add-btn"]'
     );

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-edit.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-edit.js
@@ -294,11 +294,6 @@ export default class DashboardPanel {
     await this.page.locator("body").click({ position: { x: 10, y: 10 } });
   }
 
-  // Open the in-editor "data view" query inspector.
-  async openDataViewQueryInspector() {
-    await this.dataViewQueryInspectorBtn.click();
-  }
-
   // Return the inspector query-editor entry that contains the given SQL text.
   getInspectorQueryByText(sql) {
     return this.inspectorQueryEditor.filter({ hasText: sql }).first();

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-edit.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-edit.js
@@ -250,4 +250,42 @@ export default class DashboardPanel {
     }
     await this.queryInspector.click();
   }
+
+  // Return the panel-name element locator (edit panel header).
+  getPanelNameLocator() {
+    return this.namepanel;
+  }
+
+  // Return the dashboard panel container locator (hover target for panel menu).
+  getPanelContainer() {
+    return this.page.locator('[data-test="dashboard-panel-container"]');
+  }
+
+  // Alert context menu options (shown on chart right-click).
+  getAlertContextMenuAbove() {
+    return this.alertContextMenuAbove;
+  }
+  getAlertContextMenuBelow() {
+    return this.alertContextMenuBelow;
+  }
+
+  // Click on an empty page corner to dismiss the alert context menu.
+  async clickOutsideContextMenu() {
+    await this.page.locator("body").click({ position: { x: 10, y: 10 } });
+  }
+
+  // Open the in-editor "data view" query inspector.
+  async openDataViewQueryInspector() {
+    await this.dataViewQueryInspectorBtn.click();
+  }
+
+  // Return the inspector query-editor entry that contains the given SQL text.
+  getInspectorQueryByText(sql) {
+    return this.inspectorQueryEditor.filter({ hasText: sql }).first();
+  }
+
+  // Close the query inspector dialog.
+  async closeQueryInspector() {
+    await this.queryInspectorCloseBtn.click();
+  }
 }

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-edit.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-edit.js
@@ -70,6 +70,26 @@ export default class DashboardPanel {
     this.chartRendererCanvas = page.locator('[data-test="chart-renderer"]');
   }
 
+  // Click the in-editor "data view" query inspector button
+  async clickDataViewQueryInspector() {
+    await this.dataViewQueryInspectorBtn.click();
+  }
+
+  // Query inspector editor content locator (chain .filter()/.last() as needed)
+  getInspectorQueryEditor() {
+    return this.inspectorQueryEditor;
+  }
+
+  // Executed-query row in the query inspector (by index)
+  getExecutedQuery(index = 0) {
+    return this.page.locator(`[data-test="query-inspector-executed-query-${index}"]`);
+  }
+
+  // Original-query row in the query inspector (by index)
+  getOriginalQuery(index = 0) {
+    return this.page.locator(`[data-test="query-inspector-original-query-${index}"]`);
+  }
+
   // Duplicate panel
   async duplicatePanel(panelName) {
     await this.page

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-edit.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-edit.js
@@ -48,6 +48,15 @@ export default class DashboardPanel {
     this.queryInspector = page.locator(
       '[data-test="dashboard-query-inspector-panel"]'
     );
+    // In-editor "data view" query inspector (opened from the panel data view,
+    // distinct from the panel-dropdown Inspector above).
+    this.dataViewQueryInspectorBtn = page.locator(
+      '[data-test="dashboard-panel-data-view-query-inspector-btn"]'
+    );
+    this.inspectorQueryEditor = page.locator('.inspector-query-editor');
+    this.queryInspectorCloseBtn = page.locator(
+      '[data-test="query-inspector-dialog"] [data-test="o-dialog-close-btn"]'
+    );
 
     // VERIFIED: Create Alert from Panel Menu (PanelContainer.vue:289)
     this.createAlertFromPanel = page.locator('[data-test="dashboard-create-alert-from-panel"]');

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-time.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-time.js
@@ -36,6 +36,30 @@ export default class DashboardPanelTime {
   }
 
   // =========================================
+  // SIMPLE LOCATOR GETTERS
+  // =========================================
+
+  /** Panel bar (hover target that reveals panel controls) */
+  getPanelBar() {
+    return this.panelBar;
+  }
+
+  /** Panel fullscreen button */
+  getPanelFullscreenBtn() {
+    return this.panelFullscreenBtn;
+  }
+
+  /** View-panel (fullscreen) screen container */
+  getViewPanelScreen() {
+    return this.viewPanelScreen;
+  }
+
+  /** View-panel close button */
+  getViewPanelCloseBtn() {
+    return this.viewPanelCloseBtn;
+  }
+
+  // =========================================
   // FACTORY HELPERS — runtime-dynamic locators
   // =========================================
 

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-time.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-time.js
@@ -28,6 +28,11 @@ export default class DashboardPanelTime {
     this.dashboardFullscreenBtn = page.locator('[data-test="dashboard-fullscreen-btn"]');
     this.globalRefreshBtn = page.locator('[data-test="dashboard-refresh-btn"]');
     this.calendarRoot = page.locator('[data-test="daterangecalendar-root"]');
+
+    // Config-panel (AddPanel) panel-time controls
+    this.setPanelTimeBtn = page.locator('[data-test="dashboard-config-set-panel-time"]');
+    this.cancelPanelTimeBtn = page.locator('[data-test="dashboard-config-cancel-panel-time"]');
+    this.panelTimePickerWrapper = page.locator('[data-test="dashboard-config-panel-time-picker"]');
   }
 
   // =========================================

--- a/tests/ui-testing/pages/dashboardPages/dashboard-panel-time.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-panel-time.js
@@ -59,6 +59,51 @@ export default class DashboardPanelTime {
     return this.viewPanelCloseBtn;
   }
 
+  /** Config-panel "+Set" panel-time button */
+  getSetPanelTimeBtn() {
+    return this.setPanelTimeBtn;
+  }
+
+  /** Config-panel Cancel (X) panel-time button */
+  getCancelPanelTimeBtn() {
+    return this.cancelPanelTimeBtn;
+  }
+
+  /** Config-panel time picker wrapper */
+  getConfigPanelTimePicker() {
+    return this.panelTimePickerWrapper;
+  }
+
+  /** Config-panel time picker displayed text */
+  async getConfigPanelTimePickerText() {
+    return await this.panelTimePickerWrapper.textContent();
+  }
+
+  /** Wait for the date-time menu to become visible */
+  async waitForDateTimeMenuVisible(timeout = 5000) {
+    await this.dateTimeMenu.waitFor({ state: "visible", timeout });
+  }
+
+  /** Wait for the date-time menu to be hidden (swallows timeout) */
+  async waitForDateTimeMenuHidden(timeout = 3000) {
+    await this.dateTimeMenu.waitFor({ state: "hidden", timeout }).catch(() => {});
+  }
+
+  /** Click a relative time button inside an open date-time picker (page-level) */
+  async clickDateTimeRelative(timeRange) {
+    await this.page.locator(`[data-test="date-time-relative-${timeRange}-btn"]`).click();
+  }
+
+  /** Click the date-time Apply button (page-level) */
+  async clickDateTimeApplyBtn() {
+    await this.page.locator('[data-test="date-time-apply-btn"]').click();
+  }
+
+  /** Click the panel discard button (swallows errors; does not accept the dialog) */
+  async clickPanelDiscard() {
+    await this.panelDiscardBtn.click().catch(() => {});
+  }
+
   // =========================================
   // FACTORY HELPERS — runtime-dynamic locators
   // =========================================

--- a/tests/ui-testing/pages/dashboardPages/dashboard-settings.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-settings.js
@@ -9,6 +9,9 @@ export default class DashboardSetting {
   constructor(page) {
     this.page = page;
     this.setting = page.locator('[data-test="dashboard-setting-btn"]');
+    this.addVariableBtn = page.locator(
+      '[data-test="dashboard-add-variable-btn"]'
+    );
     this.general = page.locator('[data-test="dashboard-settings-general-tab"]');
     this.variables = page.locator(
       '[data-test="dashboard-settings-variable-tab"]'
@@ -428,6 +431,11 @@ export default class DashboardSetting {
     await this.page
       .locator('[data-test="dashboard-variable-save-btn"]')
       .click();
+  }
+
+  // Wait for the "Add Variable" button to be visible (variables list view)
+  async waitForAddVariableBtnVisible() {
+    await this.addVariableBtn.waitFor({ state: "visible" });
   }
 
   //Cancel variable

--- a/tests/ui-testing/pages/dashboardPages/dashboard-settings.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-settings.js
@@ -125,6 +125,13 @@ export default class DashboardSetting {
       .click();
   }
 
+  // Toast message locator scoped to a given text (assert visibility in the spec)
+  getToastMessageByText(text) {
+    return this.page
+      .locator('[data-test="o-toast-message"]')
+      .filter({ hasText: text });
+  }
+
   //Save Setting//
   async saveSetting() {
     await this.saveSettingBtn.waitFor({ state: "visible" });

--- a/tests/ui-testing/pages/dashboardPages/dashboard-settings.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-settings.js
@@ -154,6 +154,11 @@ export default class DashboardSetting {
 
   //Tab Settings//
 
+  //Click the "Tab" settings tab (tabs management view)//
+  async clickTabsSettingsTab() {
+    await this.tab.click();
+  }
+
   //Add new tab//
   async addTabSetting(tabnewName) {
     await this.tab.waitFor({ state: "visible" });

--- a/tests/ui-testing/pages/dashboardPages/dashboard-share-export.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-share-export.js
@@ -2,6 +2,13 @@
 //Methods: Share dashboard, Export dashboard
 
 const { expect } = require("@playwright/test");
+const {
+  getVariableSelector,
+  getVariableSelectorInner,
+  getEditVariableBtn,
+  getVariableLoadingIndicator,
+  SELECTORS,
+} = require("./dashboard-selectors.js");
 
 export default class DashboardShareExportPage {
   constructor(page) {
@@ -117,6 +124,36 @@ export default class DashboardShareExportPage {
     );
     await tab.waitFor({ state: "visible", timeout });
     await tab.click();
+  }
+
+  //Locator for the edit-variable button of a saved dashboard variable
+  getEditVariableButton(variableName) {
+    return this.page.locator(getEditVariableBtn(variableName));
+  }
+
+  //Locator for a dashboard variable selector on the dashboard view
+  getVariableSelectorLocator(variableName) {
+    return this.page.locator(getVariableSelector(variableName));
+  }
+
+  //Locator for a dashboard variable's loading indicator
+  getVariableLoadingIndicatorLocator(variableName) {
+    return this.page.locator(getVariableLoadingIndicator(variableName));
+  }
+
+  //Locator for the inner (select) element of a dashboard variable dropdown
+  getVariableDropdownInner(variableName) {
+    return this.page.locator(getVariableSelectorInner(variableName));
+  }
+
+  //Locator for the open dropdown menu
+  getMenu() {
+    return this.page.locator(SELECTORS.MENU);
+  }
+
+  //Locator for the first role=option entry in an open menu
+  getFirstRoleOption() {
+    return this.page.locator(SELECTORS.ROLE_OPTION).first();
   }
 
   //Navigate to a URL using a separate playwright page (new tab context)

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
@@ -367,6 +367,151 @@ export default class DashboardVariablesScoped {
     return this.page.locator(SELECTORS.PANEL_ANY).nth(index);
   }
 
+  // ==========================================
+  // Locator getters (behavior-preserving relocation of raw spec selectors)
+  // ==========================================
+
+  /**
+   * Get the "add panel" (empty dashboard) button locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getAddPanelBtnLocator() {
+    return this.page.locator(SELECTORS.ADD_PANEL_BTN);
+  }
+
+  /**
+   * Get the dashboard settings button locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getSettingBtnLocator() {
+    return this.page.locator(SELECTORS.SETTING_BTN);
+  }
+
+  /**
+   * Get the dashboard list search input locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getDashboardSearchLocator() {
+    return this.page.locator(SELECTORS.SEARCH);
+  }
+
+  /**
+   * Get a dashboard tab locator by title
+   * @param {string} tabTitle - Tab title (e.g., "Tab1")
+   * @returns {import('@playwright/test').Locator}
+   */
+  getTabLocator(tabTitle) {
+    return this.page.locator(getTabSelector(tabTitle));
+  }
+
+  /**
+   * Get the edit-variable button locator (in settings) by variable name
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getEditVariableBtnLocator(variableName) {
+    return this.page.locator(getEditVariableBtn(variableName));
+  }
+
+  /**
+   * Get a variable dropdown inner trigger locator by name
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableTriggerLocator(variableName) {
+    return this.page.locator(
+      `[data-test="variable-selector-${variableName}-inner-trigger"]`
+    );
+  }
+
+  /**
+   * Get a variable's inner popover locator by name
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariablePopoverLocator(variableName) {
+    return this.page.locator(
+      `[data-test="variable-selector-${variableName}-inner-popover"]`
+    );
+  }
+
+  /**
+   * Get a variable's inner option locators by name
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableInnerOption(variableName) {
+    return this.page.locator(
+      `[data-test="variable-selector-${variableName}-inner-option"]`
+    );
+  }
+
+  /**
+   * Get the generic OSelect option locators (any `*-option`)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getRoleOptionLocator() {
+    return this.page.locator(SELECTORS.ROLE_OPTION);
+  }
+
+  /**
+   * Get the generic OSelect option locators (alias of getRoleOptionLocator)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getOptionLocator() {
+    return this.page.locator(SELECTORS.OPTION);
+  }
+
+  /**
+   * Get the generic popover/menu locators (any `*-popover`)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getMenuLocator() {
+    return this.page.locator(SELECTORS.MENU);
+  }
+
+  /**
+   * Get the panel refresh button locators
+   * @returns {import('@playwright/test').Locator}
+   */
+  getPanelRefreshBtnLocator() {
+    return this.page.locator(SELECTORS.PANEL_REFRESH_BTN);
+  }
+
+  /**
+   * Get the variable-name field input locator (variable form)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableNameField() {
+    return this.page.locator('[data-test="dashboard-variable-name-field"]');
+  }
+
+  /**
+   * Get a variable element scoped within a numbered panel (`dashboard-panel-{n}`)
+   * @param {number|string} panelNumber - Panel data-test number
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableInPanelNumber(panelNumber, variableName) {
+    return this.page
+      .locator(`[data-test="dashboard-panel-${panelNumber}"]`)
+      .locator(`[data-test="dashboard-variable-${variableName}"]`);
+  }
+
+  /**
+   * Get a variable selector scoped within a panel container matched by title
+   * @param {string} panelTitle - Panel title (data-test-panel-title)
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableSelectorWithinPanelTitle(panelTitle, variableName) {
+    return this.page
+      .locator(
+        `[data-test="dashboard-panel-container"][data-test-panel-title="${panelTitle}"]`
+      )
+      .locator(getVariableSelector(variableName));
+  }
+
   /**
    * Wait for a dashboard tab (by title) to be visible
    * @param {string} tabTitle - Tab title (e.g., "Tab1")

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
@@ -12,6 +12,7 @@ import {
   getVariableLoadingIndicator,
   getPanelRefreshBtn,
   getMenuItemByText,
+  getTabSelector,
 } from "./dashboard-selectors.js";
 import {
   selectStreamFromDropdown,
@@ -88,6 +89,36 @@ export default class DashboardVariablesScoped {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Wait for a specific variable's inner popover to be visible
+   * @param {string} variableName - Variable name/label
+   * @param {Object} options - Wait options
+   * @param {number} options.timeout - Timeout in ms (default: 5000)
+   * @returns {Promise<import('@playwright/test').Locator>}
+   */
+  async waitForVariablePopoverVisible(variableName, options = {}) {
+    const { timeout = 5000 } = options;
+    const popover = this.page.locator(
+      `[data-test="variable-selector-${variableName}-inner-popover"]`
+    );
+    await popover.waitFor({ state: "visible", timeout });
+    return popover;
+  }
+
+  /**
+   * Wait for a specific variable's inner popover to be hidden
+   * @param {string} variableName - Variable name/label
+   * @param {Object} options - Wait options
+   * @param {number} options.timeout - Timeout in ms (default: 3000)
+   * @returns {Promise<void>}
+   */
+  async waitForVariablePopoverHidden(variableName, options = {}) {
+    const { timeout = 3000 } = options;
+    await this.page
+      .locator(`[data-test="variable-selector-${variableName}-inner-popover"]`)
+      .waitFor({ state: "hidden", timeout });
   }
 
   /**
@@ -316,6 +347,218 @@ export default class DashboardVariablesScoped {
    */
   getVariableLoadingIndicator(variableName) {
     return this.page.locator(getVariableLoadingIndicator(variableName));
+  }
+
+  /**
+   * Get variable selector locator on the dashboard by name
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableSelectorLocator(variableName) {
+    return this.page.locator(getVariableSelector(variableName));
+  }
+
+  /**
+   * Get an any-panel locator (matches any dashboard panel) by index
+   * @param {number} index - 0-based index (default 0)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getAnyPanel(index = 0) {
+    return this.page.locator(SELECTORS.PANEL_ANY).nth(index);
+  }
+
+  /**
+   * Wait for a dashboard tab (by title) to be visible
+   * @param {string} tabTitle - Tab title (e.g., "Tab1")
+   * @param {Object} options - Wait options
+   * @param {number} options.timeout - Timeout in ms (default: 10000)
+   */
+  async waitForTabVisible(tabTitle, options = {}) {
+    const { timeout = 10000 } = options;
+    await this.page.locator(getTabSelector(tabTitle)).waitFor({ state: "visible", timeout });
+  }
+
+  /**
+   * Click a dashboard tab by title
+   * @param {string} tabTitle - Tab title (e.g., "Tab1")
+   */
+  async clickTab(tabTitle) {
+    await this.page.locator(getTabSelector(tabTitle)).click();
+  }
+
+  /**
+   * Wait for tab content to load (empty add-panel button OR any panel visible)
+   * @param {Object} options - Wait options
+   * @param {number} options.timeout - Timeout in ms (default: 5000)
+   */
+  async waitForTabContentLoaded(options = {}) {
+    const { timeout = 5000 } = options;
+    await this.page
+      .locator(SELECTORS.ADD_PANEL_BTN)
+      .or(this.page.locator(SELECTORS.PANEL_ANY))
+      .first()
+      .waitFor({ state: "visible", timeout });
+  }
+
+  /**
+   * Wait for the panel editor to open (chart type item OR apply button visible)
+   * @param {Object} options - Wait options
+   * @param {number} options.timeout - Timeout in ms (default: 15000)
+   */
+  async waitForPanelEditorOpen(options = {}) {
+    const { timeout = 15000 } = options;
+    await this.page
+      .locator(SELECTORS.CHART_LINE_ITEM)
+      .or(this.page.locator(SELECTORS.APPLY_BTN))
+      .first()
+      .waitFor({ state: "visible", timeout });
+  }
+
+  /**
+   * Wait for the "Add Variable" button to be visible
+   * @param {Object} options - Wait options
+   * @param {number} options.timeout - Timeout in ms (default: 10000)
+   */
+  async waitForAddVariableBtnVisible(options = {}) {
+    const { timeout = 10000 } = options;
+    await this.page.locator(SELECTORS.ADD_VARIABLE_BTN).waitFor({ state: "visible", timeout });
+  }
+
+  /**
+   * Click the "Add Variable" button
+   */
+  async clickAddVariableBtn() {
+    await this.page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
+  }
+
+  /**
+   * Fill the variable name field
+   * @param {string} name - Variable name
+   */
+  async fillVariableName(name) {
+    await this.page.locator('[data-test="dashboard-variable-name-field"]').fill(name);
+  }
+
+  /**
+   * Select a variable scope (e.g. "global" | "tabs" | "panels") via the scope dropdown
+   * @param {string} scopeValue - data-test-value of the scope option
+   */
+  async selectVariableScope(scopeValue) {
+    await this.page.locator(SELECTORS.VARIABLE_SCOPE_SELECT).click();
+    await this.page
+      .locator('[data-test="dashboard-variable-scope-select-popover"]')
+      .waitFor({ state: "visible", timeout: 5000 });
+    await this.page
+      .locator(`[data-test="dashboard-variable-scope-select-option"][data-test-value="${scopeValue}"]`)
+      .click();
+    await this.page
+      .locator('[data-test="dashboard-variable-scope-select-popover"]')
+      .waitFor({ state: "hidden", timeout: 5000 });
+  }
+
+  /**
+   * Select a tab (by label) in the variable "Selected Tabs" dropdown, then close it
+   * @param {string} tabLabel - data-test-label of the tab option (e.g. "Tab2", "Default")
+   */
+  async selectVariableTab(tabLabel) {
+    const tabsSelect = this.page.locator(SELECTORS.VARIABLE_TABS_SELECT);
+    await tabsSelect.waitFor({ state: "visible" });
+    await tabsSelect.click();
+    await this.page
+      .locator('[data-test="dashboard-variable-tabs-select-popover"]')
+      .waitFor({ state: "visible", timeout: 5000 });
+    const option = this.page.locator(
+      `[data-test="dashboard-variable-tabs-select-option"][data-test-label="${tabLabel}"]`
+    );
+    await option.waitFor({ state: "visible" });
+    await option.click();
+    await tabsSelect.click();
+    await this.page
+      .locator('[data-test="dashboard-variable-tabs-select-popover"]')
+      .waitFor({ state: "hidden", timeout: 5000 });
+  }
+
+  /**
+   * Select a panel (by label) in the variable "Selected Panels" dropdown, then close it
+   * @param {string} panelLabel - data-test-label of the panel option (e.g. "Panel1")
+   */
+  async selectVariablePanel(panelLabel) {
+    const panelsSelect = this.page.locator(SELECTORS.VARIABLE_PANELS_SELECT);
+    await panelsSelect.waitFor({ state: "visible" });
+    await panelsSelect.click();
+    await this.page
+      .locator('[data-test="dashboard-variable-panels-select-popover"]')
+      .waitFor({ state: "visible", timeout: 5000 });
+    const option = this.page.locator(
+      `[data-test="dashboard-variable-panels-select-option"][data-test-label="${panelLabel}"]`
+    );
+    await option.waitFor({ state: "visible" });
+    await option.click();
+    await panelsSelect.click();
+    await this.page
+      .locator('[data-test="dashboard-variable-panels-select-popover"]')
+      .waitFor({ state: "hidden", timeout: 5000 });
+  }
+
+  /**
+   * Click the "Add Filter" button in the variable form
+   */
+  async clickAddFilter() {
+    await this.page.locator(SELECTORS.ADD_FILTER_BTN).click();
+  }
+
+  /**
+   * Select a filter field name in the last filter row
+   * @param {string} fieldName - Field name / data-test-value of the option
+   */
+  async selectFilterName(fieldName) {
+    const filterNameSelector = this.page.locator(SELECTORS.FILTER_NAME_SELECTOR).last();
+    await filterNameSelector.waitFor({ state: "visible" });
+    await filterNameSelector.click();
+    await this.page
+      .locator('[data-test="dashboard-query-values-filter-name-selector-search"]')
+      .fill(fieldName);
+    await this.page
+      .locator(`[data-test="dashboard-query-values-filter-name-selector-option"][data-test-value="${fieldName}"]`)
+      .click();
+  }
+
+  /**
+   * Select a filter operator in the last filter row
+   * @param {string} operator - Operator data-test-value (e.g. "=")
+   */
+  async selectFilterOperator(operator) {
+    const operatorSelector = this.page.locator(SELECTORS.FILTER_OPERATOR_SELECTOR).last();
+    await operatorSelector.click();
+    await this.page
+      .locator(`[data-test="dashboard-query-values-filter-operator-selector-option"][data-test-value="${operator}"]`)
+      .click();
+  }
+
+  /**
+   * Get the last filter-value OCombobox input locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getFilterValueInput() {
+    return this.page
+      .locator('[data-test*="filter-value-selector"][data-test$="-input"]')
+      .last();
+  }
+
+  /**
+   * Get the filter-value dependency options locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getFilterValueOptions() {
+    return this.page.locator('[data-test*="filter-value-selector"][data-test$="-option"]');
+  }
+
+  /**
+   * Get all filter-value dependency option text contents
+   * @returns {Promise<string[]>}
+   */
+  async getFilterValueOptionTexts() {
+    return await this.getFilterValueOptions().allTextContents();
   }
 
   /**

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
@@ -420,6 +420,63 @@ export default class DashboardVariablesScoped {
   }
 
   /**
+   * Get the variable "scope" select locator (edit-variable form)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableScopeSelectLocator() {
+    return this.page.locator(SELECTORS.VARIABLE_SCOPE_SELECT);
+  }
+
+  /**
+   * Get the variable "save" button locator (variable form)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableSaveBtnLocator() {
+    return this.page.locator(SELECTORS.VARIABLE_SAVE_BTN);
+  }
+
+  /**
+   * Get the variable "cancel" button locator (variable form)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableCancelBtnLocator() {
+    return this.page.locator('[data-test="dashboard-variable-cancel-btn"]');
+  }
+
+  /**
+   * Get the variable stream-type select locator (variable form)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableStreamTypeSelectLocator() {
+    return this.page.locator(SELECTORS.VARIABLE_STREAM_TYPE_SELECT);
+  }
+
+  /**
+   * Get the constant-value field locator (constant variable form)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableConstantValueFieldLocator() {
+    return this.page.locator('[data-test="dashboard-variable-constant-value-field"]');
+  }
+
+  /**
+   * Get a dashboard-list entry locator by its title text
+   * @param {string} title - Dashboard title
+   * @returns {import('@playwright/test').Locator}
+   */
+  getDashboardTitleLocator(title) {
+    return this.page.getByTitle(title, { exact: true });
+  }
+
+  /**
+   * Get the (unscoped) dashboard panel container locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getPanelContainerLocator() {
+    return this.page.locator(SELECTORS.PANEL_CONTAINER);
+  }
+
+  /**
    * Get the variable-name form field locator (dashboard-variable-name)
    * @returns {import('@playwright/test').Locator}
    */
@@ -441,6 +498,22 @@ export default class DashboardVariablesScoped {
    */
   getQueryEditorLocator() {
     return this.page.locator(SELECTORS.QUERY_EDITOR);
+  }
+
+  /**
+   * Get the global dashboard refresh button locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getDashboardRefreshBtnLocator() {
+    return this.page.locator(SELECTORS.REFRESH_BTN);
+  }
+
+  /**
+   * Get the Query Inspector dialog locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getQueryInspectorDialogLocator() {
+    return this.page.locator('[data-test="query-inspector-dialog"]');
   }
 
   /**

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
@@ -33,23 +33,8 @@ export default class DashboardVariablesScoped {
   // These replace raw selectors in spec files
   // ==========================================
 
-  /**
-   * Locator getter for a variable selector dropdown by name
-   * @param {string} variableName - Variable name
-   * @returns {import('@playwright/test').Locator}
-   */
-  getVariableSelectorLocator(variableName) {
-    return this.page.locator(getVariableSelector(variableName));
-  }
-
-  /**
-   * Locator getter for a variable's edit button by name
-   * @param {string} variableName - Variable name
-   * @returns {import('@playwright/test').Locator}
-   */
-  getEditVariableBtnLocator(variableName) {
-    return this.page.locator(getEditVariableBtn(variableName));
-  }
+  // Note: getVariableSelectorLocator() and getEditVariableBtnLocator() are
+  // defined once further below (canonical copies).
 
   /**
    * Wait for dialog to be visible

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
@@ -388,6 +388,91 @@ export default class DashboardVariablesScoped {
   }
 
   /**
+   * Get the settings/dialog overlay locator (matches legacy dialog + ODrawer/ODialog)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getDialogLocator() {
+    return this.page.locator(SELECTORS.DIALOG);
+  }
+
+  /**
+   * Get the dashboard settings drawer locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getSettingsDrawerLocator() {
+    return this.page.locator(SELECTORS.DIALOG_CARD);
+  }
+
+  /**
+   * Get the "Add Variable" button locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getAddVariableBtnLocator() {
+    return this.page.locator(SELECTORS.ADD_VARIABLE_BTN);
+  }
+
+  /**
+   * Get the variable settings draggable container locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableDragLocator() {
+    return this.page.locator(SELECTORS.VARIABLE_DRAG);
+  }
+
+  /**
+   * Get the variable-name form field locator (dashboard-variable-name)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableNameLocator() {
+    return this.page.locator(SELECTORS.VARIABLE_NAME);
+  }
+
+  /**
+   * Get the "No Data Found" indicator locator for a variable query-value selector
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableNoDataLocator() {
+    return this.page.locator('[data-test="variable-query-value-selector-no-data"]');
+  }
+
+  /**
+   * Get the Query Inspector executed-query editor locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getQueryEditorLocator() {
+    return this.page.locator(SELECTORS.QUERY_EDITOR);
+  }
+
+  /**
+   * Get the Query Inspector dialog close button locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getQueryInspectorCloseBtn() {
+    return this.page.locator(
+      '[data-test="query-inspector-dialog"] [data-test="o-dialog-close-btn"]'
+    );
+  }
+
+  /**
+   * Get generic ARIA-role option locators ([role="option"])
+   * @returns {import('@playwright/test').Locator}
+   */
+  getAriaRoleOptions() {
+    return this.page.locator('[role="option"]');
+  }
+
+  /**
+   * Get the inner selected-value element locator scoped to a variable selector
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableInnerValueLocator(variableName) {
+    return this.page
+      .locator(getVariableSelector(variableName))
+      .locator('[data-test$="-inner-value"]');
+  }
+
+  /**
    * Get the dashboard list search input locator
    * @returns {import('@playwright/test').Locator}
    */

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
@@ -34,6 +34,24 @@ export default class DashboardVariablesScoped {
   // ==========================================
 
   /**
+   * Locator getter for a variable selector dropdown by name
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getVariableSelectorLocator(variableName) {
+    return this.page.locator(getVariableSelector(variableName));
+  }
+
+  /**
+   * Locator getter for a variable's edit button by name
+   * @param {string} variableName - Variable name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getEditVariableBtnLocator(variableName) {
+    return this.page.locator(getEditVariableBtn(variableName));
+  }
+
+  /**
    * Wait for dialog to be visible
    * @param {Object} options - Wait options
    * @param {number} options.timeout - Timeout in ms (default: 5000)

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables.js
@@ -23,6 +23,21 @@ export default class DashboardVariables {
     this.adhocAddSelector = page.locator('[data-test="dashboard-variable-adhoc-add-selector"]');
     this.adhocNameSelectorField = page.locator('[data-test="dashboard-variable-adhoc-name-selector-field"]');
     this.adhocValueSelectorField = page.locator('[data-test="dashboard-variable-adhoc-value-selector-field"]');
+    this.adhocNameSelectorInput = page.locator('[data-test="dashboard-variable-adhoc-name-selector"] input');
+    this.adhocValueSelectorInput = page.locator('[data-test="dashboard-variable-adhoc-value-selector"] input');
+  }
+
+  /**
+   * Add an ad-hoc (dynamic) filter variable with the given name and value
+   * @param {string} name - ad-hoc variable field name
+   * @param {string} value - ad-hoc variable value
+   */
+  async addAdhocVariable(name, value) {
+    await this.adhocAddSelector.click();
+    await this.adhocNameSelectorInput.click();
+    await this.adhocNameSelectorInput.fill(name);
+    await this.adhocValueSelectorInput.click();
+    await this.adhocValueSelectorInput.fill(value);
   }
 
   /**

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables.js
@@ -17,6 +17,48 @@ export default class DashboardVariables {
     this.variableOptionByValue = (name, value) => page.locator(`[data-test="variable-selector-${name}-inner-option"][data-test-value="${value}"]`);
     this.variablePopover = (name) => page.locator(`[data-test="variable-selector-${name}-inner-popover"]`);
     this.variableWrapper = (name) => page.locator(`[data-test="variable-selector-${name}-inner"]`);
+    // HTML panel editor (Monaco) locators
+    this.htmlEditor = page.locator('[data-test="dashboard-html-editor"]');
+  }
+
+  /**
+   * Get the dashboard settings button locator
+   * @returns {import('@playwright/test').Locator}
+   */
+  getSettingBtnLocator() {
+    return this.page.locator('[data-test="dashboard-setting-btn"]');
+  }
+
+  /**
+   * Get a rendered HTML-panel content element by its data-test attribute
+   * @param {string} dataTest - data-test value inside the rendered HTML panel
+   * @returns {import('@playwright/test').Locator}
+   */
+  getHtmlContentLocator(dataTest) {
+    return this.page.locator(`[data-test="${dataTest}"]`);
+  }
+
+  /**
+   * Get the error-toast locator (OToast error variant)
+   * @returns {import('@playwright/test').Locator}
+   */
+  getErrorToastLocator() {
+    return this.page.locator('[data-test-variant="error"]');
+  }
+
+  /**
+   * Click into the HTML panel Monaco editor to focus it
+   */
+  async clickHtmlEditor() {
+    await this.htmlEditor.locator(".monaco-editor").click();
+  }
+
+  /**
+   * Fill the HTML panel Monaco editor input area with content
+   * @param {string} content - HTML content to enter
+   */
+  async fillHtmlEditor(content) {
+    await this.htmlEditor.locator(".inputarea").fill(content);
   }
 
   // Method to add a dashboard variable

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables.js
@@ -19,6 +19,10 @@ export default class DashboardVariables {
     this.variableWrapper = (name) => page.locator(`[data-test="variable-selector-${name}-inner"]`);
     // HTML panel editor (Monaco) locators
     this.htmlEditor = page.locator('[data-test="dashboard-html-editor"]');
+    // Ad-hoc (dynamic) filter variable selector controls
+    this.adhocAddSelector = page.locator('[data-test="dashboard-variable-adhoc-add-selector"]');
+    this.adhocNameSelectorField = page.locator('[data-test="dashboard-variable-adhoc-name-selector-field"]');
+    this.adhocValueSelectorField = page.locator('[data-test="dashboard-variable-adhoc-value-selector-field"]');
   }
 
   /**

--- a/tests/ui-testing/pages/dashboardPages/dashboardPage.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboardPage.js
@@ -145,6 +145,33 @@ export class DashboardPage {
     // Custom chart locators
     this.customChartItem = page.locator('[data-test="selected-chart-custom_chart-item"]');
     this.markdownEditor = page.locator('[data-test="dashboard-markdown-editor-query-editor"]');
+
+    // Custom chart validation: the error surfaces inside an OTooltip on the
+    // warning button and is not in the DOM until the button is hovered.
+    this.panelErrorDataBtn = page.locator('[data-test="panel-error-data"]');
+    this.unsafeCodeText = page.getByText("Unsafe code detected");
+    this.pleaseEnterQueryText = page.getByText("Please enter query for custom chart");
+  }
+
+  // Get the custom-chart error (warning) button locator.
+  getPanelErrorDataBtn() {
+    return this.panelErrorDataBtn;
+  }
+
+  // Hover the warning button and return the tooltip text locator matching `text`.
+  async getPanelErrorTooltipText(text) {
+    await this.panelErrorDataBtn.hover();
+    return this.page.locator('[data-test="o-tooltip-content"] div').getByText(text);
+  }
+
+  // Get the "Unsafe code detected" text locator.
+  getUnsafeCodeText() {
+    return this.unsafeCodeText;
+  }
+
+  // Get the "Please enter query for custom chart" text locator.
+  getPleaseEnterQueryText() {
+    return this.pleaseEnterQueryText;
   }
   async navigateToDashboards() {
     await this.page.waitForSelector('[data-test="menu-link-\\/dashboards-item"]');

--- a/tests/ui-testing/pages/dashboardPages/visualise.js
+++ b/tests/ui-testing/pages/dashboardPages/visualise.js
@@ -593,12 +593,83 @@ export default class LogsVisualise {
     return toast;
   }
 
+  // Locator for a saved panel's dropdown menu trigger
+  getPanelDropdown(panelName) {
+    return this.page.locator(`[data-test="dashboard-edit-panel-${panelName}-dropdown"]`);
+  }
+
+  // ── VRL visualization locator getters (used by visualize-vrl spec) ──────────
+
+  // Utilities menu button in the logs/visualize search bar (hosts the VRL toggle)
+  getUtilitiesMenuBtn() {
+    return this.page.locator('[data-test="logs-search-bar-utilities-menu-btn"]');
+  }
+
+  // VRL show-query toggle button rendered inside the utilities dropdown menu
+  getVrlToggleMenuBtn() {
+    return this.page.locator('[data-test="logs-search-bar-show-query-toggle-btn-btn"]');
+  }
+
+  // Rendered dashboard table panel
+  getTablePanel() {
+    return this.page.locator('[data-test="dashboard-panel-table"]');
+  }
+
+  // Data rows inside the rendered dashboard table panel
+  getTableRows() {
+    return this.page.locator('[data-test="dashboard-panel-table"] tbody tr');
+  }
+
+  // Chart-type selector item by type (e.g. "table", "line", "bar", "h-bar")
+  getChartTypeItem(chartType) {
+    return this.page.locator(`[data-test="selected-chart-${chartType}-item"]`);
+  }
+
+  // "Edit panel" action button (from a panel dropdown menu)
+  getEditPanelBtn() {
+    return this.page.locator('[data-test="dashboard-edit-panel"]');
+  }
+
+  // VRL "only supported for table chart" warning banner
+  getVrlWarningBanner() {
+    return this.page.getByText("VRL function is only supported for table chart");
+  }
+
+  // VRL error notification (present only when VRL functions are active on non-table)
+  getVrlErrorNotification() {
+    return this.page.getByText(
+      "VRL functions are present. Only table chart is supported when using VRL functions."
+    );
+  }
+
+  // Toast message locator scoped to a given text
+  getToastMessageByText(text) {
+    return this.page
+      .locator('[data-test="o-toast-message"]')
+      .filter({ hasText: text });
+  }
+
+  // Dashboard back button locator (for waits; use clickDashboardBackBtn() to click)
+  getDashboardBackBtn() {
+    return this.page.locator('[data-test="dashboard-back-btn"]');
+  }
+
+  // Dialog primary (confirm) button locator
+  getDialogPrimaryBtn() {
+    return this.page.locator('[data-test="o-dialog-primary-btn"]');
+  }
+
+  // Sidebar/table field locator matched by Playwright text engine selector
+  getFieldByTextSelector(textSelector) {
+    return this.page.locator(textSelector);
+  }
+
   // Open query inspector from a panel dropdown
   async openPanelQueryInspector(panelName) {
     // Wait for the dashboard view to fully load after panel save
     await this.page.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
 
-    const dropdown = this.page.locator(`[data-test="dashboard-edit-panel-${panelName}-dropdown"]`);
+    const dropdown = this.getPanelDropdown(panelName);
     await dropdown.waitFor({ state: "visible", timeout: 20000 });
     await dropdown.click();
 

--- a/tests/ui-testing/pages/generalPages/correlationDrawerPage.js
+++ b/tests/ui-testing/pages/generalPages/correlationDrawerPage.js
@@ -1,0 +1,121 @@
+import { expect } from '@playwright/test';
+
+/**
+ * Page Object for the Correlation Event Drawer.
+ *
+ * This is the "correlate-from-a-log" drawer surfaced from the Logs page: the
+ * correlated-logs tab/table, the correlation event-header chips, the error
+ * state, and the log-correlation entry button. Distinct from the Correlation
+ * Settings screen (see CorrelationSettingsPage).
+ */
+export class CorrelationDrawerPage {
+    constructor(page) {
+        this.page = page;
+
+        // ==================== Drawer Selectors ====================
+        this.correlatedLogsTab = '[data-test="correlated-logs-tab"]';
+        this.correlatedLogsTable = '[data-test="correlated-logs-table"]';
+        this.correlatedMetricsTab = '[data-test="correlated-metrics-tab"]';
+        // Chips render per matched dimension; match by data-test prefix.
+        this.eventHeaderChips = '[data-test^="correlation-event-header"]';
+        this.errorState = '[data-test="error-state"]';
+        this.logCorrelationBtn = '[data-test="log-correlation-btn"]';
+        // Logs result table (source of the correlate journey).
+        this.logsResultTable = '[data-test="logs-search-result-logs-table"]';
+        // Apply button on the editable DimensionFiltersBar.
+        this.applyDimensionFiltersBtn = '[data-test="apply-dimension-filters"]';
+    }
+
+    // ==================== Getters (raw-selector relocation) ====================
+
+    /**
+     * Correlated logs tab locator (first match).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getCorrelatedLogsTab() {
+        return this.page.locator(this.correlatedLogsTab).first();
+    }
+
+    /**
+     * Correlated logs table locator (first match).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getCorrelatedLogsTable() {
+        return this.page.locator(this.correlatedLogsTable).first();
+    }
+
+    /**
+     * Correlation event-header chips locator (all matches).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getEventHeaderChips() {
+        return this.page.locator(this.eventHeaderChips);
+    }
+
+    /**
+     * Error-state locator (first match).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getErrorState() {
+        return this.page.locator(this.errorState).first();
+    }
+
+    /**
+     * Log-correlation entry button locator (first match).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getLogCorrelationBtn() {
+        return this.page.locator(this.logCorrelationBtn).first();
+    }
+
+    /**
+     * Event text (e.g. a dimension value) matched by visible text, non-exact.
+     * @param {string} name - Text to match.
+     * @returns {import('@playwright/test').Locator}
+     */
+    getEventTextByName(name) {
+        return this.page.getByText(name, { exact: false });
+    }
+
+    /**
+     * Correlated metrics tab locator (first match).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getCorrelatedMetricsTab() {
+        return this.page.locator(this.correlatedMetricsTab).first();
+    }
+
+    /**
+     * Logs result table rows (`tbody tr`).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getLogsResultTableRows() {
+        return this.page.locator(`${this.logsResultTable} tbody tr`);
+    }
+
+    /**
+     * Dimension-filter control for a given dimension key.
+     * @param {string} key - Dimension key (e.g. "k8s-cluster").
+     * @returns {import('@playwright/test').Locator}
+     */
+    getDimensionFilter(key) {
+        return this.page.locator(`[data-test="dimension-filter-${key}"]`).first();
+    }
+
+    /**
+     * Apply button on the editable DimensionFiltersBar (first match).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getApplyDimensionFiltersButton() {
+        return this.page.locator(this.applyDimensionFiltersBtn).first();
+    }
+
+    /**
+     * Role=option locator matched by name (string or RegExp).
+     * @param {string|RegExp} name - Option accessible name.
+     * @returns {import('@playwright/test').Locator}
+     */
+    getOptionByName(name) {
+        return this.page.getByRole('option', { name });
+    }
+}

--- a/tests/ui-testing/pages/generalPages/correlationSettingsPage.js
+++ b/tests/ui-testing/pages/generalPages/correlationSettingsPage.js
@@ -22,10 +22,20 @@ export class CorrelationSettingsPage {
         // Tab selectors (OTabs - render as [role="tablist"] / [role="tab"])
         // Note: tabs use name attribute: services, discovery, alert-correlation, field-aliases
         this.tabsContainer = '[role="tablist"]';
+        // The Correlation Settings tabs wrapper (data-test container).
+        this.correlationSettingsTabs = '[data-test="correlation-settings-tabs"]';
+        // Save button on the Detection Rules ("Distinguish Services By") view.
+        this.saveConfigurationButtonName = 'Save Configuration';
+        // Placeholder text of the "+ Add field" OSelect trigger.
+        this.selectAFieldText = 'Select a field';
         this.servicesTabName = 'Services';
         this.serviceDiscoveryTabName = 'Configuration';
         this.alertCorrelationTabName = 'Alert Correlation';
         this.fieldAliasesTabName = 'Field Mappings';
+        // Detection Rules view (the "Distinguish Services By" configuration tab)
+        this.detectionRulesTabName = 'Detection Rules';
+        // "+ Add field" button that reveals the "Select a field" OSelect
+        this.addFieldButtonName = 'Add field';
 
         // ==================== Service Identity Tab Selectors ====================
         this.serviceIdentityBackwardBtn = '[data-test="correlation-service-identity-backward-btn"]';
@@ -48,6 +58,7 @@ export class CorrelationSettingsPage {
         this.semanticGroupCategorySelect = '[data-test="semantic-group-category-select"]';
         this.importJsonBtn = '[data-test="correlation-semanticfieldgroup-import-json-btn"]';
         this.addCustomGroupBtn = '[data-test="correlation-semanticfieldgroup-add-custom-group-btn"]';
+        this.semanticFieldGroupSaveBtn = '[data-test="correlation-semanticfieldgroup-save-btn"]';
 
         // ==================== Semantic Group Item Selectors ====================
         this.semanticGroupDisplayInput = '[data-test="semantic-group-display-input"]';
@@ -229,6 +240,99 @@ export class CorrelationSettingsPage {
     async expectAlertCorrelationTabActive() {
         const tab = this.page.getByRole('tab', { name: this.alertCorrelationTabName });
         await expect(tab).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+    }
+
+    // ==================== Tab / Button Getters (raw-selector relocation) ====================
+
+    /**
+     * Field Mappings tab locator (a.k.a. Field Aliases).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getFieldMappingsTab() {
+        return this.page.getByRole('tab', { name: this.fieldAliasesTabName });
+    }
+
+    /**
+     * Detection Rules tab locator (the "Distinguish Services By" configuration).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getDetectionRulesTab() {
+        return this.page.getByRole('tab', { name: this.detectionRulesTabName });
+    }
+
+    /**
+     * "+ Add field" button on the Detection Rules view.
+     * @returns {import('@playwright/test').Locator}
+     */
+    getAddFieldButton() {
+        return this.page.getByRole('button', { name: this.addFieldButtonName }).first();
+    }
+
+    /**
+     * The Correlation Settings tabs container (data-test wrapper).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getCorrelationSettingsTabs() {
+        return this.page.locator(this.correlationSettingsTabs);
+    }
+
+    /**
+     * "+ Add custom group" button on the Field Mappings view.
+     * @returns {import('@playwright/test').Locator}
+     */
+    getAddCustomGroupButton() {
+        return this.page.locator(this.addCustomGroupBtn);
+    }
+
+    /**
+     * Semantic-group display-input wrapper (data-test sits on the component
+     * wrapper; the editable element is inside).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getSemanticGroupDisplayWrap() {
+        return this.page.locator(this.semanticGroupDisplayInput);
+    }
+
+    /**
+     * Save button for a semantic field group.
+     * @returns {import('@playwright/test').Locator}
+     */
+    getSemanticFieldGroupSaveButton() {
+        return this.page.locator(this.semanticFieldGroupSaveBtn);
+    }
+
+    /**
+     * "Save Configuration" button on the Detection Rules view.
+     * @returns {import('@playwright/test').Locator}
+     */
+    getSaveConfigurationButton() {
+        return this.page.getByRole('button', { name: this.saveConfigurationButtonName });
+    }
+
+    /**
+     * "Select a field" OSelect trigger (placeholder text, non-exact).
+     * @returns {import('@playwright/test').Locator}
+     */
+    getSelectAFieldTrigger() {
+        return this.page.getByText(this.selectAFieldText, { exact: false });
+    }
+
+    /**
+     * Role=option locator matched by name (string or RegExp).
+     * @param {string|RegExp} name - Option accessible name.
+     * @returns {import('@playwright/test').Locator}
+     */
+    getOptionByName(name) {
+        return this.page.getByRole('option', { name });
+    }
+
+    /**
+     * Visible text locator matched by string or RegExp.
+     * @param {string|RegExp} text - Text (or pattern) to match.
+     * @returns {import('@playwright/test').Locator}
+     */
+    getTextByPattern(text) {
+        return this.page.getByText(text);
     }
 
     async clickFieldAliasesTab() {

--- a/tests/ui-testing/pages/generalPages/crossLinkPage.js
+++ b/tests/ui-testing/pages/generalPages/crossLinkPage.js
@@ -80,6 +80,59 @@ export class CrossLinkPage {
         return `[data-test="log-detail-row-${fieldName}"]`;
     }
 
+    // ---- Sentinel POM locator getters (relocated from spec raw selectors) ----
+    getAddCrossLinkBtnLocator() {
+        return this.page.locator('[data-test="add-cross-link-btn"]');
+    }
+
+    getCrossLinkEmptyLocator() {
+        return this.page.locator('[data-test="cross-link-empty"]').first();
+    }
+
+    getCrossLinkListLocator() {
+        return this.page.locator('[data-test="cross-link-list"]').first();
+    }
+
+    getCrossLinkNameInputLocator() {
+        return this.page.locator('[data-test="cross-link-name-input"]');
+    }
+
+    getCrossLinkUrlInputLocator() {
+        return this.page.locator('[data-test="cross-link-url-input"]');
+    }
+
+    getCrossLinkFieldInputLocator() {
+        return this.page.locator('[data-test="cross-link-field-input"]');
+    }
+
+    getCrossLinkCancelBtnLocator() {
+        return this.page.locator('[data-test="cross-link-dialog"] [data-test="o-dialog-secondary-btn"]');
+    }
+
+    getCrossLinkItemLocator(idx) {
+        return this.page.locator(this.crossLinkItem(idx));
+    }
+
+    getCrossLinkEditBtnLocator(idx) {
+        return this.page.locator(this.crossLinkEditBtn(idx));
+    }
+
+    getCrossLinkDeleteBtnLocator(idx) {
+        return this.page.locator(this.crossLinkDeleteBtn(idx));
+    }
+
+    getLogDetailRowLocator(fieldName) {
+        return this.page.locator(this.logDetailRow(fieldName));
+    }
+
+    async getCrossLinkItemNameCount() {
+        return await this.page.locator('[data-test^="cross-link-item-name-"]').count();
+    }
+
+    async getDeletableCrossLinkCount() {
+        return await this.page.locator('[data-test^="cross-link-delete-"]').count();
+    }
+
     logDetailsCrossLinkMenuItem(crossLinkName) {
         return `[data-test="log-details-cross-link-${crossLinkName}"]`;
     }

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -11224,6 +11224,15 @@ export class LogsPage {
     }
 
     /**
+     * Get a logs result table column header by field name.
+     * @param {string} fieldName - The field/column name.
+     * @returns {import('@playwright/test').Locator}
+     */
+    getTableHeaderByField(fieldName) {
+        return this.page.locator(`[data-test="o2-table-th-${fieldName}"]`);
+    }
+
+    /**
      * Get bar chart / histogram container
      * @returns {import('@playwright/test').Locator}
      */

--- a/tests/ui-testing/pages/page-manager.js
+++ b/tests/ui-testing/pages/page-manager.js
@@ -75,6 +75,7 @@ import { EnrichmentPage } from "./generalPages/enrichmentPage.js";
 import { ThemePage } from "./generalPages/themePage.js";
 import { LanguagePage } from "./generalPages/languagePage.js";
 import { CorrelationSettingsPage } from "./generalPages/correlationSettingsPage.js";
+import { CorrelationDrawerPage } from "./generalPages/correlationDrawerPage.js";
 import { CrossLinkPage } from "./generalPages/crossLinkPage.js";
 import { ModelPricingPage } from "./generalPages/modelPricingPage.js";
 import { EditionFeaturesPage } from "./generalPages/editionFeaturesPage.js";
@@ -195,6 +196,7 @@ class PageManager {
     this.themePage = new ThemePage(page);
     this.languagePage = new LanguagePage(page);
     this.correlationSettingsPage = new CorrelationSettingsPage(page);
+    this.correlationDrawerPage = new CorrelationDrawerPage(page);
     this.crossLinkPage = new CrossLinkPage(page);
     this.modelPricingPage = new ModelPricingPage(page);
     this.editionFeaturesPage = new EditionFeaturesPage(page);

--- a/tests/ui-testing/playwright-tests/Correlation/ui-B1-settings.ui.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/ui-B1-settings.ui.spec.js
@@ -5,6 +5,7 @@
 const { test, expect } = require("@playwright/test");
 const { CorrApi } = require("./utils/correlationApi");
 const { UI_BASE_URL, login } = require("./utils/corrUi");
+const PageManager = require("../../pages/page-manager.js");
 
 test.describe("TC-B1 — custom group visible everywhere immediately", () => {
   let api;
@@ -22,27 +23,26 @@ test.describe("TC-B1 — custom group visible everywhere immediately", () => {
   test("group created in Field Mappings appears in Detection Rules dropdown without reload", async ({
     page,
   }) => {
+    const pm = new PageManager(page);
     await login(page);
     await page.goto(
       `${UI_BASE_URL}/web/settings/correlation?org_identifier=${api.org}`,
       { waitUntil: "domcontentloaded" },
     );
-    await page
-      .locator('[data-test="correlation-settings-tabs"]')
+    await pm.correlationSettingsPage
+      .getCorrelationSettingsTabs()
       .waitFor({ state: "visible", timeout: 20_000 });
 
     // --- Field Mappings tab: create the custom group ---
-    await page.getByRole("tab", { name: "Field Mappings" }).click();
-    await page
-      .locator(
-        '[data-test="correlation-semanticfieldgroup-add-custom-group-btn"]',
-      )
+    await pm.correlationSettingsPage.getFieldMappingsTab().click();
+    await pm.correlationSettingsPage
+      .getAddCustomGroupButton()
       .first()
       .click();
 
     // data-test sits on the component wrapper; the editable element is inside.
-    const displayWrap = page
-      .locator('[data-test="semantic-group-display-input"]')
+    const displayWrap = pm.correlationSettingsPage
+      .getSemanticGroupDisplayWrap()
       .first();
     await displayWrap.waitFor({ state: "visible", timeout: 10_000 });
     const display = (await displayWrap.locator("input").count())
@@ -73,8 +73,8 @@ test.describe("TC-B1 — custom group visible everywhere immediately", () => {
         analyticsRefetches++;
     });
 
-    await page
-      .locator('[data-test="correlation-semanticfieldgroup-save-btn"]')
+    await pm.correlationSettingsPage
+      .getSemanticFieldGroupSaveButton()
       .first()
       .click();
     // Save reaches the backend before we switch tabs.
@@ -96,9 +96,9 @@ test.describe("TC-B1 — custom group visible everywhere immediately", () => {
       analyticsRefetches,
       "semantic-group save must trigger an _analytics refetch (mount-snapshot fix)",
     ).toBeGreaterThan(0);
-    await page.getByRole("tab", { name: "Detection Rules" }).click();
-    await page
-      .getByRole("button", { name: "Save Configuration" })
+    await pm.correlationSettingsPage.getDetectionRulesTab().click();
+    await pm.correlationSettingsPage
+      .getSaveConfigurationButton()
       .first()
       .waitFor({ state: "visible", timeout: 15_000 });
   });

--- a/tests/ui-testing/playwright-tests/Correlation/ui-D3-D4-caches.ui.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/ui-D3-D4-caches.ui.spec.js
@@ -15,6 +15,7 @@ const {
   sniff,
   waitFor,
 } = require("./utils/corrUi");
+const PageManager = require("../../pages/page-manager.js");
 
 test.describe.configure({ mode: "serial" });
 
@@ -59,10 +60,9 @@ test.describe("Journey D (UI) — FE cache invalidation", () => {
   test.afterAll(async () => api.dispose());
 
   async function correlateViaDialog(page) {
+    const pm = new PageManager(page);
     await openFirstRowDialog(page);
-    const metricsTab = page
-      .locator('[data-test="correlated-metrics-tab"]')
-      .first();
+    const metricsTab = pm.correlationDrawerPage.getCorrelatedMetricsTab();
     await metricsTab.waitFor({ state: "visible", timeout: 15_000 });
     await metricsTab.click();
     await page.waitForTimeout(5000);
@@ -130,6 +130,7 @@ test.describe("Journey D (UI) — FE cache invalidation", () => {
   test("TC-D4: identity-config saved via settings UI reaches the next correlate in the same SPA session", async ({
     page,
   }) => {
+    const pm = new PageManager(page);
     const traffic = sniff(page);
     await login(page);
     await openLogsAndQuery(page, api.org, "d_ui_logs");
@@ -153,37 +154,37 @@ test.describe("Journey D (UI) — FE cache invalidation", () => {
       `${UI_BASE_URL}/web/settings/correlation?org_identifier=${api.org}`,
       { waitUntil: "domcontentloaded" },
     );
-    await page.getByRole("tab", { name: "Detection Rules" }).click();
+    await pm.correlationSettingsPage.getDetectionRulesTab().click();
     await page.waitForTimeout(2500);
 
     // This branch's Detection Rules view: a "Distinguish Services By" card
     // with a "+ Add field" button that reveals a "Select a field" OSelect.
     // Add Environment as a distinguish field, then save. (OSelect renders the
     // placeholder as trigger TEXT; its search input appears on open, focused.)
-    const addFieldBtn = page.getByRole("button", { name: "Add field" }).first();
+    const addFieldBtn = pm.correlationSettingsPage.getAddFieldButton();
     await addFieldBtn.waitFor({ state: "visible", timeout: 15_000 });
     await addFieldBtn.click();
-    const fieldTrigger = page
-      .getByText("Select a field", { exact: false })
+    const fieldTrigger = pm.correlationSettingsPage
+      .getSelectAFieldTrigger()
       .first();
     await fieldTrigger.waitFor({ state: "visible", timeout: 10_000 });
     await fieldTrigger.click();
     await page.waitForTimeout(600);
     await page.keyboard.type("Environment");
     await page.waitForTimeout(800);
-    await page
-      .getByRole("option", { name: /Environment/i })
+    await pm.correlationSettingsPage
+      .getOptionByName(/Environment/i)
       .first()
       .click()
       .catch(async () => {
-        await page
-          .getByText(/^Environment$/)
+        await pm.correlationSettingsPage
+          .getTextByPattern(/^Environment$/)
           .first()
           .click();
       });
     await page.waitForTimeout(500);
-    const saveBtn = page
-      .getByRole("button", { name: "Save Configuration" })
+    const saveBtn = pm.correlationSettingsPage
+      .getSaveConfigurationButton()
       .first();
     await saveBtn.waitFor({ state: "visible", timeout: 10_000 });
     await saveBtn.click();

--- a/tests/ui-testing/playwright-tests/Correlation/ui-E-drawer.ui.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/ui-E-drawer.ui.spec.js
@@ -12,6 +12,7 @@ const {
   sniff,
   waitFor,
 } = require("./utils/corrUi");
+const PageManager = require("../../pages/page-manager.js");
 
 test.describe.configure({ mode: "serial" });
 
@@ -93,17 +94,18 @@ test.describe("Journey E (UI) — correlation drawer", () => {
   test("TC-E1: happy path — correlated logs populated, raw values on the wire (F1)", async ({
     page,
   }) => {
+    const pm = new PageManager(page);
     const traffic = sniff(page);
     await login(page);
     await openLogsAndQuery(page, api.org, "e_logs_a");
     await openFirstRowDialog(page);
 
-    const logsTab = page.locator('[data-test="correlated-logs-tab"]').first();
+    const logsTab = pm.correlationDrawerPage.getCorrelatedLogsTab();
     await logsTab.waitFor({ state: "visible", timeout: 15_000 });
     await logsTab.click();
 
     // Related rows render (correlated-logs-table with content).
-    const table = page.locator('[data-test="correlated-logs-table"]').first();
+    const table = pm.correlationDrawerPage.getCorrelatedLogsTable();
     await table.waitFor({ state: "visible", timeout: 30_000 });
     // The sniffer also catches the page's own (pre-toggle, quick-mode) search;
     // wait specifically for a correlated-tab query carrying the raw value.
@@ -124,21 +126,20 @@ test.describe("Journey E (UI) — correlation drawer", () => {
     ).toBe(false);
 
     // Chips render for the matched dimensions.
-    const chips = page.locator('[data-test^="correlation-event-header"]');
+    const chips = pm.correlationDrawerPage.getEventHeaderChips();
     expect(await chips.count()).toBeGreaterThan(0);
   });
 
   test("TC-E2: dropped-dimensions banner when a stream can't resolve a dimension (F14)", async ({
     page,
   }) => {
+    const pm = new PageManager(page);
     const traffic = sniff(page);
     await login(page);
     await openLogsAndQuery(page, api.org, "e_logs_a");
     await openFirstRowDialog(page);
 
-    const metricsTab = page
-      .locator('[data-test="correlated-metrics-tab"]')
-      .first();
+    const metricsTab = pm.correlationDrawerPage.getCorrelatedMetricsTab();
     await metricsTab.waitFor({ state: "visible", timeout: 15_000 });
     await metricsTab.click();
 
@@ -161,7 +162,7 @@ test.describe("Journey E (UI) — correlation drawer", () => {
     // field asserted above. UI-side we only require the metrics tab to render
     // without an error state despite the partial-resolution stream.
     await expect(
-      page.locator('[data-test="error-state"]').first(),
+      pm.correlationDrawerPage.getErrorState(),
       "metrics tab must not error on a partially-resolvable stream",
     ).not.toBeVisible();
   });
@@ -180,6 +181,7 @@ test.describe("Journey E (UI) — correlation drawer", () => {
       true,
       "dimension-filter editing has no reachable UI entry from the logs journey (see comment)",
     );
+    const pm = new PageManager(page);
     const traffic = sniff(page);
     await login(page);
     await openLogsAndQuery(page, api.org, "e_logs_a");
@@ -191,9 +193,7 @@ test.describe("Journey E (UI) — correlation drawer", () => {
     // Expand the first row INLINE via the dedicated expand cell (a plain td
     // click opens the Source Details dialog, whose own log-correlation-btn
     // only switches dialog tabs — filters stay hidden there).
-    const firstRow = page
-      .locator('[data-test="logs-search-result-logs-table"] tbody tr')
-      .first();
+    const firstRow = pm.correlationDrawerPage.getLogsResultTableRows().first();
     const expander = firstRow
       .locator(
         '[data-test="o2-table-expand-cell"], [data-test^="o2-table-expand-"]',
@@ -201,28 +201,27 @@ test.describe("Journey E (UI) — correlation drawer", () => {
       .first();
     await expander.waitFor({ state: "visible", timeout: 15_000 });
     await expander.click();
-    const corrBtn = page.locator('[data-test="log-correlation-btn"]').first();
+    const corrBtn = pm.correlationDrawerPage.getLogCorrelationBtn();
     await corrBtn.waitFor({ state: "visible", timeout: 15_000 });
     await corrBtn.click();
 
     // Full dashboard renders with the dimension filter bar.
-    const filter = page
-      .locator('[data-test="dimension-filter-k8s-cluster"]')
-      .first();
+    const filter = pm.correlationDrawerPage.getDimensionFilter("k8s-cluster");
     await filter.waitFor({ state: "visible", timeout: 30_000 });
     await filter.click();
     await page.waitForTimeout(600);
-    await page
-      .getByRole("option", { name: /C2-West/i })
+    await pm.correlationDrawerPage
+      .getOptionByName(/C2-West/i)
       .first()
       .click()
       .catch(async () => {
-        await page.getByText("C2-West", { exact: false }).last().click();
+        await pm.correlationDrawerPage
+          .getEventTextByName("C2-West")
+          .last()
+          .click();
       });
 
-    const applyBtn = page
-      .locator('[data-test="apply-dimension-filters"]')
-      .first();
+    const applyBtn = pm.correlationDrawerPage.getApplyDimensionFiltersButton();
     if (await applyBtn.isVisible().catch(() => false)) await applyBtn.click();
 
     // F35: the re-issued queries must carry the new value under EACH stream's

--- a/tests/ui-testing/playwright-tests/Dashboards/crossLinking.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/crossLinking.spec.js
@@ -84,7 +84,7 @@ test.describe("Cross-Linking testcases", () => {
         if (isVisible) {
             await pm.crossLinkPage.clickCrossLinkingTab();
             // Verify the Add Cross-Link button is visible (always present on stream-level manager)
-            await expect(page.locator('[data-test="add-cross-link-btn"]')).toBeVisible({ timeout: 5000 });
+            await expect(pm.crossLinkPage.getAddCrossLinkBtnLocator()).toBeVisible({ timeout: 5000 });
             testLogger.info('Cross-linking tab is visible and accessible');
         } else {
             testLogger.info('Cross-linking tab not visible - feature flag may be disabled, skipping gracefully');
@@ -110,11 +110,11 @@ test.describe("Cross-Linking testcases", () => {
         await pm.crossLinkPage.clickCrossLinkingTab();
 
         // Verify add button is present (confirms tab content loaded)
-        await expect(page.locator('[data-test="add-cross-link-btn"]')).toBeVisible({ timeout: 5000 });
+        await expect(pm.crossLinkPage.getAddCrossLinkBtnLocator()).toBeVisible({ timeout: 5000 });
 
         // Check if empty state or existing links are shown
-        const emptyState = page.locator('[data-test="cross-link-empty"]').first();
-        const linkList = page.locator('[data-test="cross-link-list"]').first();
+        const emptyState = pm.crossLinkPage.getCrossLinkEmptyLocator();
+        const linkList = pm.crossLinkPage.getCrossLinkListLocator();
         const hasEmpty = await emptyState.isVisible().catch(() => false);
         const hasList = await linkList.isVisible().catch(() => false);
 
@@ -147,11 +147,11 @@ test.describe("Cross-Linking testcases", () => {
         await pm.crossLinkPage.expectDialogVisible();
 
         // Verify all dialog fields are present
-        await expect(page.locator('[data-test="cross-link-name-input"]')).toBeVisible();
-        await expect(page.locator('[data-test="cross-link-url-input"]')).toBeVisible();
-        await expect(page.locator('[data-test="cross-link-field-input"]')).toBeVisible();
-        await expect(page.locator('[data-test="cross-link-dialog"] [data-test="o-dialog-primary-btn"]')).toBeVisible();
-        await expect(page.locator('[data-test="cross-link-dialog"] [data-test="o-dialog-secondary-btn"]')).toBeVisible();
+        await expect(pm.crossLinkPage.getCrossLinkNameInputLocator()).toBeVisible();
+        await expect(pm.crossLinkPage.getCrossLinkUrlInputLocator()).toBeVisible();
+        await expect(pm.crossLinkPage.getCrossLinkFieldInputLocator()).toBeVisible();
+        await expect(pm.crossLinkPage.getCrossLinkSaveBtnLocator()).toBeVisible();
+        await expect(pm.crossLinkPage.getCrossLinkCancelBtnLocator()).toBeVisible();
 
         testLogger.info('Test completed');
     });
@@ -334,7 +334,7 @@ test.describe("Cross-Linking testcases", () => {
         await pm.crossLinkPage.clickCrossLinkingTab();
 
         // Create a link to delete if none exist
-        const linkList = page.locator('[data-test="cross-link-list"]').first();
+        const linkList = pm.crossLinkPage.getCrossLinkListLocator();
         const hasList = await linkList.isVisible().catch(() => false);
 
         if (!hasList) {
@@ -348,14 +348,14 @@ test.describe("Cross-Linking testcases", () => {
         // Count links before delete. Use the per-item-name data-test so the
         // count includes only the top-level rows (each item exposes a single
         // `cross-link-item-name-<idx>` which is a 1:1 with the row).
-        const itemsBefore = await page.locator('[data-test^="cross-link-item-name-"]').count();
+        const itemsBefore = await pm.crossLinkPage.getCrossLinkItemNameCount();
         expect(itemsBefore).toBeGreaterThan(0);
 
         // Delete first link
         await pm.crossLinkPage.clickDeleteCrossLink(0);
 
         // Verify count decreased
-        const itemsAfter = await page.locator('[data-test^="cross-link-item-name-"]').count();
+        const itemsAfter = await pm.crossLinkPage.getCrossLinkItemNameCount();
         expect(itemsAfter).toBe(itemsBefore - 1);
 
         testLogger.info('Test completed');
@@ -382,7 +382,7 @@ test.describe("Cross-Linking testcases", () => {
         // per row, so it gives an accurate per-row count (unlike the broader
         // `cross-link-item-` prefix which also matches the per-cell url/name
         // attributes inside each row).
-        const itemsBefore = await page.locator('[data-test^="cross-link-item-name-"]').count();
+        const itemsBefore = await pm.crossLinkPage.getCrossLinkItemNameCount();
 
         // Open dialog, fill form, cancel
         await pm.crossLinkPage.clickAddCrossLink();
@@ -395,7 +395,7 @@ test.describe("Cross-Linking testcases", () => {
         await pm.crossLinkPage.expectDialogNotVisible();
 
         // Verify no new link was added
-        const itemsAfter = await page.locator('[data-test^="cross-link-item-name-"]').count();
+        const itemsAfter = await pm.crossLinkPage.getCrossLinkItemNameCount();
         expect(itemsAfter).toBe(itemsBefore);
 
         testLogger.info('Test completed');
@@ -449,7 +449,7 @@ test.describe("Cross-Linking testcases", () => {
         await page.waitForTimeout(2000);
 
         // Step 3: Expand a log row to reveal the inline JSON detail (JsonPreview)
-        const expandBtn = page.locator('[data-test^="o2-table-expand-"]').first();
+        const expandBtn = pm.crossLinkPage.firstLogRowExpand;
         await expandBtn.waitFor({ state: 'visible', timeout: 15000 });
         await expandBtn.click();
         await page.waitForTimeout(2000);
@@ -790,8 +790,8 @@ test.describe("Cross-Linking testcases", () => {
         // Verify edit and delete action buttons exist on the stream-level
         // (editable) manager; the org-level read-only manager doesn't emit
         // these so we only need to assert presence at all.
-        await expect(page.locator('[data-test="cross-link-edit-0"]').first()).toBeVisible();
-        await expect(page.locator('[data-test="cross-link-delete-0"]').first()).toBeVisible();
+        await expect(pm.crossLinkPage.getCrossLinkEditBtnLocator(0).first()).toBeVisible();
+        await expect(pm.crossLinkPage.getCrossLinkDeleteBtnLocator(0).first()).toBeVisible();
 
         testLogger.info('List item display verified');
     });
@@ -817,11 +817,11 @@ test.describe("Cross-Linking testcases", () => {
         // (org-level read-only items render with `cross-link-item-name-<idx>`
         // but no matching `cross-link-delete-<idx>` — clicking idx=0 then
         // would time out).
-        let existingCount = await page.locator('[data-test^="cross-link-delete-"]').count();
+        let existingCount = await pm.crossLinkPage.getDeletableCrossLinkCount();
         while (existingCount > 0) {
             await pm.crossLinkPage.clickDeleteCrossLink(0);
             await page.waitForTimeout(500);
-            existingCount = await page.locator('[data-test^="cross-link-delete-"]').count();
+            existingCount = await pm.crossLinkPage.getDeletableCrossLinkCount();
         }
 
         const editLinkName = `Edit Prefill ${Date.now()}`;
@@ -906,7 +906,7 @@ test.describe("Cross-Linking testcases", () => {
 
         // Check the configured field — cross-link SHOULD appear
         // Resolve the configured field row via PO/data-test (no class/text selectors)
-        const configuredFieldRow = page.locator(pm.crossLinkPage.logDetailRow('kubernetes_container_name'));
+        const configuredFieldRow = pm.crossLinkPage.getLogDetailRowLocator('kubernetes_container_name');
         const configuredVisible = await configuredFieldRow.isVisible().catch(() => false);
 
         if (configuredVisible) {
@@ -925,7 +925,7 @@ test.describe("Cross-Linking testcases", () => {
         }
 
         // Check a different field — cross-link should NOT appear
-        const otherFieldRow = page.locator(pm.crossLinkPage.logDetailRow('_timestamp'));
+        const otherFieldRow = pm.crossLinkPage.getLogDetailRowLocator('_timestamp');
         const otherVisible = await otherFieldRow.isVisible().catch(() => false);
 
         if (otherVisible) {
@@ -955,7 +955,7 @@ test.describe("Cross-Linking testcases", () => {
         await pm.crossLinkPage.navigateToOrgSettings();
 
         // Verify the CrossLinkManager is present (feature flag must be enabled)
-        const addBtn = page.locator('[data-test="add-cross-link-btn"]');
+        const addBtn = pm.crossLinkPage.getAddCrossLinkBtnLocator();
         try {
             await addBtn.waitFor({ state: 'visible', timeout: 10000 });
         } catch {
@@ -992,7 +992,7 @@ test.describe("Cross-Linking testcases", () => {
 
         await pm.crossLinkPage.navigateToOrgSettings();
 
-        const addBtn = page.locator('[data-test="add-cross-link-btn"]');
+        const addBtn = pm.crossLinkPage.getAddCrossLinkBtnLocator();
         try {
             await addBtn.waitFor({ state: 'visible', timeout: 10000 });
         } catch {
@@ -1039,7 +1039,7 @@ test.describe("Cross-Linking testcases", () => {
 
         await pm.crossLinkPage.navigateToOrgSettings();
 
-        const addBtn = page.locator('[data-test="add-cross-link-btn"]');
+        const addBtn = pm.crossLinkPage.getAddCrossLinkBtnLocator();
         try {
             await addBtn.waitFor({ state: 'visible', timeout: 10000 });
         } catch {
@@ -1065,7 +1065,7 @@ test.describe("Cross-Linking testcases", () => {
 
         // Verify it's gone (empty state or no items). Count via the per-row
         // name attribute so we don't double-count internal cells.
-        const remainingCount = await page.locator('[data-test^="cross-link-item-name-"]').count();
+        const remainingCount = await pm.crossLinkPage.getCrossLinkItemNameCount();
         expect(remainingCount).toBe(0);
 
         // Save org settings to persist deletion
@@ -1081,7 +1081,7 @@ test.describe("Cross-Linking testcases", () => {
 
         await pm.crossLinkPage.navigateToOrgSettings();
 
-        const addBtn = page.locator('[data-test="add-cross-link-btn"]');
+        const addBtn = pm.crossLinkPage.getAddCrossLinkBtnLocator();
         try {
             await addBtn.waitFor({ state: 'visible', timeout: 10000 });
         } catch {
@@ -1122,7 +1122,7 @@ test.describe("Cross-Linking testcases", () => {
         // Step 1: Create an org-level cross-link
         await pm.crossLinkPage.navigateToOrgSettings();
 
-        const addBtn = page.locator('[data-test="add-cross-link-btn"]');
+        const addBtn = pm.crossLinkPage.getAddCrossLinkBtnLocator();
         try {
             await addBtn.waitFor({ state: 'visible', timeout: 10000 });
         } catch {
@@ -1156,11 +1156,11 @@ test.describe("Cross-Linking testcases", () => {
 
         // Clean up only stream-level cross-links (those with visible delete buttons)
         // Org-level items are read-only and have no delete button
-        let deletableCount = await page.locator('[data-test^="cross-link-delete-"]').count();
+        let deletableCount = await pm.crossLinkPage.getDeletableCrossLinkCount();
         while (deletableCount > 0) {
             await pm.crossLinkPage.clickDeleteCrossLink(0);
             await page.waitForTimeout(500);
-            deletableCount = await page.locator('[data-test^="cross-link-delete-"]').count();
+            deletableCount = await pm.crossLinkPage.getDeletableCrossLinkCount();
         }
 
         // Verify the org cross-link item is visible (rendered by the readonly CrossLinkManager)
@@ -1168,18 +1168,18 @@ test.describe("Cross-Linking testcases", () => {
         const orgIdx = await pm.crossLinkPage.findCrossLinkItemIndexByName(orgLinkName);
         expect(orgIdx, `Org cross-link "${orgLinkName}" should be rendered`).toBeGreaterThanOrEqual(0);
 
-        const orgItem = page.locator(pm.crossLinkPage.crossLinkItem(orgIdx));
+        const orgItem = pm.crossLinkPage.getCrossLinkItemLocator(orgIdx);
         await expect(orgItem).toBeVisible({ timeout: 10000 });
         const itemText = await orgItem.textContent();
         expect(itemText).toContain(orgLinkName);
         expect(itemText).toContain('org-readonly.example.com');
 
         // Verify org-level items do NOT have edit/delete buttons (readonly prop hides them)
-        await expect(page.locator(pm.crossLinkPage.crossLinkEditBtn(orgIdx))).toHaveCount(0);
-        await expect(page.locator(pm.crossLinkPage.crossLinkDeleteBtn(orgIdx))).toHaveCount(0);
+        await expect(pm.crossLinkPage.getCrossLinkEditBtnLocator(orgIdx)).toHaveCount(0);
+        await expect(pm.crossLinkPage.getCrossLinkDeleteBtnLocator(orgIdx)).toHaveCount(0);
 
         // Verify the stream-level manager still has its add button (editable)
-        const streamAddBtn = page.locator('[data-test="add-cross-link-btn"]');
+        const streamAddBtn = pm.crossLinkPage.getAddCrossLinkBtnLocator();
         await expect(streamAddBtn).toBeVisible({ timeout: 5000 });
 
         testLogger.info('Org-level cross-link visible in stream schema as read-only, no edit/delete buttons');
@@ -1205,12 +1205,12 @@ test.describe("Cross-Linking testcases", () => {
 
         // Only delete stream-level cross-links (those with visible delete buttons)
         // Org-level cross-links are read-only and don't have delete buttons
-        const initialDeletableCount = await page.locator('[data-test^="cross-link-delete-"]').count();
+        const initialDeletableCount = await pm.crossLinkPage.getDeletableCrossLinkCount();
         let deletableCount = initialDeletableCount;
         while (deletableCount > 0) {
             await pm.crossLinkPage.clickDeleteCrossLink(0);
             await page.waitForTimeout(500);
-            deletableCount = await page.locator('[data-test^="cross-link-delete-"]').count();
+            deletableCount = await pm.crossLinkPage.getDeletableCrossLinkCount();
         }
 
         // Only save if we actually deleted something (button is disabled if no changes)
@@ -1222,7 +1222,7 @@ test.describe("Cross-Linking testcases", () => {
         // Step 1: Create an org-level cross-link with start_time and end_time in URL template
         await pm.crossLinkPage.navigateToOrgSettings();
 
-        const addBtn = page.locator('[data-test="add-cross-link-btn"]');
+        const addBtn = pm.crossLinkPage.getAddCrossLinkBtnLocator();
         try {
             await addBtn.waitFor({ state: 'visible', timeout: 10000 });
         } catch {
@@ -1258,7 +1258,7 @@ test.describe("Cross-Linking testcases", () => {
         await page.waitForTimeout(2000);
 
         // Step 3: Expand a log row to reveal the inline JSON detail (JsonPreview)
-        const expandBtn = page.locator('[data-test^="o2-table-expand-"]').first();
+        const expandBtn = pm.crossLinkPage.firstLogRowExpand;
         await expandBtn.waitFor({ state: 'visible', timeout: 15000 });
         await expandBtn.click();
         await page.waitForTimeout(2000);
@@ -1371,12 +1371,12 @@ test.describe("Cross-Linking testcases", () => {
         await pm.crossLinkPage.clickCrossLinkingTab();
 
         // Only delete stream-level cross-links (those with visible delete buttons)
-        const initialDeletableCount2 = await page.locator('[data-test^="cross-link-delete-"]').count();
+        const initialDeletableCount2 = await pm.crossLinkPage.getDeletableCrossLinkCount();
         let deletableCount2 = initialDeletableCount2;
         while (deletableCount2 > 0) {
             await pm.crossLinkPage.clickDeleteCrossLink(0);
             await page.waitForTimeout(500);
-            deletableCount2 = await page.locator('[data-test^="cross-link-delete-"]').count();
+            deletableCount2 = await pm.crossLinkPage.getDeletableCrossLinkCount();
         }
 
         // Only save if we actually deleted something (button is disabled if no changes)
@@ -1389,7 +1389,7 @@ test.describe("Cross-Linking testcases", () => {
         await pm.crossLinkPage.navigateToOrgSettings();
         testLogger.info('Navigated to org settings');
 
-        const addBtn = page.locator('[data-test="add-cross-link-btn"]');
+        const addBtn = pm.crossLinkPage.getAddCrossLinkBtnLocator();
         try {
             await addBtn.waitFor({ state: 'visible', timeout: 10000 });
             testLogger.info('Add cross-link button found in org settings');
@@ -1549,7 +1549,7 @@ test.describe("Cross-Linking testcases", () => {
 
         await pm.crossLinkPage.navigateToOrgSettings();
 
-        const addBtn = page.locator('[data-test="add-cross-link-btn"]');
+        const addBtn = pm.crossLinkPage.getAddCrossLinkBtnLocator();
         try {
             await addBtn.waitFor({ state: 'visible', timeout: 10000 });
         } catch {

--- a/tests/ui-testing/playwright-tests/Dashboards/custom-charts.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/custom-charts.spec.js
@@ -52,11 +52,10 @@ test.describe("Custom Charts Tests", () => {
 
     // The validation error is displayed inside an OTooltip on the warning
     // button — it is not in the DOM until the button is hovered.
-    const errorBtn = page.locator('[data-test="panel-error-data"]');
+    const errorBtn = pm.dashboardPage.getPanelErrorDataBtn();
     await expect(errorBtn).toBeVisible({ timeout: 30000 });
-    await errorBtn.hover();
     await expect(
-      page.locator('[data-test="o-tooltip-content"] div').getByText(
+      await pm.dashboardPage.getPanelErrorTooltipText(
         "Unsafe code detected: Access to 'document' is not allowed"
       )
     ).toBeVisible({ timeout: 5000 });
@@ -81,9 +80,7 @@ test.describe("Custom Charts Tests", () => {
     // actually render the chart — NOT surface a validation/empty-query error.
     // (Previously this test only waited 3s and asserted nothing.)
     await pm.dashboardPanelActions.expectCustomChartRendered(expect);
-    await expect(page.getByText("Unsafe code detected")).toBeHidden();
-    await expect(
-      page.getByText("Please enter query for custom chart")
-    ).toBeHidden();
+    await expect(pm.dashboardPage.getUnsafeCodeText()).toBeHidden();
+    await expect(pm.dashboardPage.getPleaseEnterQueryText()).toBeHidden();
   });
 });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-advanced.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-advanced.spec.js
@@ -34,7 +34,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await setupLinePanelWithConfig(page, pm, dashboardName);
 
     // Count added time shift rows by their remove buttons (0m ref row has no remove button)
-    const removeButtons = page.locator('[data-test^="dashboard-addpanel-config-time-shift-remove-"]');
+    const removeButtons = pm.dashboardPanelConfigs.timeShiftRemoveButtons;
     await expect(removeButtons).toHaveCount(0);
 
     // Add two time shifts
@@ -54,7 +54,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying time shift count persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test^="dashboard-addpanel-config-time-shift-remove-"]')).toHaveCount(1);
+    await expect(pm.dashboardPanelConfigs.timeShiftRemoveButtons).toHaveCount(1);
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -66,7 +66,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await setupBarPanelWithBreakdownAndConfig(page, pm, dashboardName);
     await pm.dashboardPanelConfigs.addTimeShift();
 
-    await expect(page.locator('[data-test="dashboard-trellis-chart-trigger"]')).toBeDisabled();
+    await expect(pm.dashboardPanelConfigs.trellisTrigger).toBeDisabled();
     testLogger.info("Trellis disabled with time shifts active");
 
     await pm.dashboardPanelActions.savePanel();
@@ -79,18 +79,18 @@ test.describe("ConfigPanel — Advanced Settings", () => {
 
     await setupBarPanelWithBreakdownAndConfig(page, pm, dashboardName);
 
-    await expect(page.locator('[data-test="dashboard-addpanel-config-colorBySeries-add-btn"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.colorBySeriesBtn).toBeVisible();
 
     // Open popup → select first available series → set custom color → save
     await pm.dashboardPanelConfigs.openColorBySeries();
-    await expect(page.locator('[data-test="dashboard-color-by-series-popup"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.colorBySeriesPopup).toBeVisible();
 
     const customColor = "#e63946";
     await pm.dashboardPanelConfigs.configureColorBySeries({ rowIndex: 0, optionIndex: 0, color: customColor });
     testLogger.info("Color by series: first series selected with custom color");
 
     await pm.dashboardPanelConfigs.saveColorBySeries();
-    await expect(page.locator('[data-test="dashboard-color-by-series-popup"]')).not.toBeVisible();
+    await expect(pm.dashboardPanelConfigs.colorBySeriesPopup).not.toBeVisible();
     testLogger.info("Color by series saved");
 
     // Apply, wait for API response + ECharts repaint before pixel scan
@@ -115,7 +115,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     testLogger.info("Override config: field + Bytes unit saved");
 
     await pm.dashboardPanelActions.applyDashboardBtn();
-    await expect(page.locator('[data-test="dashboard-panel-table"]')).toBeVisible();
+    await expect(pm.dashboardPanelActions.dashboardTable).toBeVisible();
     testLogger.info("Override config applied — table renders");
 
     // Verify override config persists after save
@@ -144,7 +144,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     testLogger.info("Value mapping: applied with value, display text, and color");
 
     await pm.dashboardPanelActions.applyDashboardBtn();
-    await expect(page.locator('[data-test="dashboard-panel-table"]')).toBeVisible();
+    await expect(pm.dashboardPanelActions.dashboardTable).toBeVisible();
     testLogger.info("Value mapping applied — table renders");
 
     // Verify value mapping persists after save
@@ -167,7 +167,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
 
     await setupMetricPanelWithConfig(page, pm, dashboardName);
 
-    const bgColorDropdown = page.locator('[data-test="dashboard-config-color-mode"]');
+    const bgColorDropdown = pm.dashboardPanelConfigs.bgColor;
     await expect(bgColorDropdown).toBeVisible();
     await pm.dashboardPanelConfigs.selectBGColor("Single Color");
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -176,7 +176,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying background color Single Color persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-color-mode"]')).toContainText("Single Color");
+    await expect(pm.dashboardPanelConfigs.bgColor).toContainText("Single Color");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -187,7 +187,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
 
     await setupBarPanelWithBreakdownAndConfig(page, pm, dashboardName);
 
-    const topNInput = page.locator('[data-test="dashboard-config-top_results"]');
+    const topNInput = pm.dashboardPanelConfigs.topResults;
     await expect(topNInput).toBeVisible();
     await topNInput.locator('[data-test$="-field"]').fill("5");
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -198,7 +198,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying top N value persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-top_results"]').locator('[data-test$="-field"]')).toHaveValue("5");
+    await expect(pm.dashboardPanelConfigs.topResults.locator('[data-test$="-field"]')).toHaveValue("5");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -210,12 +210,12 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await setupBarPanelWithBreakdownAndConfig(page, pm, dashboardName);
 
     // Set top N to make the "Others" toggle appear
-    const topNInput = page.locator('[data-test="dashboard-config-top_results"]');
+    const topNInput = pm.dashboardPanelConfigs.topResults;
     await expect(topNInput).toBeVisible();
     await topNInput.locator('[data-test$="-field"]').fill("5");
 
     // Others toggle should now be visible
-    const othersToggle = page.locator('[data-test="dashboard-config-top_results_others"]');
+    const othersToggle = pm.dashboardPanelConfigs.topResultsOthers;
     await expect(othersToggle).toBeVisible({ timeout: 5000 });
     testLogger.info("Top N Others toggle appeared after setting top_results");
 
@@ -243,7 +243,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const alignDropdown = page.locator('[data-test="dashboard-config-chart-align"]');
+    const alignDropdown = pm.dashboardPanelConfigs.chartAlign;
     // Alignment may not be present for all chart types — skip gracefully
     const isVisible = await alignDropdown.isVisible().catch(() => false);
     if (!isVisible) {
@@ -257,7 +257,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
 
     // Click dropdown and pick the first available option
     await alignDropdown.click();
-    const options = page.locator('[data-test="dashboard-config-chart-align-option"]');
+    const options = pm.dashboardPanelConfigs.chartAlignOptions;
     await options.first().waitFor({ state: "visible", timeout: 5000 });
     const firstOptionText = await options.first().textContent();
     await options.first().click();
@@ -270,7 +270,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying chart alignment persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-chart-align"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.chartAlign).toBeVisible();
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -286,7 +286,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     // Sparkline is metric-only — enable it; sub-controls should appear
     await pm.dashboardPanelConfigs.enableSparkline();
     expect(await pm.dashboardPanelConfigs.isSparklineEnabled()).toBe(true);
-    await expect(page.locator('[data-test="dashboard-config-sparkline-type"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.sparklineType).toBeVisible();
     testLogger.info("Sparkline enabled — sub-controls visible");
 
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -310,8 +310,8 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await setupMetricPanelWithConfig(page, pm, dashboardName);
     await pm.dashboardPanelConfigs.enableSparkline();
 
-    const lineWidth = page.locator('[data-test="dashboard-config-sparkline-line-width"]');
-    const fillOpacity = page.locator('[data-test="dashboard-config-sparkline-fill-opacity"]');
+    const lineWidth = pm.dashboardPanelConfigs.sparklineLineWidthInput;
+    const fillOpacity = pm.dashboardPanelConfigs.sparklineFillOpacity;
 
     // Default type is Auto (→ area): line width visible
     await expect(lineWidth).toBeVisible();
@@ -355,8 +355,8 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     testLogger.info("Apply fired exactly 2 data queries (metric value + sparkline histogram)");
 
     // Metric panels render as SVG; the sparkline trend draws at least one path.
-    const chart = page.locator('[data-test="chart-renderer"]');
-    const errorMessage = page.locator('[data-test="panel-schema-renderer-error-message"]');
+    const chart = pm.dashboardPanelActions.getChartRendererCanvas();
+    const errorMessage = pm.dashboardPanelConfigs.panelSchemaRendererError;
     await Promise.race([
       chart.waitFor({ state: "visible", timeout: 15000 }),
       errorMessage.waitFor({ state: "visible", timeout: 15000 }),
@@ -387,7 +387,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
 
     // Switch layout to Background
     await pm.dashboardPanelConfigs.selectSparklineLayout("Background");
-    await expect(page.locator('[data-test="dashboard-config-sparkline-layout"]')).toContainText("Background");
+    await expect(pm.dashboardPanelConfigs.sparklineLayout).toContainText("Background");
     testLogger.info("Sparkline colour swatch + Background layout set");
 
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -397,7 +397,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await reopenPanelConfig(page, pm);
     await pm.dashboardPanelConfigs.expandAllConfigSections();
     expect(await pm.dashboardPanelConfigs.isSparklineEnabled()).toBe(true);
-    await expect(page.locator('[data-test="dashboard-config-sparkline-layout"]')).toContainText("Background");
+    await expect(pm.dashboardPanelConfigs.sparklineLayout).toContainText("Background");
 
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
@@ -427,7 +427,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     testLogger.info("Value mapping row added then removed");
 
     await pm.dashboardPanelConfigs.applyValueMappingPopup(popup);
-    await expect(page.locator('[data-test="dashboard-panel-table"]')).toBeVisible();
+    await expect(pm.dashboardPanelActions.dashboardTable).toBeVisible();
     testLogger.info("Value mapping applied — table renders");
 
     await pm.dashboardPanelActions.savePanel();
@@ -459,7 +459,7 @@ test.describe("ConfigPanel — Advanced Settings", () => {
     await page.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
 
     // The mapped text replaces the metric value on the SVG renderer
-    const chart = page.locator('[data-test="chart-renderer"]');
+    const chart = pm.dashboardPanelActions.getChartRendererCanvas();
     await expect(chart).toBeVisible();
     await expect(chart).toContainText("MAPPED_OK");
     testLogger.info("Mapped text reflected in the metric chart");

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-axis.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-axis.spec.js
@@ -28,8 +28,8 @@ test.describe("ConfigPanel — Axis Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const yAxisMinInput = page.locator('[data-test="dashboard-config-y_axis_min"]');
-    const yAxisMaxInput = page.locator('[data-test="dashboard-config-y_axis_max"]');
+    const yAxisMinInput = pm.dashboardPanelConfigs.yAxisMin;
+    const yAxisMaxInput = pm.dashboardPanelConfigs.yAxisMax;
     await expect(yAxisMinInput).toBeVisible();
     await expect(yAxisMaxInput).toBeVisible();
 
@@ -51,8 +51,8 @@ test.describe("ConfigPanel — Axis Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying Y-axis cleared state persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-y_axis_min"]').locator('[data-test$="-field"]')).toHaveValue("");
-    await expect(page.locator('[data-test="dashboard-config-y_axis_max"]').locator('[data-test$="-field"]')).toHaveValue("");
+    await expect(pm.dashboardPanelConfigs.yAxisMin.locator('[data-test$="-field"]')).toHaveValue("");
+    await expect(pm.dashboardPanelConfigs.yAxisMax.locator('[data-test$="-field"]')).toHaveValue("");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -63,7 +63,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    await expect(page.locator('[data-test="dashboard-config-axis-width"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.axisWidth).toBeVisible();
     await pm.dashboardPanelConfigs.selectAxisWidth("80");
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Axis width set to 80");
@@ -73,7 +73,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying axis width persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-axis-width"]').locator('[data-test$="-field"]')).toHaveValue("80");
+    await expect(pm.dashboardPanelConfigs.axisWidth.locator('[data-test$="-field"]')).toHaveValue("80");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -84,7 +84,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const axisBorderToggle = page.locator('[data-test="dashboard-config-axis-border"]');
+    const axisBorderToggle = pm.dashboardPanelConfigs.axisBorder;
     await expect(axisBorderToggle).toBeVisible();
     await axisBorderToggle.click();
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -95,7 +95,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying axis border enabled persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-axis-border"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
+    await expect(pm.dashboardPanelConfigs.axisBorder.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -106,7 +106,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const gridlinesToggle = page.locator('[data-test="dashboard-config-show-gridlines"]');
+    const gridlinesToggle = pm.dashboardPanelConfigs.showGridlines;
     await expect(gridlinesToggle).toBeVisible();
     await gridlinesToggle.click();
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -117,7 +117,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying gridlines disabled persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-show-gridlines"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "false");
+    await expect(pm.dashboardPanelConfigs.showGridlines.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "false");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -128,7 +128,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    await expect(page.locator('[data-test="dashboard-config-label-position"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.valuePosition).toBeVisible();
     await pm.dashboardPanelConfigs.selectValuePosition("Top");
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Label position set to Top");
@@ -144,8 +144,8 @@ test.describe("ConfigPanel — Axis Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying label position and rotate persist after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-label-position-trigger"]')).toHaveAttribute('data-test-selected-value', 'top');
-    await expect(page.locator('[data-test="dashboard-config-label-rotate"]').locator('[data-test$="-field"]')).toHaveValue("45");
+    await expect(pm.dashboardPanelConfigs.labelPositionTrigger).toHaveAttribute('data-test-selected-value', 'top');
+    await expect(pm.dashboardPanelConfigs.valueRotate.locator('[data-test$="-field"]')).toHaveValue("45");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -156,7 +156,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const axisLabelRotateInput = page.locator('[data-test="dashboard-config-axis-label-rotate"]');
+    const axisLabelRotateInput = pm.dashboardPanelConfigs.axisLabelRotate;
     await expect(axisLabelRotateInput).toBeVisible();
     await axisLabelRotateInput.locator('[data-test$="-field"]').fill("30");
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -167,7 +167,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying x-axis label rotate persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-axis-label-rotate"]').locator('[data-test$="-field"]')).toHaveValue("30");
+    await expect(pm.dashboardPanelConfigs.axisLabelRotate.locator('[data-test$="-field"]')).toHaveValue("30");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -178,7 +178,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const truncateInput = page.locator('[data-test="dashboard-config-axis-label-truncate"]');
+    const truncateInput = pm.dashboardPanelConfigs.axisLabelTruncate;
     await expect(truncateInput).toBeVisible();
     await truncateInput.locator('[data-test$="-field"]').fill("50");
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -189,7 +189,7 @@ test.describe("ConfigPanel — Axis Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying label truncate width persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-axis-label-truncate"]').locator('[data-test$="-field"]')).toHaveValue("50");
+    await expect(pm.dashboardPanelConfigs.axisLabelTruncate.locator('[data-test$="-field"]')).toHaveValue("50");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-gauge-maps.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-gauge-maps.spec.js
@@ -30,8 +30,8 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
 
     await setupGaugePanelWithConfig(page, pm, dashboardName);
 
-    const gaugeMinInput = page.locator('[data-test="dashboard-config-gauge-min"]');
-    const gaugeMaxInput = page.locator('[data-test="dashboard-config-gauge-max"]');
+    const gaugeMinInput = pm.dashboardPanelConfigs.gaugeMin;
+    const gaugeMaxInput = pm.dashboardPanelConfigs.gaugeMax;
     await expect(gaugeMinInput).toBeVisible();
     await expect(gaugeMaxInput).toBeVisible();
 
@@ -45,8 +45,8 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying gauge min/max persist after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-gauge-min"]').locator('[data-test$="-field"]')).toHaveValue("10");
-    await expect(page.locator('[data-test="dashboard-config-gauge-max"]').locator('[data-test$="-field"]')).toHaveValue("500");
+    await expect(pm.dashboardPanelConfigs.gaugeMin.locator('[data-test$="-field"]')).toHaveValue("10");
+    await expect(pm.dashboardPanelConfigs.gaugeMax.locator('[data-test$="-field"]')).toHaveValue("500");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -57,10 +57,10 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
 
     await setupGeomapPanelWithConfig(page, pm, dashboardName);
 
-    await expect(page.locator('[data-test="dashboard-config-basemap"]')).toBeVisible();
-    await expect(page.locator('[data-test="dashboard-config-latitude"]')).toBeVisible();
-    await expect(page.locator('[data-test="dashboard-config-longitude"]')).toBeVisible();
-    await expect(page.locator('[data-test="dashboard-config-zoom"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.baseMap).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.latitude).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.longitude).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.zoom).toBeVisible();
 
     await pm.dashboardPanelConfigs.selectLatitude("40.7128");
     await pm.dashboardPanelConfigs.selectLongitude("-74.006");
@@ -68,14 +68,14 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Geomap lat/lng/zoom set");
     await pm.dashboardPanelActions.waitForChartToRender();
-    await expect(page.locator('[data-test="dashboard-geomap-renderer"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(pm.dashboardPanelConfigs.geomapRenderer.first()).toBeVisible({ timeout: 10000 });
 
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying geomap lat/lng/zoom persist after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-latitude"]').locator('[data-test$="-field"]')).toHaveValue("40.7128");
-    await expect(page.locator('[data-test="dashboard-config-longitude"]').locator('[data-test$="-field"]')).toHaveValue("-74.006");
-    await expect(page.locator('[data-test="dashboard-config-zoom"]').locator('[data-test$="-field"]')).toHaveValue("5");
+    await expect(pm.dashboardPanelConfigs.latitude.locator('[data-test$="-field"]')).toHaveValue("40.7128");
+    await expect(pm.dashboardPanelConfigs.longitude.locator('[data-test$="-field"]')).toHaveValue("-74.006");
+    await expect(pm.dashboardPanelConfigs.zoom.locator('[data-test$="-field"]')).toHaveValue("5");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -88,8 +88,8 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
 
     // By Value — min and max inputs appear
     await pm.dashboardPanelConfigs.selectSymbolSize("By Value");
-    const symbolMinInput = page.locator('[data-test="dashboard-config-map-symbol-min"]');
-    const symbolMaxInput = page.locator('[data-test="dashboard-config-map-symbol-max"]');
+    const symbolMinInput = pm.dashboardPanelConfigs.minimumSize;
+    const symbolMaxInput = pm.dashboardPanelConfigs.maximumSize;
     await expect(symbolMinInput).toBeVisible();
     await expect(symbolMaxInput).toBeVisible();
     await symbolMinInput.locator('[data-test$="-field"]').fill("5");
@@ -97,20 +97,20 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Symbol size By Value with min=5 and max=30");
     await pm.dashboardPanelActions.waitForChartToRender();
-    await expect(page.locator('[data-test="dashboard-geomap-renderer"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(pm.dashboardPanelConfigs.geomapRenderer.first()).toBeVisible({ timeout: 10000 });
 
     // Fixed — fixed input appears, min/max hidden
     await pm.dashboardPanelConfigs.selectSymbolSize("Fixed");
     await expect(symbolMinInput).not.toBeVisible();
     await expect(symbolMaxInput).not.toBeVisible();
-    await expect(page.locator('[data-test="dashboard-config-map-symbol-fixed"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.mapSymbolFixed).toBeVisible();
     testLogger.info("Symbol size Fixed: fixed input visible, min/max hidden");
 
     await pm.dashboardPanelActions.applyDashboardBtn();
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying symbol size Fixed persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-symbol-trigger"]')).toHaveAttribute('data-test-selected-value', 'fixed');
+    await expect(pm.dashboardPanelConfigs.symbolTrigger).toHaveAttribute('data-test-selected-value', 'fixed');
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -121,24 +121,24 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
 
     await setupGeomapPanelWithConfig(page, pm, dashboardName);
 
-    await expect(page.locator('[data-test="dashboard-config-layer-type"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.layerType).toBeVisible();
 
     await pm.dashboardPanelConfigs.selectLayerType("Scatter");
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Layer type set to Scatter");
     await pm.dashboardPanelActions.waitForChartToRender();
-    await expect(page.locator('[data-test="dashboard-geomap-renderer"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(pm.dashboardPanelConfigs.geomapRenderer.first()).toBeVisible({ timeout: 10000 });
 
     await pm.dashboardPanelConfigs.selectLayerType("Heatmap");
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Layer type set to Heatmap");
     await pm.dashboardPanelActions.waitForChartToRender();
-    await expect(page.locator('[data-test="dashboard-geomap-renderer"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(pm.dashboardPanelConfigs.geomapRenderer.first()).toBeVisible({ timeout: 10000 });
 
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying layer type Heatmap persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-layer-type-trigger"]')).toHaveAttribute('data-test-selected-value', 'heatmap');
+    await expect(pm.dashboardPanelConfigs.layerTypeTrigger).toHaveAttribute('data-test-selected-value', 'heatmap');
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -150,7 +150,7 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
     await setupGeomapPanelWithConfig(page, pm, dashboardName);
 
     // weight_fixed input appears for geomap when no weight field is mapped (isWeightFieldPresent = false)
-    const weightInput = page.locator('[data-test="dashboard-config-weight"]');
+    const weightInput = pm.dashboardPanelConfigs.weight;
     await expect(weightInput).toBeVisible({ timeout: 5000 });
     testLogger.info("Weight (fixed) input visible for geomap");
 
@@ -159,12 +159,12 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Applied with weight_fixed = 2");
     await pm.dashboardPanelActions.waitForChartToRender();
-    await expect(page.locator('[data-test="dashboard-geomap-renderer"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(pm.dashboardPanelConfigs.geomapRenderer.first()).toBeVisible({ timeout: 10000 });
 
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying weight value persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-weight"]').locator('[data-test$="-field"]')).toHaveValue("2");
+    await expect(pm.dashboardPanelConfigs.weight.locator('[data-test$="-field"]')).toHaveValue("2");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -175,7 +175,7 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
 
     await setupMapsPanelWithConfig(page, pm, dashboardName);
 
-    await expect(page.locator('[data-test="dashboard-config-map-type"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.mapType).toBeVisible();
     await pm.dashboardPanelConfigs.selectMapType("World");
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Map type set to World");
@@ -185,7 +185,7 @@ test.describe("ConfigPanel — Gauge and Maps Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying map type World persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-map-type-trigger"]')).toHaveAttribute('data-test-selected-value', 'world');
+    await expect(pm.dashboardPanelConfigs.mapTypeTrigger).toHaveAttribute('data-test-selected-value', 'world');
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-general.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-general.spec.js
@@ -31,7 +31,7 @@ test.describe("ConfigPanel — General Settings", () => {
     await setupBarPanel(page, pm, dashboardName);
     await pm.dashboardPanelConfigs.openConfigPanel();
 
-    const descriptionField = page.locator('[data-test="dashboard-config-description"]');
+    const descriptionField = pm.dashboardPanelConfigs.description;
     await expect(descriptionField).toBeVisible();
     await descriptionField.locator('[data-test$="-field"]').fill(description);
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -39,7 +39,7 @@ test.describe("ConfigPanel — General Settings", () => {
 
     testLogger.info("Description saved, re-opening panel to verify persistence");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-description"]').locator('[data-test$="-field"]')).toHaveValue(description);
+    await expect(pm.dashboardPanelConfigs.description.locator('[data-test$="-field"]')).toHaveValue(description);
 
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
@@ -51,7 +51,7 @@ test.describe("ConfigPanel — General Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const unitDropdown = page.locator('[data-test="dashboard-config-unit"]');
+    const unitDropdown = pm.dashboardPanelConfigs.unit;
     await expect(unitDropdown).toBeVisible();
 
     // Set to Bytes
@@ -64,7 +64,7 @@ test.describe("ConfigPanel — General Settings", () => {
     // Set to Custom — custom unit input appears
     await pm.dashboardPanelConfigs.selectUnit("Custom");
     await expect(unitDropdown).toBeVisible();
-    const customUnitInput = page.locator('[data-test="dashboard-config-custom-unit"]');
+    const customUnitInput = pm.dashboardPanelConfigs.customUnit;
     await expect(customUnitInput).toBeVisible();
     await customUnitInput.locator('[data-test$="-field"]').fill("ms");
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -74,8 +74,8 @@ test.describe("ConfigPanel — General Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying unit config persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-unit"]')).toContainText("Custom");
-    await expect(page.locator('[data-test="dashboard-config-custom-unit"]').locator('[data-test$="-field"]')).toHaveValue("ms");
+    await expect(pm.dashboardPanelConfigs.unit).toContainText("Custom");
+    await expect(pm.dashboardPanelConfigs.customUnit.locator('[data-test$="-field"]')).toHaveValue("ms");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -86,7 +86,7 @@ test.describe("ConfigPanel — General Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const decimalsInput = page.locator('[data-test="dashboard-config-decimals"]');
+    const decimalsInput = pm.dashboardPanelConfigs.decimals;
     await expect(decimalsInput).toBeVisible();
 
     await pm.dashboardPanelConfigs.selectDecimals("0");
@@ -104,7 +104,7 @@ test.describe("ConfigPanel — General Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying decimals config persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-decimals"]').locator('[data-test$="-field"]')).toHaveValue("4");
+    await expect(pm.dashboardPanelConfigs.decimals.locator('[data-test$="-field"]')).toHaveValue("4");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -115,7 +115,7 @@ test.describe("ConfigPanel — General Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const noValueInput = page.locator('[data-test="dashboard-config-no-value-replacement"]');
+    const noValueInput = pm.dashboardPanelConfigs.noValueReplacementWrapper;
     await expect(noValueInput).toBeVisible();
 
     await pm.dashboardPanelConfigs.selectNoValueReplace("N/A");
@@ -127,7 +127,7 @@ test.describe("ConfigPanel — General Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying no-value replacement persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-no-value-replacement"]').locator('[data-test$="-field"]')).toHaveValue("N/A");
+    await expect(pm.dashboardPanelConfigs.noValueReplacementWrapper.locator('[data-test$="-field"]')).toHaveValue("N/A");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -138,7 +138,7 @@ test.describe("ConfigPanel — General Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const limitInput = page.locator('[data-test="dashboard-config-limit"]');
+    const limitInput = pm.dashboardPanelConfigs.queryLimit;
     await expect(limitInput).toBeVisible();
 
     await pm.dashboardPanelConfigs.selectQueryLimit("100");
@@ -150,7 +150,7 @@ test.describe("ConfigPanel — General Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying query limit persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-limit"]').locator('[data-test$="-field"]')).toHaveValue("100");
+    await expect(pm.dashboardPanelConfigs.queryLimit.locator('[data-test$="-field"]')).toHaveValue("100");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-legends.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-legends.spec.js
@@ -28,7 +28,7 @@ test.describe("ConfigPanel — Legends", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const showLegendsToggle = page.locator('[data-test="dashboard-config-show-legend"]');
+    const showLegendsToggle = pm.dashboardPanelConfigs.showLegend;
     await expect(showLegendsToggle).toBeVisible();
     await showLegendsToggle.click();
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -40,7 +40,7 @@ test.describe("ConfigPanel — Legends", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying show legends toggle persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-show-legend"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "false");
+    await expect(pm.dashboardPanelConfigs.showLegend.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "false");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -52,21 +52,21 @@ test.describe("ConfigPanel — Legends", () => {
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
     // Width input requires legends_type=plain AND legends_position=right — set type first
-    const legendTypeDropdown = page.locator('[data-test="dashboard-config-legends-scrollable"]');
+    const legendTypeDropdown = pm.dashboardPanelConfigs.legendsScrollable;
     await legendTypeDropdown.click();
-    await page.locator('[data-test="dashboard-config-legends-scrollable-option"][data-test-label="Plain"]').click();
+    await pm.dashboardPanelConfigs.getLegendsScrollableOption("Plain").click();
     await pm.dashboardPanelConfigs.legendPosition("Right");
 
     // Width input appears, height input does not
-    const legendWidthInput = page.locator('[data-test="dashboard-config-legend-width"]');
+    const legendWidthInput = pm.dashboardPanelConfigs.legendWidth;
     await expect(legendWidthInput).toBeVisible();
-    await expect(page.locator('[data-test="dashboard-config-legend-height"]')).not.toBeVisible();
+    await expect(pm.dashboardPanelConfigs.legendHeight).not.toBeVisible();
 
     // Toggle unit from px to % FIRST, then fill a safe % value
     // (filling 200 then switching to % would set 200% width which collapses the chart area)
-    await expect(page.locator('[data-test="dashboard-config-legend-width-unit-active"]').first()).toBeVisible();
-    await page.locator('[data-test="dashboard-config-legend-width-unit-inactive"]').click();
-    await expect(page.locator('[data-test="dashboard-config-legend-width-unit-active"]').first()).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.legendWidthUnitActive.first()).toBeVisible();
+    await pm.dashboardPanelConfigs.legendWidthUnitInactive.click();
+    await expect(pm.dashboardPanelConfigs.legendWidthUnitActive.first()).toBeVisible();
 
     // Set width value in % (30% keeps enough chart area for canvas pixel check)
     await legendWidthInput.locator('[data-test$="-field"]').fill("30");
@@ -79,8 +79,8 @@ test.describe("ConfigPanel — Legends", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying legend position Right persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-legend-position"]')).toHaveAttribute('data-test-selected-value', 'right');
-    await expect(page.locator('[data-test="dashboard-config-legend-width"]').locator('[data-test$="-field"]')).toHaveValue("30");
+    await expect(pm.dashboardPanelConfigs.legend).toHaveAttribute('data-test-selected-value', 'right');
+    await expect(pm.dashboardPanelConfigs.legendWidth.locator('[data-test$="-field"]')).toHaveValue("30");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -92,23 +92,23 @@ test.describe("ConfigPanel — Legends", () => {
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
     // Height input requires legends_type=plain AND legends_position=bottom — set type first
-    const legendTypeDropdown = page.locator('[data-test="dashboard-config-legends-scrollable"]');
+    const legendTypeDropdown = pm.dashboardPanelConfigs.legendsScrollable;
     await legendTypeDropdown.click();
-    await page.locator('[data-test="dashboard-config-legends-scrollable-option"][data-test-label="Plain"]').click();
+    await pm.dashboardPanelConfigs.getLegendsScrollableOption("Plain").click();
     await pm.dashboardPanelConfigs.legendPosition("Bottom");
 
     // Height input appears, width input does not
-    const legendHeightInput = page.locator('[data-test="dashboard-config-legend-height"]');
+    const legendHeightInput = pm.dashboardPanelConfigs.legendHeight;
     await expect(legendHeightInput).toBeVisible();
-    await expect(page.locator('[data-test="dashboard-config-legend-width"]')).not.toBeVisible();
+    await expect(pm.dashboardPanelConfigs.legendWidth).not.toBeVisible();
 
     // Set height value
     await legendHeightInput.locator('[data-test$="-field"]').fill("100");
 
     // Toggle unit from px to %
-    await expect(page.locator('[data-test="dashboard-config-legend-height-unit-active"]').first()).toBeVisible();
-    await page.locator('[data-test="dashboard-config-legend-height-unit-inactive"]').click();
-    await expect(page.locator('[data-test="dashboard-config-legend-height-unit-active"]').first()).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.legendHeightUnitActive.first()).toBeVisible();
+    await pm.dashboardPanelConfigs.legendHeightUnitInactive.click();
+    await expect(pm.dashboardPanelConfigs.legendHeightUnitActive.first()).toBeVisible();
 
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Legend position Bottom: height set and unit toggled to %");
@@ -118,8 +118,8 @@ test.describe("ConfigPanel — Legends", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying legend position Bottom persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-legend-position"]')).toHaveAttribute('data-test-selected-value', 'bottom');
-    await expect(page.locator('[data-test="dashboard-config-legend-height"]').locator('[data-test$="-field"]')).toHaveValue("100");
+    await expect(pm.dashboardPanelConfigs.legend).toHaveAttribute('data-test-selected-value', 'bottom');
+    await expect(pm.dashboardPanelConfigs.legendHeight.locator('[data-test$="-field"]')).toHaveValue("100");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -140,7 +140,7 @@ test.describe("ConfigPanel — Legends", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying legend position Auto persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-legend-position"]')).toHaveAttribute('data-test-selected-value', 'null');
+    await expect(pm.dashboardPanelConfigs.legend).toHaveAttribute('data-test-selected-value', 'null');
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -151,18 +151,18 @@ test.describe("ConfigPanel — Legends", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const legendTypeDropdown = page.locator('[data-test="dashboard-config-legends-scrollable"]');
+    const legendTypeDropdown = pm.dashboardPanelConfigs.legendsScrollable;
     await expect(legendTypeDropdown).toBeVisible();
 
     await legendTypeDropdown.click();
-    await page.locator('[data-test="dashboard-config-legends-scrollable-option"][data-test-label="Scroll"]').click();
+    await pm.dashboardPanelConfigs.getLegendsScrollableOption("Scroll").click();
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Legend type set to Scroll");
     await pm.dashboardPanelActions.waitForChartToRender();
     await pm.dashboardPanelActions.verifyChartHasData(expect);
 
     await legendTypeDropdown.click();
-    await page.locator('[data-test="dashboard-config-legends-scrollable-option"][data-test-label="Plain"]').click();
+    await pm.dashboardPanelConfigs.getLegendsScrollableOption("Plain").click();
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Legend type set to Plain");
     await pm.dashboardPanelActions.waitForChartToRender();
@@ -171,7 +171,7 @@ test.describe("ConfigPanel — Legends", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying legend type Plain persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-legends-scrollable"]')).toHaveAttribute('data-test-selected-value', 'plain');
+    await expect(pm.dashboardPanelConfigs.legendsScrollable).toHaveAttribute('data-test-selected-value', 'plain');
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-line-style.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-line-style.spec.js
@@ -28,7 +28,7 @@ test.describe("ConfigPanel — Line Style Settings", () => {
 
     await setupLinePanelWithConfig(page, pm, dashboardName);
 
-    const symbolDropdown = page.locator('[data-test="dashboard-config-show_symbol"]');
+    const symbolDropdown = pm.dashboardPanelConfigs.showSymbols;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(symbolDropdown);
     await expect(symbolDropdown).toBeVisible();
 
@@ -47,7 +47,7 @@ test.describe("ConfigPanel — Line Style Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying symbol No persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-show_symbol-trigger"]')).toHaveAttribute('data-test-selected-value', 'false');
+    await expect(pm.dashboardPanelConfigs.showSymbolTrigger).toHaveAttribute('data-test-selected-value', 'false');
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -58,7 +58,7 @@ test.describe("ConfigPanel — Line Style Settings", () => {
 
     await setupLinePanelWithConfig(page, pm, dashboardName);
 
-    const interpolationDropdown = page.locator('[data-test="dashboard-config-line_interpolation"]');
+    const interpolationDropdown = pm.dashboardPanelConfigs.lineInterpolation;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(interpolationDropdown);
     await expect(interpolationDropdown).toBeVisible();
 
@@ -73,7 +73,7 @@ test.describe("ConfigPanel — Line Style Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying line interpolation Step After persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-line_interpolation-trigger"]')).toHaveAttribute('data-test-selected-value', 'step-end');
+    await expect(pm.dashboardPanelConfigs.lineInterpolationTrigger).toHaveAttribute('data-test-selected-value', 'step-end');
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -84,7 +84,7 @@ test.describe("ConfigPanel — Line Style Settings", () => {
 
     await setupLinePanelWithConfig(page, pm, dashboardName);
 
-    await expect(page.locator('[data-test="dashboard-config-line_thickness"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.lineThickness).toBeVisible();
     await pm.dashboardPanelConfigs.selectLineThickness("3");
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Line thickness set to 3");
@@ -94,7 +94,7 @@ test.describe("ConfigPanel — Line Style Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying line thickness persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-line_thickness"]').locator('[data-test$="-field"]')).toHaveValue("3");
+    await expect(pm.dashboardPanelConfigs.lineThickness.locator('[data-test$="-field"]')).toHaveValue("3");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -105,7 +105,7 @@ test.describe("ConfigPanel — Line Style Settings", () => {
 
     await setupLinePanelWithConfig(page, pm, dashboardName);
 
-    const connectNullToggle = page.locator('[data-test="dashboard-config-connect-null-values"]');
+    const connectNullToggle = pm.dashboardPanelConfigs.connectNullValuesToggle;
     await expect(connectNullToggle).toBeVisible();
     await connectNullToggle.click();
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -116,7 +116,7 @@ test.describe("ConfigPanel — Line Style Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying connect null values enabled persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-connect-null-values"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
+    await expect(pm.dashboardPanelConfigs.connectNullValuesToggle.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-markline.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-markline.spec.js
@@ -30,36 +30,36 @@ test.describe("ConfigPanel — Mark Line Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const addBtn = page.locator('[data-test="dashboard-addpanel-config-markline-add-btn"]');
+    const addBtn = pm.dashboardPanelConfigs.marklineAddBtn;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(addBtn);
     await expect(addBtn).toBeVisible();
 
     // Add mark line — default type is yAxis, value input should appear immediately
     await addBtn.click();
-    const typeSelect = page.locator('[data-test="dashboard-config-markline-type-0"]');
+    const typeSelect = pm.dashboardPanelConfigs.getMarklineTypeSelect(0);
     await typeSelect.waitFor({ state: 'visible', timeout: 10000 });
-    const valueInput = page.locator('[data-test="dashboard-config-markline-value-0"]');
+    const valueInput = pm.dashboardPanelConfigs.getMarklineValue(0);
     await expect(valueInput).toBeVisible();
     testLogger.info("Value input visible for yAxis type");
 
     // Switch to average — value input should hide
     await typeSelect.click();
-    await page.locator('[data-test="dashboard-config-markline-type-0-option"][data-test-label="Average"]').waitFor({ state: 'visible', timeout: 10000 });
-    await page.locator('[data-test="dashboard-config-markline-type-0-option"][data-test-label="Average"]').click();
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(0, "Average").waitFor({ state: 'visible', timeout: 10000 });
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(0, "Average").click();
     // Wait for dropdown to close before checking value input visibility
-    await page.locator('[data-test="dashboard-config-markline-type-0-option"][data-test-label="Average"]').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(0, "Average").waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
     await expect(valueInput).not.toBeVisible();
     testLogger.info("Value input hidden for Average type");
 
     // Switch back to yAxis — value input re-appears, fill it
     await typeSelect.click();
-    await page.locator('[data-test="dashboard-config-markline-type-0-option"][data-test-label="Y-Axis"]').waitFor({ state: 'visible', timeout: 10000 });
-    await page.locator('[data-test="dashboard-config-markline-type-0-option"][data-test-label="Y-Axis"]').click();
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(0, "Y-Axis").waitFor({ state: 'visible', timeout: 10000 });
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(0, "Y-Axis").click();
     // Wait for dropdown to close before interacting with value input
-    await page.locator('[data-test="dashboard-config-markline-type-0-option"][data-test-label="Y-Axis"]').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(0, "Y-Axis").waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
     await expect(valueInput).toBeVisible();
     await valueInput.locator('[data-test$="-field"]').fill("100");
-    await page.locator('[data-test="dashboard-config-markline-name-0"]').locator('[data-test$="-field"]').fill("threshold");
+    await pm.dashboardPanelConfigs.getMarklineName(0).locator('[data-test$="-field"]').fill("threshold");
     testLogger.info("Mark line configured: yAxis, value=100, label=threshold");
 
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -69,11 +69,11 @@ test.describe("ConfigPanel — Mark Line Settings", () => {
     testLogger.info("Verifying mark line persists after save");
     await reopenPanelConfig(page, pm);
 
-    const valueAfter = page.locator('[data-test="dashboard-config-markline-value-0"]');
-    const nameAfter = page.locator('[data-test="dashboard-config-markline-name-0"]');
+    const valueAfter = pm.dashboardPanelConfigs.getMarklineValue(0);
+    const nameAfter = pm.dashboardPanelConfigs.getMarklineName(0);
     await pm.dashboardPanelConfigs.scrollSidebarToElement(valueAfter);
     // the select uses emit-value without map-options → displays raw stored value ("yAxis" not "Y-Axis")
-    await expect(page.locator('[data-test="dashboard-config-markline-type-0-trigger"]')).toHaveAttribute('data-test-selected-value', 'yAxis');
+    await expect(pm.dashboardPanelConfigs.getMarklineTypeTrigger(0)).toHaveAttribute('data-test-selected-value', 'yAxis');
     await expect(valueAfter.locator('[data-test$="-field"]')).toHaveValue("100");
     await expect(nameAfter.locator('[data-test$="-field"]')).toHaveValue("threshold");
     testLogger.info("Mark line type, value and label persisted");
@@ -89,43 +89,43 @@ test.describe("ConfigPanel — Mark Line Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const addBtn = page.locator('[data-test="dashboard-addpanel-config-markline-add-btn"]');
+    const addBtn = pm.dashboardPanelConfigs.marklineAddBtn;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(addBtn);
 
     // Add first mark line
     await addBtn.click();
-    const type0 = page.locator('[data-test="dashboard-config-markline-type-0"]');
+    const type0 = pm.dashboardPanelConfigs.getMarklineTypeSelect(0);
     await type0.waitFor({ state: 'visible', timeout: 10000 });
     // Scroll into sidebar viewport — waitFor only checks CSS visibility, not scroll position.
     await pm.dashboardPanelConfigs.scrollSidebarToElement(type0);
     await type0.click();
-    await page.locator('[data-test="dashboard-config-markline-type-0-option"][data-test-label="Average"]').waitFor({ state: 'visible', timeout: 10000 });
-    await page.locator('[data-test="dashboard-config-markline-type-0-option"][data-test-label="Average"]').click();
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(0, "Average").waitFor({ state: 'visible', timeout: 10000 });
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(0, "Average").click();
     // Wait for dropdown to close before filling name — avoids interaction with open dropdown
-    await page.locator('[data-test="dashboard-config-markline-type-0-option"][data-test-label="Average"]').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
-    await page.locator('[data-test="dashboard-config-markline-name-0"]').locator('[data-test$="-field"]').fill("avg");
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(0, "Average").waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    await pm.dashboardPanelConfigs.getMarklineName(0).locator('[data-test$="-field"]').fill("avg");
 
     // Add second mark line
     await pm.dashboardPanelConfigs.scrollSidebarToElement(addBtn);
     await addBtn.click();
-    const type1 = page.locator('[data-test="dashboard-config-markline-type-1"]');
+    const type1 = pm.dashboardPanelConfigs.getMarklineTypeSelect(1);
     await type1.waitFor({ state: 'visible', timeout: 10000 });
     await pm.dashboardPanelConfigs.scrollSidebarToElement(type1);
     await type1.click();
-    await page.locator('[data-test="dashboard-config-markline-type-1-option"][data-test-label="Max"]').waitFor({ state: 'visible', timeout: 10000 });
-    await page.locator('[data-test="dashboard-config-markline-type-1-option"][data-test-label="Max"]').click();
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(1, "Max").waitFor({ state: 'visible', timeout: 10000 });
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(1, "Max").click();
     // Wait for dropdown to close before asserting state
-    await page.locator('[data-test="dashboard-config-markline-type-1-option"][data-test-label="Max"]').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
-    await page.locator('[data-test="dashboard-config-markline-name-1"]').locator('[data-test$="-field"]').fill("max");
+    await pm.dashboardPanelConfigs.getMarklineTypeOption(1, "Max").waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    await pm.dashboardPanelConfigs.getMarklineName(1).locator('[data-test$="-field"]').fill("max");
 
-    await expect(page.locator('[data-test="dashboard-config-markline-type-0-trigger"]')).toHaveAttribute('data-test-selected-value', 'average');
-    await expect(page.locator('[data-test="dashboard-config-markline-type-1-trigger"]')).toHaveAttribute('data-test-selected-value', 'max');
+    await expect(pm.dashboardPanelConfigs.getMarklineTypeTrigger(0)).toHaveAttribute('data-test-selected-value', 'average');
+    await expect(pm.dashboardPanelConfigs.getMarklineTypeTrigger(1)).toHaveAttribute('data-test-selected-value', 'max');
     testLogger.info("Two mark lines added with independent types");
 
     // Remove first row — second shifts to index 0
-    await page.locator('[data-test="dashboard-addpanel-config-markline-remove-0"]').click();
+    await pm.dashboardPanelConfigs.getMarklineRemoveBtn(0).click();
     await expect(type1).not.toBeVisible();
-    await expect(page.locator('[data-test="dashboard-config-markline-name-0"]').locator('[data-test$="-field"]')).toHaveValue("max");
+    await expect(pm.dashboardPanelConfigs.getMarklineName(0).locator('[data-test$="-field"]')).toHaveValue("max");
     testLogger.info("First mark line removed, second shifted to index 0");
 
     await pm.dashboardPanelActions.applyDashboardBtn();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-panel-time.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-panel-time.spec.js
@@ -28,8 +28,8 @@ test.describe("ConfigPanel — Panel Time Settings", () => {
 
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
-    const panelTimeToggle = page.locator('[data-test="dashboard-config-allow-panel-time"]');
-    const setBtn = page.locator('[data-test="dashboard-config-set-panel-time"]');
+    const panelTimeToggle = pm.dashboardPanelTime.panelTimeToggle;
+    const setBtn = pm.dashboardPanelTime.setPanelTimeBtn;
 
     await expect(panelTimeToggle).toBeVisible();
     await expect(panelTimeToggle.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "false");
@@ -39,7 +39,7 @@ test.describe("ConfigPanel — Panel Time Settings", () => {
     await expect(setBtn).toBeVisible();
 
     await setBtn.click();
-    await expect(page.locator('[data-test="dashboard-config-panel-time-picker"]')).toBeVisible();
+    await expect(pm.dashboardPanelTime.panelTimePickerWrapper).toBeVisible();
     testLogger.info("Panel time toggle enabled, +Set clicked, picker visible");
 
     await pm.dashboardPanelActions.savePanel();
@@ -53,16 +53,16 @@ test.describe("ConfigPanel — Panel Time Settings", () => {
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
     await pm.dashboardPanelTime.enablePanelTime();
-    await page.locator('[data-test="dashboard-config-set-panel-time"]').click();
+    await pm.dashboardPanelTime.setPanelTimeBtn.click();
     await pm.dashboardPanelTime.setPanelTimeRelative("1-h");
 
-    const timePicker = page.locator('[data-test="dashboard-config-panel-time-picker"]');
+    const timePicker = pm.dashboardPanelTime.panelTimePickerWrapper;
     await expect(timePicker).toBeVisible();
     testLogger.info("Relative time set to Last 1h");
 
     // Cancel X → +Set reappears
-    await page.locator('[data-test="dashboard-config-cancel-panel-time"]').click();
-    await expect(page.locator('[data-test="dashboard-config-set-panel-time"]')).toBeVisible();
+    await pm.dashboardPanelTime.cancelPanelTimeBtn.click();
+    await expect(pm.dashboardPanelTime.setPanelTimeBtn).toBeVisible();
     testLogger.info("Cancel X clicked — +Set reappeared");
 
     await pm.dashboardPanelActions.savePanel();
@@ -76,10 +76,10 @@ test.describe("ConfigPanel — Panel Time Settings", () => {
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
     await pm.dashboardPanelTime.enablePanelTime();
-    await expect(page.locator('[data-test="dashboard-config-set-panel-time"]')).toBeVisible();
+    await expect(pm.dashboardPanelTime.setPanelTimeBtn).toBeVisible();
 
     await pm.dashboardPanelTime.disablePanelTime();
-    await expect(page.locator('[data-test="dashboard-config-set-panel-time"]')).not.toBeVisible();
+    await expect(pm.dashboardPanelTime.setPanelTimeBtn).not.toBeVisible();
     testLogger.info("Panel time section hidden after disabling toggle");
 
     await pm.dashboardPanelActions.savePanel();
@@ -93,15 +93,13 @@ test.describe("ConfigPanel — Panel Time Settings", () => {
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
     await pm.dashboardPanelTime.enablePanelTime();
-    await page.locator('[data-test="dashboard-config-set-panel-time"]').click();
+    await pm.dashboardPanelTime.setPanelTimeBtn.click();
     await pm.dashboardPanelTime.setPanelTimeRelative("15-m");
     await pm.dashboardPanelActions.applyDashboardBtn();
     await pm.dashboardPanelActions.savePanel();
 
     testLogger.info("Panel saved with panel time, re-opening to verify persistence");
-    await page.locator('[data-test="dashboard-panel-bar"]').first().hover();
-    await page.locator('[data-test*="dashboard-edit-panel"][data-test$="-dropdown"]').first().click();
-    await page.locator('[data-test="dashboard-edit-panel"]').click();
+    await pm.dashboardPanelActions.openFirstPanelEditor();
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     expect(await pm.dashboardPanelTime.isPanelTimeEnabled()).toBe(true);
@@ -118,7 +116,7 @@ test.describe("ConfigPanel — Panel Time Settings", () => {
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
     await pm.dashboardPanelTime.enablePanelTime();
-    await page.locator('[data-test="dashboard-config-set-panel-time"]').click();
+    await pm.dashboardPanelTime.setPanelTimeBtn.click();
     await pm.dashboardPanelTime.setPanelTimeRelative("1-h");
     await pm.dashboardPanelActions.applyDashboardBtn();
 
@@ -143,7 +141,7 @@ test.describe("ConfigPanel — Panel Time Settings", () => {
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
     await pm.dashboardPanelTime.enablePanelTime();
-    await page.locator('[data-test="dashboard-config-set-panel-time"]').click();
+    await pm.dashboardPanelTime.setPanelTimeBtn.click();
     const today = new Date().getDate();
     const startDay = Math.max(1, today - 4);
     await pm.dashboardPanelTime.setPanelTimeAbsolute(startDay, today);
@@ -155,7 +153,7 @@ test.describe("ConfigPanel — Panel Time Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying panel time toggle enabled persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-allow-panel-time"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
+    await expect(pm.dashboardPanelTime.panelTimeToggle.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-promql.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-promql.spec.js
@@ -39,7 +39,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await setupPromQLPanelWithConfig(page, pm, dashboardName);
 
-    const stepValueInput = page.locator('[data-test="dashboard-config-step-value"]');
+    const stepValueInput = pm.dashboardPanelConfigs.stepValue;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(stepValueInput);
     await expect(stepValueInput).toBeVisible();
 
@@ -53,7 +53,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying step value persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-step-value"]').locator('[data-test$="-field"]')).toHaveValue("5m");
+    await expect(pm.dashboardPanelConfigs.stepValue.locator('[data-test$="-field"]')).toHaveValue("5m");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -64,7 +64,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await setupPromQLPanelWithConfig(page, pm, dashboardName);
 
-    const legendInfo = page.locator('[data-test="dashboard-config-promql-legend-info"]');
+    const legendInfo = pm.dashboardPanelConfigs.promqlLegendInfo;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(legendInfo);
     await expect(legendInfo).toBeVisible();
     testLogger.info("PromQL legend info icon is visible in PromQL mode");
@@ -79,19 +79,19 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await setupPromQLPiePanelWithConfig(page, pm, dashboardName);
 
-    const aggregationDropdown = page.locator('[data-test="dashboard-config-aggregation"]');
+    const aggregationDropdown = pm.dashboardPanelConfigs.aggregation;
     await expect(aggregationDropdown).toBeVisible();
 
     // Change aggregation to Max — full option label is "Max (maximum value)"
     await aggregationDropdown.click();
-    await page.locator('[data-test="dashboard-config-aggregation-option"][data-test-label="Max (maximum value)"]').click();
+    await pm.dashboardPanelConfigs.getAggregationOption("Max (maximum value)").click();
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Aggregation set to Max");
     await pm.dashboardPanelActions.waitForChartToRender().catch((e) => testLogger.warn("waitForChartToRender:", e.message));
 
     // Change aggregation to Avg — full option label is "Avg (average)"
     await aggregationDropdown.click();
-    await page.locator('[data-test="dashboard-config-aggregation-option"][data-test-label="Avg (average)"]').click();
+    await pm.dashboardPanelConfigs.getAggregationOption("Avg (average)").click();
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Aggregation set to Avg");
     await pm.dashboardPanelActions.waitForChartToRender().catch((e) => testLogger.warn("waitForChartToRender:", e.message));
@@ -99,7 +99,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying aggregation Avg persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-aggregation"]')).toContainText("Avg");
+    await expect(pm.dashboardPanelConfigs.aggregation).toContainText("Avg");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -110,13 +110,13 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await setupPromQLTablePanelWithConfig(page, pm, dashboardName);
 
-    const tableModeDropdown = page.locator('[data-test="dashboard-config-promql-table-mode"]');
+    const tableModeDropdown = pm.dashboardPanelConfigs.promqlTableMode;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(tableModeDropdown);
     await expect(tableModeDropdown).toBeVisible();
 
     // Switch to "Expanded Time series"
-    await page.locator('[data-test="dashboard-config-promql-table-mode-trigger"]').click();
-    const expandedOption = page.locator('[data-test="dashboard-config-promql-table-mode-option"][data-test-label="Expanded Time series"]');
+    await pm.dashboardPanelConfigs.promqlTableModeTrigger.click();
+    const expandedOption = pm.dashboardPanelConfigs.getPromqlTableModeOption("Expanded Time series");
     await expandedOption.waitFor({ state: "visible" });
     await expandedOption.click();
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -124,8 +124,8 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await pm.dashboardPanelActions.waitForChartToRender().catch((e) => testLogger.warn("waitForChartToRender:", e.message));
 
     // Switch to "Aggregate"
-    await page.locator('[data-test="dashboard-config-promql-table-mode-trigger"]').click();
-    const aggregateOption = page.locator('[data-test="dashboard-config-promql-table-mode-option"][data-test-label="Aggregate"]');
+    await pm.dashboardPanelConfigs.promqlTableModeTrigger.click();
+    const aggregateOption = pm.dashboardPanelConfigs.getPromqlTableModeOption("Aggregate");
     await aggregateOption.waitFor({ state: "visible" });
     await aggregateOption.click();
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -136,9 +136,9 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     testLogger.info("Verifying PromQL table mode 'Aggregate' persists after save");
     await reopenPanelConfig(page, pm);
     await pm.dashboardPanelConfigs.scrollSidebarToElement(
-      page.locator('[data-test="dashboard-config-promql-table-mode"]')
+      pm.dashboardPanelConfigs.promqlTableMode
     );
-    await expect(page.locator('[data-test="dashboard-config-promql-table-mode"]')).toContainText("Aggregate");
+    await expect(pm.dashboardPanelConfigs.promqlTableMode).toContainText("Aggregate");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -151,13 +151,13 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     // Sticky first column only appears when promql_table_mode is 'all' or 'expanded_timeseries'
     // Switch to "Aggregate" mode first to reveal the sticky column controls
-    const tableModeDropdown = page.locator('[data-test="dashboard-config-promql-table-mode"]');
+    const tableModeDropdown = pm.dashboardPanelConfigs.promqlTableMode;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(tableModeDropdown);
     await tableModeDropdown.click();
-    await page.locator('[data-test="dashboard-config-promql-table-mode-option"][data-test-label="Aggregate"]').click();
+    await pm.dashboardPanelConfigs.getPromqlTableModeOption("Aggregate").click();
     testLogger.info("Table mode set to Aggregate — sticky column controls now visible");
 
-    const stickyFirstCol = page.locator('[data-test="dashboard-config-sticky-first-column"]');
+    const stickyFirstCol = pm.dashboardPanelConfigs.stickyFirstColumn;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(stickyFirstCol);
     await expect(stickyFirstCol).toBeVisible();
 
@@ -170,7 +170,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying sticky first column toggle persists after save");
     await reopenPanelConfig(page, pm);
-    const toggle = page.locator('[data-test="dashboard-config-sticky-first-column"]');
+    const toggle = pm.dashboardPanelConfigs.stickyFirstColumn;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(toggle);
     const ariaChecked = await toggle.locator('[data-test$="-btn"]').getAttribute("aria-checked");
     expect(ariaChecked).toBe("true");
@@ -184,7 +184,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await setupPromQLPanelWithConfig(page, pm, dashboardName);
 
-    const connectNullToggle = page.locator('[data-test="dashboard-config-connect-null-values"]');
+    const connectNullToggle = pm.dashboardPanelConfigs.connectNullValuesToggle;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(connectNullToggle);
     await expect(connectNullToggle).toBeVisible();
 
@@ -197,7 +197,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying connect null values persists after save");
     await reopenPanelConfig(page, pm);
-    const toggleAfter = page.locator('[data-test="dashboard-config-connect-null-values"]');
+    const toggleAfter = pm.dashboardPanelConfigs.connectNullValuesToggle;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(toggleAfter);
     const ariaChecked = await toggleAfter.locator('[data-test$="-btn"]').getAttribute("aria-checked");
     expect(ariaChecked).toBe("true");
@@ -211,7 +211,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await setupPromQLTablePanelWithConfig(page, pm, dashboardName);
 
-    const wrapToggle = page.locator('[data-test="dashboard-config-wrap-table-cells"]');
+    const wrapToggle = pm.dashboardPanelConfigs.wrapcell;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(wrapToggle);
     await expect(wrapToggle).toBeVisible();
 
@@ -223,7 +223,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying wrap table cells persists after save");
     await reopenPanelConfig(page, pm);
-    const toggleAfter = page.locator('[data-test="dashboard-config-wrap-table-cells"]');
+    const toggleAfter = pm.dashboardPanelConfigs.wrapcell;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(toggleAfter);
     const ariaChecked = await toggleAfter.locator('[data-test$="-btn"]').getAttribute("aria-checked");
     expect(ariaChecked).toBe("true");
@@ -240,16 +240,16 @@ test.describe("ConfigPanel — PromQL Settings", () => {
    * Extracted to avoid repeating the same 4 steps in every Aggregate test.
    */
   async function switchToAggregateMode(page, pm) {
-    const tableModeDropdown = page.locator('[data-test="dashboard-config-promql-table-mode"]');
+    const tableModeDropdown = pm.dashboardPanelConfigs.promqlTableMode;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(tableModeDropdown);
     // Skip the switch if already in Aggregate mode — re-clicking the trigger then
     // the same option adds unnecessary UI interactions that increase flakiness risk.
-    const triggerText = await page.locator('[data-test="dashboard-config-promql-table-mode-trigger"]').textContent();
+    const triggerText = await pm.dashboardPanelConfigs.promqlTableModeTrigger.textContent();
     if (triggerText && triggerText.includes('Aggregate')) {
       testLogger.info("Table mode already in Aggregate — skipping switch");
       return;
     }
-    await page.locator('[data-test="dashboard-config-promql-table-mode-trigger"]').click();
+    await pm.dashboardPanelConfigs.promqlTableModeTrigger.click();
     // Use atomic waitForFunction click — virtualised list items can detach between
     // waitFor({state:'visible'}) and click(), causing intermittent "element detached" errors.
     await page.waitForFunction(
@@ -265,7 +265,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     );
     // Wait for the dropdown to close before returning so callers can immediately
     // interact with Aggregate-mode-specific fields.
-    await page.locator('[data-test="dashboard-config-promql-table-mode-option"][data-test-label="Aggregate"]').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    await pm.dashboardPanelConfigs.getPromqlTableModeOption("Aggregate").waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
     testLogger.info("Table mode switched to Aggregate");
   }
 
@@ -276,13 +276,13 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await setupPromQLTablePanelWithConfig(page, pm, dashboardName);
     await switchToAggregateMode(page, pm);
 
-    const aggDropdown = page.locator('[data-test="dashboard-config-table-aggregations"]');
+    const aggDropdown = pm.dashboardPanelConfigs.tableAggregations;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(aggDropdown);
     await expect(aggDropdown).toBeVisible();
 
     // Default is ["last"] — add "avg" to get ["last", "avg"]; display shows "last +1 more"
-    await page.locator('[data-test="dashboard-config-table-aggregations-trigger"]').click();
-    const avgOption = page.locator('[data-test="dashboard-config-table-aggregations-option"][data-test-label="Avg (average)"]');
+    await pm.dashboardPanelConfigs.tableAggregationsTrigger.click();
+    const avgOption = pm.dashboardPanelConfigs.getTableAggregationsOption("Avg (average)");
     await avgOption.waitFor({ state: "visible" });
     await avgOption.click();
     await page.keyboard.press('Escape');
@@ -295,7 +295,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     testLogger.info("Verifying table aggregations persist after save");
     await reopenPanelConfig(page, pm);
     await switchToAggregateMode(page, pm);
-    const aggAfter = page.locator('[data-test="dashboard-config-table-aggregations"]');
+    const aggAfter = pm.dashboardPanelConfigs.tableAggregations;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(aggAfter);
     await expect(aggAfter).toContainText("+1 more");
     await pm.dashboardPanelActions.savePanel();
@@ -309,7 +309,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await setupPromQLTablePanelWithConfig(page, pm, dashboardName);
     await switchToAggregateMode(page, pm);
 
-    const visibleColsInput = page.locator('[data-test="dashboard-config-visible-columns"]');
+    const visibleColsInput = pm.dashboardPanelConfigs.visibleColumns;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(visibleColsInput);
     await expect(visibleColsInput).toBeVisible();
 
@@ -317,8 +317,8 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     // ArrowDown highlights the first matching option if the metric already has an
     // "instance" label (CI backend). When no options are present (creatable path),
     // ArrowDown is a no-op and Enter creates the value instead.
-    await page.locator('[data-test="dashboard-config-visible-columns-trigger"]').click();
-    const visibleSearchInput = page.locator('[data-test="dashboard-config-visible-columns-search"]');
+    await pm.dashboardPanelConfigs.visibleColumnsTrigger.click();
+    const visibleSearchInput = pm.dashboardPanelConfigs.visibleColumnsSearch;
     await visibleSearchInput.waitFor({ state: "visible" });
     await visibleSearchInput.fill("instance");
     await page.keyboard.press("ArrowDown"); // highlight first match if dropdown has options
@@ -336,7 +336,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     testLogger.info("Verifying visible columns persist after save");
     await reopenPanelConfig(page, pm);
     await switchToAggregateMode(page, pm);
-    const visibleAfterInput = page.locator('[data-test="dashboard-config-visible-columns"]');
+    const visibleAfterInput = pm.dashboardPanelConfigs.visibleColumns;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(visibleAfterInput);
     await expect(visibleAfterInput).toContainText("instance", { timeout: 10000 });
     await pm.dashboardPanelActions.savePanel();
@@ -350,12 +350,12 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await setupPromQLTablePanelWithConfig(page, pm, dashboardName);
     await switchToAggregateMode(page, pm);
 
-    const hiddenColsInput = page.locator('[data-test="dashboard-config-hidden-columns"]');
+    const hiddenColsInput = pm.dashboardPanelConfigs.hiddenColumns;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(hiddenColsInput);
     await expect(hiddenColsInput).toBeVisible();
 
-    await page.locator('[data-test="dashboard-config-hidden-columns-trigger"]').click();
-    const hiddenSearchInput = page.locator('[data-test="dashboard-config-hidden-columns-search"]');
+    await pm.dashboardPanelConfigs.hiddenColumnsTrigger.click();
+    const hiddenSearchInput = pm.dashboardPanelConfigs.hiddenColumnsSearch;
     await hiddenSearchInput.waitFor({ state: "visible" });
     await hiddenSearchInput.fill("job");
     await page.keyboard.press("Enter"); // create the typed value (no stream fields in PromQL mode)
@@ -371,7 +371,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     testLogger.info("Verifying hidden columns persist after save");
     await reopenPanelConfig(page, pm);
     await switchToAggregateMode(page, pm);
-    const hiddenAfterInput = page.locator('[data-test="dashboard-config-hidden-columns"]');
+    const hiddenAfterInput = pm.dashboardPanelConfigs.hiddenColumns;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(hiddenAfterInput);
     await expect(hiddenAfterInput).toContainText("job", { timeout: 10000 });
     await pm.dashboardPanelActions.savePanel();
@@ -386,12 +386,12 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await switchToAggregateMode(page, pm);
 
     // Sticky columns multi-select is disabled when sticky_first_column=true — leave that toggle off
-    const stickyColsInput = page.locator('[data-test="dashboard-config-sticky-columns"]');
+    const stickyColsInput = pm.dashboardPanelConfigs.stickyColumns;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(stickyColsInput);
     await expect(stickyColsInput).toBeVisible();
 
-    await page.locator('[data-test="dashboard-config-sticky-columns-trigger"]').click();
-    const stickySearchInput = page.locator('[data-test="dashboard-config-sticky-columns-search"]');
+    await pm.dashboardPanelConfigs.stickyColumnsTrigger.click();
+    const stickySearchInput = pm.dashboardPanelConfigs.stickyColumnsSearch;
     await stickySearchInput.waitFor({ state: "visible" });
     await stickySearchInput.fill("instance");
     await page.keyboard.press("ArrowDown"); // highlight first match if dropdown has options
@@ -408,7 +408,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     testLogger.info("Verifying sticky columns persist after save");
     await reopenPanelConfig(page, pm);
     await switchToAggregateMode(page, pm);
-    const stickyAfterInput = page.locator('[data-test="dashboard-config-sticky-columns"]');
+    const stickyAfterInput = pm.dashboardPanelConfigs.stickyColumns;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(stickyAfterInput);
     await expect(stickyAfterInput).toContainText("instance", { timeout: 10000 });
     await pm.dashboardPanelActions.savePanel();
@@ -422,9 +422,9 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await setupPromQLTablePanelWithConfig(page, pm, dashboardName);
     await switchToAggregateMode(page, pm);
 
-    const stickyFirstColToggle = page.locator('[data-test="dashboard-config-sticky-first-column"]');
-    const stickyColsInput = page.locator('[data-test="dashboard-config-sticky-columns"]');
-    const stickyColsTrigger = page.locator('[data-test="dashboard-config-sticky-columns-trigger"]');
+    const stickyFirstColToggle = pm.dashboardPanelConfigs.stickyFirstColumn;
+    const stickyColsInput = pm.dashboardPanelConfigs.stickyColumns;
+    const stickyColsTrigger = pm.dashboardPanelConfigs.stickyColumnsTrigger;
 
     // Scroll sticky columns into view to verify initial state
     await pm.dashboardPanelConfigs.scrollSidebarToElement(stickyColsInput);
@@ -460,7 +460,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await setupPromQLTablePanelWithConfig(page, pm, dashboardName);
     await switchToAggregateMode(page, pm);
 
-    const columnOrderBtn = page.locator('[data-test="dashboard-config-column-order-button"]');
+    const columnOrderBtn = pm.dashboardPanelConfigs.columnOrderBtn;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(columnOrderBtn);
     await expect(columnOrderBtn).toBeVisible();
 
@@ -468,14 +468,12 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     testLogger.info("Column order button clicked");
 
     // Dialog should open
-    const dialog = page.locator('[data-test="dashboard-column-order-popup"]');
+    const dialog = pm.dashboardPanelConfigs.columnOrderDialog;
     await expect(dialog).toBeVisible({ timeout: 5000 });
     testLogger.info("Column order dialog opened");
 
     // Cancel closes the dialog (ODialog secondary button inside the scoped panel)
-    await page
-      .locator('[data-test="dashboard-column-order-popup"] [data-test="o-dialog-secondary-btn"]')
-      .click();
+    await pm.dashboardPanelConfigs.columnOrderDialogSecondaryBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
     testLogger.info("Column order dialog closed via Cancel");
 
@@ -582,9 +580,9 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await setupPromQLGeomapPanelWithConfig(page, pm, dashboardName);
 
-    const latInput = page.locator('[data-test="dashboard-config-geo-lat-label"]');
-    const lonInput = page.locator('[data-test="dashboard-config-geo-lon-label"]');
-    const weightInput = page.locator('[data-test="dashboard-config-geo-weight-label"]');
+    const latInput = pm.dashboardPanelConfigs.geoLatLabel;
+    const lonInput = pm.dashboardPanelConfigs.geoLonLabel;
+    const weightInput = pm.dashboardPanelConfigs.geoWeightLabel;
 
     await pm.dashboardPanelConfigs.scrollSidebarToElement(latInput);
     await expect(latInput).toBeVisible();
@@ -603,9 +601,9 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     testLogger.info("Verifying geo labels persist after save");
     await reopenPanelConfig(page, pm);
 
-    const latAfter = page.locator('[data-test="dashboard-config-geo-lat-label"]');
-    const lonAfter = page.locator('[data-test="dashboard-config-geo-lon-label"]');
-    const weightAfter = page.locator('[data-test="dashboard-config-geo-weight-label"]');
+    const latAfter = pm.dashboardPanelConfigs.geoLatLabel;
+    const lonAfter = pm.dashboardPanelConfigs.geoLonLabel;
+    const weightAfter = pm.dashboardPanelConfigs.geoWeightLabel;
 
     await pm.dashboardPanelConfigs.scrollSidebarToElement(latAfter);
     await expect(latAfter.locator('[data-test$="-field"]')).toHaveValue("lat_field");
@@ -627,8 +625,8 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await setupPromQLMapsPanelWithConfig(page, pm, dashboardName);
 
-    const nameLabelInput = page.locator('[data-test="dashboard-config-maps-name-label"]');
-    const mapTypeSelect = page.locator('[data-test="dashboard-config-map-type"]');
+    const nameLabelInput = pm.dashboardPanelConfigs.mapsNameLabel;
+    const mapTypeSelect = pm.dashboardPanelConfigs.mapType;
 
     await pm.dashboardPanelConfigs.scrollSidebarToElement(nameLabelInput);
     await expect(nameLabelInput).toBeVisible();
@@ -639,8 +637,8 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     // Map type select — click and choose "World" (label is capitalized via t("dashboard.world"))
     await pm.dashboardPanelConfigs.scrollSidebarToElement(mapTypeSelect);
     await expect(mapTypeSelect).toBeVisible();
-    await page.locator('[data-test="dashboard-config-map-type-trigger"]').click();
-    const worldOption = page.locator('[data-test="dashboard-config-map-type-option"][data-test-label="World"]');
+    await pm.dashboardPanelConfigs.mapTypeTrigger.click();
+    const worldOption = pm.dashboardPanelConfigs.getMapTypeOption("World");
     await worldOption.waitFor({ state: "visible" });
     await worldOption.click();
     testLogger.info("Maps map type set to 'World'");
@@ -652,15 +650,15 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     testLogger.info("Verifying maps config persists after save");
     await reopenPanelConfig(page, pm);
 
-    const nameLabelAfter = page.locator('[data-test="dashboard-config-maps-name-label"]');
-    const mapTypeAfter = page.locator('[data-test="dashboard-config-map-type"]');
+    const nameLabelAfter = pm.dashboardPanelConfigs.mapsNameLabel;
+    const mapTypeAfter = pm.dashboardPanelConfigs.mapType;
 
     await pm.dashboardPanelConfigs.scrollSidebarToElement(nameLabelAfter);
     await expect(nameLabelAfter.locator('[data-test$="-field"]')).toHaveValue("country_name");
 
     // OSelect trigger carries data-test-selected-value with the raw stored value
     await pm.dashboardPanelConfigs.scrollSidebarToElement(mapTypeAfter);
-    await expect(page.locator('[data-test="dashboard-config-map-type-trigger"]')).toHaveAttribute('data-test-selected-value', 'world');
+    await expect(pm.dashboardPanelConfigs.mapTypeTrigger).toHaveAttribute('data-test-selected-value', 'world');
     testLogger.info("Maps name label and map type persisted after save");
 
     await pm.dashboardPanelActions.savePanel();
@@ -677,12 +675,12 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await setupPromQLDonutPanelWithConfig(page, pm, dashboardName);
 
-    const aggregationDropdown = page.locator('[data-test="dashboard-config-aggregation"]');
+    const aggregationDropdown = pm.dashboardPanelConfigs.aggregation;
     await expect(aggregationDropdown).toBeVisible();
     testLogger.info("Aggregation dropdown visible for donut chart");
 
     await aggregationDropdown.click();
-    await page.locator('[data-test="dashboard-config-aggregation-option"][data-test-label="Min (minimum value)"]').click();
+    await pm.dashboardPanelConfigs.getAggregationOption("Min (minimum value)").click();
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Aggregation set to Min on donut");
     await pm.dashboardPanelActions.waitForChartToRender().catch((e) => testLogger.warn("waitForChartToRender:", e.message));
@@ -690,7 +688,7 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying aggregation Min persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-aggregation"]')).toContainText("Min");
+    await expect(pm.dashboardPanelConfigs.aggregation).toContainText("Min");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -708,21 +706,21 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     // Set legend for Query 1 (currentQueryIndex = 0 by default).
     // The PromQL legend uses OCombobox (data-test="dashboard-config-promql-legend");
     // its inner input carries data-test="dashboard-config-promql-legend-input".
-    const legendInput = page.locator('[data-test="dashboard-config-promql-legend"]');
+    const legendInput = pm.dashboardPanelConfigs.promqlLegend;
     const legendField = legendInput.locator('[data-test="dashboard-config-promql-legend-input"]');
     await pm.dashboardPanelConfigs.scrollSidebarToElement(legendInput);
     await legendField.fill("Legend Q1");
     testLogger.info("Legend set for Query 1");
 
     // Add a second query via query editor add button (data-test has literal backticks — use *=)
-    const addQueryBtn = page.locator('[data-test*="query-tab-add"]');
+    const addQueryBtn = pm.dashboardPanelConfigs.addQueryBtn;
     await addQueryBtn.waitFor({ state: 'visible', timeout: 10000 });
     await addQueryBtn.click();
     testLogger.info("Second query added");
 
     // Config panel now shows 2 tabs — switch to Query 2
-    const tab0 = page.locator('[data-test="dashboard-config-query-tab-0"]');
-    const tab1 = page.locator('[data-test="dashboard-config-query-tab-1"]');
+    const tab0 = pm.dashboardPanelConfigs.getConfigQueryTab(0);
+    const tab1 = pm.dashboardPanelConfigs.getConfigQueryTab(1);
     await tab1.waitFor({ state: 'visible', timeout: 5000 });
     await expect(tab0).toBeVisible();
     await expect(tab1).toBeVisible();
@@ -743,8 +741,8 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await reopenPanelConfig(page, pm);
 
     // Query 1 tab should show "Legend Q1"
-    const tab0After = page.locator('[data-test="dashboard-config-query-tab-0"]');
-    const tab1After = page.locator('[data-test="dashboard-config-query-tab-1"]');
+    const tab0After = pm.dashboardPanelConfigs.getConfigQueryTab(0);
+    const tab1After = pm.dashboardPanelConfigs.getConfigQueryTab(1);
     await tab0After.waitFor({ state: 'visible', timeout: 5000 });
     await tab0After.click();
     await expect(tab0After).toHaveAttribute("aria-selected", "true");
@@ -784,8 +782,8 @@ test.describe("ConfigPanel — PromQL Settings", () => {
 
     await pm.dashboardPanelConfigs.enableSparkline();
     expect(await pm.dashboardPanelConfigs.isSparklineEnabled()).toBe(true);
-    await expect(page.locator('[data-test="dashboard-config-sparkline-type"]')).toBeVisible();
-    await expect(page.locator('[data-test="dashboard-config-sparkline-layout"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.sparklineType).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.sparklineLayout).toBeVisible();
     testLogger.info("Sparkline enabled on PromQL metric panel — sub-controls visible");
 
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -809,8 +807,8 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     await setupPromQLMetricPanelWithConfig(page, pm, dashboardName);
     await pm.dashboardPanelConfigs.enableSparkline();
 
-    const lineWidth = page.locator('[data-test="dashboard-config-sparkline-line-width"]');
-    const fillOpacity = page.locator('[data-test="dashboard-config-sparkline-fill-opacity"]');
+    const lineWidth = pm.dashboardPanelConfigs.sparklineLineWidthInput;
+    const fillOpacity = pm.dashboardPanelConfigs.sparklineFillOpacity;
 
     // Default type is Auto (→ area): line width visible
     await expect(lineWidth).toBeVisible();
@@ -834,8 +832,8 @@ test.describe("ConfigPanel — PromQL Settings", () => {
     testLogger.info("Verifying sparkline type/layout/width persist after save");
     await reopenPanelConfig(page, pm);
     await pm.dashboardPanelConfigs.expandAllConfigSections();
-    await expect(page.locator('[data-test="dashboard-config-sparkline-type"]')).toContainText("Area");
-    await expect(page.locator('[data-test="dashboard-config-sparkline-layout"]')).toContainText("Background");
+    await expect(pm.dashboardPanelConfigs.sparklineType).toContainText("Area");
+    await expect(pm.dashboardPanelConfigs.sparklineLayout).toContainText("Background");
     expect(await pm.dashboardPanelConfigs.getSparklineLineWidth()).toBe("3");
 
     await pm.dashboardPanelActions.savePanel();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-table.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-table.spec.js
@@ -29,18 +29,18 @@ test.describe("ConfigPanel — Table Settings", () => {
 
     await setupTablePanelWithConfig(page, pm, dashboardName);
 
-    const wrapCellsToggle = page.locator('[data-test="dashboard-config-wrap-table-cells"]');
+    const wrapCellsToggle = pm.dashboardPanelConfigs.wrapcell;
     await expect(wrapCellsToggle).toBeVisible();
     await pm.dashboardPanelConfigs.selectWrapCell();
     await pm.dashboardPanelActions.applyDashboardBtn();
 
     testLogger.info("Wrap cells enabled for table chart");
-    await expect(page.locator('[data-test="dashboard-panel-table"]')).toBeVisible();
+    await expect(pm.dashboardPanelActions.dashboardTable).toBeVisible();
 
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying wrap cells toggle persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-wrap-table-cells"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
+    await expect(pm.dashboardPanelConfigs.wrapcell.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -51,18 +51,18 @@ test.describe("ConfigPanel — Table Settings", () => {
 
     await setupTablePanelWithConfig(page, pm, dashboardName);
 
-    const transposeToggle = page.locator('[data-test="dashboard-config-table_transpose"]');
+    const transposeToggle = pm.dashboardPanelConfigs.transpose;
     await expect(transposeToggle).toBeVisible();
     await pm.dashboardPanelConfigs.selectTranspose();
     await pm.dashboardPanelActions.applyDashboardBtn();
 
     testLogger.info("Transpose enabled");
-    await expect(page.locator('[data-test="dashboard-panel-table"]')).toBeVisible();
+    await expect(pm.dashboardPanelActions.dashboardTable).toBeVisible();
 
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying transpose toggle persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-table_transpose"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
+    await expect(pm.dashboardPanelConfigs.transpose.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -73,18 +73,18 @@ test.describe("ConfigPanel — Table Settings", () => {
 
     await setupTablePanelWithConfig(page, pm, dashboardName);
 
-    const dynamicColsToggle = page.locator('[data-test="dashboard-config-table_dynamic_columns"]');
+    const dynamicColsToggle = pm.dashboardPanelConfigs.dynamicColumn;
     await expect(dynamicColsToggle).toBeVisible();
     await pm.dashboardPanelConfigs.selectDynamicColumns();
     await pm.dashboardPanelActions.applyDashboardBtn();
 
     testLogger.info("Dynamic columns enabled");
-    await expect(page.locator('[data-test="dashboard-panel-table"]')).toBeVisible();
+    await expect(pm.dashboardPanelActions.dashboardTable).toBeVisible();
 
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying dynamic columns toggle persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-table_dynamic_columns"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
+    await expect(pm.dashboardPanelConfigs.dynamicColumn.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -95,8 +95,8 @@ test.describe("ConfigPanel — Table Settings", () => {
 
     await setupTablePanelWithConfig(page, pm, dashboardName);
 
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
 
     await expect(paginationToggle).toBeVisible();
     await expect(rowsPerPageInput).not.toBeVisible();
@@ -109,7 +109,7 @@ test.describe("ConfigPanel — Table Settings", () => {
     await rowsPerPageInput.locator('[data-test$="-field"]').fill("25");
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Pagination enabled, rows per page set to 25");
-    await expect(page.locator('[data-test="dashboard-table-pagination"]')).toBeVisible();
+    await expect(pm.dashboardPanelConfigs.tablePagination).toBeVisible();
 
     // Re-open config and disable pagination → input hidden again
     await paginationToggle.click();
@@ -118,8 +118,8 @@ test.describe("ConfigPanel — Table Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying pagination disabled state persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-show-pagination"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "false");
-    await expect(page.locator('[data-test="dashboard-config-rows-per-page"]')).not.toBeVisible();
+    await expect(pm.dashboardPanelConfigs.paginationToggle.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "false");
+    await expect(pm.dashboardPanelConfigs.rowsPerPageWrapper).not.toBeVisible();
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-trellis.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-config-trellis.spec.js
@@ -29,7 +29,7 @@ test.describe("ConfigPanel — Trellis Settings", () => {
 
     await setupBarPanelWithBreakdownAndConfig(page, pm, dashboardName);
 
-    const trellisDropdown = page.locator('[data-test="dashboard-trellis-chart"]');
+    const trellisDropdown = pm.dashboardPanelConfigs.trellisLayout;
     await expect(trellisDropdown).toBeVisible();
 
     // Auto
@@ -48,7 +48,7 @@ test.describe("ConfigPanel — Trellis Settings", () => {
 
     // Custom — columns input appears, set 3, then cap at 16
     await pm.dashboardPanelConfigs.selectTrellisLayout("Custom");
-    const colInput = page.locator('[data-test="trellis-chart-num-of-columns"]');
+    const colInput = pm.dashboardPanelConfigs.trellisNumColumns;
     await expect(colInput).toBeVisible();
     await colInput.locator('[data-test$="-field"]').fill("3");
     await pm.dashboardPanelActions.applyDashboardBtn();
@@ -65,8 +65,8 @@ test.describe("ConfigPanel — Trellis Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying trellis Custom layout and 16 columns persist after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-trellis-chart-trigger"]')).toHaveAttribute('data-test-selected-value', 'custom');
-    await expect(page.locator('[data-test="trellis-chart-num-of-columns"]').locator('[data-test$="-field"]')).toHaveValue("16");
+    await expect(pm.dashboardPanelConfigs.trellisTrigger).toHaveAttribute('data-test-selected-value', 'custom');
+    await expect(pm.dashboardPanelConfigs.trellisNumColumns.locator('[data-test$="-field"]')).toHaveValue("16");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });
@@ -78,7 +78,7 @@ test.describe("ConfigPanel — Trellis Settings", () => {
     await setupBarPanelWithConfig(page, pm, dashboardName);
 
     // OSelect disabled state is on the trigger button, not the root wrapper div.
-    await expect(page.locator('[data-test="dashboard-trellis-chart-trigger"]')).toBeDisabled();
+    await expect(pm.dashboardPanelConfigs.trellisTrigger).toBeDisabled();
     testLogger.info("Trellis disabled with no breakdown field");
 
     await pm.dashboardPanelActions.savePanel();
@@ -92,7 +92,7 @@ test.describe("ConfigPanel — Trellis Settings", () => {
     await setupBarPanelWithBreakdownAndConfig(page, pm, dashboardName);
     await pm.dashboardPanelConfigs.addTimeShift();
 
-    await expect(page.locator('[data-test="dashboard-trellis-chart-trigger"]')).toBeDisabled();
+    await expect(pm.dashboardPanelConfigs.trellisTrigger).toBeDisabled();
     testLogger.info("Trellis disabled with time shifts active");
 
     await pm.dashboardPanelActions.savePanel();
@@ -107,7 +107,7 @@ test.describe("ConfigPanel — Trellis Settings", () => {
     await pm.dashboardPanelConfigs.selectTrellisLayout("Auto");
     await pm.dashboardPanelActions.applyDashboardBtn();
 
-    const groupByYAxisToggle = page.locator('[data-test="dashboard-config-trellis-group-by-y-axis"]');
+    const groupByYAxisToggle = pm.dashboardPanelConfigs.trellisGroupByYAxis;
     await pm.dashboardPanelConfigs.scrollSidebarToElement(groupByYAxisToggle);
     await expect(groupByYAxisToggle).toBeVisible();
     await groupByYAxisToggle.click();
@@ -119,7 +119,7 @@ test.describe("ConfigPanel — Trellis Settings", () => {
     await pm.dashboardPanelActions.savePanel();
     testLogger.info("Verifying group by Y axis enabled persists after save");
     await reopenPanelConfig(page, pm);
-    await expect(page.locator('[data-test="dashboard-config-trellis-group-by-y-axis"]').locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
+    await expect(pm.dashboardPanelConfigs.trellisGroupByYAxis.locator('[data-test$="-btn"]')).toHaveAttribute("aria-checked", "true");
     await pm.dashboardPanelActions.savePanel();
     await cleanupTestDashboard(page, pm, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-create-alert.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-create-alert.spec.js
@@ -31,8 +31,8 @@ const returnToDashboardFolder = async (page, pm, folderName = "default") => {
   // before the folder sidebar paints — give the tab its own window rather than
   // inheriting openFolderByName's 10s, which the list coming off the alert form
   // routinely overruns.
-  await page
-    .locator(`[data-test="dashboard-folder-tab-name-${folderName}"]`)
+  await pm.dashboardFolder
+    .getFolderCardByName(folderName)
     .waitFor({ state: "visible", timeout: 30000 });
   await pm.dashboardFolder.openFolderByName(folderName);
 };
@@ -84,8 +84,8 @@ test.describe("Dashboard Create Alert testcases", () => {
       await pm.dashboardPanelActions.savePanel();
 
       // Hover over the panel to reveal the dropdown menu
-      await page
-        .locator('[data-test="dashboard-panel-container"]')
+      await pm.dashboardPanelEdit
+        .getPanelContainer()
         .first()
         .hover();
 
@@ -160,7 +160,7 @@ test.describe("Dashboard Create Alert testcases", () => {
       );
       await pm.dashboardPanelActions.savePanel();
       await dashboardStreamPromise;
-      await page.locator('[data-test="chart-renderer"] canvas').first().waitFor({ state: "visible", timeout: 15000 });
+      await pm.dashboardPanelActions.getChartRendererCanvasElement().first().waitFor({ state: "visible", timeout: 15000 });
 
       // Right-click on the chart renderer to trigger alert context menu
       await pm.dashboardPanelEdit.rightClickChartForAlert();
@@ -170,15 +170,11 @@ test.describe("Dashboard Create Alert testcases", () => {
       testLogger.info("Alert context menu is visible after right-click");
 
       // Verify menu items contain threshold text
-      const aboveOption = page.locator(
-        '[data-test="alert-context-menu-above"]'
-      );
+      const aboveOption = pm.dashboardPanelEdit.getAlertContextMenuAbove();
       await expect(aboveOption).toBeVisible({ timeout: 5000 });
       await expect(aboveOption).toContainText("Create Alert with threshold above");
 
-      const belowOption = page.locator(
-        '[data-test="alert-context-menu-below"]'
-      );
+      const belowOption = pm.dashboardPanelEdit.getAlertContextMenuBelow();
       await expect(belowOption).toBeVisible({ timeout: 5000 });
       await expect(belowOption).toContainText("Create Alert with threshold below");
 
@@ -256,7 +252,7 @@ test.describe("Dashboard Create Alert testcases", () => {
       );
       await pm.dashboardPanelActions.savePanel();
       await dashboardStreamPromise;
-      await page.locator('[data-test="chart-renderer"] canvas').first().waitFor({ state: "visible", timeout: 15000 });
+      await pm.dashboardPanelActions.getChartRendererCanvasElement().first().waitFor({ state: "visible", timeout: 15000 });
 
       // Right-click on the chart renderer
       await pm.dashboardPanelEdit.rightClickChartForAlert();
@@ -333,7 +329,7 @@ test.describe("Dashboard Create Alert testcases", () => {
       );
       await pm.dashboardPanelActions.savePanel();
       await dashboardStreamPromise;
-      await page.locator('[data-test="chart-renderer"] canvas').first().waitFor({ state: "visible", timeout: 15000 });
+      await pm.dashboardPanelActions.getChartRendererCanvasElement().first().waitFor({ state: "visible", timeout: 15000 });
 
       // Right-click on the chart renderer
       await pm.dashboardPanelEdit.rightClickChartForAlert();
@@ -343,7 +339,7 @@ test.describe("Dashboard Create Alert testcases", () => {
       testLogger.info("Context menu visible, clicking outside");
 
       // Click outside the context menu (on the page body)
-      await page.locator("body").click({ position: { x: 10, y: 10 } });
+      await pm.dashboardPanelEdit.clickOutsideContextMenu();
 
       // Verify context menu is hidden
       await pm.dashboardPanelEdit.expectAlertContextMenuHidden();
@@ -414,8 +410,8 @@ test.describe("Dashboard Create Alert testcases", () => {
       testLogger.info("Dashboard panel created and saved", { panelName });
 
       // Step 3: Click "Create Alert" from panel dropdown menu
-      await page
-        .locator('[data-test="dashboard-panel-container"]')
+      await pm.dashboardPanelEdit
+        .getPanelContainer()
         .first()
         .hover();
       await pm.dashboardPanelEdit.createAlertFromPanelMenu(panelName);
@@ -426,16 +422,14 @@ test.describe("Dashboard Create Alert testcases", () => {
       });
 
       // Get the pre-filled alert name
-      const alertNameInput = page.locator(
-        '[data-test="add-alert-name-input"]'
-      );
+      const alertNameInput = pm.alertsPage.getAlertNameInput();
       await expect(alertNameInput).toBeVisible({ timeout: 30000 });
       const alertName = await alertNameInput.inputValue();
       expect(alertName).toContain("Alert_from_");
       testLogger.info("Alert form pre-filled from panel", { alertName });
 
       // Step 4: Complete the alert wizard (scheduled alert from panel data)
-      const continueBtn = page.getByRole("button", { name: "Continue" });
+      const continueBtn = pm.alertsPage.getContinueButton();
 
       // Step 1 (Setup) - pre-filled → Continue
       await continueBtn.click();
@@ -447,33 +441,25 @@ test.describe("Dashboard Create Alert testcases", () => {
       await continueBtn.click();
 
       // Step 4 (Settings) → Set threshold and select destination
-      const thresholdOperator = page.locator(
-        '[data-test="alert-threshold-operator-select"]'
-      );
+      const thresholdOperator = pm.alertsPage.getThresholdOperatorSelect();
       await thresholdOperator.waitFor({ state: "visible", timeout: 10000 });
       await thresholdOperator.click();
-      await page.getByText(">=", { exact: true }).waitFor({ state: "visible", timeout: 5000 });
-      await page.getByText(">=", { exact: true }).click();
+      await pm.alertsPage.getThresholdOperatorOption(">=").waitFor({ state: "visible", timeout: 5000 });
+      await pm.alertsPage.getThresholdOperatorOption(">=").click();
 
       // The input may place data-test on the native <input> or on its root div,
       // so match both: 'input[data-test]' (on input) and '[data-test] input' (input inside parent)
-      const thresholdInput = page.locator(
-        'input[data-test="alert-threshold-value-input"], [data-test="alert-threshold-value-input"] input'
-      );
+      const thresholdInput = pm.alertsPage.getThresholdValueInput();
       await thresholdInput.waitFor({ state: "visible", timeout: 10000 });
       await thresholdInput.clear();
       await thresholdInput.fill("1");
 
       // Select destination
-      const destinationDropdown = page.locator(
-        '[data-test="alert-destinations-select"]'
-      );
+      const destinationDropdown = pm.alertsPage.getDestinationsSelect();
       await destinationDropdown.waitFor({ state: "visible", timeout: 5000 });
       await destinationDropdown.click();
 
-      const destOption = page.locator(
-        `[data-test="alert-destination-option-${destinationName}"]`
-      );
+      const destOption = pm.alertsPage.getDestinationOption(destinationName);
       await expect(destOption).toBeVisible({ timeout: 5000 });
       await destOption.click();
       await page.keyboard.press("Escape");
@@ -485,26 +471,24 @@ test.describe("Dashboard Create Alert testcases", () => {
       await continueBtn.click();
 
       // Submit the alert
-      await page.locator('[data-test="add-alert-submit-btn"]').click();
+      await pm.alertsPage.getAddAlertSubmitButton().click();
 
       // Verify alert saved successfully
       await expect(
-        page.locator('[data-test="o-toast-message"]').filter({ hasText: 'Alert saved successfully.' })
+        pm.alertsPage.getToastMessageByText('Alert saved successfully.')
       ).toBeVisible({ timeout: 30000 });
       testLogger.info("Alert created successfully from dashboard panel", {
         alertName,
       });
 
       // Verify alert appears in the alerts list
-      const alertSearchInput = page.locator(
-        '[data-test="alert-list-search-input"]'
-      );
+      const alertSearchInput = pm.alertsPage.getAlertListSearchInput();
       await alertSearchInput.waitFor({ state: "visible", timeout: 15000 });
       await alertSearchInput.fill(alertName.toLowerCase());
-      await page.locator("table tbody tr").first().waitFor({ state: "visible", timeout: 10000 });
+      await pm.alertsPage.getAlertTableRows().first().waitFor({ state: "visible", timeout: 10000 });
 
       // Verify alert row is visible
-      const firstRow = page.locator("table tbody tr").first();
+      const firstRow = pm.alertsPage.getAlertTableRows().first();
       await expect(firstRow).toBeVisible({ timeout: 10000 });
       const firstRowText = await firstRow.textContent();
       expect(firstRowText).toContain("Alert_from_");
@@ -514,10 +498,10 @@ test.describe("Dashboard Create Alert testcases", () => {
       const kebabButton = firstRow.locator('[data-test*="-more-options"]').first();
       await kebabButton.waitFor({ state: "visible", timeout: 5000 });
       await kebabButton.click();
-      await page.getByText("Delete", { exact: true }).waitFor({ state: "visible", timeout: 5000 });
-      await page.getByText("Delete", { exact: true }).click();
-      await page.locator('[data-test="o-dialog-primary-btn"]').click();
-      await expect(page.getByText("Alert deleted")).toBeVisible({ timeout: 10000 });
+      await pm.alertsPage.getDeleteMenuOption().waitFor({ state: "visible", timeout: 5000 });
+      await pm.alertsPage.getDeleteMenuOption().click();
+      await pm.alertsPage.getDialogPrimaryButton().click();
+      await expect(pm.alertsPage.getAlertDeletedText()).toBeVisible({ timeout: 10000 });
       testLogger.info("Alert deleted", { alertName });
 
       // Cleanup: Delete the dashboard

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-filter.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-filter.spec.js
@@ -42,11 +42,7 @@ test.describe("dashboard filter testcases", () => {
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
 
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -113,12 +109,10 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Verify query inspector for AND operator
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     await expect(
-      page.locator('[data-test="query-inspector-executed-query-0"]')
+      pm.dashboardPanelEdit.getExecutedQuery(0)
     ).toContainText(
       'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'ziox\' AND kubernetes_container_image <> \'ziox\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
     );
@@ -126,9 +120,9 @@ test.describe("dashboard filter testcases", () => {
     await pm.logsVisualise.closeQueryInspector();
 
     // Change operator to OR and verify
-    await page.locator('[data-test="dashboard-add-condition-logical-operator-1"]').click();
+    await pm.dashboardFilter.clickLogicalOperator(1);
 
-    await page.getByRole("option", { name: "OR" }).click();
+    await pm.dashboardFilter.selectOperatorOption("OR");
 
     await pm.dashboardPanelActions.applyDashboardBtn();
 
@@ -136,12 +130,10 @@ test.describe("dashboard filter testcases", () => {
 
     await page.waitForTimeout(2000);
 
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     await expect(
-      page.locator('[data-test="query-inspector-executed-query-0"]')
+      pm.dashboardPanelEdit.getExecutedQuery(0)
     ).toContainText(
       'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'ziox\' OR kubernetes_container_image <> \'ziox\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
     );
@@ -172,11 +164,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     await pm.dashboardSetting.openSetting();
 
     await pm.dashboardVariables.addDashboardVariable(
@@ -223,13 +211,11 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Verify query inspector
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
     await page.waitForTimeout(2000);
 
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'ziox\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -256,11 +242,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     await pm.dashboardSetting.openSetting();
 
     await pm.dashboardVariables.addDashboardVariable(
@@ -295,9 +277,9 @@ test.describe("dashboard filter testcases", () => {
     );
     // await page.waitForTimeout(3000);
 
-    await page.locator('[data-test="dashboard-add-condition-add"]').click();
+    await pm.dashboardFilter.clickAddConditionBtn();
 
-    await page.getByText("Add Group").click();
+    await pm.dashboardFilter.clickAddGroupOption();
 
     await pm.dashboardFilter.addGroupFilterCondition(
       0,
@@ -306,12 +288,8 @@ test.describe("dashboard filter testcases", () => {
       "$variablename"
     );
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^kubernetes_container_namearrow_drop_downcloseadd$/ })
-      .locator('[data-test="dashboard-add-condition-add"]')
-      .click();
-    await page.locator("div").filter({ hasText: "Add Group" }).nth(3).click();
+    await pm.dashboardFilter.clickAddConditionWithinRowText(/^kubernetes_container_namearrow_drop_downcloseadd$/);
+    await pm.dashboardFilter.clickAddGroupDivByNth(3);
 
     await pm.dashboardFilter.addGroupFilterCondition(
       0,
@@ -323,16 +301,12 @@ test.describe("dashboard filter testcases", () => {
 
     await pm.dashboardPanelActions.waitForChartToRender();
 
-    // await page.getByText("arrow_rightQueryAutoPromQLCustom SQL").click();
+    await expect(pm.dashboardPanelActions.getVisibleText("'$variablename'").first()).toBeVisible();
 
-    await expect(page.getByText("'$variablename'").first()).toBeVisible();
-
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1"'
       }).last()
     ).toBeVisible();
@@ -360,11 +334,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     await pm.dashboardSetting.openSetting();
     await pm.dashboardVariables.addDashboardVariable(
       "variablename",
@@ -379,9 +349,7 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.addPanelName(panelName);
     await pm.chartTypeSelector.selectStreamType("logs");
     await pm.chartTypeSelector.selectStream("e2e_automate");
-    await page
-      .locator('[data-test="dashboard-x-item-x_axis_1-remove"]')
-      .click();
+    await pm.chartTypeSelector.removeField("x_axis_1", "x");
     await pm.chartTypeSelector.searchAndAddField(
       "kubernetes_container_name",
       "x"
@@ -411,12 +379,10 @@ test.describe("dashboard filter testcases", () => {
 
     await pm.dashboardPanelActions.waitForChartToRender();
 
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Verify the query is displayed in the Query Inspector
-    const queryEditor = page.locator('.inspector-query-editor').filter({
+    const queryEditor = pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
       hasText:  `SELECT kubernetes_container_name as "x_axis_1", count(kubernetes_container_image) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_namespace_name IN ('ingress-nginx', 'kube-system') GROUP BY x_axis_1`
     }).last();
 
@@ -448,11 +414,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     await pm.dashboardSetting.openSetting();
     await pm.dashboardVariables.addDashboardVariable(
       "variablename",
@@ -482,11 +444,9 @@ test.describe("dashboard filter testcases", () => {
     );
 
     await expect(
-      page.locator(
-        '[data-test="dashboard-add-condition-label-0-kubernetes_namespace_name"]'
-      )
+      pm.dashboardFilter.getAddConditionLabel(0, "kubernetes_namespace_name")
     ).toBeVisible();
-    await page.locator('[data-test="dashboard-add-condition-remove"]').click();
+    await pm.dashboardFilter.clickRemoveCondition();
 
     await pm.dashboardPanelActions.applyDashboardBtn();
 
@@ -557,10 +517,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Expect error message
     await expect(
-      page
-        .getByText(
-          /(sql parser error: Expected:|Search field not found:|Schema error: No field named controller\.?)/i
-        )
+      pm.dashboardPanelActions.getVisibleText(/(sql parser error: Expected:|Search field not found:|Schema error: No field named controller\.?)/i)
         .first()
     ).toBeVisible();
 
@@ -654,11 +611,9 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector and verify
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1", kubernetes_container_name as "breakdown_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'$variablename\' GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -699,11 +654,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     await pm.dashboardSetting.openSetting();
     await pm.dashboardVariables.addDashboardVariable(
       "variablename",
@@ -737,12 +688,12 @@ test.describe("dashboard filter testcases", () => {
 
     // Perform custom value search in variable dropdown to trigger _values API calls
     // OSelect trigger opens the dropdown; search input receives typed terms
-    const variableTrigger = page.locator('[data-test="variable-selector-variablename-inner-trigger"]');
+    const variableTrigger = pm.dashboardVariables.variableTrigger("variablename");
     await variableTrigger.waitFor({ state: "visible", timeout: 10000 });
     await variableTrigger.click();
-    await page.locator('[data-test="variable-selector-variablename-inner-popover"]').waitFor({ state: "visible", timeout: 5000 });
+    await pm.dashboardVariables.variablePopover("variablename").waitFor({ state: "visible", timeout: 5000 });
 
-    const variableSearch = page.locator('[data-test="variable-selector-variablename-inner-search"]');
+    const variableSearch = pm.dashboardVariables.variableSearchInput("variablename");
     // Type partial search terms to trigger multiple _values API calls
     const searchTerms = ["zi", "zio", "ziox"];
     for (const term of searchTerms) {
@@ -751,7 +702,7 @@ test.describe("dashboard filter testcases", () => {
     }
 
     // Select the final value using OSelect option convention
-    const option = page.locator('[data-test="variable-selector-variablename-inner-option"][data-test-value="ziox"]');
+    const option = pm.dashboardVariables.variableOptionByValue("variablename", "ziox");
     await option.waitFor({ state: "visible", timeout: 10000 });
     await option.click();
 
@@ -800,11 +751,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     await pm.dashboardSetting.openSetting();
 
     await pm.dashboardVariables.addDashboardVariable(
@@ -837,11 +784,11 @@ test.describe("dashboard filter testcases", () => {
     );
 
     // Add first group
-    await page.locator('[data-test="dashboard-add-condition-add"]').click();
-    await page.getByText("Add Group").click();
+    await pm.dashboardFilter.clickAddConditionBtn();
+    await pm.dashboardFilter.clickAddGroupOption();
 
     // Wait for first group to be created
-    await page.locator('[data-test="dashboard-group"][style*="--group-index: 1"]').waitFor({ state: "visible" });
+    await pm.dashboardFilter.waitForGroupVisible(1);
 
     // Add first condition in group 1
     await pm.dashboardFilter.addNestedGroupFilterCondition(
@@ -856,14 +803,11 @@ test.describe("dashboard filter testcases", () => {
     await page.waitForTimeout(500);
 
     // Add nested group inside group 1
-    await page
-      .locator('[data-test="dashboard-group"][style*="--group-index: 1"]')
-      .locator('[data-test="dashboard-add-condition-add"]')
-      .click();
-    await page.getByText("Add Group").last().click();
+    await pm.dashboardFilter.clickAddConditionInGroup(1);
+    await pm.dashboardFilter.clickAddGroupOptionLast();
 
     // Wait for nested group to be created
-    await page.locator('[data-test="dashboard-group"][style*="--group-index: 2"]').waitFor({ state: "visible" });
+    await pm.dashboardFilter.waitForGroupVisible(2);
 
     // Add condition in nested group 2
     await pm.dashboardFilter.addNestedGroupFilterCondition(
@@ -880,15 +824,13 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Verify the variable is displayed
-    await expect(page.getByText("'$variablename'").first()).toBeVisible();
+    await expect(pm.dashboardPanelActions.getVisibleText("'$variablename'").first()).toBeVisible();
 
     // Verify the generated query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE (kubernetes_container_name = \'ziox\' AND (kubernetes_container_image <> \'ziox\')) GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -918,11 +860,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -974,16 +912,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the str_match() function for Contains operator
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE str_match(kubernetes_container_name, \'ziox\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -1012,11 +948,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -1075,16 +1007,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name NOT IN (${variablename}) GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -1113,11 +1043,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -1169,16 +1095,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the str_match() function for Contains operator
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE str_match(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -1207,11 +1131,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -1267,16 +1187,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE re_match(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -1305,11 +1223,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -1365,16 +1279,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the match_all clause
     await expect(
-      page.locator('[data-test="query-inspector-original-query-0"]')
+      pm.dashboardPanelEdit.getOriginalQuery(0)
     ).toContainText("match_all('$variablename')");
 
     await pm.logsVisualise.closeQueryInspector();
@@ -1401,11 +1313,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -1461,16 +1369,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the str_match_ignore_case clause
     await expect(
-      page.locator('[data-test="query-inspector-original-query-0"]')
+      pm.dashboardPanelEdit.getOriginalQuery(0)
     ).toContainText("str_match_ignore_case(kubernetes_container_name, '$variablename')");
 
     await pm.logsVisualise.closeQueryInspector();
@@ -1497,11 +1403,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -1557,16 +1459,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE re_not_match(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -1595,11 +1495,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -1655,16 +1551,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     // await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name LIKE \'$variablename%\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -1693,11 +1587,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -1753,16 +1643,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     // await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name LIKE \'%$variablename\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();
@@ -1791,11 +1679,7 @@ test.describe("dashboard filter testcases", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a variable
     await pm.dashboardSetting.openSetting();
@@ -1851,16 +1735,14 @@ test.describe("dashboard filter testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open query inspector to verify SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
 
     // Wait for query inspector to be visible
     // await page.waitForTimeout(2000);
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.locator('.inspector-query-editor').filter({
+      pm.dashboardPanelEdit.getInspectorQueryEditor().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name NOT LIKE \'%$variablename%\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
       }).last()
     ).toBeVisible();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-folder.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-folder.spec.js
@@ -61,7 +61,7 @@ test.describe("dashboard folder testcases", () => {
     await pm.dashboardPage.verifyShareDashboardLink(randomDashboardName);
     await page.waitForTimeout(1000);
     // Click the back button to return to the folder dashboard list.
-    await page.locator('[data-test="dashboard-back-btn"]').click();
+    await pm.dashboardCreate.backToDashboardList();
     await page.waitForTimeout(1000);
     await pm.dashboardPage.deleteSearchedDashboard(randomDashboardName);
 

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-general-setting.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-general-setting.spec.js
@@ -12,7 +12,7 @@ test.describe.configure({ mode: "parallel" });
 
 test.describe("dashboard general setting", () => {
   test.beforeEach(async ({ page }) => {
-    console.log("running before each");
+    testLogger.info('running before each');
     await navigateToBase(page);
     await ingestion(page);
 
@@ -35,11 +35,7 @@ test.describe("dashboard general setting", () => {
     await pm.dashboardList.menuItem("dashboards-item");
     await waitForDashboardPage(page);
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     // Open dashboard settings
 
     await pm.dashboardSetting.openSetting();
@@ -48,7 +44,7 @@ test.describe("dashboard general setting", () => {
     // Fix: Use relativeTimeSelection from pm.dashboardSetting POM
     await pm.dashboardSetting.relativeTimeSelection("3", "h");
     await pm.dashboardSetting.saveSetting();
-    await expect(page.locator('[data-test="o-toast-message"]').filter({ hasText: "Dashboard updated successfully" })).toBeVisible({
+    await expect(pm.dashboardSetting.getToastMessageByText("Dashboard updated successfully")).toBeVisible({
       timeout: 30000,
     });
     // add tab in dashboard
@@ -74,11 +70,7 @@ test.describe("dashboard general setting", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings
     await pm.dashboardSetting.openSetting(); // Ensure settings are opened
@@ -87,7 +79,7 @@ test.describe("dashboard general setting", () => {
     //verify that dynamic toggle is disabled
     await pm.dashboardSetting.showDynamicFilter();
     await pm.dashboardSetting.saveSetting();
-    await expect(page.locator('[data-test="o-toast-message"]').filter({ hasText: "Dashboard updated successfully" })).toBeVisible({
+    await expect(pm.dashboardSetting.getToastMessageByText("Dashboard updated successfully")).toBeVisible({
       timeout: 30000,
     });
     await pm.dashboardSetting.closeSettingDashboard();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-geoMap.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-geoMap.spec.js
@@ -36,12 +36,7 @@ test.describe("dashboard maps testcases", () => {
     // Add new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
 
-    await page.waitForSelector('[data-test="dashboard-setting-btn"]', {
-      state: "visible",
-      timeout: 15000,
-    });
-    const settingsButton = page.locator('[data-test="dashboard-setting-btn"]');
-    await settingsButton.click();
+    await pm.dashboardSetting.openSetting();
 
     // Add variable
     await pm.dashboardVariables.addDashboardVariable(
@@ -103,15 +98,13 @@ test.describe("dashboard maps testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Click specific position on map
-    await page.locator("#chart-map canvas").click({
-      position: { x: 643, y: 69 },
-    });
+    await pm.chartTypeSelector.clickMapCanvas({ x: 643, y: 69 });
 
     await pm.dashboardPanelActions.addPanelName(randomDashboardName);
     await pm.dashboardPanelActions.savePanel();
 
     // Delete Dashboard
-    await page.locator('[data-test="dashboard-back-btn"]').click();
+    await pm.dashboardCreate.backToDashboardList();
     await deleteDashboard(page, randomDashboardName);
   });
 
@@ -156,9 +149,7 @@ test.describe("dashboard maps testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Click on the map at the given position
-    await page.locator("#chart-map canvas").click({
-      position: { x: 26.1206, y: 91.6523 }, // Ensure this translates correctly to pixels
-    });
+    await pm.chartTypeSelector.clickMapCanvas({ x: 26.1206, y: 91.6523 }); // Ensure this translates correctly to pixels
 
     // Save panel
 
@@ -166,7 +157,7 @@ test.describe("dashboard maps testcases", () => {
     await pm.dashboardPanelActions.savePanel();
 
     // Delete Dashboard
-    await page.locator('[data-test="dashboard-back-btn"]').click();
+    await pm.dashboardCreate.backToDashboardList();
     await deleteDashboard(page, randomDashboardName);
   });
 });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-html-chart.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-html-chart.spec.js
@@ -81,18 +81,10 @@ test.describe("HTML chart dashboard", () => {
 
     await pm.chartTypeSelector.selectChartType("html");
 
-    await page
-      .locator('[data-test="dashboard-html-editor"]')
-      .locator(".monaco-editor")
-      .click();
-
-    await page
-      .locator('[data-test="dashboard-html-editor"]')
-      .locator(".inputarea")
-      .fill(BASIC_HTML_SNIPPET);
+    await pm.chartTypeSelector.fillHtmlEditor(BASIC_HTML_SNIPPET);
 
     await expect(
-      page.getByRole("heading", { name: "Openobserve" })
+      pm.chartTypeSelector.getHtmlHeading("Openobserve")
     ).toBeVisible();
 
     // Add the panel name and save the panel
@@ -139,18 +131,10 @@ test.describe("HTML chart dashboard", () => {
 
     await pm.dashboardTimeRefresh.setRelative("30", "m");
 
-    await page
-      .locator('[data-test="dashboard-html-editor"]')
-      .locator(".monaco-editor")
-      .click();
-
-    await page
-      .locator('[data-test="dashboard-html-editor"]')
-      .locator(".inputarea")
-      .fill(VARIABLE_HTML_SNIPPET);
+    await pm.chartTypeSelector.fillHtmlEditor(VARIABLE_HTML_SNIPPET);
 
     await expect(
-      page.getByRole("heading", { name: "Openobserve" })
+      pm.chartTypeSelector.getHtmlHeading("Openobserve")
     ).toBeVisible();
 
     // Wait for values stream API to complete before selecting variable value
@@ -165,7 +149,7 @@ test.describe("HTML chart dashboard", () => {
     await valuesStreamPromise;
 
     await expect(
-      page.locator('[data-test="html-renderer"]').getByText("controller")
+      pm.chartTypeSelector.getHtmlRendererText("controller")
     ).toBeVisible();
 
     // Save the dashboard panel
@@ -194,18 +178,11 @@ test.describe("HTML chart dashboard", () => {
     await pm.dashboardCreate.addPanel();
     await pm.chartTypeSelector.selectChartType("html");
 
-    await page
-      .locator('[data-test="dashboard-html-editor"]')
-      .locator(".monaco-editor")
-      .click();
-    await page
-      .locator('[data-test="dashboard-html-editor"]')
-      .locator(".inputarea")
-      .fill(XSS_HTML_SNIPPET);
+    await pm.chartTypeSelector.fillHtmlEditor(XSS_HTML_SNIPPET);
 
-    await expect(page.getByRole("heading", { name: "XSS Test" })).toBeVisible();
+    await expect(pm.chartTypeSelector.getHtmlHeading("XSS Test")).toBeVisible();
     await expect(
-      page.locator('[data-test="html-renderer"] script')
+      pm.chartTypeSelector.getHtmlRendererScripts()
     ).toHaveCount(0);
 
     await pm.dashboardPanelActions.addPanelName(panelName);
@@ -228,17 +205,10 @@ test.describe("HTML chart dashboard", () => {
     await pm.dashboardCreate.addPanel();
     await pm.chartTypeSelector.selectChartType("html");
 
-    await page
-      .locator('[data-test="dashboard-html-editor"]')
-      .locator(".monaco-editor")
-      .click();
-    await page
-      .locator('[data-test="dashboard-html-editor"]')
-      .locator(".inputarea")
-      .fill(UNDEFINED_VARIABLE_HTML_SNIPPET);
+    await pm.chartTypeSelector.fillHtmlEditor(UNDEFINED_VARIABLE_HTML_SNIPPET);
 
     await expect(
-      page.locator('[data-test="html-renderer"]').getByText("$undefinedvar")
+      pm.chartTypeSelector.getHtmlRendererText("$undefinedvar")
     ).toBeVisible();
 
     await pm.dashboardPanelActions.addPanelName(panelName);

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-maps.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-maps.spec.js
@@ -46,20 +46,7 @@ test.describe("dashboard maps testcases", () => {
     await pm.chartTypeSelector.searchAndAddField("country", "filter");
 
     // Apply Country Filter
-    const conditionLabel = page.locator(
-      '[data-test="dashboard-add-condition-label-0-country"]'
-    );
-    await conditionLabel.click();
-    const conditionList = page.locator('[data-test="dashboard-add-condition-list-tab"]');
-    await conditionList.click();
-    // Fill the search input inside the OSelect popover
-    const conditionSearch = page.locator('[data-test="dashboard-add-condition-list-tab-search"]');
-    await conditionSearch.waitFor({ state: "visible", timeout: 5000 });
-    await conditionSearch.fill("India");
-    // Select the matching option via data-test-value
-    const indiaOption = page.locator('[data-test="dashboard-add-condition-list-tab-option"][data-test-value="India"]');
-    await indiaOption.waitFor({ state: "visible", timeout: 5000 });
-    await indiaOption.click();
+    await pm.dashboardFilter.applyListConditionBySearch(0, "country", "India", "India");
 
     // Apply Dashboard Changes
 
@@ -68,9 +55,7 @@ test.describe("dashboard maps testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Click on Map at Specific Position
-    await page
-      .locator("#chart-map canvas")
-      .click({ position: { x: 19.0748, y: 72.8856 } });
+    await pm.chartTypeSelector.clickMapCanvas({ x: 19.0748, y: 72.8856 });
 
     // Save panel
 
@@ -78,7 +63,7 @@ test.describe("dashboard maps testcases", () => {
     await pm.dashboardPanelActions.savePanel();
 
     // Delete Dashboard
-    await page.locator('[data-test="dashboard-back-btn"]').click();
+    await pm.dashboardCreate.backToDashboardList();
     await deleteDashboard(page, randomDashboardName);
   });
 });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-metric-camelcase.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-metric-camelcase.spec.js
@@ -46,10 +46,10 @@ test.describe("Dashboard Metric Chart CamelCase Alias", () => {
    * Helper: Assert metric chart renders with data (not "No Data").
    */
   async function assertMetricRenders(page) {
-    const chartRenderer = page.locator('[data-test="chart-renderer"]');
+    const chartRenderer = pm.dashboardPanelActions.getChartRendererCanvas();
     await expect(chartRenderer).toBeVisible({ timeout: 15000 });
 
-    const noDataElement = page.locator('[data-test="no-data"]');
+    const noDataElement = pm.dashboardPanelActions.getNoDataLocator();
     const noDataText = await noDataElement.textContent({ timeout: 5000 }).catch(() => "");
     expect(noDataText.trim()).not.toBe("No Data");
   }
@@ -177,8 +177,8 @@ test.describe("Dashboard Metric Chart CamelCase Alias", () => {
 
     // For count(*) with a WHERE that matches nothing, the result may still be 0
     // which is a valid metric value. Assert the panel is in a valid state.
-    const chartRenderer = page.locator('[data-test="chart-renderer"]');
-    const noDataElement = page.locator('[data-test="no-data"]');
+    const chartRenderer = pm.dashboardPanelActions.getChartRendererCanvas();
+    const noDataElement = pm.dashboardPanelActions.getNoDataLocator();
 
     const chartVisible = await chartRenderer.isVisible().catch(() => false);
     const noDataText = await noDataElement.textContent({ timeout: 5000 }).catch(() => "");

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-multi-sql.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-multi-sql.spec.js
@@ -86,10 +86,9 @@ async function addAndConfigureSecondQuery(pm, { yField = "kubernetes_namespace_n
  * @param {string} vrlProgram - VRL program to type (may be empty string for no-op)
  */
 async function enterVrlForActiveQuery(page, vrlProgram) {
-  const vrlToggle = page.locator(
-    '[data-test="logs-search-bar-show-query-toggle-btn"]'
-  );
-  const vrlEditor = page.locator('[data-test="dashboard-vrl-function-editor"]');
+  const pm = new PageManager(page);
+  const vrlToggle = pm.chartTypeSelector.vrlToggleBtn;
+  const vrlEditor = pm.chartTypeSelector.vrlFunctionEditor;
   if (!(await vrlEditor.isVisible())) {
     await vrlToggle.waitFor({ state: "visible", timeout: 10000 });
     await vrlToggle.click();
@@ -146,9 +145,7 @@ test.describe("Multi-SQL Query Support", () => {
 
       await buildPanel(page, pm, dashboardName, { chartType: "bar" });
       await expect(msql.queryTab(0)).toBeVisible();
-      await expect(
-        page.locator('.text-subtitle2.text-weight-bold:has-text("SQL")')
-      ).not.toBeVisible();
+      await expect(msql.sqlModeSubtitle).not.toBeVisible();
 
       for (const type of ["line", "area", "table", "pie", "gauge"]) {
         await pm.chartTypeSelector.selectChartType(type);
@@ -238,7 +235,7 @@ test.describe("Multi-SQL Query Support", () => {
       await pm.chartTypeSelector.searchAndAddField("kubernetes_pod_name", "y");
 
       // Switching tabs must surface that query's own Y-axis field.
-      const yLayout = page.locator('[data-test="dashboard-y-layout"]');
+      const yLayout = pm.chartTypeSelector.yLayout;
 
       await msql.switchToQueryTab(0);
       await expect(msql.queryTab(0)).toBeVisible();
@@ -768,7 +765,7 @@ test.describe("Multi-SQL Query Support", () => {
       //   - the outer conditional wrapper (first)
       //   - the inner list container (second)
       // Use .first() to target the outer wrapper for visibility checks.
-      const errorWrapper = page.locator('[data-test="dashboard-error"]').first();
+      const errorWrapper = pm.dashboardPanelActions.getDashboardErrorLocator();
       await expect(errorWrapper).toBeVisible({ timeout: 10000 });
 
       // Switch to Q2 — error panel must persist (not cleared by tab switch alone)
@@ -875,7 +872,7 @@ test.describe("Multi-SQL Query Support", () => {
         await pm.dashboardPanelActions.waitForChartToRender().catch(() => {});
 
         await expect(
-          page.locator('[data-test="dashboard-error"]').first()
+          pm.dashboardPanelActions.getDashboardErrorLocator()
         ).not.toBeVisible({ timeout: 5000 });
         await pm.dashboardPanelActions.verifyChartRenders(expect);
 
@@ -905,7 +902,7 @@ test.describe("Multi-SQL Query Support", () => {
         await pm.dashboardPanelActions.waitForChartToRender().catch(() => {});
 
         await expect(
-          page.locator('[data-test="dashboard-error"]').first()
+          pm.dashboardPanelActions.getDashboardErrorLocator()
         ).not.toBeVisible({ timeout: 5000 });
 
         await msql.applyAndSave(pm);
@@ -991,7 +988,7 @@ test.describe("Multi-SQL Query Support", () => {
     // The warning button lives in PanelErrorButtons.vue (panel editor header).
     // It reacts to field config changes without needing an Apply click.
     const xAliasWarning = (page) =>
-      page.locator('[data-test="panel-x-alias-inconsistency-warning"]');
+      new PageManager(page).dashboardMultiSQL.xAliasInconsistencyWarning;
 
     /**
      * Remove the first x-axis field from the currently active query tab.
@@ -999,8 +996,9 @@ test.describe("Multi-SQL Query Support", () => {
      * non-histogram field.
      */
     async function removeFirstXField(page) {
-      const btn = page
-        .locator('[data-test="dashboard-x-layout"] [data-test$="-remove"]')
+      const pm = new PageManager(page);
+      const btn = pm.chartTypeSelector.xLayout
+        .locator('[data-test$="-remove"]')
         .first();
       await btn.waitFor({ state: "visible", timeout: 8000 });
       await btn.click();
@@ -1327,14 +1325,10 @@ test.describe("Multi-SQL Query Support", () => {
 
         // Warning must NOT appear nested inside axis layout sections
         await expect(
-          page.locator(
-            '[data-test="dashboard-y-layout"] [data-test="panel-x-alias-inconsistency-warning"]'
-          )
+          msql.xAliasWarningInLayout("dashboard-y-layout")
         ).not.toBeVisible({ timeout: 2000 });
         await expect(
-          page.locator(
-            '[data-test="dashboard-breakdown-layout"] [data-test="panel-x-alias-inconsistency-warning"]'
-          )
+          msql.xAliasWarningInLayout("dashboard-breakdown-layout")
         ).not.toBeVisible({ timeout: 2000 });
 
         await msql.applyAndSave(pm);
@@ -1408,7 +1402,7 @@ test.describe("Multi-SQL Query Support", () => {
         await pm.dashboardPanelActions.waitForChartToRender().catch(() => {});
         await pm.dashboardPanelActions.verifyChartRenders(expect);
         await expect(
-          page.locator('[data-test="dashboard-error"]').first()
+          pm.dashboardPanelActions.getDashboardErrorLocator()
         ).not.toBeVisible({ timeout: 5000 });
 
         await msql.applyAndSave(pm);
@@ -1444,12 +1438,12 @@ test.describe("Multi-SQL Query Support", () => {
 
         await msql.switchToQueryTab(0);
         await expect(
-          page.locator('[data-test="dashboard-vrl-function-editor"]')
+          pm.chartTypeSelector.vrlFunctionEditor
         ).toContainText("kubernetes_container_hash", { timeout: 10000 });
 
         await msql.switchToQueryTab(1);
         await expect(
-          page.locator('[data-test="dashboard-vrl-function-editor"]')
+          pm.chartTypeSelector.vrlFunctionEditor
         ).toContainText("kubernetes_namespace_name", { timeout: 10000 });
 
         await pm.dashboardPanelActions.applyDashboardBtn();
@@ -1487,7 +1481,7 @@ test.describe("Multi-SQL Query Support", () => {
         await pm.dashboardPanelActions.waitForChartToRender().catch(() => {});
         await pm.dashboardPanelActions.verifyChartRenders(expect);
         await expect(
-          page.locator('[data-test="dashboard-error"]').first()
+          pm.dashboardPanelActions.getDashboardErrorLocator()
         ).not.toBeVisible({ timeout: 5000 });
 
         await msql.applyAndSave(pm);
@@ -1526,7 +1520,7 @@ test.describe("Multi-SQL Query Support", () => {
         await pm.dashboardPanelActions.waitForChartToRender().catch(() => {});
         await pm.dashboardPanelActions.verifyChartRenders(expect);
         await expect(
-          page.locator('[data-test="dashboard-error"]').first()
+          pm.dashboardPanelActions.getDashboardErrorLocator()
         ).not.toBeVisible({ timeout: 5000 });
 
         // Inspector should show at least 2 SELECT statements (one per query)
@@ -1581,14 +1575,10 @@ test.describe("Multi-SQL Query Support", () => {
         // Verify the VRL toggle is still ON for Q1 (persisted with panel).
         // When VRL is saved, the toggle stays on when the panel is reopened.
         await msql.switchToQueryTab(0);
-        const vrlEditorQ1 = page.locator(
-          '[data-test="dashboard-vrl-function-editor"]'
-        );
+        const vrlEditorQ1 = pm.chartTypeSelector.vrlFunctionEditor;
         // If toggle was NOT persisted, click it to show editor
         if (!(await vrlEditorQ1.isVisible().catch(() => false))) {
-          await page
-            .locator('[data-test="logs-search-bar-show-query-toggle-btn"]')
-            .click();
+          await pm.chartTypeSelector.vrlToggleBtn.click();
           await vrlEditorQ1.waitFor({ state: "visible", timeout: 10000 });
         } else {
           // Toggle IS persisted — VRL survived save/reopen
@@ -1680,11 +1670,7 @@ test.describe("Multi-SQL Query Support", () => {
           await pm.dateTimeHelper.setRelativeTimeRange("2-d");
           await searchDone;
 
-          await expect(
-            page
-              .locator('[data-test="panel-max-duration-warning"]')
-              .first()
-          ).toBeVisible({ timeout: 30000 });
+          await expect(mqr.warningIcon.first()).toBeVisible({ timeout: 30000 });
 
           await cleanupTestDashboard(page, pm, dashboardName);
         }
@@ -1734,9 +1720,7 @@ test.describe("Multi-SQL Query Support", () => {
           await allSearchDone;
 
           // Warning icon must be visible
-          const warningIcon = page
-            .locator('[data-test="panel-max-duration-warning"]')
-            .first();
+          const warningIcon = mqr.warningIcon.first();
           await expect(warningIcon).toBeVisible({ timeout: 30000 });
 
           // Hover to read tooltip
@@ -1798,11 +1782,7 @@ test.describe("Multi-SQL Query Support", () => {
           await pm.dateTimeHelper.setRelativeTimeRange("2-d");
           await searchDone;
 
-          await expect(
-            page
-              .locator('[data-test="panel-max-duration-warning"]')
-              .first()
-          ).toBeVisible({ timeout: 30000 });
+          await expect(mqr.warningIcon.first()).toBeVisible({ timeout: 30000 });
 
           const tooltipText = await mqr.getWarningTooltipText();
           expect(tooltipText).toContain("Data returned for:");
@@ -1860,7 +1840,7 @@ test.describe("Multi-SQL Query Support", () => {
           await pm.dashboardPanelActions.waitForChartToRender().catch(() => {});
 
           await expect(
-            page.locator('[data-test="panel-max-duration-warning"]').first()
+            mqr.warningIcon.first()
           ).not.toBeVisible({ timeout: 5000 });
 
           await cleanupTestDashboard(page, pm, dashboardName);
@@ -1910,11 +1890,7 @@ test.describe("Multi-SQL Query Support", () => {
           await searchDoneWide;
 
           // Warning must be visible with the wide range
-          await expect(
-            page
-              .locator('[data-test="panel-max-duration-warning"]')
-              .first()
-          ).toBeVisible({ timeout: 30000 });
+          await expect(mqr.warningIcon.first()).toBeVisible({ timeout: 30000 });
 
           // Switch to 1-hour range — within both limits
           await waitForDateTimeButtonToBeEnabled(page);
@@ -1925,7 +1901,7 @@ test.describe("Multi-SQL Query Support", () => {
 
           // Warning must disappear
           await expect(
-            page.locator('[data-test="panel-max-duration-warning"]').first()
+            mqr.warningIcon.first()
           ).not.toBeVisible({ timeout: 10000 });
 
           await cleanupTestDashboard(page, pm, dashboardName);

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-multi-y-axis.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-multi-y-axis.spec.js
@@ -67,27 +67,24 @@ test.describe("dashboard multi y axis testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open the query inspector and verify the SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.openDataViewQueryInspector();
     await page.waitForTimeout(1000);
     // Verify the query is displayed in the Query Inspector
     await expect(
-      page.locator('.inspector-query-editor').filter({
-        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", kubernetes_labels_name as "breakdown_1" FROM "e2e_automate" GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC',
-        })
-        .first()
+      pm.dashboardPanelEdit.getInspectorQueryByText(
+        'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", kubernetes_labels_name as "breakdown_1" FROM "e2e_automate" GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC'
+      )
     ).toBeVisible();
 
     // Close the query inspector
-    await page.locator('[data-test="query-inspector-dialog"] [data-test="o-dialog-close-btn"]').click();
+    await pm.dashboardPanelEdit.closeQueryInspector();
 
     // Add the panel name and save the panel
     await pm.dashboardPanelActions.addPanelName(panelName);
     await pm.dashboardPanelActions.savePanel();
 
     // Go back to the dashboard list and delete the created dashboard
-    await page.locator('[data-test="dashboard-back-btn"]').click();
+    await pm.dashboardCreate.backToDashboardList();
     await deleteDashboard(page, randomDashboardName);
   });
 
@@ -131,19 +128,16 @@ test.describe("dashboard multi y axis testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open the query inspector and verify the SQL query
-    await page
-      .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-      .click();
+    await pm.dashboardPanelEdit.openDataViewQueryInspector();
     // Verify the query is displayed in the Query Inspector
     await expect(
-      page.locator('.inspector-query-editor').filter({
-        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", kubernetes_labels_name as "breakdown_1" FROM "e2e_automate" GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC',
-        })
-        .first()
+      pm.dashboardPanelEdit.getInspectorQueryByText(
+        'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", kubernetes_labels_name as "breakdown_1" FROM "e2e_automate" GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC'
+      )
     ).toBeVisible();
 
     // Close the query inspector
-    await page.locator('[data-test="query-inspector-dialog"] [data-test="o-dialog-close-btn"]').click();
+    await pm.dashboardPanelEdit.closeQueryInspector();
 
     // Edit the panel to add another field to Y-axis
     await pm.dashboardPanelActions.addPanelName(panelName);
@@ -160,7 +154,7 @@ test.describe("dashboard multi y axis testcases", () => {
     await pm.dashboardPanelActions.savePanel();
 
     // Go back to the dashboard list and delete the created dashboard
-    await page.locator('[data-test="dashboard-back-btn"]').click();
+    await pm.dashboardCreate.backToDashboardList();
     await deleteDashboard(page, randomDashboardName);
   });
 });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-multi-y-axis.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-multi-y-axis.spec.js
@@ -67,7 +67,7 @@ test.describe("dashboard multi y axis testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open the query inspector and verify the SQL query
-    await pm.dashboardPanelEdit.openDataViewQueryInspector();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
     await page.waitForTimeout(1000);
     // Verify the query is displayed in the Query Inspector
     await expect(
@@ -128,7 +128,7 @@ test.describe("dashboard multi y axis testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Open the query inspector and verify the SQL query
-    await pm.dashboardPanelEdit.openDataViewQueryInspector();
+    await pm.dashboardPanelEdit.clickDataViewQueryInspector();
     // Verify the query is displayed in the Query Inspector
     await expect(
       pm.dashboardPanelEdit.getInspectorQueryByText(

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-mustache-variables.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-mustache-variables.spec.js
@@ -124,7 +124,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable
         await pm.dashboardSetting.openSetting();
@@ -140,19 +140,13 @@ test.describe(
         await pm.chartTypeSelector.selectChartType("html");
         await pm.dashboardTimeRefresh.setRelative("30", "m");
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".monaco-editor")
-          .click();
+        await pm.dashboardVariables.clickHtmlEditor();
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".inputarea")
-          .fill(MUSTACHE_HTML_SNIPPET);
+        await pm.dashboardVariables.fillHtmlEditor(MUSTACHE_HTML_SNIPPET);
 
         // Verify heading renders
         await expect(
-          page.locator('[data-test="mustache-heading"]')
+          pm.dashboardVariables.getHtmlContentLocator("mustache-heading")
         ).toBeVisible();
 
         // Wait for values stream and select a value
@@ -167,7 +161,7 @@ test.describe(
 
         // Verify the mustache variable was substituted with the selected value
         await expect(
-          page.locator('[data-test="mustache-value"]')
+          pm.dashboardVariables.getHtmlContentLocator("mustache-value")
         ).toBeVisible();
 
         testLogger.info(
@@ -203,7 +197,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable
         await pm.dashboardSetting.openSetting();
@@ -219,19 +213,13 @@ test.describe(
         await pm.chartTypeSelector.selectChartType("html");
         await pm.dashboardTimeRefresh.setRelative("30", "m");
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".monaco-editor")
-          .click();
+        await pm.dashboardVariables.clickHtmlEditor();
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".inputarea")
-          .fill(DOLLAR_SIGN_HTML_SNIPPET);
+        await pm.dashboardVariables.fillHtmlEditor(DOLLAR_SIGN_HTML_SNIPPET);
 
         // Verify heading renders
         await expect(
-          page.locator('[data-test="dollar-heading"]')
+          pm.dashboardVariables.getHtmlContentLocator("dollar-heading")
         ).toBeVisible();
 
         // Wait for values stream and select a value
@@ -246,7 +234,7 @@ test.describe(
 
         // Verify the dollar-sign variable was substituted with the selected value
         await expect(
-          page.locator('[data-test="dollar-value"]')
+          pm.dashboardVariables.getHtmlContentLocator("dollar-value")
         ).toBeVisible();
 
         testLogger.info(
@@ -282,7 +270,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable
         await pm.dashboardSetting.openSetting();
@@ -298,19 +286,13 @@ test.describe(
         await pm.chartTypeSelector.selectChartType("html");
         await pm.dashboardTimeRefresh.setRelative("30", "m");
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".monaco-editor")
-          .click();
+        await pm.dashboardVariables.clickHtmlEditor();
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".inputarea")
-          .fill(MIXED_SYNTAX_HTML_SNIPPET);
+        await pm.dashboardVariables.fillHtmlEditor(MIXED_SYNTAX_HTML_SNIPPET);
 
         // Verify heading renders
         await expect(
-          page.locator('[data-test="mixed-heading"]')
+          pm.dashboardVariables.getHtmlContentLocator("mixed-heading")
         ).toBeVisible();
 
         // Wait for values stream and select a value
@@ -325,7 +307,7 @@ test.describe(
 
         // Verify both mustache and dollar-sign were substituted
         // The rendered output should contain "controller and controller"
-        const renderer = page.locator('[data-test="html-renderer"]');
+        const renderer = pm.dashboardVariables.getHtmlContentLocator("html-renderer");
         const renderedText = await renderer.textContent();
 
         // Both occurrences should be replaced with "controller"
@@ -367,19 +349,13 @@ test.describe(
         await pm.dashboardCreate.addPanel();
         await pm.chartTypeSelector.selectChartType("html");
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".monaco-editor")
-          .click();
+        await pm.dashboardVariables.clickHtmlEditor();
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".inputarea")
-          .fill(UNDEFINED_MUSTACHE_HTML_SNIPPET);
+        await pm.dashboardVariables.fillHtmlEditor(UNDEFINED_MUSTACHE_HTML_SNIPPET);
 
         // Verify the undefined mustache variable remains as literal text
         await expect(
-          page.locator('[data-test="undefined-var-text"]')
+          pm.dashboardVariables.getHtmlContentLocator("undefined-var-text")
         ).toBeVisible();
 
         testLogger.info(
@@ -415,7 +391,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable
         await pm.dashboardSetting.openSetting();
@@ -455,7 +431,7 @@ test.describe(
         await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
         // Verify no error toast appeared — check for OToast error elements
-        const errorToast = page.locator('[data-test-variant="error"]');
+        const errorToast = pm.dashboardVariables.getErrorToastLocator();
         const errorCount = await errorToast.count();
 
         // We expect no errors since the mustache variable should be substituted
@@ -492,7 +468,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable and select a value
         await pm.dashboardSetting.openSetting();
@@ -609,7 +585,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable
         await pm.dashboardSetting.openSetting();
@@ -625,19 +601,13 @@ test.describe(
         await pm.chartTypeSelector.selectChartType("html");
         await pm.dashboardTimeRefresh.setRelative("30", "m");
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".monaco-editor")
-          .click();
+        await pm.dashboardVariables.clickHtmlEditor();
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".inputarea")
-          .fill(SPACED_MUSTACHE_HTML_SNIPPET);
+        await pm.dashboardVariables.fillHtmlEditor(SPACED_MUSTACHE_HTML_SNIPPET);
 
         // Verify heading renders
         await expect(
-          page.locator('[data-test="spaced-mustache-heading"]')
+          pm.dashboardVariables.getHtmlContentLocator("spaced-mustache-heading")
         ).toBeVisible();
 
         // Wait for values stream and select a value
@@ -652,7 +622,7 @@ test.describe(
 
         // Verify the spaced mustache variable was substituted with the selected value
         await expect(
-          page.locator('[data-test="spaced-mustache-value"]')
+          pm.dashboardVariables.getHtmlContentLocator("spaced-mustache-value")
         ).toBeVisible();
 
         testLogger.info(
@@ -690,7 +660,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable
         await pm.dashboardSetting.openSetting();
@@ -706,19 +676,13 @@ test.describe(
         await pm.chartTypeSelector.selectChartType("html");
         await pm.dashboardTimeRefresh.setRelative("30", "m");
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".monaco-editor")
-          .click();
+        await pm.dashboardVariables.clickHtmlEditor();
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".inputarea")
-          .fill(SPACED_DOLLAR_BRACE_HTML_SNIPPET);
+        await pm.dashboardVariables.fillHtmlEditor(SPACED_DOLLAR_BRACE_HTML_SNIPPET);
 
         // Verify heading renders
         await expect(
-          page.locator('[data-test="spaced-dollar-heading"]')
+          pm.dashboardVariables.getHtmlContentLocator("spaced-dollar-heading")
         ).toBeVisible();
 
         // Wait for values stream and select a value
@@ -733,7 +697,7 @@ test.describe(
 
         // Verify the spaced dollar-brace variable was substituted with the selected value
         await expect(
-          page.locator('[data-test="spaced-dollar-value"]')
+          pm.dashboardVariables.getHtmlContentLocator("spaced-dollar-value")
         ).toBeVisible();
 
         testLogger.info(
@@ -771,7 +735,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable
         await pm.dashboardSetting.openSetting();
@@ -787,19 +751,13 @@ test.describe(
         await pm.chartTypeSelector.selectChartType("html");
         await pm.dashboardTimeRefresh.setRelative("30", "m");
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".monaco-editor")
-          .click();
+        await pm.dashboardVariables.clickHtmlEditor();
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".inputarea")
-          .fill(MIXED_SPACED_HTML_SNIPPET);
+        await pm.dashboardVariables.fillHtmlEditor(MIXED_SPACED_HTML_SNIPPET);
 
         // Verify heading renders
         await expect(
-          page.locator('[data-test="mixed-spaced-heading"]')
+          pm.dashboardVariables.getHtmlContentLocator("mixed-spaced-heading")
         ).toBeVisible();
 
         // Wait for values stream and select a value
@@ -814,7 +772,7 @@ test.describe(
 
         // Verify both spaced {{ var }} and non-spaced {{var}} were substituted
         // The rendered output should contain "controller and controller"
-        const renderer = page.locator('[data-test="html-renderer"]');
+        const renderer = pm.dashboardVariables.getHtmlContentLocator("html-renderer");
         const renderedText = await renderer.textContent();
 
         expect(renderedText).toContain("controller and controller");
@@ -854,7 +812,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable
         await pm.dashboardSetting.openSetting();
@@ -894,7 +852,7 @@ test.describe(
         await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
         // Verify no error toast appeared — check for OToast error elements
-        const errorToast = page.locator('[data-test-variant="error"]');
+        const errorToast = pm.dashboardVariables.getErrorToastLocator();
         const errorCount = await errorToast.count();
 
         // We expect no errors since the spaced mustache variable should be normalized and substituted
@@ -935,7 +893,7 @@ test.describe(
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
 
-        await page.locator('[data-test="dashboard-setting-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardVariables.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
         // Add a variable
         await pm.dashboardSetting.openSetting();
@@ -951,19 +909,13 @@ test.describe(
         await pm.chartTypeSelector.selectChartType("html");
         await pm.dashboardTimeRefresh.setRelative("30", "m");
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".monaco-editor")
-          .click();
+        await pm.dashboardVariables.clickHtmlEditor();
 
-        await page
-          .locator('[data-test="dashboard-html-editor"]')
-          .locator(".inputarea")
-          .fill(EXCESSIVE_SPACES_HTML_SNIPPET);
+        await pm.dashboardVariables.fillHtmlEditor(EXCESSIVE_SPACES_HTML_SNIPPET);
 
         // Verify heading renders
         await expect(
-          page.locator('[data-test="excessive-spaces-heading"]')
+          pm.dashboardVariables.getHtmlContentLocator("excessive-spaces-heading")
         ).toBeVisible();
 
         // Wait for values stream and select a value
@@ -978,7 +930,7 @@ test.describe(
 
         // Verify the excessively-spaced mustache variable was substituted
         await expect(
-          page.locator('[data-test="excessive-value"]')
+          pm.dashboardVariables.getHtmlContentLocator("excessive-value")
         ).toBeVisible();
 
         testLogger.info(

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-config-behavior.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-config-behavior.spec.js
@@ -58,7 +58,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Add a basic panel using helper (panel time disabled initially)
     let panelId = await addPanelWithPanelTime(page, pm, {
@@ -76,14 +76,14 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await assertPanelTimeToggleState(page, true);
 
     // Step 4: Verify "+Set" button appears with "Default Duration" title
-    const setButton = page.locator('[data-test="dashboard-config-set-panel-time"]');
+    const setButton = pm.dashboardPanelTime.getSetPanelTimeBtn();
     await expect(setButton).toBeVisible();
 
     // Step 5: Click "+Set" button to open date time picker
     await setButton.click();
 
     // Step 6: Verify date time picker is visible
-    const timePicker = page.locator('[data-test="dashboard-config-panel-time-picker"]');
+    const timePicker = pm.dashboardPanelTime.getConfigPanelTimePicker();
     await expect(timePicker).toBeVisible();
 
     // Step 7: Select "Last 1h" in the config picker
@@ -91,11 +91,11 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
 
     // Step 8: Click the global Apply button (at top of panel edit screen)
     // Note: Config picker doesn't have its own Apply button, uses global one
-    await page.locator('[data-test="dashboard-apply"]').click();
+    await pm.dashboardCreate.applyButton();
 
     // Step 9: Verify "Last 1h" is shown with Cancel button, "+Set" hidden
     await expect(setButton).not.toBeVisible();
-    const cancelButton = page.locator('[data-test="dashboard-config-cancel-panel-time"]');
+    const cancelButton = pm.dashboardPanelTime.getCancelPanelTimeBtn();
     await expect(cancelButton).toBeVisible();
 
     // Step 10: Click Cancel (X) button to clear panel_time_range
@@ -133,7 +133,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Add a basic panel without panel time
     let panelId = await addPanelWithPanelTime(page, pm, {
@@ -149,13 +149,13 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelTime.enablePanelTime();
 
     // Click "+Set" button
-    await page.locator('[data-test="dashboard-config-set-panel-time"]').click();
+    await pm.dashboardPanelTime.getSetPanelTimeBtn().click();
 
     // Select "Last 1h" in config picker
     await pm.dashboardPanelTime.setPanelTimeRelative("1-h");
 
     // Click global Apply button
-    await page.locator('[data-test="dashboard-apply"]').click();
+    await pm.dashboardCreate.applyButton();
 
     // Save panel
     await savePanel(page);
@@ -168,16 +168,16 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Click Cancel to clear current time
-    await page.locator('[data-test="dashboard-config-cancel-panel-time"]').click();
+    await pm.dashboardPanelTime.getCancelPanelTimeBtn().click();
 
     // Click "+Set" button
-    await page.locator('[data-test="dashboard-config-set-panel-time"]').click();
+    await pm.dashboardPanelTime.getSetPanelTimeBtn().click();
 
     // Select "Last 15m" in config picker
     await pm.dashboardPanelTime.setPanelTimeRelative("15-m");
 
     // Click global Apply button (config picker uses global Apply)
-    await page.locator('[data-test="dashboard-apply"]').click();
+    await pm.dashboardCreate.applyButton();
 
     await savePanel(page);
 
@@ -186,16 +186,16 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Click Cancel to clear current time
-    await page.locator('[data-test="dashboard-config-cancel-panel-time"]').click();
+    await pm.dashboardPanelTime.getCancelPanelTimeBtn().click();
 
     // Click "+Set" button
-    await page.locator('[data-test="dashboard-config-set-panel-time"]').click();
+    await pm.dashboardPanelTime.getSetPanelTimeBtn().click();
 
     // Select "Last 6d" in config picker
     await pm.dashboardPanelTime.setPanelTimeRelative("6-d");
 
     // Click global Apply button
-    await page.locator('[data-test="dashboard-apply"]').click();
+    await pm.dashboardCreate.applyButton();
 
     await savePanel(page);
 
@@ -207,16 +207,16 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Click Cancel to clear current time
-    await page.locator('[data-test="dashboard-config-cancel-panel-time"]').click();
+    await pm.dashboardPanelTime.getCancelPanelTimeBtn().click();
 
     // Click "+Set" button
-    await page.locator('[data-test="dashboard-config-set-panel-time"]').click();
+    await pm.dashboardPanelTime.getSetPanelTimeBtn().click();
 
     // Set absolute time in config picker
     await pm.dashboardPanelTime.setPanelTimeAbsolute("1", "1");
 
     // Click global Apply button
-    await page.locator('[data-test="dashboard-apply"]').click();
+    await pm.dashboardCreate.applyButton();
 
     await savePanel(page);
 
@@ -236,7 +236,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Create basic panel without panel time enabled
     let panelId = await addPanelWithPanelTime(page, pm, {
@@ -254,7 +254,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelTime.enablePanelTime();
 
     // Verify "+Set" button appears
-    const setButton = page.locator('[data-test="dashboard-config-set-panel-time"]');
+    const setButton = pm.dashboardPanelTime.getSetPanelTimeBtn();
     await expect(setButton).toBeVisible();
 
     // Click "+Set" button to open date time picker
@@ -264,7 +264,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelTime.setPanelTimeRelative("1-h");
 
     // Click the global Apply button (at top of panel edit screen)
-    await page.locator('[data-test="dashboard-apply"]').click();
+    await pm.dashboardCreate.applyButton();
 
     // Save panel
     await savePanel(page);
@@ -275,7 +275,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     // Open config panel sidebar
     await pm.dashboardPanelConfigs.openConfigPanel();
     // Step 3: Verify top date time picker shows "Last 1h" (NOT global time)
-    const pickerText = await page.locator('[data-test="dashboard-config-panel-time-picker"]').textContent();
+    const pickerText = await pm.dashboardPanelTime.getConfigPanelTimePickerText();
     expect(pickerText).toContain("1");
     expect(pickerText.toLowerCase()).toContain("hour");
 
@@ -284,16 +284,16 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelTime.setPanelTimeRelative("6-d");
 
     // Click the global Apply button (required for config time changes)
-    await page.locator('[data-test="dashboard-apply"]').click();
+    await pm.dashboardCreate.applyButton();
 
-    await page.locator('[data-test="dashboard-panel-save"]').click();
+    await pm.dashboardPanelActions.getPanelSaveBtn().click();
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
     // Step 5: Edit panel again
     await editPanel(page, panelName);
     await pm.dashboardPanelConfigs.openConfigPanel();
     // Step 6: Verify picker shows "Last 6d"
-    const pickerText2 = await page.locator('[data-test="dashboard-config-panel-time-picker"]').textContent();
+    const pickerText2 = await pm.dashboardPanelTime.getConfigPanelTimePickerText();
     expect(pickerText2).toContain("6");
     expect(pickerText2.toLowerCase()).toContain("day");
 
@@ -303,7 +303,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
       expect(dialog.message()).toContain("unsaved changes");
       await dialog.accept();
     });
-    await page.locator('[data-test="dashboard-panel-discard"]').click().catch(() => {});
+    await pm.dashboardPanelTime.clickPanelDiscard();
     await page.waitForLoadState('networkidle', { timeout: 3000 }).catch(() => {});
 
     // Step 9: Edit panel without panel time config
@@ -314,7 +314,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     await pm.dashboardPanelTime.disablePanelTime();
-    await page.locator('[data-test="dashboard-panel-save"]').click();
+    await pm.dashboardPanelActions.getPanelSaveBtn().click();
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
     // Step 10: Edit again and verify panel time picker is NOT in config sidebar
@@ -323,7 +323,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Verify panel time picker is NOT present in config because panel time is disabled
-    const panelTimePickerInConfig = page.locator('[data-test="dashboard-config-panel-time-picker"]');
+    const panelTimePickerInConfig = pm.dashboardPanelTime.getConfigPanelTimePicker();
     await expect(panelTimePickerInConfig).not.toBeVisible();
 
     // Cleanup
@@ -332,7 +332,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
       expect(dialog.message()).toContain("unsaved changes");
       await dialog.accept();
     });
-    await page.locator('[data-test="dashboard-panel-discard"]').click().catch(() => {});
+    await pm.dashboardPanelTime.clickPanelDiscard();
     await page.waitForLoadState('networkidle', { timeout: 3000 }).catch(() => {});
     await cleanupDashboard(page, pm, dashboardName);
   });
@@ -347,7 +347,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Panel A: panel_time_enabled: true with individual time "Last 1h"
     const panelAId = await addPanelWithPanelTime(page, pm, {
@@ -372,11 +372,11 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await pm.dashboardPanelTime.clickPanelTimePicker(panelAId);
 
     // Verify dropdown opens
-    await page.locator('#date-time-menu').waitFor({ state: "visible", timeout: 5000 });
+    await pm.dashboardPanelTime.waitForDateTimeMenuVisible(5000);
 
     // Step 5: Press Escape to close
     await page.keyboard.press('Escape');
-    await page.locator('#date-time-menu').waitFor({ state: "hidden", timeout: 3000 }).catch(() => {});
+    await pm.dashboardPanelTime.waitForDateTimeMenuHidden(3000);
 
     // Wait for initial pt-period URL param to land before changing time — ensures
     // panelsInitializing guard in RenderDashboardCharts has cleared.
@@ -422,7 +422,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
 
     // Step 2: Click panel picker, select "Last 6 days"
     await pm.dashboardPanelTime.clickPanelTimePicker(panelId);
-    await page.locator('[data-test="date-time-relative-6-d-btn"]').click();
+    await pm.dashboardPanelTime.clickDateTimeRelative("6-d");
 
     // Step 3: Verify panel data does NOT refresh yet
     await assertPanelDataNotRefreshed(page, 2000);
@@ -431,7 +431,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     expect(page.url()).toBe(initialURL);
 
     // Step 5: Click Apply button
-    await page.locator('[data-test="date-time-apply-btn"]').click();
+    await pm.dashboardPanelTime.clickDateTimeApplyBtn();
 
     // Step 6: Verify API call fires immediately
     await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
@@ -443,8 +443,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     expect(page.url()).not.toBe(initialURL);
 
     // Step 9: Open Query Inspector from panel dropdown menu in View Dashboard
-    await page.locator(`[data-test="dashboard-edit-panel-${panelName}-dropdown"]`).click();
-    await page.locator('[data-test="dashboard-query-inspector-panel"]').click();
+    await pm.dashboardPanelActions.selectPanelAction(panelName, "Inspector");
     await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
 
     // Step 10: Verify query inspector shows new time (6d, not the old 1h)
@@ -468,7 +467,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Panel A: useDefaultTime enabled with panel_time_range set to "Last 1h" (custom time via +Set)
     const panelAId = await addPanelWithPanelTime(page, pm, {
@@ -507,13 +506,13 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await assertPanelTimeInURL(page, panelBId, "15m");
 
     // Step 3: Verify Panel A picker shows "Last 1h" (has custom time)
-    const panelAText = await page.locator(`[data-test="panel-time-picker-${panelAId}"]`).textContent();
+    const panelAText = await pm.dashboardPanelTime.panelTimePicker(panelAId).textContent();
     expect(panelAText).toContain("1");
     expect(panelAText.toLowerCase()).toContain("hour");
 
     // Step 4: Verify Panel B has picker visible showing "15m" (initial global time)
     await assertPanelTimePickerVisible(page, panelBId);
-    const panelBText = await page.locator(`[data-test="panel-time-picker-${panelBId}"]`).textContent();
+    const panelBText = await pm.dashboardPanelTime.panelTimePicker(panelBId).textContent();
     expect(panelBText).toContain("15");
     expect(panelBText.toLowerCase()).toContain("minute");
 
@@ -528,7 +527,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await assertPanelTimeInURL(page, panelAId, "6d");
 
     // Step 8: Verify Panel A picker updated to show "6d"
-    const panelATextAfter = await page.locator(`[data-test="panel-time-picker-${panelAId}"]`).textContent();
+    const panelATextAfter = await pm.dashboardPanelTime.panelTimePicker(panelAId).textContent();
     expect(panelATextAfter).toContain("6");
     expect(panelATextAfter.toLowerCase()).toContain("day");
 
@@ -556,7 +555,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Step 2: Add global variable
     await pm.dashboardSetting.openSetting();
@@ -567,7 +566,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
       "kubernetes_container_name",
       { scope: "global" }
     );
-    await page.locator(getEditVariableBtn(globalVariableName)).waitFor({ state: "visible", timeout: 15000 });
+    await pm.dashboardVariablesScoped.getEditVariableBtnLocator(globalVariableName).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await pm.dashboardSetting.closeSettingWindow();
     await safeWaitForHidden(page, SELECTORS.DIALOG, { timeout: 5000 });
@@ -589,7 +588,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
       "kubernetes_namespace_name",
       { scope: "panels", assignedPanels: [panelName] }
     );
-    await page.locator(getEditVariableBtn(panelVariableName)).waitFor({ state: "visible", timeout: 15000 });
+    await pm.dashboardVariablesScoped.getEditVariableBtnLocator(panelVariableName).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await pm.dashboardSetting.closeSettingWindow();
     await safeWaitForHidden(page, SELECTORS.DIALOG, { timeout: 5000 });
@@ -606,10 +605,10 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await assertPanelTimeInURL(page, panelAId, "1h");
 
     // Step 6: Verify panel variable is visible
-    await page.locator(getVariableSelector(panelVariableName)).waitFor({ state: "visible", timeout: 10000 });
+    await pm.dashboardVariablesScoped.getVariableSelectorLocator(panelVariableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Step 7: Change Panel A's panel variable
-    const panelVariableDropdown = page.locator(getVariableSelector(panelVariableName));
+    const panelVariableDropdown = pm.dashboardVariablesScoped.getVariableSelectorLocator(panelVariableName);
     await panelVariableDropdown.waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -639,7 +638,7 @@ test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior",
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Step 12: Test global variable uses global time (not panel time)
-    const globalVariableDropdown = page.locator(getVariableSelector(globalVariableName));
+    const globalVariableDropdown = pm.dashboardVariablesScoped.getVariableSelectorLocator(globalVariableName);
     await globalVariableDropdown.waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-url-priority.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-url-priority.spec.js
@@ -215,7 +215,7 @@ test.describe("Dashboard Panel Time - Part 2: URL Synchronization and Priority",
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Panel A: config "1h"
     const panelAId = await addPanelWithPanelTime(page, pm, {
@@ -235,7 +235,7 @@ test.describe("Dashboard Panel Time - Part 2: URL Synchronization and Priority",
     await assertPanelTimeInURL(page, panelAId, "1h");
 
     // Step 4: Verify Panel B has no picker (uses global)
-    const panelBPicker = page.locator(`[data-test="panel-time-picker-${panelBId}"]`);
+    const panelBPicker = pm.dashboardPanelTime.panelTimePicker(panelBId);
     expect(await panelBPicker.isVisible().catch(() => false)).toBe(false);
 
     // Step 6: Load with URL override for Panel A
@@ -261,7 +261,7 @@ test.describe("Dashboard Panel Time - Part 2: URL Synchronization and Priority",
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Panel A: useDefaultTime enabled but panel_time_range is null (follows global)
     // v4.0: toggle ON but no +Set done yet = follows global time as-is
@@ -280,7 +280,7 @@ test.describe("Dashboard Panel Time - Part 2: URL Synchronization and Priority",
     });
 
     // Step 2: Verify Panel A shows picker and follows global (panel_time_range is null)
-    const panelAPicker = page.locator(`[data-test="panel-time-picker-${panelAId}"]`);
+    const panelAPicker = pm.dashboardPanelTime.panelTimePicker(panelAId);
     expect(await panelAPicker.isVisible()).toBe(true);
 
     // Step 3: Load with URL param for Panel A

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-variables-behavior.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-variables-behavior.spec.js
@@ -41,19 +41,13 @@ test.describe("Dashboard Panel Time - Variables Time Behavior", () => {
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({
-      state: "visible",
-      timeout: 10000
-    });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible(10000);
 
     // Step 2: Add a query-based variable to the dashboard
     await dashboardVariables.addQueryVariable(variableName);
 
     // Wait for dashboard to be ready after variable addition
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({
-      state: "visible",
-      timeout: 10000
-    });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible(10000);
 
     // Step 3: Add panel with useDefaultTime enabled and panel_time_range set to "Last 1h"
     // This config is for VIEW MODE ONLY in v4.0
@@ -115,19 +109,13 @@ test.describe("Dashboard Panel Time - Variables Time Behavior", () => {
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({
-      state: "visible",
-      timeout: 10000
-    });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible(10000);
 
     // Step 2: Add a query-based variable to the dashboard
     await dashboardVariables.addQueryVariable(variableName);
 
     // Wait for dashboard to be ready after variable addition
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({
-      state: "visible",
-      timeout: 10000
-    });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible(10000);
 
     // Step 3: Add panel with useDefaultTime enabled and panel_time_range set to "Last 1h"
     // This config is for VIEW MODE ONLY in v4.0
@@ -193,19 +181,13 @@ test.describe("Dashboard Panel Time - Variables Time Behavior", () => {
     await waitForDashboardPage(page);
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({
-      state: "visible",
-      timeout: 10000
-    });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible(10000);
 
     // Step 2: Add a query-based variable to the dashboard
     await dashboardVariables.addQueryVariable(variableName);
 
     // Wait for dashboard to be ready after variable addition
-    await page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]').waitFor({
-      state: "visible",
-      timeout: 10000
-    });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible(10000);
 
     // Step 3: Add panel WITHOUT useDefaultTime enabled (no panel time feature)
     // v4.0: useDefaultTime is false/undefined, panel behaves like main branch

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-pie-donut.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-pie-donut.spec.js
@@ -103,7 +103,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
     await reopenPanelConfig(page, pm);
 
     // Verify chart type is still pie
-    const pieSelector = page.locator('[data-test="selected-chart-pie-item"]');
+    const pieSelector = pm.chartTypeSelector.getSelectedChartItem("pie");
     await expect(pieSelector).toBeVisible();
     testLogger.info("Pie chart type persisted after reopen");
 
@@ -129,7 +129,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
     await pm.dashboardPanelActions.savePanel();
     await reopenPanelConfig(page, pm);
 
-    const donutSelector = page.locator('[data-test="selected-chart-donut-item"]');
+    const donutSelector = pm.chartTypeSelector.getSelectedChartItem("donut");
     await expect(donutSelector).toBeVisible();
     testLogger.info("Donut chart type persisted after reopen");
 
@@ -188,7 +188,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
     await pm.dashboardPanelActions.applyDashboardBtn();
     await pm.dashboardPanelActions.waitForChartToRender().catch((e) => testLogger.warn("waitForChartToRender:", e.message));
     await pm.dashboardPanelActions.verifyChartRenders(expect);
-    await expect(page.locator('[data-test="selected-chart-donut-item"]')).toBeVisible();
+    await expect(pm.chartTypeSelector.getSelectedChartItem("donut")).toBeVisible();
     testLogger.info("verifyChartRenders passed - donut after switch", { coloredPixels: await getPlottedPixelCount(page) });
 
     // Switch back to pie
@@ -196,7 +196,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
     await pm.dashboardPanelActions.applyDashboardBtn();
     await pm.dashboardPanelActions.waitForChartToRender().catch((e) => testLogger.warn("waitForChartToRender:", e.message));
     await pm.dashboardPanelActions.verifyChartRenders(expect);
-    await expect(page.locator('[data-test="selected-chart-pie-item"]')).toBeVisible();
+    await expect(pm.chartTypeSelector.getSelectedChartItem("pie")).toBeVisible();
     testLogger.info("verifyChartRenders passed - pie after switch back", { coloredPixels: await getPlottedPixelCount(page) });
 
     await pm.dashboardPanelActions.savePanel();
@@ -279,7 +279,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
     await pm.dashboardPanelActions.savePanel();
 
     // Hover over panel bar to reveal legend button
-    const panelBar = page.locator('[data-test="dashboard-panel-bar"]').first();
+    const panelBar = pm.dashboardPanelTime.getPanelBar().first();
     await panelBar.waitFor({ state: "visible", timeout: 10000 });
     await panelBar.hover();
 
@@ -289,12 +289,12 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
 
     if (isLegendBtnVisible) {
       await legendBtn.click();
-      const legendPopup = page.locator('[data-test="dashboard-show-legends-popup"]');
+      const legendPopup = pm.dashboardLegendsCopy.getLegendsPopup();
       await expect(legendPopup).toBeVisible({ timeout: 5000 });
       testLogger.info("Legend popup is visible");
 
       // Verify at least one legend item exists
-      const legendItem = page.locator('[data-test^="dashboard-legend-item-"]');
+      const legendItem = pm.dashboardLegendsCopy.getLegendItems();
       expect(await legendItem.count()).toBeGreaterThan(0);
       testLogger.info("Legend items found in popup");
 
@@ -349,7 +349,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
 
     await setupPiePanelWithConfig(page, pm, dashboardName, "Pie Description");
 
-    const descriptionInput = page.locator('[data-test="dashboard-config-description-field"]');
+    const descriptionInput = pm.dashboardPanelConfigs.getDescriptionField();
     await expect(descriptionInput).toBeVisible();
     await descriptionInput.fill("Test pie chart description");
     testLogger.info("Description set");
@@ -360,7 +360,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
     await pm.dashboardPanelActions.savePanel();
     await reopenPanelConfig(page, pm);
 
-    await expect(page.locator('[data-test="dashboard-config-description-field"]')).toHaveValue("Test pie chart description");
+    await expect(pm.dashboardPanelConfigs.getDescriptionField()).toHaveValue("Test pie chart description");
     testLogger.info("Description persisted after save and reopen");
 
     await pm.dashboardPanelActions.savePanel();
@@ -436,7 +436,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
 
     // 3. Wait for chart to render in dashboard view then reveal legend button
     await pm.dashboardPanelActions.waitForChartToRender().catch(() => {});
-    const panelBar = page.locator('[data-test="dashboard-panel-bar"]').first();
+    const panelBar = pm.dashboardPanelTime.getPanelBar().first();
     await panelBar.waitFor({ state: "visible", timeout: 10000 });
     await panelBar.hover();
 
@@ -446,7 +446,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
 
     if (isLegendBtnVisible) {
       await legendBtn.click();
-      const legendPopup = page.locator('[data-test="dashboard-show-legends-popup"]');
+      const legendPopup = pm.dashboardLegendsCopy.getLegendsPopup();
       await expect(legendPopup).toBeVisible({ timeout: 5000 });
 
       const legendCount = await pm.dashboardLegendsCopy.getLegendCount();
@@ -488,7 +488,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
     testLogger.info("Pie panel applied without Y-axis field");
 
     // Page should still be functional (no crash) — chart may render empty or show no-data
-    await expect(page.locator('[data-test="dashboard-panel-name"]')).toBeVisible();
+    await expect(pm.dashboardPanelEdit.getPanelNameLocator()).toBeVisible();
     testLogger.info("Page remains functional after apply without Y-axis field", { coloredPixels: await getPlottedPixelCount(page) });
 
     // Navigate to dashboard list (skip savePanel — no valid config to save)
@@ -511,24 +511,24 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
     await pm.dashboardPanelActions.savePanel();
 
     // Open panel in fullscreen
-    const panelBar = page.locator('[data-test="dashboard-panel-bar"]').first();
+    const panelBar = pm.dashboardPanelTime.getPanelBar().first();
     await panelBar.waitFor({ state: "visible", timeout: 10000 });
     await panelBar.hover();
-    const fullscreenBtn = page.locator('[data-test="dashboard-panel-fullscreen-btn"]').first();
+    const fullscreenBtn = pm.dashboardPanelTime.getPanelFullscreenBtn().first();
     await fullscreenBtn.click();
 
     // Verify view panel opens
-    const viewPanel = page.locator('[data-test="view-panel-screen"]');
+    const viewPanel = pm.dashboardPanelTime.getViewPanelScreen();
     await expect(viewPanel).toBeVisible({ timeout: 10000 });
     testLogger.info("Panel opened in fullscreen/view mode");
 
     // Verify chart renders in fullscreen
-    const chartRenderer = page.locator('[data-test="chart-renderer"]').first();
+    const chartRenderer = pm.dashboardPanelActions.getChartRendererCanvas().first();
     await expect(chartRenderer).toBeVisible({ timeout: 15000 });
     testLogger.info("Chart renders in fullscreen view", { coloredPixels: await getPlottedPixelCount(page) });
 
     // Close fullscreen
-    await page.locator('[data-test="dashboard-viewpanel-close-btn"]').click();
+    await pm.dashboardPanelTime.getViewPanelCloseBtn().click();
     testLogger.info("Fullscreen view closed");
 
     await cleanupTestDashboard(page, pm, dashboardName);
@@ -550,7 +550,7 @@ test.describe("Pie & Donut Chart — E2E Tests (SQL Builder / Logs Stream)", () 
     testLogger.info("Pie panel applied without stream selection");
 
     // Page should still be functional (no crash) — chart may render empty or show no-data
-    await expect(page.locator('[data-test="dashboard-panel-name"]')).toBeVisible();
+    await expect(pm.dashboardPanelEdit.getPanelNameLocator()).toBeVisible();
     testLogger.info("Page remains functional after apply without stream selection", { coloredPixels: await getPlottedPixelCount(page) });
 
     // Navigate to dashboard list (skip savePanel — no valid config to save)

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-pivot-table.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-pivot-table.spec.js
@@ -73,9 +73,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       // Search for a field and verify +P is NOT visible for line chart
       await pm.chartTypeSelector.searchField("kubernetes_container_name");
 
-      const pivotButton = page
-        .locator('[data-test="dashboard-add-p-data"]')
-        .first();
+      const pivotButton = pm.chartTypeSelector.pivotAddBtn.first();
       await expect(pivotButton).not.toBeVisible();
 
       testLogger.info("Verified +P button is NOT visible for line chart");
@@ -88,8 +86,8 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
 
       // Hover over the field row to reveal the action buttons (they are hidden
       // by CSS until the row is hovered — see OFieldRow.__actions display:none)
-      const fieldRow = page
-        .locator('[data-test="o-field-list-row-kubernetes_container_name"]')
+      const fieldRow = pm.chartTypeSelector
+        .getFieldListRow("kubernetes_container_name")
         .first();
       await fieldRow.waitFor({ state: "visible", timeout: 5000 });
       await fieldRow.hover();
@@ -149,19 +147,15 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await pm.chartTypeSelector.waitForTableDataLoad();
 
       // Verify pivot table rendered - breakdown layout should show the pivot field
-      const breakdownLayout = page.locator(
-        '[data-test="dashboard-b-layout"]'
-      );
+      const breakdownLayout = pm.chartTypeSelector.breakdownLayout;
       await expect(breakdownLayout).toBeVisible();
 
       // Verify the breakdown item is present
-      const breakdownItem = page.locator(
-        '[data-test="dashboard-b-item-breakdown_1"]'
-      );
+      const breakdownItem = pm.chartTypeSelector.getBreakdownItem(1);
       await expect(breakdownItem).toBeVisible();
 
       // Verify table has data
-      const table = page.locator('[data-test="dashboard-panel-table"]');
+      const table = pm.dashboardPanelActions.dashboardTable;
       await expect(table).toBeVisible();
 
       testLogger.info("Verified basic pivot table renders successfully");
@@ -209,9 +203,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
 
       // Open config panel - pivot options should NOT be visible
       await pm.dashboardPanelConfigs.openConfigPanel();
-      const pivotRowTotals = page.locator(
-        '[data-test="dashboard-config-pivot-row-totals"]'
-      );
+      const pivotRowTotals = pm.dashboardPanelConfigs.pivotRowTotals;
       await expect(pivotRowTotals).not.toBeVisible();
 
       testLogger.info(
@@ -228,9 +220,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await pivotRowTotals.waitFor({ state: "visible", timeout: 10000 });
       await expect(pivotRowTotals).toBeVisible();
 
-      const pivotColTotals = page.locator(
-        '[data-test="dashboard-config-pivot-col-totals"]'
-      );
+      const pivotColTotals = pm.dashboardPanelConfigs.pivotColTotals;
       await expect(pivotColTotals).toBeVisible();
 
       testLogger.info("Verified pivot options appear when pivot mode active");
@@ -278,12 +268,8 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
 
       // Open config panel - verify transpose and dynamic columns are enabled
       await pm.dashboardPanelConfigs.openConfigPanel();
-      const transposeToggle = page.locator(
-        '[data-test="dashboard-config-table_transpose"]'
-      );
-      const dynamicColumnsToggle = page.locator(
-        '[data-test="dashboard-config-table_dynamic_columns"]'
-      );
+      const transposeToggle = pm.dashboardPanelConfigs.transpose;
+      const dynamicColumnsToggle = pm.dashboardPanelConfigs.dynamicColumn;
 
       await expect(transposeToggle).toBeVisible();
       await expect(dynamicColumnsToggle).toBeVisible();
@@ -357,8 +343,8 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await pm.chartTypeSelector.configureYAxisFunction("y_axis_1", "count");
 
       // Check for "First Column" label (non-pivot mode)
-      await expect(page.getByText("First Column")).toBeVisible();
-      await expect(page.getByText("Other Columns")).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("First Column")).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("Other Columns")).toBeVisible();
 
       testLogger.info("Verified non-pivot labels: First Column, Other Columns");
 
@@ -366,8 +352,8 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await pm.chartTypeSelector.searchAndAddField("kubernetes_host", "p");
 
       // Labels should update to pivot mode
-      await expect(page.getByText("Row Fields")).toBeVisible();
-      await expect(page.getByText("Value Fields")).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("Row Fields")).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("Value Fields")).toBeVisible();
 
       testLogger.info("Verified pivot labels: Row Fields, Value Fields");
 
@@ -375,8 +361,8 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await pm.chartTypeSelector.removeField("breakdown_1", "b");
 
       // Labels should revert to non-pivot mode
-      await expect(page.getByText("First Column")).toBeVisible();
-      await expect(page.getByText("Other Columns")).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("First Column")).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("Other Columns")).toBeVisible();
 
       testLogger.info("Verified labels revert when pivot field removed");
 
@@ -426,12 +412,8 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await pm.dashboardPanelConfigs.openConfigPanel();
 
       // Verify pivot options are visible
-      const rowTotalsToggle = page.locator(
-        '[data-test="dashboard-config-pivot-row-totals"]'
-      );
-      const colTotalsToggle = page.locator(
-        '[data-test="dashboard-config-pivot-col-totals"]'
-      );
+      const rowTotalsToggle = pm.dashboardPanelConfigs.pivotRowTotals;
+      const colTotalsToggle = pm.dashboardPanelConfigs.pivotColTotals;
       await expect(rowTotalsToggle).toBeVisible();
       await expect(colTotalsToggle).toBeVisible();
 
@@ -449,9 +431,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       expect(rowTotalsCheckedAfter).toBe(true);
 
       // Sticky column totals sub-option should appear
-      const stickyColTotals = page.locator(
-        '[data-test="dashboard-config-pivot-sticky-col-totals"]'
-      );
+      const stickyColTotals = pm.dashboardPanelConfigs.pivotStickyColTotals;
       await expect(stickyColTotals).toBeVisible();
 
       testLogger.info(
@@ -465,9 +445,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       expect(colTotalsCheckedAfter).toBe(true);
 
       // Sticky row totals sub-option should appear
-      const stickyRowTotals = page.locator(
-        '[data-test="dashboard-config-pivot-sticky-row-totals"]'
-      );
+      const stickyRowTotals = pm.dashboardPanelConfigs.pivotStickyRowTotals;
       await expect(stickyRowTotals).toBeVisible();
 
       testLogger.info(
@@ -484,8 +462,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       // With single breakdown + single y-axis, buildPivotHeaderLevels returns []
       // (no multi-row header needed), so the Total column is rendered as a regular
       // column header: data-test="o2-table-th-Total_y_axis_1".
-      const totalHeader = page
-        .locator('[data-test^="o2-table-th-"]')
+      const totalHeader = pm.dashboardPanelActions.tableThCells
         .filter({ hasText: /^Total$/ })
         .first();
 
@@ -535,9 +512,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
 
       // Open config panel - pivot options should be visible
       await pm.dashboardPanelConfigs.openConfigPanel();
-      const pivotRowTotals = page.locator(
-        '[data-test="dashboard-config-pivot-row-totals"]'
-      );
+      const pivotRowTotals = pm.dashboardPanelConfigs.pivotRowTotals;
       await expect(pivotRowTotals).toBeVisible();
 
       testLogger.info("Verified pivot options visible with pivot field");
@@ -552,9 +527,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await expect(pivotRowTotals).not.toBeVisible();
 
       // Transpose should be re-enabled
-      const transposeToggle = page.locator(
-        '[data-test="dashboard-config-table_transpose"]'
-      );
+      const transposeToggle = pm.dashboardPanelConfigs.transpose;
       const transposeDisabled =
         await transposeToggle.getAttribute("aria-disabled");
       expect(transposeDisabled).not.toBe("true");
@@ -613,13 +586,13 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
 
       // Verify all 3 breakdown items are present
       await expect(
-        page.locator('[data-test="dashboard-b-item-breakdown_1"]')
+        pm.chartTypeSelector.getBreakdownItem(1)
       ).toBeVisible();
       await expect(
-        page.locator('[data-test="dashboard-b-item-breakdown_2"]')
+        pm.chartTypeSelector.getBreakdownItem(2)
       ).toBeVisible();
       await expect(
-        page.locator('[data-test="dashboard-b-item-breakdown_3"]')
+        pm.chartTypeSelector.getBreakdownItem(3)
       ).toBeVisible();
 
       testLogger.info("Verified 3 pivot fields added successfully");
@@ -627,9 +600,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       // Try to add a 4th pivot field - the +P button should be disabled
       await pm.chartTypeSelector.searchField("log");
 
-      const pivotButton = page
-        .locator('[data-test="dashboard-add-p-data"]')
-        .first();
+      const pivotButton = pm.chartTypeSelector.pivotAddBtn.first();
 
       // The button should be disabled (greyed out / not clickable)
       const isDisabled = await pivotButton.isDisabled();
@@ -690,24 +661,19 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await pm.dashboardPanelActions.savePanel();
 
       // Wait for panel to be saved
-      await page
-        .locator(
-          `[data-test="dashboard-edit-panel-${panelName}-dropdown"]`
-        )
+      await pm.dashboardPanelActions
+        .getEditPanelDropdown(panelName)
         .waitFor({ state: "visible", timeout: 30000 });
 
       testLogger.info("Saved pivot table panel with row/col totals enabled");
 
       // Edit the panel again
       await pm.dashboardPanelActions.selectPanelAction(panelName, "Edit");
-      await page
-        .locator('[data-test="dashboard-apply"]')
+      await pm.dashboardPanelActions.applyDashboard
         .waitFor({ state: "visible", timeout: 30000 });
 
       // Verify pivot field still present
-      const breakdownItem = page.locator(
-        '[data-test="dashboard-b-item-breakdown_1"]'
-      );
+      const breakdownItem = pm.chartTypeSelector.getBreakdownItem(1);
       await expect(breakdownItem).toBeVisible();
 
       // Open config panel and verify settings persisted
@@ -766,9 +732,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await pm.dashboardPanelActions.waitForChartToRender();
 
       // Verify breakdown field is present
-      const breakdownItem = page.locator(
-        '[data-test="dashboard-b-item-breakdown_1"]'
-      );
+      const breakdownItem = pm.chartTypeSelector.getBreakdownItem(1);
       await expect(breakdownItem).toBeVisible();
 
       testLogger.info("Pivot table created with breakdown field");
@@ -792,7 +756,7 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await expect(breakdownItem).toBeVisible();
 
       // Verify pivot mode is active (labels should show "Row Fields")
-      await expect(page.getByText("Row Fields")).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("Row Fields")).toBeVisible();
 
       testLogger.info(
         "Breakdown preserved when switching back to table (pivot mode restored)"
@@ -841,12 +805,8 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       // Open config panel
       await pm.dashboardPanelConfigs.openConfigPanel();
 
-      const stickyColTotals = page.locator(
-        '[data-test="dashboard-config-pivot-sticky-col-totals"]'
-      );
-      const stickyRowTotals = page.locator(
-        '[data-test="dashboard-config-pivot-sticky-row-totals"]'
-      );
+      const stickyColTotals = pm.dashboardPanelConfigs.pivotStickyColTotals;
+      const stickyRowTotals = pm.dashboardPanelConfigs.pivotStickyRowTotals;
 
       // Initially, sticky sub-options should NOT be visible
       await expect(stickyColTotals).not.toBeVisible();
@@ -927,13 +887,11 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       // Open config panel - pivot options should NOT be visible
       // (no X field → isPivotMode is false)
       await pm.dashboardPanelConfigs.openConfigPanel();
-      const pivotRowTotals = page.locator(
-        '[data-test="dashboard-config-pivot-row-totals"]'
-      );
+      const pivotRowTotals = pm.dashboardPanelConfigs.pivotRowTotals;
       await expect(pivotRowTotals).not.toBeVisible();
 
       // Labels should show "First Column" (non-pivot mode)
-      await expect(page.getByText("First Column")).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("First Column")).toBeVisible();
 
       testLogger.info(
         "Verified flat table renders when breakdown + Y without X"
@@ -986,13 +944,11 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       // Open config panel - pivot options should NOT be visible
       // (no Y field → isPivotMode is false)
       await pm.dashboardPanelConfigs.openConfigPanel();
-      const pivotRowTotals = page.locator(
-        '[data-test="dashboard-config-pivot-row-totals"]'
-      );
+      const pivotRowTotals = pm.dashboardPanelConfigs.pivotRowTotals;
       await expect(pivotRowTotals).not.toBeVisible();
 
       // Labels should show "First Column" (non-pivot mode)
-      await expect(page.getByText("First Column")).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("First Column")).toBeVisible();
 
       testLogger.info(
         "Verified flat table renders when X + breakdown without Y"
@@ -1044,13 +1000,11 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await pm.chartTypeSelector.waitForTableDataLoad();
 
       // Verify that the breakdown layout accommodates multiple Y aggregations correctly
-      const table = page.locator('[data-test="dashboard-panel-table"]');
+      const table = pm.dashboardPanelActions.dashboardTable;
       await expect(table).toBeVisible();
 
       // Verify breakdown is present, signifying pivot mode is active
-      const breakdownItem = page.locator(
-        '[data-test="dashboard-b-item-breakdown_1"]'
-      );
+      const breakdownItem = pm.chartTypeSelector.getBreakdownItem(1);
       await expect(breakdownItem).toBeVisible();
 
       testLogger.info("Verified render pivot with compound hierarchical headers");
@@ -1097,11 +1051,11 @@ test.describe("Dashboard Table Chart - Pivot Table Feature", () => {
       await streamPromise;
       await pm.chartTypeSelector.waitForTableDataLoad();
 
-      const table = page.locator('[data-test="dashboard-panel-table"]');
+      const table = pm.dashboardPanelActions.dashboardTable;
       await expect(table).toBeVisible();
 
       // Ensure 2 X Fields and 1 breakdown were handled correctly
-      const bLayout = page.locator('[data-test="dashboard-b-layout"]');
+      const bLayout = pm.chartTypeSelector.breakdownLayout;
       await expect(bLayout).toBeVisible();
 
       testLogger.info("Verified multi-row pivot configuration");

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-raw-query.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-raw-query.spec.js
@@ -281,9 +281,9 @@ test.describe("Dashboard Raw Query testcases", () => {
     await page.goto(
       `${process.env["ZO_BASE_URL"]}/web/dashboards?org_identifier=${process.env["ORGNAME"]}`
     );
-    await page.locator('[data-test="dashboard-search"]').waitFor({ state: "visible", timeout: 30000 });
+    await pm.dashboardCreate.waitForSearchVisible(30000);
     await pm.dashboardCreate.searchDashboard(dashboardName);
-    await page.locator('[data-test="dashboard-table"]').waitFor({ state: "visible", timeout: 10000 });
+    await pm.dashboardCreate.waitForDashboardTableVisible(10000);
     await deleteDashboard(page, dashboardName);
   });
 

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-sankey.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-sankey.spec.js
@@ -40,13 +40,13 @@ test.describe("Sankey chart testcases", () => {
 
       // Verify Sankey builder layout areas are visible
       await expect(
-        page.locator('[data-test="dashboard-source-layout"]')
+        pm.chartTypeSelector.getSankeySourceLayout()
       ).toBeVisible({ timeout: 10000 });
       await expect(
-        page.locator('[data-test="dashboard-target-layout"]')
+        pm.chartTypeSelector.getSankeyTargetLayout()
       ).toBeVisible();
       await expect(
-        page.locator('[data-test="dashboard-value-layout"]')
+        pm.chartTypeSelector.getSankeyValueLayout()
       ).toBeVisible();
 
       testLogger.info("Sankey chart builder layout verified");
@@ -172,9 +172,7 @@ test.describe("Sankey chart testcases", () => {
       await pm.chartTypeSelector.searchAndAddField("source", "source");
 
       // Verify source field is shown in the builder
-      const sourceLayout = page.locator(
-        '[data-test="dashboard-source-layout"]'
-      );
+      const sourceLayout = pm.chartTypeSelector.getSankeySourceLayout();
       await expect(
         sourceLayout.locator('[data-test^="dashboard-source-item-"]').first()
       ).toBeVisible({ timeout: 10000 });
@@ -222,11 +220,11 @@ test.describe("Sankey chart testcases", () => {
       await pm.chartTypeSelector.searchAndAddField("source", "source");
 
       // Search for another field and verify +S button is disabled
-      const searchInput = page.locator('[data-test="o-field-list-search-field"]');
+      const searchInput = pm.chartTypeSelector.getFieldSearchInput();
       await searchInput.click();
       await searchInput.fill("target");
 
-      const fieldItem = page.locator('[data-test="o-field-list-row-target"]').first();
+      const fieldItem = pm.chartTypeSelector.getFieldListRow("target").first();
       await fieldItem.waitFor({ state: "visible", timeout: 5000 });
       await fieldItem.hover();
       const sourceBtn = fieldItem.locator('[data-test="dashboard-add-source-data"]');
@@ -274,7 +272,7 @@ test.describe("Sankey chart testcases", () => {
       await pm.dashboardPanelActions.waitForChartToRender();
 
       // Wait for field list to populate from query result
-      await page.locator('[data-test="o-field-list-search-field"]').waitFor({ state: "visible", timeout: 10000 });
+      await pm.chartTypeSelector.getFieldSearchInput().waitFor({ state: "visible", timeout: 10000 });
 
       // Assign fields from custom query result to Sankey axes
       await pm.chartTypeSelector.searchAndAddField("source", "source");
@@ -313,14 +311,7 @@ test.describe("Sankey chart testcases", () => {
       await pm.dashboardCreate.createDashboard(dashName);
 
       // Open dashboard settings and add a variable on `source` field (country names)
-      await page.waitForSelector('[data-test="dashboard-setting-btn"]', {
-        state: "visible",
-        timeout: 15000,
-      });
-      const settingsButton = page.locator(
-        '[data-test="dashboard-setting-btn"]'
-      );
-      await settingsButton.click();
+      await pm.dashboardSetting.openSetting();
 
       await pm.dashboardVariables.addDashboardVariable(
         "countryvar",
@@ -342,10 +333,10 @@ test.describe("Sankey chart testcases", () => {
       // Add source as a filter field
       // Sankey mode renders two button groups per field: standard (+X +Y +B +F) and sankey (+S +T +V +F).
       // Scope to the sankey group by finding +F that's a sibling of the +S button.
-      const searchInput = page.locator('[data-test="o-field-list-search-field"]');
+      const searchInput = pm.chartTypeSelector.getFieldSearchInput();
       await searchInput.click();
       await searchInput.fill("source");
-      const fieldItem = page.locator('[data-test="o-field-list-row-source"]').first();
+      const fieldItem = pm.chartTypeSelector.getFieldListRow("source").first();
       await fieldItem.waitFor({ state: "visible", timeout: 5000 });
       await fieldItem.hover();
       const filterBtn = fieldItem.locator('[data-test="dashboard-add-filter-data"]');

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-share-link.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-share-link.spec.js
@@ -17,10 +17,7 @@ import { waitForDashboardPage, deleteDashboard } from "./utils/dashCreation.js";
 import { safeWaitForHidden, safeWaitForNetworkIdle } from "../utils/wait-helpers.js";
 import {
   getVariableSelector,
-  getVariableSelectorInner,
-  getEditVariableBtn,
   getVariableLoadingIndicator,
-  SELECTORS,
 } from "../../pages/dashboardPages/dashboard-selectors.js";
 
 test.describe.configure({ mode: "parallel" });
@@ -312,8 +309,8 @@ test.describe("dashboard share URL button testcases", () => {
     await pm.dashboardSetting.saveVariable();
 
     // Wait for variable to be saved in settings
-    await page
-      .locator(getEditVariableBtn(variableName))
+    await pm.dashboardShareExport
+      .getEditVariableButton(variableName)
       .waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -324,30 +321,29 @@ test.describe("dashboard share URL button testcases", () => {
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable selector to appear on dashboard
-    await page
-      .locator(getVariableSelector(variableName))
+    await pm.dashboardShareExport
+      .getVariableSelectorLocator(variableName)
       .waitFor({ state: "visible", timeout: 15000 });
 
     // Wait for variable loading to complete
-    await page
-      .locator(getVariableLoadingIndicator(variableName))
+    await pm.dashboardShareExport
+      .getVariableLoadingIndicatorLocator(variableName)
       .waitFor({ state: "hidden", timeout: 10000 })
       .catch(() => {});
 
     // Click the variable dropdown (inner select element)
-    const variableDropdown = page.locator(
-      getVariableSelectorInner(variableName)
-    );
+    const variableDropdown =
+      pm.dashboardShareExport.getVariableDropdownInner(variableName);
     await variableDropdown.waitFor({ state: "visible", timeout: 10000 });
     await variableDropdown.click();
 
     // Wait for dropdown menu to open
-    await page
-      .locator(SELECTORS.MENU)
+    await pm.dashboardShareExport
+      .getMenu()
       .waitFor({ state: "visible", timeout: 5000 });
 
     // Select the first option
-    const firstOption = page.locator(SELECTORS.ROLE_OPTION).first();
+    const firstOption = pm.dashboardShareExport.getFirstRoleOption();
     await firstOption.waitFor({ state: "visible", timeout: 5000 });
     const selectedValue = await firstOption.textContent();
     await firstOption.click();
@@ -544,8 +540,8 @@ test.describe("dashboard share URL button testcases", () => {
     await pm.dashboardSetting.saveVariable();
 
     // Wait for variable to be saved in settings
-    await page
-      .locator(getEditVariableBtn(variableName))
+    await pm.dashboardShareExport
+      .getEditVariableButton(variableName)
       .waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -556,28 +552,27 @@ test.describe("dashboard share URL button testcases", () => {
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable selector to appear on dashboard
-    await page
-      .locator(getVariableSelector(variableName))
+    await pm.dashboardShareExport
+      .getVariableSelectorLocator(variableName)
       .waitFor({ state: "visible", timeout: 15000 });
 
     // Wait for variable loading to complete
-    await page
-      .locator(getVariableLoadingIndicator(variableName))
+    await pm.dashboardShareExport
+      .getVariableLoadingIndicatorLocator(variableName)
       .waitFor({ state: "hidden", timeout: 10000 })
       .catch(() => {});
 
     // Click the variable dropdown (inner select element)
-    const variableDropdown = page.locator(
-      getVariableSelectorInner(variableName)
-    );
+    const variableDropdown =
+      pm.dashboardShareExport.getVariableDropdownInner(variableName);
     await variableDropdown.waitFor({ state: "visible", timeout: 10000 });
     await variableDropdown.click();
 
     // Wait for dropdown menu to open and select first option
-    await page
-      .locator(SELECTORS.MENU)
+    await pm.dashboardShareExport
+      .getMenu()
       .waitFor({ state: "visible", timeout: 5000 });
-    await page.locator(SELECTORS.ROLE_OPTION).first().click();
+    await pm.dashboardShareExport.getFirstRoleOption().click();
 
     // Wait for dropdown to close and selection to apply
     await safeWaitForHidden(page, `[data-test="variable-selector-${variableName}-inner-popover"]`, { timeout: 3000 });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-streaming.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-streaming.spec.js
@@ -57,11 +57,7 @@ test.describe("dashboard streaming testcases", () => {
     await pm.dashboardCreate.createDashboard(
       randomDashboardName + "_streaming"
     );
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     await pm.dashboardSetting.openSetting();
     await pm.dashboardVariables.addDashboardVariable(
       "variablename",
@@ -212,11 +208,7 @@ test.describe("dashboard streaming testcases", () => {
     await pm.dashboardCreate.createDashboard(
       randomDashboardName + "_filter"
     );
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     await pm.dashboardSetting.openSetting();
 
     // Add first variable without filter (existing behavior)

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
@@ -15,8 +15,6 @@ import {
 import { waitForStreamComplete } from "../utils/streaming-helpers.js";
 import testLogger from "../utils/test-logger.js";
 import {
-  TABLE_SELECTOR,
-  TABLE_HEADER_SELECTOR,
   getTableHeaders,
   getTableCellText,
 } from "../../pages/dashboardPages/dashboard-table-helpers.js";
@@ -128,10 +126,10 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await setupTablePanel(page, pm, dashboardName);
       await pm.chartTypeSelector.waitForTableDataLoad();
 
-      const table = page.locator(TABLE_SELECTOR);
+      const table = pm.dashboardPanelActions.dashboardTable;
 
       // Click on the first column header to trigger sort
-      const firstHeader = page.locator(TABLE_HEADER_SELECTOR).first();
+      const firstHeader = pm.dashboardPanelActions.tableHeaderCells.first();
       await firstHeader.click();
 
       // Table should still render after sort
@@ -257,7 +255,7 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await pm.dashboardPanelConfigs.selectTranspose();
       await pm.dashboardPanelActions.applyDashboardBtn();
 
-      const table = page.locator(TABLE_SELECTOR);
+      const table = pm.dashboardPanelActions.dashboardTable;
       await expect(table).toBeVisible();
 
       testLogger.info("Table with wrap cells + transpose rendered");
@@ -267,10 +265,10 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await reopenPanelConfig(page, pm);
 
       await expect(
-        page.locator('[data-test="dashboard-config-wrap-table-cells-btn"]')
+        pm.dashboardPanelConfigs.wrapCellBtn
       ).toHaveAttribute("aria-checked", "true");
       await expect(
-        page.locator('[data-test="dashboard-config-table_transpose-btn"]')
+        pm.dashboardPanelConfigs.transposeBtn
       ).toHaveAttribute("aria-checked", "true");
 
       await pm.dashboardPanelActions.savePanel();
@@ -297,10 +295,10 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await pm.chartTypeSelector.searchAndAddField("kubernetes_pod_name", "y");
 
       // Enable VRL function toggle and add a VRL function that creates a new field
-      const vrlToggle = page.locator('[data-test="logs-search-bar-show-query-toggle-btn"]');
+      const vrlToggle = pm.chartTypeSelector.vrlToggleBtn;
       await vrlToggle.click();
 
-      const vrlEditor = page.locator('[data-test="dashboard-vrl-function-editor"]');
+      const vrlEditor = pm.chartTypeSelector.vrlFunctionEditor;
       await vrlEditor.waitFor({ state: "visible", timeout: 10000 });
       const monacoInput = vrlEditor.getByRole("code");
       await monacoInput.click();
@@ -521,7 +519,7 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await pm.chartTypeSelector.waitForTableDataLoad();
 
       // Screenshot shows "1-7 of 7" at bottom right of table
-      const table = page.locator(TABLE_SELECTOR);
+      const table = pm.dashboardPanelActions.dashboardTable;
       const tableText = await table.textContent();
       const hasRowCountInfo = /\d+-\d+\s+of\s+\d+/.test(tableText);
       expect(hasRowCountInfo).toBe(true);
@@ -555,7 +553,7 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await pm.dashboardPanelActions.applyDashboardBtn();
 
       // Screenshot shows: "Pivot Field ⓘ:  Add 0 or 1 field here"
-      const pivotPlaceholder = page.getByText("Add 0 or 1 field here");
+      const pivotPlaceholder = pm.chartTypeSelector.getFieldSectionLabel("Add 0 or 1 field here");
       await expect(pivotPlaceholder).toBeVisible();
 
       testLogger.info("Pivot field placeholder visible with no pivot field");
@@ -632,15 +630,13 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       expect(filteredRowCount).toBeLessThanOrEqual(unfilteredRowCount);
 
       // Verify the filter is reflected in the query via query inspector
-      await page
-        .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
-        .click();
+      await pm.dashboardPanelEdit.dataViewQueryInspectorBtn.click();
       await expect(
-        page.locator(".inspector-query-editor").filter({
+        pm.dashboardPanelEdit.inspectorQueryEditor.filter({
           hasText: "kubernetes_container_name = 'ziox'",
         }).last()
       ).toBeVisible();
-      await page.locator('[data-test="query-inspector-dialog"] [data-test="o-dialog-close-btn"]').click();
+      await pm.dashboardPanelEdit.queryInspectorCloseBtn.click();
 
       testLogger.info("Table filtered by variable", { unfilteredRowCount, filteredRowCount });
 
@@ -675,7 +671,7 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await pm.chartTypeSelector.waitForTableDataLoad();
 
       // --- BEFORE filter: capture row count and table content ---
-      const table = page.locator(TABLE_SELECTOR);
+      const table = pm.dashboardPanelActions.dashboardTable;
       await table.waitFor({ state: "visible", timeout: 15000 });
       const beforeRowCount = await pm.dashboardPanelActions.getTableRowCount();
       const beforeHeaders = await getTableHeaders(page);
@@ -690,16 +686,16 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       expect(beforeRowCount).toBeGreaterThan(1);
 
       // --- Apply dynamic filter: kubernetes_container_name = ziox ---
-      const adhocAddBtn = page.locator('[data-test="dashboard-variable-adhoc-add-selector"]');
+      const adhocAddBtn = pm.dashboardVariables.adhocAddSelector;
       await adhocAddBtn.waitFor({ state: "visible", timeout: 15000 });
       await adhocAddBtn.click();
 
-      const nameSelector = page.locator('[data-test="dashboard-variable-adhoc-name-selector-field"]');
+      const nameSelector = pm.dashboardVariables.adhocNameSelectorField;
       await nameSelector.click();
       await nameSelector.fill("kubernetes_container_name");
       await nameSelector.press("Tab"); // flush OInput debounce immediately
 
-      const valueSelector = page.locator('[data-test="dashboard-variable-adhoc-value-selector-field"]');
+      const valueSelector = pm.dashboardVariables.adhocValueSelectorField;
       await valueSelector.click();
       await valueSelector.fill("ziox");
       await valueSelector.press("Tab"); // flush OInput debounce immediately
@@ -778,12 +774,12 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       testLogger.info("Builder mode table rows", { builderRowCount });
 
       // Switch to Custom query mode
-      const customBtn = page.locator('[data-test="dashboard-custom-query-type"]');
+      const customBtn = pm.chartTypeSelector.customQueryTypeBtn;
       await customBtn.waitFor({ state: "visible", timeout: 10000 });
       await customBtn.click();
 
       // The auto-generated SQL should be visible in the editor
-      const queryEditor = page.locator('[data-test="dashboard-panel-query-editor"]');
+      const queryEditor = pm.chartTypeSelector.queryEditor;
       await queryEditor.waitFor({ state: "visible", timeout: 10000 });
 
       // Apply in custom mode — table should still render
@@ -825,13 +821,13 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await pm.chartTypeSelector.searchAndAddField("code", "y");
 
       // Verify layout labels
-      await expect(page.getByText("First Column").first()).toBeVisible();
-      await expect(page.getByText("Other Columns").first()).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("First Column").first()).toBeVisible();
+      await expect(pm.chartTypeSelector.getFieldSectionLabel("Other Columns").first()).toBeVisible();
 
       // Verify field chips in correct layout areas
-      const xLayout = page.locator('[data-test="dashboard-x-layout"]');
+      const xLayout = pm.chartTypeSelector.xLayout;
       await expect(xLayout).toBeVisible();
-      const yLayout = page.locator('[data-test="dashboard-y-layout"]');
+      const yLayout = pm.chartTypeSelector.yLayout;
       await expect(yLayout).toBeVisible();
 
       testLogger.info("First Column and Other Columns labels visible");

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-column-filtering.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-column-filtering.spec.js
@@ -12,8 +12,6 @@ import {
   reopenPanelConfig,
 } from "./utils/configPanelHelpers.js";
 import {
-  TABLE_SELECTOR,
-  TABLE_DATA_ROW_SELECTOR,
   getColumnFilterBtn,
   openColumnFilter,
   columnFilter,
@@ -41,7 +39,7 @@ test.describe("Dashboard Table — Column Filtering (PR #12531)", () => {
     await pm.dashboardPanelActions.applyDashboardBtn();
     testLogger.info("Table filtering enabled");
 
-    await expect(page.locator(TABLE_SELECTOR)).toBeVisible();
+    await expect(pm.dashboardPanelActions.dashboardTable).toBeVisible();
     await expect(getColumnFilterBtn(page, 0)).toBeVisible();
     testLogger.info("Filter icon visible in column header");
 
@@ -62,7 +60,7 @@ test.describe("Dashboard Table — Column Filtering (PR #12531)", () => {
     // mid-click — see waitForPanelTableSettled.
     await waitForPanelTableSettled(page);
 
-    const rows = page.locator(TABLE_DATA_ROW_SELECTOR);
+    const rows = pm.dashboardPanelActions.getTableDataRows();
     await rows.first().waitFor({ state: "visible", timeout: 15000 });
     const totalRowCount = await rows.count();
     expect(totalRowCount).toBeGreaterThan(0);
@@ -98,7 +96,7 @@ test.describe("Dashboard Table — Column Filtering (PR #12531)", () => {
     await pm.dashboardPanelActions.applyDashboardBtn();
     await waitForPanelTableSettled(page);
 
-    const rows = page.locator(TABLE_DATA_ROW_SELECTOR);
+    const rows = pm.dashboardPanelActions.getTableDataRows();
     await rows.first().waitFor({ state: "visible", timeout: 15000 });
     const totalRowCount = await rows.count();
 

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-column-formatting.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-column-formatting.spec.js
@@ -13,8 +13,6 @@ import {
   discardAndCleanupTestDashboard,
 } from "./utils/configPanelHelpers.js";
 import {
-  TABLE_SELECTOR,
-  TABLE_DATA_ROW_SELECTOR,
   readColumnCells,
   waitForPanelTableSettled,
 } from "../../pages/dashboardPages/dashboard-table-helpers.js";
@@ -86,7 +84,7 @@ test.describe("Dashboard Table — Column Formatting (PR #12531)", () => {
     // resolves to numeric once the query re-applies.
     await pm.chartTypeSelector.configureYAxisFunction("y_axis_1", "count");
     await pm.dashboardPanelActions.applyDashboardBtn();
-    await expect(page.locator(TABLE_SELECTOR)).toBeVisible();
+    await expect(pm.dashboardPanelActions.dashboardTable).toBeVisible();
 
     await addYAxisOverrideColumn(pm);
 
@@ -133,7 +131,7 @@ test.describe("Dashboard Table — Column Formatting (PR #12531)", () => {
     await pm.dashboardPanelConfigs.overrideSaveBtn.click();
     await pm.dashboardPanelConfigs.overrideDialog.waitFor({ state: "hidden", timeout: 5000 });
     await pm.dashboardPanelActions.applyDashboardBtn();
-    await expect(page.locator(TABLE_SELECTOR)).toBeVisible();
+    await expect(pm.dashboardPanelActions.dashboardTable).toBeVisible();
 
     await pm.dashboardPanelActions.savePanel();
     await reopenPanelConfig(page, pm);
@@ -168,7 +166,7 @@ test.describe("Dashboard Table — Column Formatting (PR #12531)", () => {
     await pm.dashboardPanelConfigs.overrideDialog.waitFor({ state: "hidden", timeout: 5000 });
     await pm.dashboardPanelActions.applyDashboardBtn();
 
-    const firstRow = page.locator(TABLE_DATA_ROW_SELECTOR).first();
+    const firstRow = pm.dashboardPanelActions.getTableDataRows().first();
     await firstRow.waitFor({ state: "visible", timeout: 15000 });
     const styledCell = firstRow.locator("td").last();
     await expect(styledCell).toHaveCSS("background-color", hexToRgb(bgHex));
@@ -219,7 +217,7 @@ test.describe("Dashboard Table — Column Formatting (PR #12531)", () => {
     // has to run against a table that has stopped moving.
     await waitForPanelTableSettled(page);
 
-    const rows = page.locator(TABLE_DATA_ROW_SELECTOR);
+    const rows = pm.dashboardPanelActions.getTableDataRows();
     await rows.first().waitFor({ state: "visible", timeout: 15000 });
     const rowCount = await rows.count();
     expect(rowCount).toBeGreaterThan(1);
@@ -264,7 +262,7 @@ test.describe("Dashboard Table — Column Formatting (PR #12531)", () => {
     await pm.dashboardPanelConfigs.overrideDialog.waitFor({ state: "hidden", timeout: 5000 });
     await pm.dashboardPanelActions.applyDashboardBtn();
 
-    const firstRow = page.locator(TABLE_DATA_ROW_SELECTOR).first();
+    const firstRow = pm.dashboardPanelActions.getTableDataRows().first();
     await firstRow.waitFor({ state: "visible", timeout: 15000 });
     const wrapperDiv = firstRow.locator("td").last().locator("div").first();
     await expect(wrapperDiv).toHaveClass(/justify-center/);
@@ -299,7 +297,7 @@ test.describe("Dashboard Table — Column Formatting (PR #12531)", () => {
     // a feature that works.
     await waitForPanelTableSettled(page);
 
-    const rows = page.locator(TABLE_DATA_ROW_SELECTOR);
+    const rows = pm.dashboardPanelActions.getTableDataRows();
     await rows.first().waitFor({ state: "visible", timeout: 15000 });
     const rowCount = await rows.count();
     expect(rowCount).toBeGreaterThan(1);

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-copy-cell.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-copy-cell.spec.js
@@ -12,8 +12,6 @@ import {
 import { waitForStreamComplete } from "../utils/streaming-helpers.js";
 import testLogger from "../utils/test-logger.js";
 import {
-  TABLE_SELECTOR,
-  TABLE_DATA_ROW_SELECTOR,
   getTableCellText,
 } from "../../pages/dashboardPages/dashboard-table-helpers.js";
 
@@ -114,7 +112,7 @@ test.describe("Dashboard Table Chart - Copy Cell Timestamp Formatting", () => {
       await pm.chartTypeSelector.waitForTableDataLoad();
 
       // Hover the first timestamp cell to reveal the copy button
-      const firstRow = page.locator(TABLE_DATA_ROW_SELECTOR).first();
+      const firstRow = pm.dashboardPanelActions.getTableDataRows().first();
       const firstCell = firstRow.locator("td").first();
       await firstCell.hover();
 
@@ -168,7 +166,7 @@ test.describe("Dashboard Table Chart - Copy Cell Timestamp Formatting", () => {
       const displayedText = await getTableCellText(page, 0, 0);
 
       // Hover and click the copy button
-      const firstRow = page.locator(TABLE_DATA_ROW_SELECTOR).first();
+      const firstRow = pm.dashboardPanelActions.getTableDataRows().first();
       const firstCell = firstRow.locator("td").first();
       await firstCell.hover();
       const copyBtn = firstCell.locator("[data-test^='o2-table-cell-copy-']").first();
@@ -218,7 +216,7 @@ test.describe("Dashboard Table Chart - Copy Cell Timestamp Formatting", () => {
       testLogger.info("Non-timestamp cell display value", { displayedText });
 
       // Hover the second cell and click its copy button
-      const firstRow = page.locator(TABLE_DATA_ROW_SELECTOR).first();
+      const firstRow = pm.dashboardPanelActions.getTableDataRows().first();
       const secondCell = firstRow.locator("td").nth(1);
       await secondCell.hover();
       const copyBtn = secondCell.locator("[data-test^='o2-table-cell-copy-']").first();
@@ -304,7 +302,7 @@ test.describe("Dashboard Table Chart - Copy Cell Timestamp Formatting", () => {
       await pm.chartTypeSelector.waitForTableDataLoad();
 
       // Hover first data cell and click its copy button
-      const firstRow = page.locator(TABLE_DATA_ROW_SELECTOR).first();
+      const firstRow = pm.dashboardPanelActions.getTableDataRows().first();
       const firstCell = firstRow.locator("td").first();
       await firstCell.hover();
       const copyBtn = firstCell.locator("[data-test^='o2-table-cell-copy-']").first();
@@ -351,7 +349,7 @@ test.describe("Dashboard Table Chart - Copy Cell Timestamp Formatting", () => {
       // Read displayed value then copy and compare
       const displayedText = await getTableCellText(page, 0, 0);
 
-      const firstRow = page.locator(TABLE_DATA_ROW_SELECTOR).first();
+      const firstRow = pm.dashboardPanelActions.getTableDataRows().first();
       const firstCell = firstRow.locator("td").first();
       await firstCell.hover();
       const copyBtn = firstCell.locator("[data-test^='o2-table-cell-copy-']").first();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-csv-download.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-csv-download.spec.js
@@ -103,8 +103,7 @@ test.describe("Dashboard Table Chart — CSV Download", () => {
     testLogger.info("Navigated to dashboard view");
 
     // 2. Wait for the panel bar (dashboard container) to render
-    await page
-      .locator('[data-test="dashboard-panel-bar"]')
+    await pm.dashboardPanelActions.panelBar
       .first()
       .waitFor({ state: "visible", timeout: 15000 });
 
@@ -393,7 +392,7 @@ test.describe("Dashboard PromQL Table Chart — CSV Download", () => {
     await page.waitForTimeout(500);
 
     // Click save button — use force in case an overlay partially covers it
-    const saveBtn = page.locator('[data-test="dashboard-panel-save"]');
+    const saveBtn = pm.dashboardPanelActions.panelSaveBtn;
     await saveBtn.waitFor({ state: "visible", timeout: 10000 });
     await saveBtn.click({ force: true });
 

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-pagination.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-pagination.spec.js
@@ -76,7 +76,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Verify pagination toggle is NOT visible for line chart
-    const paginationToggleLine = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggleLine = pm.dashboardPanelConfigs.paginationToggle;
     await expect(paginationToggleLine).not.toBeVisible();
 
     testLogger.info('Verified pagination toggle is NOT visible for line chart');
@@ -87,7 +87,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Verify pagination toggle IS visible for table chart
-    const paginationToggleTable = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggleTable = pm.dashboardPanelConfigs.paginationToggle;
     await expect(paginationToggleTable).toBeVisible();
 
     testLogger.info('Verified pagination toggle IS visible for table chart');
@@ -126,11 +126,11 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Verify pagination toggle is visible
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await expect(paginationToggle).toBeVisible();
 
     // Verify rows per page input is NOT visible when pagination is disabled
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
     await expect(rowsPerPageInput).not.toBeVisible();
 
     testLogger.info('Verified rows per page input is hidden when pagination is disabled');
@@ -145,7 +145,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     testLogger.info('Verified rows per page input is visible when pagination is enabled');
 
     // Verify info icon is visible
-    const infoIcon = page.locator('[data-test="dashboard-config-rows-per-page-info"]');
+    const infoIcon = pm.dashboardPanelConfigs.rowsPerPageInfo;
     await expect(infoIcon).toBeVisible();
 
     // Clean up - save panel first before navigating back
@@ -182,11 +182,11 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Enable pagination
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
     // Wait for rows per page input to be visible
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
     await rowsPerPageInput.waitFor({ state: "visible" });
 
     // Set custom rows per page value
@@ -240,7 +240,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
 
     // Open config panel and enable pagination
     await pm.dashboardPanelConfigs.openConfigPanel();
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
     // Set rows per page to 10
@@ -251,11 +251,11 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Verify pagination controls are visible in the table
-    const tableBottom = page.locator('[data-test="dashboard-panel-table"] [data-test="dashboard-table-pagination"]');
+    const tableBottom = pm.dashboardPanelConfigs.tablePaginationInTable;
     await expect(tableBottom).toBeVisible();
 
     // Check for "Records per page" text
-    const rowsPerPageText = page.locator('[data-test="dashboard-table-rows-per-page-label"]');
+    const rowsPerPageText = pm.dashboardPanelConfigs.tableRowsPerPageLabel;
     await expect(rowsPerPageText).toBeVisible();
 
     testLogger.info('Verified pagination controls are visible in table');
@@ -298,7 +298,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Verify pagination is disabled
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     const isChecked = await pm.dashboardPanelConfigs.isPaginationEnabled();
     expect(isChecked).toBe(false);
 
@@ -307,7 +307,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Verify "Records per page" text is NOT visible
-    const rowsPerPageText = page.locator('[data-test="dashboard-table-rows-per-page-label"]');
+    const rowsPerPageText = pm.dashboardPanelConfigs.tableRowsPerPageLabel;
     await expect(rowsPerPageText).not.toBeVisible();
 
     testLogger.info('Verified pagination controls are hidden when disabled');
@@ -344,10 +344,10 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
 
     // Open config panel and enable pagination with custom value
     await pm.dashboardPanelConfigs.openConfigPanel();
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
     await rowsPerPageInput.waitFor({ state: "visible" });
     await pm.dashboardPanelConfigs.setRowsPerPage("50");
 
@@ -358,7 +358,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be saved - the panel dropdown should be visible after save
-    await page.locator(`[data-test="dashboard-edit-panel-${panelName}-dropdown"]`).waitFor({ state: "visible", timeout: 30000 });
+    await pm.dashboardPanelActions.getEditPanelDropdown(panelName).waitFor({ state: "visible", timeout: 30000 });
 
     testLogger.info('Saved panel with pagination enabled and table_pagination_rows_per_page=50');
 
@@ -366,7 +366,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelActions.selectPanelAction(panelName, "Edit");
 
     // Wait for edit mode to load
-    await page.locator('[data-test="dashboard-apply"]').waitFor({ state: "visible", timeout: 30000 });
+    await pm.dashboardPanelActions.applyDashboard.waitFor({ state: "visible", timeout: 30000 });
 
     // Open config panel and verify settings persisted
     await pm.dashboardPanelConfigs.openConfigPanel();
@@ -414,8 +414,8 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     // Open config panel
     await pm.dashboardPanelConfigs.openConfigPanel();
 
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
 
     // Initial state: pagination OFF, rows per page hidden
     await expect(rowsPerPageInput).not.toBeVisible();
@@ -477,7 +477,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
 
     // Open config panel and enable pagination
     await pm.dashboardPanelConfigs.openConfigPanel();
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
     // Set rows per page to 10
@@ -496,7 +496,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
       },
       { timeout: 15000 }
     );
-    const rowCount = page.locator('[data-test="dashboard-table-row-count"]');
+    const rowCount = pm.dashboardPanelConfigs.tableRowCount;
     const bottomText = await rowCount.textContent();
 
     // Verify the text contains the expected format (e.g., "1-10 of 100" or similar)
@@ -540,7 +540,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Verify pagination toggle is NOT visible for area chart
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await expect(paginationToggle).not.toBeVisible();
     testLogger.info('Verified pagination toggle is hidden for area chart');
 
@@ -596,7 +596,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Enable pagination
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
     // Set rows per page
@@ -614,7 +614,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     expect(paginationChecked).toBe(true);
 
     // Verify table wrapper has wrap-enabled class (set by TenstackTable when wrap=true)
-    const tableWrapper = page.locator('[data-test="dashboard-panel-table"]');
+    const tableWrapper = pm.dashboardPanelActions.dashboardTable;
     await expect(tableWrapper).toHaveClass(/wrap-enabled/);
 
     testLogger.info('Verified pagination works with wrap cells option');
@@ -653,7 +653,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Enable pagination
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
     // Set rows per page
@@ -704,11 +704,11 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
 
     // Open config panel and enable pagination
     await pm.dashboardPanelConfigs.openConfigPanel();
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
     // Verify the input has min="1" attribute
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
     await rowsPerPageInput.waitFor({ state: "visible" });
     const minAttr = await rowsPerPageInput.getAttribute('min');
     expect(minAttr).toBe('1');
@@ -750,7 +750,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
 
     // Open config panel and enable pagination
     await pm.dashboardPanelConfigs.openConfigPanel();
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
     // Leave rows per page empty (clear any default)
@@ -761,7 +761,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Table should still work with default value (10)
-    const tableBottom = page.locator('[data-test="dashboard-panel-table"] [data-test="dashboard-table-pagination"]');
+    const tableBottom = pm.dashboardPanelConfigs.tablePaginationInTable;
     await tableBottom.waitFor({ state: "visible" });
     await expect(tableBottom).toBeVisible();
 
@@ -799,10 +799,10 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
 
     // Open config panel and enable pagination with custom value
     await pm.dashboardPanelConfigs.openConfigPanel();
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
     await rowsPerPageInput.waitFor({ state: "visible" });
     await pm.dashboardPanelConfigs.setRowsPerPage("30");
 
@@ -866,20 +866,20 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
 
     // Open config panel and enable pagination
     await pm.dashboardPanelConfigs.openConfigPanel();
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
     // Wait for rows per page input to be visible
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
     await rowsPerPageInput.waitFor({ state: "visible" });
 
     // Hover over the info icon to see tooltip
-    const infoIcon = page.locator('[data-test="dashboard-config-rows-per-page-info"]');
+    const infoIcon = pm.dashboardPanelConfigs.rowsPerPageInfo;
     await expect(infoIcon).toBeVisible();
     await infoIcon.hover();
 
     // Verify tooltip appears with expected text
-    const tooltip = page.locator('[role="tooltip"]');
+    const tooltip = pm.dashboardPanelConfigs.infoTooltip;
     await expect(tooltip).toBeVisible();
     const tooltipText = await tooltip.textContent();
     expect(tooltipText).toContain('default number of records');
@@ -921,12 +921,12 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.chartTypeSelector.searchAndAddField("kubernetes_container_name", "y");
 
     // Switch to Custom SQL editor (Y field from builder mode is preserved)
-    await page.locator('[data-test="dashboard-sql-query-type"]').click();
-    await page.locator('[data-test="dashboard-custom-query-type"]').click();
+    await pm.chartTypeSelector.sqlQueryTypeBtn.click();
+    await pm.chartTypeSelector.customQueryTypeBtn.click();
 
     // Fill the SQL query
-    await page.locator('[data-test="dashboard-panel-query-editor"]').getByRole('code').click();
-    await page.locator('[data-test="dashboard-panel-query-editor"]').locator('.inputarea').fill(
+    await pm.chartTypeSelector.queryEditor.getByRole('code').click();
+    await pm.chartTypeSelector.queryEditor.locator('.inputarea').fill(
       'SELECT kubernetes_container_name, count(*) as count FROM "e2e_automate" GROUP BY kubernetes_container_name'
     );
 
@@ -936,12 +936,12 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
 
     // Open config panel and enable pagination
     await pm.dashboardPanelConfigs.openConfigPanel();
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await expect(paginationToggle).toBeVisible();
 
     await paginationToggle.click();
 
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
     await rowsPerPageInput.waitFor({ state: "visible" });
     await expect(rowsPerPageInput).toBeVisible();
     await pm.dashboardPanelConfigs.setRowsPerPage("5");
@@ -950,7 +950,7 @@ test.describe("Dashboard Table Chart Pagination Feature - SQL Tables", () => {
     await pm.dashboardPanelActions.waitForChartToRender();
 
     // Verify pagination controls are visible
-    const rowsPerPageText = page.locator('[data-test="dashboard-table-rows-per-page-label"]');
+    const rowsPerPageText = pm.dashboardPanelConfigs.tableRowsPerPageLabel;
     await rowsPerPageText.waitFor({ state: "visible" });
     await expect(rowsPerPageText).toBeVisible();
 
@@ -999,7 +999,7 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
     await pm.chartTypeSelector.selectStreamType("metrics");
 
     // Check if PromQL button is visible (only shows for metrics stream type)
-    const promqlButton = page.locator('[data-test="dashboard-promql-query-type"]');
+    const promqlButton = pm.chartTypeSelector.promqlQueryTypeBtn;
     const isPromqlVisible = await promqlButton.isVisible().catch(() => false);
 
     if (!isPromqlVisible) {
@@ -1015,12 +1015,12 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
     await promqlButton.click();
 
     // Switch to Custom mode to enable the query editor for manual input
-    const customButton = page.locator('[data-test="dashboard-custom-query-type"]');
+    const customButton = pm.chartTypeSelector.customQueryTypeBtn;
     await customButton.waitFor({ state: "visible", timeout: 5000 });
     await customButton.click();
 
     // Wait for query editor to appear (uses same editor for SQL and PromQL)
-    const queryEditor = page.locator('[data-test="dashboard-panel-query-editor"]');
+    const queryEditor = pm.chartTypeSelector.queryEditor;
     await queryEditor.waitFor({ state: "visible", timeout: 10000 });
 
     // Use .inputarea.fill() to directly set Monaco's textarea value — same pattern as
@@ -1037,14 +1037,14 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Verify pagination toggle is visible for PromQL table
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await expect(paginationToggle).toBeVisible();
 
     // Enable pagination
     await paginationToggle.click();
 
     // Set rows per page
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
     await rowsPerPageInput.waitFor({ state: "visible" });
     await expect(rowsPerPageInput).toBeVisible();
 
@@ -1060,7 +1060,7 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
     // The router guard (onBeforeRouteLeave) fires window.confirm when leaving with
     // unsaved changes. Accept it so navigation to ViewDashboard completes.
     page.once('dialog', dialog => dialog.accept());
-    await page.locator('[data-test="dashboard-panel-discard"]').click();
+    await pm.dashboardPanelActions.discardPanelBtn.click();
     await pm.dashboardCreate.backToDashboardList();
     await deleteDashboard(page, dashboardName);
   });
@@ -1090,7 +1090,7 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
     await pm.chartTypeSelector.selectStreamType("metrics");
 
     // Check if PromQL button is visible (only shows for metrics stream type)
-    const promqlButton = page.locator('[data-test="dashboard-promql-query-type"]');
+    const promqlButton = pm.chartTypeSelector.promqlQueryTypeBtn;
     const isPromqlVisible = await promqlButton.isVisible().catch(() => false);
 
     if (!isPromqlVisible) {
@@ -1106,12 +1106,12 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
     await promqlButton.click();
 
     // Switch to Custom mode to enable the query editor for manual input
-    const customButton = page.locator('[data-test="dashboard-custom-query-type"]');
+    const customButton = pm.chartTypeSelector.customQueryTypeBtn;
     await customButton.waitFor({ state: "visible", timeout: 5000 });
     await customButton.click();
 
     // Wait for query editor to appear (uses same editor for SQL and PromQL)
-    const queryEditor = page.locator('[data-test="dashboard-panel-query-editor"]');
+    const queryEditor = pm.chartTypeSelector.queryEditor;
     await queryEditor.waitFor({ state: "visible", timeout: 10000 });
 
     // Focus on the editor and enter a PromQL query using keyboard.type for reliable Monaco input
@@ -1126,11 +1126,11 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
 
     // Open config panel and enable pagination
     await pm.dashboardPanelConfigs.openConfigPanel();
-    const paginationToggle = page.locator('[data-test="dashboard-config-show-pagination"]');
+    const paginationToggle = pm.dashboardPanelConfigs.paginationToggle;
     await paginationToggle.click();
 
     // Set rows per page
-    const rowsPerPageInput = page.locator('[data-test="dashboard-config-rows-per-page"]');
+    const rowsPerPageInput = pm.dashboardPanelConfigs.rowsPerPageWrapper;
     await pm.dashboardPanelConfigs.setRowsPerPage("10");
 
     // Apply changes and wait for table data to load
@@ -1139,7 +1139,7 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
 
     // Wait for the table to render with data rows
     // TenstackTable does NOT render the pagination container when rows are empty
-    const tablePanel = page.locator('[data-test="dashboard-panel-table"]');
+    const tablePanel = pm.dashboardPanelActions.dashboardTable;
     await tablePanel.waitFor({ state: "visible", timeout: 15000 });
 
     // Wait for table rows - if first attempt returns no data, re-apply to retry the query
@@ -1159,11 +1159,11 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
 
     // Wait for the table bottom container which holds all pagination controls
     // (PromQL with legend uses a custom bottom slot that also has this data-test)
-    const tableBottom = page.locator('[data-test="dashboard-table-pagination"]');
+    const tableBottom = pm.dashboardPanelConfigs.tablePagination;
     await tableBottom.waitFor({ state: "visible", timeout: 15000 });
 
     // Verify "Records per page" text is visible
-    const rowsPerPageText = page.locator('[data-test="dashboard-table-rows-per-page-label"]');
+    const rowsPerPageText = pm.dashboardPanelConfigs.tableRowsPerPageLabel;
     await expect(rowsPerPageText).toBeVisible({ timeout: 10000 });
 
     // Wait for row count to show actual data in format "X-Y of Z"
@@ -1174,7 +1174,7 @@ test.describe("Dashboard Table Chart Pagination Feature - PromQL Tables", () => 
       },
       { timeout: 15000 }
     );
-    const paginationInfo = page.locator('[data-test="dashboard-table-row-count"]');
+    const paginationInfo = pm.dashboardPanelConfigs.tableRowCount;
 
     // Verify pagination shows correct format (e.g., "1-10 of X" or "1-N of N" if fewer records)
     const paginationText = await paginationInfo.textContent();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-tabs-setting.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-tabs-setting.spec.js
@@ -29,11 +29,7 @@ test.describe("dashboard tabs setting", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a tab
     await pm.dashboardSetting.openSetting();
@@ -63,18 +59,14 @@ test.describe("dashboard tabs setting", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting(newTabName);
     await pm.dashboardSetting.saveTabSetting();
 
-    await expect(page.locator('[data-test="o-toast-message"]').filter({ hasText: "Tab added successfully" })).toBeVisible({
+    await expect(pm.dashboardSetting.getToastMessageByText("Tab added successfully")).toBeVisible({
       timeout: 5000,
     });
 
@@ -99,20 +91,13 @@ test.describe("dashboard tabs setting", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting(newTabName);
     await pm.dashboardSetting.saveTabSetting();
-    // await expect(page.getByText("Dashboard added successfully.")).toBeVisible({
-    //   timeout: 3000,
-    // });
-    await expect(page.locator('[data-test="o-toast-message"]').filter({ hasText: "Tab added successfully" })).toBeVisible({
+    await expect(pm.dashboardSetting.getToastMessageByText("Tab added successfully")).toBeVisible({
       timeout: 5000,
     });
 
@@ -123,10 +108,7 @@ test.describe("dashboard tabs setting", () => {
     );
 
     await pm.dashboardSetting.saveEditedtab();
-    // await expect(page.getByText("Tab added successfully")).toBeVisible({
-    //   timeout: 2000,
-    // });
-    await expect(page.locator('[data-test="o-toast-message"]').filter({ hasText: "Tab updated successfully" })).toBeVisible({
+    await expect(pm.dashboardSetting.getToastMessageByText("Tab updated successfully")).toBeVisible({
       timeout: 5000,
     });
     await pm.dashboardSetting.closeSettingDashboard();
@@ -149,21 +131,14 @@ test.describe("dashboard tabs setting", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and add a tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting(newTabName);
     await pm.dashboardSetting.saveTabSetting();
 
-    // await expect(page.getByText("Dashboard added successfully.")).toBeVisible({
-    //   timeout: 3000,
-    // });
-    await expect(page.locator('[data-test="o-toast-message"]').filter({ hasText: "Tab added successfully" })).toBeVisible({
+    await expect(pm.dashboardSetting.getToastMessageByText("Tab added successfully")).toBeVisible({
       timeout: 5000,
     });
 
@@ -192,27 +167,20 @@ test.describe("dashboard tabs setting", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(randomDashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings, add a tab, and delete it
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting(newTabName);
     await pm.dashboardSetting.saveTabSetting();
 
-    // await expect(page.getByText("Dashboard added successfully.")).toBeVisible({
-    //   timeout: 3000,
-    // });
-    await expect(page.locator('[data-test="o-toast-message"]').filter({ hasText: "Tab added successfully" })).toBeVisible({
+    await expect(pm.dashboardSetting.getToastMessageByText("Tab added successfully")).toBeVisible({
       timeout: 5000,
     });
 
     // Delete the tab
     await pm.dashboardSetting.deleteTab(newTabName);
-    await expect(page.locator('[data-test="o-toast-message"]').filter({ hasText: "Tab deleted successfully" })).toBeVisible({
+    await expect(pm.dashboardSetting.getToastMessageByText("Tab deleted successfully")).toBeVisible({
       timeout: 5000,
     });
     await pm.dashboardSetting.closeSettingDashboard();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-transpose.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-transpose.spec.js
@@ -337,20 +337,14 @@ test.describe("dashboard UI testcases", () => {
     await pm.chartTypeSelector.removeField("x_axis_1", "x");
 
     // Open Custom SQL editor
-    await page.locator('[data-test="dashboard-sql-query-type"]').click();
-    await page.locator('[data-test="dashboard-custom-query-type"]').click();
+    await pm.chartTypeSelector.clickSqlQueryType();
+    await pm.chartTypeSelector.clickCustomQueryType();
 
     // Focus on the editor and enter the custom SQL query
-    await page
-      .locator('[data-test="dashboard-panel-query-editor"]')
-      .getByRole('code')
-      .click();
-    await page
-      .locator('[data-test="dashboard-panel-query-editor"]')
-      .locator(".inputarea")
-      .fill(
-        'SELECT kubernetes_namespace_name as "xAxis", count(kubernetes_namespace_name) as "y_axis_1"  FROM "e2e_automate"  GROUP BY "xAxis"'
-      );
+    await pm.chartTypeSelector.clickQueryEditorCode();
+    await pm.chartTypeSelector.fillQueryEditorInputArea(
+      'SELECT kubernetes_namespace_name as "xAxis", count(kubernetes_namespace_name) as "y_axis_1"  FROM "e2e_automate"  GROUP BY "xAxis"'
+    );
 
     await pm.chartTypeSelector.searchAndAddField("y_axis_1", "x");
     await pm.chartTypeSelector.searchAndAddField("xAxis", "y");

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-creation-scopes.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-creation-scopes.spec.js
@@ -37,14 +37,14 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab1");
 
     // Add global variable
     await scopedVars.addScopedVariable(globalVar, "logs", "e2e_automate", "kubernetes_namespace_name", { scope: "global" });
@@ -72,7 +72,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 
@@ -88,7 +88,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add panel
     await pm.dashboardCreate.addPanel();
@@ -101,19 +101,19 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard and panel editor to close
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     // Wait for panel editor dialog to be fully closed
     await safeWaitForHidden(page, SELECTORS.COMPONENTS.DIALOG, { timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     // Wait for settings button to be available (indicates panel editor has closed)
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.waitForDashboardReady({ timeout: 15000 });
 
     // Add tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab1");
 
     // Add panel variable using panel name instead of panel ID
     await scopedVars.addScopedVariable(panelVar, "logs", "e2e_automate", "kubernetes_namespace_name", {
@@ -122,17 +122,14 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     });
 
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(panelVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(panelVar);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Try to add tab variable
-    await page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
-    await page.locator('[data-test="dashboard-variable-name-field"]').fill(tabVar);
+    await scopedVars.clickAddVariableBtn();
+    await scopedVars.fillVariableName(tabVar);
 
-    await page.locator(SELECTORS.VARIABLE_SCOPE_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-scope-select-option"][data-test-value="tabs"]').click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariableScope("tabs");
 
     // Select stream and field using shared utilities
     await selectStreamType(page, "logs");
@@ -141,29 +138,23 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
 
     // Check dependency dropdown via filter - should NOT show panel variables
     // Add filter to check available dependency options
-    await page.locator(SELECTORS.ADD_FILTER_BTN).click();
+    await scopedVars.clickAddFilter();
 
-    const filterNameSelector = page.locator(SELECTORS.FILTER_NAME_SELECTOR).last();
-    await filterNameSelector.waitFor({ state: "visible" });
-    await filterNameSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-search"]').fill("kubernetes_namespace_name");
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-option"][data-test-value="kubernetes_namespace_name"]').click();
+    await scopedVars.selectFilterName("kubernetes_namespace_name");
 
-    const operatorSelector = page.locator(SELECTORS.FILTER_OPERATOR_SELECTOR).last();
-    await operatorSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-operator-selector-option"][data-test-value="="]').click();
+    await scopedVars.selectFilterOperator("=");
 
     // Click on the filter value OCombobox input to open autocomplete suggestions
-    const filterValueInput = page.locator('[data-test*="filter-value-selector"][data-test$="-input"]').last();
+    const filterValueInput = scopedVars.getFilterValueInput();
     await filterValueInput.waitFor({ state: "visible", timeout: 5000 });
     await filterValueInput.click();
 
     // OCombobox opens on focus (:open-on-focus="true"); options appear immediately
-    const hasDropdown = await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').first().isVisible({ timeout: 2000 }).catch(() => false);
+    const hasDropdown = await scopedVars.getFilterValueOptions().first().isVisible({ timeout: 2000 }).catch(() => false);
 
     if (hasDropdown) {
       // If dropdown appears, verify panel variable is NOT in the list
-      const options = await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').allTextContents();
+      const options = await scopedVars.getFilterValueOptionTexts();
       expect(options).not.toContain(panelVar);
     } else {
       // If dropdown doesn't appear, it means there are no variables available (correct behavior)
@@ -179,7 +170,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 
@@ -195,19 +186,19 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add Tab1 and Tab2
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab1");
 
     await pm.dashboardSetting.addTabSetting("Tab2");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab2")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab2");
 
     // Add variable to Tab1
     await scopedVars.addScopedVariable(tab1Var, "logs", "e2e_automate", "kubernetes_namespace_name", {
@@ -216,28 +207,17 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     });
 
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(tab1Var)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(tab1Var);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Try to add variable to Tab2
-    await page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
-    await page.locator('[data-test="dashboard-variable-name-field"]').fill(tab2Var);
+    await scopedVars.clickAddVariableBtn();
+    await scopedVars.fillVariableName(tab2Var);
 
-    await page.locator(SELECTORS.VARIABLE_SCOPE_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-scope-select-option"][data-test-value="tabs"]').click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariableScope("tabs");
 
     // Open tabs dropdown and select tab2
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).waitFor({ state: "visible" });
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).click();
-    // Wait for dropdown popover to be visible
-    await page.locator('[data-test="dashboard-variable-tabs-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    // Click the Tab2 option by label
-    await page.locator('[data-test="dashboard-variable-tabs-select-option"][data-test-label="Tab2"]').waitFor({ state: "visible" });
-    await page.locator('[data-test="dashboard-variable-tabs-select-option"][data-test-label="Tab2"]').click();
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-tabs-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariableTab("Tab2");
 
     // Select stream and field using shared utilities
     await selectStreamType(page, "logs");
@@ -245,29 +225,23 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await selectFieldFromDropdown(page, "kubernetes_container_name");
 
     // Check dependency dropdown via filter - should NOT show Tab1's variable
-    await page.locator(SELECTORS.ADD_FILTER_BTN).click();
+    await scopedVars.clickAddFilter();
 
-    const filterNameSelector = page.locator(SELECTORS.FILTER_NAME_SELECTOR).last();
-    await filterNameSelector.waitFor({ state: "visible" });
-    await filterNameSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-search"]').fill("kubernetes_namespace_name");
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-option"][data-test-value="kubernetes_namespace_name"]').click();
+    await scopedVars.selectFilterName("kubernetes_namespace_name");
 
-    const operatorSelector = page.locator(SELECTORS.FILTER_OPERATOR_SELECTOR).last();
-    await operatorSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-operator-selector-option"][data-test-value="="]').click();
+    await scopedVars.selectFilterOperator("=");
 
     // Click on the filter value OCombobox input to open autocomplete suggestions
-    const filterValueInput2 = page.locator('[data-test*="filter-value-selector"][data-test$="-input"]').last();
+    const filterValueInput2 = scopedVars.getFilterValueInput();
     await filterValueInput2.waitFor({ state: "visible", timeout: 5000 });
     await filterValueInput2.click();
 
     // OCombobox opens on focus (:open-on-focus="true"); options appear immediately
-    const hasDropdown2 = await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').first().isVisible({ timeout: 2000 }).catch(() => false);
+    const hasDropdown2 = await scopedVars.getFilterValueOptions().first().isVisible({ timeout: 2000 }).catch(() => false);
 
     if (hasDropdown2) {
       // If dropdown appears, verify tab1's variable is NOT in the list
-      const options2 = await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').allTextContents();
+      const options2 = await scopedVars.getFilterValueOptionTexts();
       expect(options2).not.toContain(tab1Var);
     } else {
       // If dropdown doesn't appear, it means there are no variables available (correct behavior)
@@ -283,7 +257,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 
@@ -300,19 +274,19 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab1");
 
     // Add global and tab variables
     await scopedVars.addScopedVariable(globalVar, "logs", "e2e_automate", "kubernetes_namespace_name", { scope: "global" });
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(globalVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(globalVar);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // open setting window
@@ -323,7 +297,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
       assignedTabs: ["tab1"]
     });
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(tabVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(tabVar);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -333,13 +307,13 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardReady({ timeout: 10000 });
 
     // Switch to Tab1 and add panel
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.waitForTabVisible("Tab1");
+    await scopedVars.clickTab("Tab1");
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForAddPanelBtn({ timeout: 5000 });
     // Ensure no dialogs are open before adding panel
     await safeWaitForHidden(page, SELECTORS.COMPONENTS.DIALOG, { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
@@ -354,12 +328,12 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard and panel editor to close
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     // Wait for panel editor dialog to be fully closed
     await safeWaitForHidden(page, SELECTORS.COMPONENTS.DIALOG, { timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     // Wait for settings button to be available (indicates panel editor has closed)
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.waitForDashboardReady({ timeout: 15000 });
     // Additional wait to ensure dashboard is stable after panel creation
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
@@ -368,35 +342,17 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // openSetting() already waits for the dialog to be fully open (verifies general tab is visible)
     await pm.dashboardSetting.openVariables();
     // Wait for variables tab to be active and add button to be visible
-    await page.locator(SELECTORS.ADD_VARIABLE_BTN).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
-    await page.locator('[data-test="dashboard-variable-name-field"]').fill(panelVar);
+    await scopedVars.waitForAddVariableBtnVisible();
+    await scopedVars.clickAddVariableBtn();
+    await scopedVars.fillVariableName(panelVar);
 
-    await page.locator(SELECTORS.VARIABLE_SCOPE_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-scope-select-option"][data-test-value="panels"]').click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariableScope("panels");
 
     // First select the tab containing the panel
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).waitFor({ state: "visible" });
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).click();
-    // Wait for dropdown popover to be visible
-    await page.locator('[data-test="dashboard-variable-tabs-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    // Click the Tab1 option by label
-    await page.locator('[data-test="dashboard-variable-tabs-select-option"][data-test-label="Tab1"]').waitFor({ state: "visible" });
-    await page.locator('[data-test="dashboard-variable-tabs-select-option"][data-test-label="Tab1"]').click();
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-tabs-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariableTab("Tab1");
 
     // Then select the panel by name
-    await page.locator(SELECTORS.VARIABLE_PANELS_SELECT).waitFor({ state: "visible" });
-    await page.locator(SELECTORS.VARIABLE_PANELS_SELECT).click();
-    // Wait for dropdown popover to be visible
-    await page.locator('[data-test="dashboard-variable-panels-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-panels-select-option"][data-test-label="Panel1"]').waitFor({ state: "visible" });
-    await page.locator('[data-test="dashboard-variable-panels-select-option"][data-test-label="Panel1"]').click();
-    await page.locator(SELECTORS.VARIABLE_PANELS_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-panels-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariablePanel("Panel1");
 
     // Select stream and field using shared utilities
     await selectStreamType(page, "logs");
@@ -404,27 +360,21 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await selectFieldFromDropdown(page, "kubernetes_pod_name");
 
     // Check dependency dropdown via filter - should show both global and tab variables
-    await page.locator(SELECTORS.ADD_FILTER_BTN).click();
+    await scopedVars.clickAddFilter();
 
-    const filterNameSelector = page.locator(SELECTORS.FILTER_NAME_SELECTOR).last();
-    await filterNameSelector.waitFor({ state: "visible" });
-    await filterNameSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-search"]').fill("kubernetes_namespace_name");
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-option"][data-test-value="kubernetes_namespace_name"]').click();
+    await scopedVars.selectFilterName("kubernetes_namespace_name");
 
-    const operatorSelector = page.locator(SELECTORS.FILTER_OPERATOR_SELECTOR).last();
-    await operatorSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-operator-selector-option"][data-test-value="="]').click();
+    await scopedVars.selectFilterOperator("=");
 
     // Click on the filter value OCombobox input to open autocomplete suggestions
-    const filterValueInput3 = page.locator('[data-test*="filter-value-selector"][data-test$="-input"]').last();
+    const filterValueInput3 = scopedVars.getFilterValueInput();
     await filterValueInput3.waitFor({ state: "visible", timeout: 10000 });
     await filterValueInput3.click();
 
     // OCombobox opens on focus; wait for options to appear
-    await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').first().waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getFilterValueOptions().first().waitFor({ state: "visible", timeout: 10000 });
 
-    const options3 = await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').allTextContents();
+    const options3 = await scopedVars.getFilterValueOptionTexts();
     expect(options3).toContain(globalVar);
     expect(options3).toContain(tabVar);
 
@@ -437,7 +387,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 
@@ -453,7 +403,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add Panel1
     await pm.dashboardCreate.addPanel();
@@ -481,34 +431,16 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     });
 
     // Try to add variable to Panel2 depending on Panel1's variable
-    await page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
-    await page.locator('[data-test="dashboard-variable-name-field"]').fill(panel2Var);
+    await scopedVars.clickAddVariableBtn();
+    await scopedVars.fillVariableName(panel2Var);
 
-    await page.locator(SELECTORS.VARIABLE_SCOPE_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-scope-select-option"][data-test-value="panels"]').click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariableScope("panels");
 
     // First select the default tab to enable the panels dropdown
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).waitFor({ state: "visible" });
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).click();
-    // Wait for dropdown popover to be visible
-    await page.locator('[data-test="dashboard-variable-tabs-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    // Click the Default tab option by label
-    await page.locator('[data-test="dashboard-variable-tabs-select-option"][data-test-label="Default"]').waitFor({ state: "visible" });
-    await page.locator('[data-test="dashboard-variable-tabs-select-option"][data-test-label="Default"]').click();
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-tabs-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariableTab("Default");
 
     // Now open the panels dropdown and select panel2 by name
-    await page.locator(SELECTORS.VARIABLE_PANELS_SELECT).waitFor({ state: "visible" });
-    await page.locator(SELECTORS.VARIABLE_PANELS_SELECT).click();
-    // Wait for dropdown popover to be visible
-    await page.locator('[data-test="dashboard-variable-panels-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-panels-select-option"][data-test-label="Panel2"]').waitFor({ state: "visible" });
-    await page.locator('[data-test="dashboard-variable-panels-select-option"][data-test-label="Panel2"]').click();
-    await page.locator(SELECTORS.VARIABLE_PANELS_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-panels-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariablePanel("Panel2");
 
     // Select stream and field using shared utilities
     await selectStreamType(page, "logs");
@@ -516,29 +448,23 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await selectFieldFromDropdown(page, "kubernetes_pod_name");
 
     // Check dependency dropdown via filter - should NOT show Panel1's variable
-    await page.locator(SELECTORS.ADD_FILTER_BTN).click();
+    await scopedVars.clickAddFilter();
 
-    const filterNameSelector = page.locator(SELECTORS.FILTER_NAME_SELECTOR).last();
-    await filterNameSelector.waitFor({ state: "visible" });
-    await filterNameSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-search"]').fill("kubernetes_namespace_name");
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-option"][data-test-value="kubernetes_namespace_name"]').click();
+    await scopedVars.selectFilterName("kubernetes_namespace_name");
 
-    const operatorSelector = page.locator(SELECTORS.FILTER_OPERATOR_SELECTOR).last();
-    await operatorSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-operator-selector-option"][data-test-value="="]').click();
+    await scopedVars.selectFilterOperator("=");
 
     // Click on the filter value OCombobox input to open autocomplete suggestions
-    const filterValueInput4 = page.locator('[data-test*="filter-value-selector"][data-test$="-input"]').last();
+    const filterValueInput4 = scopedVars.getFilterValueInput();
     await filterValueInput4.waitFor({ state: "visible", timeout: 5000 });
     await filterValueInput4.click();
 
     // OCombobox opens on focus (:open-on-focus="true"); options appear immediately
-    const hasDropdown4 = await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').first().isVisible({ timeout: 2000 }).catch(() => false);
+    const hasDropdown4 = await scopedVars.getFilterValueOptions().first().isVisible({ timeout: 2000 }).catch(() => false);
 
     if (hasDropdown4) {
       // If dropdown appears, verify panel1's variable is NOT in the list
-      const options4 = await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').allTextContents();
+      const options4 = await scopedVars.getFilterValueOptionTexts();
       expect(options4).not.toContain(panel1Var);
     } else {
       // If dropdown doesn't appear, it means there are no variables available (correct behavior)
@@ -554,7 +480,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 
@@ -569,24 +495,24 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add multiple tabs
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab1");
 
     await pm.dashboardSetting.addTabSetting("Tab2");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab2")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab2");
 
     await pm.dashboardSetting.addTabSetting("Tab3");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab3")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab3");
 
     // Add variable assigned to all tabs
     await scopedVars.addScopedVariable(variableName, "logs", "e2e_automate", "kubernetes_namespace_name", {
@@ -595,24 +521,23 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     });
 
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(variableName);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardReady({ timeout: 10000 });
 
     // Verify variable is visible in all tabs
     const tabMapping = { tab1: "Tab1", tab2: "Tab2", tab3: "Tab3" };
     for (const tabId of ["tab1", "tab2", "tab3"]) {
-      const tabLocator = page.locator(getTabSelector(tabMapping[tabId]));
-      await tabLocator.click();
+      await scopedVars.clickTab(tabMapping[tabId]);
       // Wait for tab to be active by checking for active state or waiting for tab content to load
-      await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+      await scopedVars.waitForTabContentLoaded();
 
       // Wait for variable to appear on the dashboard after tab switch
-      await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
       await scopedVars.verifyVariableVisibility(variableName, true);
     }
@@ -620,7 +545,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 
@@ -635,7 +560,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add multiple panels
     await pm.dashboardCreate.addPanel();
@@ -655,9 +580,9 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for both panels to be fully rendered
-    await page.locator(SELECTORS.PANEL_ANY).nth(1).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(1).waitFor({ state: "visible", timeout: 15000 });
     // Wait for settings button to ensure panels are fully loaded
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardReady({ timeout: 10000 });
 
     // Add variable assigned to both panels using panel names
     await pm.dashboardSetting.openSetting();
@@ -666,15 +591,15 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
       assignedPanels: ["Panel1", "Panel2"]
     });
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(variableName);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
     // Wait for variable selectors to appear on panels
-    await page.locator(getVariableSelector(variableName)).first().waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).first().waitFor({ state: "visible", timeout: 10000 });
 
     // Verify variable is visible for both panels - should have 2 variable selectors (one per panel)
-    const variableSelectors = page.locator(getVariableSelector(variableName));
+    const variableSelectors = scopedVars.getVariableSelectorLocator(variableName);
     await expect(variableSelectors).toHaveCount(2, { timeout: 10000 });
     // Verify both are visible
     await expect(variableSelectors.first()).toBeVisible({ timeout: 5000 });
@@ -683,7 +608,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 
@@ -698,14 +623,14 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab1");
 
     // Create tab variable WITHOUT any global variables
     await scopedVars.addScopedVariable(tabVar, "logs", "e2e_automate", "kubernetes_namespace_name", {
@@ -714,28 +639,28 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     });
 
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(tabVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(tabVar);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardReady({ timeout: 10000 });
 
     // Switch to Tab1 and verify variable exists
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.clickTab("Tab1");
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on the dashboard after tab switch
-    await page.locator(getVariableSelector(tabVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(tabVar).waitFor({ state: "visible", timeout: 10000 });
 
     await scopedVars.verifyVariableVisibility(tabVar, true);
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 
@@ -751,19 +676,19 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add Tab1
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab1");
 
     // Add global and tab variables
     await scopedVars.addScopedVariable(globalVar, "logs", "e2e_automate", "kubernetes_namespace_name", { scope: "global" });
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(globalVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(globalVar);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // open setting window
@@ -774,7 +699,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
       assignedTabs: ["tab1"]
     });
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(tabVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(tabVar);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -784,12 +709,12 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardReady({ timeout: 10000 });
 
     // Switch to Tab1
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.clickTab("Tab1");
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForAddPanelBtn({ timeout: 5000 });
     // Ensure no dialogs are open before adding panel
     await safeWaitForHidden(page, SELECTORS.COMPONENTS.DIALOG, { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
@@ -797,8 +722,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Go to add panel
     await pm.dashboardCreate.addPanel();
     // Wait for panel editor to open - wait for the chart type selection which appears first
-    const panelEditorIndicator = page.locator(SELECTORS.CHART_LINE_ITEM).or(page.locator(SELECTORS.APPLY_BTN)).first();
-    await panelEditorIndicator.waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.waitForPanelEditorOpen();
 
     // Check available variables in panel edit mode
     // Both global and tab1 variables should be available
@@ -816,7 +740,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 
@@ -832,19 +756,19 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.waitForAddPanelBtn();
 
     // Add Tab1 and Tab2
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab1");
 
     await pm.dashboardSetting.addTabSetting("Tab2");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab2")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForTabVisible("Tab2");
 
     // Add variables to both tabs
     await scopedVars.addScopedVariable(tab1Var, "logs", "e2e_automate", "kubernetes_namespace_name", {
@@ -852,7 +776,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
       assignedTabs: ["tab1"]
     });
     // Wait for first variable to be saved
-    await page.locator(getEditVariableBtn(tab1Var)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(tab1Var);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await scopedVars.addScopedVariable(tab2Var, "logs", "e2e_automate", "kubernetes_container_name", {
@@ -860,7 +784,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
       assignedTabs: ["tab2"]
     });
     // Wait for second variable to be saved
-    await page.locator(getEditVariableBtn(tab2Var)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForEditVariableBtnVisible(tab2Var);
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -870,17 +794,16 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardReady({ timeout: 10000 });
 
     // Go to Tab1 and add panel
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.clickTab("Tab1");
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForAddPanelBtn({ timeout: 5000 });
 
     await pm.dashboardCreate.addPanel();
     // Wait for panel editor to open - wait for the chart type selection which appears first
-    const panelEditorIndicator2 = page.locator(SELECTORS.CHART_LINE_ITEM).or(page.locator(SELECTORS.APPLY_BTN)).first();
-    await panelEditorIndicator2.waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.waitForPanelEditorOpen();
 
     // Should see Tab1 variable, but NOT Tab2 variable
     await scopedVars.verifyVariableInPanelEdit(tab1Var, true);
@@ -897,7 +820,7 @@ test.describe("Dashboard Variables - Creation & Scope Restrictions", { tag: ['@d
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForDashboardSearch();
     await deleteDashboard(page, dashboardName);
   });
 });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-custom-parents.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-custom-parents.spec.js
@@ -367,9 +367,9 @@ test.describe("Dashboard Variables - Custom/Constant/Textbox as Parents", { tag:
     await parentSelector.click();
 
     // Confirm dropdown is open, then close without selecting
-    await page.locator(`[data-test="variable-selector-${customVar}-inner-popover"]`).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForVariablePopoverVisible(customVar, { timeout: 5000 });
     await page.keyboard.press("Escape");
-    await page.locator(`[data-test="variable-selector-${customVar}-inner-popover"]`).waitFor({ state: "hidden", timeout: 3000 });
+    await scopedVars.waitForVariablePopoverHidden(customVar, { timeout: 3000 });
 
     // Check API monitoring result (monitor has its own 3s timeout)
     const apiResult = await apiMonitorPromise;

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-default-values-chain.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-default-values-chain.spec.js
@@ -37,7 +37,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable A (independent)
     await pm.dashboardSetting.openSetting();
@@ -51,7 +51,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     );
     await pm.dashboardSetting.closeSettingWindow();
 
-    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varA).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Add variable B (depends on A, with "all" default, single-select)
@@ -72,7 +72,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     await pm.dashboardSetting.closeSettingWindow();
 
     // Verify B has "All" value
-    const varBSelector = page.locator(getVariableSelector(varB));
+    const varBSelector = scopedVars.getVariableSelectorLocator(varB);
     await varBSelector.waitFor({ state: "visible", timeout: 10000 });
     const varBValue = await varBSelector.locator('[data-test$="-inner-value"]').textContent();
     expect(varBValue).toContain("ALL");
@@ -108,7 +108,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable A (independent)
     await pm.dashboardSetting.openSetting();
@@ -122,7 +122,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     );
     await pm.dashboardSetting.closeSettingWindow();
 
-    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varA).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Add variable B (depends on A, with custom default, multi-select)
@@ -148,7 +148,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
 
 
     // Verify B has custom values
-    const varBSelector = page.locator(getVariableSelector(varB));
+    const varBSelector = scopedVars.getVariableSelectorLocator(varB);
     await varBSelector.waitFor({ state: "visible", timeout: 10000 });
     const varBValue = await varBSelector.locator('[data-test$="-inner-value"]').textContent();
     expect(varBValue).toContain(customValue1);
@@ -185,7 +185,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable A (independent)
     await pm.dashboardSetting.openSetting();
@@ -237,17 +237,17 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     await pm.dashboardSetting.closeSettingWindow();
 
     // Verify all variables are visible
-    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(getVariableSelector(varB)).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(getVariableSelector(varC)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varA).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varB).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varC).waitFor({ state: "visible", timeout: 10000 });
 
     // Verify B has "All" value
-    const varBSelector = page.locator(getVariableSelector(varB));
+    const varBSelector = scopedVars.getVariableSelectorLocator(varB);
     const varBValue = await varBSelector.locator('[data-test$="-inner-value"]').textContent();
     expect(varBValue).toContain("ALL");
 
     // Verify C has a value (not null)
-    const varCSelector = page.locator(getVariableSelector(varC));
+    const varCSelector = scopedVars.getVariableSelectorLocator(varC);
     const varCValue = await varCSelector.locator('[data-test$="-inner-value"]').textContent();
     expect(varCValue).toBeTruthy();
     expect(varCValue.length).toBeGreaterThan(0);
@@ -292,7 +292,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add A (independent)
     await pm.dashboardSetting.openSetting();
@@ -361,19 +361,19 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     await pm.dashboardSetting.closeSettingWindow();
 
     // Verify all variables are visible
-    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(getVariableSelector(varB)).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(getVariableSelector(varC)).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(getVariableSelector(varD)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varA).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varB).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varC).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varD).waitFor({ state: "visible", timeout: 10000 });
 
     // Verify initial values
-    const varBValue = await page.locator(getVariableSelector(varB)).locator('[data-test$="-inner-value"]').textContent();
+    const varBValue = await scopedVars.getVariableInnerValueLocator(varB).textContent();
     expect(varBValue).toContain("ALL");
 
-    const varCValue = await page.locator(getVariableSelector(varC)).locator('[data-test$="-inner-value"]').textContent();
+    const varCValue = await scopedVars.getVariableInnerValueLocator(varC).textContent();
     expect(varCValue).toContain("custom_pod");
 
-    const varDValue = await page.locator(getVariableSelector(varD)).locator('[data-test$="-inner-value"]').textContent();
+    const varDValue = await scopedVars.getVariableInnerValueLocator(varD).textContent();
     expect(varDValue).toBeTruthy();
 
     // Change A and verify the entire chain
@@ -388,13 +388,13 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     // Verify all values are maintained/loaded properly
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
-    const varBValueAfter = await page.locator(getVariableSelector(varB)).locator('[data-test$="-inner-value"]').textContent();
+    const varBValueAfter = await scopedVars.getVariableInnerValueLocator(varB).textContent();
     expect(varBValueAfter).toContain("ALL");
 
-    const varCValueAfter = await page.locator(getVariableSelector(varC)).locator('[data-test$="-inner-value"]').textContent();
+    const varCValueAfter = await scopedVars.getVariableInnerValueLocator(varC).textContent();
     expect(varCValueAfter).toContain("custom_pod");
 
-    const varDValueAfter = await page.locator(getVariableSelector(varD)).locator('[data-test$="-inner-value"]').textContent();
+    const varDValueAfter = await scopedVars.getVariableInnerValueLocator(varD).textContent();
     expect(varDValueAfter).toBeTruthy();
     expect(varDValueAfter.length).toBeGreaterThan(0);
 
@@ -415,7 +415,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable A (independent)
     await pm.dashboardSetting.openSetting();
@@ -429,7 +429,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     );
     await pm.dashboardSetting.closeSettingWindow();
 
-    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varA).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Add variable B (depends on A, with custom default, single-select)
@@ -452,7 +452,7 @@ test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag:
     await pm.dashboardSetting.closeSettingWindow();
 
     // Verify B has custom value
-    const varBSelector = page.locator(getVariableSelector(varB));
+    const varBSelector = scopedVars.getVariableSelectorLocator(varB);
     await varBSelector.waitFor({ state: "visible", timeout: 10000 });
     const varBValue = await varBSelector.locator('[data-test$="-inner-value"]').textContent();
     expect(varBValue).toContain(customValue);

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-dependency.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-dependency.spec.js
@@ -43,7 +43,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable A (independent)
     await pm.dashboardSetting.openSetting();
@@ -59,7 +59,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
     // Wait for variable to be saved
-    await page.locator(`[data-test="dashboard-edit-variable-${varA}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(varA).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Add variable B (depends on A)
@@ -76,7 +76,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     );
 
     // Wait for variable to be saved
-    await page.locator(`[data-test="dashboard-edit-variable-${varB}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(varB).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -86,7 +86,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(`[data-test="variable-selector-${varB}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varB).waitFor({ state: "visible", timeout: 10000 });
 
     // Change A and monitor B's reload using the new helper function
     const result = await scopedVars.changeVariableValueAndMonitorDependencies(varA, {
@@ -117,7 +117,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variables: A (independent), B (depends on A), C (depends on B)
     await pm.dashboardSetting.openSetting();
@@ -127,8 +127,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varA}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varA).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -141,14 +141,14 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
     await pm.dashboardSetting.openVariables();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
-    await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     await scopedVars.addScopedVariable(varB, "logs", "e2e_automate", "kubernetes_container_name", { scope: "global", dependsOn: varA, dependsOnField: "kubernetes_namespace_name" });
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varB}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varB).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -161,19 +161,19 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
     await pm.dashboardSetting.openVariables();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
-    await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     await scopedVars.addScopedVariable(varC, "logs", "e2e_automate", "_timestamp", { scope: "global", dependsOn: varB, dependsOnField: "kubernetes_container_name" });
 
     // Wait for variable to be saved - either in settings or redirected to dashboard
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varC}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varC).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Close settings if still open
-    const isDialogOpen = await page.locator(SELECTORS.DIALOG).isVisible().catch(() => false);
+    const isDialogOpen = await scopedVars.isDialogVisible();
     if (isDialogOpen) {
       await pm.dashboardSetting.closeSettingWindow();
     }
@@ -183,7 +183,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(varC)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varC).waitFor({ state: "visible", timeout: 10000 });
 
     // Monitor 2 API calls (B and C) when A changes
     // Change A and monitor B and C's reload using the new helper function
@@ -213,7 +213,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -235,8 +235,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
       // Wait for variable to be saved - either in settings or redirected to dashboard
       await Promise.race([
-        page.locator(`[data-test="dashboard-edit-variable-${vars[i]}"]`).waitFor({ state: "visible", timeout: 10000 }),
-        page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+        scopedVars.getEditVariableBtnLocator(vars[i]).waitFor({ state: "visible", timeout: 10000 }),
+        scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
       ]).catch(() => {});
       await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -256,12 +256,12 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
         await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
         // Wait for Add Variable button to be visible and ready
-        await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
       }
     }
 
     // Close settings if still open
-    const isDialogOpen = await page.locator(SELECTORS.DIALOG).isVisible().catch(() => false);
+    const isDialogOpen = await scopedVars.isDialogVisible();
     if (isDialogOpen) {
       await pm.dashboardSetting.closeSettingWindow();
     }
@@ -272,7 +272,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Check if we're actually on the dashboard view by looking for the add panel button or variable selector
     // If not visible, we may have been redirected to the dashboard list, so navigate back
-    const isDashboardView = await page.locator(SELECTORS.ADD_PANEL_BTN).isVisible().catch(() => false);
+    const isDashboardView = await scopedVars.getAddPanelBtnLocator().isVisible().catch(() => false);
     if (!isDashboardView) {
       // Not on dashboard, navigate back to it
       await pm.dashboardList.clickOnDashboard(dashboardName);
@@ -281,7 +281,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     }
 
     // Wait for variable to appear on dashboard
-    await page.locator(`[data-test="variable-selector-${vars[3]}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(vars[3]).waitFor({ state: "visible", timeout: 10000 });
 
     // Change A and monitor cascade using the new helper function
     const result = await scopedVars.changeVariableValueAndMonitorDependencies(vars[0], {
@@ -310,7 +310,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -340,8 +340,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
       // Wait for variable to be saved - either in settings or redirected to dashboard
       await Promise.race([
-        page.locator(`[data-test="dashboard-edit-variable-${vars[i]}"]`).waitFor({ state: "visible", timeout: 10000 }),
-        page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+        scopedVars.getEditVariableBtnLocator(vars[i]).waitFor({ state: "visible", timeout: 10000 }),
+        scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
       ]).catch(() => {});
       await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -361,12 +361,12 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
         await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
         // Wait for Add Variable button to be visible and ready
-        await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
       }
     }
 
     // Close settings if still open
-    const isDialogOpen = await page.locator(SELECTORS.DIALOG).isVisible().catch(() => false);
+    const isDialogOpen = await scopedVars.isDialogVisible();
     if (isDialogOpen) {
       await pm.dashboardSetting.closeSettingWindow();
     }
@@ -377,7 +377,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Check if we're actually on the dashboard view by looking for the add panel button or variable selector
     // If not visible, we may have been redirected to the dashboard list, so navigate back
-    const isDashboardView = await page.locator(SELECTORS.ADD_PANEL_BTN).isVisible().catch(() => false);
+    const isDashboardView = await scopedVars.getAddPanelBtnLocator().isVisible().catch(() => false);
     if (!isDashboardView) {
       // Not on dashboard, navigate back to it
       await pm.dashboardList.clickOnDashboard(dashboardName);
@@ -386,13 +386,13 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     }
 
     // Wait for variable to appear on dashboard
-    await page.locator(`[data-test="variable-selector-${vars[5]}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(vars[5]).waitFor({ state: "visible", timeout: 10000 });
 
     // Change first variable and monitor cascade
     const apiMonitor = monitorVariableAPICalls(page, { expectedCount: 5, timeout: 30000 });
 
     // Wait for variable dropdown to be visible and ready
-    const var0Dropdown = page.locator(`[data-test="variable-selector-${vars[0]}"]`);
+    const var0Dropdown = scopedVars.getVariableSelectorLocator(vars[0]);
     await var0Dropdown.waitFor({ state: "visible", timeout: 5000 });
     // Ensure network is idle before clicking
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
@@ -401,8 +401,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await var0Dropdown.click();
 
     // Wait for dropdown menu to open and options to load
-    await page.locator(`[data-test="variable-selector-${vars[0]}-inner-popover"]`).waitFor({ state: "visible", timeout: 5000 });
-    const options = page.locator('[role="option"]');
+    await scopedVars.getVariablePopoverLocator(vars[0]).waitFor({ state: "visible", timeout: 5000 });
+    const options = scopedVars.getAriaRoleOptions();
     await options.first().waitFor({ state: "visible", timeout: 5000 });
 
     // Wait for dropdown to stabilize and all options to render
@@ -437,7 +437,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -470,8 +470,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
       // Wait for variable to be saved - either in settings or redirected to dashboard
       await Promise.race([
-        page.locator(`[data-test="dashboard-edit-variable-${vars[i]}"]`).waitFor({ state: "visible", timeout: 10000 }),
-        page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+        scopedVars.getEditVariableBtnLocator(vars[i]).waitFor({ state: "visible", timeout: 10000 }),
+        scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
       ]).catch(() => {});
       await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -491,12 +491,12 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
         await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
         // Wait for Add Variable button to be visible and ready
-        await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+        await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
       }
     }
 
     // Close settings if still open
-    const isDialogOpen = await page.locator(SELECTORS.DIALOG).isVisible().catch(() => false);
+    const isDialogOpen = await scopedVars.isDialogVisible();
     if (isDialogOpen) {
       await pm.dashboardSetting.closeSettingWindow();
     }
@@ -507,7 +507,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Check if we're actually on the dashboard view by looking for the add panel button or variable selector
     // If not visible, we may have been redirected to the dashboard list, so navigate back
-    const isDashboardView = await page.locator(SELECTORS.ADD_PANEL_BTN).isVisible().catch(() => false);
+    const isDashboardView = await scopedVars.getAddPanelBtnLocator().isVisible().catch(() => false);
     if (!isDashboardView) {
       // Not on dashboard, navigate back to it
       await pm.dashboardList.clickOnDashboard(dashboardName);
@@ -516,13 +516,13 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     }
 
     // Wait for all variables to appear on dashboard - especially important for 9 variables
-    await page.locator(`[data-test="variable-selector-${vars[8]}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(vars[8]).waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for all variables to fully load
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Scroll the first variable into view before changing it
-    const var0Dropdown = page.locator(`[data-test="variable-selector-${vars[0]}"]`);
+    const var0Dropdown = scopedVars.getVariableSelectorLocator(vars[0]);
     await var0Dropdown.waitFor({ state: "visible", timeout: 60000 });
     await var0Dropdown.scrollIntoViewIfNeeded();
 
@@ -557,7 +557,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -567,8 +567,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Wait for variable to be saved - either in settings or redirected to dashboard
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varA}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varA).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -581,14 +581,14 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
     await pm.dashboardSetting.openVariables();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
-    await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     await scopedVars.addScopedVariable(varB, "logs", "e2e_automate", "kubernetes_container_name", { scope: "global" });
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varB}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varB).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -601,7 +601,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
     await pm.dashboardSetting.openVariables();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
-    await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Add C depending on both A and B
     await scopedVars.addScopedVariable(
@@ -621,8 +621,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varC}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varC).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -633,7 +633,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(varC)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varC).waitFor({ state: "visible", timeout: 10000 });
 
     // Change A, monitor if C loads using the new helper function
     const result1 = await scopedVars.changeVariableValueAndMonitorDependencies(varA, {
@@ -674,7 +674,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -687,8 +687,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varA}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varA).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -701,7 +701,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
     await pm.dashboardSetting.openVariables();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
-    await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Add variable B that depends on A
     await scopedVars.addScopedVariable(varB, "logs", "e2e_automate", "kubernetes_container_name", {
@@ -712,8 +712,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varB}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varB).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -726,20 +726,20 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     // Reopen settings and navigate to variables tab
     await pm.dashboardSetting.openSetting();
     // Wait for the settings ODrawer to be visible (replaced the legacy dialog selector)
-    await page.locator('[data-test="dashboard-settings-drawer"]').waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getSettingsDrawerLocator().waitFor({ state: "visible", timeout: 5000 });
     await pm.dashboardSetting.openVariables();
-    await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for the draggable container and variables to load
-    await page.locator('[data-test="dashboard-variable-settings-drag"]').waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(`[data-test="dashboard-edit-variable-${varA}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableDragLocator().waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(varA).waitFor({ state: "visible", timeout: 10000 });
 
     // Find and click the edit button for variable A
-    const editButton = page.locator(`[data-test="dashboard-edit-variable-${varA}"]`);
+    const editButton = scopedVars.getEditVariableBtnLocator(varA);
     await editButton.click();
 
     // Wait for the edit form to be visible and stable
-    const variableNameInput = page.locator('[data-test="dashboard-variable-name"]');
+    const variableNameInput = scopedVars.getVariableNameLocator();
     await variableNameInput.waitFor({ state: "visible", timeout: 10000 });
     await variableNameInput.waitFor({ state: "attached", timeout: 5000 });
 
@@ -773,7 +773,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -783,8 +783,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varA}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varA).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -797,14 +797,14 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
     await pm.dashboardSetting.openVariables();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
-    await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     await scopedVars.addScopedVariable(varB, "logs", "e2e_automate", "kubernetes_container_name", { scope: "global" });
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varB}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varB).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -817,14 +817,14 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
     await pm.dashboardSetting.openVariables();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
-    await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     await scopedVars.addScopedVariable(varC, "logs", "e2e_automate", "_timestamp", { scope: "global" });
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${varC}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(varC).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -836,7 +836,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Go back to dashboard list to ensure clean state
     await pm.dashboardCreate.backToDashboardList();
-    await page.locator('[data-test="dashboard-search"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Monitor API calls when reopening dashboard
@@ -848,9 +848,9 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for all variables to appear on dashboard
-    await page.locator(`[data-test="variable-selector-${varA}"]`).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(`[data-test="variable-selector-${varB}"]`).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(getVariableSelector(varC)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varA).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varB).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(varC).waitFor({ state: "visible", timeout: 10000 });
 
     const result = await apiMonitor;
 
@@ -873,7 +873,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Create a variable with a valid stream but add an impossible filter to cause error during value loading
     await pm.dashboardSetting.openSetting();
@@ -897,8 +897,8 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
 
     // Wait for variable to be saved
     await Promise.race([
-      page.locator(`[data-test="dashboard-edit-variable-${variableName}"]`).waitFor({ state: "visible", timeout: 10000 }),
-      page.locator(SELECTORS.DIALOG).waitFor({ state: "hidden", timeout: 10000 })
+      scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 }),
+      scopedVars.getDialogLocator().waitFor({ state: "hidden", timeout: 10000 })
     ]).catch(() => {});
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
@@ -909,14 +909,14 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await safeWaitForNetworkIdle(page, { timeout: 30000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(`[data-test="variable-selector-${variableName}"]`).waitFor({ state: "visible", timeout: 30000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 30000 });
 
     // Wait for UI to stabilize - variable should show empty/no data state
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Check if variable shows error or empty state
     // Since the filter returns no results, the variable should be visible but may show as empty
-    const variableSelector = page.locator(`[data-test="variable-selector-${variableName}"]`);
+    const variableSelector = scopedVars.getVariableSelectorLocator(variableName);
     await expect(variableSelector).toBeVisible();
 
     // Cleanup
@@ -979,7 +979,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await scopedVars.waitForMenuVisible({ timeout: 5000 });
 
     // When a variable query returns no results, it should show "No Data Found"
-    const noDataText = page.locator('[data-test="variable-query-value-selector-no-data"]');
+    const noDataText = scopedVars.getVariableNoDataLocator();
     await expect(noDataText).toBeVisible({ timeout: 5000 });
 
     // Close the dropdown
@@ -1008,7 +1008,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added
-    await page.locator('[data-test*="dashboard-panel-"]').first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel().waitFor({ state: "visible", timeout: 15000 });
 
     // Verify panel renders without errors (despite the variable having no data)
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
@@ -1028,7 +1028,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     // Verify the query is displayed in the Query Inspector (Executed Query section)
     // Using SELECTORS constant instead of raw selector
     await expect(
-      page.locator(SELECTORS.QUERY_EDITOR).filter({
+      scopedVars.getQueryEditorLocator().filter({
         hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_pod_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_pod_name = \'_o2_all_\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
       }).last()
     ).toBeVisible();
@@ -1039,9 +1039,7 @@ test.describe("Dashboard Variables - Dependency Loading", { tag: ['@dashboards',
     // does nothing and the overlay stays mounted, intercepting later clicks
     // (e.g. dashboard-back-btn during cleanup). Click the dialog's explicit
     // close button instead — matches the pattern used by other dashboard specs.
-    await page
-      .locator('[data-test="query-inspector-dialog"] [data-test="o-dialog-close-btn"]')
-      .click();
+    await scopedVars.getQueryInspectorCloseBtn().click();
     await scopedVars.waitForDialogHidden({ timeout: 5000 });
 
     // Clean up using consolidated helper

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-global.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-global.spec.js
@@ -31,6 +31,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
 
   test("1-should verify old/existing variable defaults to global scope", async ({ page }) => {
     const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
     const dashboardName = `Dashboard_Global_${Date.now()}`;
     const variableName = `var_${Date.now()}`;
 
@@ -40,7 +41,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable without specifying scope (should default to global)
     await pm.dashboardSetting.openSetting();
@@ -54,7 +55,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     );
     await pm.dashboardSetting.saveVariable();
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -63,30 +64,30 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await safeWaitForHidden(page, '[data-test="dashboard-settings-drawer"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Verify variable exists and is global
-    await expect(page.locator(getVariableSelector(variableName))).toBeVisible();
+    await expect(scopedVars.getVariableSelectorLocator(variableName)).toBeVisible();
 
     // Verify variable scope is global in the settings
     await pm.dashboardSetting.openSetting();
     // Wait for the settings ODrawer to be visible
-    const settingsDrawer = page.locator('[data-test="dashboard-settings-drawer"]');
+    const settingsDrawer = scopedVars.getSettingsDrawerLocator();
     await settingsDrawer.waitFor({ state: "visible", timeout: 5000 });
     await pm.dashboardSetting.openVariables();
     // Wait for variables tab to be active
-    await page.locator(SELECTORS.ADD_VARIABLE_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for the draggable container and variables to load
-    await page.locator(SELECTORS.VARIABLE_DRAG).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariableDragLocator().waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 5000 });
 
     // Click on the variable to edit
-    await page.locator(getEditVariableBtn(variableName)).click();
+    await scopedVars.getEditVariableBtnLocator(variableName).click();
 
     // The Edit Variable form replaces the variable list inside the same drawer;
     // wait for the form scope select to be visible to confirm the edit view loaded.
-    await page.locator(SELECTORS.VARIABLE_SCOPE_SELECT).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariableScopeSelectLocator().waitFor({ state: "visible", timeout: 5000 });
 
     // Verify scope shows "Global" — scope is rendered inside the drawer's edit form
     await expect(settingsDrawer).toContainText('Global', { ignoreCase: true });
@@ -96,13 +97,14 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
 
   test("2-should call query_values API when clicking on variable dropdown", async ({ page }) => {
     const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
     const dashboardName = `Dashboard_API_${Date.now()}`;
     const variableName = `var_${Date.now()}`;
 
@@ -112,7 +114,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -125,7 +127,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     );
     await pm.dashboardSetting.saveVariable();
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -134,14 +136,14 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await safeWaitForHidden(page, '[data-test="dashboard-settings-drawer"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for variable to be fully initialized
-    const variableDropdown = page.locator(getVariableSelectorInner(variableName));
+    const variableDropdown = scopedVars.getVariableDropdown(variableName);
     await variableDropdown.waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for any loading indicators to disappear
-    const loadingIndicator = page.locator(getVariableLoadingIndicator(variableName));
+    const loadingIndicator = scopedVars.getVariableLoadingIndicator(variableName);
     await loadingIndicator.waitFor({ state: "hidden", timeout: 5000 }).catch(() => {});
 
     // Ensure network is idle after variable initialization
@@ -157,7 +159,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     // Wait for loading state to complete after API call
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     // Wait for dropdown menu to open
-    await page.locator(SELECTORS.MENU).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getMenuLocator().waitFor({ state: "visible", timeout: 5000 });
 
     // Assert API was called successfully
     assertVariableAPILoading(result, {
@@ -172,13 +174,14 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
 
   test("3-should load variable values when clicking dropdown", async ({ page }) => {
     const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
     const dashboardName = `Dashboard_Load_${Date.now()}`;
     const variableName = `var_${Date.now()}`;
 
@@ -187,7 +190,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -200,7 +203,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     );
     await pm.dashboardSetting.saveVariable();
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -209,18 +212,18 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await safeWaitForHidden(page, '[data-test="dashboard-settings-drawer"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Click dropdown and wait for values to load
-    const variableDropdown = page.locator(getVariableSelectorInner(variableName));
+    const variableDropdown = scopedVars.getVariableDropdown(variableName);
     await variableDropdown.click();
 
     // Wait for dropdown options to appear
     await page.waitForSelector('[role="option"]', { state: "visible", timeout: 10000 });
 
     // Verify at least one option is available
-    const options = page.locator(SELECTORS.ROLE_OPTION);
+    const options = scopedVars.getRoleOptionLocator();
     const optionCount = await options.count();
 
     expect(optionCount).toBeGreaterThan(0);
@@ -228,13 +231,14 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
 
   test("4-should successfully select and apply variable value", async ({ page }) => {
     const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
     const dashboardName = `Dashboard_Select_${Date.now()}`;
     const variableName = `var_${Date.now()}`;
 
@@ -243,7 +247,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable
     await pm.dashboardSetting.openSetting();
@@ -258,7 +262,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardSetting.addMaxRecord("5");
     await pm.dashboardSetting.saveVariable();
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -267,10 +271,10 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await safeWaitForHidden(page, '[data-test="dashboard-settings-drawer"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     // Wait for variable to appear on dashboard and be fully initialized
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for variable to be fully visible and ready
-    const variableDropdown = page.locator(getVariableSelectorInner(variableName));
+    const variableDropdown = scopedVars.getVariableDropdown(variableName);
     await variableDropdown.waitFor({ state: "visible", timeout: 10000 });
     // Ensure network is idle after variable initialization
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
@@ -278,10 +282,10 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     // Click dropdown to load values
     await variableDropdown.click();
     // Wait for dropdown menu to open
-    await page.locator(SELECTORS.MENU).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getMenuLocator().waitFor({ state: "visible", timeout: 5000 });
 
     // Get first available option
-    const firstOption = page.locator(SELECTORS.ROLE_OPTION).first();
+    const firstOption = scopedVars.getRoleOptionLocator().first();
     await firstOption.waitFor({ state: "visible", timeout: 5000 });
     const optionText = await firstOption.textContent();
     await firstOption.click();
@@ -290,19 +294,20 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await safeWaitForHidden(page, `[data-test="variable-selector-${variableName}-inner-popover"]`, { timeout: 3000 });
 
     // Verify selection - check the displayed value in the select component
-    const variableSelector = page.locator(getVariableSelector(variableName));
+    const variableSelector = scopedVars.getVariableSelectorLocator(variableName);
     await expect(variableSelector).toContainText(optionText.trim());
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
 
   test("5-should load values with max record size limit", async ({ page }) => {
     const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
     const dashboardName = `Dashboard_MaxRecord_${Date.now()}`;
     const variableName = `var_${Date.now()}`;
     const maxRecords = 3;
@@ -312,7 +317,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -326,7 +331,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardSetting.addMaxRecord(maxRecords.toString());
     await pm.dashboardSetting.saveVariable();
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -336,14 +341,14 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Click dropdown
-    const variableDropdown = page.locator(`[data-test="variable-selector-${variableName}"]`);
+    const variableDropdown = scopedVars.getVariableSelectorLocator(variableName);
     await variableDropdown.click();
     // Wait for dropdown menu to open and options to load
-    await page.locator(`[data-test="variable-selector-${variableName}-inner-popover"]`).waitFor({ state: "visible", timeout: 5000 });
-    await page.locator(SELECTORS.ROLE_OPTION).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariablePopoverLocator(variableName).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getRoleOptionLocator().first().waitFor({ state: "visible", timeout: 5000 });
 
     // Count options
-    const options = page.locator(SELECTORS.ROLE_OPTION);
+    const options = scopedVars.getRoleOptionLocator();
     const optionCount = await options.count();
 
     // Should have at most maxRecords options (plus possible "All" option)
@@ -352,7 +357,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -361,6 +366,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
 
   test("6-should set and use default value for variable", async ({ page }) => {
     const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
     const dashboardName = `Dashboard_Default_${Date.now()}`;
     const variableName = `var_${Date.now()}`;
     const defaultValue = "ziox";
@@ -370,7 +376,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -384,7 +390,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardSetting.addCustomValue(defaultValue);
     await pm.dashboardSetting.saveVariable();
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -393,16 +399,16 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await safeWaitForHidden(page, '[data-test="dashboard-settings-drawer"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Verify default value is set - check the displayed value in the select component
-    const variableSelector = page.locator(getVariableSelector(variableName));
+    const variableSelector = scopedVars.getVariableSelectorLocator(variableName);
     await expect(variableSelector).toContainText(defaultValue, { timeout: 10000 });
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -411,6 +417,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
 
   test("7-should reload values when time range changes", async ({ page }) => {
     const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
     const dashboardName = `Dashboard_TimeRange_${Date.now()}`;
     const variableName = `var_${Date.now()}`;
 
@@ -419,7 +426,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -432,7 +439,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     );
     await pm.dashboardSetting.saveVariable();
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -441,15 +448,15 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await safeWaitForHidden(page, '[data-test="dashboard-settings-drawer"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Click dropdown to load initial values
-    const variableDropdown = page.locator(getVariableSelectorInner(variableName));
+    const variableDropdown = scopedVars.getVariableDropdown(variableName);
     await variableDropdown.waitFor({ state: "visible", timeout: 10000 });
     await variableDropdown.click();
     // Wait for dropdown menu to open and options to load
-    await page.locator(SELECTORS.MENU).waitFor({ state: "visible", timeout: 5000 });
-    await page.locator(SELECTORS.ROLE_OPTION).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getMenuLocator().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getRoleOptionLocator().first().waitFor({ state: "visible", timeout: 5000 });
 
     // Close dropdown
     await page.keyboard.press("Escape");
@@ -457,11 +464,10 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     await safeWaitForHidden(page, `[data-test="variable-selector-${variableName}-inner-popover"]`, { timeout: 3000 });
 
     // Change time range
-    await page.locator(SELECTORS.DATE_TIME_BTN).click();
-    await page.locator(SELECTORS.DATE_TIME_RELATIVE_6H).click();
+    await scopedVars.selectTimeRange6Hours();
 
     // Click refresh button to trigger variable refresh with new time range
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
 
     // Wait for variable to refresh after time range change
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
@@ -478,7 +484,7 @@ test.describe("Dashboard Variables - Global Level", { tag: ['@dashboards', '@das
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-panel-level.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-panel-level.spec.js
@@ -38,7 +38,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add first panel
     await pm.dashboardCreate.addPanel();
@@ -50,9 +50,9 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard and panel editor to close
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     // Wait for settings button to be available (indicates panel editor has closed)
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Add panel-scoped variable using panel name
     await pm.dashboardSetting.openSetting();
@@ -67,7 +67,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -77,7 +77,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Verify variable is visible for Panel1
     await scopedVars.verifyVariableVisibility(variableName, true);
@@ -92,17 +92,16 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).nth(1).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(1).waitFor({ state: "visible", timeout: 15000 });
 
     // Variable should not be visible for Panel2 context
-    const panel2Context = page.locator('[data-test="dashboard-panel-2"]');
-    const variableInPanel2 = panel2Context.locator(`[data-test="dashboard-variable-${variableName}"]`);
+    const variableInPanel2 = scopedVars.getVariableInPanelNumber(2, variableName);
     await expect(variableInPanel2).not.toBeVisible();
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -118,7 +117,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add multiple dummy panels to push test panel out of viewport
     for (let i = 0; i < 6; i++) {
@@ -133,7 +132,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
       await pm.chartTypeSelector.searchAndAddField("kubernetes_pod_name", "y");
       await pm.dashboardPanelActions.addPanelName(`DummyPanel${i + 1}`);
       await pm.dashboardPanelActions.savePanel();
-      await page.locator(SELECTORS.PANEL_CONTAINER).nth(i).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getPanelContainer(i).waitFor({ state: "visible", timeout: 10000 });
       await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
     }
 
@@ -147,8 +146,8 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added and rendered
-    await page.locator(SELECTORS.PANEL_CONTAINER).nth(6).waitFor({ state: "visible", timeout: 15000 });
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getPanelContainer(6).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
 
     // Scroll to top to ensure Panel1 is out of viewport
@@ -175,11 +174,11 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
         assignedPanels: ["Panel1"]
       }
     );
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await pm.dashboardSetting.closeSettingWindow();
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Panel1 should be out of viewport, so variable should not be loaded yet
@@ -206,7 +205,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -224,14 +223,14 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getTabLocator("Tab1").waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
 
     // Add global variable
@@ -243,7 +242,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
       { scope: "global" }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(globalVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(globalVar).waitFor({ state: "visible", timeout: 10000 });
     // Ensure settings is closed and then re-open to add another variable
     await pm.dashboardSetting.closeSettingWindow();
     await pm.dashboardSetting.openSetting();
@@ -261,7 +260,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(tabVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(tabVar).waitFor({ state: "visible", timeout: 10000 });
 
     await pm.dashboardSetting.closeSettingWindow();
 
@@ -270,11 +269,11 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variables to appear on dashboard and settings to fully close
-    await page.locator(getVariableSelector(globalVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(globalVar).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
 
     // Switch to Tab1 and add panel
-    const tab1Selector = page.locator(getTabSelector("Tab1"));
+    const tab1Selector = scopedVars.getTabLocator("Tab1");
     await tab1Selector.waitFor({ state: "visible", timeout: 10000 });
 
     // Ensure the tab is clickable and not obscured
@@ -293,8 +292,8 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Add panel variable that depends on both global and tab using panel name
     await pm.dashboardSetting.openSetting();
@@ -312,11 +311,11 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(panelVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(panelVar).waitFor({ state: "visible", timeout: 10000 });
     await pm.dashboardSetting.closeSettingWindow();
 
     // Wait for panel variable to appear on dashboard
-    await page.locator(getVariableSelector(panelVar)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(panelVar).waitFor({ state: "visible", timeout: 10000 });
 
     // Verify all variables are visible
     await scopedVars.verifyVariableVisibility(globalVar, true);
@@ -326,7 +325,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -343,7 +342,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add first panel
     await pm.dashboardCreate.addPanel();
@@ -355,8 +354,8 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for Panel1 to be added
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Add second panel
     await pm.dashboardCreate.addPanelToExistingDashboard();
@@ -368,7 +367,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for Panel2 to be added
-    await page.locator(SELECTORS.PANEL_ANY).nth(1).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(1).waitFor({ state: "visible", timeout: 15000 });
 
     // Add panel variable for Panel1
     await pm.dashboardSetting.openSetting();
@@ -382,34 +381,21 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
         assignedPanels: ["Panel1"]
       }
     );
-    await page.locator(getEditVariableBtn(panelVar1)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(panelVar1).waitFor({ state: "visible", timeout: 10000 });
 
     // Try to add panel variable for Panel2 and check if Panel1's variable appears in dependency options
-    await page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
-    await page.locator('[data-test="dashboard-variable-name-field"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-name-field"]').fill(panelVar2);
+    await scopedVars.clickAddVariableBtn();
+    await scopedVars.getVariableNameField().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.fillVariableName(panelVar2);
 
     // Select scope as panels
-    await page.locator(SELECTORS.VARIABLE_SCOPE_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-scope-select-option"][data-test-value="panels"]').click();
-    await page.locator('[data-test="dashboard-variable-scope-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariableScope("panels");
 
     // Select default tab
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).waitFor({ state: "visible", timeout: 5000 });
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-tabs-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-tabs-select-option"][data-test-label="Default"]').click();
-    await page.locator(SELECTORS.VARIABLE_TABS_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-tabs-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariableTab("Default");
 
     // Select Panel2
-    await page.locator(SELECTORS.VARIABLE_PANELS_SELECT).waitFor({ state: "visible", timeout: 5000 });
-    await page.locator(SELECTORS.VARIABLE_PANELS_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-panels-select-popover"]').waitFor({ state: "visible", timeout: 5000 });
-    await page.locator('[data-test="dashboard-variable-panels-select-option"][data-test-label="Panel2"]').click();
-    await page.locator(SELECTORS.VARIABLE_PANELS_SELECT).click();
-    await page.locator('[data-test="dashboard-variable-panels-select-popover"]').waitFor({ state: "hidden", timeout: 5000 });
+    await scopedVars.selectVariablePanel("Panel2");
 
     // Select stream type, stream, and field using shared utilities
     await selectStreamType(page, "logs");
@@ -417,27 +403,19 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await selectFieldFromDropdown(page, "kubernetes_container_name");
 
     // Add a filter to check dependency dropdown - panel variables should NOT be in the list
-    await page.locator(SELECTORS.ADD_FILTER_BTN).click();
-
-    const filterNameSelector = page.locator(SELECTORS.FILTER_NAME_SELECTOR).last();
-    await filterNameSelector.waitFor({ state: "visible", timeout: 5000 });
-    await filterNameSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-search"]').fill("kubernetes_namespace_name");
-    await page.locator('[data-test="dashboard-query-values-filter-name-selector-option"][data-test-value="kubernetes_namespace_name"]').click();
-
-    const operatorSelector = page.locator(SELECTORS.FILTER_OPERATOR_SELECTOR).last();
-    await operatorSelector.click();
-    await page.locator('[data-test="dashboard-query-values-filter-operator-selector-option"][data-test-value="="]').click();
+    await scopedVars.clickAddFilter();
+    await scopedVars.selectFilterName("kubernetes_namespace_name");
+    await scopedVars.selectFilterOperator("=");
 
     // Click on the filter value OCombobox input to open autocomplete suggestions
-    const filterValueInput = page.locator('[data-test*="filter-value-selector"][data-test$="-input"]').last();
+    const filterValueInput = scopedVars.getFilterValueInput();
     await filterValueInput.waitFor({ state: "visible", timeout: 5000 });
     await filterValueInput.click();
 
     // OCombobox opens on focus; wait briefly for options to appear
-    const hasDropdown = await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').first().isVisible({ timeout: 2000 }).catch(() => false);
+    const hasDropdown = await scopedVars.getFilterValueOptions().first().isVisible({ timeout: 2000 }).catch(() => false);
     const optionTexts = hasDropdown
-      ? await page.locator('[data-test*="filter-value-selector"][data-test$="-option"]').allTextContents()
+      ? await scopedVars.getFilterValueOptionTexts()
       : [];
 
     // Panel1's variable should NOT be in the list
@@ -453,7 +431,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -469,7 +447,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add panel
     await pm.dashboardCreate.addPanel();
@@ -481,8 +459,8 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Add panel variable using panel name
     await pm.dashboardSetting.openSetting();
@@ -497,7 +475,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -507,7 +485,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Delete the panel using the panel dropdown menu
     await pm.dashboardPanelEdit.deletePanel("Panel1");
@@ -518,7 +496,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
     // Wait for variables tab to be active
-    await page.locator(SELECTORS.ADD_VARIABLE_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForAddVariableBtnVisible();
 
     // Verify deleted panel label using common function
     await scopedVars.verifyDeletedScopeLabel("panel");
@@ -532,7 +510,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -548,7 +526,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add panel first
     await pm.dashboardCreate.addPanel();
@@ -560,8 +538,8 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Now create panel variable
     await pm.dashboardSetting.openSetting();
@@ -576,7 +554,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -586,7 +564,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Edit panel to add filter using the variable
     await pm.dashboardPanelEdit.editPanel("Panel1");
@@ -608,7 +586,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Set variable value
-    const varDropdown = page.locator(getVariableSelectorInner(variableName));
+    const varDropdown = scopedVars.getVariableDropdown(variableName);
     await varDropdown.waitFor({ state: "visible", timeout: 5000 });
 
     // Ensure network is idle before clicking dropdown
@@ -616,9 +594,9 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
 
     await varDropdown.click();
     // Wait for dropdown menu to open
-    await page.locator(SELECTORS.MENU).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getMenuLocator().waitFor({ state: "visible", timeout: 10000 });
 
-    const option = page.locator(SELECTORS.OPTION).first();
+    const option = scopedVars.getOptionLocator().first();
     await option.waitFor({ state: "visible", timeout: 10000 });
     await option.click();
 
@@ -626,19 +604,19 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await safeWaitForHidden(page, `[data-test="variable-selector-${variableName}-inner-popover"]`, { timeout: 3000 });
 
     // Trigger panel refresh
-    await page.locator(SELECTORS.PANEL_REFRESH_BTN).first().click();
+    await scopedVars.getPanelRefreshBtnLocator().first().click();
 
     // Wait for panel to refresh
     await safeWaitForNetworkIdle(page, { timeout: 10000 });
 
     // Panel should render with variable value
-    const panelElement = page.locator(SELECTORS.PANEL_ANY).first();
+    const panelElement = scopedVars.getAnyPanel(0);
     await expect(panelElement).toBeVisible();
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -654,7 +632,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add first panel
     await pm.dashboardCreate.addPanel();
@@ -666,8 +644,8 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Add second panel
     await pm.dashboardCreate.addPanelToExistingDashboard();
@@ -679,7 +657,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for second panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).nth(1).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(1).waitFor({ state: "visible", timeout: 15000 });
 
     // Add variable assigned to both panels using panel names
     await pm.dashboardSetting.openSetting();
@@ -694,7 +672,7 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -704,19 +682,17 @@ test.describe("Dashboard Variables - Panel Level", { tag: ['@dashboards', '@dash
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Verify variable appears in Panel1
-    const panel1Container = page.locator('[data-test="dashboard-panel-container"][data-test-panel-title="Panel1"]');
-    const panel1Variable = panel1Container.locator(`[data-test="variable-selector-${variableName}"]`);
+    const panel1Variable = scopedVars.getVariableSelectorWithinPanelTitle("Panel1", variableName);
     await expect(panel1Variable).toBeVisible({ timeout: 10000 });
 
     // Verify variable appears in Panel2
-    const panel2Container = page.locator('[data-test="dashboard-panel-container"][data-test-panel-title="Panel2"]');
-    const panel2Variable = panel2Container.locator(`[data-test="variable-selector-${variableName}"]`);
+    const panel2Variable = scopedVars.getVariableSelectorWithinPanelTitle("Panel2", variableName);
     await expect(panel2Variable).toBeVisible({ timeout: 10000 });
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-refresh.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-refresh.spec.js
@@ -59,13 +59,13 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
 
     // Add panel using consolidated helper
     await addSimplePanel(pm, "Panel1");
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     await scopedVars.waitForDashboardReady();
 
     // Change variable value - select a DIFFERENT value than current
@@ -75,7 +75,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Check global refresh button shows indicator
-    const globalRefreshBtn = page.locator(SELECTORS.REFRESH_BTN);
+    const globalRefreshBtn = scopedVars.getDashboardRefreshBtnLocator();
     await globalRefreshBtn.waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for the refresh indicator to appear (button should change from outline to warning variant)
@@ -114,7 +114,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardSetting.openSetting();
     // await pm.dashboardSetting.openVariables();
     // // Wait for variable to be saved and visible in settings
-    // await page.locator(`[data-test="dashboard-edit-variable-${varA}"]`).waitFor({ state: "visible", timeout: 15000 });
+    // await scopedVars.getEditVariableBtnLocator(varA).waitFor({ state: "visible", timeout: 15000 });
     // await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await scopedVars.addScopedVariable(varB, "logs", "e2e_automate", "kubernetes_container_name", {
@@ -124,7 +124,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     });
 
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(varB)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getEditVariableBtnLocator(varB).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -134,7 +134,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(varB)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getVariableSelectorLocator(varB).waitFor({ state: "visible", timeout: 15000 });
 
     // Add panel using variable B with filter
     await pm.dashboardCreate.addPanel();
@@ -156,15 +156,15 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     await scopedVars.waitForDashboardReady();
 
     // Wait for panel to fully render and both variables to be visible and ready
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for both variable selectors to be fully visible and stable
-    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 15000 });
-    await page.locator(getVariableSelector(varB)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getVariableSelectorLocator(varA).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getVariableSelectorLocator(varB).waitFor({ state: "visible", timeout: 15000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Change variable A (which affects B) - select a DIFFERENT value than current
@@ -175,7 +175,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
 
     // Check the panel refresh button for warning indicator
     // When a variable changes that affects a panel, the panel's refresh button should show warning color
-    const panelRefreshBtn = page.locator(SELECTORS.PANEL_REFRESH_BTN);
+    const panelRefreshBtn = scopedVars.getPanelRefreshBtnLocator();
     await panelRefreshBtn.waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for the panel refresh button to get warning variant
@@ -214,7 +214,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
 
     // Add two panels
     await pm.dashboardCreate.addPanel();
@@ -226,7 +226,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     await scopedVars.waitForDashboardReady();
 
     await pm.dashboardCreate.addPanelToExistingDashboard();
@@ -238,7 +238,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for second panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).nth(1).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(1).waitFor({ state: "visible", timeout: 15000 });
 
     // Change variable
     await scopedVars.changeVariableValue(variableName, { monitorApi: true });
@@ -248,7 +248,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
       page,
       null,
       async () => {
-        await page.locator(SELECTORS.REFRESH_BTN).click();
+        await scopedVars.clickDashboardRefresh();
       },
       15000
     );
@@ -291,7 +291,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
 
     // Add Panel1 with filter using the variable - only this panel will be affected by variable changes
     await pm.dashboardCreate.addPanel();
@@ -312,11 +312,11 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard and get panel container with data-test-panel-id
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     await scopedVars.waitForDashboardReady();
 
     // Get the panel container that has data-test-panel-id attribute
-    const panelContainer1 = page.locator(SELECTORS.PANEL_CONTAINER).first();
+    const panelContainer1 = scopedVars.getFirstPanelContainer();
     await panelContainer1.waitFor({ state: "attached", timeout: 5000 });
     const panelId1 = await panelContainer1.getAttribute("data-test-panel-id");
 
@@ -330,7 +330,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for second panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).nth(1).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(1).waitFor({ state: "visible", timeout: 15000 });
 
     // Wait for panels to fully render
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
@@ -342,7 +342,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Check Panel1's refresh button for warning indicator - scope to specific panel using data-test-panel-id
-    const panel1RefreshBtn = page.locator(getPanelRefreshBtn(panelId1));
+    const panel1RefreshBtn = scopedVars.getPanelRefreshBtn(panelId1);
     await panel1RefreshBtn.waitFor({ state: "visible", timeout: 10000 });
 
     // Panel1's refresh button should have warning variant since it uses the variable
@@ -419,24 +419,24 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     await scopedVars.waitForDashboardReady();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Capture the initial query inspector content before making changes
     // Hover over panel to make dropdown visible
-    await page.locator(SELECTORS.PANEL_CONTAINER).first().hover();
+    await scopedVars.getFirstPanelContainer().hover();
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Use page object method to open query inspector
     await pm.dashboardPanelEdit.openQueryInspector("Panel1");
 
     // Wait for Query Inspector dialog to open and load content
-    await page.locator('[data-test="query-inspector-dialog"]').waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getQueryInspectorDialogLocator().waitFor({ state: "visible", timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Get all text from Query Inspector dialog (includes query, time, variables)
-    const dialogContent = page.locator('[data-test="query-inspector-dialog"]');
+    const dialogContent = scopedVars.getQueryInspectorDialogLocator();
     await dialogContent.waitFor({ state: "visible", timeout: 5000 });
     const queryInspectorBeforeRefresh = await dialogContent.textContent();
 
@@ -444,19 +444,18 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     // internal search input (it just blurs the field), so click the ODialog's
     // built-in close button instead so the dialog (and its overlay) actually
     // unmount before the next interaction.
-    await page.locator('[data-test="query-inspector-dialog"] [data-test="o-dialog-close-btn"]').click();
+    await scopedVars.getQueryInspectorCloseBtn().click();
     await safeWaitForHidden(page, '[data-test="query-inspector-dialog"]', { timeout: 5000 });
 
     // Change variable
     await scopedVars.changeVariableValue(variableName, { monitorApi: true });
 
     // Change time range
-    await page.locator(SELECTORS.DATE_TIME_BTN).click();
-    await page.locator(SELECTORS.DATE_TIME_RELATIVE_6H).click();
+    await scopedVars.selectTimeRange6Hours();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Click global refresh
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for panels to finish loading
@@ -464,14 +463,14 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
 
     // Capture the query inspector content after refresh
     // Hover over panel to make dropdown visible
-    await page.locator(SELECTORS.PANEL_CONTAINER).first().hover();
+    await scopedVars.getFirstPanelContainer().hover();
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Use page object method to open query inspector
     await pm.dashboardPanelEdit.openQueryInspector("Panel1");
 
     // Wait for Query Inspector dialog to open and load content
-    await page.locator('[data-test="query-inspector-dialog"]').waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getQueryInspectorDialogLocator().waitFor({ state: "visible", timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Get all text from Query Inspector dialog (includes query, time, variables)
@@ -481,7 +480,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     // internal search input (it just blurs the field), so click the ODialog's
     // built-in close button instead so the dialog (and its overlay) actually
     // unmount before the next interaction.
-    await page.locator('[data-test="query-inspector-dialog"] [data-test="o-dialog-close-btn"]').click();
+    await scopedVars.getQueryInspectorCloseBtn().click();
     await safeWaitForHidden(page, '[data-test="query-inspector-dialog"]', { timeout: 5000 });
 
     // Verify query inspector content is different - both variable value and time range should have changed
@@ -492,7 +491,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     expect(queryInspectorAfterRefresh).toContain("kubernetes_namespace_name");
 
     // Verify panel reloaded with new data
-    const panelElement = page.locator(SELECTORS.PANEL_ANY).first();
+    const panelElement = scopedVars.getAnyPanel(0);
     await expect(panelElement).toBeVisible();
 
     // Verify panel is loaded (not in loading state)
@@ -531,13 +530,13 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
 
     // Add panel using consolidated helper
     await addSimplePanel(pm, "Panel1");
 
     // Wait for panel to be added to dashboard
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     await scopedVars.waitForDashboardReady();
 
     // Change variable
@@ -547,7 +546,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for the refresh indicator to appear
-    const globalRefreshBtn = page.locator(SELECTORS.REFRESH_BTN);
+    const globalRefreshBtn = scopedVars.getDashboardRefreshBtnLocator();
     await expect(globalRefreshBtn).toHaveAttribute('data-o2-variant', 'warning', { timeout: 10000 });
 
     // Verify indicator shows
@@ -555,7 +554,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     expect(hasIndicator).toBe(true);
 
     // Click global refresh
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for panels to finish loading
@@ -597,7 +596,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
 
     // Add panel with filter using the variable
     await pm.dashboardCreate.addPanel();
@@ -618,10 +617,10 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard and get panel ID
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     await scopedVars.waitForDashboardReady();
 
-    const panelContainer = page.locator(SELECTORS.PANEL_CONTAINER).first();
+    const panelContainer = scopedVars.getFirstPanelContainer();
     await panelContainer.waitFor({ state: "attached", timeout: 5000 });
     const panelId = await panelContainer.getAttribute("data-test-panel-id");
 
@@ -632,7 +631,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for panel refresh button to show warning variant
-    const panelRefreshBtn = page.locator(getPanelRefreshBtn(panelId));
+    const panelRefreshBtn = scopedVars.getPanelRefreshBtn(panelId);
     await panelRefreshBtn.waitFor({ state: "visible", timeout: 10000 });
     await expect(panelRefreshBtn).toHaveAttribute('data-o2-variant', 'ghost-warning', { timeout: 10000 });
 
@@ -675,7 +674,7 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 15000 });
 
     // Add Panel1 with filter using the variable
     await pm.dashboardCreate.addPanel();
@@ -696,10 +695,10 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard and get panel ID
-    await page.locator(SELECTORS.PANEL_ANY).first().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(0).waitFor({ state: "visible", timeout: 15000 });
     await scopedVars.waitForDashboardReady();
 
-    const panelContainer1 = page.locator(SELECTORS.PANEL_CONTAINER).first();
+    const panelContainer1 = scopedVars.getFirstPanelContainer();
     await panelContainer1.waitFor({ state: "attached", timeout: 5000 });
     const panelId1 = await panelContainer1.getAttribute("data-test-panel-id");
 
@@ -722,9 +721,9 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for second panel to be added to dashboard and get panel ID
-    await page.locator(SELECTORS.PANEL_ANY).nth(1).waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getAnyPanel(1).waitFor({ state: "visible", timeout: 15000 });
 
-    const panelContainer2 = page.locator(SELECTORS.PANEL_CONTAINER).nth(1);
+    const panelContainer2 = scopedVars.getPanelContainer(1);
     await panelContainer2.waitFor({ state: "attached", timeout: 5000 });
     const panelId2 = await panelContainer2.getAttribute("data-test-panel-id");
 
@@ -735,8 +734,8 @@ test.describe("Dashboard Variables - Refresh Indicators & Panel Reload", { tag: 
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for both panel refresh buttons to show warning color
-    const panel1RefreshBtn = page.locator(getPanelRefreshBtn(panelId1));
-    const panel2RefreshBtn = page.locator(getPanelRefreshBtn(panelId2));
+    const panel1RefreshBtn = scopedVars.getPanelRefreshBtn(panelId1);
+    const panel2RefreshBtn = scopedVars.getPanelRefreshBtn(panelId2);
 
     await panel1RefreshBtn.waitFor({ state: "visible", timeout: 10000 });
     await panel2RefreshBtn.waitFor({ state: "visible", timeout: 10000 });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-setting.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-setting.spec.js
@@ -31,11 +31,7 @@ test.describe("dashboard variables settings", () => {
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     // Open the setting and variables
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -72,11 +68,7 @@ test.describe("dashboard variables settings", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     // Open the setting and variables
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -114,11 +106,7 @@ test.describe("dashboard variables settings", () => {
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open the setting and variables
     await pm.dashboardSetting.openSetting();
@@ -157,11 +145,7 @@ test.describe("dashboard variables settings", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open the setting and variables
     await pm.dashboardSetting.openSetting();
@@ -204,11 +188,7 @@ test.describe("dashboard variables settings", () => {
     await pm.dashboardCreate.createDashboard(dashboardName);
 
     // Wait for the add panel button to be visible
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open the setting and variables
     await pm.dashboardSetting.openSetting();
@@ -256,11 +236,7 @@ test.describe("dashboard variables settings", () => {
     await pm.dashboardCreate.createDashboard(dashboardName);
 
     // Wait for the add panel button to be visible
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open the setting and variables
     await pm.dashboardSetting.openSetting();
@@ -294,11 +270,7 @@ test.describe("dashboard variables settings", () => {
     await pm.dashboardCreate.waitForDashboardUIStable();
 
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open the setting and save variables
     await pm.dashboardSetting.openSetting();
@@ -310,9 +282,7 @@ test.describe("dashboard variables settings", () => {
     );
     await pm.dashboardSetting.hideVariable();
     await pm.dashboardSetting.saveVariable();
-    await page
-      .locator('[data-test="dashboard-add-variable-btn"]')
-      .waitFor({ state: "visible" });
+    await pm.dashboardSetting.waitForAddVariableBtnVisible();
     await pm.dashboardSetting.closeSettingWindow();
 
     // Delete the dashboard
@@ -334,9 +304,7 @@ test.describe("dashboard variables settings", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open dashboard settings and variables section
     await pm.dashboardSetting.openSetting();
@@ -349,9 +317,7 @@ test.describe("dashboard variables settings", () => {
     await pm.dashboardSetting.saveVariable();
 
     // Ensure the add variable button is visible
-    await page
-      .locator('[data-test="dashboard-add-variable-btn"]')
-      .waitFor({ state: "visible" });
+    await pm.dashboardSetting.waitForAddVariableBtnVisible();
 
     // Close the settings window
     await pm.dashboardSetting.closeSettingWindow();
@@ -375,9 +341,7 @@ test.describe("dashboard variables settings", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open the settings and variables section and save variables
     await pm.dashboardSetting.openSetting();
@@ -387,15 +351,11 @@ test.describe("dashboard variables settings", () => {
     await pm.dashboardSetting.saveVariable();
 
     // Ensure the add variable button is visible
-    await page
-      .locator('[data-test="dashboard-add-variable-btn"]')
-      .waitFor({ state: "visible" });
+    await pm.dashboardSetting.waitForAddVariableBtnVisible();
 
     // Close the settings window
     await pm.dashboardSetting.closeSettingWindow();
-    await expect(
-      page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-    ).toBeVisible();
+    await expect(pm.dashboardCreate.addPanelIfEmptyBtn).toBeVisible();
 
     // Delete the dashboard
     await pm.dashboardCreate.backToDashboardList();
@@ -416,11 +376,7 @@ test.describe("dashboard variables settings", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open the settings and variables section and save variables
     await pm.dashboardSetting.openSetting();
@@ -437,9 +393,7 @@ test.describe("dashboard variables settings", () => {
     await pm.dashboardSetting.closeSettingWindow();
 
     // Ensure the panel is visible
-    await expect(
-      page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-    ).toBeVisible();
+    await expect(pm.dashboardCreate.addPanelIfEmptyBtn).toBeVisible();
     // Delete the dashboard
     await pm.dashboardCreate.backToDashboardList();
     await deleteDashboard(page, dashboardName);
@@ -460,9 +414,7 @@ test.describe("dashboard variables settings", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({ state: "visible" });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
 
     // Open settings and variables
     await pm.dashboardSetting.openSetting();
@@ -481,9 +433,7 @@ test.describe("dashboard variables settings", () => {
     await pm.dashboardSetting.saveVariable();
 
     await pm.dashboardSetting.closeSettingWindow();
-    await expect(
-      page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-    ).toBeVisible();
+    await expect(pm.dashboardCreate.addPanelIfEmptyBtn).toBeVisible();
 
     // Delete the dashboard
     await pm.dashboardCreate.backToDashboardList();
@@ -504,11 +454,7 @@ test.describe("dashboard variables settings", () => {
 
     // Create a new dashboard
     await pm.dashboardCreate.createDashboard(dashboardName);
-    await page
-      .locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-      .waitFor({
-        state: "visible",
-      });
+    await pm.dashboardCreate.waitForAddPanelIfEmptyVisible();
     // Open settings and variables
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.openVariables();
@@ -526,9 +472,7 @@ test.describe("dashboard variables settings", () => {
     await pm.dashboardSetting.saveVariable();
 
     await pm.dashboardSetting.closeSettingWindow();
-    await expect(
-      page.locator('[data-test="dashboard-if-no-panel-add-panel-btn"]')
-    ).toBeVisible();
+    await expect(pm.dashboardCreate.addPanelIfEmptyBtn).toBeVisible();
 
     // Delete the dashboard
     await pm.dashboardCreate.backToDashboardList();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-stream-field.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-stream-field.spec.js
@@ -52,17 +52,19 @@ async function setupDashboardAndOpenVariables(page, pm, dashboardName) {
  * for the "add panel if no panel" button which is hidden when panels exist.
  */
 async function openDashboardWithPanels(page, dashboardName) {
-  // Use page.getByTitle() instead of XPath string concatenation — Playwright
-  // handles all escaping internally so dashboard names with special characters
-  // (quotes, brackets, etc.) are matched safely.
-  await page.getByTitle(dashboardName, { exact: true }).first().click();
-  await page
-    .locator('[data-test="dashboard-panel-container"]')
+  const scopedVars = new DashboardVariablesScoped(page);
+  // Use getByTitle (via page object) instead of XPath string concatenation —
+  // Playwright handles all escaping internally so dashboard names with special
+  // characters (quotes, brackets, etc.) are matched safely.
+  await scopedVars.getDashboardTitleLocator(dashboardName).first().click();
+  await scopedVars
+    .getPanelContainerLocator()
     .waitFor({ state: "visible", timeout: 20000 });
 }
 
 // Helper: Close settings, reopen, and go back to variables tab
 async function reopenSettingsVariables(page, pm) {
+  const scopedVars = new DashboardVariablesScoped(page);
   await pm.dashboardSetting.closeSettingWindow();
   await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
   await safeWaitForNetworkIdle(page, { timeout: 5000 });
@@ -70,8 +72,8 @@ async function reopenSettingsVariables(page, pm) {
   await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
   await pm.dashboardSetting.openVariables();
   await safeWaitForNetworkIdle(page, { timeout: 5000 });
-  await page
-    .locator(SELECTORS.ADD_VARIABLE_BTN)
+  await scopedVars
+    .getAddVariableBtnLocator()
     .waitFor({ state: "visible", timeout: 10000 });
 }
 
@@ -105,8 +107,8 @@ test.describe(
       await reopenSettingsVariables(page, pm);
 
       // --- A1: Verify $streamVar appears in stream dropdown with (variable) label ---
-      await page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
-      await page.locator('[data-test="dashboard-variable-name-field"]').fill("child");
+      await scopedVars.clickAddVariableBtn();
+      await scopedVars.fillVariableName("child");
       await selectStreamType(page, "logs");
 
       const streamResult = await scopedVars.verifyStreamDropdownContainsVariable("streamVar");
@@ -123,7 +125,7 @@ test.describe(
       expect(noError).toBe(true);
 
       // Verify save button is still usable
-      const saveBtn = page.locator(SELECTORS.VARIABLE_SAVE_BTN);
+      const saveBtn = scopedVars.getVariableSaveBtnLocator();
       await expect(saveBtn).toBeVisible();
 
       // --- A2: Save variable with $streamVar as stream, $fieldVar as field ---
@@ -135,7 +137,7 @@ test.describe(
 
       // Reopen settings to verify variable was created
       await reopenSettingsVariables(page, pm);
-      const editBtn = page.locator(getEditVariableBtn("child"));
+      const editBtn = scopedVars.getEditVariableBtnLocator("child");
       await expect(editBtn).toBeVisible({ timeout: 10000 });
 
       // Cleanup
@@ -173,8 +175,8 @@ test.describe(
       await reopenSettingsVariables(page, pm);
 
       // --- B1: Verify $fieldVar appears in field dropdown with (variable) label ---
-      await page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
-      await page.locator('[data-test="dashboard-variable-name-field"]').fill("child");
+      await scopedVars.clickAddVariableBtn();
+      await scopedVars.fillVariableName("child");
       await selectStreamType(page, "logs");
       await scopedVars.selectStream("e2e_automate");
 
@@ -188,7 +190,7 @@ test.describe(
       // --- B2: Save variable with $fieldVar as field ---
       await scopedVars.selectField("$fieldVar");
 
-      const saveBtn = page.locator(SELECTORS.VARIABLE_SAVE_BTN);
+      const saveBtn = scopedVars.getVariableSaveBtnLocator();
       await saveBtn.waitFor({ state: "visible", timeout: 10000 });
       await saveBtn.click();
 
@@ -197,7 +199,7 @@ test.describe(
 
       // Reopen settings to verify variable was created
       await reopenSettingsVariables(page, pm);
-      const editBtn = page.locator(getEditVariableBtn("child"));
+      const editBtn = scopedVars.getEditVariableBtnLocator("child");
       await expect(editBtn).toBeVisible({ timeout: 10000 });
 
       // Cleanup
@@ -255,7 +257,7 @@ test.describe(
       );
 
       await reopenSettingsVariables(page, pm);
-      const editCombined = page.locator(getEditVariableBtn("combined"));
+      const editCombined = scopedVars.getEditVariableBtnLocator("combined");
       await expect(editCombined).toBeVisible({ timeout: 10000 });
 
       // --- C2: Same variable in field and filter value ---
@@ -274,7 +276,7 @@ test.describe(
       );
 
       await reopenSettingsVariables(page, pm);
-      const editDedup = page.locator(getEditVariableBtn("dedup"));
+      const editDedup = scopedVars.getEditVariableBtnLocator("dedup");
       await expect(editDedup).toBeVisible({ timeout: 10000 });
 
       // Cleanup
@@ -453,7 +455,7 @@ test.describe(
 
       // Verify variable C was created — if creation failed silently, the cycle
       // test below would pass vacuously (no $C in dropdown → no cycle).
-      const editCBtn = page.locator('[data-test="dashboard-edit-variable-C"]');
+      const editCBtn = scopedVars.getEditVariableBtnLocator("C");
       await expect(editCBtn).toBeVisible({ timeout: 5000 });
 
       // F2 variables (valid chain: env → region → pod)
@@ -492,7 +494,7 @@ test.describe(
       // Click save directly — don't use clickSaveButton() which waits up to 10s for
       // the button to hide. A brief DOM rerender can trick it into thinking save
       // succeeded, masking the cycle error. For cycle detection we just need the click.
-      const saveBtnF1 = page.locator(SELECTORS.VARIABLE_SAVE_BTN);
+      const saveBtnF1 = scopedVars.getVariableSaveBtnLocator();
       await saveBtnF1.waitFor({ state: "visible", timeout: 10000 });
       await saveBtnF1.click();
 
@@ -500,12 +502,12 @@ test.describe(
       expect(hasCycleF1).toBe(true);
 
       // Cancel the edit form, go back to variable list
-      await page.locator('[data-test="dashboard-variable-cancel-btn"]').click();
+      await scopedVars.getVariableCancelBtnLocator().click();
       // Wait for edit form to close (save button hidden indicates form is gone)
-      await page.locator(SELECTORS.VARIABLE_SAVE_BTN).waitFor({ state: "hidden", timeout: 8000 }).catch(() => {});
+      await scopedVars.getVariableSaveBtnLocator().waitFor({ state: "hidden", timeout: 8000 }).catch(() => {});
       await safeWaitForNetworkIdle(page, { timeout: 5000 });
-      await page
-        .locator(SELECTORS.ADD_VARIABLE_BTN)
+      await scopedVars
+        .getAddVariableBtnLocator()
         .waitFor({ state: "visible", timeout: 10000 });
 
       // --- F2: Edit env to introduce cycle in env→region→pod chain ---
@@ -513,13 +515,13 @@ test.describe(
       await scopedVars.editVariable("env");
       await scopedVars.changeVariableType("Query Values");
       // Wait for Query Values form fields to render after type change
-      await page.locator(SELECTORS.VARIABLE_STREAM_TYPE_SELECT).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getVariableStreamTypeSelectLocator().waitFor({ state: "visible", timeout: 10000 });
       await selectStreamType(page, "logs");
       await scopedVars.selectStream("$pod");
       await scopedVars.selectField("$region");
 
       // Click save directly for cycle detection (same reason as F1 above)
-      const saveBtnF2 = page.locator(SELECTORS.VARIABLE_SAVE_BTN);
+      const saveBtnF2 = scopedVars.getVariableSaveBtnLocator();
       await saveBtnF2.waitFor({ state: "visible", timeout: 10000 });
       await saveBtnF2.click();
 
@@ -527,8 +529,8 @@ test.describe(
       expect(hasCycleF2).toBe(true);
 
       // Cancel the edit form before cleanup
-      await page.locator('[data-test="dashboard-variable-cancel-btn"]').click();
-      await page.locator(SELECTORS.VARIABLE_SAVE_BTN).waitFor({ state: "hidden", timeout: 8000 }).catch(() => {});
+      await scopedVars.getVariableCancelBtnLocator().click();
+      await scopedVars.getVariableSaveBtnLocator().waitFor({ state: "hidden", timeout: 8000 }).catch(() => {});
       await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
       // Cleanup
@@ -613,7 +615,7 @@ test.describe(
       await pm.dashboardSetting.closeSettingWindow();
       await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 10000 });
       await pm.dashboardCreate.backToDashboardList();
-      await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
       await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
       // Reopen dashboard — this is the initial load we want to test
@@ -626,10 +628,10 @@ test.describe(
       await scopedVars.waitForVariableSelectorVisible("streamChild", { timeout: 40000 });
       await scopedVars.waitForVariableSelectorVisible("fieldChild", { timeout: 40000 });
 
-      await expect(page.locator(getVariableSelector("streamName"))).toBeVisible();
-      await expect(page.locator(getVariableSelector("streamChild"))).toBeVisible();
-      await expect(page.locator(getVariableSelector("fieldName"))).toBeVisible();
-      await expect(page.locator(getVariableSelector("fieldChild"))).toBeVisible();
+      await expect(scopedVars.getVariableSelectorLocator("streamName")).toBeVisible();
+      await expect(scopedVars.getVariableSelectorLocator("streamChild")).toBeVisible();
+      await expect(scopedVars.getVariableSelectorLocator("fieldName")).toBeVisible();
+      await expect(scopedVars.getVariableSelectorLocator("fieldChild")).toBeVisible();
 
       // Allow all initial variable API calls to settle before cascade testing.
       // In CI, SSE streaming responses can take longer to complete, so give
@@ -729,7 +731,7 @@ test.describe(
         "$fieldConst"
       );
       await reopenSettingsVariables(page, pm);
-      const editHyphen = page.locator(getEditVariableBtn("hyphenChild"));
+      const editHyphen = scopedVars.getEditVariableBtnLocator("hyphenChild");
       await expect(editHyphen).toBeVisible({ timeout: 10000 });
 
       // --- H2: Variable name with underscores in field ---
@@ -746,7 +748,7 @@ test.describe(
         "$field_name"
       );
       await reopenSettingsVariables(page, pm);
-      const editUnderscore = page.locator(getEditVariableBtn("underscoreChild"));
+      const editUnderscore = scopedVars.getEditVariableBtnLocator("underscoreChild");
       await expect(editUnderscore).toBeVisible({ timeout: 10000 });
 
       // --- H3: Switch variable type from query_values to constant ---
@@ -764,14 +766,14 @@ test.describe(
       // Edit var1, change type to Constant
       await scopedVars.editVariable("var1");
       await scopedVars.changeVariableType("Constant");
-      await page
-        .locator('[data-test="dashboard-variable-constant-value-field"]')
+      await scopedVars
+        .getVariableConstantValueFieldLocator()
         .fill("some_value");
       await scopedVars.clickSaveButton();
 
       // Verify save succeeded
       await reopenSettingsVariables(page, pm);
-      const editVar1 = page.locator(getEditVariableBtn("var1"));
+      const editVar1 = scopedVars.getEditVariableBtnLocator("var1");
       await expect(editVar1).toBeVisible({ timeout: 10000 });
 
       // Cleanup
@@ -849,8 +851,8 @@ test.describe(
         "$fieldConst",
         { scope: "tabs", assignedTabs: ["tab1"] }
       );
-      await page
-        .locator(getEditVariableBtn("tabChildVar"))
+      await scopedVars
+        .getEditVariableBtnLocator("tabChildVar")
         .waitFor({ state: "visible", timeout: 15000 });
 
       // Close settings and navigate away then back for a clean initial load.
@@ -859,7 +861,7 @@ test.describe(
       await pm.dashboardSetting.closeSettingWindow();
       await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 10000 });
       await pm.dashboardCreate.backToDashboardList();
-      await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
       await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
       // Reopen dashboard — this is the initial load we want to test
@@ -885,9 +887,9 @@ test.describe(
         },
       });
 
-      await page.locator(getTabSelector("Tab1")).click();
-      await page
-        .locator(getVariableSelector("tabChildVar"))
+      await scopedVars.clickTab("Tab1");
+      await scopedVars
+        .getVariableSelectorLocator("tabChildVar")
         .waitFor({ state: "visible", timeout: 20000 });
 
       const result = await apiMonitor;
@@ -937,8 +939,8 @@ test.describe(
         "$globalField",
         { scope: "tabs", assignedTabs: ["tab1"] }
       );
-      await page
-        .locator(getEditVariableBtn("tabFieldVar"))
+      await scopedVars
+        .getEditVariableBtnLocator("tabFieldVar")
         .waitFor({ state: "visible", timeout: 15000 });
 
       // Close settings and navigate away then back for a clean initial load.
@@ -947,7 +949,7 @@ test.describe(
       await pm.dashboardSetting.closeSettingWindow();
       await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 10000 });
       await pm.dashboardCreate.backToDashboardList();
-      await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
       await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
       // Reopen dashboard — this is the initial load we want to test
@@ -971,9 +973,9 @@ test.describe(
         },
       });
 
-      await page.locator(getTabSelector("Tab1")).click();
-      await page
-        .locator(getVariableSelector("tabFieldVar"))
+      await scopedVars.clickTab("Tab1");
+      await scopedVars
+        .getVariableSelectorLocator("tabFieldVar")
         .waitFor({ state: "visible", timeout: 20000 });
 
       const result = await apiMonitor;
@@ -1025,8 +1027,8 @@ test.describe(
         "$fieldConst",
         { scope: "tabs", assignedTabs: ["tab1"] }
       );
-      await page
-        .locator(getEditVariableBtn("tabCustomChild"))
+      await scopedVars
+        .getEditVariableBtnLocator("tabCustomChild")
         .waitFor({ state: "visible", timeout: 15000 });
 
       // Close settings and navigate away then back for a clean initial load.
@@ -1035,7 +1037,7 @@ test.describe(
       await pm.dashboardSetting.closeSettingWindow();
       await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 10000 });
       await pm.dashboardCreate.backToDashboardList();
-      await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
       await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
       // Reopen dashboard — this is the initial load we want to test
@@ -1060,9 +1062,9 @@ test.describe(
         },
       });
 
-      await page.locator(getTabSelector("Tab1")).click();
-      await page
-        .locator(getVariableSelector("tabCustomChild"))
+      await scopedVars.clickTab("Tab1");
+      await scopedVars
+        .getVariableSelectorLocator("tabCustomChild")
         .waitFor({ state: "visible", timeout: 20000 });
 
       const result = await apiMonitor;
@@ -1137,7 +1139,7 @@ test.describe(
       // Open settings and navigate to variables tab
       await pm.dashboardSetting.openSetting();
       await pm.dashboardSetting.openVariables();
-      await page.locator(SELECTORS.ADD_VARIABLE_BTN).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
       // Global constant holds the stream name
       await scopedVars.addConstantVariable("globalStream", "e2e_automate");
@@ -1156,15 +1158,15 @@ test.describe(
         "$fieldConst",
         { scope: "panels", assignedPanels: ["TestPanel"] }
       );
-      await page
-        .locator(getEditVariableBtn("panelChildVar"))
+      await scopedVars
+        .getEditVariableBtnLocator("panelChildVar")
         .waitFor({ state: "visible", timeout: 15000 });
 
       // Close settings and navigate away for a clean initial load
       await pm.dashboardSetting.closeSettingWindow();
       await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 10000 });
       await pm.dashboardCreate.backToDashboardList();
-      await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
       await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
       // Start monitor BEFORE reopening — panel variables load on initial dashboard render
@@ -1219,7 +1221,7 @@ test.describe(
 
       await pm.dashboardSetting.openSetting();
       await pm.dashboardSetting.openVariables();
-      await page.locator(SELECTORS.ADD_VARIABLE_BTN).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
       // Global constant holds the field name
       await scopedVars.addConstantVariable("globalField", "kubernetes_namespace_name");
@@ -1234,14 +1236,14 @@ test.describe(
         "$globalField",
         { scope: "panels", assignedPanels: ["TestPanel"] }
       );
-      await page
-        .locator(getEditVariableBtn("panelFieldVar"))
+      await scopedVars
+        .getEditVariableBtnLocator("panelFieldVar")
         .waitFor({ state: "visible", timeout: 15000 });
 
       await pm.dashboardSetting.closeSettingWindow();
       await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 10000 });
       await pm.dashboardCreate.backToDashboardList();
-      await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
       await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
       const apiMonitor = monitorVariableAPICalls(page, {
@@ -1293,7 +1295,7 @@ test.describe(
 
       await pm.dashboardSetting.openSetting();
       await pm.dashboardSetting.openVariables();
-      await page.locator(SELECTORS.ADD_VARIABLE_BTN).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getAddVariableBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
       // Global custom variable selecting the stream
       await scopedVars.addCustomVariable("streamSelector", [
@@ -1313,14 +1315,14 @@ test.describe(
         "$fieldConst",
         { scope: "panels", assignedPanels: ["TestPanel"] }
       );
-      await page
-        .locator(getEditVariableBtn("panelCustomChild"))
+      await scopedVars
+        .getEditVariableBtnLocator("panelCustomChild")
         .waitFor({ state: "visible", timeout: 15000 });
 
       await pm.dashboardSetting.closeSettingWindow();
       await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 10000 });
       await pm.dashboardCreate.backToDashboardList();
-      await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+      await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
       await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
       const apiMonitor = monitorVariableAPICalls(page, {

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-tab-level.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-tab-level.spec.js
@@ -44,7 +44,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add tabs using consolidated helper
     await pm.dashboardSetting.openSetting();
@@ -63,7 +63,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -73,29 +73,29 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Switch to Tab1 and verify variable is visible
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.getTabLocator("Tab1").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on the dashboard after tab switch
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     await scopedVars.verifyVariableVisibility(variableName, true);
 
     // Switch to Tab2 and verify variable is NOT visible
-    await page.locator(getTabSelector("Tab2")).click();
+    await scopedVars.getTabLocator("Tab2").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     await scopedVars.verifyVariableVisibility(variableName, false);
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -111,19 +111,19 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add two tabs
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getTabLocator("Tab1").waitFor({ state: "visible", timeout: 10000 });
 
     await pm.dashboardSetting.addTabSetting("Tab2");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab2")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getTabLocator("Tab2").waitFor({ state: "visible", timeout: 10000 });
 
     // Add same variable to both tabs
     await scopedVars.addScopedVariable(
@@ -137,7 +137,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -147,22 +147,22 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Go to Tab1 and set value
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.getTabLocator("Tab1").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on the dashboard after tab switch
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
-    const varTrigger1 = page.locator(`[data-test="variable-selector-${variableName}-inner-trigger"]`);
+    const varTrigger1 = scopedVars.getVariableTriggerLocator(variableName);
     await varTrigger1.waitFor({ state: "visible", timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await varTrigger1.click();
     // Wait for dropdown menu to open
-    const popover1 = page.locator(`[data-test="variable-selector-${variableName}-inner-popover"]`);
+    const popover1 = scopedVars.getVariablePopoverLocator(variableName);
     await popover1.waitFor({ state: "visible", timeout: 5000 });
 
     const option1 = popover1.locator(`[data-test="variable-selector-${variableName}-inner-option"]`).nth(0);
@@ -172,19 +172,19 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await safeWaitForHidden(page, `[data-test="variable-selector-${variableName}-inner-popover"]`, { timeout: 3000 });
 
     // Go to Tab2 and set different value
-    await page.locator(getTabSelector("Tab2")).click();
+    await scopedVars.getTabLocator("Tab2").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on the dashboard after tab switch
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
-    const varTrigger2 = page.locator(`[data-test="variable-selector-${variableName}-inner-trigger"]`);
+    const varTrigger2 = scopedVars.getVariableTriggerLocator(variableName);
     await varTrigger2.waitFor({ state: "visible", timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await varTrigger2.click();
     // Wait for dropdown menu to open
-    const popover2 = page.locator(`[data-test="variable-selector-${variableName}-inner-popover"]`);
+    const popover2 = scopedVars.getVariablePopoverLocator(variableName);
     await popover2.waitFor({ state: "visible", timeout: 5000 });
 
     // Wait for at least 2 options to load in the dropdown
@@ -203,37 +203,37 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     expect(value1.trim()).not.toBe(value2.trim());
 
     // Switch back to Tab1 and verify value persists
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.getTabLocator("Tab1").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
     // Wait for variable to appear on the dashboard after tab switch
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for inner dropdown to be fully initialized
-    await page.locator(`[data-test="variable-selector-${variableName}-inner"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableDropdown(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for network idle to ensure value is loaded
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     // Verify the persisted value is displayed in the selector
-    const variableSelector1 = page.locator(getVariableSelector(variableName));
+    const variableSelector1 = scopedVars.getVariableSelectorLocator(variableName);
     await expect(variableSelector1).toContainText(value1.trim(), { timeout: 10000 });
 
     // Switch to Tab2 and verify value persists
-    await page.locator(getTabSelector("Tab2")).click();
+    await scopedVars.getTabLocator("Tab2").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
     // Wait for variable to appear on the dashboard after tab switch
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for inner dropdown to be fully initialized
-    await page.locator(`[data-test="variable-selector-${variableName}-inner"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableDropdown(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for network idle to ensure value is loaded
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     // Verify the persisted value is displayed in the selector
-    const variableSelector2 = page.locator(getVariableSelector(variableName));
+    const variableSelector2 = scopedVars.getVariableSelectorLocator(variableName);
     await expect(variableSelector2).toContainText(value2.trim(), { timeout: 10000 });
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -249,14 +249,14 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add Tab2
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab2");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab2")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getTabLocator("Tab2").waitFor({ state: "visible", timeout: 10000 });
 
     // Add variable to Tab2 only
     await scopedVars.addScopedVariable(
@@ -270,7 +270,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -280,7 +280,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Initially on default tab - variable should not load yet
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
@@ -289,7 +289,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     const apiMonitor = monitorVariableAPICalls(page, { expectedCount: 1, timeout: 10000 });
 
     // Switch to Tab2
-    await page.locator(getTabSelector("Tab2")).click();
+    await scopedVars.getTabLocator("Tab2").click();
 
     const result = await apiMonitor;
 
@@ -300,7 +300,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -316,19 +316,19 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add two tabs
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getTabLocator("Tab1").waitFor({ state: "visible", timeout: 10000 });
 
     await pm.dashboardSetting.addTabSetting("Tab2");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab2")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getTabLocator("Tab2").waitFor({ state: "visible", timeout: 10000 });
 
     // Add variable to both tabs
     await scopedVars.addScopedVariable(
@@ -342,7 +342,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -352,24 +352,24 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Set value on Tab1
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.getTabLocator("Tab1").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on the dashboard after tab switch
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
-    const varDropdown = page.locator(`[data-test="variable-selector-${variableName}"]`);
+    const varDropdown = scopedVars.getVariableSelectorLocator(variableName);
     await varDropdown.waitFor({ state: "visible", timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await varDropdown.click();
     // Wait for dropdown menu to open
-    await page.locator(`[data-test="variable-selector-${variableName}-inner-popover"]`).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariablePopoverLocator(variableName).waitFor({ state: "visible", timeout: 5000 });
 
-    const option1 = page.locator(SELECTORS.ROLE_OPTION).nth(0);
+    const option1 = scopedVars.getRoleOptionLocator().nth(0);
     await option1.waitFor({ state: "visible", timeout: 5000 });
     const originalValue = await option1.textContent();
     await option1.click();
@@ -382,36 +382,36 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     ).catch(() => null);
 
     // Switch to Tab2
-    await page.locator(getTabSelector("Tab2")).click();
+    await scopedVars.getTabLocator("Tab2").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on the dashboard after tab switch
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for inner dropdown to be fully initialized
-    await page.locator(`[data-test="variable-selector-${variableName}-inner"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableDropdown(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for the variable values API to complete so Tab2 shows its loaded value
     await tab2VarLoadPromise;
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Get initial value on Tab2 (should be default, not changed by Tab1)
-    const tab2Selector = page.locator(getVariableSelector(variableName));
+    const tab2Selector = scopedVars.getVariableSelectorLocator(variableName);
     const tab2Value = await tab2Selector.innerText();
 
     // Go back to Tab1 and change value
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.getTabLocator("Tab1").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Re-query the dropdown after tab switch
-    const varDropdownTab1Again = page.locator(`[data-test="variable-selector-${variableName}"]`);
+    const varDropdownTab1Again = scopedVars.getVariableSelectorLocator(variableName);
     await varDropdownTab1Again.waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
     await varDropdownTab1Again.click();
     // Wait for dropdown menu to open
-    await page.locator(`[data-test="variable-selector-${variableName}-inner-popover"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariablePopoverLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
-    const option2 = page.locator(SELECTORS.ROLE_OPTION).nth(1);
+    const option2 = scopedVars.getRoleOptionLocator().nth(1);
     await option2.waitFor({ state: "visible", timeout: 5000 });
     await option2.click();
     await safeWaitForHidden(page, `[data-test="variable-selector-${variableName}-inner-popover"]`, { timeout: 3000 });
@@ -423,27 +423,27 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     ).catch(() => null);
 
     // Switch to Tab2 and verify value hasn't changed
-    await page.locator(getTabSelector("Tab2")).click();
+    await scopedVars.getTabLocator("Tab2").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on the dashboard after tab switch
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for inner dropdown to be fully initialized
-    await page.locator(`[data-test="variable-selector-${variableName}-inner"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableDropdown(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for any variable API call to settle before reading the value
     await tab2VarReloadPromise;
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Verify value hasn't changed
-    const tab2SelectorAfter = page.locator(getVariableSelector(variableName));
+    const tab2SelectorAfter = scopedVars.getVariableSelectorLocator(variableName);
     const tab2ValueAfter = await tab2SelectorAfter.innerText();
     expect(tab2ValueAfter).toContain(tab2Value);
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -460,14 +460,14 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getTabLocator("Tab1").waitFor({ state: "visible", timeout: 10000 });
 
     // Add global variable
     await scopedVars.addScopedVariable(
@@ -494,7 +494,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
       }
     );
     // Wait for variable to be saved
-    await page.locator(`[data-test="dashboard-edit-variable-${tabVar}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(tabVar).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -504,24 +504,24 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Change global variable value
-    await page.locator(getTabSelector("Tab1")).click();
+    await scopedVars.getTabLocator("Tab1").click();
     // Wait for tab content to load
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on dashboard
-    await page.locator(`[data-test="variable-selector-${globalVar}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(globalVar).waitFor({ state: "visible", timeout: 10000 });
 
-    const globalDropdown = page.locator(`[data-test="variable-selector-${globalVar}"]`);
+    const globalDropdown = scopedVars.getVariableSelectorLocator(globalVar);
     await globalDropdown.waitFor({ state: "visible", timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await globalDropdown.click();
     // Wait for dropdown menu to open
-    await page.locator(`[data-test="variable-selector-${globalVar}-inner-popover"]`).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariablePopoverLocator(globalVar).waitFor({ state: "visible", timeout: 5000 });
 
-    const globalOption = page.locator(SELECTORS.ROLE_OPTION).first();
+    const globalOption = scopedVars.getRoleOptionLocator().first();
     await globalOption.waitFor({ state: "visible", timeout: 5000 });
     await globalOption.click();
     await safeWaitForHidden(page, `[data-test="variable-selector-${globalVar}-inner-popover"]`, { timeout: 3000 });
@@ -540,7 +540,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -556,7 +556,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add tab variable to default tab
     await pm.dashboardSetting.openSetting();
@@ -571,7 +571,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -581,22 +581,22 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Stay on default tab and set value
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
-    const varDropdown = page.locator(`[data-test="variable-selector-${variableName}"]`);
+    const varDropdown = scopedVars.getVariableSelectorLocator(variableName);
     await varDropdown.waitFor({ state: "visible", timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await varDropdown.click();
     // Wait for dropdown menu to open
-    await page.locator(`[data-test="variable-selector-${variableName}-inner-popover"]`).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariablePopoverLocator(variableName).waitFor({ state: "visible", timeout: 5000 });
 
-    const option = page.locator(SELECTORS.ROLE_OPTION).first();
+    const option = scopedVars.getRoleOptionLocator().first();
     await option.waitFor({ state: "visible", timeout: 5000 });
     const selectedValue = await option.textContent();
     await option.click();
@@ -613,23 +613,23 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for default tab content to load after reload
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator(SELECTORS.PANEL_ANY)).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded();
 
     // Wait for variable to appear on dashboard after reload
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for inner dropdown to be fully initialized
-    await page.locator(`[data-test="variable-selector-${variableName}-inner"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableDropdown(variableName).waitFor({ state: "visible", timeout: 10000 });
     // Wait for network idle to ensure value is loaded
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Verify value persisted
-    const variableSelectorAfterReload = page.locator(getVariableSelector(variableName));
+    const variableSelectorAfterReload = scopedVars.getVariableSelectorLocator(variableName);
     await expect(variableSelectorAfterReload).toContainText(selectedValue.trim(), { timeout: 10000 });
 
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });
@@ -645,14 +645,14 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add tab
     await pm.dashboardSetting.openSetting();
     await pm.dashboardSetting.addTabSetting("Tab1");
     await pm.dashboardSetting.saveTabSetting();
     // Wait for tab to be created and visible
-    await page.locator(getTabSelector("Tab1")).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getTabLocator("Tab1").waitFor({ state: "visible", timeout: 10000 });
 
     // Add variable to tab
     await scopedVars.addScopedVariable(
@@ -666,7 +666,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -678,7 +678,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     // Now delete the tab
     await pm.dashboardSetting.openSetting();
     // Make sure we're on the tabs settings tab
-    await page.locator('[data-test="dashboard-settings-tab-tab"]').click();
+    await pm.dashboardSetting.clickTabsSettingsTab();
     await safeWaitForDOMContentLoaded(page, { timeout: 5000 });
     await pm.dashboardSetting.deleteTab("Tab1");
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
@@ -686,7 +686,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     // Open variables to verify deleted tab label
     await pm.dashboardSetting.openVariables();
     // Wait for variables tab to be active
-    await page.locator('[data-test="dashboard-add-variable-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.waitForAddVariableBtnVisible();
 
     // Verify deleted tab label using common function
     await scopedVars.verifyDeletedScopeLabel("tab");
@@ -700,7 +700,7 @@ test.describe("Dashboard Variables - Tab Level", { tag: ['@dashboards', '@dashbo
     // Cleanup
     await pm.dashboardCreate.backToDashboardList();
     // Wait for dashboard list to be fully loaded
-    await page.locator(SELECTORS.SEARCH).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getDashboardSearchLocator().waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await deleteDashboard(page, dashboardName);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-url-sync.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-url-sync.spec.js
@@ -38,7 +38,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add global variable
     await pm.dashboardSetting.openSetting();
@@ -50,7 +50,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
       { scope: "global" }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -60,13 +60,13 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Set variable value using page object method
     const { selectedValue } = await scopedVars.changeVariableValue(variableName, { optionIndex: 0, returnSelectedValue: true });
 
     // Click refresh to update URL
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Verify URL contains var-{variable}={value}
@@ -91,7 +91,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add tab variable to default tab
     await pm.dashboardSetting.openSetting();
@@ -106,7 +106,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -116,19 +116,19 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Stay on default tab and wait for variable to appear
-    await page.locator(SELECTORS.ADD_PANEL_BTN).or(page.locator('[data-test*="dashboard-panel-"]')).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.waitForTabContentLoaded({ timeout: 5000 });
 
     // Wait for variable to appear on the dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Set variable value using page object method
     const { selectedValue } = await scopedVars.changeVariableValue(variableName, { optionIndex: 0, returnSelectedValue: true });
 
     // Click refresh
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Verify URL contains var-{variable}.t.default={value}
@@ -152,7 +152,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add panel and capture panel ID from API response
     await pm.dashboardCreate.addPanel();
@@ -181,8 +181,8 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     }
 
     // Wait for panel to be added to dashboard
-    await page.locator('[data-test*="dashboard-panel-"]').first().waitFor({ state: "visible", timeout: 15000 });
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAnyPanel().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Add panel variable using panel name
     await pm.dashboardSetting.openSetting();
@@ -197,7 +197,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -207,13 +207,13 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Set variable value using page object method
     await scopedVars.changeVariableValue(variableName, { optionIndex: 0 });
 
     // Click global refresh to update URL
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Verify URL contains panel variable parameter
@@ -242,7 +242,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable
     await pm.dashboardSetting.openSetting();
@@ -254,7 +254,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
       { scope: "global" }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -264,13 +264,13 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Set value using page object method
     const { selectedValue } = await scopedVars.changeVariableValue(variableName, { optionIndex: 0, returnSelectedValue: true });
 
     // Click refresh to update URL
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Get current URL
@@ -281,14 +281,14 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for dashboard to load after reload
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for variable selector to appear
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Verify variable value restored - check the displayed value in the selector
-    const variableSelector = page.locator(getVariableSelector(variableName));
+    const variableSelector = scopedVars.getVariableSelectorLocator(variableName);
     await expect(variableSelector).toContainText(selectedValue.trim(), { timeout: 10000 });
 
     // Cleanup
@@ -308,7 +308,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable with default value
     await pm.dashboardSetting.openSetting();
@@ -323,7 +323,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
       }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -333,7 +333,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Get dashboard URL
     const baseURL = page.url();
@@ -346,14 +346,14 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Wait for dashboard to load
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for variable selector to appear
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Verify value is set from URL - check the displayed value in the selector
-    const variableSelector = page.locator(getVariableSelector(variableName));
+    const variableSelector = scopedVars.getVariableSelectorLocator(variableName);
     await expect(variableSelector).toContainText(testValue, { timeout: 10000 });
 
     // Cleanup
@@ -372,7 +372,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable
     await pm.dashboardSetting.openSetting();
@@ -384,7 +384,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
       { scope: "global" }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -394,13 +394,13 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Set value using page object method
     const { selectedValue } = await scopedVars.changeVariableValue(variableName, { optionIndex: 0, returnSelectedValue: true });
 
     // Click refresh to update URL
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Get URL
@@ -441,7 +441,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add two variables
     await pm.dashboardSetting.openSetting();
@@ -449,8 +449,8 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardSetting.openSetting();
     await scopedVars.addScopedVariable(var2, "logs", "e2e_automate", "kubernetes_container_name", { scope: "global" });
     // Wait for variables to be saved
-    await page.locator(`[data-test="dashboard-edit-variable-${var1}"]`).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(`[data-test="dashboard-edit-variable-${var2}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(var1).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(var2).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -460,8 +460,8 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variables to appear on dashboard
-    await page.locator(`[data-test="variable-selector-${var1}"]`).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(`[data-test="variable-selector-${var2}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(var1).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(var2).waitFor({ state: "visible", timeout: 10000 });
 
     // Set both values using the established POM method (uses inner-trigger, proven reliable)
     await scopedVars.changeVariableValue(var1, { optionIndex: 0 });
@@ -471,7 +471,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Click refresh
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Verify URL contains both variables
@@ -495,7 +495,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add variable
     await pm.dashboardSetting.openSetting();
@@ -507,7 +507,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
       { scope: "global" }
     );
     // Wait for variable to be saved
-    await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -517,7 +517,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for variable to appear on dashboard
-    await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
 
     // Add panel with drilldown configuration
     await pm.dashboardCreate.addPanel();
@@ -534,14 +534,14 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardPanelActions.savePanel();
 
     // Wait for panel to be added to dashboard
-    await page.locator('[data-test*="dashboard-panel-"]').first().waitFor({ state: "visible", timeout: 15000 });
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getAnyPanel().waitFor({ state: "visible", timeout: 15000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Set variable value using page object method
     const { selectedValue: drillValue } = await scopedVars.changeVariableValue(variableName, { optionIndex: 0, returnSelectedValue: true });
 
     // Refresh to commit
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Get URL with drilldown variable
@@ -571,7 +571,7 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardCreate.waitForDashboardUIStable();
     await pm.dashboardCreate.createDashboard(dashboardName);
 
-    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+    await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
     // Add global and tab variables using default tab
     await pm.dashboardSetting.openSetting();
@@ -579,8 +579,8 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await pm.dashboardSetting.openSetting();
     await scopedVars.addScopedVariable(tabVar, "logs", "e2e_automate", "kubernetes_container_name", { scope: "tabs", assignedTabs: ["default"] });
     // Wait for variables to be saved
-    await page.locator(`[data-test="dashboard-edit-variable-${globalVar}"]`).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(`[data-test="dashboard-edit-variable-${tabVar}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(globalVar).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getEditVariableBtnLocator(tabVar).waitFor({ state: "visible", timeout: 10000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     await pm.dashboardSetting.closeSettingWindow();
@@ -590,36 +590,36 @@ test.describe("Dashboard Variables - URL Sync & Drilldown", { tag: ['@dashboards
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
     // Wait for dashboard to be fully loaded after closing settings
-    await page.locator(SELECTORS.SETTING_BTN).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getSettingBtnLocator().waitFor({ state: "visible", timeout: 10000 });
 
     // Wait for both variables to appear on dashboard (both are on default tab)
-    await page.locator(`[data-test="variable-selector-${globalVar}"]`).waitFor({ state: "visible", timeout: 10000 });
-    await page.locator(`[data-test="variable-selector-${tabVar}"]`).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(globalVar).waitFor({ state: "visible", timeout: 10000 });
+    await scopedVars.getVariableSelectorLocator(tabVar).waitFor({ state: "visible", timeout: 10000 });
 
     // Set values
-    const globalDropdown = page.locator(`[data-test="variable-selector-${globalVar}-inner-trigger"]`);
+    const globalDropdown = scopedVars.getVariableTriggerLocator(globalVar);
     await globalDropdown.waitFor({ state: "visible", timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await globalDropdown.click();
     // Wait for dropdown menu to open
-    await page.locator(`[data-test="variable-selector-${globalVar}-inner-popover"]`).waitFor({ state: "visible", timeout: 5000 });
-    await page.locator(`[data-test="variable-selector-${globalVar}-inner-popover"]`).locator(SELECTORS.ROLE_OPTION).first().waitFor({ state: "visible", timeout: 5000 });
-    await page.locator(`[data-test="variable-selector-${globalVar}-inner-popover"]`).locator(SELECTORS.ROLE_OPTION).first().click();
+    await scopedVars.getVariablePopoverLocator(globalVar).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariablePopoverLocator(globalVar).locator(SELECTORS.ROLE_OPTION).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariablePopoverLocator(globalVar).locator(SELECTORS.ROLE_OPTION).first().click();
     await safeWaitForHidden(page, `[data-test="variable-selector-${globalVar}-inner-popover"]`, { timeout: 3000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
 
-    const tabDropdown = page.locator(`[data-test="variable-selector-${tabVar}-inner-trigger"]`);
+    const tabDropdown = scopedVars.getVariableTriggerLocator(tabVar);
     await tabDropdown.waitFor({ state: "visible", timeout: 5000 });
     await safeWaitForNetworkIdle(page, { timeout: 3000 });
     await tabDropdown.click();
     // Wait for dropdown menu to open
-    await page.locator(`[data-test="variable-selector-${tabVar}-inner-popover"]`).waitFor({ state: "visible", timeout: 5000 });
-    await page.locator(`[data-test="variable-selector-${tabVar}-inner-popover"]`).locator(SELECTORS.ROLE_OPTION).first().waitFor({ state: "visible", timeout: 5000 });
-    await page.locator(`[data-test="variable-selector-${tabVar}-inner-popover"]`).locator(SELECTORS.ROLE_OPTION).first().click();
+    await scopedVars.getVariablePopoverLocator(tabVar).waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariablePopoverLocator(tabVar).locator(SELECTORS.ROLE_OPTION).first().waitFor({ state: "visible", timeout: 5000 });
+    await scopedVars.getVariablePopoverLocator(tabVar).locator(SELECTORS.ROLE_OPTION).first().click();
     await safeWaitForHidden(page, `[data-test="variable-selector-${tabVar}-inner-popover"]`, { timeout: 3000 });
 
     // Refresh
-    await page.locator(SELECTORS.REFRESH_BTN).click();
+    await scopedVars.clickDashboardRefresh();
     await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
     // Verify URL structure

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard.spec.js
@@ -41,9 +41,7 @@ test.describe("dashboard UI testcases", () => {
 
     await pm.dashboardCreate.backToDashboardList();
 
-    await page.locator('[data-test="dashboard-folder-tab-default"]').waitFor({
-      state: "visible",
-    });
+    await pm.dashboardCreate.waitForDefaultFolderTabVisible();
 
     await deleteDashboard(page, randomDashboardName);
   });
@@ -60,9 +58,7 @@ test.describe("dashboard UI testcases", () => {
     await pm.dashboardCreate.createDashboard(randomDashboardName);
     // Toast is already validated inside createDashboard() and auto-dismisses before we get here
     await pm.dashboardCreate.backToDashboardList();
-    await page.locator('[data-test="dashboard-folder-tab-default"]').waitFor({
-      state: "visible",
-    });
+    await pm.dashboardCreate.waitForDefaultFolderTabVisible();
 
     // Search for the created dashboard
     await pm.dashboardCreate.searchDashboard(randomDashboardName);
@@ -97,9 +93,7 @@ test.describe("dashboard UI testcases", () => {
     await pm.dashboardCreate.createDashboard(randomDashboardName);
 
     // Wait for dashboard tab to be visible
-    await page.locator('[data-test="dashboard-tab-default"]').waitFor({
-      state: "visible",
-    });
+    await pm.dashboardCreate.waitForDefaultDashboardTabVisible();
 
     // Add a new panel
     await pm.dashboardCreate.addPanel();
@@ -349,23 +343,10 @@ test.describe("dashboard UI testcases", () => {
 
     await pm.dashboardPanelActions.applyDashboardBtn();
 
-    await page
-      .locator('[data-test="dashboard-variable-adhoc-add-selector"]')
-      .click();
-    await page
-      .locator('[data-test="dashboard-variable-adhoc-name-selector"] input')
-      .click();
-    await page
-      .locator('[data-test="dashboard-variable-adhoc-name-selector"] input')
-      .fill("kubernetes_container_hash");
-    await page
-      .locator('[data-test="dashboard-variable-adhoc-value-selector"] input')
-      .click();
-    await page
-      .locator('[data-test="dashboard-variable-adhoc-value-selector"] input')
-      .fill(
-        "058694856476.dkr.ecr.us-west-2.amazonaws.com/zinc-cp@sha256:56e216b3d61bd282846e3f6d1bd9cb82f83b90b7e401ad0afc0052aa3f15715c"
-      );
+    await pm.dashboardVariables.addAdhocVariable(
+      "kubernetes_container_hash",
+      "058694856476.dkr.ecr.us-west-2.amazonaws.com/zinc-cp@sha256:56e216b3d61bd282846e3f6d1bd9cb82f83b90b7e401ad0afc0052aa3f15715c"
+    );
     await pm.dashboardTimeRefresh.setRelative("3", "h");
 
     await pm.dashboardPanelActions.savePanel();
@@ -691,7 +672,7 @@ test.describe("dashboard UI testcases", () => {
 
     // Verify the gauge chart is visible
     await pm.dashboardPanelActions.waitForChartToRender();
-    await page.locator('[data-test="dashboard-panel-discard"]').click();
+    await pm.dashboardPanelActions.discardPanel();
 
     // Listen for the dialog and assert its message
     page.once("dialog", async (dialog) => {
@@ -741,7 +722,7 @@ test.describe("dashboard UI testcases", () => {
     expect(await dataRows.count()).toBeGreaterThan(0);
     await expect(pm.dashboardPanelActions.firstRowNthCell(0)).not.toHaveText("");
     await expect(pm.dashboardPanelActions.firstRowNthCell(1)).not.toHaveText("");
-    await expect(page.locator('[data-test="no-data"]')).not.toBeVisible();
+    await expect(pm.dashboardPanelActions.getNoDataLocator()).not.toBeVisible();
 
     // Save panel and cleanup
     await pm.dashboardPanelActions.savePanel();
@@ -803,10 +784,10 @@ test.describe("dashboard UI testcases", () => {
     });
 
     // Validate chart is properly rendered
-    const chartContainer = page.locator('[data-test="chart-renderer"]');
+    const chartContainer = pm.dashboardPanelActions.getChartRendererCanvas();
     const boundingBox = await chartContainer.boundingBox();
-    const canvasCount = await page
-      .locator('[data-test="chart-renderer"] canvas')
+    const canvasCount = await pm.dashboardPanelActions
+      .getChartRendererCanvasElement()
       .count();
 
     // Enhanced validation: Check for meaningful data rendering
@@ -814,7 +795,7 @@ test.describe("dashboard UI testcases", () => {
     expect(canvasCount).toBeGreaterThanOrEqual(1); // Should have at least 1 canvas element
     expect(boundingBox.width).toBeGreaterThan(100); // Reasonable width
     expect(boundingBox.height).toBeGreaterThan(50); // Reasonable height (not the tiny 38px no-data case)
-    await expect(page.locator('[data-test="no-data"]')).not.toBeVisible();
+    await expect(pm.dashboardPanelActions.getNoDataLocator()).not.toBeVisible();
 
     // Verify canvas has visual content
     const canvasHasContent = await page.evaluate(() => {

--- a/tests/ui-testing/playwright-tests/Dashboards/maxquery.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/maxquery.spec.js
@@ -17,9 +17,6 @@ const testLogger = require("../utils/test-logger.js");
 // Use a dedicated stream for max query range tests (not e2e_automate)
 const MAX_QUERY_STREAM = "e2e_max_query_range";
 
-// Warning icon selector (from PanelErrorButtons.vue)
-const WARNING_SELECTOR = '[data-test="panel-max-duration-warning"]';
-
 // Serial mode is required: all tests share the same stream (e2e_max_query_range)
 // and its max_query_range setting. Running in parallel would cause tests to
 // reset each other's stream state mid-execution.
@@ -104,7 +101,7 @@ test.describe("Dashboard Max Query Range", () => {
       await searchDone1;
 
       // Assert warning icon is visible
-      await expect(page.locator(WARNING_SELECTOR).first()).toBeVisible({
+      await expect(pm.dashboardMaxQueryRange.warningIcon.first()).toBeVisible({
         timeout: 15000,
       });
 
@@ -150,7 +147,7 @@ test.describe("Dashboard Max Query Range", () => {
       await searchDone6w;
 
       // Warning should be visible
-      await expect(page.locator(WARNING_SELECTOR).first()).toBeVisible({
+      await expect(pm.dashboardMaxQueryRange.warningIcon.first()).toBeVisible({
         timeout: 15000,
       });
       testLogger.info("Warning visible with 6-week range (exceeds 4h limit)");
@@ -162,7 +159,7 @@ test.describe("Dashboard Max Query Range", () => {
       await searchDone2h;
 
       // Warning should disappear
-      await expect(page.locator(WARNING_SELECTOR)).not.toBeVisible({
+      await expect(pm.dashboardMaxQueryRange.warningIcon).not.toBeVisible({
         timeout: 15000,
       });
       testLogger.info("Warning hidden with 2-hour range (within 4h limit)");
@@ -211,7 +208,7 @@ test.describe("Dashboard Max Query Range", () => {
       await pm.dashboardPanelActions.waitForChartToRender().catch(() => {});
 
       // Warning should be visible in editor
-      await expect(page.locator(WARNING_SELECTOR).first()).toBeVisible({
+      await expect(pm.dashboardMaxQueryRange.warningIcon.first()).toBeVisible({
         timeout: 15000,
       });
       testLogger.info("Warning visible in panel editor when range exceeds max");
@@ -281,7 +278,7 @@ test.describe("Dashboard Max Query Range", () => {
       await allSearchesDone;
 
       // Verify all panels show the warning (retries until count is met or timeout)
-      await expect(page.locator(WARNING_SELECTOR)).toHaveCount(chartTypes.length, { timeout: 15000 });
+      await expect(pm.dashboardMaxQueryRange.warningIcon).toHaveCount(chartTypes.length, { timeout: 15000 });
       testLogger.info(`All ${chartTypes.length} panels show max query range warning`);
 
       // Cleanup
@@ -319,7 +316,7 @@ test.describe("Dashboard Max Query Range", () => {
       await searchDone5;
 
       // Verify warning is present
-      await expect(page.locator(WARNING_SELECTOR).first()).toBeVisible({
+      await expect(pm.dashboardMaxQueryRange.warningIcon.first()).toBeVisible({
         timeout: 15000,
       });
 
@@ -356,7 +353,7 @@ test.describe("Dashboard Max Query Range", () => {
       await buildPanelWithWideRange(page, pm, "No Limit Panel", "area");
 
       // Warning should NOT be visible since there is no max query range limit
-      await expect(page.locator(WARNING_SELECTOR)).not.toBeVisible({
+      await expect(pm.dashboardMaxQueryRange.warningIcon).not.toBeVisible({
         timeout: 5000,
       });
       testLogger.info("No warning shown when max query range is not set");
@@ -408,7 +405,7 @@ test.describe("Dashboard Max Query Range", () => {
       await pm.dashboardPanelActions.applyDashboardBtn();
       await pm.dashboardPanelActions.waitForChartToRender().catch(() => {});
 
-      await expect(page.locator(WARNING_SELECTOR).first()).toBeVisible({
+      await expect(pm.dashboardMaxQueryRange.warningIcon.first()).toBeVisible({
         timeout: 15000,
       });
       testLogger.info("Warning visible with multi-SQL queries exceeding max range");

--- a/tests/ui-testing/playwright-tests/Dashboards/visualize-vrl.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/visualize-vrl.spec.js
@@ -36,12 +36,13 @@ const histogramQuery = `SELECT histogram(_timestamp) as "x_axis_1", count(kubern
 
 // Helper function to enable VRL editor with deterministic wait
 async function enableVrlEditor(page) {
+  const pm = new PageManager(page);
   // VRL toggle lives inside the utilities menu dropdown
-  const utilitiesBtn = page.locator('[data-test="logs-search-bar-utilities-menu-btn"]');
+  const utilitiesBtn = pm.logsVisualise.getUtilitiesMenuBtn();
   await utilitiesBtn.waitFor({ state: "visible", timeout: 10000 });
   await utilitiesBtn.click();
 
-  const vrlToggleBtn = page.locator('[data-test="logs-search-bar-show-query-toggle-btn-btn"]');
+  const vrlToggleBtn = pm.logsVisualise.getVrlToggleMenuBtn();
   await vrlToggleBtn.waitFor({ state: "visible", timeout: 10000 });
 
   const dataState = await vrlToggleBtn.getAttribute("data-state");
@@ -49,7 +50,7 @@ async function enableVrlEditor(page) {
   if (dataState === "unchecked") {
     await vrlToggleBtn.click();
     await page.keyboard.press("Escape");
-    const vrlEditor = page.locator('[data-test="logs-vrl-function-editor"]');
+    const vrlEditor = pm.logsVisualise.functionEditor;
     await vrlEditor.first().waitFor({ state: "visible", timeout: 10000 });
   } else {
     await page.keyboard.press("Escape");
@@ -83,11 +84,11 @@ test.describe("VRL visualization support testcases", () => {
     await pm.logsVisualise.openVisualiseTabWithVrl();
 
     // VRL toggle lives inside the utilities menu dropdown - must open it to check
-    const utilitiesBtn = page.locator('[data-test="logs-search-bar-utilities-menu-btn"]');
+    const utilitiesBtn = pm.logsVisualise.getUtilitiesMenuBtn();
     await expect(utilitiesBtn).toBeVisible({ timeout: 10000 });
     await utilitiesBtn.click();
 
-    const vrlToggleBtn = page.locator('[data-test="logs-search-bar-show-query-toggle-btn-btn"]');
+    const vrlToggleBtn = pm.logsVisualise.getVrlToggleMenuBtn();
     await expect(vrlToggleBtn).toBeVisible({ timeout: 5000 });
 
     const dataState = await vrlToggleBtn.getAttribute("data-state");
@@ -97,14 +98,14 @@ test.describe("VRL visualization support testcases", () => {
       await vrlToggleBtn.click();
       await page.keyboard.press("Escape");
       // Wait for VRL editor to appear
-      const vrlEditor = page.locator('[data-test="logs-vrl-function-editor"]');
+      const vrlEditor = pm.logsVisualise.functionEditor;
       await vrlEditor.first().waitFor({ state: "visible", timeout: 10000 });
     } else {
       await page.keyboard.press("Escape");
     }
 
     // Verify VRL editor is visible
-    const vrlEditor = page.locator('[data-test="logs-vrl-function-editor"]');
+    const vrlEditor = pm.logsVisualise.functionEditor;
     await expect(vrlEditor.first()).toBeVisible();
   });
 
@@ -135,14 +136,14 @@ test.describe("VRL visualization support testcases", () => {
     await pm.logsVisualise.verifyChartRenders(page);
 
     // Verify table panel is visible
-    const tablePanel = page.locator('[data-test="dashboard-panel-table"]');
+    const tablePanel = pm.logsVisualise.getTablePanel();
     await expect(tablePanel).toBeVisible({ timeout: 15000 });
 
     // Verify table chart is selected
     await pm.logsVisualise.verifyChartTypeSelected(page, "table", true);
 
     // Verify table has data
-    const tableRows = page.locator('[data-test="dashboard-panel-table"] tbody tr');
+    const tableRows = pm.logsVisualise.getTableRows();
     await expect(tableRows).not.toHaveCount(0, { timeout: 15000 });
     const rowCount = await tableRows.count();
     expect(rowCount).toBeGreaterThan(0);
@@ -176,14 +177,14 @@ test.describe("VRL visualization support testcases", () => {
     // await waitForTableData(page);
 
     // Verify table panel is displayed initially
-    const tablePanel = page.locator('[data-test="dashboard-panel-table"]');
+    const tablePanel = pm.logsVisualise.getTablePanel();
     await expect(tablePanel).toBeVisible({ timeout: 10000 });
 
     // Switch to line chart (now allowed with new behavior)
-    await page.locator('[data-test="selected-chart-line-item"]').click();
+    await pm.logsVisualise.getChartTypeItem("line").click();
 
     // Wait for VRL warning banner to appear
-    const vrlWarningBanner = page.getByText("VRL function is only supported for table chart");
+    const vrlWarningBanner = pm.logsVisualise.getVrlWarningBanner();
     await expect(vrlWarningBanner).toBeVisible({ timeout: 5000 });
 
     // NEW BEHAVIOR: Chart switching is now allowed - line chart should be selected
@@ -218,17 +219,17 @@ test.describe("VRL visualization support testcases", () => {
     const chartTypes = ["line", "bar", "area", "scatter"];
 
     for (const chartType of chartTypes) {
-      await page.locator(`[data-test="selected-chart-${chartType}-item"]`).click();
+      await pm.logsVisualise.getChartTypeItem(chartType).click();
 
       // Wait for VRL warning banner to appear
-      const vrlWarningBanner = page.getByText("VRL function is only supported for table chart");
+      const vrlWarningBanner = pm.logsVisualise.getVrlWarningBanner();
       await expect(vrlWarningBanner).toBeVisible({ timeout: 5000 });
 
       // NEW BEHAVIOR: Chart switching is now allowed - verify selected chart type changed
       await pm.logsVisualise.verifyChartTypeSelected(page, chartType, true);
 
       // Switch back to table for next iteration
-      await page.locator('[data-test="selected-chart-table-item"]').click();
+      await pm.logsVisualise.getChartTypeItem("table").click();
       // Wait for table to be selected
       await pm.logsVisualise.verifyChartTypeSelected(page, "table", true);
     }
@@ -263,21 +264,19 @@ test.describe("VRL visualization support testcases", () => {
     );
 
     // Verify success
-    const successMessage = page.locator('[data-test="o-toast-message"]').filter({ hasText: "Panel added to dashboard" });
+    const successMessage = pm.logsVisualise.getToastMessageByText("Panel added to dashboard");
     await expect(successMessage).toBeVisible({ timeout: 10000 });
 
     // Verify table chart is displayed on dashboard
-    const tableOnDashboard = page.locator('[data-test="dashboard-panel-table"]');
+    const tableOnDashboard = pm.logsVisualise.getTablePanel();
     await expect(tableOnDashboard).toBeVisible();
 
     // Edit the panel to verify VRL function is preserved
-    await page
-      .locator('[data-test="dashboard-edit-panel-' + panelName + '-dropdown"]')
-      .click();
-    await page.locator('[data-test="dashboard-edit-panel"]').click();
+    await pm.logsVisualise.getPanelDropdown(panelName).click();
+    await pm.logsVisualise.getEditPanelBtn().click();
 
     // Wait for edit panel to load - use deterministic wait for table
-    const tablePanel = page.locator('[data-test="dashboard-panel-table"]');
+    const tablePanel = pm.logsVisualise.getTablePanel();
     await expect(tablePanel).toBeVisible({ timeout: 15000 });
 
     await pm.dashboardTimeRefresh.setRelative("8", "h");
@@ -285,34 +284,34 @@ test.describe("VRL visualization support testcases", () => {
     await pm.dashboardPanelActions.waitForChartToRender(page);
 
     // Verify table has data rows
-    const tableRows = page.locator('[data-test="dashboard-panel-table"] tbody tr');
+    const tableRows = pm.logsVisualise.getTableRows();
     await expect(tableRows).not.toHaveCount(0, { timeout: 15000 });
     const rowCount = await tableRows.count();
     expect(rowCount).toBeGreaterThan(0);
 
     // Verify VRL configuration is preserved by checking the "vrl" column is visible in the table
     // The VRL function creates a "vrl" column with value 100
-    const vrlColumnInFields = page.locator('text=vrl').first();
+    const vrlColumnInFields = pm.logsVisualise.getFieldByTextSelector('text=vrl').first();
     await expect(vrlColumnInFields).toBeVisible({ timeout: 10000 });
 
     // Verify VRL values (100.00) are displayed in the table
-    const vrlValues = page.locator('[data-test="dashboard-panel-table"]').getByText('100.00').first();
+    const vrlValues = pm.logsVisualise.getTablePanel().getByText('100.00').first();
     await expect(vrlValues).toBeVisible({ timeout: 10000 });
 
     // Go back to dashboard
-    await page.locator('[data-test="dashboard-panel-discard"]').click();
+    await pm.dashboardPanelActions.discardPanel();
 
     // Handle discard confirmation if it appears
-    const discardConfirm = page.locator('[data-test="o-dialog-primary-btn"]');
+    const discardConfirm = pm.logsVisualise.getDialogPrimaryBtn();
     if (await discardConfirm.isVisible({ timeout: 2000 }).catch(() => false)) {
       await discardConfirm.click();
     }
 
     // Wait for navigation back to dashboard
-    await page.locator('[data-test="dashboard-back-btn"]').waitFor({ state: "visible", timeout: 10000 });
+    await pm.logsVisualise.getDashboardBackBtn().waitFor({ state: "visible", timeout: 10000 });
 
     // Cleanup - delete the dashboard
-    await page.locator('[data-test="dashboard-back-btn"]').click();
+    await pm.logsVisualise.clickDashboardBackBtn();
     await deleteDashboard(page, randomDashboardName);
   });
 
@@ -336,20 +335,20 @@ test.describe("VRL visualization support testcases", () => {
     await pm.logsVisualise.verifyChartRenders(page);
 
     // Verify table is displayed
-    const tablePanel = page.locator('[data-test="dashboard-panel-table"]');
+    const tablePanel = pm.logsVisualise.getTablePanel();
     await expect(tablePanel).toBeVisible({ timeout: 10000 });
 
     // Verify table has data rows
-    const tableRows = page.locator('[data-test="dashboard-panel-table"] tbody tr');
+    const tableRows = pm.logsVisualise.getTableRows();
     await expect(tableRows).not.toHaveCount(0, { timeout: 15000 });
     const rowCount = await tableRows.count();
     expect(rowCount).toBeGreaterThan(0);
 
     // Verify VRL toggle is enabled (confirming VRL is active) - open utilities dropdown to check
     {
-      const utilitiesBtn = page.locator('[data-test="logs-search-bar-utilities-menu-btn"]');
+      const utilitiesBtn = pm.logsVisualise.getUtilitiesMenuBtn();
       await utilitiesBtn.click();
-      const vrlToggleBtn = page.locator('[data-test="logs-search-bar-show-query-toggle-btn-btn"]');
+      const vrlToggleBtn = pm.logsVisualise.getVrlToggleMenuBtn();
       await vrlToggleBtn.waitFor({ state: "visible", timeout: 5000 });
       const dataState = await vrlToggleBtn.getAttribute("data-state");
       expect(dataState).toBe("checked");
@@ -358,7 +357,7 @@ test.describe("VRL visualization support testcases", () => {
 
     // Verify at least one VRL-generated field is visible in the Fields list (left sidebar)
     // The complexVrlFunction creates: vrl_status, vrl_count, vrl_flag
-    const vrlFieldInList = page.locator('text=vrl_status, text=vrl_count, text=vrl_flag').first();
+    const vrlFieldInList = pm.logsVisualise.getFieldByTextSelector('text=vrl_status, text=vrl_count, text=vrl_flag').first();
     const isVrlFieldVisible = await vrlFieldInList.isVisible().catch(() => false);
 
     // If VRL field not found in sidebar, check in table - either location is valid
@@ -388,9 +387,9 @@ test.describe("VRL visualization support testcases", () => {
 
     // Verify VRL toggle is enabled before switching - open utilities dropdown to check
     {
-      const utilitiesBtn = page.locator('[data-test="logs-search-bar-utilities-menu-btn"]');
+      const utilitiesBtn = pm.logsVisualise.getUtilitiesMenuBtn();
       await utilitiesBtn.click();
-      const vrlToggleBtn = page.locator('[data-test="logs-search-bar-show-query-toggle-btn-btn"]');
+      const vrlToggleBtn = pm.logsVisualise.getVrlToggleMenuBtn();
       await vrlToggleBtn.waitFor({ state: "visible", timeout: 5000 });
       expect(await vrlToggleBtn.getAttribute("data-state")).toBe("checked");
       await page.keyboard.press("Escape");
@@ -405,11 +404,11 @@ test.describe("VRL visualization support testcases", () => {
     // await waitForTableData(page);
 
     // Verify table is displayed with data
-    const tablePanel = page.locator('[data-test="dashboard-panel-table"]');
+    const tablePanel = pm.logsVisualise.getTablePanel();
     await expect(tablePanel).toBeVisible({ timeout: 10000 });
 
     // Verify table has data rows
-    const tableRows = page.locator('[data-test="dashboard-panel-table"] tbody tr');
+    const tableRows = pm.logsVisualise.getTableRows();
     const rowCount = await tableRows.count();
     expect(rowCount).toBeGreaterThan(0);
 
@@ -418,16 +417,16 @@ test.describe("VRL visualization support testcases", () => {
 
     // ASSERT: Verify VRL toggle is still enabled after switching back to logs - open utilities dropdown
     {
-      const utilitiesBtn = page.locator('[data-test="logs-search-bar-utilities-menu-btn"]');
+      const utilitiesBtn = pm.logsVisualise.getUtilitiesMenuBtn();
       await utilitiesBtn.click();
-      const vrlToggleBtn = page.locator('[data-test="logs-search-bar-show-query-toggle-btn-btn"]');
+      const vrlToggleBtn = pm.logsVisualise.getVrlToggleMenuBtn();
       await vrlToggleBtn.waitFor({ state: "visible", timeout: 5000 });
       expect(await vrlToggleBtn.getAttribute("data-state")).toBe("checked");
       await page.keyboard.press("Escape");
     }
 
     // ASSERT: Verify VRL editor is still visible
-    const vrlEditor = page.locator('[data-test="logs-vrl-function-editor"]');
+    const vrlEditor = pm.logsVisualise.functionEditor;
     await expect(vrlEditor.first()).toBeVisible();
 
     // Switch to visualization again
@@ -504,17 +503,17 @@ test.describe("VRL visualization support testcases", () => {
     await pm.logsVisualise.verifyChartRenders(page);
 
     // Verify table is displayed
-    const table = page.locator('[data-test="dashboard-panel-table"]');
+    const table = pm.logsVisualise.getTablePanel();
     await expect(table).toBeVisible();
 
     // Verify table has data rows
-    const tableRows = page.locator('[data-test="dashboard-panel-table"] tbody tr');
+    const tableRows = pm.logsVisualise.getTableRows();
     await expect(tableRows).not.toHaveCount(0, { timeout: 15000 });
     const rowCount = await tableRows.count();
     expect(rowCount).toBeGreaterThan(0);
 
     // Verify table has headers (columns)
-    const headers = page.locator('[data-test^="o2-table-th-"]');
+    const headers = pm.dashboardPanelActions.tableThCells;
     const headerCount = await headers.count();
     expect(headerCount).toBeGreaterThan(0);
   });
@@ -543,17 +542,17 @@ test.describe("VRL visualization support testcases", () => {
     // await waitForTableData(page);
 
     // Verify table panel is displayed
-    const tablePanel = page.locator('[data-test="dashboard-panel-table"]');
+    const tablePanel = pm.logsVisualise.getTablePanel();
     await expect(tablePanel).toBeVisible({ timeout: 10000 });
 
     // Click table chart - should NOT show VRL warning
-    await page.locator('[data-test="selected-chart-table-item"]').click();
+    await pm.logsVisualise.getChartTypeItem("table").click();
 
     // Wait for table to be selected
     await pm.logsVisualise.verifyChartTypeSelected(page, "table", true);
 
     // Verify NO VRL warning appears for table chart selection
-    const vrlWarningBanner = page.getByText("VRL function is only supported for table chart");
+    const vrlWarningBanner = pm.logsVisualise.getVrlWarningBanner();
     let isVrlWarningVisible = await vrlWarningBanner.isVisible().catch(() => false);
     expect(isVrlWarningVisible).toBe(false);
 
@@ -561,7 +560,7 @@ test.describe("VRL visualization support testcases", () => {
     await expect(tablePanel).toBeVisible({ timeout: 5000 });
 
     // NEW BEHAVIOR: Switch to line chart - should show VRL warning and allow switching
-    await page.locator('[data-test="selected-chart-line-item"]').click();
+    await pm.logsVisualise.getChartTypeItem("line").click();
 
     // Wait for VRL warning banner to appear
     await expect(vrlWarningBanner).toBeVisible({ timeout: 5000 });
@@ -592,21 +591,21 @@ test.describe("VRL visualization support testcases", () => {
     // await waitForTableData(page);
 
     // Verify table is displayed
-    const table = page.locator('[data-test="dashboard-panel-table"]');
+    const table = pm.logsVisualise.getTablePanel();
     await expect(table).toBeVisible({ timeout: 10000 });
 
     // Open config panel to verify dynamic columns is enabled
     await pm.dashboardPanelConfigs.openConfigPanel();
 
     // Verify "Allow Dynamic Columns" toggle is enabled
-    const dynamicColumnsToggle = page.locator('[data-test="dashboard-config-table_dynamic_columns-btn"]');
+    const dynamicColumnsToggle = pm.dashboardPanelConfigs.dynamicColumnBtn;
     await dynamicColumnsToggle.waitFor({ state: "visible", timeout: 10000 });
 
     const isChecked = await dynamicColumnsToggle.getAttribute("aria-checked");
     expect(isChecked).toBe("true");
 
     // Verify table has data rows
-    const tableRows = page.locator('[data-test="dashboard-panel-table"] tbody tr');
+    const tableRows = pm.logsVisualise.getTableRows();
     const rowCount = await tableRows.count();
     expect(rowCount).toBeGreaterThan(0);
   });
@@ -635,9 +634,9 @@ test.describe("VRL visualization support testcases", () => {
     await pm.logsVisualise.backToLogs();
 
     // Disable VRL toggle via utilities dropdown
-    const utilitiesBtn = page.locator('[data-test="logs-search-bar-utilities-menu-btn"]');
+    const utilitiesBtn = pm.logsVisualise.getUtilitiesMenuBtn();
     await utilitiesBtn.click();
-    const vrlToggleBtn = page.locator('[data-test="logs-search-bar-show-query-toggle-btn-btn"]');
+    const vrlToggleBtn = pm.logsVisualise.getVrlToggleMenuBtn();
     await vrlToggleBtn.waitFor({ state: "visible", timeout: 10000 });
     const isChecked = await vrlToggleBtn.getAttribute("data-state");
 
@@ -645,17 +644,17 @@ test.describe("VRL visualization support testcases", () => {
       await vrlToggleBtn.click();
       await page.keyboard.press("Escape");
       // Wait for VRL editor to be hidden or disabled
-      const vrlEditor = page.locator('[data-test="logs-vrl-function-editor"]');
+      const vrlEditor = pm.logsVisualise.functionEditor;
       await vrlEditor.first().waitFor({ state: "hidden", timeout: 10000 }).catch(() => {});
     } else {
       await page.keyboard.press("Escape");
     }
 
     // Clear the VRL function editor
-    const vrlEditor = page.locator('[data-test="logs-vrl-function-editor"]');
+    const vrlEditor = pm.logsVisualise.functionEditor;
     if (await vrlEditor.first().isVisible().catch(() => false)) {
       await vrlEditor.first().click();
-      await page.locator('[data-test="logs-vrl-function-editor"]').locator(".inputarea").fill("");
+      await pm.logsVisualise.functionEditor.locator(".inputarea").fill("");
     }
 
     // Apply query without VRL
@@ -690,12 +689,12 @@ test.describe("VRL visualization support testcases", () => {
     // await waitForTableData(page);
 
     // Try to switch to h-bar chart
-    const hbarChart = page.locator('[data-test="selected-chart-h-bar-item"]');
+    const hbarChart = pm.logsVisualise.getChartTypeItem("h-bar");
     if (await hbarChart.isVisible().catch(() => false)) {
       await hbarChart.click();
 
       // Wait for VRL warning banner to appear
-      const vrlWarningBanner = page.getByText("VRL function is only supported for table chart");
+      const vrlWarningBanner = pm.logsVisualise.getVrlWarningBanner();
       const isWarningVisible = await vrlWarningBanner.isVisible({ timeout: 5000 }).catch(() => false);
       expect(isWarningVisible).toBe(true);
 
@@ -730,18 +729,18 @@ test.describe("VRL visualization support testcases", () => {
     // await waitForTableData(page);
 
     // Verify table is displayed with data initially
-    const tablePanel = page.locator('[data-test="dashboard-panel-table"]');
+    const tablePanel = pm.logsVisualise.getTablePanel();
     await expect(tablePanel).toBeVisible({ timeout: 10000 });
 
     // Verify data is displayed in table
-    const tableRows = page.locator('[data-test="dashboard-panel-table"] tbody tr');
+    const tableRows = pm.logsVisualise.getTableRows();
     await expect(tableRows).not.toHaveCount(0, { timeout: 15000 });
 
     // NEW BEHAVIOR: Switch to bar chart - should show VRL warning and allow switching
-    await page.locator('[data-test="selected-chart-bar-item"]').click();
+    await pm.logsVisualise.getChartTypeItem("bar").click();
 
     // Wait for VRL warning banner to appear
-    const vrlWarningBanner = page.getByText("VRL function is only supported for table chart");
+    const vrlWarningBanner = pm.logsVisualise.getVrlWarningBanner();
     const isWarningVisible = await vrlWarningBanner.isVisible({ timeout: 5000 }).catch(() => false);
     expect(isWarningVisible).toBe(true);
 
@@ -766,15 +765,13 @@ test.describe("VRL visualization support testcases", () => {
     await pm.logsVisualise.verifyChartRenders(page);
 
     // Try to switch to bar chart - should NOT show VRL error
-    await page.locator('[data-test="selected-chart-bar-item"]').click();
+    await pm.logsVisualise.getChartTypeItem("bar").click();
 
     // Wait for bar chart to be selected
     await pm.logsVisualise.verifyChartTypeSelected(page, "bar", true);
 
     // Verify VRL-specific error notification does NOT appear
-    const vrlErrorNotification = page.getByText(
-      "VRL functions are present. Only table chart is supported when using VRL functions."
-    );
+    const vrlErrorNotification = pm.logsVisualise.getVrlErrorNotification();
     const isVrlErrorVisible = await vrlErrorNotification.isVisible().catch(() => false);
     expect(isVrlErrorVisible).toBe(false);
   });
@@ -792,11 +789,11 @@ test.describe("VRL visualization support testcases", () => {
     await enableVrlEditor(page);
 
     // Verify VRL editor is visible
-    const vrlEditor = page.locator('[data-test="logs-vrl-function-editor"]');
+    const vrlEditor = pm.logsVisualise.functionEditor;
     await expect(vrlEditor.first()).toBeVisible();
 
     // Verify editor is ready to accept input
-    const editorInput = page.locator('[data-test="logs-vrl-function-editor"]')
+    const editorInput = pm.logsVisualise.functionEditor
       .locator(".inputarea")
       .first();
     await expect(editorInput).toBeVisible();
@@ -805,7 +802,7 @@ test.describe("VRL visualization support testcases", () => {
     await pm.logsVisualise.vrlFunctionEditor(simpleVrlFunction);
 
     // Verify the VRL content was entered
-    const editorContent = page.locator('[data-test="logs-vrl-function-editor"]')
+    const editorContent = pm.logsVisualise.functionEditor
       .locator(".inputarea")
       .first();
     await expect(editorContent).toBeVisible();

--- a/tests/ui-testing/playwright-tests/Dashboards/visualize.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/visualize.spec.js
@@ -307,7 +307,7 @@ test.describe("logs testcases", () => {
     await pm.logsVisualise.verifyToastMessage("Panel added to dashboard");
 
     // Verify the panel is visible on the dashboard
-    const panelDropdown = page.locator(`[data-test="dashboard-edit-panel-${panelName}-dropdown"]`);
+    const panelDropdown = pm.logsVisualise.getPanelDropdown(panelName);
     await expect(panelDropdown).toBeVisible({ timeout: 20000 });
     testLogger.info("SELECT * panel saved to dashboard successfully");
 

--- a/tests/ui-testing/playwright-tests/Logs/logstable.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/logstable.spec.js
@@ -109,8 +109,8 @@ test.describe("Logs Table Field Management - Complete Test Suite", () => {
       await page.waitForLoadState('domcontentloaded');
       await pageManager.logsPage.expectLogsTableVisible().catch(() => {});
       await pageManager.logsPage.waitForFieldListReady().catch(() => {});
-      restored = await page
-        .locator(`[data-test="o2-table-th-${fieldName}"]`)
+      restored = await pageManager.logsPage
+        .getTableHeaderByField(fieldName)
         .first()
         .waitFor({ state: 'visible', timeout: 20000 })
         .then(() => true)

--- a/tests/ui-testing/playwright-tests/RegressionSet/Dashboards/dashboard-regression.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Dashboards/dashboard-regression.spec.js
@@ -18,11 +18,6 @@ import DashboardVariablesScoped from "../../../pages/dashboardPages/dashboard-va
 import { ingestion } from "../../Dashboards/utils/dashIngestion.js";
 import { waitForDashboardPage, deleteDashboard } from "../../Dashboards/utils/dashCreation.js";
 const { safeWaitForHidden, safeWaitForNetworkIdle } = require("../../utils/wait-helpers.js");
-const {
-  SELECTORS,
-  getVariableSelector,
-  getEditVariableBtn,
-} = require("../../../pages/dashboardPages/dashboard-selectors.js");
 const testLogger = require("../../utils/test-logger.js");
 
 // =============================================================================
@@ -75,7 +70,7 @@ test.describe(
         await waitForDashboardPage(page);
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
-        await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+        await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
         // ── 2. Add global variable ───────────────────────────────────────────
         await pm.dashboardSetting.openSetting();
@@ -83,7 +78,7 @@ test.describe(
           variableName, "logs", "e2e_automate", "kubernetes_namespace_name",
           { scope: "global" }
         );
-        await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+        await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
         await safeWaitForNetworkIdle(page, { timeout: 3000 });
         await pm.dashboardSetting.closeSettingWindow();
         await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
@@ -103,43 +98,43 @@ test.describe(
         // ── 4. Configure drilldown: same dashboard + custom variable mapping ─
         await pm.dashboardPanelConfigs.openConfigPanel();
 
-        const addBtn = page.locator('[data-test="dashboard-addpanel-config-drilldown-add-btn"]').first();
+        const addBtn = pm.dashboardDrilldown.addButton;
         await addBtn.scrollIntoViewIfNeeded();
         await addBtn.click();
-        const popup = page.locator('[data-test="dashboard-drilldown-popup"]');
+        const popup = pm.dashboardDrilldown.popup;
         await popup.waitFor({ state: "visible", timeout: 10000 });
 
-        await page.locator('[data-test="dashboard-config-panel-drilldown-name-field"]').fill("Same Dash Custom Var");
+        await pm.dashboardDrilldown.nameInput.fill("Same Dash Custom Var");
 
-        await page.locator('[data-test="dashboard-drilldown-folder-select"]').waitFor({ state: "visible", timeout: 10000 });
-        await page.locator('[data-test="dashboard-drilldown-folder-select"]').click();
-        await page.getByRole("option", { name: "default", exact: true }).click();
+        await pm.dashboardDrilldown.folderSelect.waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardDrilldown.folderSelect.click();
+        await pm.dashboardDrilldown.optionByRole("default").click();
 
-        await page.locator('[data-test="dashboard-drilldown-dashboard-select"]').waitFor({ state: "visible", timeout: 10000 });
-        await page.locator('[data-test="dashboard-drilldown-dashboard-select"]').click();
-        await page.getByRole("option", { name: dashboardName, exact: true }).click();
+        await pm.dashboardDrilldown.dashboardSelect.waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardDrilldown.dashboardSelect.click();
+        await pm.dashboardDrilldown.optionByRole(dashboardName).click();
 
-        await page.locator('[data-test="dashboard-drilldown-tab-select"]').waitFor({ state: "visible", timeout: 10000 });
-        await page.locator('[data-test="dashboard-drilldown-tab-select"]').click();
-        await page.getByRole("option").first().click();
+        await pm.dashboardDrilldown.tabSelect.waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardDrilldown.tabSelect.click();
+        await pm.dashboardDrilldown.firstOptionByRole().click();
         testLogger.info("Drilldown target: same dashboard selected");
 
         // Add variable mapping: variableName → drilldownVarValue (literal value)
-        const addVarBtn = page.locator('[data-test="dashboard-drilldown-add-variable"]');
+        const addVarBtn = pm.dashboardDrilldown.addVariableButton;
         await addVarBtn.waitFor({ state: "visible", timeout: 5000 });
         await addVarBtn.click();
         await page.waitForTimeout(300);
 
         // OCombobox in DrilldownPopUp has no data-test; use placeholder attributes
-        const nameInput = popup.getByPlaceholder('Name').first();
-        const valueInput = popup.getByPlaceholder('Value').first();
+        const nameInput = pm.dashboardDrilldown.variableNameInput;
+        const valueInput = pm.dashboardDrilldown.variableValueInput;
         await nameInput.waitFor({ state: "visible", timeout: 5000 });
         await nameInput.fill(variableName);
         await valueInput.fill(drilldownVarValue);
         testLogger.info(`Variable mapping: ${variableName} → ${drilldownVarValue}`);
 
-        await page.locator('[data-test="o-dialog-primary-btn"]').waitFor({ state: "visible", timeout: 5000 });
-        await page.locator('[data-test="o-dialog-primary-btn"]').click();
+        await pm.dashboardDrilldown.dialogPrimaryButton.waitFor({ state: "visible", timeout: 5000 });
+        await pm.dashboardDrilldown.dialogPrimaryButton.click();
         await popup.waitFor({ state: "hidden", timeout: 10000 });
 
         // ── 5. Save panel ────────────────────────────────────────────────────
@@ -148,7 +143,7 @@ test.describe(
         await pm.dashboardPanelActions.savePanel();
         testLogger.info("Panel saved — now on dashboard view");
 
-        await page.locator('[data-test="dashboard-panel-table"]').first().waitFor({ state: "attached", timeout: 20000 });
+        await pm.dashboardDrilldown.panelTable.waitFor({ state: "attached", timeout: 20000 });
         await safeWaitForNetworkIdle(page, { timeout: 5000 });
 
         // ── 6. Trigger same-dashboard drilldown ──────────────────────────────
@@ -206,7 +201,7 @@ test.describe(
         await waitForDashboardPage(page);
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
-        await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+        await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
         // ── 2. Add global variable ───────────────────────────────────────────
         await pm.dashboardSetting.openSetting();
@@ -214,7 +209,7 @@ test.describe(
           variableName, "logs", "e2e_automate", "kubernetes_namespace_name",
           { scope: "global" }
         );
-        await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+        await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
         await safeWaitForNetworkIdle(page, { timeout: 3000 });
         await pm.dashboardSetting.closeSettingWindow();
         await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
@@ -232,32 +227,32 @@ test.describe(
 
         await pm.dashboardPanelConfigs.openConfigPanel();
 
-        const addBtn = page.locator('[data-test="dashboard-addpanel-config-drilldown-add-btn"]').first();
+        const addBtn = pm.dashboardDrilldown.addButton;
         await addBtn.scrollIntoViewIfNeeded();
         await addBtn.click();
-        const popup = page.locator('[data-test="dashboard-drilldown-popup"]');
+        const popup = pm.dashboardDrilldown.popup;
         await popup.waitFor({ state: "visible", timeout: 10000 });
 
-        await page.locator('[data-test="dashboard-config-panel-drilldown-name-field"]').fill("PassAll Same Dash");
+        await pm.dashboardDrilldown.nameInput.fill("PassAll Same Dash");
 
-        await page.locator('[data-test="dashboard-drilldown-folder-select"]').waitFor({ state: "visible", timeout: 10000 });
-        await page.locator('[data-test="dashboard-drilldown-folder-select"]').click();
-        await page.getByRole("option", { name: "default", exact: true }).click();
+        await pm.dashboardDrilldown.folderSelect.waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardDrilldown.folderSelect.click();
+        await pm.dashboardDrilldown.optionByRole("default").click();
 
-        await page.locator('[data-test="dashboard-drilldown-dashboard-select"]').waitFor({ state: "visible", timeout: 10000 });
-        await page.locator('[data-test="dashboard-drilldown-dashboard-select"]').click();
-        await page.getByRole("option", { name: dashboardName, exact: true }).click();
+        await pm.dashboardDrilldown.dashboardSelect.waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardDrilldown.dashboardSelect.click();
+        await pm.dashboardDrilldown.optionByRole(dashboardName).click();
 
-        await page.locator('[data-test="dashboard-drilldown-tab-select"]').waitFor({ state: "visible", timeout: 10000 });
-        await page.locator('[data-test="dashboard-drilldown-tab-select"]').click();
-        await page.getByRole("option").first().click();
+        await pm.dashboardDrilldown.tabSelect.waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardDrilldown.tabSelect.click();
+        await pm.dashboardDrilldown.firstOptionByRole().click();
 
-        const passAllToggle = page.locator('[data-test="dashboard-drilldown-pass-all-variables"]');
+        const passAllToggle = pm.dashboardDrilldown.passAllVariablesToggle;
         await passAllToggle.waitFor({ state: "visible", timeout: 5000 });
         await passAllToggle.click();
         testLogger.info("passAllVariables enabled");
 
-        await page.locator('[data-test="o-dialog-primary-btn"]').click();
+        await pm.dashboardDrilldown.dialogPrimaryButton.click();
         await popup.waitFor({ state: "hidden", timeout: 10000 });
 
         await pm.dashboardPanelActions.applyDashboardBtn();
@@ -266,7 +261,7 @@ test.describe(
         testLogger.info("Panel with passAllVariables drilldown saved");
 
         // ── 4. Select a variable value ───────────────────────────────────────
-        await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+        await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
         const { selectedValue } = await scopedVars.changeVariableValue(
           variableName, { optionIndex: 0, returnSelectedValue: true }
         );
@@ -328,14 +323,14 @@ test.describe(
         await waitForDashboardPage(page);
         await pm.dashboardCreate.waitForDashboardUIStable();
         await pm.dashboardCreate.createDashboard(dashboardName);
-        await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+        await scopedVars.getAddPanelBtnLocator().waitFor({ state: "visible" });
 
         await pm.dashboardSetting.openSetting();
         await scopedVars.addScopedVariable(
           variableName, "logs", "e2e_automate", "kubernetes_namespace_name",
           { scope: "global" }
         );
-        await page.locator(getEditVariableBtn(variableName)).waitFor({ state: "visible", timeout: 10000 });
+        await scopedVars.getEditVariableBtnLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
         await safeWaitForNetworkIdle(page, { timeout: 3000 });
         await pm.dashboardSetting.closeSettingWindow();
         await safeWaitForHidden(page, '[data-test="dashboard-settings-dialog"]', { timeout: 5000 });
@@ -365,32 +360,32 @@ test.describe(
 
         await pm.dashboardPanelConfigs.openConfigPanel();
 
-        const addBtn = page.locator('[data-test="dashboard-addpanel-config-drilldown-add-btn"]').first();
+        const addBtn = pm.dashboardDrilldown.addButton;
         await addBtn.scrollIntoViewIfNeeded();
         await addBtn.click();
-        const popup = page.locator('[data-test="dashboard-drilldown-popup"]');
+        const popup = pm.dashboardDrilldown.popup;
         await popup.waitFor({ state: "visible", timeout: 10000 });
 
-        await page.locator('[data-test="dashboard-config-panel-drilldown-name-field"]').fill("Same Dash Tab Drilldown");
+        await pm.dashboardDrilldown.nameInput.fill("Same Dash Tab Drilldown");
 
-        await page.locator('[data-test="dashboard-drilldown-folder-select"]').waitFor({ state: "visible", timeout: 10000 });
-        await page.locator('[data-test="dashboard-drilldown-folder-select"]').click();
-        await page.getByRole("option", { name: "default", exact: true }).click();
+        await pm.dashboardDrilldown.folderSelect.waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardDrilldown.folderSelect.click();
+        await pm.dashboardDrilldown.optionByRole("default").click();
 
-        await page.locator('[data-test="dashboard-drilldown-dashboard-select"]').waitFor({ state: "visible", timeout: 10000 });
-        await page.locator('[data-test="dashboard-drilldown-dashboard-select"]').click();
-        await page.getByRole("option", { name: dashboardName, exact: true }).click();
+        await pm.dashboardDrilldown.dashboardSelect.waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardDrilldown.dashboardSelect.click();
+        await pm.dashboardDrilldown.optionByRole(dashboardName).click();
 
-        await page.locator('[data-test="dashboard-drilldown-tab-select"]').waitFor({ state: "visible", timeout: 10000 });
-        await page.locator('[data-test="dashboard-drilldown-tab-select"]').click();
-        await page.getByRole("option", { name: secondTabName, exact: true }).click();
+        await pm.dashboardDrilldown.tabSelect.waitFor({ state: "visible", timeout: 10000 });
+        await pm.dashboardDrilldown.tabSelect.click();
+        await pm.dashboardDrilldown.optionByRole(secondTabName).click();
         testLogger.info(`Drilldown target: same dashboard, tab "${secondTabName}"`);
 
-        const passAllToggle = page.locator('[data-test="dashboard-drilldown-pass-all-variables"]');
+        const passAllToggle = pm.dashboardDrilldown.passAllVariablesToggle;
         await passAllToggle.waitFor({ state: "visible", timeout: 5000 });
         await passAllToggle.click();
 
-        await page.locator('[data-test="o-dialog-primary-btn"]').click();
+        await pm.dashboardDrilldown.dialogPrimaryButton.click();
         await popup.waitFor({ state: "hidden", timeout: 10000 });
 
         await pm.dashboardPanelActions.applyDashboardBtn();
@@ -399,7 +394,7 @@ test.describe(
         testLogger.info("Panel with tab-switch drilldown saved");
 
         // ── 3. Select a variable value ───────────────────────────────────────
-        await page.locator(getVariableSelector(variableName)).waitFor({ state: "visible", timeout: 10000 });
+        await scopedVars.getVariableSelectorLocator(variableName).waitFor({ state: "visible", timeout: 10000 });
         const { selectedValue } = await scopedVars.changeVariableValue(
           variableName, { optionIndex: 0, returnSelectedValue: true }
         );


### PR DESCRIPTION
## Summary

Completes the Sentinel **Page Object Model** compliance sweep of the Playwright suite (follow-up to #13727, which covered the non-Dashboards shards). Every raw `page.locator(...)` / `page.getBy*(...)` selector — in **actions and assertions** — is relocated out of the spec files into the relevant page object; specs now call page-object methods/getters only.

**Result: 0 raw fixture-`page` selectors across the entire `playwright-tests` suite** (single-line *and* multi-line, verified with a dotall/multiline scanner). Together with #13727, the whole suite is POM-clean.

## What's in this PR

**Dashboards shards — ~1,460 selectors** relocated into their page objects (`dashboard-panel-configs/actions/edit/time`, `dashboard-chart`, `dashboard-variables-scoped`, `dashboard-filter`, `dashboard-drilldown`, `crossLinkPage`, `visualise`, `dashboard-share-export`, `dashboard-create`, `dashboard-settings`, `dashboard-variables`):

| Shard | selectors |
|-------|----------:|
| Dashboard-Config-Settings (11 specs) | ~255 |
| Dashboards-Variables (12 specs, 4 batches) | ~693 |
| Dashboards-Tables (7 specs) | ~127 |
| Dashboards-Charts (9 specs) | ~81 |
| Dashboards-Core + Visualize (10 specs) | ~144 |
| Dashboards-Settings + Panel-DateTime (8 specs) | ~107 |
| Dashboard-Regression (1 spec) | ~52 |

**Correlation UI specs** (3 new `Correlation/*.ui.spec.js` that arrived via main's merge, after the original audit) — converted into a new `correlationDrawerPage` + an extended `correlationSettingsPage`, with `PageManager` wired into specs that previously used none.

**Audit stragglers** the original **single-line** audit grep undercounted — multi-line `page\n.locator(...)` chains in `logstable.spec.js` (→ `logsPage.getTableHeaderByField()`) and `dashboard-streaming.spec.js` (2 add-panel selectors).

**AI-review fixes** (DeepSeek, on this PR) — removed 2 dead-code duplicate getters + 1 redundant method alias (merge artifacts from the sequential batch commits).

One Node-context `console.log` (`dashboard-general-setting`'s `beforeEach`) → `testLogger.info`.

## Approach

Nearly every Dashboards spec shares the same page objects, so the work was done in **sequential batches** (one committed, verified unit at a time) to keep page-object edits conflict-free. 13 commits, mapping 1:1 to those batches.

## Not changed (by design)

- **`waitForTimeout`** left as-is — logged in the audit, not rewritten (per direction).
- **Browser-context code inside `page.evaluate()` / `waitForFunction()`** (`document.querySelector`, `window.*`) left as-is — it runs in the page's JS engine, not Node, so `testLogger` (a Node module) can't be called there. *No `console.*` remained in dashboards specs*; the Node-context ones were converted to `testLogger`.
- **`newPage.locator(...)`** on separate popup `Page` instances left as-is (not the fixture `page`).

## Verification

- **0 raw fixture-`page` selectors** across all specs — single- and multi-line, comments stripped.
- All changed `.js` files pass `node --check`.
- **CI-gated** for browser execution (no local runs), consistent with #13727. The enterprise E2E crosscheck already passed against this PR.

## Stats

82 files changed (+3,355 / −2,211) — 61 specs, 21 page objects. Selectors **moved into page objects, not deleted**.
