### PR TITLE
test(reports): e2e regression coverage for dashboard scheduled reports drawer (#13569)

### DIFF
--- a/tests/ui-testing/ci-matrix/ci_matrix.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix.json
@@ -290,7 +290,8 @@
       "reportFolders.spec.js",
       "reports-bulk-operations.spec.js",
       "reports-form-validation.spec.js",
-      "reportCsvMediaType.spec.js"
+      "reportCsvMediaType.spec.js",
+      "scheduledReportsDrawer.spec.js"
     ],
     "disabled": []
   },

--- a/tests/ui-testing/pages/apiCleanup.js
+++ b/tests/ui-testing/pages/apiCleanup.js
@@ -391,6 +391,42 @@ class APICleanup {
         }
     }
 
+    /**
+     * Delete a single report by its id (v2, folder-aware).
+     *
+     * Prefer this over deleteReport() whenever a report may live outside the
+     * default folder: the v1 `DELETE /api/{org}/reports/{name}` route resolves
+     * names within the default folder only and returns 404 for a report saved
+     * in a custom report folder, which then blocks deleting that folder.
+     *
+     * @param {string} reportId - The report id (`report_id` from fetchReports)
+     * @param {string} reportName - Optional, for logging only
+     * @returns {Promise<Object>} { code, message }
+     */
+    async deleteReportById(reportId, reportName = '') {
+        try {
+            const response = await this._fetch(`${this.baseUrl}/api/v2/${this.org}/reports/${reportId}`, {
+                method: 'DELETE',
+                headers: {
+                    'Authorization': this.authHeader,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            const text = await response.text();
+
+            if (!response.ok) {
+                testLogger.error('Failed to delete report by id', { reportId, reportName, status: response.status, body: text });
+                return { code: response.status, message: text };
+            }
+
+            return { code: 200, message: text };
+        } catch (error) {
+            testLogger.error('Failed to delete report by id', { reportId, reportName, error: error.message });
+            return { code: 500, message: error.message, error: error.message };
+        }
+    }
+
 
     /**
      * Fetch all pipelines

--- a/tests/ui-testing/pages/dashboardPages/scheduledReportsDrawer.js
+++ b/tests/ui-testing/pages/dashboardPages/scheduledReportsDrawer.js
@@ -1,0 +1,148 @@
+import { expect } from '@playwright/test';
+
+/**
+ * Page object for the "Scheduled Dashboards" drawer opened from a dashboard's
+ * view toolbar (web/src/views/Dashboards/ScheduledDashboards.vue, opened by
+ * ViewDashboard.vue's `view-dashboard-scheduled-reports` button).
+ *
+ * Covers the two regressions fixed in PR #13569:
+ *   1. rows duplicating each time the drawer is reopened
+ *   2. reports saved in a custom REPORT folder being filtered out
+ */
+export class ScheduledReportsDrawerPage {
+  constructor(page) {
+    this.page = page;
+
+    // Toolbar trigger on the dashboard view page (ViewDashboard.vue:195).
+    this.openDrawerBtn = page.locator('[data-test="view-dashboard-scheduled-reports"]');
+
+    // ODrawer sets its DialogContent data-test from the consumer's attr
+    // (parentDataTest), so the panel itself carries `scheduled-dashboards-drawer`.
+    this.drawer = page.locator('[data-test="scheduled-dashboards-drawer"]');
+    this.drawerCloseBtn = this.drawer.locator('[data-test="o-drawer-close-btn"]');
+    this.drawerOverlay = page.locator('[data-test="o-drawer-overlay"]');
+
+    // Drawer body. OTable does not set inheritAttrs:false, so the table's own
+    // `o2-table-root` and the consumer's `scheduled-dashboard-table` land on the
+    // same element — scope row lookups through the container to stay unambiguous.
+    this.container = page.locator('[data-test="scheduled-dashboards-container"]');
+    this.table = this.container.locator('[data-test="scheduled-dashboard-table"]');
+    // `tr` qualifier keeps the drag-handle button (`o2-table-row-drag-handle`,
+    // OTableBodyRow.vue:247) out of the prefix match.
+    this.rows = this.container.locator('tr[data-test^="o2-table-row-"]');
+    this.emptyState = this.container.locator('[data-test="no-data-message"]');
+    this.loadingBanner = this.container.locator('[data-test="o2-table-loading-banner"]');
+
+    // AppTabs renders `tab-<value>`; values are "cached" / "shared"
+    // (ScheduledDashboards.vue:167-170).
+    this.cachedTab = this.drawer.locator('[data-test="tab-cached"]');
+    this.scheduledTab = this.drawer.locator('[data-test="tab-shared"]');
+
+    // OSearchInput wrapper carries `alert-list-search-input`; OInput forwards the
+    // native input as `<parent>-field`.
+    this.searchInput = this.drawer.locator('[data-test="alert-list-search-input-field"]');
+    this.newReportBtn = this.drawer.locator('[data-test="alert-list-add-alert-btn"]');
+  }
+
+  /**
+   * Row locator for a named report. The drawer's OTable rows have no per-name
+   * data-test (only `o2-table-row-<index>`), so the name is matched on row text.
+   * Safe here because report names in these tests are unique random strings.
+   */
+  rowByReportName(reportName) {
+    return this.rows.filter({ hasText: reportName });
+  }
+
+  /**
+   * Open a dashboard's view page directly by id.
+   */
+  async openDashboard(dashboardId, { folderId = 'default', tabId = 'default' } = {}) {
+    const url =
+      `${process.env["ZO_BASE_URL"]}/web/dashboards/view` +
+      `?org_identifier=${process.env["ORGNAME"]}` +
+      `&dashboard=${dashboardId}&folder=${folderId}&tab=${tabId}`;
+    await this.page.goto(url, { waitUntil: 'domcontentloaded' });
+    await this.page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await expect(this.openDrawerBtn).toBeVisible({ timeout: 30000 });
+  }
+
+  /**
+   * Click the toolbar button and wait for the reports list call to settle.
+   * @returns {Promise<string>} the URL of the `GET /api/{org}/reports` request,
+   *          so a test can assert the query contract (no `folder_id=`).
+   */
+  async openDrawer() {
+    const listResponse = this.page.waitForResponse(
+      (response) =>
+        /\/api\/[^/]+\/reports(\?|$)/.test(response.url()) &&
+        response.request().method() === 'GET',
+      { timeout: 30000 }
+    );
+    await this.openDrawerBtn.click();
+    const response = await listResponse;
+    expect(response.status()).toBe(200);
+
+    await expect(this.drawer).toBeVisible({ timeout: 15000 });
+    await this.loadingBanner.waitFor({ state: 'hidden', timeout: 15000 }).catch(() => {});
+    return response.url();
+  }
+
+  async closeDrawer() {
+    await this.drawerCloseBtn.click();
+    await expect(this.drawer).toBeHidden({ timeout: 15000 });
+    // The overlay fades out after the panel detaches; wait so the next click on
+    // the toolbar button is not swallowed by the backdrop.
+    await this.drawerOverlay.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+  }
+
+  async selectCachedTab() {
+    await this.cachedTab.click();
+  }
+
+  async selectScheduledTab() {
+    await this.scheduledTab.click();
+  }
+
+  async searchReports(query) {
+    await this.searchInput.fill(query);
+  }
+
+  async clearSearch() {
+    await this.searchInput.fill('');
+  }
+
+  async getRowCount() {
+    return await this.rows.count();
+  }
+
+  async expectDrawerVisible() {
+    await expect(this.drawer).toBeVisible({ timeout: 15000 });
+    await expect(this.table).toBeVisible({ timeout: 15000 });
+  }
+
+  async expectRowCount(expected) {
+    await expect(this.rows).toHaveCount(expected, { timeout: 20000 });
+  }
+
+  async expectReportVisible(reportName) {
+    await expect(this.rowByReportName(reportName)).toHaveCount(1, { timeout: 20000 });
+  }
+
+  async expectReportNotVisible(reportName) {
+    await expect(this.rowByReportName(reportName)).toHaveCount(0, { timeout: 15000 });
+  }
+
+  async expectEmptyState() {
+    await expect(this.emptyState).toBeVisible({ timeout: 15000 });
+    await expect(this.rows).toHaveCount(0);
+  }
+
+  /**
+   * PR #13569 (bug 2): the list request must NOT carry `folder_id`, because that
+   * param filters by the REPORT's own folder rather than the dashboard's folder.
+   */
+  expectNoFolderIdInListRequest(requestUrl) {
+    expect(requestUrl).toContain('dashboard_id=');
+    expect(requestUrl).not.toContain('folder_id=');
+  }
+}

--- a/tests/ui-testing/pages/page-manager.js
+++ b/tests/ui-testing/pages/page-manager.js
@@ -24,6 +24,7 @@ import DateTimeHelper from "./dashboardPages/dashboard-time";
 import DashboardPanelTime from "./dashboardPages/dashboard-panel-time";
 import LogsVisualise from "./dashboardPages/visualise";
 import { DashboardPage } from "./dashboardPages/dashboardPage.js";
+import { ScheduledReportsDrawerPage } from "./dashboardPages/scheduledReportsDrawer.js";
 import { AlertsPage } from "./alertsPages/alertsPage.js";
 import { AlertHistoryPage } from "./alertsPages/alertHistoryPage.js";
 import { AlertDetailPage } from "./alertsPages/alertDetailPage.js";
@@ -144,6 +145,7 @@ class PageManager {
     this.dashboardPanelTime = new DashboardPanelTime(page);
     this.logsVisualise = new LogsVisualise(page);
     this.dashboardPage = new DashboardPage(page);
+    this.scheduledReportsDrawer = new ScheduledReportsDrawerPage(page);
 
     // ===== EXISTING ALERTS PAGE OBJECT =====
     this.alertsPage = new AlertsPage(page);

--- a/tests/ui-testing/pages/reportsPages/reportCreation.js
+++ b/tests/ui-testing/pages/reportsPages/reportCreation.js
@@ -90,3 +90,136 @@ export async function createReportViaApi(api, reportName, folderId = 'default') 
         return { success: false, error: error.message };
     }
 }
+
+/**
+ * Create a report folder (folder_type = "reports") via API.
+ * Report folders are a separate namespace from dashboard folders — a report can
+ * live in report folder F while the dashboard it renders lives in dashboard
+ * folder D. See PR #13569.
+ * @param {Object} api - apiCleanup instance
+ * @param {string} folderName - Unique folder name
+ * @param {string} description - Optional description
+ * @returns {Promise<Object>} { success, folderId, error }
+ */
+export async function createReportFolderViaApi(api, folderName, description = '') {
+    testLogger.info('Creating report folder via API', { folderName });
+
+    try {
+        const response = await api._fetch(`${api.baseUrl}/api/v2/${api.org}/folders/reports`, {
+            method: 'POST',
+            headers: {
+                'Authorization': api.authHeader,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ name: folderName, description })
+        });
+
+        if (!response.ok) {
+            const errorBody = await response.text();
+            testLogger.error('Failed to create report folder via API', { folderName, status: response.status, body: errorBody });
+            return { success: false, error: `HTTP ${response.status}: ${errorBody}` };
+        }
+
+        const result = await response.json();
+        const folderId = result.folderId || result.folder_id;
+        if (!folderId) {
+            return { success: false, error: `Report folder create returned no folderId: ${JSON.stringify(result)}` };
+        }
+
+        testLogger.info('Report folder created via API', { folderName, folderId });
+        return { success: true, folderId };
+    } catch (error) {
+        testLogger.error('Failed to create report folder via API', { folderName, error: error.message });
+        return { success: false, error: error.message };
+    }
+}
+
+/**
+ * Create a report bound to a SPECIFIC dashboard, optionally saved into a
+ * non-default report folder.
+ *
+ * Differs from createReportViaApi (which picks an arbitrary existing dashboard
+ * and always uses one folder id for both the dashboard and the report): here the
+ * dashboard folder and the report folder are independent, which is exactly the
+ * configuration PR #13569 fixed.
+ *
+ * @param {Object} api - apiCleanup instance
+ * @param {Object} opts
+ * @param {string} opts.reportName - Unique report name
+ * @param {string} opts.dashboardId - Dashboard the report renders
+ * @param {string} [opts.tabId="default"] - Dashboard tab id
+ * @param {string} [opts.dashboardFolderId="default"] - Folder holding the dashboard
+ * @param {string} [opts.reportFolderId="default"] - Folder the REPORT is saved into
+ * @param {boolean} [opts.cached=true] - true => no destinations ("Cached" tab);
+ *                                       false => one email destination ("Scheduled" tab)
+ * @returns {Promise<Object>} { success, reportName, error }
+ */
+export async function createDashboardReportViaApi(api, opts) {
+    const {
+        reportName,
+        dashboardId,
+        tabId = 'default',
+        dashboardFolderId = 'default',
+        reportFolderId = 'default',
+        cached = true,
+    } = opts;
+
+    testLogger.info('Creating dashboard-bound report via API', {
+        reportName, dashboardId, dashboardFolderId, reportFolderId, cached
+    });
+
+    try {
+        const payload = {
+            name: reportName,
+            description: '',
+            dashboards: [{
+                folder: dashboardFolderId,
+                dashboard: dashboardId,
+                tabs: [tabId],
+                variables: [],
+                timerange: { type: 'relative', period: '30m', from: 0, to: 0 },
+                report_type: 'pdf',
+                email_attachment_type: 'standard'
+            }],
+            // An empty destinations list is what makes a report "cached" in the
+            // drawer (isCached: !report.destinations?.length) and is accepted by
+            // the backend even when SMTP is disabled.
+            destinations: cached ? [] : [{ email: api.email }],
+            enabled: true,
+            imagePreview: false,
+            title: `Test Report ${reportName}`,
+            message: '',
+            orgId: api.org,
+            frequency: { interval: 1, type: 'once', cron: '' },
+            timezone: 'UTC',
+            timezoneOffset: 0,
+            lastTriggeredAt: null,
+            owner: api.email,
+            lastEditedBy: api.email
+        };
+
+        const response = await api._fetch(
+            `${api.baseUrl}/api/v2/${api.org}/reports?folder=${encodeURIComponent(reportFolderId)}`,
+            {
+                method: 'POST',
+                headers: {
+                    'Authorization': api.authHeader,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(payload)
+            }
+        );
+
+        if (!response.ok) {
+            const errorBody = await response.text();
+            testLogger.error('Failed to create dashboard-bound report via API', { reportName, status: response.status, body: errorBody });
+            return { success: false, error: `HTTP ${response.status}: ${errorBody}` };
+        }
+
+        testLogger.info('Dashboard-bound report created via API', { reportName, reportFolderId });
+        return { success: true, reportName };
+    } catch (error) {
+        testLogger.error('Failed to create dashboard-bound report via API', { reportName, error: error.message });
+        return { success: false, error: error.message };
+    }
+}

--- a/tests/ui-testing/playwright-tests/Reports/scheduledReportsDrawer.spec.js
+++ b/tests/ui-testing/playwright-tests/Reports/scheduledReportsDrawer.spec.js
@@ -1,0 +1,283 @@
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+const { createDashboardViaApi } = require('../../pages/dashboardPages/dashCreation.js');
+const {
+  createReportFolderViaApi,
+  createDashboardReportViaApi,
+} = require('../../pages/reportsPages/reportCreation.js');
+
+/**
+ * Regression coverage for PR #13569 —
+ * "fix: dashboard reports drawer duplicates entries and hides reports in custom folders"
+ *
+ * Bug 1: ScheduledDashboards.vue seeded `scheduledReports` with the `reports` prop
+ *        array and pushed onto it, mutating the prop. The drawer stays mounted
+ *        between opens, so every reopen multiplied the rows.
+ * Bug 2: ViewDashboard.vue passed the DASHBOARD's folder id as `folder_id` to
+ *        `reports.list`, but that param filters by the REPORT's own folder — so a
+ *        report saved in a custom report folder never appeared.
+ */
+
+const timestamp = Date.now();
+const DASHBOARD_A = `test_dash_sched_a_${timestamp}`;
+const DASHBOARD_B = `test_dash_sched_b_${timestamp}`;
+const REPORT_FOLDER = `test_folder_sched_${timestamp}`;
+const REPORT_DEFAULT_FOLDER = `test_report_sched_default_${timestamp}`;
+const REPORT_CUSTOM_FOLDER = `test_report_sched_custom_${timestamp}`;
+const REPORT_OTHER_DASHBOARD = `test_report_sched_other_${timestamp}`;
+
+test.describe("Dashboard Scheduled Reports Drawer", () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let pm;
+  // Shared across the serial suite — created once in the first test.
+  let dashboardAId;
+  let dashboardBId;
+  let customFolderId;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    testLogger.info('Test setup completed');
+  });
+
+  // ===== P0: SMOKE / DIRECT BUG REGRESSIONS =====
+
+  test("P0: Drawer opens and lists the dashboard's cached report", {
+    tag: ['@scheduledReportsDrawer', '@dashboards', '@smoke', '@P0']
+  }, async ({ page }) => {
+    testLogger.info('Creating dashboards and reports via API');
+
+    const dashA = await createDashboardViaApi(pm.apiCleanup, DASHBOARD_A);
+    expect(dashA.success, `Dashboard A creation failed: ${dashA.error}`).toBeTruthy();
+    dashboardAId = dashA.dashboard.dashboard_id;
+
+    const dashB = await createDashboardViaApi(pm.apiCleanup, DASHBOARD_B);
+    expect(dashB.success, `Dashboard B creation failed: ${dashB.error}`).toBeTruthy();
+    dashboardBId = dashB.dashboard.dashboard_id;
+
+    const folder = await createReportFolderViaApi(pm.apiCleanup, REPORT_FOLDER, 'PR 13569 regression');
+    expect(folder.success, `Report folder creation failed: ${folder.error}`).toBeTruthy();
+    customFolderId = folder.folderId;
+
+    // Report in the DEFAULT report folder, bound to dashboard A, no destinations
+    // => it belongs to the drawer's default "Cached" tab.
+    const defaultFolderReport = await createDashboardReportViaApi(pm.apiCleanup, {
+      reportName: REPORT_DEFAULT_FOLDER,
+      dashboardId: dashboardAId,
+      cached: true,
+    });
+    expect(defaultFolderReport.success,
+      `Default-folder report creation failed: ${defaultFolderReport.error}`).toBeTruthy();
+
+    testLogger.info('Opening dashboard A and its scheduled reports drawer');
+    await pm.scheduledReportsDrawer.openDashboard(dashboardAId);
+    await pm.scheduledReportsDrawer.openDrawer();
+
+    await pm.scheduledReportsDrawer.expectDrawerVisible();
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_DEFAULT_FOLDER);
+
+    testLogger.info('Drawer lists the dashboard-bound cached report');
+  });
+
+  test("P0: Bug 13569-1 — reopening the drawer does not duplicate rows", {
+    tag: ['@scheduledReportsDrawer', '@dashboards', '@smoke', '@P0']
+  }, async ({ page }) => {
+    testLogger.info('Verifying row count is stable across repeated open/close cycles');
+
+    await pm.scheduledReportsDrawer.openDashboard(dashboardAId);
+
+    await pm.scheduledReportsDrawer.openDrawer();
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_DEFAULT_FOLDER);
+    const baselineCount = await pm.scheduledReportsDrawer.getRowCount();
+    expect(baselineCount).toBeGreaterThan(0);
+    testLogger.info(`Baseline row count on first open: ${baselineCount}`);
+
+    // Before the fix each reopen appended the whole list again (1 -> 2 -> 4 ...),
+    // because formatReports() pushed onto the aliased `reports` prop.
+    for (let cycle = 1; cycle <= 3; cycle++) {
+      await pm.scheduledReportsDrawer.closeDrawer();
+      await pm.scheduledReportsDrawer.openDrawer();
+      await pm.scheduledReportsDrawer.expectRowCount(baselineCount);
+      await pm.scheduledReportsDrawer.expectReportVisible(REPORT_DEFAULT_FOLDER);
+      testLogger.info(`Reopen cycle ${cycle}: row count still ${baselineCount}`);
+    }
+
+    testLogger.info('No duplication across three reopen cycles');
+  });
+
+  test("P0: Bug 13569-2 — report saved in a custom report folder is listed", {
+    tag: ['@scheduledReportsDrawer', '@dashboards', '@smoke', '@P0']
+  }, async ({ page }) => {
+    testLogger.info('Creating a report in a custom report folder for dashboard A');
+
+    // Dashboard A lives in the DEFAULT dashboard folder, but this report is saved
+    // into a custom REPORT folder. Before the fix the drawer sent the dashboard's
+    // folder id as `folder_id` and filtered this report out.
+    const result = await createDashboardReportViaApi(pm.apiCleanup, {
+      reportName: REPORT_CUSTOM_FOLDER,
+      dashboardId: dashboardAId,
+      dashboardFolderId: 'default',
+      reportFolderId: customFolderId,
+      cached: true,
+    });
+    expect(result.success, `Custom-folder report creation failed: ${result.error}`).toBeTruthy();
+
+    await pm.scheduledReportsDrawer.openDashboard(dashboardAId);
+    await pm.scheduledReportsDrawer.openDrawer();
+
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_CUSTOM_FOLDER);
+    // The default-folder report must still be there — the fix widens the list,
+    // it does not swap one folder's reports for another's.
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_DEFAULT_FOLDER);
+
+    testLogger.info('Custom report folder report is visible in the drawer');
+  });
+
+  // ===== P1: FUNCTIONAL =====
+
+  test("P1: Reports list request omits folder_id", {
+    tag: ['@scheduledReportsDrawer', '@dashboards', '@functional', '@P1']
+  }, async ({ page }) => {
+    testLogger.info('Asserting the reports list query contract');
+
+    await pm.scheduledReportsDrawer.openDashboard(dashboardAId);
+    const requestUrl = await pm.scheduledReportsDrawer.openDrawer();
+
+    pm.scheduledReportsDrawer.expectNoFolderIdInListRequest(requestUrl);
+
+    testLogger.info(`Reports list request scoped by dashboard only: ${requestUrl}`);
+  });
+
+  test("P1: Switching tabs re-filters the list without duplicating rows", {
+    tag: ['@scheduledReportsDrawer', '@dashboards', '@functional', '@P1']
+  }, async ({ page }) => {
+    testLogger.info('Round-tripping the Cached/Scheduled tabs');
+
+    await pm.scheduledReportsDrawer.openDashboard(dashboardAId);
+    await pm.scheduledReportsDrawer.openDrawer();
+
+    // Default tab is "Cached".
+    const cachedCount = await pm.scheduledReportsDrawer.getRowCount();
+    expect(cachedCount).toBeGreaterThan(1);
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_DEFAULT_FOLDER);
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_CUSTOM_FOLDER);
+
+    // The "Scheduled" tab is the complement of "Cached", so neither cached
+    // report may appear there.
+    await pm.scheduledReportsDrawer.selectScheduledTab();
+    await pm.scheduledReportsDrawer.expectReportNotVisible(REPORT_DEFAULT_FOLDER);
+    await pm.scheduledReportsDrawer.expectReportNotVisible(REPORT_CUSTOM_FOLDER);
+
+    // Switching back re-runs filterReports() over the same source array — the
+    // count must be identical, not doubled.
+    await pm.scheduledReportsDrawer.selectCachedTab();
+    await pm.scheduledReportsDrawer.expectRowCount(cachedCount);
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_DEFAULT_FOLDER);
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_CUSTOM_FOLDER);
+
+    testLogger.info('Tab round-trip leaves the cached list unchanged');
+  });
+
+  test("P1: Search filter does not survive a reopen or leave stale rows", {
+    tag: ['@scheduledReportsDrawer', '@dashboards', '@functional', '@P1']
+  }, async ({ page }) => {
+    testLogger.info('Filtering the drawer, then reopening it');
+
+    await pm.scheduledReportsDrawer.openDashboard(dashboardAId);
+    await pm.scheduledReportsDrawer.openDrawer();
+
+    const unfilteredCount = await pm.scheduledReportsDrawer.getRowCount();
+    expect(unfilteredCount).toBeGreaterThan(1);
+
+    await pm.scheduledReportsDrawer.searchReports(REPORT_CUSTOM_FOLDER);
+    await pm.scheduledReportsDrawer.expectRowCount(1);
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_CUSTOM_FOLDER);
+
+    await pm.scheduledReportsDrawer.clearSearch();
+    await pm.scheduledReportsDrawer.expectRowCount(unfilteredCount);
+
+    // Reopen: the list must be rebuilt from scratch, not re-accumulated.
+    await pm.scheduledReportsDrawer.closeDrawer();
+    await pm.scheduledReportsDrawer.openDrawer();
+    await pm.scheduledReportsDrawer.expectRowCount(unfilteredCount);
+
+    testLogger.info('Row count after filtering and reopening is unchanged');
+  });
+
+  // ===== P2: EDGE CASES =====
+
+  test("P2: Dashboard with no reports shows the empty state on every open", {
+    tag: ['@scheduledReportsDrawer', '@dashboards', '@edge', '@P2']
+  }, async ({ page }) => {
+    testLogger.info('Opening the drawer for a dashboard without reports');
+
+    await pm.scheduledReportsDrawer.openDashboard(dashboardBId);
+    await pm.scheduledReportsDrawer.openDrawer();
+    await pm.scheduledReportsDrawer.expectEmptyState();
+
+    await pm.scheduledReportsDrawer.closeDrawer();
+    await pm.scheduledReportsDrawer.openDrawer();
+    await pm.scheduledReportsDrawer.expectEmptyState();
+
+    testLogger.info('Empty state is stable across reopen');
+  });
+
+  test("P2: A report bound to another dashboard is not listed", {
+    tag: ['@scheduledReportsDrawer', '@dashboards', '@edge', '@P2']
+  }, async ({ page }) => {
+    testLogger.info('Creating a report bound to dashboard B in the custom folder');
+
+    const result = await createDashboardReportViaApi(pm.apiCleanup, {
+      reportName: REPORT_OTHER_DASHBOARD,
+      dashboardId: dashboardBId,
+      reportFolderId: customFolderId,
+      cached: true,
+    });
+    expect(result.success, `Dashboard B report creation failed: ${result.error}`).toBeTruthy();
+
+    // Dashboard B shows only its own report...
+    await pm.scheduledReportsDrawer.openDashboard(dashboardBId);
+    await pm.scheduledReportsDrawer.openDrawer();
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_OTHER_DASHBOARD);
+    await pm.scheduledReportsDrawer.expectReportNotVisible(REPORT_DEFAULT_FOLDER);
+
+    // ...and dashboard A does not pick it up even though both reports share the
+    // same custom report folder (dropping folder_id must not drop dashboard_id).
+    await pm.scheduledReportsDrawer.openDashboard(dashboardAId);
+    await pm.scheduledReportsDrawer.openDrawer();
+    await pm.scheduledReportsDrawer.expectReportVisible(REPORT_CUSTOM_FOLDER);
+    await pm.scheduledReportsDrawer.expectReportNotVisible(REPORT_OTHER_DASHBOARD);
+
+    testLogger.info('Reports stay scoped to their own dashboard');
+  });
+
+  // ===== CLEANUP via API =====
+
+  test("Cleanup: Remove all test resources via API", {
+    tag: ['@scheduledReportsDrawer', '@cleanup']
+  }, async ({ page }) => {
+    testLogger.info('Cleaning up scheduled-reports-drawer test resources');
+
+    const reports = await pm.apiCleanup.fetchReports();
+    expect(Array.isArray(reports)).toBeTruthy();
+    const testReports = reports.filter(r => r.name && r.name.startsWith('test_report_sched_'));
+    for (const report of testReports) {
+      // Delete by id: these reports live in a custom report folder, and the
+      // name-based v1 route only resolves names inside the default folder.
+      const result = await pm.apiCleanup.deleteReportById(report.report_id, report.name);
+      // 404 is fine — a prior partial cleanup may already have removed it.
+      if (result.code !== 200 && result.code !== 404) {
+        throw new Error(`Unexpected status deleting report ${report.name}: ${result.code} — ${result.message}`);
+      }
+      testLogger.info(`Deleted/already gone report: ${report.name} (${result.code})`);
+    }
+
+    await pm.apiCleanup.cleanupReportFolders(['test_folder_sched_']);
+    await pm.apiCleanup.cleanupDashboards();
+
+    testLogger.info('Cleanup completed');
+  });
+});


