### PR TITLE
ci: add Playwright e2e Stuck-Run-Reaper workflow

### DIFF
--- a/.github/workflows/stuck-run-reaper.yml
+++ b/.github/workflows/stuck-run-reaper.yml
@@ -53,6 +53,10 @@ jobs:
             const inputs = context.payload.inputs || {};
             const dryRun = inputs.dry_run === true || inputs.dry_run === "true";
             const threshold = parseInt(inputs.threshold_minutes || process.env.DEFAULT_THRESHOLD_MINUTES, 10);
+            if (isNaN(threshold) || threshold <= 0) {
+              core.setFailed(`Invalid threshold_minutes: "${inputs.threshold_minutes}". Provide a positive integer number of minutes.`);
+              return;
+            }
             const thresholdMs = threshold * 60 * 1000;
             const workflows = process.env.WORKFLOWS.split(",").map(s => s.trim()).filter(Boolean);
             const labelPrefix = process.env.RUNNER_LABEL_PREFIX;
@@ -108,8 +112,11 @@ jobs:
                   const unassigned = !j.runner_name;
                   const waiting = j.status === "queued";
                   if (!(wantsEks && unassigned && waiting)) continue;
-                  // "waiting since": job.started_at (queue entry) if present, else run start.
-                  const sinceStr = j.started_at || run.run_started_at || run.created_at;
+                  // "waiting since": prefer job.created_at (when the job entered the queue and
+                  // became eligible for a runner). started_at stays null while a job is queued, so
+                  // falling back to run timestamps would measure from run-creation and could
+                  // prematurely reap a young job inside an old (e.g. matrix) run.
+                  const sinceStr = j.created_at || j.started_at || run.run_started_at || run.created_at;
                   const waited = now - Date.parse(sinceStr);
                   if (waited <= thresholdMs) continue;
                   eligible.push({
@@ -140,7 +147,12 @@ jobs:
 
                 const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
                 core.info(`[REAP${dryRun ? " (dry-run)" : ""}] ${wf} #${run.id} (${run.head_branch}) — ${eligible.length} stuck job(s)`);
-                summaryRows.push(`| [${wf} #${run.id}](${runUrl}) | \`${run.head_branch}\` | ${eligible.length} | ${humanize(Math.max(...eligible.map(e => e.waited)))} |`);
+                summaryRows.push([
+                  `<a href="${runUrl}">${wf} #${run.id}</a>`,
+                  run.head_branch || "(none)",
+                  String(eligible.length),
+                  humanize(Math.max(...eligible.map(e => e.waited))),
+                ]);
 
                 // Resolve the PR to comment on.
                 let prNumber = (run.pull_requests && run.pull_requests[0] && run.pull_requests[0].number) || null;
@@ -156,6 +168,7 @@ jobs:
                 }
 
                 // Force-cancel the run.
+                let alreadyCancelled = false;
                 if (!dryRun) {
                   try {
                     await github.request("POST /repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel", {
@@ -163,8 +176,12 @@ jobs:
                     });
                     reapedCount++;
                   } catch (e) {
-                    // 409 == already cancelling/cancelled; ignore.
-                    if (e.status !== 409) {
+                    if (e.status === 409) {
+                      // Already cancelling/cancelled by another actor or a prior reaper tick.
+                      // Skip the comment below so we don't falsely claim the reaper did it.
+                      alreadyCancelled = true;
+                      core.info(`Run ${run.id} was already being cancelled (409) — skipping comment.`);
+                    } else {
                       core.warning(`force-cancel failed for run ${run.id}: ${e.message}`);
                       continue;
                     }
@@ -207,6 +224,8 @@ jobs:
                   continue;
                 }
 
+                if (alreadyCancelled) continue; // run was already being cancelled — no comment
+
                 if (prNumber) {
                   try {
                     await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
@@ -225,6 +244,6 @@ jobs:
               .addRaw(`Threshold: **${threshold} min** · Workflows: \`${workflows.join(", ")}\``)
               .addTable([
                 [{ data: "Run", header: true }, { data: "Branch", header: true }, { data: "Stuck jobs", header: true }, { data: "Max wait", header: true }],
-                ...summaryRows.map(r => r.split("|").slice(1, -1).map(c => c.trim())),
+                ...summaryRows,
               ])
               .write();

--- a/.github/workflows/stuck-run-reaper.yml
+++ b/.github/workflows/stuck-run-reaper.yml
@@ -1,0 +1,229 @@
+name: Playwright e2e Stuck-Run-Reaper
+
+# Cancels CI runs whose jobs are stuck waiting for a self-hosted EKS runner
+# that is never assigned. GitHub's `timeout-minutes` only counts EXECUTION time
+# (it starts once a job runs), so it cannot catch a job that never gets a runner.
+# This reaper enforces a wait-for-runner cap and explains every cancellation on
+# the associated pull request.
+
+on:
+  schedule:
+    # Every 15 minutes. Worst-case a stuck job lives ~threshold + 15m.
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report stuck runs but do NOT cancel or comment"
+        type: boolean
+        default: false
+      threshold_minutes:
+        description: "Minutes a job may wait for a runner before being reaped"
+        type: string
+        default: "60"
+
+concurrency:
+  group: stuck-run-reaper
+  cancel-in-progress: false
+
+permissions:
+  actions: write # force-cancel workflow runs
+  pull-requests: write # comment on the PR explaining the cancellation
+  contents: read
+
+jobs:
+  reap:
+    name: Reap runs stuck waiting for an EKS runner
+    # MUST run on a GitHub-hosted runner — it must not depend on the same
+    # self-hosted EKS pool it is policing.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Cancel runs stuck waiting for an EKS runner
+        uses: actions/github-script@v7
+        env:
+          # Comma-separated workflow file names to police.
+          WORKFLOWS: "playwright.yml"
+          DEFAULT_THRESHOLD_MINUTES: "60"
+          # Only reap jobs whose requested runner label starts with this prefix.
+          RUNNER_LABEL_PREFIX: "eks-"
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const inputs = context.payload.inputs || {};
+            const dryRun = inputs.dry_run === true || inputs.dry_run === "true";
+            const threshold = parseInt(inputs.threshold_minutes || process.env.DEFAULT_THRESHOLD_MINUTES, 10);
+            const thresholdMs = threshold * 60 * 1000;
+            const workflows = process.env.WORKFLOWS.split(",").map(s => s.trim()).filter(Boolean);
+            const labelPrefix = process.env.RUNNER_LABEL_PREFIX;
+            const now = Date.now();
+
+            const humanize = (ms) => {
+              const totalMin = Math.max(0, Math.floor(ms / 60000));
+              const h = Math.floor(totalMin / 60);
+              const m = totalMin % 60;
+              return h > 0 ? `${h}h ${m}m` : `${m}m`;
+            };
+            const iso = (s) => s
+              ? new Date(s).toISOString().replace("T", " ").replace(/\..+/, " UTC")
+              : "unknown";
+            const nowIso = new Date(now).toISOString().replace("T", " ").replace(/\..+/, " UTC");
+            const reaperUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            let reapedCount = 0;
+            const summaryRows = [];
+
+            for (const wf of workflows) {
+              let runs = [];
+              try {
+                runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                  owner, repo, workflow_id: wf, per_page: 100,
+                }, (res) => res.data);
+              } catch (e) {
+                core.warning(`Could not list runs for ${wf}: ${e.message}`);
+                continue;
+              }
+
+              // Only runs that have not completed.
+              const active = runs.filter(r => r.status !== "completed");
+              core.info(`[${wf}] ${active.length} active run(s) to inspect`);
+
+              for (const run of active) {
+                let jobs = [];
+                try {
+                  jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                    owner, repo, run_id: run.id, per_page: 100, filter: "latest",
+                  }, (res) => res.data);
+                } catch (e) {
+                  core.warning(`Could not list jobs for run ${run.id}: ${e.message}`);
+                  continue;
+                }
+
+                const eligible = [];
+
+                // --- Job-level: a job queued with no runner assigned, past threshold ---
+                for (const j of jobs) {
+                  const labels = j.labels || [];
+                  const wantsEks = labels.some(l => l.startsWith(labelPrefix));
+                  const unassigned = !j.runner_name;
+                  const waiting = j.status === "queued";
+                  if (!(wantsEks && unassigned && waiting)) continue;
+                  // "waiting since": job.started_at (queue entry) if present, else run start.
+                  const sinceStr = j.started_at || run.run_started_at || run.created_at;
+                  const waited = now - Date.parse(sinceStr);
+                  if (waited <= thresholdMs) continue;
+                  eligible.push({
+                    name: j.name,
+                    runner: labels.join(", ") || "(none listed)",
+                    sinceStr,
+                    waited,
+                    kind: "job",
+                  });
+                }
+
+                // --- Run-level fallback: run never created any jobs, past threshold ---
+                if (jobs.length === 0 && ["queued", "pending", "waiting", "requested"].includes(run.status)) {
+                  const sinceStr = run.run_started_at || run.created_at;
+                  const waited = now - Date.parse(sinceStr);
+                  if (waited > thresholdMs) {
+                    eligible.push({
+                      name: "(run never dispatched any jobs)",
+                      runner: "n/a — no jobs were scheduled",
+                      sinceStr,
+                      waited,
+                      kind: "run",
+                    });
+                  }
+                }
+
+                if (eligible.length === 0) continue;
+
+                const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
+                core.info(`[REAP${dryRun ? " (dry-run)" : ""}] ${wf} #${run.id} (${run.head_branch}) — ${eligible.length} stuck job(s)`);
+                summaryRows.push(`| [${wf} #${run.id}](${runUrl}) | \`${run.head_branch}\` | ${eligible.length} | ${humanize(Math.max(...eligible.map(e => e.waited)))} |`);
+
+                // Resolve the PR to comment on.
+                let prNumber = (run.pull_requests && run.pull_requests[0] && run.pull_requests[0].number) || null;
+                if (!prNumber && run.event === "pull_request" && run.head_branch) {
+                  try {
+                    const prs = await github.rest.pulls.list({
+                      owner, repo, state: "open", head: `${owner}:${run.head_branch}`, per_page: 1,
+                    });
+                    if (prs.data.length) prNumber = prs.data[0].number;
+                  } catch (e) {
+                    core.warning(`PR lookup failed for ${run.head_branch}: ${e.message}`);
+                  }
+                }
+
+                // Force-cancel the run.
+                if (!dryRun) {
+                  try {
+                    await github.request("POST /repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel", {
+                      owner, repo, run_id: run.id,
+                    });
+                    reapedCount++;
+                  } catch (e) {
+                    // 409 == already cancelling/cancelled; ignore.
+                    if (e.status !== 409) {
+                      core.warning(`force-cancel failed for run ${run.id}: ${e.message}`);
+                      continue;
+                    }
+                  }
+                }
+
+                // Build and post the explanatory comment.
+                const jobRows = eligible.map(e =>
+                  `| \`${e.name}\` | \`${e.runner}\` | ${iso(e.sinceStr)} | ${humanize(e.waited)} | ❌ never assigned |`
+                ).join("\n");
+
+                const body = [
+                  `## 🛑 Playwright run auto-cancelled by the runner-reaper`,
+                  ``,
+                  `A job in this run was **waiting for a self-hosted EKS runner that was never assigned**, past the ${threshold}-minute threshold. The reaper force-cancelled the run to free the queue.`,
+                  ``,
+                  `| | |`,
+                  `|---|---|`,
+                  `| **Run** | [\`${wf}\` #${run.id}](${runUrl}) (attempt ${run.run_attempt}) |`,
+                  `| **Branch** | \`${run.head_branch}\` |`,
+                  `| **Identified as stuck at** | ${nowIso} |`,
+                  `| **Wait threshold** | ${threshold} minutes |`,
+                  `| **Action taken** | \`POST /actions/runs/${run.id}/force-cancel\`${dryRun ? " _(dry-run — not executed)_" : ""} |`,
+                  ``,
+                  `### Stuck job(s)`,
+                  ``,
+                  `| Job | Requested runner | Waiting since | Waited | Runner status |`,
+                  `|---|---|---|---|---|`,
+                  jobRows,
+                  ``,
+                  `**Why this happened:** the job(s) sat in \`queued\` because no matching EKS runner picked them up. GitHub's \`timeout-minutes\` does not cover runner-wait time — it only starts once a job begins executing — so the reaper enforces the ${threshold}-minute wait cap instead.`,
+                  ``,
+                  `**What to do:** re-run once EKS runner capacity is available (\`gh run rerun ${run.id}\`, or push a new commit). If this keeps happening, check the scale/health of the requested EKS runner pool(s) above.`,
+                  ``,
+                  `<sub>🤖 Automated by \`.github/workflows/stuck-run-reaper.yml\` · reaper run [#${context.runId}](${reaperUrl})</sub>`,
+                ].join("\n");
+
+                if (dryRun) {
+                  core.info(`[dry-run] Would comment on ${prNumber ? `PR #${prNumber}` : "(no PR found)"}:\n${body}`);
+                  continue;
+                }
+
+                if (prNumber) {
+                  try {
+                    await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+                  } catch (e) {
+                    core.warning(`Could not comment on PR #${prNumber}: ${e.message}`);
+                  }
+                } else {
+                  core.info(`Run ${run.id} (event=${run.event}, branch=${run.head_branch}) has no associated PR — cancelled without a comment.`);
+                }
+              }
+            }
+
+            // Job summary.
+            await core.summary
+              .addHeading(`🛑 Runner Reaper — ${dryRun ? "dry-run" : `${reapedCount} run(s) reaped`}`)
+              .addRaw(`Threshold: **${threshold} min** · Workflows: \`${workflows.join(", ")}\``)
+              .addTable([
+                [{ data: "Run", header: true }, { data: "Branch", header: true }, { data: "Stuck jobs", header: true }, { data: "Max wait", header: true }],
+                ...summaryRows.map(r => r.split("|").slice(1, -1).map(c => c.trim())),
+              ])
+              .write();

--- a/.github/workflows/stuck-run-reaper.yml
+++ b/.github/workflows/stuck-run-reaper.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Cancel runs stuck waiting for an EKS runner
         uses: actions/github-script@v7
         env:
-          # Comma-separated workflow file names to police.
-          WORKFLOWS: "playwright.yml"
+          # Comma-separated workflow file names to police (all use eks-openobserve-* runners).
+          # Release workflows are intentionally excluded — a stuck release build is left for a human.
+          WORKFLOWS: "playwright.yml,playwright_regression.yml"
           DEFAULT_THRESHOLD_MINUTES: "60"
           # Only reap jobs whose requested runner label starts with this prefix.
           RUNNER_LABEL_PREFIX: "eks-"


### PR DESCRIPTION
## What

Adds a scheduled **Playwright e2e Stuck-Run-Reaper** workflow (`.github/workflows/stuck-run-reaper.yml`) that force-cancels CI runs whose jobs are stuck **waiting for a self-hosted EKS runner that is never assigned**.

## Why

`timeout-minutes` (job- and step-level) only counts **execution** time — the clock starts once a job is running on a runner. It does **not** cover the time a job spends `queued` waiting for a runner to be assigned. So a job that never gets an `eks-openobserve-*` runner sits indefinitely; GitHub's only native cap for that is a very lax ~24h auto-cancel. We recently had several runs stuck 3–11h in exactly this state.

This reaper closes that gap.

## How

- **Trigger:** cron every 15 min + `workflow_dispatch` (with `dry_run` and `threshold_minutes` inputs).
- **Runner:** `ubuntu-latest` (GitHub-hosted — deliberately not the EKS pool it polices).
- **Logic:** scans non-completed runs of the policed workflows → finds jobs that are `queued`, have **no runner assigned**, request an `eks-*` label, and have waited **> 60 min** → `force-cancel`s the run. Also covers the "run never dispatched any jobs" case.
- **Transparency:** on `pull_request` runs it comments on the PR explaining **which runner was never assigned, when the job was queued, how long it waited, and when it was identified as stuck**. Non-PR runs (scheduled/dispatch) are still cancelled to free the queue, with the details logged to the job summary.

## Coverage (OSS)

Polices every OSS workflow using the `eks-openobserve-*` runners:

| Workflow | Triggers | Reaped? |
|---|---|---|
| `playwright.yml` | pull_request, merge_group | ✅ (comments on PR) |
| `playwright_regression.yml` | schedule, workflow_dispatch | ✅ (cancel + log) |
| `release.yml` | push | ❌ excluded — stuck release builds left for a human |

Job-level `timeout-minutes` in the policed workflows are intentionally left unchanged — those are correctly-sized execution caps and address a different failure mode.

### Example reaper comment

> ## 🛑 Playwright run auto-cancelled by the runner-reaper
> A job in this run was **waiting for a self-hosted EKS runner that was never assigned**, past the 60-minute threshold. The reaper force-cancelled the run to free the queue.
>
> | Job | Requested runner | Waiting since | Waited | Runner status |
> |---|---|---|---|---|
> | `e2e / Alerts` | `eks-openobserve-standard-8` | 2026-08-11 00:58:04 UTC | 10h 44m | ❌ never assigned |

## Notes

- Safe to merge and observe: run manually via **Actions → Playwright e2e Stuck-Run-Reaper → Run workflow** with `dry_run: true` to see what it *would* cancel without acting.
- Companion PR in o2-enterprise on the same branch `test/stuck-run-reaper` (broader coverage list there).