### PR TITLE
test(e2e/alpha1): fix share-link redirect origin and cloud metrics ingest auth

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -7442,6 +7442,32 @@ export class LogsPage {
             testLogger.info('Converted HTTP to HTTPS', { url: sharedUrl });
         }
 
+        // Re-point the short URL at the host the tests authenticated against (ZO_BASE_URL).
+        // On deployed/cloud envs the app builds the share link from its PUBLIC base URL
+        // (e.g. *.external.zinclabs.dev) which differs from the ingress the tests use
+        // (e.g. *.internal.zinclabs.dev). Navigating cross-origin drops the auth cookies
+        // and bounces to Dex, so the redirected page reads back an empty/logged-out state.
+        // The /short/<id> id resolves identically on the backend regardless of ingress
+        // host, so swapping only the origin keeps the session valid and the test intent
+        // (verify state preservation through the short-URL redirect) unchanged. Same-origin
+        // envs (localhost, matching deployed host) fall through untouched.
+        const baseUrl = process.env.ZO_BASE_URL;
+        if (baseUrl && !sharedUrl.includes('localhost')) {
+            try {
+                const shared = new URL(sharedUrl);
+                const base = new URL(baseUrl);
+                if (shared.origin !== base.origin) {
+                    shared.protocol = base.protocol;
+                    shared.host = base.host;
+                    const rewritten = shared.toString();
+                    testLogger.info('Re-pointed share URL to ZO_BASE_URL origin', { from: sharedUrl, to: rewritten });
+                    sharedUrl = rewritten;
+                }
+            } catch (e) {
+                testLogger.warn('Could not re-point share URL origin', { error: e.message });
+            }
+        }
+
         testLogger.info('Share link URL captured', { url: sharedUrl });
 
         return sharedUrl;

--- a/tests/ui-testing/playwright-tests/Logs/searchPatterns.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/searchPatterns.spec.js
@@ -20,8 +20,13 @@ const patternsTestData = require("../../../test-data/patterns_test_data.json");
 const { ingestCustomData, enableLogPatternsExtraction, waitForStreamData } = require('../utils/data-ingestion.js');
 const { getOrgIdentifier } = require('../utils/cloud-auth.js');
 
-// Dedicated stream for pattern tests with proper configuration
-const PATTERNS_STREAM = "e2e_http_patterns";
+// Dedicated stream for pattern tests with proper configuration.
+// Unique per-run suffix so concurrent alpha runs never share the name: on the shared
+// cloud org a fixed name meant one run's pre-test cleanup was deleting the stream while
+// another run's beforeAll ingested into it, returning 400 "stream is being deleted" and
+// leaving the stream absent for selectStream. cleanup.spec.js reclaims these via the
+// `/^e2e_http_patterns/` prefix pattern.
+const PATTERNS_STREAM = `e2e_http_patterns_${Date.now().toString(36)}`;
 
 // Track if data has been ingested (for serial test execution)
 let dataIngested = false;
@@ -98,12 +103,21 @@ test.describe("Search Patterns Feature", { tag: ['@enterprise', '@searchPatterns
             }));
 
             testLogger.info(`Ingesting ${freshData.length} logs to stream: ${PATTERNS_STREAM}`);
-            const ingestResponse = await ingestCustomData(page, PATTERNS_STREAM, freshData);
+            // Retry on the transient "stream is being deleted" (400) that a concurrent run's
+            // cleanup can trigger — the delete completes, then the POST recreates the stream.
+            let ingestResponse;
+            for (let attempt = 1; attempt <= 3; attempt++) {
+                ingestResponse = await ingestCustomData(page, PATTERNS_STREAM, freshData);
+                if (ingestResponse.status === 200) break;
+                const msg = JSON.stringify(ingestResponse.data || {});
+                testLogger.warn(`Pattern data ingestion attempt ${attempt} returned ${ingestResponse.status}`, { data: msg.slice(0, 160) });
+                if (attempt < 3) await page.waitForTimeout(3000);
+            }
 
             if (ingestResponse.status === 200) {
-                testLogger.info('Pattern data ingested successfully', { status: ingestResponse.status });
+                testLogger.info('Pattern data ingested successfully', { status: ingestResponse.status, stream: PATTERNS_STREAM });
             } else {
-                testLogger.error('Pattern data ingestion failed', { status: ingestResponse.status, data: ingestResponse.data });
+                testLogger.error('Pattern data ingestion failed after retries', { status: ingestResponse.status, data: ingestResponse.data });
             }
 
             // Enable log patterns extraction on the stream
