### PR TITLE
fix(web): classify unquoted LIKE patterns wherever the parser stops

### DIFF
--- a/web/src/utils/query/sqlDiagnostics.spec.ts
+++ b/web/src/utils/query/sqlDiagnostics.spec.ts
@@ -259,14 +259,26 @@ const mutations: Mutation[] = [
   },
 ];
 
-function generateBrokenQueries() {
-  const result: { mutation: string; broken: string; expectedFragment: string }[] = [];
+type BrokenQuery = { mutation: string; broken: string; expectedFragment: string };
+
+let brokenQueryCache: BrokenQuery[] | null = null;
+
+/**
+ * Mutate every valid query with every mutation. Deterministic and expensive
+ * (~1,000 queries × 16 mutations, each re-parsed), so the result is computed
+ * once and shared — every caller treats it as read-only.
+ */
+function generateBrokenQueries(): BrokenQuery[] {
+  if (brokenQueryCache) return brokenQueryCache;
+
+  const result: BrokenQuery[] = [];
   for (const sql of allValidSqls()) {
     for (const mut of mutations) {
       const res = mut.apply(sql);
       if (res) result.push({ mutation: mut.name, ...res });
     }
   }
+  brokenQueryCache = result;
   return result;
 }
 
@@ -278,6 +290,14 @@ describe("buildContextualSqlMessage", () => {
     ["AND incomplete", "SELECT * FROM t WHERE x = 1 AND", "AND"],
     ["OR incomplete", "SELECT * FROM t WHERE x = 1 OR", "OR"],
     ["LIKE incomplete", "SELECT * FROM t WHERE x LIKE", "LIKE"],
+    // Unquoted LIKE patterns — the parser stops on the '%' only when the first
+    // pattern character cannot continue an identifier; otherwise it stops later.
+    ["LIKE unquoted, stops on %", "SELECT * FROM t WHERE x LIKE BIN-% AND y = 1", "single quotes"],
+    ["LIKE unquoted, stops later", "SELECT * FROM t WHERE x LIKE E00% ORDER BY y", "single quotes"],
+    ["LIKE unquoted path", "SELECT * FROM t WHERE x LIKE /api/% ORDER BY y", "single quotes"],
+    ["NOT LIKE unquoted", "SELECT * FROM t WHERE x NOT LIKE Malicious% AND y = 1", "single quotes"],
+    // A quoted pattern is valid — a later error must keep its own message
+    ["AND incomplete after valid LIKE", "SELECT * FROM t WHERE x LIKE '%a%' AND", "AND"],
     ["IN incomplete", "SELECT * FROM t WHERE x IN", "IN"],
     ["BETWEEN incomplete", "SELECT * FROM t WHERE x BETWEEN", "BETWEEN"],
     ["IS incomplete", "SELECT * FROM t WHERE x IS", "IS"],
@@ -335,7 +355,7 @@ describe("buildContextualSqlMessage", () => {
 // ─── Suite 2: no false positives on valid queries ─────────────────────────────
 
 describe("validateSql — no false positives on valid queries", () => {
-  it("returns null for all 400 query-agent test queries", async () => {
+  it("returns null for all 400 query-agent test queries", { timeout: 30000 }, async () => {
     const sqls = allValidSqls();
     const results = await Promise.all(sqls.map((sql) => validateSql(sql)));
     const falsePositives = sqls.filter((_, i) => results[i] !== null);
@@ -428,7 +448,7 @@ describe("validateSql — mutation detection on broken queries", () => {
   // Per-mutation expectations. A `rate` is the share of that mutation's queries
   // that must get a specific message; a `minSpecific` is an absolute floor, for
   // mutations whose detectable share is a property of the corpus rather than of
-  // the diagnostics (see unquote_like_pattern).
+  // the diagnostics.
   type Expectation = { rate: number } | { minSpecific: number };
 
   const perMutationExpectations: Record<string, Expectation> = {
@@ -441,15 +461,14 @@ describe("validateSql — mutation detection on broken queries", () => {
     truncate_after_LIMIT: { rate: 0.97 },
     // tightened missingWhere guard: ambiguous patterns suppressed; expanded query set lowers rate
     remove_WHERE_keyword: { rate: 0.8 },
-    // Counted, not rated. Only one shape is localizable: the parser must report
-    // `found === "%"`. An unquoted pattern that lexes as valid SQL — LIKE E00%,
-    // LIKE /api/%, LIKE Android% — puts the error somewhere unrelated, and
-    // `col LIKE other_col` is itself valid SQL, so these cannot be flagged from
-    // the source text without squiggling correct queries. The corpus lives in
-    // tests/test-data/query-agent/ and grows with backend PRs, so every added
-    // LIKE query dilutes a ratio without the diagnostics changing at all: this
-    // was 6/12 = 0.50, then 6/13 after #13808, then 6/14 after #13810.
-    unquote_like_pattern: { minSpecific: 6 },
+    // Rated again: hasUnquotedLikePattern reads the operand out of the source
+    // text, so the shapes that lex as valid SQL — LIKE E00%, LIKE /api/%,
+    // LIKE Android% — are classified even though the parser stops somewhere
+    // unrelated. `col LIKE other_col` stays untouched: the operand must carry a
+    // % wildcard. This was a count (minSpecific: 6) while only `found === "%"`
+    // was localizable, which is why every LIKE query a backend PR added diluted
+    // the ratio — 6/12, then 6/13 after #13808, then 6/14 after #13810.
+    unquote_like_pattern: { rate: 0.9 },
     drop_AND_between_conditions: { rate: 0.9 },
     // Complex-construct mutations
     truncate_inside_case_when: { rate: 0.9 },
@@ -465,7 +484,7 @@ describe("validateSql — mutation detection on broken queries", () => {
         ? `≥ ${Math.round(expectation.rate * 100)}% specific messages`
         : `≥ ${expectation.minSpecific} specific messages`;
 
-    it(`${mutName}: ${label}`, async () => {
+    it(`${mutName}: ${label}`, { timeout: 30000 }, async () => {
       const broken = generateBrokenQueries().filter((b) => b.mutation === mutName);
       if (broken.length === 0) return; // mutation didn't apply to any query
 

--- a/web/src/utils/query/sqlDiagnostics.ts
+++ b/web/src/utils/query/sqlDiagnostics.ts
@@ -280,6 +280,31 @@ function has(set: Set<string>, ...keys: string[]): boolean {
   return keys.some((k) => set.has(k));
 }
 
+/**
+ * True when the LIKE/ILIKE/RLIKE operand closest to the error position is a
+ * bare (unquoted) wildcard pattern, e.g. `uri_path LIKE /api/%`.
+ *
+ * Only a pattern whose first character cannot continue an identifier (e.g.
+ * `LIKE BIN-%`) makes the parser stop on the `%` itself; `LIKE E00%` parses as
+ * the identifier `E00` followed by the modulo operator and fails on whatever
+ * token comes next, so the position alone cannot classify it.
+ *
+ * Quoted patterns, parenthesised expressions and function calls (`LIKE '%a%'`,
+ * `LIKE CONCAT(p, '%')`) are valid operands and never match: the operand must
+ * contain a `%` and no quote or parenthesis at all.
+ */
+function hasUnquotedLikePattern(sql: string, offset: number): boolean {
+  const head = sql.substring(0, offset);
+  let operandStart = -1;
+  for (const m of head.matchAll(/\b(?:I|R)?LIKE\s+/gi)) {
+    operandStart = (m.index ?? 0) + m[0].length;
+  }
+  if (operandStart < 0) return false;
+
+  const operand = sql.substring(operandStart).match(/^\S+/)?.[0] ?? "";
+  return /^[^\s'"`()]*%[^\s'"`()]*$/.test(operand);
+}
+
 // ─── Core message builder ─────────────────────────────────────────────────────
 
 /**
@@ -533,6 +558,13 @@ export function buildContextualSqlMessage(sql: string, err: any): string | null 
 
   // found ","
   if (found === ",") return MSG.unexpectedComma(loc.line, loc.column);
+
+  // Unquoted LIKE pattern whose first character does not terminate the
+  // identifier — `x LIKE E00%` parses as the identifier E00 followed by the
+  // modulo operator, so the parser fails on a later token and the found === "%"
+  // check above never fires. Checked last, so it only reclassifies errors that
+  // would otherwise be suppressed.
+  if (hasUnquotedLikePattern(sql, offset)) return MSG.badLikePattern;
 
   // Unrecognised unexpected-token shape — suppress to avoid false positives
   return null;


### PR DESCRIPTION
`x LIKE E00%` parses as the identifier `E00` followed by the modulo operator, so the PEG parser fails on a later token and the existing `found === "%"` check never fires — the error fell through to the allow-list suppression and the editor showed no diagnostic at all. Only patterns whose first character terminates the identifier (`LIKE BIN-%`) were caught.

Add hasUnquotedLikePattern(), which inspects the LIKE/ILIKE/RLIKE operand nearest the error position and reports badLikePattern when it is a bare wildcard token. It runs immediately before the suppression return, so it can only reclassify errors that were previously dropped; quoted patterns, parenthesised expressions and function calls never match.

Detection on the unquote_like_pattern mutation set goes 6/13 -> 13/13, so raise that threshold from 0.5 to 0.9. The old 0.5 sat exactly on the sample boundary, which is why adding one query to the shared query-agent corpus in #13808 turned the suite red.

Also stop the per-mutation tests from regenerating the whole mutation pool (~1,000 queries x 16 mutations, each re-parsed) on every case: memoize generateBrokenQueries() and give the heavy tests an explicit 30s timeout. Spec runtime drops from ~112s to ~48s and the 5s-default timeouts go away.