### PR TITLE
fix: return empty when usage is not there instead of report error

### DIFF
--- a/src/core/src/self_reporting/search.rs
+++ b/src/core/src/self_reporting/search.rs
@@ -21,6 +21,7 @@ use config::{
         search::{
             Query, Request as SearchRequest, RequestEncoding, SearchEventType, default_use_cache,
         },
+        self_reporting::usage::USAGE_STREAM,
         stream::StreamType,
     },
     utils::json,
@@ -41,6 +42,11 @@ pub async fn get_usage(
     } else {
         (vec![], vec![])
     };
+
+    // return empty if usage stream is not there
+    if !infra::schema::exists(META_ORG_ID, StreamType::Logs, USAGE_STREAM).await {
+        return Ok(vec![]);
+    }
 
     let req = SearchRequest {
         query: Query {

--- a/src/jobs/src/job/service_graph.rs
+++ b/src/jobs/src/job/service_graph.rs
@@ -41,8 +41,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 {
                     log::error!("[SERVICE_GRAPH::JOB] Processing failed: {e}");
                 }
-            },
-            sleep_after
+            }
         );
     }
 


### PR DESCRIPTION
- [x] Should start check job after node start, otherwise it will report gRPC can't connect.
- [x] Should skip usage check when there is no usage stream, otherwise it will always report error.