### PR TITLE
refactor(sentinel): dedup page-object methods + testLogger convention (follow-up to #13735)

### DIFF
--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -408,7 +408,8 @@ export class AlertsPage {
     }
 
     getTemplateRowByText(name) {
-        return this.page.getByText(name);
+        // Same locator as getAlertRowByText — kept as a semantic alias, single impl.
+        return this.getAlertRowByText(name);
     }
 
     getAlertHistoryRowsLocator() {
@@ -4409,7 +4410,7 @@ export class AlertsPage {
 
     /** Destination select control */
     getDestinationsSelect() {
-        return this.page.locator(this.locators.alertDestinationsSelect);
+        return this.getAlertDestinationsSelectLocator();
     }
 
     /** Destination option by name */
@@ -4421,7 +4422,7 @@ export class AlertsPage {
 
     /** Add-alert submit button */
     getAddAlertSubmitButton() {
-        return this.page.locator(this.locators.alertSubmitButton);
+        return this.getAlertSubmitButtonLocator();
     }
 
     /** Toast message filtered by text */

--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -491,10 +491,7 @@ export class AlertsPage {
         return this.page.locator(this.locators.errorToastOrAlert);
     }
 
-    /** Toast message filtered by exact text. */
-    getToastMessageByText(text) {
-        return this.page.locator(this.locators.oToastMessage).filter({ hasText: text });
-    }
+
 
     /** Page body (used for click-away to dismiss dropdowns). */
     getBodyLocator() {
@@ -563,10 +560,7 @@ export class AlertsPage {
         return this.page.locator(this.locators.helpCurrentSection);
     }
 
-    /** Advanced tab Template Override select (form-side). */
-    getAdvancedTemplateOverrideSelect() {
-        return this.page.locator(this.locators.advancedTemplateOverrideSelect);
-    }
+
 
     /** In-drawer preview template select (root — pass to openOSelectDropdown). */
     getHelpPreviewTemplateSelect() {
@@ -1136,29 +1130,9 @@ export class AlertsPage {
 
     // ==================== REGRESSION TEST HELPER METHODS ====================
 
-    /**
-     * Click the "Add Alert" button on the alerts list page
-     */
-    async clickAddAlertButton() {
-        const btn = this.page.locator(this.locators.addAlertButton);
-        await btn.waitFor({ state: 'visible', timeout: 5000 });
-        await btn.click();
-        await this.page.waitForLoadState('domcontentloaded', { timeout: 10000 }).catch(() => {});
-        testLogger.info('Clicked Add Alert button');
-    }
 
-    /**
-     * Fill the alert name input in the add alert form
-     * @param {string} name - Alert name
-     */
-    async fillAlertName(name) {
-        // Inline-edit title: click the trigger to open the editor, then fill the input.
-        await this.page.locator(this.locators.alertNameTrigger).waitFor({ state: 'visible', timeout: 3000 });
-        await this.page.locator(this.locators.alertNameTrigger).click();
-        await this.page.locator(this.locators.alertNameInputField).waitFor({ state: 'visible', timeout: 3000 });
-        await this.page.locator(this.locators.alertNameInputField).fill(name);
-        testLogger.info(`Filled alert name: ${name}`);
-    }
+
+
 
     /**
      * Read the current alert name from the inline-edit title (OFormInlineEdit).
@@ -3169,12 +3143,7 @@ export class AlertsPage {
         return this.page.locator(this.locators.conditionColumnSelect).first();
     }
 
-    /**
-     * Get the Step 2: Query Config section container
-     */
-    getStepQueryConfigSection() {
-        return this.page.locator(this.locators.stepQueryConfig);
-    }
+
 
     /**
      * Get the operator select dropdown

--- a/tests/ui-testing/pages/generalPages/cipherKeysFormValidationPage.js
+++ b/tests/ui-testing/pages/generalPages/cipherKeysFormValidationPage.js
@@ -141,10 +141,7 @@ export class CipherKeysFormValidationPage {
     await this.continueButton.click();
   }
 
-  async clickSave() {
-    await this.saveButton.waitFor({ state: 'visible' });
-    await this.saveButton.click();
-  }
+
 
   // ── OpenObserve secret ──────────────────────────────────────────────────────
 

--- a/tests/ui-testing/pages/generalPages/correlationSettingsPage.js
+++ b/tests/ui-testing/pages/generalPages/correlationSettingsPage.js
@@ -373,10 +373,7 @@ export class CorrelationSettingsPage {
         await expect(this.page.locator(this.importJsonBtn)).toBeVisible({ timeout: 15000 });
     }
 
-    async expectAlertCorrelationContentVisible() {
-        // Wait for the Alert Correlation tab content to be visible
-        await expect(this.page.locator(this.dedupSettingsRefreshBtn)).toBeVisible({ timeout: 15000 });
-    }
+
 
     // ==================== Service Discovery (Configuration) Tab Actions ====================
 

--- a/tests/ui-testing/pages/generalPages/crossLinkPage.js
+++ b/tests/ui-testing/pages/generalPages/crossLinkPage.js
@@ -752,13 +752,6 @@ export class CrossLinkPage {
         return this.page.locator(this.crossLinkItem(idx));
     }
 
-    async crossLinkItemEditBtnLocatorByIdx(idx) {
-        return this.page.locator(this.crossLinkEditBtn(idx));
-    }
-
-    async crossLinkItemDeleteBtnLocatorByIdx(idx) {
-        return this.page.locator(this.crossLinkDeleteBtn(idx));
-    }
 
     // ── Locator getters for assertions in spec files ──────────────────────────
 

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -1659,24 +1659,7 @@ export class LogsPage {
         return isOn;
     }
 
-    // Histogram methods
-    async toggleHistogram() {
-        // Histogram is a standalone toolbar button (data-test="logs-search-bar-histogram-btn")
-        // in normal-width viewports. It falls back into the utilities ("More") dropdown only
-        // when the viewport is very narrow (shouldMoveButtonsToMenu breakpoint < 328px).
-        await this.page.keyboard.press('Escape').catch(() => {});
-        const inlineBtn = this.page.locator('[data-test="logs-search-bar-histogram-btn"]');
-        const isInline = await inlineBtn.isVisible({ timeout: 2000 }).catch(() => false);
-        if (isInline) {
-            await inlineBtn.click();
-            return;
-        }
-        // Narrow-viewport fallback: open the utilities menu and click the menu item.
-        await this.page.locator(this.utilitiesMenuButton).click();
-        const histogramMenuItem = this.page.locator(this.menuHistogramBtn);
-        await histogramMenuItem.waitFor({ state: 'visible', timeout: 5000 });
-        await histogramMenuItem.click();
-    }
+
 
     async toggleHistogramAndExecute() {
         await this.toggleHistogram();
@@ -2412,22 +2395,14 @@ export class LogsPage {
 
     // --- Sentinel POM helpers (relocated from spec files) ---
 
-    // Open the date-time picker and select a relative range, e.g. '1-h', '30-m', '15-m'.
-    async setRelativeTimeRange(rangeToken) {
-        await this.page.locator(this.dateTimeButton).click();
-        await this.page.waitForTimeout(500);
-        await this.page.locator(`[data-test="date-time-relative-${rangeToken}-btn"]`).click();
-        await this.page.waitForTimeout(1000);
-    }
+
 
     // Text of the quick-pick "+N more" footer.
     async getQuickPickMoreFooterText() {
         return await this.page.locator(this.quickPickMoreFooter).innerText();
     }
 
-    getQueryEditorLocator() {
-        return this.page.locator(this.queryEditor);
-    }
+
 
     getShareLinkButtonLocator() {
         return this.page.locator(this.shareLinkButton);
@@ -2548,10 +2523,7 @@ export class LogsPage {
         return await this.managementPage.navigateToManagement();
     }
 
-    // Additional methods needed for tests
-    async clickDateTimeButton() {
-        return await this.page.locator(this.dateTimeButton).click({ force: true });
-    }
+
 
     async clickRelative15MinButton() {
         return await this.page.locator(this.relative15MinButton).click({ force: true });
@@ -3982,12 +3954,7 @@ export class LogsPage {
         await expect(this.page.getByText(text, { exact: true })).toBeVisible();
     }
 
-    async expectLogsTableVisible() {
-        const table = this.page.locator(this.logsTable);
-        // Wait for the table to be visible with a timeout
-        await table.waitFor({ state: 'visible', timeout: 30000 });
-        return await expect(table).toBeVisible();
-    }
+
 
     async waitForSearchResults(timeout = 30000) {
         const table = this.page.locator(this.logsTable);
@@ -4004,9 +3971,7 @@ export class LogsPage {
         return await expect(this.page.getByText(/Field is required/).first()).toBeVisible();
     }
 
-    async expectErrorWhileFetchingNotVisible() {
-        return await expect(this.page.getByRole('heading', { name: 'Error while fetching' })).not.toBeVisible();
-    }
+
 
     async clickBarChartCanvas() {
         // Wait for network idle to ensure chart data has loaded
@@ -4556,9 +4521,7 @@ export class LogsPage {
         return await expect(this.page.locator(this.searchBarRefreshButton)).toBeVisible();
     }
 
-    async expectQuickModeToggleVisible() {
-        return await expect(this.page.locator(this.quickModeToggle)).toBeVisible();
-    }
+
 
     async clickInterestingFieldButton(field) {
         const btnLocator = this.page.locator(this.interestingFieldBtn(field)).first();
@@ -4813,12 +4776,7 @@ export class LogsPage {
         return await this.page.locator(this.savedFunctionNameInput).click();
     }
 
-    async fillSavedFunctionNameInput(text) {
-        // OInput wrapper data-test is "saved-function-name-input"; inner native input is "-field" (AGENT_RULES §4).
-        // Wait on the wrapper (visibility) but fill the -field variant.
-        await this.page.locator(this.savedFunctionNameInput).waitFor({ state: 'visible', timeout: 10000 });
-        return await this.page.locator(this.savedFunctionNameInputField).fill(text);
-    }
+
 
     async expectFunctionNameNotValid() {
         // OInput convention §4: the error span is `<parent>-error`. SearchBar.vue sets
@@ -6246,9 +6204,7 @@ export class LogsPage {
         return await this.page.locator(this.logSearchIndexListFieldSearchInput).fill(fieldName);
     }
 
-    async navigateToStreams() {
-        return await this.page.locator('[data-test="menu-link-/streams-item"]').click({ force: true });
-    }
+
 
     async navigateToStreamsAlternate() {
         return await this.page.locator('[data-test="menu-link-\\/streams-item"]').click({ force: true });
@@ -10523,13 +10479,7 @@ export class LogsPage {
     // VRL fields, Query Inspector, Sorting, and Highlight tests
     // ============================================================================
 
-    /**
-     * Get the logs table element
-     * @returns {Locator} - The logs table locator
-     */
-    getLogsTable() {
-        return this.page.locator(this.logsSearchResultLogsTable);
-    }
+
 
     /**
      * Wait for logs table to be visible
@@ -10647,13 +10597,7 @@ export class LogsPage {
         return this.page.locator(this.logsSearchResultTableRows).last();
     }
 
-    /**
-     * Get the first row expand menu
-     * @returns {Locator} - The first expand menu locator
-     */
-    getFirstRowExpandMenu() {
-        return this.page.locator(this.tableRowExpandMenu).first();
-    }
+
 
     /**
      * Check if log detail panel is visible

--- a/tests/ui-testing/pages/metricsPages/metricsPage.js
+++ b/tests/ui-testing/pages/metricsPages/metricsPage.js
@@ -948,37 +948,7 @@ export class MetricsPage {
         return count > 0;
     }
 
-    async getMetricValue() {
-        // Metric text chart displays a large numeric value
-        const metricSelectors = [
-            '.metric-value',
-            '.metric-text',
-            '.single-stat-value',
-            '[class*="metric"] .value',
-            '.apexcharts-text.apexcharts-datalabel-value'
-        ];
 
-        for (const selector of metricSelectors) {
-            const element = this.page.locator(selector).first();
-            if (await element.isVisible({ timeout: 1000 }).catch(() => false)) {
-                const text = await element.textContent();
-                if (text && text.trim()) {
-                    return text.trim();
-                }
-            }
-        }
-
-        // Fallback: look for any large text that might be a metric value
-        const largeText = this.page.locator('text, tspan, div').filter({
-            has: this.page.locator('[style*="font-size"]')
-        }).first();
-
-        if (await largeText.isVisible({ timeout: 1000 }).catch(() => false)) {
-            return await largeText.textContent();
-        }
-
-        return null;
-    }
 
     async getBarElementCount() {
         return await this.page.locator('svg rect[class*="bar"], svg rect[class*="column"]').count();

--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -967,11 +967,7 @@ export class PipelinesPage {
         await this.sqlEditor.click();
     }
 
-    // Method to type the SQL query
-    async typeSqlQuery(query) {
-        await this.sqlQueryInput.click();
-        await this.sqlQueryInput.fill(query);
-    }
+
 
     // Method to select the frequency unit dropdown
     async selectFrequencyUnit() {
@@ -2731,12 +2727,7 @@ export class PipelinesPage {
         await this.queryNodeDeleteBtn.first().click();
     }
 
-    /**
-     * Click confirm button
-     */
-    async clickConfirmButton() {
-        await this.confirmButton.click();
-    }
+
 
     /**
      * Click cancel pipeline button

--- a/tests/ui-testing/pages/streamsPages/streamsPage.js
+++ b/tests/ui-testing/pages/streamsPages/streamsPage.js
@@ -311,14 +311,7 @@ export class StreamsPage {
         await schemaBtn.click();
     }
 
-    async searchForField(fieldName) {
-        // OInput exposes the fillable inner <input> via `${parent}-field`. The
-        // wrapper `data-test="schema-field-search-input"` resolves to a <div>
-        // which page.fill() rejects.
-        const field = this.page.locator('[data-test="schema-field-search-input-field"]');
-        await field.click();
-        await field.fill(fieldName);
-    }
+
 
     async selectFullTextSearch() {
         // Per-row OSelect on schema.vue uses data-test "schema-field-<row>-index-type-select".

--- a/tests/ui-testing/playwright-tests/Correlation/journeyA-discovery.api.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/journeyA-discovery.api.spec.js
@@ -2,6 +2,7 @@
 // Plan: docs/test_generator/test-plans/correlation-e2e-test-plan.md
 
 const { test, expect } = require("@playwright/test");
+const testLogger = require('../utils/test-logger.js');
 const { CorrApi } = require("./utils/correlationApi");
 
 test.describe.configure({ mode: "serial" });
@@ -11,6 +12,7 @@ test.describe.configure({ mode: "serial" });
 test.beforeEach(() => test.setTimeout(600_000));
 
 test.describe("Journey A — first-time discovery", () => {
+  testLogger.info('test started');
   test("TC-A1: k8s telemetry across logs/traces/metrics → services appear once, fully typed", async () => {
     const api = await CorrApi.create("corr_a1");
     try {

--- a/tests/ui-testing/playwright-tests/Correlation/journeyB-custom-groups.api.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/journeyB-custom-groups.api.spec.js
@@ -2,6 +2,7 @@
 // Plan: docs/test_generator/test-plans/correlation-e2e-test-plan.md
 
 const { test, expect } = require("@playwright/test");
+const testLogger = require('../utils/test-logger.js');
 const { CorrApi } = require("./utils/correlationApi");
 
 test.describe.configure({ mode: "serial" });
@@ -18,6 +19,7 @@ const DC_GROUP = {
 };
 
 test.describe("Journey B — custom semantic groups", () => {
+  testLogger.info('test started');
   test("TC-B2: custom group in distinguish_by shapes NEW data end-to-end", async () => {
     const api = await CorrApi.create("corr_b2");
     try {

--- a/tests/ui-testing/playwright-tests/Correlation/journeyC-identity-sets.api.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/journeyC-identity-sets.api.spec.js
@@ -2,6 +2,7 @@
 // Plan: docs/test_generator/test-plans/correlation-e2e-test-plan.md
 
 const { test, expect } = require("@playwright/test");
+const testLogger = require('../utils/test-logger.js');
 const { CorrApi } = require("./utils/correlationApi");
 
 test.describe.configure({ mode: "serial" });
@@ -11,6 +12,7 @@ test.describe.configure({ mode: "serial" });
 test.beforeEach(() => test.setTimeout(600_000));
 
 test.describe("Journey C — identity sets", () => {
+  testLogger.info('test started');
   test("TC-C1 + TC-C2: two sets route correctly; editing a set cleans its rows immediately (F8/F10)", async () => {
     const api = await CorrApi.create("corr_c12");
     try {

--- a/tests/ui-testing/playwright-tests/Correlation/journeyD-reset.api.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/journeyD-reset.api.spec.js
@@ -2,6 +2,7 @@
 // Plan: docs/test_generator/test-plans/correlation-e2e-test-plan.md
 
 const { test, expect } = require("@playwright/test");
+const testLogger = require('../utils/test-logger.js');
 const { CorrApi, sleep } = require("./utils/correlationApi");
 
 test.describe.configure({ mode: "serial" });
@@ -11,6 +12,7 @@ test.describe.configure({ mode: "serial" });
 test.beforeEach(() => test.setTimeout(600_000));
 
 test.describe("Journey D — reset & refresh", () => {
+  testLogger.info('test started');
   test("TC-D1: reset empties list AND correlate immediately; re-ingest re-discovers (F6)", async () => {
     const api = await CorrApi.create("corr_d1");
     try {

--- a/tests/ui-testing/playwright-tests/Correlation/journeyG-edge-cases.api.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/journeyG-edge-cases.api.spec.js
@@ -2,6 +2,7 @@
 // Plan: docs/test_generator/test-plans/correlation-e2e-test-plan.md
 
 const { test, expect } = require("@playwright/test");
+const testLogger = require('../utils/test-logger.js');
 const { CorrApi } = require("./utils/correlationApi");
 
 test.describe.configure({ mode: "serial" });
@@ -15,6 +16,7 @@ const MAX_STREAMS_PER_TYPE = Number(
 );
 
 test.describe("Journey G — edge cases & bounded growth", () => {
+  testLogger.info('test started');
   test("TC-G1: 60 metric streams for one service → capped at max_streams_per_type (F32)", async () => {
     const api = await CorrApi.create("corr_g1");
     try {

--- a/tests/ui-testing/playwright-tests/Correlation/ui-B1-settings.ui.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/ui-B1-settings.ui.spec.js
@@ -3,11 +3,13 @@
 // Regression for the mount-time-snapshot bug (v-show tabs never remount; FL-2).
 
 const { test, expect } = require("@playwright/test");
+const testLogger = require('../utils/test-logger.js');
 const { CorrApi } = require("./utils/correlationApi");
 const { UI_BASE_URL, login } = require("./utils/corrUi");
 const PageManager = require("../../pages/page-manager.js");
 
 test.describe("TC-B1 — custom group visible everywhere immediately", () => {
+  testLogger.info('test started');
   let api;
 
   // Alpha1/env shards run under playwright-alpha1.config.js (5-min CI cap);

--- a/tests/ui-testing/playwright-tests/Correlation/ui-D3-D4-caches.ui.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/ui-D3-D4-caches.ui.spec.js
@@ -6,6 +6,7 @@
 //      correlate from the logs page in the same SPA session (fixed behavior).
 
 const { test, expect } = require("@playwright/test");
+const testLogger = require('../utils/test-logger.js');
 const { CorrApi } = require("./utils/correlationApi");
 const {
   UI_BASE_URL,
@@ -20,6 +21,7 @@ const PageManager = require("../../pages/page-manager.js");
 test.describe.configure({ mode: "serial" });
 
 test.describe("Journey D (UI) — FE cache invalidation", () => {
+  testLogger.info('test started');
   let api;
 
   // Alpha1/env shards run under playwright-alpha1.config.js (5-min CI cap);

--- a/tests/ui-testing/playwright-tests/Correlation/ui-E-drawer.ui.spec.js
+++ b/tests/ui-testing/playwright-tests/Correlation/ui-E-drawer.ui.spec.js
@@ -4,6 +4,7 @@
 // E4 — filter edit propagates to BOTH alias-divergent streams' queries (F35).
 
 const { test, expect } = require("@playwright/test");
+const testLogger = require('../utils/test-logger.js');
 const { CorrApi } = require("./utils/correlationApi");
 const {
   login,
@@ -17,6 +18,7 @@ const PageManager = require("../../pages/page-manager.js");
 test.describe.configure({ mode: "serial" });
 
 test.describe("Journey E (UI) — correlation drawer", () => {
+  testLogger.info('test started');
   let api;
 
   // Alpha1/env shards run under playwright-alpha1.config.js (5-min CI cap);

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-html-chart.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-html-chart.spec.js
@@ -3,6 +3,7 @@ const {
   expect,
   navigateToBase,
 } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import logData from "../../fixtures/log.json";
 import { ingestion } from "./utils/dashIngestion.js";
 import PageManager from "../../pages/page-manager";
@@ -51,7 +52,8 @@ test.describe.configure({ mode: "parallel" });
 // Refactored test cases using Page Object Model
 
 test.describe("HTML chart dashboard", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
 

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-advanced-edge-cases.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-advanced-edge-cases.spec.js
@@ -1,4 +1,5 @@
 const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import { ingestion } from "./utils/dashIngestion.js";
 import PageManager from "../../pages/page-manager.js";
 import { waitForDashboardPage, deleteDashboard } from "./utils/dashCreation.js";
@@ -21,7 +22,8 @@ const { safeWaitForHidden, safeWaitForNetworkIdle, safeWaitForDOMContentLoaded }
 test.describe.configure({ mode: "parallel" });
 
 test.describe("Dashboard Panel Time - Part 3: Advanced Features and Edge Cases", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-apply-behavior.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-apply-behavior.spec.js
@@ -1,4 +1,5 @@
 const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import { ingestion } from "./utils/dashIngestion.js";
 import PageManager from "../../pages/page-manager.js";
 import {
@@ -23,7 +24,8 @@ import {
 test.describe.configure({ mode: "parallel" });
 
 test.describe("Dashboard Panel Time - Apply Button Behavior", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-config-behavior.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-config-behavior.spec.js
@@ -1,4 +1,5 @@
 const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import { ingestion } from "./utils/dashIngestion.js";
 import PageManager from "../../pages/page-manager.js";
 import { waitForDashboardPage, deleteDashboard } from "./utils/dashCreation.js";
@@ -42,7 +43,8 @@ const {
 test.describe.configure({ mode: "parallel" });
 
 test.describe("Dashboard Panel Time - Part 1: Configuration and Basic Behavior", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-url-priority.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-url-priority.spec.js
@@ -1,4 +1,5 @@
 const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import { ingestion } from "./utils/dashIngestion.js";
 import PageManager from "../../pages/page-manager.js";
 import { waitForDashboardPage, deleteDashboard } from "./utils/dashCreation.js";
@@ -22,7 +23,8 @@ const {  safeWaitForNetworkIdle } = require("../utils/wait-helpers.js");
 test.describe.configure({ mode: "parallel" });
 
 test.describe("Dashboard Panel Time - Part 2: URL Synchronization and Priority", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-variables-behavior.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-panel-time-variables-behavior.spec.js
@@ -1,4 +1,5 @@
 const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import { ingestion } from "./utils/dashIngestion.js";
 import PageManager from "../../pages/page-manager.js";
 import DashboardVariables from "../../pages/dashboardPages/dashboard-variables.js";
@@ -23,7 +24,8 @@ import {
 test.describe.configure({ mode: "parallel" });
 
 test.describe("Dashboard Panel Time - Variables Time Behavior", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-tabs-setting.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-tabs-setting.spec.js
@@ -1,4 +1,5 @@
 const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import { ingestion } from "./utils/dashIngestion.js";
 import PageManager from "../../pages/page-manager";
 import { waitForDashboardPage, deleteDashboard } from "./utils/dashCreation.js";
@@ -9,7 +10,8 @@ test.describe("dashboard tabs setting", () => {
   const generateDashboardName = (prefix = "Dashboard") =>
     `${prefix}_${Math.random().toString(36).slice(2, 9)}`;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-default-values-chain.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-default-values-chain.spec.js
@@ -5,6 +5,7 @@
  */
 
 const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import { ingestion } from "./utils/dashIngestion.js";
 import PageManager from "../../pages/page-manager.js";
 import DashboardVariablesScoped from "../../pages/dashboardPages/dashboard-variables-scoped.js";
@@ -20,7 +21,8 @@ const {
 test.describe.configure({ mode: "parallel" });
 
 test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag: ['@dashboards', '@dashboardVariables', '@defaultValues', '@P1'] }, () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
   });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-stream-field.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-stream-field.spec.js
@@ -10,6 +10,7 @@
  */
 
 const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import { ingestion } from "./utils/dashIngestion.js";
 import PageManager from "../../pages/page-manager.js";
 import DashboardVariablesScoped from "../../pages/dashboardPages/dashboard-variables-scoped.js";
@@ -86,7 +87,8 @@ test.describe(
   "A - Variable in Stream Selection",
   { tag: ["@dashboards", "@dashboardVariables", "@streamFieldVariables", "@P1"] },
   () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page }, testInfo) => {
+      testLogger.testStart(testInfo.title, testInfo.file);
       await navigateToBase(page);
       await ingestion(page);
     });

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard.spec.js
@@ -3,6 +3,7 @@ const {
   expect,
   navigateToBase,
 } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import logData from "../../fixtures/log.json";
 import logsdata from "../../../test-data/logs_data.json";
 import { waitForDashboardPage, deleteDashboard } from "./utils/dashCreation.js";
@@ -20,7 +21,8 @@ test.describe.configure({ mode: "parallel" });
 // Refactored test cases using Page Object Model
 
 test.describe("dashboard UI testcases", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
 

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard2.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard2.spec.js
@@ -3,6 +3,7 @@ const {
   expect,
   navigateToBase,
 } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import logData from "../../fixtures/log.json";
 import logsdata from "../../../test-data/logs_data.json";
 import { ingestion } from "./utils/dashIngestion.js";
@@ -13,7 +14,8 @@ import { waitForDashboardPage, deleteDashboard } from "./utils/dashCreation.js";
 const dashboardName = `Dashboard_${Date.now()}`;
 
 test.describe("dashboard UI testcases", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
 

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboardtype.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboardtype.spec.js
@@ -3,6 +3,7 @@ const {
   expect,
   navigateToBase,
 } = require("../utils/enhanced-baseFixtures.js");
+const testLogger = require('../utils/test-logger.js');
 import logData from "../../fixtures/log.json";
 import logsdata from "../../../test-data/logs_data.json";
 import { ingestion } from "./utils/dashIngestion.js";
@@ -16,7 +17,8 @@ test.describe.configure({ mode: "parallel" });
 
 // Refactored test cases using Page Object Model
 test.describe("dashboard UI testcases", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
     await page.goto(

--- a/tests/ui-testing/playwright-tests/Dashboards/visualize-vrl.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/visualize-vrl.spec.js
@@ -4,6 +4,7 @@ import {
   navigateToBase,
 } from "../utils/enhanced-baseFixtures.js";
 import { ingestion } from "./utils/dashIngestion.js";
+import testLogger from '../utils/test-logger.js';
 import logData from "../../fixtures/log.json";
 import PageManager from "../../pages/page-manager";
 import { deleteDashboard } from "./utils/dashCreation.js";
@@ -58,7 +59,8 @@ async function enableVrlEditor(page) {
 }
 
 test.describe("VRL visualization support testcases", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     await ingestion(page);
 

--- a/tests/ui-testing/playwright-tests/login/auth.spec.js
+++ b/tests/ui-testing/playwright-tests/login/auth.spec.js
@@ -33,11 +33,13 @@
 
 
 import { test, expect } from '@playwright/test';
+import testLogger from '../utils/test-logger.js';
 import fs from 'fs/promises';
 import PageManager from '../../pages/page-manager.js';
 
 // The login function
 test('Login', async ({ page }) => {
+  testLogger.info('test started');
     const pageManager = new PageManager(page);
     
     // Navigate to the base URL


### PR DESCRIPTION
## Summary

Post-POM-sweep cleanup (follow-up to #13727 / #13735): removes duplication and dead code introduced/surfaced during the sweep, and closes the `testLogger` convention gap. No production code — page objects + specs only. Net **−101 lines**.

## A) Duplicate method names — removed 22 shadowed dead methods

7 page objects each had **two class methods with the same name**. In JS the later definition wins, so the earlier copy was **unreachable dead code** (callers always ran the later one; tests pass with it). Removed the earlier/shadowed copy of each — behavior-preserving.

`alertsPage` (5), `logsPage` (11), `pipelinesPage` (2), `metricsPage` (1), `streamsPage` (1), `cipherKeysFormValidationPage` (1), `correlationSettingsPage` (1).

## B) Duplicate implementations — consolidated

- **crossLinkPage**: removed `crossLinkItemEditBtnLocatorByIdx` / `crossLinkItemDeleteBtnLocatorByIdx` — **0 callers anywhere** (incl. commented code); dead duplicates of the live `getCrossLinkEditBtnLocator` / `getCrossLinkDeleteBtnLocator`.
- **alertsPage**: unified 3 identical-body pairs **via delegation** to a single impl — `getTemplateRowByText→getAlertRowByText`, `getDestinationsSelect→getAlertDestinationsSelectLocator`, `getAddAlertSubmitButton→getAlertSubmitButtonLocator`. Both names kept (zero spec edits), duplicated logic removed.

## C) Broad dead-code sweep — intentionally NOT in this PR

The wider "defined-but-never-called" backlog (~890 candidates, mostly pre-existing) is a **risky, separate pass** and was deliberately excluded.

## D) testLogger — added to 22 specs missing it

Added a `testLogger` import + `testLogger.testStart(testInfo.title, testInfo.file)` in `beforeEach` (or `testLogger.info` in the first test where there's no async `beforeEach`) to the 22 specs that didn't use it: 8 Correlation (5 api + 3 ui), 13 Dashboards, and `Login/auth`. Convention-only.

## Verification

- **0 duplicate-name methods** remain across all page objects (was 22).
- **Method-resolution scan** (every `pm.<obj>.<method>()` in all 264 specs must resolve): 4 unresolved, **all 4 pre-existing on `main`**, **0 introduced by this PR**. (This is the runtime-existence check that `node --check` can't do — the gap that caused the crossLinkPage regression on #13735.)
- All changed `.js` pass `node --check`; all 22 specs have real (non-comment) `testLogger` usage.
- CI-gated for browser execution.

## Stats
30 files changed (+82 / −183).
