### PR TITLE
fix(logs): stop quick mode rewriting SELECT inside subqueries

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -331,6 +331,7 @@ import {
   extractWhereClause,
 } from "@/utils/query/sqlUtils";
 import { buildColumnIdentifierAst, quoteSqlIdentifierIfNeeded } from "@/utils/query/sqlIdentifiers";
+import { replaceSelectFieldList } from "@/utils/query/quickModeFieldList";
 import useNotifications from "@/composables/useNotifications";
 import { checkIfConfigChangeRequiredApiCallOrNot } from "@/utils/dashboard/checkConfigChangeApiCall";
 import SearchBar from "@/plugins/logs/SearchBar.vue";
@@ -1560,9 +1561,7 @@ export default defineComponent({
             .join(",");
         }
         if (searchObj.meta.sqlMode == true) {
-          searchObj.data.query = searchObj.data.query.replace(/SELECT\s+(.*?)\s+FROM/gi, () => {
-            return `SELECT ${field_list} FROM`;
-          });
+          searchObj.data.query = replaceSelectFieldList(searchObj.data.query, field_list);
           setQuery(searchObj.meta.quickMode);
           updateUrlQueryParams();
         }

--- a/web/src/utils/query/quickModeFieldList.spec.ts
+++ b/web/src/utils/query/quickModeFieldList.spec.ts
@@ -1,0 +1,135 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, it, expect } from "vitest";
+import { hasSubquery, replaceSelectFieldList } from "./quickModeFieldList";
+
+describe("replaceSelectFieldList", () => {
+  describe("queries containing a subquery are left alone", () => {
+    // The query from the bug report. Enabling quick mode rewrote only the inner
+    // SELECT — the outer one spans a newline, which `.` does not match — turning
+    // `select distinct trace_id` into a two-column projection and dropping
+    // DISTINCT, so the IN (...) no longer type-checked.
+    const reported = `select trace_id,
+  array_agg(distinct service_name) as name
+from trace_list_index where trace_id in (
+    select distinct trace_id
+    from trace_list_index
+    order by trace_id limit 10000)
+group by trace_id
+order by trace_id
+limit 10`;
+
+    it("returns the reported query byte-for-byte unchanged", () => {
+      expect(replaceSelectFieldList(reported, "trace_id,_timestamp")).toBe(reported);
+    });
+
+    it("keeps the subquery's DISTINCT", () => {
+      const out = replaceSelectFieldList(reported, "trace_id,_timestamp");
+      expect(out).toContain("select distinct trace_id");
+    });
+
+    it("leaves a single-line subquery alone too", () => {
+      const sql = "select a, b from t where a in (select distinct a from t2 order by a limit 10)";
+      expect(replaceSelectFieldList(sql, "x,y")).toBe(sql);
+    });
+
+    it("leaves a derived table in FROM alone", () => {
+      const sql = "select a from (select b from t) x";
+      expect(replaceSelectFieldList(sql, "x,y")).toBe(sql);
+    });
+
+    it("leaves a CTE alone", () => {
+      const sql = "with t as (select a from logs) select a from t";
+      expect(replaceSelectFieldList(sql, "x,y")).toBe(sql);
+    });
+
+    it("matches a nested SELECT regardless of case or inner spacing", () => {
+      expect(hasSubquery("select a from t where a in (  SeLeCt b from t2)")).toBe(true);
+    });
+  });
+
+  describe("a comment cannot hide a subquery from the check", () => {
+    it("sees through a block comment before the nested SELECT", () => {
+      const sql = "select a from t where x in (/* pick them */ select b from t2)";
+      expect(replaceSelectFieldList(sql, "x,y")).toBe(sql);
+    });
+
+    it("sees through a line comment before the nested SELECT", () => {
+      const sql = "select a from t where x in ( -- pick them\n select b from t2)";
+      expect(replaceSelectFieldList(sql, "x,y")).toBe(sql);
+    });
+  });
+
+  describe("string literals are never rewritten", () => {
+    it("does not touch SQL text stored in a quoted value", () => {
+      const sql = `SELECT * FROM "logs" WHERE msg = 'select id from users'`;
+      expect(replaceSelectFieldList(sql, "f1,f2")).toBe(
+        `SELECT f1,f2 FROM "logs" WHERE msg = 'select id from users'`,
+      );
+    });
+
+    it("does not treat a parenthesised SELECT inside a literal as a subquery", () => {
+      expect(hasSubquery("select a from t where msg = 'x (select y from z)'")).toBe(false);
+    });
+
+    it("handles an escaped quote inside the value", () => {
+      const sql = `select a from t where msg = 'it''s select b from c'`;
+      expect(replaceSelectFieldList(sql, "x")).toBe(
+        `SELECT x FROM t where msg = 'it''s select b from c'`,
+      );
+    });
+  });
+
+  describe("ordinary queries are rewritten", () => {
+    it("replaces the projection of a simple query", () => {
+      expect(replaceSelectFieldList("select a, b from logs", "x,y")).toBe("SELECT x,y FROM logs");
+    });
+
+    it("replaces the projection when the query spans lines", () => {
+      expect(replaceSelectFieldList("select a, b\nfrom logs", "x,y")).toBe("SELECT x,y FROM logs");
+    });
+
+    it("preserves everything after FROM", () => {
+      expect(replaceSelectFieldList("select a from logs where code = 200 limit 5", "x,y")).toBe(
+        "SELECT x,y FROM logs where code = 200 limit 5",
+      );
+    });
+
+    it("rewrites every stream of a multi-stream UNION", () => {
+      // A multi-stream search is one SELECT per stream joined by UNION, so all
+      // of them must take the field list — none of them is nested.
+      const out = replaceSelectFieldList(
+        'SELECT a FROM "s1" UNION ALL BY NAME SELECT a FROM "s2"',
+        "x,y",
+      );
+      expect(out).toBe('SELECT x,y FROM "s1" UNION ALL BY NAME SELECT x,y FROM "s2"');
+    });
+
+    it("treats a field list containing $& literally", () => {
+      expect(replaceSelectFieldList("select a from logs", "$&,b")).toBe("SELECT $&,b FROM logs");
+    });
+  });
+
+  describe("queries with nothing to rewrite", () => {
+    it("returns a query with no FROM unchanged", () => {
+      expect(replaceSelectFieldList("select 1", "x,y")).toBe("select 1");
+    });
+
+    it("returns an empty query unchanged", () => {
+      expect(replaceSelectFieldList("", "x,y")).toBe("");
+    });
+  });
+});

