### PR TITLE
ci(tests): fix flaky rye setup by reusing setup-python interpreter

### DIFF
--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -113,6 +113,7 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v7
+        id: setup-python
         with:
           python-version: "3.11.6"
 
@@ -124,7 +125,7 @@ jobs:
           # during `rye self install`. That download is flaky and intermittently
           # fails with exit 1, after which the next step ("Pin cpython") dies with
           # "rye: command not found" (exit 127).
-          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
+          RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: true
           working-directory: "tests/api-testing/"
@@ -248,6 +249,7 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v7
+        id: setup-python
         with:
           python-version: "3.11.6"
 
@@ -259,7 +261,7 @@ jobs:
           # during `rye self install`. That download is flaky and intermittently
           # fails with exit 1, after which the next step ("Pin cpython") dies with
           # "rye: command not found" (exit 127).
-          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
+          RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: true
           working-directory: "tests/api-testing/"
@@ -377,6 +379,7 @@ jobs:
         run: cargo build --features mimalloc
 
       - uses: actions/setup-python@v7
+        id: setup-python
         with: { python-version: "3.11.6" }
 
       - name: Setup rye
@@ -387,7 +390,7 @@ jobs:
           # during `rye self install`. That download is flaky and intermittently
           # fails with exit 1, after which the next step ("Pin cpython") dies with
           # "rye: command not found" (exit 127).
-          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
+          RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: true
           working-directory: "tests/api-testing/"
@@ -493,6 +496,7 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v7
+        id: setup-python
         with:
           python-version: "3.11.6"
 
@@ -504,7 +508,7 @@ jobs:
           # during `rye self install`. That download is flaky and intermittently
           # fails with exit 1, after which the next step ("Pin cpython") dies with
           # "rye: command not found" (exit 127).
-          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
+          RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: true
           working-directory: "tests/api-testing/"

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -118,6 +118,13 @@ jobs:
 
       - name: Setup rye
         uses: eifinger/setup-rye@v4
+        env:
+          # Reuse the interpreter provisioned by actions/setup-python for Rye's
+          # own bootstrap toolchain instead of downloading python-build-standalone
+          # during `rye self install`. That download is flaky and intermittently
+          # fails with exit 1, after which the next step ("Pin cpython") dies with
+          # "rye: command not found" (exit 127).
+          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
         with:
           enable-cache: true
           working-directory: "tests/api-testing/"
@@ -246,6 +253,13 @@ jobs:
 
       - name: Setup rye
         uses: eifinger/setup-rye@v4
+        env:
+          # Reuse the interpreter provisioned by actions/setup-python for Rye's
+          # own bootstrap toolchain instead of downloading python-build-standalone
+          # during `rye self install`. That download is flaky and intermittently
+          # fails with exit 1, after which the next step ("Pin cpython") dies with
+          # "rye: command not found" (exit 127).
+          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
         with:
           enable-cache: true
           working-directory: "tests/api-testing/"
@@ -367,6 +381,13 @@ jobs:
 
       - name: Setup rye
         uses: eifinger/setup-rye@v4
+        env:
+          # Reuse the interpreter provisioned by actions/setup-python for Rye's
+          # own bootstrap toolchain instead of downloading python-build-standalone
+          # during `rye self install`. That download is flaky and intermittently
+          # fails with exit 1, after which the next step ("Pin cpython") dies with
+          # "rye: command not found" (exit 127).
+          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
         with:
           enable-cache: true
           working-directory: "tests/api-testing/"
@@ -477,6 +498,13 @@ jobs:
 
       - name: Setup rye
         uses: eifinger/setup-rye@v4
+        env:
+          # Reuse the interpreter provisioned by actions/setup-python for Rye's
+          # own bootstrap toolchain instead of downloading python-build-standalone
+          # during `rye self install`. That download is flaky and intermittently
+          # fails with exit 1, after which the next step ("Pin cpython") dies with
+          # "rye: command not found" (exit 127).
+          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
         with:
           enable-cache: true
           working-directory: "tests/api-testing/"

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -120,11 +120,7 @@ jobs:
       - name: Setup rye
         uses: eifinger/setup-rye@v4
         env:
-          # Reuse the interpreter provisioned by actions/setup-python for Rye's
-          # own bootstrap toolchain instead of downloading python-build-standalone
-          # during `rye self install`. That download is flaky and intermittently
-          # fails with exit 1, after which the next step ("Pin cpython") dies with
-          # "rye: command not found" (exit 127).
+          # Reuse setup-python's interpreter so `rye self install` skips the flaky toolchain download.
           RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: true
@@ -256,11 +252,7 @@ jobs:
       - name: Setup rye
         uses: eifinger/setup-rye@v4
         env:
-          # Reuse the interpreter provisioned by actions/setup-python for Rye's
-          # own bootstrap toolchain instead of downloading python-build-standalone
-          # during `rye self install`. That download is flaky and intermittently
-          # fails with exit 1, after which the next step ("Pin cpython") dies with
-          # "rye: command not found" (exit 127).
+          # Reuse setup-python's interpreter so `rye self install` skips the flaky toolchain download.
           RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: true
@@ -385,11 +377,7 @@ jobs:
       - name: Setup rye
         uses: eifinger/setup-rye@v4
         env:
