### PR TITLE
test(dashboards): e2e coverage for favorites cross-folder search fix (#13437)

### DIFF
--- a/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-favorites.js
@@ -24,6 +24,18 @@ export default class DashboardFavorites {
     this.searchInput = page.locator('[data-test="dashboard-search-field"]');
     this.refreshBtn = page.locator('[data-test="dashboard-list-refresh"]');
 
+    // Search scope toggle + clear button. OInput derives the clear button's
+    // hook from the consumer's data-test (`${parent}-clear`), and only renders
+    // it while the field is non-empty — so its absence is a real signal, not a
+    // timing artifact.
+    this.searchScopeAllFolders = page.locator(
+      '[data-test="dashboard-search-across-folders-toggle"]'
+    );
+    this.searchScopeCurrentFolder = page.locator(
+      '[data-test="dashboard-search-scope-current"]'
+    );
+    this.searchClearBtn = page.locator('[data-test="dashboard-search-clear"]');
+
     // Bulk action bar (only rendered once at least one row is selected).
     this.bulkDeleteBtn = page.locator(
       '[data-test="dashboard-list-delete-dashboards-btn"]'
@@ -103,6 +115,41 @@ export default class DashboardFavorites {
     await this.getNameCell(dashboardName)
       .waitFor({ state: "visible", timeout: 15000 })
       .catch(() => {});
+  }
+
+  // Switch the scope toggle to "All folders" and search. In the Favorites view
+  // this is the path fixed by #13437: the rows computed used to short-circuit
+  // to the stored favorites whenever the Favorites pseudo-folder was active,
+  // so cross-folder hits could never render. Filling the field triggers a
+  // 600ms-debounced list call, so callers assert with the standard 15s
+  // web-first timeout rather than sleeping here.
+  async searchAcrossFolders(query) {
+    await this.searchScopeAllFolders.waitFor({
+      state: "visible",
+      timeout: 15000,
+    });
+    await this.searchScopeAllFolders.click();
+    await this.searchInput.waitFor({ state: "visible", timeout: 15000 });
+    await this.searchInput.fill(query);
+  }
+
+  // ── Search clearing ────────────────────────────────────────────────────
+
+  async clearSearch() {
+    await this.searchClearBtn.waitFor({ state: "visible", timeout: 15000 });
+    await this.searchClearBtn.click();
+  }
+
+  // Regression guard for the `:clearable="searchAcrossFolders"` → `clearable`
+  // change: before it, the clear button only ever rendered while the "All
+  // folders" scope was active, leaving current-folder searches with no way to
+  // reset the field from the UI.
+  async verifySearchClearButtonVisible() {
+    await expect(this.searchClearBtn).toBeVisible({ timeout: 15000 });
+  }
+
+  async verifySearchInputEmpty() {
+    await expect(this.searchInput).toHaveValue("", { timeout: 15000 });
   }
 
   // ── Favorite toggling ──────────────────────────────────────────────────

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-favorites.spec.js
@@ -161,6 +161,89 @@ test.describe("dashboard favorites testcases", () => {
     await pm.dashboardFavorites.verifyDashboardNotPresent(dashboardName);
   });
 
+  // Regression (#13437): the rows computed short-circuited to the stored
+  // favorites whenever the Favorites pseudo-folder was active, so a
+  // cross-folder search made from inside Favorites returned nothing but the
+  // favorites themselves. The fix makes the favorites branch yield to an
+  // active cross-folder search.
+  test("should surface a non-favorited dashboard in the Favorites folder when searching across folders", async ({
+    page,
+  }) => {
+    // A second, deliberately un-favorited dashboard: it is the only row that
+    // can prove the search reached past the favorites list. Named so neither
+    // dashboard's name is a substring of the other, keeping both the
+    // cross-folder search and the current-folder filter unambiguous.
+    const otherDashboardName = "DashB_" + Date.now();
+    await pm.dashboardCreate.createDashboard(otherDashboardName);
+    await pm.dashboardCreate.backToDashboardList();
+    await waitForDashboardPage(page);
+
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.addToFavorites(dashboardName);
+
+    await pm.dashboardFavorites.openFavoritesFolder();
+    await pm.dashboardFavorites.verifyDashboardVisible(dashboardName);
+    // Baseline: the un-favorited dashboard is absent from the favorites-only
+    // list, so its appearance below is attributable to the search alone.
+    await pm.dashboardFavorites.verifyDashboardNotPresent(otherDashboardName);
+
+    await pm.dashboardFavorites.searchAcrossFolders(otherDashboardName);
+    await pm.dashboardFavorites.verifyDashboardVisible(otherDashboardName);
+  });
+
+  // Companion to the above: clearing the query has to hand the view back to
+  // the favorites list. `clearSearchHistory` now resets both scope models
+  // (searchQuery and filterQuery), so the cross-folder branch deactivates.
+  test("should restore the favorites-only list after clearing a cross-folder search", async ({
+    page,
+  }) => {
+    const otherDashboardName = "DashB_" + Date.now();
+    await pm.dashboardCreate.createDashboard(otherDashboardName);
+    await pm.dashboardCreate.backToDashboardList();
+    await waitForDashboardPage(page);
+
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.addToFavorites(dashboardName);
+
+    await pm.dashboardFavorites.openFavoritesFolder();
+    await pm.dashboardFavorites.searchAcrossFolders(otherDashboardName);
+    await pm.dashboardFavorites.verifyDashboardVisible(otherDashboardName);
+
+    await pm.dashboardFavorites.clearSearch();
+    await pm.dashboardFavorites.verifySearchInputEmpty();
+
+    // Back to favorites-only: the searched-for dashboard drops out and the
+    // favorite returns.
+    await pm.dashboardFavorites.verifyDashboardNotPresent(otherDashboardName);
+    await pm.dashboardFavorites.verifyDashboardVisible(dashboardName);
+  });
+
+  // Regression (#13437): the search field was `:clearable="searchAcrossFolders"`,
+  // so in the default "this folder" scope no clear button rendered at all and
+  // a filter could only be undone by selecting the text by hand.
+  test("should expose a clear button for a current-folder search and restore the full list", async ({
+    page,
+  }) => {
+    const otherDashboardName = "DashB_" + Date.now();
+    await pm.dashboardCreate.createDashboard(otherDashboardName);
+    await pm.dashboardCreate.backToDashboardList();
+    await waitForDashboardPage(page);
+
+    // Default scope is "this folder" — no toggling, that is the mode the
+    // clear button used to be missing from.
+    await pm.dashboardFavorites.searchDashboard(dashboardName);
+    await pm.dashboardFavorites.verifyDashboardVisible(dashboardName);
+    await pm.dashboardFavorites.verifyDashboardNotPresent(otherDashboardName);
+
+    await pm.dashboardFavorites.verifySearchClearButtonVisible();
+    await pm.dashboardFavorites.clearSearch();
+    await pm.dashboardFavorites.verifySearchInputEmpty();
+
+    // Both folder members are listed again once the filter is dropped.
+    await pm.dashboardFavorites.verifyDashboardVisible(dashboardName);
+    await pm.dashboardFavorites.verifyDashboardVisible(otherDashboardName);
+  });
+
   test.afterEach(async ({ page }) => {
     // Un-favorite before deleting the folder. Deleting a folder does not
     // prune favorites for the dashboards inside it, so without this, tests


### PR DESCRIPTION
## Summary

Adds E2E coverage for #13437 (`fix: dashboard all folder search for favorites`).
That PR changed three things in `Dashboards.vue`; this adds one test per change.

## Test cases added

| # | Test case | Covers | Priority |
|---|-----------|--------|----------|
| 1 | `should surface a non-favorited dashboard in the Favorites folder when searching across folders` | Favorites view yields to an active cross-folder search instead of short-circuiting to the stored favorites list | P0 |
| 2 | `should restore the favorites-only list after clearing a cross-folder search` | Clearing resets both scope models (`searchQuery` + `filterQuery`), so the favorites-only list comes back | P1 |
| 3 | `should expose a clear button for a current-folder search and restore the full list` | Search field is unconditionally `clearable` — the clear (X) button now renders in "This folder" scope too | P1 |

## What each test proves

**1.** Seeds two dashboards in one folder, favorites only the first. Asserts the
un-favorited one is **absent** from the Favorites view, then switches the scope
toggle to "All folders", searches it by name, and asserts it appears. Before the
fix the rows computed returned `favorites.value.map(...)` whenever the
`__favorites__` pseudo-folder was active, so a cross-folder hit could never render.

**2.** Runs that same cross-folder search, then clicks clear and asserts the field
is empty, the searched-for dashboard drops out, and the favorite is listed again.

**3.** Searches in the default "This folder" scope, asserts the filter is active
(second dashboard filtered out), that `[data-test="dashboard-search-clear"]` is
visible, and that clicking it empties the field and restores both rows.
Previously `:clearable="searchAcrossFolders"` meant no clear button existed in
this mode at all.

## Files changed

- `tests/ui-testing/playwright-tests/dashboards/dashboard-favorites.spec.js` — 3 new tests (file now has 9)
- `tests/ui-testing/pages/dashboardPages/dashboard-favorites.js` — 3 locators (`searchScopeAllFolders`, `searchScopeCurrentFolder`, `searchClearBtn`) + 5 methods (`searchAcrossFolders`, `clearSearch`, `verifySearchClearButtonVisible`, `verifySearchInputEmpty`)

## Test design

Each test seeds a second, deliberately un-favorited dashboard (`DashB_<ts>`), named
so neither dashboard's name is a substring of the other — that second row is the
only thing that can prove the search reached past the favorites list. Every test
asserts its own baseline *before* the action, so a pass is attributable to the
change under test rather than to a permissive list. All selectors read from source;
no new `waitForTimeout` sleeps; cleanup covered by the existing `afterEach`.

## Test results

`9 passed` locally against `localhost:5080`. New tests verified green on repeated
isolated runs.

## Caveats

- Tests were **not** verified to fail against pre-fix code — the app is served from
  a prebuilt bundle (no dev server), so reverting the hunks would require a full
  frontend rebuild. The in-test baseline assertions mitigate this but don't replace it.
- This spec file is **self-hosted-only**: `login()` in `dashLogin.js` waits for the
  `login-user-id-field` form, while alpha cloud uses Dex SSO. Confirmed pre-existing
  (an untouched test in this file fails at the identical line), but it means these
  tests won't run in a cloud-targeted CI job.
