### PR TITLE
fix: MCP tool calls return 404 when ZO_BASE_URI is set (v0.92 backport)

### DIFF
--- a/src/mcp/src/tools.rs
+++ b/src/mcp/src/tools.rs
@@ -360,8 +360,12 @@ pub fn init_mcp_tools(api: &OpenApi) -> Result<()> {
     let spec = rmcp_openapi::Spec::from_value(api_json)?;
 
     let zo_config = config::get_config();
-    let base_url = url::Url::parse(&format!("http://localhost:{}", zo_config.http.port))
-        .map_err(|e| anyhow::anyhow!("Invalid base URL: {e}"))?;
+    // Include ZO_BASE_URI so tool calls hit the routes actually mounted under it
+    let base_url = url::Url::parse(&format!(
+        "http://localhost:{}{}",
+        zo_config.http.port, zo_config.common.base_uri
+    ))
+    .map_err(|e| anyhow::anyhow!("Invalid base URL: {e}"))?;
 
     // Set default headers including x-o2-mcp for MCP-initiated calls
     let mut default_headers = reqwest::header::HeaderMap::new();


### PR DESCRIPTION
Backport of #13844 to `branch-v0.92.0` (clean cherry-pick of 04aaf1ebfc).

Related to #13845

## What changed

The MCP shared HTTP client (used to execute tool calls against the local REST API) now includes `ZO_BASE_URI` in its base URL: `http://localhost:{port}{base_uri}` instead of `http://localhost:{port}`.

## Why

When `ZO_BASE_URI` is set (e.g. `/abc`), all HTTP routes are mounted under that prefix. The MCP endpoint itself was reachable (`POST /abc/api/default/mcp` → 200), but every tool execution failed: the internal client sent requests to the unprefixed path and got a 404.

## Notes for reviewers

- `cfg.common.base_uri` is already normalized at config load to have no trailing slash (empty when unset), so the empty-prefix behavior is unchanged.
- The join semantics are safe for path-prefixed base URLs: rmcp-openapi's `with_base_url` appends a trailing slash and `build_url` strips the tool path's leading slash before `Url::join`.