### PR TITLE
fix: preserve online evaluation provider API keys

### DIFF
--- a/src/core/src/providers.rs
+++ b/src/core/src/providers.rs
@@ -46,23 +46,6 @@ fn scorer_uses_provider(scorer: &table::scorers::Scorer, provider_id: &str) -> b
     scorer.params.get("provider_id").and_then(|v| v.as_str()) == Some(provider_id)
 }
 
-fn resolve_updated_auth_config(
-    requested: &serde_json::Value,
-    existing: &serde_json::Value,
-) -> serde_json::Value {
-    let has_new_api_key = requested
-        .get("api_key")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .is_some_and(|value| !value.is_empty());
-
-    if has_new_api_key {
-        requested.clone()
-    } else {
-        existing.clone()
-    }
-}
-
 #[cfg(feature = "enterprise")]
 fn validate_provider_config(provider: &table::providers::Provider) -> Result<(), ProviderError> {
     o2_enterprise::enterprise::llm_evaluations::provider::PreparedProvider::parse(provider.into())
@@ -116,8 +99,6 @@ pub async fn update_provider(
     if existing.org_id != org_id {
         return Err(ProviderError::NotFound);
     }
-    provider.auth_config =
-        resolve_updated_auth_config(&provider.auth_config, &existing.auth_config);
 
     // Check name uniqueness excluding self
     let all = table::providers::get_all_by_org(org_id).await?;
@@ -314,24 +295,5 @@ mod tests {
 
         assert!(scorer_uses_provider(&scorer, "provider-1"));
         assert!(!scorer_uses_provider(&scorer, "provider-2"));
-    }
-
-    #[test]
-    fn test_blank_updated_api_key_preserves_existing_auth_config() {
-        let existing = serde_json::json!({"api_key": "sk-existing"});
-        let requested = serde_json::json!({"api_key": "  "});
-
-        assert_eq!(resolve_updated_auth_config(&requested, &existing), existing);
-    }
-
-    #[test]
-    fn test_non_empty_updated_api_key_replaces_existing_auth_config() {
-        let existing = serde_json::json!({"api_key": "sk-existing"});
-        let requested = serde_json::json!({"api_key": "sk-new"});
-
-        assert_eq!(
-            resolve_updated_auth_config(&requested, &existing),
-            requested
-        );
     }
 }

--- a/src/core/src/providers.rs
+++ b/src/core/src/providers.rs
@@ -46,6 +46,23 @@ fn scorer_uses_provider(scorer: &table::scorers::Scorer, provider_id: &str) -> b
     scorer.params.get("provider_id").and_then(|v| v.as_str()) == Some(provider_id)
 }
 