--- a/web/src/utils/query/quickModeFieldList.ts
+++ b/web/src/utils/query/quickModeFieldList.ts
@@ -1,0 +1,132 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Enabling quick mode swaps the SELECT list of the query in the search bar for
+ * the user's interesting fields. The projection is located by regex, so a query
+ * containing a subquery cannot be rewritten safely: the pattern matches an inner
+ * `SELECT ... FROM` just as readily as the outer one, and replacing it discards
+ * the subquery's own projection along with any `DISTINCT` it carried. Such a
+ * query is left untouched — `quick_mode` still goes out on the request, so field
+ * trimming for `SELECT *` is unaffected.
+ *
+ * Both the subquery check and the rewrite run over a masked copy of the query in
+ * which string literals and comments are blanked, so a `select ... from` inside a
+ * quoted value is neither mistaken for a subquery nor rewritten, and a comment
+ * cannot hide a subquery from the check.
+ */
+
+/** A `(` opening a nested SELECT — subquery, derived table, or CTE body. */
+const SUBQUERY = /\(\s*SELECT\b/i;
+
+/**
+ * The projection of a `SELECT ... FROM` pair. Applied globally, because a
+ * multi-stream search is a UNION of one SELECT per stream and each needs the
+ * field list; anything nested has already been excluded by [[SUBQUERY]].
+ */
+const SELECT_FROM = /SELECT\s+.*?\s+FROM/i;
+
+/**
+ * Blank out string literals, line comments and block comments, replacing each
+ * character with a space and keeping newlines. The result is the same length as
+ * the input, so offsets found in it address the original text directly.
+ *
+ * A single pass is needed rather than sequential regex replacements: a quote can
+ * appear inside a comment (`-- don't`) and a `--` inside a quoted value, so
+ * whichever construct opens first has to consume the other.
+ */
+const maskLiteralsAndComments = (sql: string): string => {
+  const out = sql.split("");
+  const blank = (from: number, to: number): void => {
+    for (let k = from; k < to && k < out.length; k++) {
+      if (out[k] !== "\n") out[k] = " ";
+    }
+  };
+
+  let i = 0;
+  while (i < sql.length) {
+    const ch = sql[i];
+
+    // Quoted value or quoted identifier. '' inside a single-quoted value is an
+    // escaped quote, not the end of it.
+    if (ch === "'" || ch === '"') {
+      let j = i + 1;
+      while (j < sql.length) {
+        if (sql[j] === ch) {
+          if (ch === "'" && sql[j + 1] === "'") {
+            j += 2;
+            continue;
+          }
+          break;
+        }
+        j++;
+      }
+      const end = Math.min(j + 1, sql.length);
+      blank(i, end);
+      i = end;
+      continue;
+    }
+
+    if (ch === "-" && sql[i + 1] === "-") {
+      const nl = sql.indexOf("\n", i);
+      const end = nl === -1 ? sql.length : nl;
+      blank(i, end);
+      i = end;
+      continue;
+    }
+
+    if (ch === "/" && sql[i + 1] === "*") {
+      const close = sql.indexOf("*/", i + 2);
+      const end = close === -1 ? sql.length : close + 2;
+      blank(i, end);
+      i = end;
+      continue;
+    }
+
+    i++;
+  }
+
+  return out.join("");
+};
+
+/** Whether the query nests a SELECT, ignoring quoted values and comments. */
+export const hasSubquery = (query: string): boolean =>
+  SUBQUERY.test(maskLiteralsAndComments(query));
+
+/**
+ * Replace each top-level projection with `fieldList`, unless the query nests a
+ * SELECT — in which case the query is returned unchanged.
+ */
+export const replaceSelectFieldList = (query: string, fieldList: string): string => {
+  const masked = maskLiteralsAndComments(query);
+  if (SUBQUERY.test(masked)) return query;
+
+  // Matched against the mask but spliced into the original, so a projection is
+  // replaced with the real text around it left byte-for-byte intact.
+  const pattern = new RegExp(SELECT_FROM.source, "gi");
+  let rewritten = "";
+  let cursor = 0;
+  let match: RegExpExecArray | null = pattern.exec(masked);
+
+  while (match !== null) {
+    rewritten += query.slice(cursor, match.index) + `SELECT ${fieldList} FROM`;
+    cursor = match.index + match[0].length;
+    match = pattern.exec(masked);
+  }
+
+  return rewritten + query.slice(cursor);
+};
+
+export default replaceSelectFieldList;


### PR DESCRIPTION
## Summary

- move the quick-mode field-list rewrite out of `Index.vue` into `replaceSelectFieldList`
- return the query untouched when it nests a SELECT, instead of corrupting it
- mask string literals and comments before matching, so neither can be rewritten or hide a subquery
- add `quickModeFieldList.spec.ts` covering the reported query and the literal/comment cases

Fixes #8542.

## Root cause

Enabling quick mode replaced the search bar's SELECT list via `query.replace(/SELECT\s+(.*?)\s+FROM/gi, ...)`. The global flag applied that to *every* `SELECT ... FROM` pair, so a subquery was rewritten as readily as the outer query, and `(.*?)` swallowed the projection including any `DISTINCT`:

```sql
where trace_id in (select distinct trace_id from trace_list_index ...)
where trace_id in (SELECT trace_id,_timestamp FROM trace_list_index ...)
```

The `IN (...)` is left comparing against two columns and the `DISTINCT` is gone.

Dropping the global flag is **not** enough: `.` does not match a newline, so in a query formatted over several lines the outer pair never matches and the subquery is the *first* match, not the second. The rewrite has to bail out instead.

The check and the rewrite both run over a masked copy of the query, so `msg = 'select id from users'` is not rewritten and `in (/* c */ select ...)` cannot hide a subquery. Masking is a single pass because a quote can appear inside a comment and a `--` inside a quoted value. The global flag is kept — a multi-stream search is a UNION of one SELECT per stream and each needs the field list.

`quick_mode` still goes out on the request, so field trimming for `SELECT *` is unaffected. When the query is skipped the toggle stays silent rather than notifying — happy to add a message if you'd prefer one.

## Testing

- `npx vitest run src/utils/query/quickModeFieldList.spec.ts` — 18 passing
- mutation-tested: removing the subquery guard turns 7 red, removing the masking turns 5 red
- `src/plugins/logs/Index.spec.ts` — 65 passing, unchanged
- `npm run type-check:app`, `lint:ci`, `format:check` — clean

Two nearby things I noticed but did not touch: disabling quick mode does not restore the previous query, and the field list joins without a space after the comma.
