### PR TITLE
feat(metrics): sort metrics files by series during compaction

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1342,6 +1342,12 @@ pub struct Common {
     )]
     pub file_format: FileFormatConfig,
     #[env_config(
+        name = "ZO_METRICS_SORT_BY_SERIES",
+        default = true,
+        help = "Sort metrics files by (__hash__, _timestamp) during compaction instead of _timestamp desc. Greatly improves compression ratio and series-lookup locality, at the cost of in-file time ordering (file-level time pruning still applies)"
+    )]
+    pub metrics_sort_by_series: bool,
+    #[env_config(
         name = "ZO_VORTEX_USE_NATIVE_COMPRESSION",
         default = false,
         help = "Use Vortex's built-in compression strategy. By default, OpenObserve's custom UTF8/Zstd compressor is used"

--- a/src/search/src/datafusion/merge/mod.rs
+++ b/src/search/src/datafusion/merge/mod.rs
@@ -18,7 +18,10 @@ use std::sync::Arc;
 use arrow::array::RecordBatch;
 use config::{
     FileFormat, FileFormatConfig, TIMESTAMP_COL_NAME, get_config,
-    meta::stream::{FileMeta, StreamType},
+    meta::{
+        promql::HASH_LABEL,
+        stream::{FileMeta, StreamType},
+    },
     utils::{
         parquet::{VORTEX_FILE_META_KEY, encode_vortex_file_meta, new_parquet_writer},
         util::DISTINCT_STREAM_PREFIX,
@@ -103,6 +106,12 @@ pub async fn merge_parquet_files(
         }
     }
 
+    // Sort metrics files by series when enabled: groups each series' rows
+    // together so __hash__ collapses under RLE/dictionary encoding.
+    let sort_by_series = stream_type == StreamType::Metrics
+        && cfg.common.metrics_sort_by_series
+        && schema.field_with_name(HASH_LABEL).is_ok();
+
     // get all sorted data
     let sql = if cfg.limit.distinct_values_hourly
         && stream_type == StreamType::Metadata
@@ -121,14 +130,18 @@ pub async fn merge_parquet_files(
     } else if stream_type == StreamType::Filelist {
         // for file list we do not have timestamp, so we instead sort by min ts of entries
         "SELECT * FROM tbl ORDER BY min_ts DESC".to_string()
+    } else if sort_by_series {
+        format!("SELECT * FROM tbl ORDER BY {HASH_LABEL} ASC, {TIMESTAMP_COL_NAME} ASC")
     } else {
         format!("SELECT * FROM tbl ORDER BY {TIMESTAMP_COL_NAME} DESC")
     };
     log::debug!("merge_parquet_files sql: {sql}");
 
+    // Once series sorting is enabled, previously compacted input files are no
+    // longer time-ordered, so the time-sorted claim must be dropped.
     let ctx = DataFusionContextBuilder::new()
         .trace_id("merge_parquet_files")
-        .sorted_by_time(true)
+        .sorted_by_time(!sort_by_series)
         .build(get_config().limit.datafusion_min_partition_num)
         .await?;
     // register union table

--- a/src/search_service/src/grpc/storage.rs
+++ b/src/search_service/src/grpc/storage.rs
@@ -23,7 +23,7 @@ use config::{
     meta::{
         inverted_index::IndexOptimizeMode,
         search::{ScanStats, StorageType},
-        stream::FileKey,
+        stream::{FileKey, StreamType},
     },
     metrics::{self, QUERY_PARQUET_CACHE_RATIO_NODE},
     utils::size::bytes_to_human_readable,
@@ -69,6 +69,11 @@ pub async fn search(
     } = query.as_ref();
     let enter_span = tracing::span::Span::current();
     log::info!("[trace_id {trace_id}] search->storage: enter");
+    // Metrics files are sorted by (__hash__, _timestamp) when
+    // metrics_sort_by_series is enabled, so they must not be declared
+    // time-sorted to DataFusion.
+    let sorted_by_time = sorted_by_time
+        && !(*stream_type == StreamType::Metrics && get_config().common.metrics_sort_by_series);
     let mut files = file_list.to_vec();
     if files.is_empty() {
         return Ok((vec![], ScanStats::default(), HashSet::new()));


### PR DESCRIPTION
## Motivation

For metrics streams, `__hash__` (the series identifier, a hash of metric name + labels) dominates storage: on a 548M-row benchmark dataset it accounts for **89.4%** of total file size and is incompressible (1.0x with zstd) — random u64 values have maximal entropy.

However, the column has structure that the current layout cannot exploit: only ~900K distinct series across 548M rows (~610 rows per series). With the current `ORDER BY _timestamp DESC` compaction order, rows of the same series are interleaved, so every row group sees nearly-unique values and dictionary/RLE encoding falls back to PLAIN.

Sorting files by `(__hash__, _timestamp)` during compaction groups each series' rows together, letting RLE_DICTIONARY collapse the column almost entirely.

## Measured impact (offline experiment on the same dataset)

| | time-ordered | series-ordered | change |
|---|---|---|---|
| Parquet dataset size | 5.7 GB | **1.1 GB** | **-81%** |
| Vortex dataset size | 6.4 GB | 2.2 GB | -66% |
| Series point lookup (`__hash__ = x`) | 0.79s | **0.014s** | 24x faster (row-group pruning now effective) |
| String contains filter | 1.35s | 0.28–1.3s | up to 4.6x faster |
| Time-range query (in-file page pruning lost) | 0.08s | 0.53s | slower — see trade-off notes |
| Full-scan aggregations | ~1.1s | ~1.4s | ~30% slower |

The time-range regression is bounded in production: file-level `min_ts`/`max_ts` pruning (the primary time filter) is unaffected; only in-file page-level time pruning is lost. The benchmark dataset spans just ~3h so the loss is exaggerated there.

## Changes

Gated behind a new flag **`ZO_METRICS_SORT_BY_SERIES`** (default `false`):

1. **`config.rs`** — new `common.metrics_sort_by_series` setting.
2. **`search/datafusion/merge/mod.rs`** — compaction merge for metrics streams whose schema contains `__hash__` uses `ORDER BY __hash__ ASC, _timestamp ASC` instead of `ORDER BY _timestamp DESC`. The merge read-context also drops its `sorted_by_time` claim in this mode, since second-generation input files are no longer time-ordered.
3. **`search_service/grpc/storage.rs`** — SQL search no longer declares `file_sort_order = [_timestamp DESC]` on metrics listing tables when the flag is on (that claim is a correctness contract that lets DataFusion elide sorts). The PromQL path (`register_metrics_table`) never made this claim and needs no change.

Ingester-written files keep time order (real-time query locality); the layout converges as the compactor rewrites files, so no migration of existing data is required.

## Not covered / follow-ups

- Downsampling merge path is unchanged (it aggregates rather than passes rows through).
- Vortex benefits less than parquet from this ordering with the current write strategy (2.2 GB vs 1.1 GB); worth tuning separately.

## Testing

- `cargo check` on `config` / `search` / `search_service`; full release build passes.
- Offline layout experiment above (sort + rewrite of the benchmark dataset, checksum-verified identical query results across layouts on 14 query shapes).
- TODO (reason for draft): end-to-end ingest → compact → PromQL verification with the flag enabled.