-          # Reuse the interpreter provisioned by actions/setup-python for Rye's
-          # own bootstrap toolchain instead of downloading python-build-standalone
-          # during `rye self install`. That download is flaky and intermittently
-          # fails with exit 1, after which the next step ("Pin cpython") dies with
-          # "rye: command not found" (exit 127).
+          # Reuse setup-python's interpreter so `rye self install` skips the flaky toolchain download.
           RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: true
@@ -503,11 +491,7 @@ jobs:
       - name: Setup rye
         uses: eifinger/setup-rye@v4
         env:
-          # Reuse the interpreter provisioned by actions/setup-python for Rye's
-          # own bootstrap toolchain instead of downloading python-build-standalone
-          # during `rye self install`. That download is flaky and intermittently
-          # fails with exit 1, after which the next step ("Pin cpython") dies with
-          # "rye: command not found" (exit 127).
+          # Reuse setup-python's interpreter so `rye self install` skips the flaky toolchain download.
           RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: true

--- a/.github/workflows/db-testing.yml
+++ b/.github/workflows/db-testing.yml
@@ -141,11 +141,7 @@ jobs:
       - name: Setup rye
         uses: eifinger/setup-rye@v4
         env:
-          # Reuse the interpreter provisioned by actions/setup-python for Rye's
-          # own bootstrap toolchain instead of downloading python-build-standalone
-          # during `rye self install`. That download is flaky and intermittently
-          # fails with exit 1, after which the next step ("Pin cpython") dies with
-          # "rye: command not found" (exit 127).
+          # Reuse setup-python's interpreter so `rye self install` skips the flaky toolchain download.
           RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: false

--- a/.github/workflows/db-testing.yml
+++ b/.github/workflows/db-testing.yml
@@ -139,6 +139,13 @@ jobs:
 
       - name: Setup rye
         uses: eifinger/setup-rye@v4
+        env:
+          # Reuse the interpreter provisioned by actions/setup-python for Rye's
+          # own bootstrap toolchain instead of downloading python-build-standalone
+          # during `rye self install`. That download is flaky and intermittently
+          # fails with exit 1, after which the next step ("Pin cpython") dies with
+          # "rye: command not found" (exit 127).
+          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
         with:
           enable-cache: false
           working-directory: "tests/db-testing/"

--- a/.github/workflows/db-testing.yml
+++ b/.github/workflows/db-testing.yml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v7
+        id: setup-python
         with:
           python-version: "3.11.6"
 
@@ -145,7 +146,7 @@ jobs:
           # during `rye self install`. That download is flaky and intermittently
           # fails with exit 1, after which the next step ("Pin cpython") dies with
           # "rye: command not found" (exit 127).
-          RYE_TOOLCHAIN: ${{ env.pythonLocation }}/bin/python
+          RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
         with:
           enable-cache: false
           working-directory: "tests/db-testing/"


### PR DESCRIPTION
## Problem

The API/DB integration test jobs intermittently fail — often, and retries don't reliably help. CI reports the failure on the **`Pin cpython`** step:

```
rye: command not found
##[error]Process completed with exit code 127
```

But that step is a **victim, not the cause**. The real failure is the preceding **`Setup rye`** step (`eifinger/setup-rye@v4`). It downloads and extracts the `rye` binary fine, then runs `rye self install`, which downloads a **python-build-standalone toolchain (3.11.7)** from GitHub to bootstrap Rye's own venv:

```
Downloading Rye from ".../rye/releases/download/0.27.0/rye-x86_64-linux.gz" ...   ✓
Extracting downloaded archive...                                                  ✓
Determined RYE_TOOLCHAIN_VERSION: 3.11.7
Installing Rye into /opt/hostedtoolcache/setup-rye-.../0.27.0/x86_64
##[error]The process '.../_temp/...' failed with exit code 1                       ← real failure
```

That download flakes and exits 1, so the `rye` binary is never placed on `PATH`, and the next step (`rye pin cpython@3.11.6`) dies with `command not found` (exit 127). Retries only pass when the download happens to succeed.

Example failing run: https://github.com/openobserve/openobserve/actions/runs/31679986019/job/94383108990

## Fix

Every one of these jobs already provisions CPython 3.11.6 via `actions/setup-python`. Point **`RYE_TOOLCHAIN`** at that interpreter so `rye self install` reuses it instead of downloading a second toolchain — removing the flaky network fetch entirely:

```yaml
- name: Setup Python
  uses: actions/setup-python@v7
  id: setup-python
  with:
    python-version: "3.11.6"

- name: Setup rye
  uses: eifinger/setup-rye@v4
  env:
    RYE_TOOLCHAIN: ${{ steps.setup-python.outputs.python-path }}
  with:
    ...
```

The `setup-python` step's official `python-path` output is the absolute path to the interpreter it provisioned — used directly (no hardcoded `/bin/python`), and present in every affected job (verified 1:1).

## Scope

- `.github/workflows/api-testing.yml` — 4 `Setup rye` blocks
- `.github/workflows/db-testing.yml` — 1 `Setup rye` block

Additive, low-risk: only redirects Rye's internal bootstrap; `rye pin` / `rye sync` are untouched.


## Companion PR

Enterprise: openobserve/o2-enterprise#2424 — same fix on `api-testing.yml` (8 blocks) + `api-testing_env.yml` (2 blocks).
