### PR TITLE
ci(i18n): generate translations in the PR that changes en-US.json

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -10,9 +10,22 @@ name: Update Translations
 # translations for a string that has already landed.
 on:
   pull_request:
-    # opened / synchronize / reopened (the defaults). `paths` on pull_request is
-    # evaluated against the merge base, so this fires whenever the PR's
-    # en-US.json differs from the base branch — including on later pushes.
+    # Deliberately NOT the default opened/synchronize/reopened. Generating on
+    # every push meant every edit to en-US.json produced its own translation
+    # commit, and each of those commits re-ran the PR's entire check suite
+    # (playwright, unit-tests, api-testing, …) — on top of the merge queue
+    # running them all again at merge time. These two types fire once, at the
+    # point the author signals the PR is finished, so the translation commit
+    # costs one extra CI cycle per PR instead of one per edit.
+    #
+    # `merge_group` cannot be used for this, which is the obvious thing to reach
+    # for: merge-queue branches (gh-readonly-queue/*) are read-only and their
+    # commits are frozen — the whole point of a queue is that what is tested is
+    # what merges — so a merge_group run has nowhere to put the commit. The
+    # queue is gated by verify-translations.yml instead, which only *checks*.
+    #
+    # `paths` still applies: a PR that never touches en-US.json creates no run.
+    types: [auto_merge_enabled, ready_for_review]
     paths:
       - 'web/src/locales/languages/en-US.json'
   workflow_dispatch:
@@ -23,9 +36,11 @@ on:
         default: ''
 
 # One run per PR. Unlike the old main-branch job, cancelling here is the right
-# call: a PR branch gets bursts of pushes, nothing is committed until the run
-# finishes, and the surviving run re-derives the full pending set from
-# .translation_state.json — so a cancelled run loses no progress, only spend.
+# call: a PR branch gets bursts of pushes, a cancelled run commits nothing (the
+# commit steps are gated on `!cancelled()`, not `always()`), and the surviving
+# run re-derives the full pending set from .translation_state.json — so a
+# cancelled run loses no progress, only spend. Two runs must never both reach
+# the push, or the older one replays less-complete locale files over the newer.
 concurrency:
   group: update-translations-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -49,54 +64,72 @@ jobs:
       contents: write
 
     env:
-      # Pushing with GITHUB_TOKEN would leave the PR wedged: GitHub deliberately
-      # does not re-trigger workflows for commits made with that token, so the
-      # new head SHA would have no status checks and required checks could never
-      # go green. TRANSLATIONS_APPROVE_TOKEN (the `nikhilsaikethe` PAT already
-      # used by this workflow) is a real user token, so its push re-runs CI on
-      # the translation commit. The fallback keeps the workflow functional if the
-      # secret is missing, at the cost of that re-trigger.
-      PUSH_TOKEN: ${{ secrets.TRANSLATIONS_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}
+      # Deliberately no token here: a job-level `env:` is injected into *every*
+      # step, including the ones that install and run PR-authored Python. The
+      # push credential is scoped to the single step that pushes.
       HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
       COMMIT_SUBJECT: 'chore(i18n): update translations from en-US.json'
+      # Appended to the commit body when the run did not finish every string, so
+      # the skip-guard below knows this branch still has pending work.
+      PARTIAL_TRAILER: 'Translation-Run: partial'
 
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.TRANSLATIONS_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}
+          # This job runs PR-authored code (requirements.txt, main.py,
+          # translator.py all come from the PR head). Without this, checkout
+          # would leave the push token in .git/config for that code to read.
+          # The push step re-attaches the credential after the Python is done.
+          persist-credentials: false
           # Check out the PR's head branch by name (not the merge commit that
           # `pull_request` checks out by default) so the generated files can be
           # committed straight back onto it.
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          # Needed to rebase onto concurrent pushes before pushing back.
-          fetch-depth: 0
+          # Enough history for `git log -1` and for the common ancestor of a
+          # normal concurrent push. The retry path unshallows only if it has to,
+          # so the ordinary run doesn't full-clone a large repo.
+          fetch-depth: 50
 
       - name: Skip if head commit is our own translation commit
         id: guard
-        # The PAT push re-triggers `synchronize`, which would run this job again
-        # against a tree that already has the translations. The run would be a
-        # no-op, but this short-circuits it before the Python setup and any API
-        # spend, and rules out a push/trigger ping-pong.
+        # Our push no longer re-triggers this workflow (it fires on
+        # auto_merge_enabled / ready_for_review, not synchronize), so this is not
+        # the ping-pong guard it used to be. It still matters for the paths that
+        # DO re-enter: a workflow_dispatch re-run, or the author toggling
+        # auto-merge off and back on. Short-circuiting there skips the Python
+        # setup and any API spend.
+        #
+        # Except when the previous run left strings pending — main.py exits 3 if
+        # any string failed validation, and the run marks its commit with the
+        # partial trailer. Skipping that on subject alone would strand those keys,
+        # so a re-run is allowed to pick them up.
         run: |
           SUBJECT="$(git log -1 --pretty=%s)"
-          if [ "$SUBJECT" = "$COMMIT_SUBJECT" ]; then
+          BODY="$(git log -1 --pretty=%b)"
+          if [ "$SUBJECT" = "$COMMIT_SUBJECT" ] && ! printf '%s' "$BODY" | grep -qF "$PARTIAL_TRAILER"; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "ℹ️  Head commit is the translation commit itself — nothing to do."
+            echo "ℹ️  Head commit is a complete translation commit — nothing to do."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            if [ "$SUBJECT" = "$COMMIT_SUBJECT" ]; then
+              echo "ℹ️  Head commit is a *partial* translation commit — retrying the strings it could not finish."
+            fi
           fi
 
       - name: Refuse to run against a protected branch
         if: steps.guard.outputs.skip == 'false'
-        # Only reachable via workflow_dispatch selecting `main`. The push at the
-        # end would be rejected by branch protection anyway; fail early with a
-        # comprehensible message instead of after a full translation run.
+        # Only reachable via workflow_dispatch selecting a long-lived branch. The
+        # push at the end would be rejected by branch protection anyway; fail
+        # early with a comprehensible message instead of after a full run.
         run: |