+fn resolve_updated_auth_config(
+    requested: &serde_json::Value,
+    existing: &serde_json::Value,
+) -> serde_json::Value {
+    let has_new_api_key = requested
+        .get("api_key")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+
+    if has_new_api_key {
+        requested.clone()
+    } else {
+        existing.clone()
+    }
+}
+
 #[cfg(feature = "enterprise")]
 fn validate_provider_config(provider: &table::providers::Provider) -> Result<(), ProviderError> {
     o2_enterprise::enterprise::llm_evaluations::provider::PreparedProvider::parse(provider.into())
@@ -99,6 +116,8 @@ pub async fn update_provider(
     if existing.org_id != org_id {
         return Err(ProviderError::NotFound);
     }
+    provider.auth_config =
+        resolve_updated_auth_config(&provider.auth_config, &existing.auth_config);
 
     // Check name uniqueness excluding self
     let all = table::providers::get_all_by_org(org_id).await?;
@@ -295,5 +314,24 @@ mod tests {
 
         assert!(scorer_uses_provider(&scorer, "provider-1"));
         assert!(!scorer_uses_provider(&scorer, "provider-2"));
+    }
+
+    #[test]
+    fn test_blank_updated_api_key_preserves_existing_auth_config() {
+        let existing = serde_json::json!({"api_key": "sk-existing"});
+        let requested = serde_json::json!({"api_key": "  "});
+
+        assert_eq!(resolve_updated_auth_config(&requested, &existing), existing);
+    }
+
+    #[test]
+    fn test_non_empty_updated_api_key_replaces_existing_auth_config() {
+        let existing = serde_json::json!({"api_key": "sk-existing"});
+        let requested = serde_json::json!({"api_key": "sk-new"});
+
+        assert_eq!(
+            resolve_updated_auth_config(&requested, &existing),
+            requested
+        );
     }
 }

--- a/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.spec.ts
+++ b/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.spec.ts
@@ -136,26 +136,6 @@ describe("ProviderFormPage", () => {
     expect(wrapper.emitted("saved")).toBeTruthy();
   });
 
-  it("submits an OpenAI-compatible provider with its base URL", async () => {
-    wrapper = createWrapper();
-    setField(wrapper, "name", "MiniMax");
-    setField(wrapper, "providerType", "openai_compatible");
-    setField(wrapper, "endpoint", "https://api.minimax.io/v1");
-    setField(wrapper, "defaultModel", "MiniMax-M3");
-    setField(wrapper, "apiKey", "sk-minimax");
-
-    await submit(wrapper);
-
-    expect(onlineEvalsService.providers.create).toHaveBeenCalledWith(
-      "test-org",
-      expect.objectContaining({
-        providerType: "openai_compatible",
-        endpoint: "https://api.minimax.io/v1",
-        defaultModel: "MiniMax-M3",
-      }),
-    );
-  });
-
   it("clears a required error on change after the first submit", async () => {
     wrapper = createWrapper();
     await submit(wrapper);

--- a/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.spec.ts
+++ b/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.spec.ts
@@ -136,6 +136,26 @@ describe("ProviderFormPage", () => {
     expect(wrapper.emitted("saved")).toBeTruthy();
   });
 
+  it("submits an OpenAI-compatible provider with its base URL", async () => {
+    wrapper = createWrapper();
+    setField(wrapper, "name", "MiniMax");
+    setField(wrapper, "providerType", "openai_compatible");
+    setField(wrapper, "endpoint", "https://api.minimax.io/v1");
+    setField(wrapper, "defaultModel", "MiniMax-M3");
+    setField(wrapper, "apiKey", "sk-minimax");
+
+    await submit(wrapper);
+
+    expect(onlineEvalsService.providers.create).toHaveBeenCalledWith(
+      "test-org",
+      expect.objectContaining({
+        providerType: "openai_compatible",
+        endpoint: "https://api.minimax.io/v1",
+        defaultModel: "MiniMax-M3",
+      }),
+    );
+  });
+
   it("clears a required error on change after the first submit", async () => {
     wrapper = createWrapper();
     await submit(wrapper);

--- a/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.vue
+++ b/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.vue
@@ -140,7 +140,9 @@
           <div class="mb-3">
             <div class="text-text-heading mb-1 flex items-center text-xs font-semibold">
               {{ t("onlineEvals.provider.apiKeyLabel") }}
-              <span v-if="mode === 'create'" class="text-status-error-text ml-0.5">*</span>
+              <span v-if="mode === 'create' && apiKeyRequired" class="text-status-error-text ml-0.5"
+                >*</span
+              >
             </div>
             <OFormInput
               name="apiKey"
@@ -226,6 +228,9 @@ const form = useOForm<ProviderForm>({
   onSubmit: save,
 });
 const formValues = form.useStore((s: any) => s.values as ProviderForm);
+const apiKeyRequired = computed(() =>
+  ["openai", "deepseek", "anthropic"].includes(formValues.value.providerType),
+);
 
 const providerTypeOptions = computed(() => [
   { label: raw("OpenAI"), value: "openai" },

--- a/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.vue
+++ b/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.vue
@@ -140,9 +140,7 @@
           <div class="mb-3">
             <div class="text-text-heading mb-1 flex items-center text-xs font-semibold">
               {{ t("onlineEvals.provider.apiKeyLabel") }}
-              <span v-if="mode === 'create' && apiKeyRequired" class="text-status-error-text ml-0.5"
-                >*</span
-              >
+              <span v-if="mode === 'create'" class="text-status-error-text ml-0.5">*</span>
             </div>
             <OFormInput
               name="apiKey"
@@ -228,17 +226,16 @@ const form = useOForm<ProviderForm>({
   onSubmit: save,
 });
 const formValues = form.useStore((s: any) => s.values as ProviderForm);
-const apiKeyRequired = computed(() =>
-  ["openai", "deepseek", "anthropic"].includes(formValues.value.providerType),
-);
 
 const providerTypeOptions = computed(() => [
   { label: raw("OpenAI"), value: "openai" },
   { label: raw("DeepSeek"), value: "deepseek" },
   { label: raw("Anthropic"), value: "anthropic" },
+  { label: raw("Azure OpenAI"), value: "azure_openai" },
   { label: raw("Ollama"), value: "ollama" },
   { label: raw("vLLM"), value: "vllm" },
   { label: raw("OpenAI-compatible"), value: "openai_compatible" },
+  { label: t("ingestion.otherLabel"), value: "other" },
 ]);
 
 // Default API endpoint for each provider type, shown as a placeholder to hint
@@ -248,9 +245,9 @@ const DEFAULT_ENDPOINTS: Record<string, string> = {
   openai: "https://api.openai.com/v1",
   deepseek: "https://api.deepseek.com/v1",
   anthropic: "https://api.anthropic.com/v1",
-  ollama: "http://localhost:11434",
+  azure_openai: "https://{resource}.openai.azure.com/openai/deployments/{deployment}",
+  ollama: "http://localhost:11434/v1",
   vllm: "http://localhost:8000/v1",
-  openai_compatible: "https://api.example.com/v1",
 };
 
 const endpointPlaceholder = computed(

--- a/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.vue
+++ b/web/src/enterprise/components/onlineEvals/forms/ProviderFormPage.vue
@@ -140,7 +140,9 @@
           <div class="mb-3">
             <div class="text-text-heading mb-1 flex items-center text-xs font-semibold">
               {{ t("onlineEvals.provider.apiKeyLabel") }}
-              <span v-if="mode === 'create'" class="text-status-error-text ml-0.5">*</span>
+              <span v-if="mode === 'create' && apiKeyRequired" class="text-status-error-text ml-0.5"
+                >*</span
+              >
             </div>
             <OFormInput
               name="apiKey"
@@ -226,16 +228,17 @@ const form = useOForm<ProviderForm>({
   onSubmit: save,
 });
 const formValues = form.useStore((s: any) => s.values as ProviderForm);
+const apiKeyRequired = computed(() =>
+  ["openai", "deepseek", "anthropic"].includes(formValues.value.providerType),
+);
 
 const providerTypeOptions = computed(() => [
   { label: raw("OpenAI"), value: "openai" },
   { label: raw("DeepSeek"), value: "deepseek" },
   { label: raw("Anthropic"), value: "anthropic" },
-  { label: raw("Azure OpenAI"), value: "azure_openai" },
   { label: raw("Ollama"), value: "ollama" },
   { label: raw("vLLM"), value: "vllm" },
   { label: raw("OpenAI-compatible"), value: "openai_compatible" },
-  { label: t("ingestion.otherLabel"), value: "other" },
 ]);
 
 // Default API endpoint for each provider type, shown as a placeholder to hint
@@ -245,9 +248,9 @@ const DEFAULT_ENDPOINTS: Record<string, string> = {
   openai: "https://api.openai.com/v1",
   deepseek: "https://api.deepseek.com/v1",
   anthropic: "https://api.anthropic.com/v1",
-  azure_openai: "https://{resource}.openai.azure.com/openai/deployments/{deployment}",
-  ollama: "http://localhost:11434/v1",
+  ollama: "http://localhost:11434",
   vllm: "http://localhost:8000/v1",
+  openai_compatible: "https://api.example.com/v1",
 };
 
 const endpointPlaceholder = computed(


### PR DESCRIPTION
## Summary

- preserve the stored provider API key when an edit submits a blank value
- replace the stored key when a nonblank value is supplied
- show the create-time required marker only for providers that require authentication
- retain keyless creation for self-hosted providers

## Testing

- ProviderFormPage Vitest suite passed: 8 tests
- Targeted ESLint passed
- cargo fmt check passed
- git diff check passed
- Focused Rust test compilation is blocked by unrelated existing alert-state model errors

Related to #13655.

Companion enterprise PR: https://github.com/openobserve/o2-enterprise/pull/2390