### PR TITLE
test(metrics): E2E for explorer share URL and Visualize deep-link

### DIFF
--- a/tests/ui-testing/ci-matrix/ci_matrix.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix.json
@@ -364,7 +364,8 @@
       "metrics-table-column-order.spec.js",
       "metrics-promql-builder.spec.js",
       "promqlAutocomplete.spec.js",
-      "metrics-share-deep-link.spec.js"
+      "metrics-share-deep-link.spec.js",
+      "metrics-explorer-share-visualize.spec.js"
     ],
     "disabled": []
   },

--- a/tests/ui-testing/pages/metricsPages/metricsExplorerPage.js
+++ b/tests/ui-testing/pages/metricsPages/metricsExplorerPage.js
@@ -1,0 +1,477 @@
+// metricsExplorerPage.js
+//
+// Page object for the Metrics EXPLORER (`/web/metrics`) — the zero-query browse
+// grid and its in-page Visualize workspace.
+//
+// NOT the same surface as metricsPage.js, which drives the legacy panel editor at
+// `/web/metrics/editor`. The two share a route prefix and nothing else: the
+// explorer has a mode toggle, a card grid and its own share button
+// (`metrics-explorer-share-btn`), while the editor has the PromQL bar and
+// `metrics-share-btn`.
+//
+// Selectors verified against:
+//   web/src/plugins/metrics/explorer/MetricsExplorer.vue
+//   web/src/plugins/metrics/explorer/MetricsVisualize.vue
+//   web/src/plugins/metrics/explorer/MetricCard.vue
+//   web/src/components/common/ShareButton.vue
+import { expect } from '@playwright/test';
+const { getOrgIdentifier } = require('../../playwright-tests/utils/cloud-auth.js');
+
+/** Blob envelope version the app accepts — metricsUrlState.ts METRICS_BLOB_VERSION. */
+const METRICS_BLOB_VERSION = 1;
+
+export class MetricsExplorerPage {
+    constructor(page) {
+        this.page = page;
+
+        // ===== ROOT / SHELL =====
+        this.explorerRoot = '[data-test="metrics-explorer"]';
+        this.filterBar = '[data-test="metrics-explorer-filter-bar"]';
+        this.scrollContainer = '[data-test="metrics-explorer-scroll"]';
+
+        // ===== MODE TOGGLE =====
+        this.modeToggle = '[data-test="metrics-explorer-mode"]';
+        this.modeExplore = '[data-test="metrics-explorer-mode-explore"]';
+        this.modeVisualize = '[data-test="metrics-explorer-mode-visualize"]';
+        this.modeWorkspace = '[data-test="metrics-explorer-mode-workspace"]';
+
+        // ===== TOOLBAR ACTIONS =====
+        // In Visualize the Refresh button re-runs the built chart's query; in the
+        // grid modes it refreshes the card grid.
+        this.refreshButton = '[data-test="metrics-explorer-refresh"]';
+        this.shareButton = '[data-test="metrics-explorer-share-btn"]';
+
+        // ===== VISUALIZE PANE =====
+        this.visualizeRoot = '[data-test="metrics-explorer-visualize"]';
+        this.panelEditorContainer = '[data-test="panel-editor-container"]';
+        this.queryEditorContainer = '[data-test="dashboard-panel-query-editor"]';
+        this.chartRenderer = '[data-test="chart-renderer"]';
+
+        // ===== CARDS =====
+        // Card data-tests are name-suffixed (`…-card-select-cpu_usage`), so the
+        // "any card" locator matches on the stable prefix.
+        this.anyCardSelect = '[data-test^="metrics-explorer-card-select-"]';
+
+        // ===== EMPTY STATES =====
+        this.noMetricsState = '[data-test="metrics-explorer-no-metrics"]';
+        this.loadErrorState = '[data-test="metrics-explorer-load-error"]';
+        this.noMatchState = '[data-test="metrics-explorer-no-match"]';
+        this.workspaceEmptyState = '[data-test="metrics-workspace-empty-grid"]';
+
+        // ===== SHARE TOASTS (OToast exposes variant + message as data-test attrs) =====
+        this.shareSuccessToast = page.locator(
+            '[data-test-variant="success"][data-test-message*="Link Copied"]'
+        );
+        this.shareErrorToast = page.locator(
+            '[data-test-variant="error"][data-test-message*="shortening link"]'
+        );
+    }
+
+    /* ------------------------------------------------------------ navigation */
+
+    /**
+     * The org the page is CURRENTLY on, falling back to the configured one.
+     * Mirrors gotoMetricsEditor: change-org tests must not be pinned to default.
+     */
+    resolveOrgIdentifier() {
+        let orgIdentifier = getOrgIdentifier();
+        try {
+            orgIdentifier =
+                new URL(this.page.url()).searchParams.get('org_identifier') || orgIdentifier;
+        } catch {
+            // about:blank has no query string — keep the fallback.
+        }
+        return orgIdentifier;
+    }
+
+    /**
+     * Build an absolute explorer URL. `/web/` is mandatory — without it a cloud
+     * deployment resolves the org to _meta instead of the configured one.
+     */
+    buildExplorerUrl(params = {}) {
+        const url = new URL(`${process.env.ZO_BASE_URL}/web/metrics`);
+        url.searchParams.set('org_identifier', this.resolveOrgIdentifier());
+        for (const [key, value] of Object.entries(params)) {
+            if (value !== undefined && value !== null) url.searchParams.set(key, String(value));
+        }
+        return url.href;
+    }
+
+    /** Navigate to the explorer with optional query params, then wait for its shell. */
+    async gotoExplorer(params = {}) {
+        await this.page.goto(this.buildExplorerUrl(params));
+        await this.page
+            .locator(this.explorerRoot)
+            .waitFor({ state: 'visible', timeout: 30000 })
+            .catch(() => {});
+    }
+
+    /** Navigate to a fully-formed URL (deep-link cases that must not be rebuilt). */
+    async navigateToUrl(url) {
+        await this.page.goto(url);
+        // networkidle never settles on OpenObserve (persistent WebSocket/RUM).
+        await this.page.waitForLoadState('domcontentloaded', { timeout: 15000 }).catch(() => {});
+    }
+
+    async expectExplorerVisible() {
+        await expect(this.page.locator(this.explorerRoot)).toBeVisible({ timeout: 30000 });
+    }
+
+    /**
+     * Asserts the browser stayed on the EXPLORER route.
+     *
+     * The back-compat guard redirects `/metrics` + editor params to
+     * `/metrics/editor`, so "did not redirect" is exactly "the path is /metrics
+     * and not /metrics/editor".
+     */
+    async expectOnExplorerRoute() {
+        await expect
+            .poll(() => new URL(this.page.url()).pathname, { timeout: 15000 })
+            .toMatch(/\/web\/metrics\/?$/);
+        await expect(this.page.locator(this.explorerRoot)).toBeVisible({ timeout: 30000 });
+    }
+
+    /** Asserts the back-compat guard sent a legacy deep link to the editor route. */
+    async expectRedirectedToEditor() {
+        await expect
+            .poll(() => new URL(this.page.url()).pathname, { timeout: 15000 })
+            .toMatch(/\/web\/metrics\/editor\/?$/);
+    }
+
+    /* ----------------------------------------------------------------- modes */
+
+    async switchToExplore() {
+        await this.page.locator(this.modeExplore).click();
+    }
+
+    async switchToVisualize() {
+        await this.page.locator(this.modeVisualize).click();
+    }
+
+    async switchToWorkspace() {
+        await this.page.locator(this.modeWorkspace).click();
+    }
+
+    /** OToggleGroupItem marks the active tab with data-state="on". */
+    async expectModeActive(mode) {
+        const locators = {
+            explore: this.modeExplore,
+            visualize: this.modeVisualize,
+            workspace: this.modeWorkspace,
+        };
+        await expect(this.page.locator(locators[mode])).toHaveAttribute('data-state', 'on', {
+            timeout: 15000,
+        });
+    }
+
+    async expectVisualizeVisible() {
+        await expect(this.page.locator(this.visualizeRoot)).toBeVisible({ timeout: 30000 });
+    }
+
+    async expectGridVisible() {
+        await expect(this.page.locator(this.scrollContainer)).toBeVisible({ timeout: 30000 });
+    }
+
+    /* ------------------------------------------------------------ URL / blob */
+
+    getQueryParam(name) {
+        try {
+            return new URL(this.page.url()).searchParams.get(name);
+        } catch {
+            return null;
+        }
+    }
+
+    getMetricsDataParam() {
+        return this.getQueryParam('metrics_data');
+    }
+
+    hasMetricsDataParam() {
+        return !!this.getMetricsDataParam();
+    }
+
+    /**
+     * Decode `metrics_data` back into `{ v, data }`.
+     * Returns null when the param is absent or not decodable — the same silent
+     * fallback the app's decodeMetricsConfig applies.
+     */
+    decodeMetricsBlob() {
+        const raw = this.getMetricsDataParam();
+        if (!raw) return null;
+        try {
+            return JSON.parse(Buffer.from(decodeURIComponent(raw), 'base64').toString('utf8'));
+        } catch {
+            return null;
+        }
+    }
+
+    /** Encode a panel-data object as the app would, for deep-link construction. */
+    buildMetricsBlob(data, version = METRICS_BLOB_VERSION) {
+        return Buffer.from(JSON.stringify({ v: version, data }), 'utf8').toString('base64');
+    }
+
+    /** A minimal, valid Visualize payload carrying one PromQL query. */
+    buildPromqlBlob(query, version = METRICS_BLOB_VERSION) {
+        return this.buildMetricsBlob(
+            {
+                type: 'line',
+                queryType: 'promql',
+                queries: [{ query, queryType: 'promql', fields: { stream_type: 'metrics' } }],
+            },
+            version
+        );
+    }
+
+    /**
+     * The URL write-back is debounced 300ms, so poll rather than read once.
+     * Returns the blob param so callers can round-trip it.
+     */
+    async waitForMetricsDataParam(timeout = 20000) {
+        await expect
+            .poll(() => this.hasMetricsDataParam(), {
+                timeout,
+                intervals: [200, 400, 800],
+            })
+            .toBe(true);
+        return this.getMetricsDataParam();
+    }
+
+    /** The mirror case — leaving Visualize must strip a stale blob. */
+    async waitForMetricsDataCleared(timeout = 20000) {
+        await expect
+            .poll(() => this.hasMetricsDataParam(), {
+                timeout,
+                intervals: [200, 400, 800],
+            })
+            .toBe(false);
+    }
+
+    /* --------------------------------------------------------- visualize pane */
+
+    async waitForVisualizeReady() {
+        await this.page
+            .locator(this.panelEditorContainer)
+            .waitFor({ state: 'visible', timeout: 30000 })
+            .catch(() => {});
+        await this.page
+            .locator(this.queryEditorContainer)
+            .first()
+            .waitFor({ state: 'visible', timeout: 30000 })
+            .catch(() => {});
+    }
+
+    /**
+     * Set the PromQL query via Monaco's setValue API.
+     *
+     * setValue fires onDidChangeContent — the same event keyboard typing raises,
+     * so the Vue panel model stays in sync — without opening the autocomplete
+     * dropdown that would swallow the next click.
+     */
+    async enterVisualizeQuery(query) {
+        const editor = this.page.locator(this.queryEditorContainer).first();
+        await editor.waitFor({ state: 'visible', timeout: 30000 });
+        await this.page
+            .waitForFunction(
+                () =>
+                    !!(
+                        window.monaco &&
+                        window.monaco.editor &&
+                        window.monaco.editor.getEditors().length > 0
+                    ),
+                null,
+                { timeout: 15000 }
+            )
+            .catch(() => {});
+
+        const setViaApi = await this.page.evaluate((q) => {
+            try {
+                const editors = window.monaco?.editor?.getEditors?.();
+                if (!editors || editors.length === 0) return false;
+                const target = editors[editors.length - 1];
+                target.focus();
+                target.setValue(q);
+                return true;
+            } catch {
+                return false;
+            }
+        }, query);
+
+        if (setViaApi) return;
+
+        // Fallback: keyboard entry, which also raises Monaco change events.
+        await editor.click();
+        const selectAllKey = process.platform === 'darwin' ? 'Meta+A' : 'Control+A';
+        await this.page.keyboard.press(selectAllKey);
+        await this.page.keyboard.press('Backspace');
+        await this.page.keyboard.type(query, { delay: 50 });
+        await this.page.keyboard.press('Escape');
+    }
+
+    /** Current editor text — used to assert a shared link rehydrated the chart. */
+    async getVisualizeQueryText() {
+        return await this.page.evaluate(() => {
+            try {
+                const editors = window.monaco?.editor?.getEditors?.();
+                if (!editors || editors.length === 0) return '';
+                return editors[editors.length - 1].getValue();
+            } catch {
+                return '';
+            }
+        });
+    }
+
+    /**
+     * Best-effort wait for the query editor to stop being empty.
+     *
+     * Used before a NEGATIVE assertion, where reading too early would pass
+     * trivially against an editor that had not been populated yet. It is
+     * deliberately bounded and non-fatal: a genuinely blank canvas is a valid
+     * outcome, so a timeout here must not fail the caller.
+     */
+    async waitForVisualizeQuerySettled(timeout = 8000) {
+        await expect
+            .poll(async () => (await this.getVisualizeQueryText()).length, {
+                timeout,
+                intervals: [300, 600, 1000],
+            })
+            .toBeGreaterThan(0)
+            .catch(() => {});
+    }
+
+    /** Poll the editor text — a rehydrated seed lands after the pane mounts. */
+    async expectVisualizeQueryToContain(expected, timeout = 30000) {
+        await expect
+            .poll(async () => await this.getVisualizeQueryText(), {
+                timeout,
+                intervals: [300, 600, 1000],
+            })
+            .toContain(expected);
+    }
+
+    /** In Visualize the toolbar Refresh button runs the chart's query. */
+    async runVisualizeQuery() {
+        await this.page.locator(this.refreshButton).click();
+    }
+
+    /* ----------------------------------------------------------------- cards */
+
+    async getCardCount() {
+        return await this.page.locator(this.anyCardSelect).count();
+    }
+
+    /**
+     * Drill into the first rendered card — the real path into Visualize.
+     *
+     * The card's action row (`…-card-actions-<name>`) is w-0 / opacity-0 at rest
+     * and expands only on group-hover / group-focus-within; at rest the resting
+     * "fn · unit" and freshness spans sit over it and intercept the click. So
+     * hover the card first — the same gesture a real user makes — which hides
+     * those spans and expands the row before clicking the drill-in button.
+     */
+    async openFirstCardInVisualize() {
+        const select = this.page.locator(this.anyCardSelect).first();
+        await select.waitFor({ state: 'attached', timeout: 30000 });
+
+        const testId = await select.getAttribute('data-test');
+        const metricName = String(testId).replace('metrics-explorer-card-select-', '');
+        await this.page.locator(`[data-test="metrics-explorer-card-${metricName}"]`).hover();
+
+        await expect(select).toBeVisible({ timeout: 10000 });
+        await select.click();
+    }
+
+    /** True once at least one card has rendered (grid is populated). */
+    async waitForCards(timeout = 60000) {
+        await expect
+            .poll(async () => await this.getCardCount(), {
+                timeout,
+                intervals: [500, 1000, 2000],
+            })
+            .toBeGreaterThan(0);
+    }
+
+    /* ----------------------------------------------------------------- share */
+
+    getShareButton() {
+        return this.page.locator(this.shareButton);
+    }
+
+    async isShareButtonInDom() {
+        return (await this.page.locator(this.shareButton).count()) > 0;
+    }
+
+    async isShareButtonVisible() {
+        return await this.page
+            .locator(this.shareButton)
+            .isVisible({ timeout: 5000 })
+            .catch(() => false);
+    }
+
+    async isShareButtonEnabled() {
+        return await this.page
+            .locator(this.shareButton)
+            .isEnabled({ timeout: 5000 })
+            .catch(() => false);
+    }
+
+    async isShareButtonDisabled() {
+        return !(await this.isShareButtonEnabled());
+    }
+
+    async expectShareButtonVisible() {
+        await expect(this.page.locator(this.shareButton)).toBeVisible({ timeout: 15000 });
+    }
+
+    /** OButton surfaces its loading prop as aria-busy (OButton.vue:318). */
+    async isShareButtonLoading() {
+        const state = await this.page
+            .locator(this.shareButton)
+            .getAttribute('aria-busy')
+            .catch(() => null);
+        return state === 'true' || state === '';
+    }
+
+    async clickShareButton() {
+        await this.page.locator(this.shareButton).click();
+    }
+
+    async waitForShareSuccessToast(timeout = 15000) {
+        await expect(this.shareSuccessToast.first()).toBeVisible({ timeout });
+    }
+
+    /**
+     * The short URL the share button copied.
+     * Reading the clipboard needs clipboard-read permission — callers grant it in
+     * setup and treat a rejection as "share unavailable here".
+     */
+    async getCopiedShortUrl(timeout = 15000) {
+        let clipboard = '';
+        await expect
+            .poll(
+                async () => {
+                    clipboard = await this.page
+                        .evaluate(() => navigator.clipboard.readText())
+                        .catch(() => '');
+                    return clipboard;
+                },
+                { timeout, intervals: [300, 600, 1000] }
+            )
+            .not.toBe('');
+        return clipboard;
+    }
+
+    /**
+     * Whether share can actually be exercised here. `web_url` is a deployment
+     * setting; where it is unset ShareButton self-disables with a warning
+     * tooltip, and the share assertions have nothing to assert against.
+     */
+    async checkShareReadiness() {
+        if (!(await this.isShareButtonInDom())) {
+            return { canShare: false, reason: 'Share button not rendered on the explorer toolbar' };
+        }
+        if (!(await this.isShareButtonEnabled())) {
+            return { canShare: false, reason: 'Share button disabled — ZO_WEB_URL is not configured' };
+        }
+        return { canShare: true, reason: '' };
+    }
+}

