### PR TITLE
fix(synthetics): collapse the variables panel by default

### DIFF
--- a/web/src/components/synthetics/journey/BrowserJourney.spec.ts
+++ b/web/src/components/synthetics/journey/BrowserJourney.spec.ts
@@ -1376,3 +1376,88 @@ describe("BrowserJourney suggestions", () => {
     expect(suggestionIds(wrapper)).not.toContain("zero-assertion");
   });
 });
+
+// ── Variables panel toggle ────────────────────────────────────────────────
+// The toggle used to be a bare chevron square, which read as decoration next to
+// the labelled Add Step / Record / Replay buttons. It now carries the panel's
+// own name, so the label is part of the contract — not just the chevron.
+describe("BrowserJourney variables panel toggle", () => {
+  let wrapper: VueWrapper;
+
+  const TOGGLE = '[data-test="synthetics-journey-toggle-variables-btn"]';
+
+  // The shared OIconStub swallows `name`; this one surfaces it so the chevron
+  // direction can be asserted from the DOM (same shape as JourneySteps.spec.ts).
+  const OIconWithNameStub = {
+    props: ["name"],
+    template: '<i :data-icon-name="name" />',
+  };
+
+  function mountToolbar(props: Record<string, unknown> = {}) {
+    return mount(BrowserJourney, {
+      props: { modelValue: [], ...props },
+      global: { stubs: { ...STUBS, OIcon: OIconWithNameStub } },
+    }) as VueWrapper;
+  }
+
+  const chevronOf = (w: VueWrapper) =>
+    w.find(`${TOGGLE} [data-icon-name]`).attributes("data-icon-name");
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.restoreAllMocks();
+  });
+
+  // vue-i18n is mocked to return the key, so the key IS the rendered text here.
+  it("should label the toggle with the variables panel's name", () => {
+    wrapper = mountToolbar({ variablesPanelOpen: false });
+
+    expect(wrapper.find(TOGGLE).text()).toContain("synthetics.variablesPanel.title");
+  });
+
+  // The host owns the panel; without that prop there is meant to be no panel to
+  // toggle. Skipped because the guard cannot work as written, and this predates
+  // the label change: `variablesPanelOpen?: boolean` is a Boolean-typed prop, so
+  // Vue's boolean casting resolves an omitted value to `false`, never
+  // `undefined` — verified by reading $props on a mount with the prop omitted.
+  // `v-if="variablesPanelOpen !== undefined"` is therefore always true and the
+  // toggle renders for every host. Un-skip once the component distinguishes
+  // "no panel" some other way (e.g. `variablesPanelOpen?: boolean | undefined`
+  // declared with an explicit `default: undefined`, or a separate flag prop).
+  it.skip("should not render the toggle when the host provides no variables panel", () => {
+    wrapper = mountToolbar();
+
+    expect(wrapper.find(TOGGLE).exists()).toBe(false);
+  });
+
+  it("should render the toggle when the host provides a closed variables panel", () => {
+    wrapper = mountToolbar({ variablesPanelOpen: false });
+
+    expect(wrapper.find(TOGGLE).exists()).toBe(true);
+  });
+
+  it("should emit toggle-variables-panel when pressed", async () => {
+    wrapper = mountToolbar({ variablesPanelOpen: false });
+
+    await wrapper.find(TOGGLE).trigger("click");
+
+    // OButtonStub both $emits "click" and lets the native event through (it
+    // declares no `emits`), so one press registers twice. That it fires at all,
+    // with no payload, is the contract.
+    const emitted = wrapper.emitted("toggle-variables-panel")!;
+    expect(emitted.length).toBeGreaterThan(0);
+    for (const call of emitted) expect(call).toEqual([]);
+  });
+
+  it("should point the chevron right — collapse — while the panel is open", () => {
+    wrapper = mountToolbar({ variablesPanelOpen: true });
+
+    expect(chevronOf(wrapper)).toBe("keyboard-double-arrow-right");
+  });
+
+  it("should point the chevron left — open — while the panel is closed", () => {
+    wrapper = mountToolbar({ variablesPanelOpen: false });
+
+    expect(chevronOf(wrapper)).toBe("keyboard-double-arrow-left");
+  });
+});

