### PR TITLE
test(e2e/alpha1): unique per-run alert destination/template so Add Alert button enables

### DIFF
--- a/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-regression.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-regression.spec.js
@@ -19,8 +19,16 @@ test.describe("Alerts Regression Bugs", () => {
   let randomValue = `${Date.now()}`;
   const TEST_STREAM = 'e2e_automate';
   const METRICS_STREAM = 'e2e_test_cpu_usage';
-  const DESTINATION_NAME = 'e2e_promql_dest';
-  const TEMPLATE_NAME = 'e2e_promql_template';
+  // Unique per-run token for the template/destination. On the shared cloud org the fixed
+  // names left ghost records that a concurrent run's cleanup couldn't fully delete (delete
+  // stuck / destinations_templates_fk 500), so the beforeAll create returned 400
+  // "already exists" yet AlertList loaded ZERO destinations — and the revamped Add Alert
+  // button is disabled (`title="No destinations available"`) when destinations.length===0,
+  // failing every test at clickAddAlertButton. A fresh unique name always creates a real,
+  // loadable destination. Keeps the `e2e_promql_` prefix so cleanup.spec.js reclaims it.
+  const RUN_TOKEN = Date.now().toString(36);
+  const DESTINATION_NAME = `e2e_promql_dest_${RUN_TOKEN}`;
+  const TEMPLATE_NAME = `e2e_promql_template_${RUN_TOKEN}`;
 
   // ============================================================================
   // Setup hook: Create prerequisites (destination and template) ONCE before all tests
@@ -96,6 +104,31 @@ test.describe("Alerts Regression Bugs", () => {
         testLogger.info('Destination ready via API', { destinationName: DESTINATION_NAME, status: destResponse.status });
       } else {
         testLogger.warn('Destination creation response', { status: destResponse.status, data: destResponse.data });
+      }
+
+      // Gate on the destination actually appearing in the list API before tests run.
+      // AlertList disables the Add Alert button while destinations.length === 0, so the
+      // tests can't proceed until the just-created destination is loadable.
+      let destListed = false;
+      for (let attempt = 1; attempt <= 10; attempt++) {
+        destListed = await page.evaluate(async ({ baseUrl, org, authToken, name }) => {
+          try {
+            const r = await fetch(`${baseUrl}/api/${org}/alerts/destinations`, {
+              headers: { 'Authorization': `Basic ${authToken}` },
+            });
+            if (!r.ok) return false;
+            const d = await r.json();
+            const list = Array.isArray(d) ? d : (d.list || d.data || []);
+            return list.some(x => x && x.name === name);
+          } catch { return false; }
+        }, { baseUrl, org, authToken, name: DESTINATION_NAME });
+        if (destListed) break;
+        await page.waitForTimeout(2000);
+      }
+      if (destListed) {
+        testLogger.info('Destination confirmed in list API', { destinationName: DESTINATION_NAME });
+      } else {
+        testLogger.warn('Destination not visible in list API after retries — Add Alert button may stay disabled', { destinationName: DESTINATION_NAME });
       }
 
       testLogger.info('Prerequisites setup completed');

--- a/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-regression.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-regression.spec.js
@@ -622,8 +622,8 @@ test.describe("Alerts Regression Bugs", () => {
       await page.goto(`${process.env.ZO_BASE_URL || 'http://localhost:5080'}?org_identifier=${getOrgIdentifier() || 'default'}`);
       await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
-      await cleanupAlertDestination(page, cleanupPm);
-      await cleanupAlertTemplate(page, cleanupPm);
+      await cleanupAlertDestination(page, cleanupPm, DESTINATION_NAME);
+      await cleanupAlertTemplate(page, cleanupPm, TEMPLATE_NAME);
       testLogger.info('Test suite cleanup completed');
     } catch (e) {
       testLogger.warn('Cleanup encountered issues', { error: e.message });
@@ -753,9 +753,7 @@ async function createAlertTemplate(page, pm) {
 /**
  * Cleanup alert destination
  */
-async function cleanupAlertDestination(page, pm) {
-  const destinationName = 'e2e_promql_dest';
-
+async function cleanupAlertDestination(page, pm, destinationName = 'e2e_promql_dest') {
   try {
     // Use POM method to delete destination
     await pm.alertDestinationsPage.deleteDestinationByName(destinationName);
@@ -768,9 +766,7 @@ async function cleanupAlertDestination(page, pm) {
 /**
  * Cleanup alert template
  */
-async function cleanupAlertTemplate(page, pm) {
-  const templateName = 'e2e_promql_template';
-
+async function cleanupAlertTemplate(page, pm, templateName = 'e2e_promql_template') {
   try {
     // Use POM method to delete template
     await pm.alertTemplatesPage.deleteTemplateAndVerify(templateName);


### PR DESCRIPTION
## Why

After #13776 merged, the alpha1 **RegressionSet** shard still failed — but on a **new, different** cause than #13776 fixed. All 4 `alerts-regression` tests died at the very first step (`clickAddAlertButton`) because the button was **disabled**:

```
<button disabled aria-disabled="true"
        title="No destinations available"
        data-test="alert-list-add-alert-btn">
19 × locator resolved to disabled  → toBeEnabled() timed out after 15s
```

## Root cause (reproduced live on the RegressionSet org, auto_org_2)

[`AlertList.vue`](web/src/components/alerts/AlertList.vue#L51) disables the Add Alert button while `destinations.length === 0`:
```vue
:disabled="!destinations.length || !templates.length"
:title="!destinations.length ? t('alerts.noDestinations') : ''"
```

On the **shared** cloud org the **fixed** names `e2e_promql_dest` / `e2e_promql_template` were stuck ghost records — a concurrent run's cleanup couldn't fully delete them (UI delete timed out / `destinations_templates_fk` 500). So the beforeAll create returned `400 "already exists"`, yet the destinations list loaded **empty**, keeping the button disabled through the 15s `toBeEnabled` wait. Not a product regression — the org simply had no *loadable* destination.

This is the same **shared-org fixed-name collision** class fixed for streams in #13776.

## Fix

- `e2e_promql_dest` / `e2e_promql_template` → `..._<RUN_TOKEN>` (unique per run), so the beforeAll always creates a real, loadable destination. Keeps the `e2e_promql_` prefix so `cleanup.spec.js` still reclaims them.
- Gate the beforeAll on the destination actually appearing in the `/alerts/destinations` list API before tests run, so the button is reliably enabled (`destinations.length > 0`) instead of racing the fetch.

## Verification (alpha, RegressionSet org auto_org_2 — reproduced 100% before)

- Before: `Add Alert` disabled → `toBeEnabled` 15s timeout → 4/4 fail.
- After: `Destination confirmed in list API | e2e_promql_dest_<token>` → button enabled → **alerts-regression 5/5 pass** (#9967, #10899, #10872, #10110, #10472); alerts saved for both `>=` and `<=`.

## Scope
OSS-only test file. Picked up by the ENT alpha1 workflow the same way as #13776 (checks out opensource `main`, or dispatch with `o2_opensource_repo=test/alerts-regression-destinations-gate`).