@@ -118,7 +132,10 @@ test.describe("Search Patterns Feature", { tag: ['@enterprise', '@searchPatterns
                 testLogger.warn('Stream data polling timed out, proceeding anyway...');
             }
 
-            dataIngested = true;
+            // Only latch the "already ingested" guard when the stream actually landed, so a
+            // transient ingest failure doesn't make every test in the serial block run
+            // against a non-existent stream.
+            dataIngested = ingestResponse.status === 200;
         } finally {
             await context.close();
         }

--- a/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-regression.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-regression.spec.js
@@ -3,7 +3,7 @@ const testLogger = require('../../utils/test-logger.js');
 const PageManager = require('../../../pages/page-manager.js');
 const { getHeaders, getIngestionUrl, sendRequest } = require('../../utils/data-ingestion.js');
 const logData = require("../../../fixtures/log.json");
-const { getOrgIdentifier } = require('../../utils/cloud-auth.js');
+const { getOrgIdentifier, getAuthHeaders, refreshCloudConfig } = require('../../utils/cloud-auth.js');
 
 /**
  * Alerts Regression Bugs Test Suite
@@ -614,9 +614,14 @@ async function ingestMetricsData(page) {
   const baseUrl = process.env.INGESTION_URL || process.env.ZO_BASE_URL || 'http://localhost:5080';
   const ingestionUrl = `${baseUrl}/api/${orgId}/ingest/metrics/_json`;
 
-  const basicAuthCredentials = Buffer.from(
-    `${process.env["ZO_ROOT_USER_EMAIL"]}:${process.env["ZO_ROOT_USER_PASSWORD"]}`
-  ).toString('base64');
+  // Cloud ingestion authenticates with the per-org passcode (email:passcode), NOT the
+  // Dex login password. getAuthHeaders() returns passcode Basic-auth on cloud and
+  // ZO_ROOT_USER creds on self-hosted. Refresh the passcode from the live browser
+  // session first so a stale cloud-config.json can't 401 the ingest — a silent 401 here
+  // left the metrics stream uncreated, so the PromQL flow later timed out trying to
+  // select 'e2e_test_cpu_usage'.
+  await refreshCloudConfig(page).catch(() => {});
+  const headers = getAuthHeaders();
 
   const timestamp = Math.floor(Date.now() / 1000);
 
@@ -635,28 +640,43 @@ async function ingestMetricsData(page) {
   }
 
   try {
-    const response = await page.evaluate(async ({ url, authToken, data }) => {
+    const response = await page.evaluate(async ({ url, headers, data }) => {
       const fetchResponse = await fetch(url, {
         method: 'POST',
-        headers: {
-          'Authorization': `Basic ${authToken}`,
-          'Content-Type': 'application/json'
-        },
+        headers,
         body: JSON.stringify(data)
       });
       return {
         status: fetchResponse.status,
         data: await fetchResponse.json().catch(() => ({}))
       };
-    }, { url: ingestionUrl, authToken: basicAuthCredentials, data: metricsData });
+    }, { url: ingestionUrl, headers, data: metricsData });
 
     testLogger.info('Metrics data ingested', { response, streamName });
   } catch (e) {
     testLogger.warn('Metrics ingestion may have failed', { error: e.message });
   }
 
-  // Allow time for indexing by waiting for network activity to settle
-  await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+  // Poll until the metrics stream is queryable so the later stream-select in the alert
+  // wizard doesn't race WAL indexing lag on cloud (a fixed networkidle wait was not
+  // enough — the stream showed up in the dropdown only seconds later).
+  const streamsUrl = `${baseUrl}/api/${orgId}/streams?type=metrics&page_num=0&page_size=1000`;
+  const deadline = Date.now() + 60000;
+  while (Date.now() < deadline) {
+    const found = await page.evaluate(async ({ url, headers, streamName }) => {
+      try {
+        const r = await fetch(url, { headers });
+        if (!r.ok) return false;
+        const d = await r.json();
+        return (d.list || []).some(s => s.name === streamName);
+      } catch { return false; }
+    }, { url: streamsUrl, headers, streamName });
+    if (found) {
+      testLogger.info('Metrics stream indexed and queryable', { streamName });
+      break;
+    }
+    await page.waitForTimeout(3000);
+  }
 }
 
 /**

--- a/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-regression.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-regression.spec.js
@@ -662,8 +662,9 @@ async function ingestMetricsData(page) {
   // enough — the stream showed up in the dropdown only seconds later).
   const streamsUrl = `${baseUrl}/api/${orgId}/streams?type=metrics&page_num=0&page_size=1000`;
   const deadline = Date.now() + 60000;
+  let streamFound = false;
   while (Date.now() < deadline) {
-    const found = await page.evaluate(async ({ url, headers, streamName }) => {
+    streamFound = await page.evaluate(async ({ url, headers, streamName }) => {
       try {
         const r = await fetch(url, { headers });
         if (!r.ok) return false;
@@ -671,11 +672,16 @@ async function ingestMetricsData(page) {
         return (d.list || []).some(s => s.name === streamName);
       } catch { return false; }
     }, { url: streamsUrl, headers, streamName });
-    if (found) {
+    if (streamFound) {
       testLogger.info('Metrics stream indexed and queryable', { streamName });
       break;
     }
     await page.waitForTimeout(3000);
+  }
+  // Surface the real cause here rather than letting a later stream-select time out with
+  // a misleading error — if ingest 401'd or indexing never caught up, this is where it shows.
+  if (!streamFound) {
+    testLogger.warn('Metrics stream not indexed within 60s — downstream stream-select may fail', { streamName });
   }
 }
 

--- a/tests/ui-testing/playwright-tests/RegressionSet/Streams/streams-regression.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Streams/streams-regression.spec.js
@@ -5,6 +5,12 @@ const { ingestTestData, getHeaders, getIngestionUrl, sendRequest } = require('..
 const logData = require("../../../fixtures/log.json");
 const { getOrgIdentifier } = require('../../utils/cloud-auth.js');
 
+// Unique per-run suffix for this file's throwaway streams. On the shared cloud org a
+// fixed name collides with a concurrent run's cleanup ("stream is being deleted", 400),
+// which then leaves the stream absent for selectStream. Keeping "ellipsis_testing" in the
+// name preserves the cleanup.spec.js `/ellipsis_testing/` reclaim pattern.
+const RUN_TOKEN = Date.now().toString(36);
+
 test.describe("Streams Regression Bugs", () => {
   test.describe.configure({ mode: 'parallel' });
   let pm; // Page Manager instance
@@ -72,13 +78,14 @@ test.describe("Streams Regression Bugs", () => {
   }, async ({ page }) => {
     testLogger.info('Test: Verify ellipsis and tooltip for multiple stream selection with long names (Bug #7468)');
 
-    // Use streams with extremely long names to trigger ellipsis
+    // Use streams with extremely long names to trigger ellipsis. The per-run token keeps
+    // them long AND unique so a concurrent run's cleanup can't delete them mid-test.
     const longStreamNames = [
-      'extremely_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_one_alpha',
-      'another_incredibly_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_two_beta',
-      'yet_another_extraordinarily_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_three_gamma',
-      'fourth_tremendously_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_four_delta',
-      'fifth_exceptionally_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_five_epsilon'
+      `extremely_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_one_alpha_${RUN_TOKEN}`,
+      `another_incredibly_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_two_beta_${RUN_TOKEN}`,
+      `yet_another_extraordinarily_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_three_gamma_${RUN_TOKEN}`,
+      `fourth_tremendously_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_four_delta_${RUN_TOKEN}`,
+      `fifth_exceptionally_long_stream_name_for_comprehensive_ellipsis_testing_scenario_number_five_epsilon_${RUN_TOKEN}`
     ];
 
     const orgId = getOrgIdentifier() || 'default';
@@ -97,7 +104,17 @@ test.describe("Streams Regression Bugs", () => {
         test_id: "bug_7468",
         _timestamp: baseTimestamp + i
       };
-      return sendRequest(page, ingestionUrl, payload, headers);
+      // Retry on a transient "stream is being deleted" (400) so a concurrent cleanup
+      // racing the POST doesn't leave the stream absent for the UI selection below.
+      return (async () => {
+        let res;
+        for (let attempt = 1; attempt <= 3; attempt++) {
+          res = await sendRequest(page, ingestionUrl, payload, headers);
+          if (res && res.code === 200) return res;
+          if (attempt < 3) await page.waitForTimeout(3000);
+        }
+        return res;
+      })();
     });
 
     const responses = await Promise.all(ingestionPromises);

--- a/tests/ui-testing/playwright-tests/cleanup.spec.js
+++ b/tests/ui-testing/playwright-tests/cleanup.spec.js
@@ -306,7 +306,7 @@ test.describe("Pre-Test Cleanup", () => {
         /^e2e_universal_(src|dest)_\d+$/,     // Test 9: Universal condition test streams
         /^e2e_4level_(src|dest)_\d+$/,        // Test 10: 4-level nested test streams
         /^stream\d{13}$/,                     // stream1765164273471, etc. (timestamp-based test streams)
-        /^e2e_http_patterns$/,                // Pattern tests stream (searchPatterns.spec.js)
+        /^e2e_http_patterns/,                 // Pattern tests stream (searchPatterns.spec.js) — prefix covers the unique per-run e2e_http_patterns_<token> names
         /^e2e_stream_(a|b)_\d+$/,             // Regression test streams (e2e_stream_a_*, e2e_stream_b_*)
         /^join_[a-z0-9]+_(requests|users|sessions)$/,  // Dashboard joins test streams (join_<testId>_requests, etc.)
         /^join_[a-z0-9]+_[a-z0-9]+_(requests|users|sessions)$/,  // Dashboard joins test streams with extra segment (join_<id1>_<id2>_requests, etc.)


### PR DESCRIPTION
## Why

The scheduled **Alpha1 (Cloud)** e2e run failed on three jobs ([o2-enterprise run 31547517666](https://github.com/openobserve/o2-enterprise/actions/runs/31547517666)): **Logs-Features** (7), **Functions** (11), **RegressionSet** (4). Root-caused each against a freshly-deployed alpha; two are genuine test heals, one was pure environment skew.

## Root causes & fixes

### 1. Logs-Features — shareLink + monaco-query-prefill (7 tests) ✅ fixed
On cloud the app builds the share link from its **public** base URL (`*.external.zinclabs.dev`), while the tests authenticate against the ingress host (`*.internal.zinclabs.dev`). `page.goto(sharedUrl)` navigated **cross-origin**, dropped the auth cookies, and bounced to Dex — so every post-redirect state assertion read back `null`.

**Fix:** re-point the short URL's origin to `ZO_BASE_URL` in `clickShareLinkAndGetUrl()` (right next to the existing HTTP→HTTPS "maintain auth context" step). `/short/<id>` resolves identically on the backend regardless of ingress host, so only the origin changes and the session stays valid. Same-origin envs (localhost / matching deployed host) are untouched.

### 2. RegressionSet — alerts Bug #9967 PromQL (1 test) ✅ fixed
`ingestMetricsData()` authenticated with `ZO_ROOT_USER_EMAIL:PASSWORD`, but **cloud ingestion needs `email:passcode`**. The ingest silently 401'd → the `e2e_test_cpu_usage` metrics stream was never created → the PromQL alert flow timed out selecting it.

**Fix:** build auth via `getAuthHeaders()` (passcode on cloud, root creds on self-hosted), refresh the passcode from the live browser session first, and poll until the stream is indexed so the wizard's stream-select doesn't race WAL lag.

### 3. Functions — radio → segmented toggle (11 tests) — no change needed
The page object was already migrated to the segmented toggle in #13766; these failures were the **alpha frontend lagging the merged test code**. Green after the redeploy with zero code change.

## Verification (against alpha, `auto_org_1`)
- `shareLink.spec.js` + `monaco-query-prefill.spec.js` → **11/11 passed**
- `alerts-regression.spec.js` (full) → **5/5 passed** (#9967, #10110, #10899, #10872, #10472)
- `Functions/js-transform-type.spec.js` → **7/7**, `row-expansion.spec.js` → green

## Scope
OSS-only (test files). The ENT `playwright_alpha1.yml` checks out opensource at `main`, so merging makes the next scheduled run pick this up. It can also be pre-verified by dispatching that workflow with `o2_opensource_repo=test/alpha1-e2e-heals-0812`.