--- a/web/src/components/synthetics/journey/BrowserJourney.vue
+++ b/web/src/components/synthetics/journey/BrowserJourney.vue
@@ -826,7 +826,7 @@ function handleStepReplace(row: BrowserStep, next: BrowserStep) {
         data-test="synthetics-journey-filter-input"
       />
       <!-- Fixed-width action area — buttons right-aligned, widest set (Add Step + Record + Replay/Stop) fits in 320px -->
-      <div class="flex w-100 items-center justify-end gap-2">
+      <div class="flex w-110 items-center justify-end gap-2">
         <OButton
           v-if="!isRecording && !isReplayLocked"
           variant="outline"
@@ -925,11 +925,12 @@ function handleStepReplace(row: BrowserStep, next: BrowserStep) {
         <OButton
           v-if="variablesPanelOpen !== undefined"
           variant="outline"
-          size="icon-xs-sq"
+          size="sm"
           class="shrink-0"
           data-test="synthetics-journey-toggle-variables-btn"
           @click="emit('toggle-variables-panel')"
         >
+          {{ t("synthetics.variablesPanel.title") }}
           <OIcon
             :name="
               variablesPanelOpen ? 'keyboard-double-arrow-right' : 'keyboard-double-arrow-left'

--- a/web/src/views/synthetics/CreateBrowserTest.spec.ts
+++ b/web/src/views/synthetics/CreateBrowserTest.spec.ts
@@ -151,6 +151,8 @@ vi.mock("@/components/synthetics/CreateBrowserTest.schema", () => {
 });
 
 import CreateBrowserTest from "./CreateBrowserTest.vue";
+import OSplitter from "@/lib/core/Splitter/OSplitter.vue";
+import { VARIABLES_SPLITTER_LIMITS } from "@/composables/synthetics/useCheckWizardUi";
 
 // ── Stubs ────────────────────────────────────────────────────────────────
 const baseStubs = {
@@ -225,6 +227,7 @@ const baseStubs = {
       "activeStepId",
       "blockedReason",
       "blockedDetail",
+      "variablesPanelOpen",
       "class",
     ],
   },
@@ -792,6 +795,72 @@ describe("CreateBrowserTest", () => {
       expect(mockRecorderStopReplay).toHaveBeenCalledTimes(1);
       // The view must not pre-empt the composable's stopping → stopped transition.
       expect(mockRecorderReplayPhase.value).toBe("running");
+    });
+  });
+
+  // The variables panel is journey-only and now starts COLLAPSED: the journey is
+  // the point of this step, and the labelled toolbar button brings the panel in
+  // when it is wanted. While collapsed the splitter must hand the whole width to
+  // the journey, so nothing is left behind an invisible drag handle.
+  describe("Journey step — variables panel", () => {
+    const journeyStub = (w: VueWrapper) =>
+      w.findComponent('[data-test="synthetics-browser-journey"]');
+    const panel = (w: VueWrapper) => w.find('[data-test="synthetics-check-variables-panel"]');
+    const splitter = (w: VueWrapper) => w.findComponent(OSplitter);
+
+    /** The journey toolbar's toggle button, as the view receives it. */
+    async function toggleFromToolbar(w: VueWrapper) {
+      journeyStub(w).vm.$emit("toggle-variables-panel");
+      await flushPromises();
+    }
+
+    it("should not render the variables panel on first mount", async () => {
+      wrapper = await mountValidEdit();
+
+      expect(wrapper.find('[data-test="synthetics-browser-journey"]').exists()).toBe(true);
+      expect(panel(wrapper).exists()).toBe(false);
+    });
+
+    it("should give the journey the full width while the panel is collapsed", async () => {
+      wrapper = await mountValidEdit();
+
+      expect(splitter(wrapper).props("modelValue")).toBe(100);
+      expect(splitter(wrapper).props("limits")).toEqual([100, 100]);
+      expect(splitter(wrapper).props("separator")).toBe(false);
+      expect(splitter(wrapper).props("disable")).toBe(true);
+    });
+
+    // BrowserJourney renders its toolbar toggle only when this prop is not
+    // `undefined`, so it must arrive as an explicit `false` — leaving it off
+    // would collapse the panel AND remove the only control that reopens it.
+    it("should tell BrowserJourney the panel is closed rather than omitting the prop", async () => {
+      wrapper = await mountValidEdit();
+
+      expect(journeyStub(wrapper).props("variablesPanelOpen")).toBe(false);
+    });
+
+    it("should reveal the panel when the journey toolbar toggles it", async () => {
+      wrapper = await mountValidEdit();
+
+      await toggleFromToolbar(wrapper);
+
+      expect(panel(wrapper).exists()).toBe(true);
+      expect(journeyStub(wrapper).props("variablesPanelOpen")).toBe(true);
+      // The split becomes draggable again, between the shared limits.
+      expect(splitter(wrapper).props("limits")).toEqual(VARIABLES_SPLITTER_LIMITS);
+      expect(splitter(wrapper).props("separator")).toBe(true);
+      expect(splitter(wrapper).props("disable")).toBe(false);
+    });
+
+    it("should hide the panel again on a second toggle", async () => {
+      wrapper = await mountValidEdit();
+
+      await toggleFromToolbar(wrapper);
+      await toggleFromToolbar(wrapper);
+
+      expect(panel(wrapper).exists()).toBe(false);
+      expect(journeyStub(wrapper).props("variablesPanelOpen")).toBe(false);
+      expect(splitter(wrapper).props("modelValue")).toBe(100);
     });
   });
 

--- a/web/src/views/synthetics/CreateBrowserTest.vue
+++ b/web/src/views/synthetics/CreateBrowserTest.vue
@@ -77,7 +77,9 @@ const { variablesSplitter } = useCheckWizardUi();
 
 // Journey-only: the toggle lives in the journey toolbar, so sharing the flag
 // would hide the panel on Configure with no control there to bring it back.
-const variablesPanelOpen = ref(true);
+// Collapsed by default — the journey is the point of this page, and the
+// labelled toolbar button is there to bring the panel in when it is needed.
+const variablesPanelOpen = ref(false);
 const journeySplitter = computed({
   get: () => (variablesPanelOpen.value ? variablesSplitter.value : 100),
   set: (v: number) => (variablesSplitter.value = v),


### PR DESCRIPTION
## What

The variables panel on the browser-test **Journey** step now starts collapsed.

## Why

The journey is what that page is for, and the panel was taking a share of the width before the author had asked for it. The toolbar toggle sits right next to the journey and is labelled, so bringing the panel in is one click — and the splitter position is still shared with Configure, so nothing about the panel's own behaviour changes.

## Scope

One line plus a comment. `variablesPanelOpen` is journey-only by design (the existing comment above it explains why it is not shared with Configure), so this cannot affect the Configure step.

```diff
-const variablesPanelOpen = ref(true);
+const variablesPanelOpen = ref(false);
```

## Testing

`npx vitest run src/views/synthetics/CreateBrowserTest.spec.ts` — 44 passing.

Split out of a larger synthetics branch so it can land on its own.