### PR TITLE
fix: tighten workflow permissions and CSS selector escaping

### DIFF
--- a/.github/workflows/audit-checker.yml
+++ b/.github/workflows/audit-checker.yml
@@ -6,6 +6,9 @@ on:
       - "**.yml"
       - "**.yaml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/js-license-checker.yml
+++ b/.github/workflows/js-license-checker.yml
@@ -17,6 +17,9 @@ on:
     #   - "**.yaml"
   merge_group:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ on:
     tags:
       - "v*.*.*"
 name: Release
+
+# Default for every job; the `release` job widens this for itself below.
+permissions:
+  contents: read
+
 env:
   RUST_TOOLCHAIN: nightly-2026-05-20
 jobs:

--- a/.github/workflows/spam-cleaner.yml
+++ b/.github/workflows/spam-cleaner.yml
@@ -4,6 +4,12 @@ on:
   issue_comment:
     types: [created, edited]
 
+# issue_comment fires for both issue and PR conversation comments, and deleting
+# each is governed by a different scope.
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   delete_mediafire_comments:
     runs-on: ubicloud-standard-8

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -14,6 +14,16 @@ const { getAuthHeaders, getOrgIdentifier, isCloudEnvironment, authedRequest } = 
 const MonacoEditorHelper = require('../../playwright-tests/utils/MonacoEditorHelper.js');
 
 export class LogsPage {
+    /**
+     * Escape a value for embedding inside a double-quoted CSS attribute selector.
+     * Backslashes must be escaped first, otherwise a literal `\` in the text would
+     * be emitted unescaped and swallow the character that follows it (and a
+     * trailing `\` would escape the closing quote and break the whole selector).
+     */
+    static escapeCssAttrValue(text) {
+        return String(text).replace(/["\\]/g, '\\$&');
+    }
+
     constructor(page) {
         this.page = page;
         
@@ -3790,7 +3800,7 @@ export class LogsPage {
     }
 
     async expectNotificationMessage(text) {
-        const escaped = String(text).replace(/"/g, '\\"');
+        const escaped = LogsPage.escapeCssAttrValue(text);
         const selector = [
             `[data-test-variant="success"][data-test-message*="${escaped}"]`,
             `[data-test-variant="error"][data-test-message*="${escaped}"]`,
@@ -3818,7 +3828,7 @@ export class LogsPage {
         // Some validations in the UX-revamp moved from $q.notify toasts to inline
         // OInput error messages (rendered as `[data-test="<name>-error"]`).
         // Cover both surfaces so the wait succeeds for either feedback channel.
-        const escaped = String(text).replace(/"/g, '\\"');
+        const escaped = LogsPage.escapeCssAttrValue(text);
         const selector = [
             `[data-test-variant="success"][data-test-message*="${escaped}"]`,
             `[data-test-variant="error"][data-test-message*="${escaped}"]`,


### PR DESCRIPTION
## Summary

- set explicit least-privilege permissions for audit, JavaScript license, and release workflows while preserving release-job write access
- grant the spam-cleaner workflow the issue and pull-request scopes required to delete comments
- escape quotes and backslashes before interpolating log toast text into CSS attribute selectors

## Validation

- parsed the four modified workflow files as YAML
- ran Node syntax checking on tests/ui-testing/pages/logsPages/logsPage.js
- ran git diff whitespace validation