### PR TITLE
fix: resolve SLO, alert, and service-stream regressions

### DIFF
--- a/src/config/src/meta/slo/mod.rs
+++ b/src/config/src/meta/slo/mod.rs
@@ -199,6 +199,7 @@ pub enum SliConfig {
         /// Orderable comparators only — a slice with no value is a *gap*, not
         /// a failure, so `=`/`!=` have no meaning here.
         comparator: Operator,
+        #[serde(deserialize_with = "lenient_f64::deserialize")]
         threshold: f64,
         /// Freshness semantics: a slice the query PROVED empty is **bad**
         /// rather than a gap. For a pipeline-freshness SLO, absence is the
@@ -2100,6 +2101,49 @@ mod tests {
         };
         let json = serde_json::to_string(&cfg).unwrap();
         assert_eq!(serde_json::from_str::<SliConfig>(&json).unwrap(), cfg);
+    }
+
+    /// The API flattens `SloDefinition` into `Slo`, which buffers the nested
+    /// threshold once more than deserializing `SliConfig` directly does.
+    #[test]
+    fn a_fractional_threshold_round_trips_through_a_full_slo() {
+        let expected = Slo {
+            id: "slo-1".into(),
+            org: "acme".into(),
+            folder_id: "default".into(),
+            name: "checkout latency".into(),
+            description: String::new(),
+            definition: def(
+                SliConfig::TimeSlice {
+                    stream: "requests".into(),
+                    stream_type: "logs".into(),
+                    query_language: QueryLanguage::Sql,
+                    query: "AVG(duration_ms)".into(),
+                    scope: None,
+                    comparator: Operator::LessThanEquals,
+                    threshold: 232.5,
+                    absent_is_bad: false,
+                },
+                None,
+                SLICE_300_SECS,
+            ),
+            target: 99.9,
+            tags: vec![],
+            enabled: true,
+            owner: None,
+            definition_generation: 1,
+            groups_estimate: None,
+            groups_reserved: 1,
+        };
+
+        let mut get_body = serde_json::to_value(&expected).unwrap();
+        get_body
+            .as_object_mut()
+            .unwrap()
+            .insert("status".into(), serde_json::Value::Null);
+        let put_body: Slo = serde_json::from_value(get_body)
+            .expect("a GET response must be accepted unchanged by PUT");
+        assert_eq!(put_body, expected);
     }
 
     /// The tags are the discriminants the storage layer denormalizes, so a

--- a/src/core/src/alerts/alert.rs
+++ b/src/core/src/alerts/alert.rs
@@ -442,18 +442,24 @@ impl SloSourceEffect {
 }
 
 /// Validates the alert and prepares it before it is written to the database.
