### PR TITLE
fix(search): reject over-nested boolean predicates to avoid stack overflow

### DIFF
--- a/src/search/src/sql/complexity.rs
+++ b/src/search/src/sql/complexity.rs
@@ -1,0 +1,279 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Guards a parsed statement against pathologically deep boolean predicates.
+//!
+//! A query that ORs together a very large number of conditions — e.g. hundreds
+//! of `match_all()` terms — parses without trouble: precedence climbing consumes
+//! `a OR b OR c ...` iteratively, so the parser's own recursion limit never
+//! trips and the result is a deeply left-nested `BinaryOp` tree. Every consumer
+//! of that tree, however, recurses over its structure: DataFusion's logical
+//! optimizer, the inverted-index condition builder
+//! (`Condition::from_physical_expr` / `IndexCondition::to_tantivy_query`), the
+//! tantivy scorer, and the boxed tree's own `Drop`. A deep enough tree overflows
+//! the stack and aborts the whole process rather than failing the one query.
+//!
+//! Rejecting such a statement up front — before any of those recursions run —
+//! turns the crash into a normal query error. See issue #12398.
+
+use sqlparser::ast::{Expr, Query, SelectItem, SetExpr, Statement, TableFactor};
+
+/// Maximum boolean-operator nesting depth permitted in a query predicate.
+///
+/// Chosen to sit far above any hand-written query yet comfortably below the
+/// depth at which the downstream recursions were observed to overflow the stack.
+/// The web UI applies the same idea (`MAX_RECURSION_DEPTH` in `useSearchBar.ts`).
+pub const MAX_PREDICATE_NESTING_DEPTH: usize = 64;
+
+/// Whether any predicate in `statement` — a `WHERE`/`HAVING` clause, a `CASE`
+/// branch, or a projection expression, including inside CTEs and subqueries —
+/// nests boolean operators deeper than [`MAX_PREDICATE_NESTING_DEPTH`].
+///
+/// Not covered: predicates buried in a `JOIN ... ON` condition or a function
+/// argument; those positions are rare for the deeply-OR-ed shape this guards
+/// against.
+pub fn is_predicate_too_deep(statement: &Statement) -> bool {
+    predicate_nesting_exceeds(statement, MAX_PREDICATE_NESTING_DEPTH)
+}
+
+/// Same as [`is_predicate_too_deep`] with an explicit limit (for testing).
+///
+/// The traversal is bounded on both the query structure and the predicate
+/// expression: it descends at most `max_depth` levels before reporting a breach,
+/// so the check itself cannot overflow on a deep input.
+pub fn predicate_nesting_exceeds(statement: &Statement, max_depth: usize) -> bool {
+    match statement {
+        Statement::Query(query) => query_exceeds(query, max_depth),
+        _ => false,
+    }
+}
+
+fn query_exceeds(query: &Query, remaining: usize) -> bool {
+    if remaining == 0 {
+        return true;
+    }
+    // CTE bodies are planned like any other query, so a deep predicate hidden in
+    // a `WITH x AS (SELECT ... WHERE <deep>)` reaches the same recursive consumers.
+    if let Some(with) = &query.with
+        && with
+            .cte_tables
+            .iter()
+            .any(|cte| query_exceeds(&cte.query, remaining - 1))
+    {
+        return true;
+    }
+    set_expr_exceeds(&query.body, remaining)
+}
+
+fn set_expr_exceeds(set_expr: &SetExpr, remaining: usize) -> bool {
+    if remaining == 0 {
+        return true;
+    }
+    match set_expr {
+        SetExpr::Select(select) => {
+            // WHERE and HAVING are the boolean predicates that feed the recursive
+            // consumers; a projection expression or a FROM subquery can hide the
+            // same shape.
+            select
+                .selection
+                .as_ref()
+                .is_some_and(|expr| expr_exceeds(expr, remaining))
+                || select
+                    .having
+                    .as_ref()
+                    .is_some_and(|expr| expr_exceeds(expr, remaining))
+                || select
+                    .projection
+                    .iter()
+                    .any(|item| select_item_exceeds(item, remaining))
+                || select
+                    .from
+                    .iter()
+                    .any(|twj| table_factor_exceeds(&twj.relation, remaining))
+                || select
+                    .from
+                    .iter()
+                    .flat_map(|twj| twj.joins.iter())
+                    .any(|join| table_factor_exceeds(&join.relation, remaining))
+        }
+        SetExpr::Query(query) => query_exceeds(query, remaining - 1),
+        SetExpr::SetOperation { left, right, .. } => {
+            set_expr_exceeds(left, remaining - 1) || set_expr_exceeds(right, remaining - 1)
+        }
+        _ => false,
+    }
+}
+
+fn select_item_exceeds(item: &SelectItem, remaining: usize) -> bool {
+    match item {
+        SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => {
+            expr_exceeds(expr, remaining)
+        }
+        _ => false,
+    }
+}
+
+fn table_factor_exceeds(relation: &TableFactor, remaining: usize) -> bool {
+    if remaining == 0 {
+        return true;
+    }
+    match relation {
+        TableFactor::Derived { subquery, .. } => query_exceeds(subquery, remaining - 1),
+        _ => false,
+    }
+}
+
+/// Bounded depth check over a predicate expression: `true` if it nests
+/// `AND`/`OR`/`NOT`/parentheses/subqueries deeper than `remaining` levels.
+/// Returns as soon as the budget is exhausted, so its recursion depth never
+/// exceeds `remaining`.
+fn expr_exceeds(expr: &Expr, remaining: usize) -> bool {
+    if remaining == 0 {
+        return true;
+    }
+    match expr {
+        Expr::BinaryOp { left, right, .. } => {
+            expr_exceeds(left, remaining - 1) || expr_exceeds(right, remaining - 1)
+        }
+        Expr::UnaryOp { expr, .. } | Expr::Nested(expr) => expr_exceeds(expr, remaining - 1),
+        Expr::Subquery(query)
+        | Expr::Exists {
+            subquery: query, ..
+        } => query_exceeds(query, remaining - 1),
+        Expr::InSubquery { subquery, .. } => query_exceeds(subquery, remaining - 1),
+        Expr::Case {
+            operand,
+            conditions,
+            else_result,
+            ..
+        } => {
+            operand
+                .as_deref()
+                .is_some_and(|e| expr_exceeds(e, remaining - 1))
+                || conditions.iter().any(|w| {
+                    expr_exceeds(&w.condition, remaining - 1)
+                        || expr_exceeds(&w.result, remaining - 1)
+                })
+                || else_result
+                    .as_deref()
+                    .is_some_and(|e| expr_exceeds(e, remaining - 1))
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlparser::{dialect::PostgreSqlDialect, parser::Parser};
+
+    use super::*;
+
+    fn parse(sql: &str) -> Statement {
+        Parser::parse_sql(&PostgreSqlDialect {}, sql)
+            .unwrap()
+            .pop()
+            .unwrap()
+    }
+
+    /// N distinct `match_all()` terms OR-ed together in a WHERE clause.
+    fn or_chain_sql(n: usize) -> String {
+        let terms = (0..n)
+            .map(|i| format!("match_all('error{i}')"))
+            .collect::<Vec<_>>()
+            .join(" or ");
+        format!("SELECT * FROM t WHERE {terms}")
+    }
+
+    #[test]
+    fn ordinary_queries_are_not_too_deep() {
+        assert!(!is_predicate_too_deep(&parse("SELECT * FROM t")));
+        assert!(!is_predicate_too_deep(&parse(
+            "SELECT * FROM t WHERE a = 1 AND b = 2 OR c = 3"
+        )));
+        // A realistic number of OR-ed conditions is allowed.
+        assert!(!is_predicate_too_deep(&parse(&or_chain_sql(20))));
+    }
+
+    #[test]
+    fn a_pathologically_deep_or_chain_is_rejected() {
+        // Well beyond the limit — the shape from #12398.
+        assert!(is_predicate_too_deep(&parse(&or_chain_sql(500))));
+    }
+
+    #[test]
+    fn the_limit_is_an_exact_boundary() {
+        // The WHERE predicate gets the full budget, so a chain that consumes
+        // exactly `max` levels is allowed and one level deeper is rejected. Both
+        // sides of the cut are asserted so an off-by-one in the limit is caught.
+        let max = 8;
+        assert!(!predicate_nesting_exceeds(&parse(&or_chain_sql(max)), max));
+        assert!(predicate_nesting_exceeds(
+            &parse(&or_chain_sql(max + 1)),
+            max
+        ));
+    }
+
+    #[test]
+    fn the_check_does_not_overflow_on_a_deep_input() {
+        // Reaching the assertion at all proves the bounded check did not recurse
+        // into a stack overflow on a 5000-deep predicate.
+        assert!(is_predicate_too_deep(&parse(&or_chain_sql(5000))));
+    }
+
+    #[test]
+    fn depth_in_a_subquery_where_is_counted() {
+        let inner = (0..500)
+            .map(|i| format!("match_all('e{i}')"))
+            .collect::<Vec<_>>()
+            .join(" or ");
+        let sql = format!("SELECT * FROM (SELECT * FROM t WHERE {inner}) x");
+        assert!(is_predicate_too_deep(&parse(&sql)));
+    }
+
+    #[test]
+    fn depth_in_a_cte_body_is_counted() {
+        let inner = (0..500)
+            .map(|i| format!("match_all('e{i}')"))
+            .collect::<Vec<_>>()
+            .join(" or ");
+        let sql = format!("WITH x AS (SELECT * FROM t WHERE {inner}) SELECT * FROM x");
+        assert!(is_predicate_too_deep(&parse(&sql)));
+    }
+
+    #[test]
+    fn depth_in_a_projection_is_counted() {
+        let inner = (0..500)
+            .map(|i| format!("match_all('e{i}')"))
+            .collect::<Vec<_>>()
+            .join(" or ");
+        let sql = format!("SELECT ({inner}) AS flagged FROM t");
+        assert!(is_predicate_too_deep(&parse(&sql)));
+    }
+
+    #[test]
+    fn depth_in_a_case_branch_is_counted() {
+        let inner = (0..500)
+            .map(|i| format!("match_all('e{i}')"))
+            .collect::<Vec<_>>()
+            .join(" or ");
+        let sql = format!("SELECT * FROM t WHERE CASE WHEN ({inner}) THEN 1 ELSE 0 END = 1");
+        assert!(is_predicate_too_deep(&parse(&sql)));
+    }
+
+    #[test]
+    fn non_query_statements_are_ignored() {
+        assert!(!is_predicate_too_deep(&parse("SHOW TABLES")));
+    }
+}

--- a/src/search/src/sql/mod.rs
+++ b/src/search/src/sql/mod.rs
@@ -53,6 +53,7 @@ use crate::sql::{
     },
 };
 
+pub mod complexity;
 pub mod rewriter;
 pub mod schema;
 pub mod visitor;
@@ -140,6 +141,16 @@ impl Sql {
             .map_err(|e| Error::ErrorCode(ErrorCodes::SearchSQLNotValid(e.to_string())))?
             .pop()
             .unwrap();
+
+        // Reject a pathologically deep boolean predicate before the visitors and
+        // planner walk it: `a OR b OR c ...` parses into a tree whose depth is
+        // the term count, and the recursive consumers of that tree would
+        // otherwise overflow the stack and abort the process (#12398).
+        if complexity::is_predicate_too_deep(&statement) {
+            return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(
+                "query is too complex: too many nested AND/OR/NOT conditions".to_string(),
+            )));
+        }
 
         //********************Change the sql start*********************************//
         // 2. rewrite track_total_hits