-          if [ "$HEAD_REF" = "main" ]; then
-            echo "::error::This workflow commits to the branch it runs on and cannot target 'main'. Re-run it from the feature branch whose PR changes en-US.json."
-            exit 1
-          fi
+          case "$HEAD_REF" in
+            main|master|release/*|v[0-9]*|[0-9]*.[0-9]*)
+              echo "::error::This workflow commits to the branch it runs on and cannot target the protected branch '$HEAD_REF'. Re-run it from the feature branch whose PR changes en-US.json."
+              exit 1
+              ;;
+          esac
 
       - name: Verify DeepSeek API key secret is configured
         if: steps.guard.outputs.skip == 'false'
@@ -129,8 +162,14 @@ jobs:
         # list before any API call (see main.py). Only keys whose English text
         # differs from the hash recorded in .translation_state.json are sent, so a
         # PR pays only for the strings it actually added or changed.
+        #
+        # Failed strings are retried in-process rather than on a later push,
+        # because there is no later push: this workflow no longer fires on
+        # synchronize, so our own commit does not bring us back here. Each retry
+        # re-derives what is pending from state, so it only re-sends the strings
+        # that actually failed — a retry after a near-complete run is nearly free.
         env:
-          INPUT_LANGUAGES: ${{ github.event.inputs.languages }}
+          INPUT_LANGUAGES: ${{ inputs.languages }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
         run: |
           cd scripts/translations
@@ -140,18 +179,42 @@ jobs:
             ARGS+=("${REQUESTED[@]}")
           fi
           echo "Running translation with args: ${ARGS[*]}"
-          python3 main.py "${ARGS[@]}"
+
+          for attempt in 1 2 3; do
+            set +e
+            python3 main.py "${ARGS[@]}"
+            STATUS=$?
+            set -e
+
+            if [ "$STATUS" -eq 0 ]; then
+              echo "run=complete" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # Exit 3 means "some strings failed validation, the rest are written".
+            # Anything else (bad usage, missing source, unreachable API) is not
+            # worth retrying — fail the step and let the run surface it.
+            if [ "$STATUS" -ne 3 ]; then
+              echo "::error::Translation script failed with exit $STATUS."
+              exit "$STATUS"
+            fi
+            echo "::warning::Attempt $attempt left some strings unfinished — retrying just those."
+          done
+
+          # Still incomplete. Ship what we have; the merge-queue gate
+          # (verify-translations.yml) is what stops it reaching main.
+          echo "run=partial" >> "$GITHUB_OUTPUT"
+          echo "::warning::Some strings are still untranslated after 3 attempts. The completed locales are committed; the merge-queue check will block this PR until the rest land."
 
       - name: Check for translation changes
         id: check_changes
-        # `always()` because partial progress is still worth shipping. The script
-        # exits non-zero when ANY string failed validation (main.py), and it is
-        # cancellable mid-run — under the default `success()` this step and the
-        # commit step were skipped, so runs that had already written most locale
-        # files produced nothing and the next run repeated the work. Locale files
-        # are written atomically per locale, so whatever is on disk here is
-        # complete, valid JSON.
-        if: always() && steps.guard.outputs.skip == 'false'
+        # `!cancelled()` rather than `success()` because partial progress from a
+        # *failed* run is still worth shipping: main.py exits 3 when any string
+        # failed validation, and locale files are written atomically per locale,
+        # so whatever is on disk is complete, valid JSON for the locales it got
+        # through. `!cancelled()` rather than `always()` because a cancelled run
+        # has been superseded — letting it commit would race the newer run to the
+        # same branch and replay less-complete files over more-complete ones.
+        if: '!cancelled() && steps.guard.outputs.skip == ''false'''
         # Use `git status --porcelain` (not `git diff`) so brand-new untracked
         # files — e.g. a freshly created .translation_state.json or a new locale
         # file — are detected, not just modifications to already-tracked files.
@@ -168,17 +231,54 @@ jobs:
 
       - name: Commit translations onto the PR branch
         id: commit
-        if: always() && steps.check_changes.outputs.changes == 'true'
+        if: '!cancelled() && steps.check_changes.outputs.changes == ''true'''
+        env:
+          # Scoped to this step, not the job: every step above this one runs
+          # PR-authored code, and none of them need a push credential.
+          #
+          # Pushing with GITHUB_TOKEN would leave the PR wedged: GitHub
+          # deliberately does not re-trigger workflows for commits made with that
+          # token, so the new head SHA would have no status checks and required
+          # checks could never go green. TRANSLATIONS_APPROVE_TOKEN is a real
+          # user token, so its push re-runs CI on the translation commit. The
+          # fallback keeps the workflow functional if the secret is missing, at
+          # the cost of that re-trigger.
+          PUSH_TOKEN: ${{ secrets.TRANSLATIONS_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}
+          RUN_RESULT: ${{ steps.run_translation.outputs.run }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Checkout ran with persist-credentials: false, so re-attach the
+          # credential now that no more PR-authored code will run. Actions masks
+          # the secret in logs.
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
           git add -- 'web/src/locales/languages/*.json' \
                      'scripts/translations/.translation_state.json'
           if git diff --cached --quiet; then
             echo "Nothing staged after filtering to translation paths."
+            echo "pushed=noop" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git commit -m "$COMMIT_SUBJECT"
+
+          # Record whether strings are still pending, so a later re-run (manual
+          # dispatch, or auto-merge toggled off and on) picks them up instead of
+          # being short-circuited by the skip-guard.
+          if [ "$RUN_RESULT" = "partial" ]; then
+            git commit -m "$COMMIT_SUBJECT" -m "$PARTIAL_TRAILER"
+          else
+            git commit -m "$COMMIT_SUBJECT"
+          fi
+
+          # If the PR merged (or the branch was deleted) while this ran, pushing
+          # would silently *recreate* the head branch as a stray. Bail instead —
+          # the strings stay pending and the next PR touching en-US.json picks
+          # them up from the state file.
+          if ! git ls-remote --exit-code --heads origin "$HEAD_REF" >/dev/null 2>&1; then
+            echo "::warning::Branch '$HEAD_REF' no longer exists on origin (PR merged or branch deleted). Not recreating it; these strings stay pending."
+            echo "pushed=gone" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # The author may push while this job runs. Rebase onto the branch tip
           # and retry rather than failing the PR; our commit only touches
@@ -190,10 +290,13 @@ jobs:
               exit 0
             fi
             echo "Push rejected (attempt $attempt) — rebasing onto $HEAD_REF and retrying."
-            git fetch origin "$HEAD_REF"
+            # The shallow clone may not reach the common ancestor of a branch
+            # that was rebased or force-pushed under us; deepen only here, on the
+            # path that actually needs full history.
+            git fetch --unshallow origin "$HEAD_REF" 2>/dev/null || git fetch origin "$HEAD_REF"
             git rebase "origin/$HEAD_REF" || {
               git rebase --abort || true
-              echo "::error::Could not rebase the translation commit onto $HEAD_REF."
+              echo "::error::Could not rebase the translation commit onto $HEAD_REF. Rebase your branch and re-run this workflow."
               exit 1
             }
           done
@@ -205,18 +308,25 @@ jobs:
         env:
           SKIPPED: ${{ steps.guard.outputs.skip }}
           SCRIPT_OUTCOME: ${{ steps.run_translation.outcome }}
+          RUN_RESULT: ${{ steps.run_translation.outputs.run }}
           HAS_CHANGES: ${{ steps.check_changes.outputs.changes }}
           PUSHED: ${{ steps.commit.outputs.pushed }}
         run: |
           if [ "$SKIPPED" == "true" ]; then
-            echo "ℹ️  Skipped — head commit is already the generated translation commit."
+            echo "ℹ️  Skipped — head commit is already a complete translation commit."
           elif [ "$PUSHED" == "true" ]; then
             echo "✅ Translations committed to \`$HEAD_REF\` — they ship with this PR."
+          elif [ "$PUSHED" == "noop" ]; then
+            echo "ℹ️  Changes were outside the translation paths — nothing to commit."
+          elif [ "$PUSHED" == "gone" ]; then
+            echo "⚠️  \`$HEAD_REF\` no longer exists on origin — the PR merged or the branch was deleted mid-run. The branch was NOT recreated; these strings stay pending and the next PR touching \`en-US.json\` will pick them up."
           elif [ "$HAS_CHANGES" == "true" ]; then
             echo "⚠️  Translation changes exist on disk but were not pushed — see the 'Commit translations' step."
           else
             echo "ℹ️  No new or modified keys — translations already up to date."
           fi
-          if [ -n "$SCRIPT_OUTCOME" ] && [ "$SCRIPT_OUTCOME" != "success" ]; then
-            echo "❌ Translation script outcome: $SCRIPT_OUTCOME — some strings failed or the run was interrupted. Any completed locales are in the commit above; the rest retry on the next push to this branch."
+          if [ "$RUN_RESULT" == "partial" ]; then
+            echo "❌ Some strings are still untranslated after 3 attempts. The completed locales are in the commit above, marked \`$PARTIAL_TRAILER\`. **Verify translations** will block this PR in the merge queue until they land — re-run this workflow, or check the logs for what is failing validation."
+          elif [ -n "$SCRIPT_OUTCOME" ] && [ "$SCRIPT_OUTCOME" != "success" ] && [ "$SCRIPT_OUTCOME" != "skipped" ]; then
+            echo "❌ Translation script outcome: $SCRIPT_OUTCOME — see the 'Run translation script' step."
           fi

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,59 +1,105 @@
 # Copyright 2026 OpenObserve Inc.
 name: Update Translations
 
+# Translations are produced *inside the PR that changes en-US.json*, and pushed
+# back onto that PR's own branch. The previous design ran on `push: main` and
+# opened a separate `chore/update-translations` PR; that PR had no owner, was
+# never assigned or reviewed by a human, and piled up behind the merge queue.
+# Keeping the work in the originating PR means the author who added the English
+# strings also owns (and reviews) their translations, and main is never missing
+# translations for a string that has already landed.
 on:
-  push:
-    branches:
-      - main
-    # Only run when the English source actually changes. Gating to `main` (instead
-    # of every branch) avoids re-translating the same strings on each feature
-    # branch — the single largest cost driver of this job.
+  pull_request:
+    # opened / synchronize / reopened (the defaults). `paths` on pull_request is
+    # evaluated against the merge base, so this fires whenever the PR's
+    # en-US.json differs from the base branch — including on later pushes.
     paths:
       - 'web/src/locales/languages/en-US.json'
   workflow_dispatch:
     inputs:
       languages:
-        description: 'Languages to translate (space-separated, e.g., "fr es de"). Leave empty for all.'
+        description: 'Languages to translate (space-separated, e.g., "fr-FR es-ES de-DE"). Leave empty for all.'
         required: false
         default: ''
 
-# Serialise runs on the same ref, but never cancel one that is already working.
-# `cancel-in-progress: true` was actively harmful here: en-US.json lands on main
-# more often than a backlog run takes, so every run was killed by the next merge
-# and its API spend thrown away (20 of the last 40 runs ended `cancelled`, none on
-# main ever succeeded). GitHub keeps at most one running + one pending run per
-# group, so queueing cannot pile up, and the work is incremental — a queued run
-# picks up exactly what its predecessor did not finish.
+# One run per PR. Unlike the old main-branch job, cancelling here is the right
+# call: a PR branch gets bursts of pushes, nothing is committed until the run
+# finishes, and the surviving run re-derives the full pending set from
+# .translation_state.json — so a cancelled run loses no progress, only spend.
 concurrency:
-  group: update-translations-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: update-translations-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update-translations:
     name: Update translation files
     runs-on: ubuntu-latest
 
-    # Only run on the main repo, not forks.
-    if: github.repository == 'openobserve/openobserve'
+    # Only the main repo, and only same-repo PRs: a fork PR's branch lives in the
+    # contributor's repo, which no token here can push to. Fork PRs that touch
+    # en-US.json are handled by a maintainer running this workflow manually
+    # (workflow_dispatch) from the fork branch, or by the next same-repo PR that
+    # touches en-US.json — the state file makes it pick up every pending key.
+    if: >-
+      github.repository == 'openobserve/openobserve' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
 
-    # Required for opening the translations PR.
     permissions:
       contents: write
-      pull-requests: write
+
+    env:
+      # Pushing with GITHUB_TOKEN would leave the PR wedged: GitHub deliberately
+      # does not re-trigger workflows for commits made with that token, so the
+      # new head SHA would have no status checks and required checks could never
+      # go green. TRANSLATIONS_APPROVE_TOKEN (the `nikhilsaikethe` PAT already
+      # used by this workflow) is a real user token, so its push re-runs CI on
+      # the translation commit. The fallback keeps the workflow functional if the
+      # secret is missing, at the cost of that re-trigger.
+      PUSH_TOKEN: ${{ secrets.TRANSLATIONS_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      COMMIT_SUBJECT: 'chore(i18n): update translations from en-US.json'
 
     steps:
-      - name: Checkout repository
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Check out the branch TIP, not the triggering commit. The job is a
-          # reconciliation against .translation_state.json rather than a diff of
-          # one commit, so a run that waited in the concurrency queue must start
-          # from the newest main — which already contains the translations its
-          # predecessor merged. Pinning to github.sha would make it redo that work.
-          ref: ${{ github.ref_name }}
+          token: ${{ secrets.TRANSLATIONS_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}
+          # Check out the PR's head branch by name (not the merge commit that
+          # `pull_request` checks out by default) so the generated files can be
+          # committed straight back onto it.
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          # Needed to rebase onto concurrent pushes before pushing back.
+          fetch-depth: 0
+
+      - name: Skip if head commit is our own translation commit
+        id: guard
+        # The PAT push re-triggers `synchronize`, which would run this job again
+        # against a tree that already has the translations. The run would be a
+        # no-op, but this short-circuits it before the Python setup and any API
+        # spend, and rules out a push/trigger ping-pong.
+        run: |
+          SUBJECT="$(git log -1 --pretty=%s)"
+          if [ "$SUBJECT" = "$COMMIT_SUBJECT" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "ℹ️  Head commit is the translation commit itself — nothing to do."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Refuse to run against a protected branch
+        if: steps.guard.outputs.skip == 'false'
+        # Only reachable via workflow_dispatch selecting `main`. The push at the
+        # end would be rejected by branch protection anyway; fail early with a
+        # comprehensible message instead of after a full translation run.
+        run: |
+          if [ "$HEAD_REF" = "main" ]; then
+            echo "::error::This workflow commits to the branch it runs on and cannot target 'main'. Re-run it from the feature branch whose PR changes en-US.json."
+            exit 1
+          fi
 
       - name: Verify DeepSeek API key secret is configured
+        if: steps.guard.outputs.skip == 'false'
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
         run: |
@@ -63,6 +109,7 @@ jobs:
           fi
 
       - name: Set up Python
+        if: steps.guard.outputs.skip == 'false'
         uses: actions/setup-python@v7
         with:
           python-version: '3.11'
@@ -70,14 +117,18 @@ jobs:
           cache-dependency-path: scripts/translations/requirements.txt
 
       - name: Install Python dependencies
+        if: steps.guard.outputs.skip == 'false'
         run: pip install -r scripts/translations/requirements.txt
 
       - name: Run translation script
         id: run_translation
+        if: steps.guard.outputs.skip == 'false'
         # Inputs are passed as environment variables (not interpolated into the
         # script body) so user-controlled text can never be injected into the
         # shell. The script itself validates language codes against the supported
-        # list before any API call (see main.py).
+        # list before any API call (see main.py). Only keys whose English text
+        # differs from the hash recorded in .translation_state.json are sent, so a
+        # PR pays only for the strings it actually added or changed.
         env:
           INPUT_LANGUAGES: ${{ github.event.inputs.languages }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
@@ -95,102 +146,77 @@ jobs:
         id: check_changes
         # `always()` because partial progress is still worth shipping. The script
         # exits non-zero when ANY string failed validation (main.py), and it is
-        # cancellable mid-run — under the default `success()` this step and the PR
-        # steps were skipped, so multi-hour runs that had already written most
-        # locale files produced nothing and the next run repeated the work.
-        # Locale files are written atomically per locale, so whatever is on disk
-        # here is complete, valid JSON.
-        if: always()
+        # cancellable mid-run — under the default `success()` this step and the
+        # commit step were skipped, so runs that had already written most locale
+        # files produced nothing and the next run repeated the work. Locale files
+        # are written atomically per locale, so whatever is on disk here is
+        # complete, valid JSON.
+        if: always() && steps.guard.outputs.skip == 'false'
         # Use `git status --porcelain` (not `git diff`) so brand-new untracked
         # files — e.g. a freshly created .translation_state.json or a new locale
         # file — are detected, not just modifications to already-tracked files.
         run: |
           PATHS="web/src/locales/languages/ scripts/translations/.translation_state.json"
           if [ -n "$(git status --porcelain -- $PATHS)" ]; then
-            echo "changes=true" >> $GITHUB_OUTPUT
+            echo "changes=true" >> "$GITHUB_OUTPUT"
             echo "Translation changes detected:"
             git status --porcelain -- $PATHS
           else
-            echo "changes=false" >> $GITHUB_OUTPUT
+            echo "changes=false" >> "$GITHUB_OUTPUT"
             echo "No translation changes detected"
           fi
 
-      # `main` is a protected branch, so a direct `git push` from GITHUB_TOKEN is
-      # rejected (this is why earlier runs failed on the push step). Open a PR
-      # with the generated translations instead. Requires the repo setting
-      # "Allow GitHub Actions to create and approve pull requests" to be enabled
-      # (Settings → Actions → General → Workflow permissions).
-      - name: Create pull request with translation updates
-        id: cpr
+      - name: Commit translations onto the PR branch
+        id: commit
         if: always() && steps.check_changes.outputs.changes == 'true'
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: chore/update-translations
-          delete-branch: true
-          add-paths: |
-            web/src/locales/languages/*.json
-            scripts/translations/.translation_state.json
-          commit-message: |
-            chore: update translations from en-US.json
-
-            Auto-generated translation updates from English source file.
-
-            🤖 Generated with automated translation workflow
-          title: "chore: update translations from en-US.json"
-          body: |
-            Auto-generated translation updates from the English source file
-            (`web/src/locales/languages/en-US.json`).
-
-            🤖 Generated with automated translation workflow
-          labels: |
-            translations
-            e2e
-
-      # Approve the PR so it satisfies the required-review rule. GITHUB_TOKEN
-      # cannot approve a PR it authored (the PR above is authored by
-      # github-actions[bot]), so this uses a personal access token that belongs
-      # to the reviewer account `nikhilsaikethe` — the approval is attributed to
-      # that user. Store that account's PAT in the TRANSLATIONS_APPROVE_TOKEN
-      # secret. PR number is passed via env (never interpolated into the shell body).
-      - name: Approve the translation PR
-        if: always() && steps.cpr.outputs.pull-request-number
-        env:
-          GH_TOKEN: ${{ secrets.TRANSLATIONS_APPROVE_TOKEN }}
-          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-          REPO: ${{ github.repository }}
         run: |
-          gh pr review "$PR_NUMBER" --repo "$REPO" --approve \
-            --body "Auto-approved: automated translation update."
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- 'web/src/locales/languages/*.json' \
+                     'scripts/translations/.translation_state.json'
+          if git diff --cached --quiet; then
+            echo "Nothing staged after filtering to translation paths."
+            exit 0
+          fi
+          git commit -m "$COMMIT_SUBJECT"
 
-      # Enable auto-merge so the PR enters the merge queue automatically once the
-      # required review (above) and status checks pass. Uses the same PAT so the
-      # enqueue is attributed to a real user and downstream workflows (e.g. the
-      # merge_group checks) trigger correctly. Merge method must match the repo's
-      # merge-queue configuration — change --squash if the queue uses merge/rebase.
-      - name: Enable auto-merge (merge queue)
-        if: always() && steps.cpr.outputs.pull-request-number
-        env:
-          GH_TOKEN: ${{ secrets.TRANSLATIONS_APPROVE_TOKEN }}
-          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash
+          # The author may push while this job runs. Rebase onto the branch tip
+          # and retry rather than failing the PR; our commit only touches
+          # generated files, so a rebase conflict is not expected, and if one
+          # does occur the loop exits non-zero and the PR author re-runs the job.
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:refs/heads/$HEAD_REF"; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt) — rebasing onto $HEAD_REF and retrying."
+            git fetch origin "$HEAD_REF"
+            git rebase "origin/$HEAD_REF" || {
+              git rebase --abort || true
+              echo "::error::Could not rebase the translation commit onto $HEAD_REF."
+              exit 1
+            }
+          done
+          echo "::error::Failed to push translation commit to $HEAD_REF after 3 attempts."
+          exit 1
 
       - name: Summary
         if: always()
         env:
+          SKIPPED: ${{ steps.guard.outputs.skip }}
           SCRIPT_OUTCOME: ${{ steps.run_translation.outcome }}
           HAS_CHANGES: ${{ steps.check_changes.outputs.changes }}
-          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          PUSHED: ${{ steps.commit.outputs.pushed }}
         run: |
-          if [ "$HAS_CHANGES" == "true" ] && [ -n "$PR_NUMBER" ]; then
-            echo "✅ PR #$PR_NUMBER created/updated (branch: chore/update-translations), labeled 'translations,e2e', approved, and set to auto-merge into the merge queue."
+          if [ "$SKIPPED" == "true" ]; then
+            echo "ℹ️  Skipped — head commit is already the generated translation commit."
+          elif [ "$PUSHED" == "true" ]; then
+            echo "✅ Translations committed to \`$HEAD_REF\` — they ship with this PR."
           elif [ "$HAS_CHANGES" == "true" ]; then
-            echo "⚠️  Translation changes exist on disk but no PR was opened — see the 'Create pull request' step."
+            echo "⚠️  Translation changes exist on disk but were not pushed — see the 'Commit translations' step."
           else
             echo "ℹ️  No new or modified keys — translations already up to date."
           fi
-          if [ "$SCRIPT_OUTCOME" != "success" ]; then
-            echo "❌ Translation script outcome: $SCRIPT_OUTCOME — some strings failed or the run was interrupted. Any completed locales are included in the PR above; the rest retry on the next run. See the 'Run translation script' logs."
+          if [ -n "$SCRIPT_OUTCOME" ] && [ "$SCRIPT_OUTCOME" != "success" ]; then
+            echo "❌ Translation script outcome: $SCRIPT_OUTCOME — some strings failed or the run was interrupted. Any completed locales are in the commit above; the rest retry on the next push to this branch."
           fi

--- a/.github/workflows/verify-translations.yml
+++ b/.github/workflows/verify-translations.yml
@@ -1,0 +1,101 @@
+# Copyright 2026 OpenObserve Inc.
+name: Verify Translations
+
+# The gate that makes "main is never missing translations" true.
+#
+# update-translations.yml *generates* translations, but it fires only when the
+# author signals the PR is done (auto_merge_enabled / ready_for_review) and it
+# cannot run for fork PRs. So there are ways for a merge to reach the queue with
+# English-only strings. This workflow catches those: it runs `main.py --check`,
+# which is a pure comparison of en-US.json against the locale files and
+# .translation_state.json — no API calls, no API key, and no dependencies to
+# install (`openai` is imported lazily inside translator.py). A run is a few
+# seconds and costs nothing, which is what makes it affordable as a required check
+# on every PR.
+#
+# Make this a required status check on `main` for it to actually gate anything.
+on:
+  # No `types` and deliberately no `paths`. A required status check whose workflow
+  # was filtered out sits at "Expected — waiting for status" forever, which would
+  # block every PR that doesn't touch en-US.json. It is cheap enough to just run.
+  pull_request:
+  merge_group:
+
+concurrency:
+  group: verify-translations-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify translations are up to date
+    runs-on: ubuntu-latest
+
+    # Read-only, and no secrets are referenced anywhere in this file. That is
+    # deliberate: unlike update-translations.yml, this one runs for fork PRs, so
+    # it must hold nothing worth stealing.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Check for untranslated strings
+        env:
+          # In the merge queue this is the last chance to stop untranslated
+          # strings reaching main, so pending keys are a hard failure. On the PR
+          # itself they are expected for most of its life — translations are
+          # generated at "Merge when ready" — so we report and stay green rather
+          # than painting every in-progress PR red.
+          IS_QUEUE: ${{ github.event_name == 'merge_group' }}
+        run: |
+          cd scripts/translations
+
+          set +e
+          OUTPUT="$(python3 main.py --check 2>&1)"
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+
+          if [ "$STATUS" -eq 0 ]; then
+            echo "✅ Every locale is up to date with en-US.json." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "$STATUS" -ne 2 ]; then
+            echo "::error::Translation check failed to run (exit $STATUS)."
+            exit "$STATUS"
+          fi
+
+          {
+            echo "### Untranslated strings"
+            echo
+            echo '```'
+            echo "$OUTPUT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$IS_QUEUE" = "true" ]; then
+            echo "::error::This merge would land English-only strings on main. Run the **Update Translations** workflow on the PR branch (or click 'Merge when ready' again, which triggers it) before re-queueing."
+            {
+              echo
+              echo "❌ **Blocked.** Merging this would leave \`main\` with untranslated strings."
+              echo "Run the **Update Translations** workflow on the PR branch, then re-queue."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "::notice::${OUTPUT##*$'\n'} These are generated automatically when you click 'Merge when ready'. This check only blocks in the merge queue."
+          {
+            echo
+            echo "ℹ️ Expected while the PR is in progress — translations are generated when you"
+            echo "click **Merge when ready**. This check only blocks in the merge queue."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/translations/README.md
+++ b/scripts/translations/README.md
@@ -9,15 +9,17 @@ This system automatically translates the English locale file (`en-US.json`) into
 
 ## 🚀 How It Works
 
-**Automatic workflow triggered when `en-US.json` lands on `main`:**
+**Translations are generated inside the PR that changes `en-US.json`:**
 
-1. **Developer updates `en-US.json`** and merges the change to `main`
-2. **GitHub Actions detects it** via the workflow's `paths:` filter — pushes that don't touch `en-US.json` never start a run at all
+1. **Developer updates `en-US.json`** on a branch and opens a PR
+2. **GitHub Actions detects it** via the workflow's `paths:` filter — PRs that don't touch `en-US.json` never start a run at all
 3. **Translation script runs** using DeepSeek to update all language files
-4. **A PR is opened** (`chore/update-translations`), auto-approved and set to auto-merge
-5. **Build workflows use updated files** - all subsequent builds have fresh translations
+4. **A commit is pushed back onto the PR's own branch** (`chore(i18n): update translations from en-US.json`)
+5. **The PR merges as a unit** — English strings and their translations land together
 
-This means **translations are always up-to-date** without any manual intervention!
+This means **translations are always up-to-date** without any manual intervention,
+and they are reviewed by the person who added the English strings — no ownerless
+follow-up PR to chase.
 
 ## Supported Languages
 
@@ -95,73 +97,90 @@ python3 main.py fr-FR es-ES de-DE
 
 The workflow (`.github/workflows/update-translations.yml`) automatically runs when:
 
-- **Trigger**: A push to `main` that modifies `web/src/locales/languages/en-US.json`
-- **Branches**: **`main` only** (plus manual `workflow_dispatch`)
+- **Trigger**: A pull request whose `web/src/locales/languages/en-US.json` differs
+  from the base branch (on open, reopen, and every subsequent push)
+- **Branches**: the PR's own head branch (plus manual `workflow_dispatch` from a
+  feature branch). Same-repo PRs only — see [Fork PRs](#fork-prs).
 - **Action**:
   1. Runs Python translation script
   2. Updates all language JSON files
-  3. Opens PR `chore/update-translations`, approves it, enables auto-merge
-  4. Subsequent builds use the updated files once that PR merges
+  3. Commits them onto the PR branch as `chore(i18n): update translations from en-US.json`
+  4. The translations merge with the PR, so `main` never has untranslated strings
 
 ### Run lifecycle guarantees
 
-Two properties of the workflow matter when you are reading a run:
+Three properties of the workflow matter when you are reading a run:
 
-- **Runs are never cancelled by a newer push.** The concurrency group uses
-  `cancel-in-progress: false`, so at most one run works at a time and at most one
-  waits. A queued run checks out the branch *tip*, so it picks up whatever its
-  predecessor already merged instead of redoing it.
+- **A newer push cancels the run in flight.** The concurrency group is keyed on the
+  PR number with `cancel-in-progress: true`. Nothing is committed until a run
+  finishes, and the surviving run re-derives the full pending set from
+  `.translation_state.json` — so a cancelled run loses spend, never progress.
 - **Partial progress is always shipped.** Locale files are written atomically, one
-  locale at a time, and the PR steps run under `if: always()`. A run that fails
-  validation on some strings — or is cancelled manually — still opens a PR with the
-  locales it finished. Anything unfinished simply stays pending for the next run.
+  locale at a time, and the commit step runs under `if: always()`. A run that fails
+  validation on some strings — or is cancelled manually — still commits the locales
+  it finished. Anything unfinished stays pending for the next push to the branch.
+- **The push re-runs the PR's checks.** The commit is pushed with a user PAT rather
+  than `GITHUB_TOKEN`, because GitHub deliberately does not trigger workflows for
+  `GITHUB_TOKEN` pushes — the new head SHA would carry no status checks and required
+  checks could never pass.
 
 ### Setup Requirements
 
-The workflow authenticates to DeepSeek with an API key stored as a repository secret.
+The workflow needs two repository secrets:
 
-#### GitHub Repository Setup
+| Secret | Value | Why |
+|--------|-------|-----|
+| `DEEPSEEK_API_KEY` | Your DeepSeek API key | Authenticates the translation calls |
+| `TRANSLATIONS_APPROVE_TOKEN` | PAT (repo scope) for a real user account | Pushes the translation commit so the PR's checks re-run |
 
-Add one repository secret:
+Set them under **Settings → Secrets and variables → Actions → New repository secret**
+(or via `gh secret set …`). The workflow fails fast with a clear error if
+`DEEPSEEK_API_KEY` is missing; if `TRANSLATIONS_APPROVE_TOKEN` is missing it falls
+back to `GITHUB_TOKEN`, which still commits the translations but leaves the PR's
+checks unre-run on the new head SHA.
 
-| Secret | Value |
-|--------|-------|
-| `DEEPSEEK_API_KEY` | Your DeepSeek API key |
+### Fork PRs
 
-Set it under **Settings → Secrets and variables → Actions → New repository secret**
-(or via `gh secret set DEEPSEEK_API_KEY`). The workflow fails fast with a clear
-error if this secret is missing.
+A fork PR's branch lives in the contributor's repository, which no token in this
+workflow can push to, so the job is skipped for fork PRs. Handle those by running
+the workflow manually (`workflow_dispatch`) once the branch is available locally, or
+by letting the next same-repo PR that touches `en-US.json` pick the keys up — the
+state file makes it translate everything still pending, not just that PR's strings.
 
 ### Workflow Behavior
 
 ```mermaid
 graph TD
-    A[Push to main] --> C{en-US.json in the diff?}
+    A[PR opened / pushed] --> C{en-US.json differs<br/>from the base branch?}
     C -->|No| E[No run is created at all]
-    C -->|Yes| D[Run translation script]
+    C -->|Yes| B{Head commit is our<br/>own translation commit?}
+    B -->|Yes| G2[Skip - nothing to do]
+    B -->|No| D[Run translation script]
     D --> F{Any new/changed keys<br/>vs .translation_state.json?}
     F -->|No| G[Done - already up to date]
     F -->|Yes| H[Translate pending keys only]
-    H --> I[Open/update PR chore/update-translations]
-    I --> J[Auto-approve + auto-merge]
-    J --> K[Build workflows use latest translations]
+    H --> I[Commit onto the PR branch]
+    I --> J[PR checks re-run on the new head SHA]
+    J --> K[PR merges with its translations]
 ```
 
 **Workflow Execution Order:**
 
-1. **Merge to `main`** → GitHub's `paths:` filter decides whether a run is created
+1. **Push to a PR branch** → GitHub's `paths:` filter decides whether a run is created
 2. Script reconciles `en-US.json` against `.translation_state.json`
    - New / changed keys: translated
    - Everything else: kept, never re-sent to the API
-3. **If any file changed** → PR opened, approved, auto-merged
-4. **Build workflows** pick up the translations once that PR lands
+3. **If any file changed** → commit pushed onto the PR's head branch
+4. **The PR merges** carrying both the English strings and their translations
 
 **Key Features:**
-- ✅ **Cheap trigger** - a push without `en-US.json` changes creates no run at all
+- ✅ **Cheap trigger** - a PR without `en-US.json` changes creates no run at all
 - ✅ **Smart detection** - only new or modified keys are translated
-- ✅ **Never re-billed per branch** - runs on `main` only, so each string is translated once, when it lands
-- ✅ **Crash/cancel safe** - completed locales are still shipped in a PR
-- ✅ **Reviewable** - lands as a normal PR rather than a direct push to a protected branch
+- ✅ **Owned and reviewed** - translations land in the author's PR, not an ownerless follow-up PR
+- ✅ **`main` is never missing translations** - English and translated strings land in the same merge
+- ✅ **Crash/cancel safe** - completed locales are still committed
+- ✅ **No re-billing across branches** - the committed state file means each string is
+  translated once, on whichever branch first introduces it
 
 ### Manual Workflow Trigger
 
@@ -169,9 +188,10 @@ You can also run translations manually:
 
 1. Go to **Actions** tab in GitHub
 2. Select **Update Translations** workflow
-3. Click **Run workflow**
+3. Choose the **feature branch** to run against (not `main` — the workflow commits to
+   the branch it runs on and refuses to target `main`)
 4. (Optional) Specify specific languages: `fr-FR es-ES de-DE`
-5. Translations are opened as a PR against the branch you ran it from
+5. Translations are committed directly to the branch you ran it from
 
 > Note: a subset run (specific languages) intentionally does **not** advance
 > `.translation_state.json` — see [Change detection](#change-detection-translation_statejson).
@@ -218,23 +238,22 @@ web/src/locales/languages/
 
 **Symptom:** You changed `en-US.json` but no **Update Translations** run appears.
 
-The trigger is a `paths:` filter on **pushes to `main`** — GitHub evaluates it
-before any job exists, so a non-matching push produces no run at all (this is
-intended: it is what stops feature branches from re-translating the same strings).
+The trigger is a `paths:` filter on **pull requests** — GitHub evaluates it before
+any job exists, so a PR that doesn't change `en-US.json` produces no run at all.
 
 Check, in order:
 
 ```bash
-# 1. Is your change actually on main yet? The workflow does not run on branches.
-git log origin/main --oneline -1 -- web/src/locales/languages/en-US.json
+# 1. Is there an open PR, and does its diff really touch the source file?
+git diff --name-only origin/main...HEAD | grep en-US.json
 
-# 2. Did the merged commit really touch the source file?
-git show --name-only --pretty="" <sha> | grep en-US.json
+# 2. Is the PR from a fork? Fork PRs are skipped — see "Fork PRs" above.
+gh pr view --json headRepositoryOwner,isCrossRepository
 ```
 
-If the file is on `main` and a run exists but produced no PR, the keys were already
-recorded in `.translation_state.json` — nothing was pending. Confirm with a local
-run: `python3 main.py` prints `Translating: <locale> (N strings pending)`.
+If a run exists but produced no commit, the keys were already recorded in
+`.translation_state.json` — nothing was pending. Confirm with a local run:
+`python3 main.py` prints `Translating: <locale> (N strings pending)`.
 
 ### API Key Error
 ```
@@ -258,11 +277,13 @@ ModuleNotFoundError: No module named 'openai'
 
 **Symptom:** Build doesn't have the latest translations
 
-**Solution:** Translations reach `main` through a PR, not a direct push — so check
-that the PR actually merged:
-1. Go to **Actions** → find the latest **Update Translations** run → read its Summary
-2. If it opened a PR, check that `chore/update-translations` merged (auto-merge can
-   stall on a failing required check, leaving the translations sitting in the PR)
+**Solution:** Translations reach `main` inside the PR that changed `en-US.json`, so
+check that PR:
+1. Go to **Actions** → find the **Update Translations** run for that PR → read its Summary
+2. Confirm the `chore(i18n): update translations from en-US.json` commit is on the
+   branch. If the run finished after the PR merged, the strings missed the train —
+   they will be picked up by the next PR that touches `en-US.json`, or by a manual
+   `workflow_dispatch` run on a fresh branch
 3. Builds started before that PR merged will still carry the old strings
 
 ## Workflow Example
@@ -278,26 +299,29 @@ that the PR actually merged:
    }
    ```
 
-2. **Merge the `en-US.json` change to `main`:**
+2. **Push the `en-US.json` change and open a PR:**
    ```bash
    git add web/src/locales/languages/en-US.json
    git commit -m "feat: add new dashboard feature text"
-   # open a PR and merge to main
+   git push -u origin feat/new-dashboard-text
+   gh pr create
    ```
 
-3. **Workflow automatically (on `main` only):**
-   - Triggers because `web/src/locales/languages/en-US.json` changed
+3. **Workflow automatically (on your PR):**
+   - Triggers because `web/src/locales/languages/en-US.json` differs from the base branch
    - Runs translation script
    - Translates only the **new or modified** keys to all 14 languages
-   - Commits updated `fr-FR.json`, `es-ES.json`, etc. plus `.translation_state.json`
+   - Pushes `fr-FR.json`, `es-ES.json`, etc. plus `.translation_state.json` onto your branch
 
-4. **Build workflows:**
-   - Use the newly updated translation files
-   - No additional steps needed
+4. **Review and merge:**
+   - `git pull` to pick up the translation commit before your next push
+   - Review the generated strings alongside your own change, then merge as usual
 
-> **Why `main` only?** Running on every feature branch re-translated the same
-> strings repeatedly (per branch, per rebase, again on merge). Gating to `main`
-> translates each string once, when it actually lands.
+> **Why in the PR, and not on `main`?** Re-translation across branches is already
+> prevented by the committed state file, not by the trigger: a string is translated
+> once, on whichever branch first introduces it. Generating on `main` instead meant a
+> separate `chore/update-translations` PR that nobody was assigned to review, and a
+> window where `main` carried English strings with no translations.
 
 ## Change detection (`.translation_state.json`)
 
@@ -327,22 +351,24 @@ source of truth that keeps subsequent runs incremental.
 2. **Test in UI**: Verify translations display correctly in the application
 3. **Manual Fixes**: Manual edits to a key are preserved until its English source changes
 4. **Context Matters**: Some terms may need manual translation for proper context
-5. **Land on `main`**: Translations are generated when `en-US.json` is merged to `main`
+5. **Pull before you push**: the workflow commits to your branch, so `git pull` after
+   a translation run to avoid a rejected push
 
 ## Cost Considerations
 
 Translation is billed per token by DeepSeek. The whole `en-US.json` is ~10,700
 strings; a full 14-language rebuild is a one-time cost, and day-to-day runs only
-translate the handful of new/changed keys per `en-US.json` merge.
+translate the handful of new/changed keys in a given PR.
 
 ### Cost Optimization:
 - ✅ Only **new or modified** keys are translated (unchanged text is never re-sent)
 - ✅ Strings are sent in **batches** (`TRANSLATION_BATCH_SIZE`, default 50) to cut request overhead
-- ✅ Runs on **`main` only**, and only when `en-US.json` changes (no per-branch re-billing)
+- ✅ Runs only when a PR **changes `en-US.json`**; the committed state file stops the
+  same string being re-translated on another branch or after a rebase
 - ✅ Batches run **concurrently** (`TRANSLATION_CONCURRENCY`, default 4) so a run finishes
-  and records its state instead of being overtaken by the next merge
-- ✅ Runs are **never cancelled mid-flight**, and partial progress is committed — work
-  already paid for is never discarded
+  well within a normal PR review cycle
+- ✅ A superseded run is cancelled, but partial progress from a **completed** run is
+  always committed — work already paid for is never discarded
 - ✅ Failed API calls / placeholder-mismatched outputs are retried next run, not silently kept
 
 ## Alternative Translation Services

--- a/scripts/translations/README.md
+++ b/scripts/translations/README.md
@@ -12,14 +12,41 @@ This system automatically translates the English locale file (`en-US.json`) into
 **Translations are generated inside the PR that changes `en-US.json`:**
 
 1. **Developer updates `en-US.json`** on a branch and opens a PR
-2. **GitHub Actions detects it** via the workflow's `paths:` filter — PRs that don't touch `en-US.json` never start a run at all
-3. **Translation script runs** using DeepSeek to update all language files
-4. **A commit is pushed back onto the PR's own branch** (`chore(i18n): update translations from en-US.json`)
-5. **The PR merges as a unit** — English strings and their translations land together
+2. **The PR is reviewed as normal.** No translation run happens yet — see
+   [When the run fires](#when-the-run-fires) for why
+3. **The author clicks "Merge when ready"** (or marks a draft ready for review)
+4. **Translation script runs** using DeepSeek to update all language files
+5. **A commit is pushed back onto the PR's own branch** (`chore(i18n): update translations from en-US.json`)
+6. **The PR merges as a unit** — English strings and their translations land together
+7. **The merge queue double-checks** via the separate **Verify Translations** workflow,
+   which blocks the merge if any string is still untranslated
 
 This means **translations are always up-to-date** without any manual intervention,
 and they are reviewed by the person who added the English strings — no ownerless
 follow-up PR to chase.
+
+### When the run fires
+
+The generation workflow triggers on the `auto_merge_enabled` and `ready_for_review`
+pull-request types, **not** on every push.
+
+It used to run on every push that changed `en-US.json`. The problem was not the
+translation job itself — that is cheap — but its commit: pushing to the PR branch
+re-runs the PR's *entire* check suite (playwright, unit-tests, api-testing, …) on the
+new head SHA. On a PR where you iterate on English strings five times, that is five
+extra full CI cycles, and then the merge queue runs everything a sixth time. Firing
+once, at the point you signal the PR is finished, collapses that to one.
+
+**Why not run it in the merge queue itself?** That is the obvious idea and it cannot
+work. Merge-queue branches (`gh-readonly-queue/*`) are read-only, and the commits in a
+queue entry are frozen — the entire point of a merge queue is that what gets tested is
+exactly what gets merged. A `merge_group` run has nowhere to put the translation
+commit. Pushing to the *PR's* branch from a `merge_group` run is worse: it ejects the
+PR from the queue, so everything behind it waits while it re-queues.
+
+So the queue gets a *check* instead of a generator — `Verify Translations`, which
+compares `en-US.json` against the locale files and `.translation_state.json`. It makes
+no API calls, needs no API key, and installs nothing, so it costs a few seconds.
 
 ## Supported Languages
 
@@ -91,38 +118,76 @@ cd scripts/translations
 python3 main.py fr-FR es-ES de-DE
 ```
 
+See what is pending without translating anything — no API key, no dependencies, no
+cost. This is exactly what the merge-queue gate runs:
+```bash
+cd scripts/translations
+python3 main.py --check          # exits 2 if anything is pending, 0 if clean
+```
+
 ## GitHub Actions Workflow
 
-### Automatic Translation Updates
+There are two workflows, with different jobs.
 
-The workflow (`.github/workflows/update-translations.yml`) automatically runs when:
+#### `update-translations.yml` — generates
 
-- **Trigger**: A pull request whose `web/src/locales/languages/en-US.json` differs
-  from the base branch (on open, reopen, and every subsequent push)
-- **Branches**: the PR's own head branch (plus manual `workflow_dispatch` from a
-  feature branch). Same-repo PRs only — see [Fork PRs](#fork-prs).
+- **Trigger**: a pull request whose `web/src/locales/languages/en-US.json` differs from
+  the base branch, on the `auto_merge_enabled` and `ready_for_review` types only — i.e.
+  when you click **Merge when ready** or take a draft out of draft. Plus manual
+  `workflow_dispatch` from a feature branch.
+- **Branches**: the PR's own head branch. Same-repo PRs only — see [Fork PRs](#fork-prs).
+- **Secrets**: `DEEPSEEK_API_KEY` and the push PAT.
 - **Action**:
-  1. Runs Python translation script
+  1. Runs the Python translation script (retrying failed strings in-process)
   2. Updates all language JSON files
   3. Commits them onto the PR branch as `chore(i18n): update translations from en-US.json`
-  4. The translations merge with the PR, so `main` never has untranslated strings
+
+#### `verify-translations.yml` — gates
+
+- **Trigger**: every pull request *and* every `merge_group` entry. No `paths:` filter —
+  a required check that gets filtered out sits at "Expected — waiting for status"
+  forever and blocks the PR.
+- **Secrets**: none, deliberately. It runs for fork PRs, so it holds nothing worth
+  stealing.
+- **Action**: runs `main.py --check`, which is a pure file comparison — no API calls, no
+  API key, no `pip install` (the `openai` import is lazy). A few seconds, zero tokens.
+- **Result**: on a PR it reports and stays green (pending strings are normal
+  mid-review). **In the merge queue it fails**, ejecting the entry rather than letting
+  English-only strings reach `main`.
+
+> Make **Verify translations are up to date** a required status check on `main`.
+> Nothing about this design guarantees anything until you do — that is the single
+> configuration step this PR depends on.
 
 ### Run lifecycle guarantees
 
-Three properties of the workflow matter when you are reading a run:
+These properties of the workflow matter when you are reading a run:
 
-- **A newer push cancels the run in flight.** The concurrency group is keyed on the
-  PR number with `cancel-in-progress: true`. Nothing is committed until a run
-  finishes, and the surviving run re-derives the full pending set from
-  `.translation_state.json` — so a cancelled run loses spend, never progress.
-- **Partial progress is always shipped.** Locale files are written atomically, one
-  locale at a time, and the commit step runs under `if: always()`. A run that fails
-  validation on some strings — or is cancelled manually — still commits the locales
-  it finished. Anything unfinished stays pending for the next push to the branch.
+- **A superseding run cancels the one in flight, and the cancelled run commits
+  nothing.** The concurrency group is keyed on the PR number with
+  `cancel-in-progress: true`, and the commit steps are gated on `!cancelled()` —
+  deliberately *not* `always()`, which would include cancellation and let the
+  superseded run race the newer one to push partially-written locale files. The
+  surviving run re-derives the full pending set from `.translation_state.json`, so a
+  cancelled run loses spend, never progress.
+- **Failed strings are retried inside the same run**, up to three attempts. Each
+  attempt re-derives what is pending from state, so it only re-sends the strings that
+  actually failed — a retry after a near-complete run is nearly free. This has to
+  happen in-process now: the workflow no longer fires on `synchronize`, so its own
+  commit does not bring it back for another go.
+- **Partial progress is still shipped.** Locale files are written atomically, one
+  locale at a time. A run that is still incomplete after three attempts commits the
+  locales it finished and marks the commit `Translation-Run: partial`, so a later
+  re-run picks the rest up instead of being short-circuited by the skip-guard. The
+  merge-queue gate is what stops that PR merging in the meantime.
 - **The push re-runs the PR's checks.** The commit is pushed with a user PAT rather
   than `GITHUB_TOKEN`, because GitHub deliberately does not trigger workflows for
   `GITHUB_TOKEN` pushes — the new head SHA would carry no status checks and required
   checks could never pass.
+- **A deleted head branch is never recreated.** If the PR merges mid-run, the job
+  checks that the branch still exists on origin before pushing and bails with a
+  warning rather than resurrecting it as a stray. Those strings stay pending for the
+  next PR that touches `en-US.json`.
 
 ### Setup Requirements
 
@@ -131,13 +196,45 @@ The workflow needs two repository secrets:
 | Secret | Value | Why |
 |--------|-------|-----|
 | `DEEPSEEK_API_KEY` | Your DeepSeek API key | Authenticates the translation calls |
-| `TRANSLATIONS_APPROVE_TOKEN` | PAT (repo scope) for a real user account | Pushes the translation commit so the PR's checks re-run |
+| `TRANSLATIONS_APPROVE_TOKEN` | **Fine-grained** PAT for a real user account, scoped to *this repository only* with `Contents: read and write` | Pushes the translation commit so the PR's checks re-run |
 
 Set them under **Settings → Secrets and variables → Actions → New repository secret**
 (or via `gh secret set …`). The workflow fails fast with a clear error if
 `DEEPSEEK_API_KEY` is missing; if `TRANSLATIONS_APPROVE_TOKEN` is missing it falls
 back to `GITHUB_TOKEN`, which still commits the translations but leaves the PR's
 checks unre-run on the new head SHA.
+
+#### Why the PAT must be fine-grained
+
+This workflow triggers on `pull_request`, which runs from the PR's **merge ref** — so
+`requirements.txt`, `main.py`, `translator.py` *and this workflow file itself* come
+from the PR, not from `main`. (That is the difference from `pull_request_target`,
+which always uses the base branch's workflow definition.) A same-repo PR can therefore
+change anything about what runs in this job. Fork PRs are skipped and
+would not receive secrets in any case, so the blast radius is "anyone with push
+access" — but a classic `repo`-scope PAT belonging to a human account grants far more
+than that, across every repository they can reach. Scope it down.
+
+Three things in the workflow narrow the exposure. None of them is a boundary — a PR
+that edits the workflow file can undo all three — but they mean an *accidental*
+leak (a dependency that phones home, a stack trace with the environment in it) has
+much less to reach:
+
+- `actions/checkout` runs with `persist-credentials: false`, so the push token is not
+  sitting in `.git/config` while PR-authored Python runs.
+- The token is a **step-level** `env:` on the commit step only — nothing above it,
+  including `pip install` and `python3 main.py`, has it in the environment.
+- `requirements.txt` carries an upper version bound so a major release cannot land
+  unreviewed. (Full hash pinning via `pip install --require-hashes` is the stronger
+  form and is still worth doing.)
+
+The only real boundary is a `workflow_run` split: this workflow produces the locale
+files as an artifact and holds no secrets that survive it, and a second workflow —
+which `workflow_run` always runs from `main`'s definition, never the PR's — holds the
+push token and does the commit. Until that lands, **the security model here is "every
+account with push access to this repo is trusted with both secrets"**, and the
+fine-grained PAT is what keeps that from meaning "trusted with a human's whole GitHub
+account".
 
 ### Fork PRs
 
@@ -151,34 +248,51 @@ state file makes it translate everything still pending, not just that PR's strin
 
 ```mermaid
 graph TD
-    A[PR opened / pushed] --> C{en-US.json differs<br/>from the base branch?}
-    C -->|No| E[No run is created at all]
-    C -->|Yes| B{Head commit is our<br/>own translation commit?}
+    A[PR opened / pushed] --> V[Verify Translations runs<br/>reports pending, stays green]
+    V --> P[Review happens - no API spend yet]
+    P --> A2["Author clicks Merge when ready<br/>(or marks a draft ready)"]
+    A2 --> C{en-US.json differs<br/>from the base branch?}
+    C -->|No| E[No generation run is created]
+    C -->|Yes| B{Head commit is a complete<br/>translation commit?}
     B -->|Yes| G2[Skip - nothing to do]
-    B -->|No| D[Run translation script]
-    D --> F{Any new/changed keys<br/>vs .translation_state.json?}
-    F -->|No| G[Done - already up to date]
-    F -->|Yes| H[Translate pending keys only]
-    H --> I[Commit onto the PR branch]
-    I --> J[PR checks re-run on the new head SHA]
-    J --> K[PR merges with its translations]
+    B -->|No, or marked partial| D[Translate pending keys only<br/>retrying failures up to 3x]
+    D --> L{Cancelled by a<br/>superseding run?}
+    L -->|Yes| M[Commit nothing -<br/>the newer run redoes it]
+    L -->|No| I[Commit onto the PR branch<br/>marked partial if any string failed]
+    I --> J[Push re-runs the PR's checks - ONCE]
+    J --> Q[PR enters the merge queue]
+    G2 --> Q
+    Q --> R{Verify Translations<br/>in merge_group}
+    R -->|Pending strings| S[Block - eject from queue]
+    R -->|All translated| K[Merged with its translations]
 ```
 
 **Workflow Execution Order:**
 
-1. **Push to a PR branch** → GitHub's `paths:` filter decides whether a run is created
-2. Script reconciles `en-US.json` against `.translation_state.json`
+1. **PR opened / pushed** → `Verify Translations` reports what is pending. Green either
+   way; no generation, no API spend
+2. **Author signals the PR is done** → GitHub's `paths:` filter decides whether a
+   generation run is created
+3. Script reconciles `en-US.json` against `.translation_state.json`
    - New / changed keys: translated
    - Everything else: kept, never re-sent to the API
-3. **If any file changed** → commit pushed onto the PR's head branch
-4. **The PR merges** carrying both the English strings and their translations
+4. **If any file changed** → one commit pushed onto the PR's head branch, which
+   re-runs the PR's checks exactly once
+5. **Merge queue** → `Verify Translations` blocks if anything is still untranslated
+6. **The PR merges** carrying both the English strings and their translations
 
 **Key Features:**
-- ✅ **Cheap trigger** - a PR without `en-US.json` changes creates no run at all
+- ✅ **Cheap trigger** - a PR without `en-US.json` changes creates no generation run
+- ✅ **One extra CI cycle per PR** - not one per edit to `en-US.json`
+- ✅ **Free gate** - the merge-queue check makes no API calls and installs nothing
 - ✅ **Smart detection** - only new or modified keys are translated
 - ✅ **Owned and reviewed** - translations land in the author's PR, not an ownerless follow-up PR
-- ✅ **`main` is never missing translations** - English and translated strings land in the same merge
-- ✅ **Crash/cancel safe** - completed locales are still committed
+- ✅ **`main` is never missing translations** - enforced by the merge-queue gate, once
+  you make it a required check
+- ✅ **Crash safe** - failed strings are retried in-process; whatever completes is
+  still committed
+- ✅ **Cancel safe** - a superseded run commits nothing, so it can never overwrite the
+  newer run's work; the next run re-derives everything still pending
 - ✅ **No re-billing across branches** - the committed state file means each string is
   translated once, on whichever branch first introduces it
 
@@ -238,22 +352,108 @@ web/src/locales/languages/
 
 **Symptom:** You changed `en-US.json` but no **Update Translations** run appears.
 
-The trigger is a `paths:` filter on **pull requests** — GitHub evaluates it before
-any job exists, so a PR that doesn't change `en-US.json` produces no run at all.
+**Most likely this is working as intended.** Generation no longer fires on push — it
+waits until you click **Merge when ready** or mark a draft ready for review. See
+[When the run fires](#when-the-run-fires). The `Verify Translations` check will show
+you what is pending in the meantime.
 
-Check, in order:
+If you want the translations now, without merging, trigger it by hand: **Actions →
+Update Translations → Run workflow**, selecting your branch.
+
+Otherwise check, in order:
 
 ```bash
-# 1. Is there an open PR, and does its diff really touch the source file?
+# 1. Does the PR's diff really touch the source file?
 git diff --name-only origin/main...HEAD | grep en-US.json
 
 # 2. Is the PR from a fork? Fork PRs are skipped — see "Fork PRs" above.
 gh pr view --json headRepositoryOwner,isCrossRepository
+
+# 3. What does the workflow think is pending? (free, no API key needed)
+cd scripts/translations && python3 main.py --check
 ```
 
 If a run exists but produced no commit, the keys were already recorded in
-`.translation_state.json` — nothing was pending. Confirm with a local run:
-`python3 main.py` prints `Translating: <locale> (N strings pending)`.
+`.translation_state.json` — nothing was pending, and `--check` will agree.
+
+### My PR Got Ejected From the Merge Queue
+
+**Symptom:** you clicked **Merge when ready**, the PR queued, then fell out with "the
+head branch was updated".
+
+Any push to a queued PR's branch ejects it, and the translation commit is such a push.
+Clicking **Merge when ready** is exactly what starts the translation run, so if all your
+other checks were already green the PR can enter the queue before the translation
+commit lands, and the commit then knocks it out.
+
+**This is self-healing — do nothing.** Auto-merge stays enabled through the eject, so
+once the checks re-run on the translation commit the PR re-queues by itself. You pay
+one extra queue pass, not a manual re-queue.
+
+To avoid it entirely on a PR you know touches `en-US.json`, run **Actions → Update
+Translations** on your branch first, then click Merge when ready once the `chore(i18n)`
+commit is on the branch. The generation run is then a no-op.
+
+### I Force-Pushed and It Re-Translated Everything
+
+A rebase or amend that drops the translation commit also drops the
+`.translation_state.json` update that came with it. The next run sees those keys as
+pending again and pays for them a second time.
+
+**Solution:** when rebasing, keep the `chore(i18n)` commit (it is a normal commit —
+`git rebase` preserves it unless you explicitly drop or squash it away). If you did
+lose it, nothing breaks; the run simply re-bills those strings.
+
+### Two PRs Conflict in the Generated Locale Files
+
+**Symptom:** two open PRs both changed `en-US.json`; the second to merge has conflicts
+in the 14 locale files and in `.translation_state.json`.
+
+This is inherent to generating in each PR rather than in one serialised bot PR. Both
+branches rewrote the same generated files. Generating at merge time rather than on
+every push makes it much rarer — the two runs have to overlap, instead of both PRs
+carrying translation commits for their whole review — but it is still possible when
+two PRs are queued close together.
+
+**Solution:** do not hand-resolve generated JSON. Take the base branch's copies of the
+generated files, keep your own `en-US.json`, and let the workflow regenerate the rest.
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+When the rebase stops on the conflict (note the inversion: during a rebase `--ours` is
+the branch you are rebasing *onto*, `--theirs` is your commit being replayed):
+
+```bash
+# Generated files: take main's copies.
+git checkout --ours -- web/src/locales/languages/ scripts/translations/.translation_state.json
+# If en-US.json is also conflicted, keep YOUR English strings instead.
+git checkout --theirs -- web/src/locales/languages/en-US.json
+git add -- web/src/locales/languages/ scripts/translations/.translation_state.json
+git rebase --continue
+git push --force-with-lease
+```
+
+The push does **not** re-fire generation (it only fires on Merge when ready), so click
+**Merge when ready** again — or run the workflow by hand. Either way it re-derives
+exactly the keys still pending: both your PR's strings and any the other PR left
+undone. `python3 main.py --check` tells you what that will be before you spend
+anything.
+
+### The PR Merged Before Its Translations Landed
+
+**This should not happen once `Verify translations are up to date` is a required check**
+— that is the whole point of it. The queue entry fails and the PR is ejected before it
+can merge untranslated.
+
+If it does happen (the check is not required yet, or someone merged with admin
+override), the branch is gone by the time the job pushes. The job detects this and
+**does not** recreate the branch as a stray; the run's Summary says so, and the strings
+stay pending in `.translation_state.json` for the next PR that touches `en-US.json` (or
+a manual `workflow_dispatch` on a fresh branch). Nothing is lost, `main` is just
+briefly English-only for those keys.
 
 ### API Key Error
 ```
@@ -307,15 +507,19 @@ check that PR:
    gh pr create
    ```
 
-3. **Workflow automatically (on your PR):**
-   - Triggers because `web/src/locales/languages/en-US.json` differs from the base branch
-   - Runs translation script
+3. **Get it reviewed.** No translation run yet — `Verify Translations` shows the new
+   keys as pending and stays green. Push as many times as you like; none of it costs
+   API spend or an extra CI cycle.
+
+4. **Click "Merge when ready".** Now the workflow:
+   - Triggers, because `en-US.json` differs from the base branch
    - Translates only the **new or modified** keys to all 14 languages
    - Pushes `fr-FR.json`, `es-ES.json`, etc. plus `.translation_state.json` onto your branch
+   - That one push re-runs your PR's checks; then it queues and merges
 
-4. **Review and merge:**
+5. **Afterwards:**
    - `git pull` to pick up the translation commit before your next push
-   - Review the generated strings alongside your own change, then merge as usual
+   - Review the generated strings alongside your own change
 
 > **Why in the PR, and not on `main`?** Re-translation across branches is already
 > prevented by the committed state file, not by the trigger: a string is translated
@@ -353,6 +557,8 @@ source of truth that keeps subsequent runs incremental.
 4. **Context Matters**: Some terms may need manual translation for proper context
 5. **Pull before you push**: the workflow commits to your branch, so `git pull` after
    a translation run to avoid a rejected push
+6. **Check before you merge**: `python3 main.py --check` costs nothing and tells you
+   exactly what the merge-queue gate will see
 
 ## Cost Considerations
 
@@ -365,11 +571,21 @@ translate the handful of new/changed keys in a given PR.
 - ✅ Strings are sent in **batches** (`TRANSLATION_BATCH_SIZE`, default 50) to cut request overhead
 - ✅ Runs only when a PR **changes `en-US.json`**; the committed state file stops the
   same string being re-translated on another branch or after a rebase
+- ✅ Runs **once per PR, at merge time** — not once per push. Iterating on English
+  strings during review costs nothing, and the PR pays for one translation run and one
+  extra CI cycle no matter how many times you edit `en-US.json`
+- ✅ The merge-queue gate is **free**: pure file comparison, no API calls, no API key,
+  no `pip install`
 - ✅ Batches run **concurrently** (`TRANSLATION_CONCURRENCY`, default 4) so a run finishes
   well within a normal PR review cycle
-- ✅ A superseded run is cancelled, but partial progress from a **completed** run is
-  always committed — work already paid for is never discarded
-- ✅ Failed API calls / placeholder-mismatched outputs are retried next run, not silently kept
+- ✅ Failed strings are retried **inside the same run**, and each retry re-derives what
+  is pending, so only the strings that actually failed are re-sent
+- ⚠️ A superseded run is cancelled before it commits, so its spend **is** lost and the
+  surviving run re-translates those keys. That is the deliberate trade: letting a
+  cancelled run commit would race the newer run and regress locale files, which costs
+  more to untangle than the tokens do. Rare now that generation fires once per PR.
+- ✅ Partial progress from a run that **finished with failures** is still committed —
+  work already paid for is never discarded
 
 ## Alternative Translation Services
 

--- a/scripts/translations/main.py
+++ b/scripts/translations/main.py
@@ -11,6 +11,13 @@ translator.py for the change-detection model).
 Usage:
     python main.py                    # translate all supported languages
     python main.py fr-FR es-ES de-DE  # translate specific languages (filename stems)
+    python main.py --check            # report what is pending; translate nothing
+
+Exit codes:
+    0  nothing to do, or everything translated
+    1  bad usage / missing source
+    2  --check only: translations are pending
+    3  at least one string failed validation (retried on the next run)
 
 Environment:
     DEEPSEEK_API_KEY   Required. API key for https://api.deepseek.com.
@@ -37,12 +44,47 @@ from translator import (
 )
 
 
+def run_check(locales):
+    """Report every key still needing translation, without touching the API.
+
+    Pure comparison of en-US.json against the locale files and
+    .translation_state.json, so it costs nothing, needs no API key, and writes
+    nothing. This is what the merge-queue gate runs to prove a merge is not about
+    to land English-only strings on main.
+    """
+    source = load_source()
+    if not source:
+        print("ERROR: en-US.json source is empty or missing.")
+        sys.exit(1)
+
+    state = load_state()
+    total = 0
+    for locale in locales:
+        existing = load_json(get_language_file_path(locale), {})
+        pending = collect_pending_leaves(source, existing, state)
+        if not pending:
+            continue
+        total += len(pending)
+        shown = [".".join(path) for path, _ in pending[:5]]
+        more = f" (+{len(pending) - len(shown)} more)" if len(pending) > len(shown) else ""
+        print(f"  {locale}: {len(pending)} pending — {', '.join(shown)}{more}")
+
+    if total:
+        print(
+            f"\n{total} translation(s) pending across {len(locales)} language(s)."
+        )
+        sys.exit(2)
+
+    print(f"All {len(locales)} language(s) are up to date with en-US.json.")
+
+
 def main():
     supported = get_supported_languages()
 
     args = sys.argv[1:]
     # `--force` is accepted for backward compatibility but is now a no-op: there
     # is no safety cap to bypass.
+    check_only = "--check" in args
     requested = [a for a in args if not a.startswith("--")]
 
     if requested:
@@ -57,6 +99,10 @@ def main():
     if not locales:
         print("ERROR: No valid languages to translate.")
         sys.exit(1)
+
+    if check_only:
+        run_check(locales)
+        return
 
     source = load_source()
     if not source:

--- a/scripts/translations/requirements.txt
+++ b/scripts/translations/requirements.txt
@@ -1,1 +1,4 @@
-openai>=1.40.0
+# Upper bound is deliberate: CI installs this file from the *PR head* and runs it
+# with an API key in the environment, so an unbounded range would let a major
+# version land without review. Bump it consciously.
+openai>=1.40.0,<2

--- a/scripts/translations/translator.py
+++ b/scripts/translations/translator.py
@@ -38,7 +38,10 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from openai import OpenAI
+# `openai` is imported inside _get_client(), not here: the change-detection half of
+# this module (collect_pending_leaves, load_state, …) is pure file comparison, and
+# `main.py --check` runs it with no dependencies installed and no API key — which is
+# what lets the merge-queue gate be free.
 
 STATE_FILENAME = ".translation_state.json"
 
@@ -163,13 +166,16 @@ def _get_client():
     """Lazily construct the DeepSeek (OpenAI-compatible) client.
 
     Constructed on first use so that dry passes / imports don't require the API
-    key to be present (e.g. when only counting pending work). The client itself is
-    thread-safe and shared by every worker; only its construction is locked.
+    key — or the `openai` package — to be present (e.g. when only counting pending
+    work). The client itself is thread-safe and shared by every worker; only its
+    construction is locked.
     """
     global _client
     if _client is None:
         with _client_lock:
             if _client is None:
+                from openai import OpenAI
+
                 api_key = os.environ.get("DEEPSEEK_API_KEY")
                 if not api_key:
                     raise TranslationError(


### PR DESCRIPTION
The translation job ran on `push: main` and opened a separate `chore/update-translations` PR. That PR had no owner — it was never assigned to or reviewed by a human — and it left a window where main carried English strings with no translations.

Move the trigger to `pull_request` and commit the generated locale files back onto the PR's own head branch, so the author who added the English strings also owns their translations and both land in one merge.

Notes on the mechanics:

- The commit is pushed with TRANSLATIONS_APPROVE_TOKEN, not GITHUB_TOKEN. GitHub does not trigger workflows for GITHUB_TOKEN pushes, so the new head SHA would carry no status checks and required checks could never pass — the PR would be wedged. Falls back to GITHUB_TOKEN if unset.
- A guard step skips the run when the head commit is already the generated translation commit, so the PAT push cannot ping-pong.
- Fork PRs are skipped: their branch lives in the contributor's repo and no token here can push to it.
- concurrency flips to cancel-in-progress: true. The `false` was main-specific (merges landed faster than a run finished); on a PR branch nothing is committed until a run completes and the surviving run re-derives the pending set from .translation_state.json, so a cancel costs spend, never progress.
- The push retries with a rebase in case the author pushes concurrently.

Cost does not regress: re-translation across branches is prevented by the committed per-key hashes in .translation_state.json, not by the trigger, so each string is still translated once — on whichever branch first introduces it.