--- a/tests/ui-testing/pages/page-manager.js
+++ b/tests/ui-testing/pages/page-manager.js
@@ -46,6 +46,7 @@ import { HomePage } from "./generalPages/homePage.js";
 import { MetricsPage } from "./metricsPages/metricsPage.js";
 import { MetricsQueryEditorPage } from "./metricsPages/metricsQueryEditorPage.js";
 import { MetricsBuilderPage } from "./metricsPages/metricsBuilderPage.js";
+import { MetricsExplorerPage } from "./metricsPages/metricsExplorerPage.js";
 import { TracesPage } from "./tracesPages/tracesPage.js";
 import { ServiceGraphPage } from "./tracesPages/serviceGraphPage.js";
 import { ServicesCatalogPage } from "./tracesPages/servicesCatalogPage.js";
@@ -171,6 +172,7 @@ class PageManager {
     this.metricsPage = new MetricsPage(page);
     this.metricsQueryEditorPage = new MetricsQueryEditorPage(page);
     this.metricsBuilderPage = new MetricsBuilderPage(page);
+    this.metricsExplorerPage = new MetricsExplorerPage(page);
     this.tracesPage = new TracesPage(page);
     this.serviceGraphPage = new ServiceGraphPage(page);
     this.servicesCatalogPage = new ServicesCatalogPage(page);

--- a/tests/ui-testing/playwright-tests/Metrics/metrics-explorer-share-visualize.spec.js
+++ b/tests/ui-testing/playwright-tests/Metrics/metrics-explorer-share-visualize.spec.js
@@ -1,0 +1,450 @@
+/**
+ * Metrics Explorer — Share URL & Visualize Deep-Link E2E Suite
+ *
+ * Covers PR #13274 (`be7a44e512`, v0.92.0), fixes F1 and F2:
+ *
+ *  F1 — Share URL on the metrics page. The explorer toolbar gained a ShareButton,
+ *       and Visualize serializes the built chart into a `metrics_data` blob that is
+ *       written to the URL (debounced 300ms), stripped when leaving Visualize, and
+ *       rehydrated into the chart when a shared link is opened.
+ *
+ *  F2 — The back-compat route guard hijacked shared Visualize links. `/metrics`
+ *       carrying editor params redirects to `/metrics/editor`; that redirect now
+ *       skips when `mode=visualize`, so an explorer share link opens the explorer.
+ *
+ * NOT covered here (deliberately, per test-scope decision): F3 favorites/facet
+ * gating and F4 stacked charts + OEmptyState migration.
+ *
+ * Feature: metrics-explorer-share-visualize
+ * Area: Metrics → Metrics Explorer
+ * Feature doc: docs/test_generator/features/metrics-explorer-share-visualize-feature.md
+ *
+ * Pre-requisites:
+ *  - Global setup handles authentication + org_identifier
+ *  - Metrics ingested via ensureMetricsIngested() → up, cpu_usage, memory_usage,
+ *    request_count, request_duration (all gauges)
+ *  - ZO_WEB_URL must be configured for the clipboard tests; where it is not, the
+ *    share button self-disables and those tests skip with a reason
+ */
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+const { ensureMetricsIngested } = require('../utils/shared-metrics-setup.js');
+
+/** A metric the ingestion helper always seeds — safe to query and to drill into. */
+const SEEDED_METRIC = 'cpu_usage';
+
+test.describe("Metrics Explorer Share & Visualize Deep-Link testcases", () => {
+  test.describe.configure({ mode: 'parallel' });
+
+  test.beforeAll(async () => {
+    await ensureMetricsIngested();
+  });
+
+  /** Fresh PageManager per test — parallel workers must not share page state. */
+  async function setupTest(page, testInfo) {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    // Clipboard access for the share-button copy assertions.
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']).catch(() => {});
+    const pm = new PageManager(page);
+    testLogger.info('Test setup completed — authenticated and on base');
+    return pm;
+  }
+
+  test.afterEach(async ({}, testInfo) => {
+    testLogger.testEnd(testInfo.title, testInfo.status);
+  });
+
+  // ═══ F2: ROUTE GUARD ══════════════════════════════════════════════════════
+
+  test("Visualize deep-link stays on the explorer instead of redirecting to the editor", {
+    tag: ['@metrics-explorer-share', '@P0', '@deeplink', '@route-guard', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing mode=visualize deep-link is exempt from the editor redirect');
+
+    // `metrics_data` is an editor param, so pre-fix this URL was redirected to
+    // /metrics/editor and the shared chart never opened in the explorer.
+    const blob = pm.metricsExplorerPage.buildPromqlBlob(SEEDED_METRIC);
+    const url = pm.metricsExplorerPage.buildExplorerUrl({
+      mode: 'visualize',
+      metrics_data: blob,
+    });
+
+    await pm.metricsExplorerPage.navigateToUrl(url);
+
+    // The fix: still on /web/metrics, not /web/metrics/editor.
+    await pm.metricsExplorerPage.expectOnExplorerRoute();
+    await pm.metricsExplorerPage.expectModeActive('visualize');
+    await pm.metricsExplorerPage.expectVisualizeVisible();
+
+    testLogger.info('Visualize deep-link opened the explorer — guard exemption verified');
+  });
+
+  test("Legacy metrics_data link without a mode still redirects to the editor", {
+    tag: ['@metrics-explorer-share', '@P1', '@deeplink', '@route-guard', '@backcompat', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing the back-compat branch of the guard is intact');
+
+    // Links shared before the explorer existed carry metrics_data with NO mode.
+    // Those must keep landing on the editor — the fix narrowed the redirect, it
+    // did not remove it.
+    const blob = pm.metricsExplorerPage.buildPromqlBlob(SEEDED_METRIC);
+    const url = pm.metricsExplorerPage.buildExplorerUrl({ metrics_data: blob });
+
+    await pm.metricsExplorerPage.navigateToUrl(url);
+
+    await pm.metricsExplorerPage.expectRedirectedToEditor();
+
+    testLogger.info('Legacy deep-link still routed to the editor — back-compat preserved');
+  });
+
+  test("Explorer mode links without editor params are never redirected", {
+    tag: ['@metrics-explorer-share', '@P2', '@deeplink', '@route-guard', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing plain explorer URLs bypass the guard entirely');
+
+    // No editor params at all — hasMetricsEditorParams is false, so the guard
+    // must not fire regardless of the mode carried.
+    await pm.metricsExplorerPage.gotoExplorer({ mode: 'workspace' });
+
+    await pm.metricsExplorerPage.expectOnExplorerRoute();
+    await pm.metricsExplorerPage.expectModeActive('workspace');
+
+    testLogger.info('Plain explorer link stayed put — guard correctly inert');
+  });
+
+  // ═══ F1: SHARE BUTTON PRESENCE ════════════════════════════════════════════
+
+  test("Share button is present on the explorer toolbar in every mode", {
+    tag: ['@metrics-explorer-share', '@P0', '@share', '@smoke', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing the share affordance exists on the explorer');
+
+    // Pre-fix the explorer had no share button at all — this is the headline
+    // regression, so presence is asserted, not probed.
+    await pm.metricsExplorerPage.gotoExplorer();
+    await pm.metricsExplorerPage.expectExplorerVisible();
+    await pm.metricsExplorerPage.expectShareButtonVisible();
+
+    await pm.metricsExplorerPage.switchToVisualize();
+    await pm.metricsExplorerPage.expectModeActive('visualize');
+    await pm.metricsExplorerPage.expectShareButtonVisible();
+
+    await pm.metricsExplorerPage.switchToWorkspace();
+    await pm.metricsExplorerPage.expectModeActive('workspace');
+    await pm.metricsExplorerPage.expectShareButtonVisible();
+
+    testLogger.info('Share button rendered in explore, visualize and workspace');
+  });
+
+  // ═══ F1: URL SYNC ═════════════════════════════════════════════════════════
+
+  test("Building a chart in Visualize writes the metrics_data blob to the URL", {
+    tag: ['@metrics-explorer-share', '@P0', '@url-sync', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing Visualize serializes the built chart into the URL');
+
+    await pm.metricsExplorerPage.gotoExplorer({ mode: 'visualize' });
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+
+    // A blank Visualize carries no blob — the param only appears once there is
+    // a query to encode.
+    expect(pm.metricsExplorerPage.hasMetricsDataParam()).toBe(false);
+
+    await pm.metricsExplorerPage.enterVisualizeQuery(SEEDED_METRIC);
+
+    // The write-back is debounced 300ms, so poll for it.
+    await pm.metricsExplorerPage.waitForMetricsDataParam();
+
+    const blob = pm.metricsExplorerPage.decodeMetricsBlob();
+    expect(blob).not.toBeNull();
+    expect(blob.v).toBe(1);
+    expect(JSON.stringify(blob.data)).toContain(SEEDED_METRIC);
+
+    testLogger.info('metrics_data blob written to the URL with the built query');
+  });
+
+  test("Leaving Visualize strips the stale metrics_data blob from the URL", {
+    tag: ['@metrics-explorer-share', '@P1', '@url-sync', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing the blob is removed when the mode leaves Visualize');
+
+    await pm.metricsExplorerPage.gotoExplorer({ mode: 'visualize' });
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+    await pm.metricsExplorerPage.enterVisualizeQuery(SEEDED_METRIC);
+    await pm.metricsExplorerPage.waitForMetricsDataParam();
+
+    // Back to the grid: the blob describes a chart that is no longer on screen,
+    // so carrying it would make the URL misrepresent the page.
+    await pm.metricsExplorerPage.switchToExplore();
+    await pm.metricsExplorerPage.expectModeActive('explore');
+
+    await pm.metricsExplorerPage.waitForMetricsDataCleared();
+
+    testLogger.info('Stale blob stripped on leaving Visualize');
+  });
+
+  test("A blank Visualize adds no metrics_data param", {
+    tag: ['@metrics-explorer-share', '@P2', '@url-sync', '@edge-case', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing an unbuilt chart contributes nothing to the URL');
+
+    await pm.metricsExplorerPage.gotoExplorer();
+    await pm.metricsExplorerPage.expectExplorerVisible();
+    await pm.metricsExplorerPage.switchToVisualize();
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+
+    // visualizeBlob short-circuits on an empty queries[0].query, so nothing is
+    // encoded. Assert it stays absent rather than merely reading once — the
+    // debounce means an erroneous write would land shortly after mount.
+    await expect
+      .poll(() => pm.metricsExplorerPage.hasMetricsDataParam(), {
+        timeout: 5000,
+        intervals: [500, 1000],
+      })
+      .toBe(false);
+
+    testLogger.info('Blank Visualize left the URL clean');
+  });
+
+  test("The metrics_data blob excludes volatile keys (id, title, description)", {
+    tag: ['@metrics-explorer-share', '@P2', '@url-sync', '@volatile-data', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing volatile panel keys are stripped before sharing');
+
+    await pm.metricsExplorerPage.gotoExplorer({ mode: 'visualize' });
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+    await pm.metricsExplorerPage.enterVisualizeQuery(SEEDED_METRIC);
+    await pm.metricsExplorerPage.waitForMetricsDataParam();
+
+    // getMetricsConfig deletes these — a shared link must not carry the sender's
+    // panel identity into the recipient's session.
+    const blob = pm.metricsExplorerPage.decodeMetricsBlob();
+    expect(blob).not.toBeNull();
+    expect(blob.data.id).toBeUndefined();
+    expect(blob.data.title).toBeUndefined();
+    expect(blob.data.description).toBeUndefined();
+
+    testLogger.info('Volatile keys absent from the shared blob');
+  });
+
+  // ═══ F1 + F2: FULL ROUND-TRIP ═════════════════════════════════════════════
+
+  test("A shared Visualize URL reopens the same chart", {
+    tag: ['@metrics-explorer-share', '@P0', '@share', '@round-trip', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing the end-to-end share round-trip');
+
+    // Build a chart, then take the URL the page produced — not a hand-rolled
+    // one. This is the whole bug: what the app writes must be what it can read.
+    await pm.metricsExplorerPage.gotoExplorer({ mode: 'visualize' });
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+    await pm.metricsExplorerPage.enterVisualizeQuery(SEEDED_METRIC);
+    await pm.metricsExplorerPage.waitForMetricsDataParam();
+
+    const sharedUrl = page.url();
+    testLogger.info(`Captured shared URL of length ${sharedUrl.length}`);
+
+    // Open it as a recipient would — a cold navigation, no in-page state.
+    await pm.metricsExplorerPage.navigateToUrl(sharedUrl);
+
+    await pm.metricsExplorerPage.expectOnExplorerRoute();
+    await pm.metricsExplorerPage.expectModeActive('visualize');
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+    await pm.metricsExplorerPage.expectVisualizeQueryToContain(SEEDED_METRIC);
+
+    testLogger.info('Shared URL rehydrated the chart with its original query');
+  });
+
+  test("Card drill-in produces a shareable Visualize URL", {
+    tag: ['@metrics-explorer-share', '@P1', '@url-sync', '@drill-in', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing the card → Visualize path also serializes to the URL');
+
+    await pm.metricsExplorerPage.gotoExplorer();
+    await pm.metricsExplorerPage.expectExplorerVisible();
+    await pm.metricsExplorerPage.waitForCards();
+
+    // The real user path into Visualize: open a card rather than typing PromQL.
+    // Its seeded query must be shareable exactly like a hand-built one.
+    await pm.metricsExplorerPage.openFirstCardInVisualize();
+    await pm.metricsExplorerPage.expectModeActive('visualize');
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+
+    await pm.metricsExplorerPage.waitForMetricsDataParam();
+    const blob = pm.metricsExplorerPage.decodeMetricsBlob();
+    expect(blob).not.toBeNull();
+    expect(blob.v).toBe(1);
+    expect(blob.data.queries?.[0]?.query).toBeTruthy();
+
+    testLogger.info('Drill-in chart serialized into a shareable URL');
+  });
+
+  // ═══ F1: SHARE BUTTON BEHAVIOUR ═══════════════════════════════════════════
+
+  test("Share button copies a short URL for the built Visualize chart", {
+    tag: ['@metrics-explorer-share', '@P0', '@share', '@clipboard', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing share-to-clipboard from the explorer Visualize mode');
+
+    await pm.metricsExplorerPage.gotoExplorer({ mode: 'visualize' });
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+
+    const { canShare, reason } = await pm.metricsExplorerPage.checkShareReadiness();
+    if (!canShare) {
+      testLogger.warn(`Skipping share test — ${reason}`);
+      test.skip(true, reason);
+      return;
+    }
+
+    await pm.metricsExplorerPage.enterVisualizeQuery(SEEDED_METRIC);
+    await pm.metricsExplorerPage.waitForMetricsDataParam();
+
+    await pm.metricsExplorerPage.clickShareButton();
+    await pm.metricsExplorerPage.waitForShareSuccessToast();
+
+    const clipboardUrl = await pm.metricsExplorerPage.getCopiedShortUrl();
+    expect(clipboardUrl).toContain('/short/');
+
+    testLogger.info('Short URL copied to the clipboard from the explorer');
+  });
+
+  test("Share button clears its loading state after the shorten call completes", {
+    tag: ['@metrics-explorer-share', '@P2', '@share', '@loading', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing the share button loading lifecycle');
+
+    await pm.metricsExplorerPage.gotoExplorer({ mode: 'visualize' });
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+
+    const { canShare, reason } = await pm.metricsExplorerPage.checkShareReadiness();
+    if (!canShare) {
+      testLogger.warn(`Skipping loading-state test — ${reason}`);
+      test.skip(true, reason);
+      return;
+    }
+
+    await pm.metricsExplorerPage.enterVisualizeQuery(SEEDED_METRIC);
+    await pm.metricsExplorerPage.waitForMetricsDataParam();
+
+    await pm.metricsExplorerPage.clickShareButton();
+    await pm.metricsExplorerPage.waitForShareSuccessToast();
+
+    // Poll the real state rather than sleeping into a race — a button stuck in
+    // aria-busy is unclickable, so this is the assertion that matters.
+    await expect
+      .poll(async () => await pm.metricsExplorerPage.isShareButtonLoading(), {
+        timeout: 10000,
+        intervals: [200, 400, 800],
+      })
+      .toBe(false);
+
+    testLogger.info('Share button returned to its idle state');
+  });
+
+  test("Share URL in a grid mode carries the explorer filters and no blob", {
+    tag: ['@metrics-explorer-share', '@P1', '@share', '@grid-mode', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing grid-mode sharing is the plain filtered URL');
+
+    // In Explore and Workspace the whole page state already lives in the URL, so
+    // shareUrl is location.href untouched — no metrics_data is appended.
+    await pm.metricsExplorerPage.gotoExplorer({ search: SEEDED_METRIC, sort: 'z-a' });
+    await pm.metricsExplorerPage.expectExplorerVisible();
+    await pm.metricsExplorerPage.expectShareButtonVisible();
+
+    expect(pm.metricsExplorerPage.getQueryParam('search')).toBe(SEEDED_METRIC);
+    expect(pm.metricsExplorerPage.getQueryParam('sort')).toBe('z-a');
+    expect(pm.metricsExplorerPage.hasMetricsDataParam()).toBe(false);
+
+    testLogger.info('Grid-mode URL carries filters only — verified');
+  });
+
+  // ═══ F1 + F2: MALFORMED BLOB EDGE CASES ═══════════════════════════════════
+
+  test("Visualize deep-link with a corrupt blob opens the explorer without crashing", {
+    tag: ['@metrics-explorer-share', '@P2', '@deeplink', '@error-handling', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing corrupt metrics_data is ignored, not fatal');
+
+    // decodeMetricsConfig swallows the failure and returns null, so the pane
+    // opens blank rather than throwing — and the guard still exempts the link.
+    const url = pm.metricsExplorerPage.buildExplorerUrl({
+      mode: 'visualize',
+      metrics_data: '!!!not-valid-base64!!!',
+    });
+
+    await pm.metricsExplorerPage.navigateToUrl(url);
+
+    await pm.metricsExplorerPage.expectOnExplorerRoute();
+    await pm.metricsExplorerPage.expectModeActive('visualize');
+    await pm.metricsExplorerPage.expectVisualizeVisible();
+
+    testLogger.info('Corrupt blob ignored — explorer stable in Visualize');
+  });
+
+  test("Visualize deep-link with an unknown blob version does not apply the payload", {
+    tag: ['@metrics-explorer-share', '@P2', '@deeplink', '@version-mismatch', '@all']
+  }, async ({ page }, testInfo) => {
+    const pm = await setupTest(page, testInfo);
+    testLogger.info('Testing the blob version gate rejects future payloads');
+
+    // v:9999 is the migration hook — an unrecognised envelope decodes to null, so
+    // no seed reaches MetricsVisualize and it falls back to applyMetricsDefaults.
+    //
+    // That fallback is NOT necessarily an empty editor: the last metrics stream is
+    // remembered in localStorage per org (utils/streamPersist.ts) and the default
+    // panel runs with customQuery=false, so the builder can auto-generate a query
+    // such as `avg(cpu_usage{})` on its own. Asserting "blank" would therefore be
+    // testing the environment's leftover state, not the version gate.
+    //
+    // So the rejected payload carries a marker no generated query can produce, and
+    // the assertion is precisely that the MARKER never lands — i.e. the blob was
+    // not applied — whatever the defaults happen to fill in.
+    const REJECTED_MARKER = 'max_over_time';
+    const blob = pm.metricsExplorerPage.buildPromqlBlob(
+      `${REJECTED_MARKER}(${SEEDED_METRIC}[42h])`,
+      9999
+    );
+    const url = pm.metricsExplorerPage.buildExplorerUrl({
+      mode: 'visualize',
+      metrics_data: blob,
+    });
+
+    await pm.metricsExplorerPage.navigateToUrl(url);
+
+    await pm.metricsExplorerPage.expectOnExplorerRoute();
+    await pm.metricsExplorerPage.expectModeActive('visualize');
+    await pm.metricsExplorerPage.waitForVisualizeReady();
+
+    // Let whatever the defaults produce settle first, so the assertion runs after
+    // the editor has been populated rather than racing an empty initial state.
+    await pm.metricsExplorerPage.waitForVisualizeQuerySettled();
+
+    const queryText = await pm.metricsExplorerPage.getVisualizeQueryText();
+    expect(queryText).not.toContain(REJECTED_MARKER);
+
+    // Note: the rejected blob may REMAIN in the address bar. syncVisualizeUrl only
+    // rewrites metrics_data when the serialized chart differs from the param, and
+    // on a blank canvas it has nothing to write — nothing proactively scrubs an
+    // unrecognised inbound param. Asserting it disappears would test a guarantee
+    // the app does not make, so the invariant here is strictly "not applied".
+
+    testLogger.info('Version-gated blob rejected — payload never applied');
+  });
+});


### PR DESCRIPTION
Adds E2E coverage for PR #13274 (metric page share URL), which shipped with
unit tests but no Playwright coverage — the existing metrics-share-deep-link
suite targets the legacy `/metrics/editor` route, not the Explorer.

15 tests covering:
- F1 — share button presence, `metrics_data` blob written on chart build,
  stripped on leaving Visualize, absent on a blank canvas, volatile keys
  excluded, card drill-in, short-URL clipboard copy, full share round-trip
- F2 — `?mode=visualize` stays on the Explorer; legacy no-mode `metrics_data`
  still redirects to the editor; corrupt and version-mismatched blobs absorbed

New `MetricsExplorerPage` page object; registered in PageManager and the
`Metrics` CI shard.

Verified 15/15 on two consecutive runs against v0.92.0-rc3 (~36s).
