### PR TITLE
test(i18n): add a single en-US key to exercise the translation workflow

### DIFF
--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -440,6 +440,7 @@
     "copyContentError": "Error while copying content.",
     "contentCopiedSuccessfully": "Content Copied Successfully!",
     "valueCopiedToClipboard": "Value copied to clipboard",
+    "copyLinkToClipboard": "Copy link to clipboard",
     "replace": "Replace",
     "and": "and",
     "versionAbbreviation": "V",


### PR DESCRIPTION
Adds common.copyLinkToClipboard so the pull_request-triggered update-translations workflow has a pending key to generate translations for. This branch exists only to validate the CI change in #13741 and is not intended to merge.