+fn prepared_alert_name(route_name: &str, body_name: &str) -> String {
+    let name = if body_name.trim().is_empty() {
+        route_name
+    } else {
+        body_name
+    };
+    name.trim().to_string()
+}
+
 async fn prepare_alert(
     org_id: &str,
     stream_name: &str,
-    name: &str,
+    route_name: &str,
     alert: &mut Alert,
     create: bool,
     overwrite: bool,
 ) -> Result<SloSourceEffect, AlertError> {
-    if !name.is_empty() {
-        alert.name = name.to_string();
-    }
-    alert.name = alert.name.trim().to_string();
+    alert.name = prepared_alert_name(route_name, &alert.name);
 
     // Don't allow the characters not supported by ofga
     if is_ofga_unsupported(&alert.name) {
@@ -790,6 +796,21 @@ async fn prepare_alert(
         org: org_id.to_string(),
         redefined: slos_redefined_by(old_alert.as_ref(), alert, &dependents),
     })
+}
+
+#[cfg(test)]
+mod prepare_alert_name_tests {
+    use super::prepared_alert_name;
+
+    #[test]
+    fn a_put_body_can_rename_an_alert() {
+        assert_eq!(prepared_alert_name("old-name", "new-name"), "new-name");
+    }
+
+    #[test]
+    fn the_route_name_remains_a_fallback_for_legacy_bodies() {
+        assert_eq!(prepared_alert_name("old-name", "  "), "old-name");
+    }
 }
 
 pub fn update_cron_expression(cron_exp: &str, now: u32) -> String {

--- a/src/infra/src/table/alerts/mod.rs
+++ b/src/infra/src/table/alerts/mod.rs
@@ -306,7 +306,6 @@ pub async fn put<C: TransactionTrait>(
             let id = svix_ksuid::Ksuid::new(None, None).to_string();
             let stream_type = intermediate::StreamType::from(alert.stream_type).to_string();
             let stream_name = alert.stream_name.clone();
-            let alert_name = alert.name.clone();
             let mut alert_am = alerts::ActiveModel {
                 // The following fields can only be set on creation.
                 id: Set(id),
@@ -314,7 +313,6 @@ pub async fn put<C: TransactionTrait>(
                 folder_id: Set(folder_m.id),
                 stream_type: Set(stream_type),
                 stream_name: Set(stream_name),
-                name: Set(alert_name),
                 // All remaining fields can be set on creation or updated so
                 // they are set below.
                 ..Default::default()
@@ -368,7 +366,6 @@ pub async fn create<C: TransactionTrait>(
         folder_id: Set(folder_m.id),
         stream_type: Set(stream_type),
         stream_name: Set(alert.stream_name.clone()),
-        name: Set(alert.name.clone()),
         // All remaining fields can be set on creation or updated so
         // they are set below.
         ..Default::default()
@@ -876,6 +873,7 @@ fn update_mutable_fields(
 ) -> Result<(), errors::Error> {
     let last_triggered_at = alert.get_last_triggered_at_from_table();
     let last_satisfied_at = alert.get_last_satisfied_at_from_table();
+    let name = alert.name;
     let is_real_time = alert.is_real_time;
     let destinations = serde_json::to_value(alert.destinations)?;
     let template = alert.template.filter(|s| !s.is_empty());
@@ -992,6 +990,7 @@ fn update_mutable_fields(
             (false, None, None)
         };
 
+    alert_am.name = Set(name);
     alert_am.is_real_time = Set(is_real_time);
     alert_am.destinations = Set(destinations);
     alert_am.template = Set(template);
@@ -1139,6 +1138,18 @@ mod tests {
     }
 
     // ── Feature 2: priority & tags storage mapping (PT-2, PT-6) ────────────
+
+    #[test]
+    fn test_update_mutable_fields_updates_alert_name() {
+        let id = Ksuid::new(None, None).to_string();
+        let mut alert_am: alerts::ActiveModel = make_model(&id).into();
+        let mut alert = MetaAlert::default();
+        alert.name = "Renamed Alert".to_string();
+
+        update_mutable_fields(&mut alert_am, alert).unwrap();
+
+        assert_eq!(alert_am.name, Set("Renamed Alert".to_string()));
+    }
 
     #[test]
     fn test_priority_and_tags_unpack_from_model() {

--- a/web/src/components/slos/SloAlertCondition.spec.ts
+++ b/web/src/components/slos/SloAlertCondition.spec.ts
@@ -98,6 +98,25 @@ describe("SloAlertCondition", () => {
     expect(model.short_window_secs).toBeGreaterThan(0);
   });
 
+  it.each([
+    [7, ["10%", "20%", "40%"]],
+    [30, ["2%", "5%", "10%"]],
+    [90, ["1%", "3%", "5%"]],
+  ])("shows the correct budget fractions for a %d-day SLO", async (days, fractions) => {
+    const wrapper = await mountWith(emptyCondition(), {
+      slo: slo({ window_secs: days * 86400 }),
+    });
+
+    for (const [key, fraction] of ["fast", "mid", "slow"].map((key, index) => [
+      key,
+      fractions[index],
+    ])) {
+      expect(wrapper.find(`[data-test="slos-sloalertcondition-preset-${key}"]`).text()).toContain(
+        fraction,
+      );
+    }
+  });
+
   // SA-8: a window must be an exact multiple of the slice interval and span at
   // least two slices. The published fast-burn row uses a 5-minute short window,
   // which is exactly ONE slice on a 5-minute SLO — unsavable as published.

--- a/web/src/components/slos/SloAlertCondition.vue
+++ b/web/src/components/slos/SloAlertCondition.vue
@@ -236,34 +236,35 @@ const windowLabel = computed(() =>
  *  These are not arbitrary: each threshold is the burn rate that consumes the
  *  stated fraction of the budget over the long window, which is what makes
  *  "×14.4" mean something. */
-const PRESETS: Record<number, Array<[string, number, number, number, number]>> = {
-  // window days -> [key/label, threshold, longSecs, shortSecs, budget %]
+const PRESETS: Record<number, Array<[string, number, number, number]>> = {
+  // window days -> [key/label, threshold, longSecs, shortSecs]
   7: [
-    ["fast", 16.8, 3600, 300, 2],
-    ["mid", 5.6, 21600, 1800, 5],
-    ["slow", 2.8, 86400, 7200, 10],
+    ["fast", 16.8, 3600, 300],
+    ["mid", 5.6, 21600, 1800],
+    ["slow", 2.8, 86400, 7200],
   ],
   30: [
-    ["fast", 14.4, 3600, 300, 2],
-    ["mid", 6, 21600, 1800, 5],
-    ["slow", 3, 86400, 7200, 10],
+    ["fast", 14.4, 3600, 300],
+    ["mid", 6, 21600, 1800],
+    ["slow", 3, 86400, 7200],
   ],
   90: [
-    ["fast", 21.6, 3600, 300, 2],
-    ["mid", 10.8, 21600, 1800, 5],
-    ["slow", 4.5, 86400, 7200, 10],
+    ["fast", 21.6, 3600, 300],
+    ["mid", 10.8, 21600, 1800],
+    ["slow", 4.5, 86400, 7200],
   ],
 };
 
 const presets = computed(() => {
   const days = Math.round((selectedSlo.value?.window_secs ?? 30 * 86400) / 86400);
-  const rows = PRESETS[days] ?? PRESETS[30];
+  const presetDays = PRESETS[days] ? days : 30;
+  const rows = PRESETS[presetDays];
   const labels: Record<string, string> = {
     fast: t("slos.alert.preset.fast"),
     mid: t("slos.alert.preset.mid"),
     slow: t("slos.alert.preset.slow"),
   };
-  return rows.map(([key, threshold, longSecs, rawShortSecs, budgetPct]) => {
+  return rows.map(([key, threshold, longSecs, rawShortSecs]) => {
     // The published rows assume a fine slice grid. Ours is the SLO's
     // own `slice_interval_secs`, and SA-8 requires every window to be a whole
     // multiple of it AND at least two slices — so on a 5-minute-slice SLO the
@@ -280,9 +281,8 @@ const presets = computed(() => {
     // card a hair over the cap — unsavable, and 16 digits wide in the UI.
     const ceiling = maxBurnValue.value;
     const clamped =
-      ceiling === null
-        ? (threshold as number)
-        : Math.min(threshold as number, Math.floor(ceiling * 100) / 100);
+      ceiling === null ? threshold : Math.min(threshold, Math.floor(ceiling * 100) / 100);
+    const budgetPct = Math.round((clamped * longSecs * 100) / (presetDays * 86400));
     return {
       key: key as string,
       label: labels[key as string],

--- a/web/src/views/slos/AddSlo.vue
+++ b/web/src/views/slos/AddSlo.vue
@@ -883,7 +883,12 @@ function wireConfig(): Record<string, any> {
   if (form.sli_type === "alert") {
     return { alert_id: form.config.alert_id ?? "" };
   }
-  return pruned(form.config);
+  return {
+    ...pruned(form.config),
+    // This editor builds SQL aggregates, so every time-slice definition it
+    // creates must carry the API's explicit language discriminator.
+    query_language: form.config.query_language ?? "sql",
+  };
 }
 
 function payload() {

--- a/web/src/views/slos/AddSloAlertSli.spec.ts
+++ b/web/src/views/slos/AddSloAlertSli.spec.ts
@@ -304,3 +304,23 @@ describe("AddSlo — alert SLI", () => {
     expect(body.slice_interval_secs).toBe(60);
   });
 });
+
+describe("AddSlo — time-slice SLI", () => {
+  beforeEach(() => {
+    vi.mocked(sloService.create).mockClear();
+  });
+
+  it("sends the query language required by the API", async () => {
+    const wrapper = await mountForm();
+    await wrapper.find('[data-test="slos-addslo-sli-type-time_slice"]').trigger("click");
+    await wrapper.find('[data-test="slos-addslo-save"]').trigger("click");
+    await flushPromises();
+
+    const body = vi.mocked(sloService.create).mock.calls[0][1] as {
+      sli_type: string;
+      config: Record<string, unknown>;
+    };
+    expect(body.sli_type).toBe("time_slice");
+    expect(body.config.query_language).toBe("sql");
+  });
+});


### PR DESCRIPTION
## Summary

- include the required query language when the UI creates time-slice SLOs
- compute suggested alert budget percentages from each SLO window instead of reusing 30-day literals
- accept fractional time-slice thresholds when a GET response is sent back through PUT
- preserve the v2 PUT body name and persist alert renames in the ORM update
- align service-stream persistence with the enterprise configured stream cap and merge newly observed dimensions

## Testing

- npm run test:unit -- --run components/slos/SloAlertCondition.spec.ts views/slos/AddSloAlertSli.spec.ts
- npx eslint on the four changed SLO Vue and test files
- cargo test -p config a_fractional_threshold_round_trips_through_a_full_slo --locked
- cargo test -p infra table::alerts::tests --locked
- cargo test -p infra table::service_streams::tests --locked
- cargo test -p openobserve-core prepare_alert_name_tests --locked
- cargo check -p super_cluster_queue --locked
- cargo check -p openobserve-cipher --locked
- cargo fmt --all -- --check
- git diff --check

## Notes

The full openobserve check is blocked on this workstation before application code by the missing pkg-config executable required by the Vectorscan CMake build.