### PR DESCRIPTION
## What

Adds E2E regression coverage for the dashboard **Scheduled Reports drawer**, verifying the two
bugs fixed in #13569.

No production code is touched — this is test-only.

## Why

#13569 (`fix: dashboard reports drawer duplicates entries and hides reports in custom folders`)
shipped with unit-test updates only. The drawer had no E2E coverage at all, so both regressions
could return unnoticed.

| Bug | Root cause | Fix under test |
|-----|-----------|----------------|
| **1. Rows duplicate on reopen** | `scheduledReports` was seeded with the `reports` prop and `formatReports()` pushed onto it, mutating the prop. The drawer stays mounted between opens, so each reopen multiplied the rows. | `ScheduledDashboards.vue` now rebuilds the array with `.map()` |
| **2. Custom-folder reports hidden** | `reports.list(org, folderId, dashboardId)` passed the **dashboard's** folder, but `folder_id` filters by the **report's own** folder | `ViewDashboard.vue` passes `""` so `folder_id` is omitted |

## Tests added — 9, all passing

`tests/ui-testing/playwright-tests/Reports/scheduledReportsDrawer.spec.js`

| # | Test | Covers |
|---|------|--------|
| 1 | P0: Drawer opens and lists the dashboard's cached report | baseline |
| 2 | P0: Bug 13569-1 — reopening the drawer does not duplicate rows | **bug 1** — exact row count across 3 close/reopen cycles |
| 3 | P0: Bug 13569-2 — report saved in a custom report folder is listed | **bug 2** — report in custom folder, dashboard in default folder |
| 4 | P1: Reports list request omits `folder_id` | **bug 2** — pins the network contract the fix changed |
| 5 | P1: Switching tabs re-filters the list without duplicating rows | `filterReports()`, the second path bug 1 corrupted |
| 6 | P1: Search filter does not survive a reopen or leave stale rows | filter + rebuild interaction |
| 7 | P2: Dashboard with no reports shows the empty state on every open | empty state across reopen |
| 8 | P2: A report bound to another dashboard is not listed | guards against over-correcting bug 2 (`dashboard_id` scoping must survive) |
| 9 | Cleanup: Remove all test resources via API | teardown |