### PR DESCRIPTION
## Summary

A query that ORs together a very large number of `match_all()` full-text conditions can crash the whole node with `fatal runtime error: stack overflow, aborting` (#12398).

`a OR b OR c ...` is consumed iteratively by precedence climbing, so the parser's recursion limit never trips and the query parses into a left-nested boolean AST whose depth equals the term count. The recursive consumers of that tree then overflow the stack:

- the inverted-index condition builder (`Condition::from_physical_expr` → `to_tantivy_query`), which I measured overflowing at ~300–500 OR'd terms on a 2 MB stack — the follower path in the reported log;
- `RewriteMatchPhysical`, DataFusion's own planning, and the recursive `Drop` of the boxed tree.

## Change

Reject a statement whose `WHERE` / `HAVING` / `CASE` / projection predicate — including inside CTEs and subqueries — nests boolean operators deeper than `MAX_PREDICATE_NESTING_DEPTH` (64), in `Sql::new`, before any visitor or planner walks it. The query then fails with a normal `SearchSQLNotValid` error instead of aborting the process, which satisfies the issue's "must not abort the process". The depth check is itself bounded — it reports "too deep" the moment its budget is exhausted — so it cannot overflow on a deep input.

## Notes / judgment calls

- **Limit value:** 64 is deliberately conservative — safely below the depth at which the recursions overflow on a small stack, and well above any hand-written query. It's a single tunable constant. Because comparison operators also count toward depth, a machine-generated predicate of ~64 AND-ed `field = value` filters would be rejected; raise the constant if that's too tight.
- **Coverage:** WHERE / HAVING / CASE / projection / CTE / subqueries. Deep nesting buried in a `JOIN ... ON` condition or a function argument is not covered — rare for this shape.
- **On the original 8-term report:** 8 OR'd terms is only ~8 frames deep — far too shallow to overflow any of these — and the reporter's log shows the query planned fine (`index_condition` was built) before the crash, so that specific event looks like a different, shallow trigger I could not reproduce. This PR addresses the reproducible deep-nesting class the issue's title describes.

## Testing

- `cargo test -p search` — new `sql::complexity` tests (9) plus the full crate suite green (1052 passing).
- Each depth test mutation-checked (neutralising the bound turns them red); the bounded check is verified not to overflow on a 5000-deep input.
- `cargo clippy -p search` and `cargo fmt --check` clean.

Refs #12398.