### PR TITLE
test: fix flaky report folder move test

### DIFF
--- a/tests/ui-testing/pages/reportsPages/reportFoldersPage.js
+++ b/tests/ui-testing/pages/reportsPages/reportFoldersPage.js
@@ -304,9 +304,12 @@ export class ReportFoldersPage {
 
   async clickMove() {
     await this.moveSubmitBtn.click();
-    await this.moveDialog.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {});
-    // Wait for ODialog close animation to finish before next interaction
+    // Hard assert: the dialog only closes once the move request resolves, so catching
+    // this would let an in-flight/failed move pass and break a later test instead.
+    await expect(this.moveDialog).toBeHidden({ timeout: 15000 });
     await this.page.locator('[data-test="o-dialog-overlay"]').waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+    // onMoveUpdated re-fetches the active folder — let it settle.
+    await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
   }
 
   async cancelMove() {
@@ -338,8 +341,18 @@ export class ReportFoldersPage {
   }
 
   async searchReports(query) {
+    // Clear first — fill()-ing the value the Vue model already holds is a no-op.
+    await this.reportSearchInput.fill('');
     await this.reportSearchInput.fill(query);
     await this.page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+  }
+
+  // Real re-fetch: loadReports serves the folder from a Vuex cache, and the refresh
+  // button is the only control that drops it (invalidateFolderCache + loadReports).
+  async refreshReportList() {
+    const refreshBtn = this.page.locator('[data-test="report-list-refresh-btn"]');
+    await refreshBtn.click({ force: true, timeout: 5000 }).catch(() => {});
+    await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
   }
 
   async clearReportSearch() {
@@ -348,16 +361,13 @@ export class ReportFoldersPage {
   }
 
   async expectReportVisibleInTable(reportName) {
-    // Under parallel load the reports table is slow to pick up a just-created (via API) report:
-    // the list fetch + search debounce lag mean a single 10s wait times out (reportFolders
-    // :46/:79/:150). Poll: re-apply the search filter (which re-fetches the current folder's
-    // list) until the row's pause/start control renders. Non-masking — still fails if the
-    // report genuinely never appears.
+    // Refresh then re-filter on each attempt: the in-folder search is a client-side
+    // filter, so re-typing alone can never pull in a report the page hasn't fetched.
     const btn = this.reportPauseStartBtn(reportName);
     await expect(async () => {
       if (await btn.isVisible().catch(() => false)) return;
-      await this.reportSearchInput.fill(reportName, { force: true }).catch(() => {});
-      await this.page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+      await this.refreshReportList();
+      await this.searchReports(reportName);
       await expect(btn).toBeVisible({ timeout: 5000 });
     }).toPass({ timeout: 45000 });
   }

--- a/tests/ui-testing/playwright-tests/Reports/reportFolders.spec.js
+++ b/tests/ui-testing/playwright-tests/Reports/reportFolders.spec.js
@@ -2,13 +2,24 @@ const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures
 const testLogger = require('../utils/test-logger.js');
 const PageManager = require('../../pages/page-manager.js');
 const { createDashboardViaApi } = require('../../pages/dashboardPages/dashCreation.js');
-const { createReportViaApi } = require('../../pages/reportsPages/reportCreation.js');
+const { createDashboardReportViaApi } = require('../../pages/reportsPages/reportCreation.js');
 
 const timestamp = Date.now();
 const FOLDER_A = `test_folder_a_${timestamp}`;
 const FOLDER_B = `test_folder_b_${timestamp}`;
 const FOLDER_SPECIAL = `test_special_chars_${timestamp}`;
-const REPORT_A = `test_report_${timestamp}`;
+// Spec-scoped report prefix. 'test_report_' also matches scheduledReportsDrawer's
+// test_report_sched_* names, so the prefix cleanup below was deleting that spec's
+// reports mid-run under fullyParallel.
+const RPT_PREFIX = 'test_rf_report_';
+const REPORT_A = `${RPT_PREFIX}${timestamp}`;
+// Own the dashboard REPORT_A binds to. The suite runs fullyParallel against a
+// shared org, and deleting a report's dashboard removes the report from the
+// folder listing entirely — so binding to an arbitrary existing dashboard let a
+// concurrent spec's cleanup make REPORT_A vanish mid-test. The prefix also lets
+// cleanup target only our dashboards, including leaks from a crashed run.
+const DASH_PREFIX = 'test_rf_dash_';
+const DASHBOARD_A = `${DASH_PREFIX}${timestamp}`;
 
 test.describe("Report Folders", () => {
   test.describe.configure({ mode: 'serial' });
@@ -49,20 +60,25 @@ test.describe("Report Folders", () => {
     testLogger.info('Creating dashboard via API for report');
 
     // Create a dashboard via API helper (from dashCreation.js)
-    const dashResult = await createDashboardViaApi(
-      pm.apiCleanup,
-      `dash_${Date.now()}`
-    );
+    const dashResult = await createDashboardViaApi(pm.apiCleanup, DASHBOARD_A);
     if (!dashResult.success) {
       throw new Error(`Failed to create dashboard: ${dashResult.error}`);
     }
-    testLogger.info(`Dashboard "${dashResult.dashboard.dashboard_id}" created via API`);
+    const dashboardId = dashResult.dashboard.dashboard_id;
+    testLogger.info(`Dashboard "${dashboardId}" created via API`);
 
     // Navigate to reports
     await pm.reportFoldersPage.navigateToReports();
 
     testLogger.info('Creating test report via API');
-    const result = await createReportViaApi(pm.apiCleanup, REPORT_A);
+    // Bind explicitly to the dashboard we just created, and keep a destination
+    // (cached: false) so the report lands in the "Scheduled" tab the list shows.
+    const result = await createDashboardReportViaApi(pm.apiCleanup, {
+      reportName: REPORT_A,
+      dashboardId,
+      tabId: dashResult.dashboard.tabs?.[0]?.tab_id || 'default',
+      cached: false,
+    });
     if (!result.success) {
       throw new Error(`Failed to create test report: ${result.error}`);
     }
@@ -233,7 +249,7 @@ test.describe("Report Folders", () => {
     // Delete all test reports matching prefix (catches leftovers from failed runs too)
     const reports = await pm.apiCleanup.fetchReports();
     expect(Array.isArray(reports)).toBeTruthy();
-    const testReports = reports.filter(r => r.name && r.name.startsWith('test_report_'));
+    const testReports = reports.filter(r => r.name && r.name.startsWith(RPT_PREFIX));
     for (const report of testReports) {
       const result = await pm.apiCleanup.deleteReport(report.name);
       // Accept 200 (deleted) or 404 (already gone from a prior partial cleanup)
@@ -248,8 +264,16 @@ test.describe("Report Folders", () => {
     expect(Array.isArray(foldersBefore)).toBeTruthy();
     await pm.apiCleanup.cleanupReportFolders(['test_folder_', 'test_special_']);
 
-    // Delete dashboards created during tests
-    await pm.apiCleanup.cleanupDashboards();
+    // Delete only the dashboards this spec created. cleanupDashboards() removes
+    // every dashboard in `default` owned by the automation user — which under
+    // fullyParallel is every other spec's too, breaking them mid-run. Runs after
+    // the report deletes above: dropping a dashboard first orphans its report.
+    const dashboards = await pm.apiCleanup.fetchDashboardsInFolder('default');
+    const ourDashboards = dashboards.filter(d => d.title && d.title.startsWith(DASH_PREFIX));
+    for (const dash of ourDashboards) {
+      await pm.apiCleanup.deleteDashboard(dash.dashboard_id, dash.folder_id || 'default');
+      testLogger.info(`Deleted test dashboard: ${dash.title}`);
+    }
 
     testLogger.info('Cleanup completed');
   });

--- a/tests/ui-testing/playwright-tests/Reports/reportFolders.spec.js
+++ b/tests/ui-testing/playwright-tests/Reports/reportFolders.spec.js
@@ -103,12 +103,17 @@ test.describe("Report Folders", () => {
     await pm.reportFoldersPage.clickFolderTab(FOLDER_B);
     await pm.reportFoldersPage.expectReportVisibleInTable(REPORT_A);
 
-    // Move it back to default
+    // Move it back to default — later serial tests expect REPORT_A there.
     await pm.reportFoldersPage.searchReports(REPORT_A);
     await pm.reportFoldersPage.expectReportVisibleInTable(REPORT_A);
     await pm.reportFoldersPage.openMoveDialog(REPORT_A);
     await pm.reportFoldersPage.selectMoveDestination('default');
+    await pm.reportFoldersPage.expectMoveButtonEnabled();
     await pm.reportFoldersPage.clickMove();
+
+    // Confirm it landed before handing off to the next test.
+    await pm.reportFoldersPage.clickFolderTab('default');
+    await pm.reportFoldersPage.expectReportVisibleInTable(REPORT_A);
 
     testLogger.info('Report moved to another folder and back successfully');
   });

--- a/tests/ui-testing/playwright-tests/Reports/reports-bulk-operations.spec.js
+++ b/tests/ui-testing/playwright-tests/Reports/reports-bulk-operations.spec.js
@@ -1,17 +1,46 @@
 const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
 const testLogger = require('../utils/test-logger.js');
 const PageManager = require('../../pages/page-manager.js');
-const { createReportViaApi } = require('../../pages/reportsPages/reportCreation.js');
+const { createDashboardViaApi } = require('../../pages/dashboardPages/dashCreation.js');
+const { createDashboardReportViaApi } = require('../../pages/reportsPages/reportCreation.js');
 
 const timestamp = Date.now();
 const BULK_FOLDER = `bulk_test_folder_${timestamp}`;
 const REPORT_1 = `bulk_report_1_${timestamp}`;
 const REPORT_2 = `bulk_report_2_${timestamp}`;
 const REPORT_3 = `bulk_report_3_${timestamp}`;
+// Own the dashboard our reports bind to. createReportViaApi used to attach them
+// to an arbitrary existing dashboard and auto-create stray e2e_setup_dashboard_*
+// that nothing ever deleted.
+const DASH_PREFIX = 'bulk_test_dash_';
+const DASHBOARD_NAME = `${DASH_PREFIX}${timestamp}`;
 
 test.describe("Report Bulk Operations", () => {
   test.describe.configure({ mode: 'serial' });
   let pm;
+  let dashboardId = null;
+  let dashboardTabId = 'default';
+
+  // Create our dashboard once, lazily, and bind every report in this file to it.
+  async function ensureDashboard() {
+    if (dashboardId) return dashboardId;
+    const res = await createDashboardViaApi(pm.apiCleanup, DASHBOARD_NAME);
+    if (!res.success) throw new Error(`Setup: failed to create dashboard: ${res.error}`);
+    dashboardId = res.dashboard.dashboard_id;
+    dashboardTabId = res.dashboard.tabs?.[0]?.tab_id || 'default';
+    return dashboardId;
+  }
+
+  // cached:false keeps a destination set, so the report lands in the Scheduled tab.
+  async function createReport(name) {
+    await ensureDashboard();
+    return createDashboardReportViaApi(pm.apiCleanup, {
+      reportName: name,
+      dashboardId,
+      tabId: dashboardTabId,
+      cached: false,
+    });
+  }
 
   test.beforeEach(async ({ page }, testInfo) => {
     testLogger.testStart(testInfo.title, testInfo.file);
@@ -35,7 +64,7 @@ test.describe("Report Bulk Operations", () => {
     tag: ['@reportBulkOps', '@smoke', '@P0']
   }, async ({ page }) => {
     testLogger.info('Creating a report via API to ensure table is non-empty');
-    const result = await createReportViaApi(pm.apiCleanup, REPORT_1);
+    const result = await createReport(REPORT_1);
     if (!result.success) {
       throw new Error(`Setup: failed to create report: ${result.error}`);
     }
@@ -44,6 +73,8 @@ test.describe("Report Bulk Operations", () => {
     await pm.reportFoldersPage.expectReportVisibleInTable(REPORT_1);
 
     testLogger.info('Selecting all reports via header checkbox');
+    // select-all ticks whatever the table shows — narrow it to this run's own reports.
+    await pm.reportFoldersPage.searchReports(String(timestamp));
     await pm.reportFoldersPage.selectAllReports();
     await pm.reportFoldersPage.expectBulkButtonsVisible();
 
@@ -62,8 +93,8 @@ test.describe("Report Bulk Operations", () => {
     await pm.reportFoldersPage.createFolder(BULK_FOLDER);
     await pm.reportFoldersPage.expectFolderTabVisible(BULK_FOLDER);
 
-    const r1 = await createReportViaApi(pm.apiCleanup, `${REPORT_1}_move`);
-    const r2 = await createReportViaApi(pm.apiCleanup, `${REPORT_2}_move`);
+    const r1 = await createReport(`${REPORT_1}_move`);
+    const r2 = await createReport(`${REPORT_2}_move`);
     if (!r1.success || !r2.success) {
       throw new Error('Setup: failed to create reports for bulk move test');
     }
@@ -72,6 +103,8 @@ test.describe("Report Bulk Operations", () => {
     await pm.reportFoldersPage.clickFolderTab('default');
 
     testLogger.info('Selecting all reports and initiating bulk move');
+    // select-all ticks whatever the table shows — narrow it to this run's own reports.
+    await pm.reportFoldersPage.searchReports(String(timestamp));
     await pm.reportFoldersPage.selectAllReports();
     await pm.reportFoldersPage.clickBulkMove();
 
@@ -98,8 +131,8 @@ test.describe("Report Bulk Operations", () => {
     tag: ['@reportBulkOps', '@functional', '@P1']
   }, async ({ page }) => {
     testLogger.info('Creating reports for bulk delete test');
-    const r1 = await createReportViaApi(pm.apiCleanup, `${REPORT_2}_del`);
-    const r2 = await createReportViaApi(pm.apiCleanup, `${REPORT_3}_del`);
+    const r1 = await createReport(`${REPORT_2}_del`);
+    const r2 = await createReport(`${REPORT_3}_del`);
     if (!r1.success || !r2.success) {
       throw new Error('Setup: failed to create reports for bulk delete test');
     }
@@ -108,6 +141,8 @@ test.describe("Report Bulk Operations", () => {
     await pm.reportFoldersPage.expectReportVisibleInTable(`${REPORT_2}_del`);
 
     testLogger.info('Selecting all reports and clicking bulk delete');
+    // select-all ticks whatever the table shows — narrow it to this run's own reports.
+    await pm.reportFoldersPage.searchReports(String(timestamp));
     await pm.reportFoldersPage.selectAllReports();
     await pm.reportFoldersPage.clickBulkDelete();
 
@@ -127,7 +162,7 @@ test.describe("Report Bulk Operations", () => {
     tag: ['@reportBulkOps', '@edge', '@P2']
   }, async ({ page }) => {
     testLogger.info('Creating a report to verify cancel behaviour');
-    const r1 = await createReportViaApi(pm.apiCleanup, `${REPORT_3}_cancel`);
+    const r1 = await createReport(`${REPORT_3}_cancel`);
     if (!r1.success) {
       throw new Error('Setup: failed to create report for cancel test');
     }
@@ -136,6 +171,8 @@ test.describe("Report Bulk Operations", () => {
     await pm.reportFoldersPage.expectReportVisibleInTable(`${REPORT_3}_cancel`);
 
     testLogger.info('Selecting reports and clicking bulk delete then cancelling');
+    // select-all ticks whatever the table shows — narrow it to this run's own reports.
+    await pm.reportFoldersPage.searchReports(String(timestamp));
     await pm.reportFoldersPage.selectAllReports();
     await pm.reportFoldersPage.clickBulkDelete();
     await pm.reportFoldersPage.cancelBulkDelete();
@@ -155,7 +192,7 @@ test.describe("Report Bulk Operations", () => {
     await pm.reportFoldersPage.createFolder(cancelFolder);
     await pm.reportFoldersPage.expectFolderTabVisible(cancelFolder);
 
-    const r1 = await createReportViaApi(pm.apiCleanup, `${REPORT_1}_cancel_move`);
+    const r1 = await createReport(`${REPORT_1}_cancel_move`);
     if (!r1.success) {
       throw new Error('Setup: failed to create report');
     }
@@ -164,6 +201,8 @@ test.describe("Report Bulk Operations", () => {
     await pm.reportFoldersPage.clickFolderTab('default');
 
     testLogger.info('Opening bulk move dialog and cancelling');
+    // select-all ticks whatever the table shows — narrow it to this run's own reports.
+    await pm.reportFoldersPage.searchReports(String(timestamp));
     await pm.reportFoldersPage.selectAllReports();
     await pm.reportFoldersPage.clickBulkMove();
     await pm.reportFoldersPage.cancelMove();
@@ -175,5 +214,19 @@ test.describe("Report Bulk Operations", () => {
     // Cleanup
     await pm.apiCleanup.deleteReport(`${REPORT_1}_cancel_move`);
     await pm.reportFoldersPage.deleteFolderIfExists(cancelFolder);
+  });
+
+  // ===== CLEANUP =====
+
+  test("Cleanup: Remove the dashboard this spec created", {
+    tag: ['@reportBulkOps', '@cleanup']
+  }, async ({ page }) => {
+    const dashboards = await pm.apiCleanup.fetchDashboardsInFolder('default');
+    const ourDashboards = dashboards.filter(d => d.title && d.title.startsWith(DASH_PREFIX));
+    for (const dash of ourDashboards) {
+      await pm.apiCleanup.deleteDashboard(dash.dashboard_id, dash.folder_id || 'default');
+      testLogger.info(`Deleted test dashboard: ${dash.title}`);
+    }
+    testLogger.info('Cleanup completed');
   });
 });

--- a/tests/ui-testing/playwright-tests/Reports/scheduledReportsDrawer.spec.js
+++ b/tests/ui-testing/playwright-tests/Reports/scheduledReportsDrawer.spec.js
@@ -20,8 +20,9 @@ const {
  */
 
 const timestamp = Date.now();
-const DASHBOARD_A = `test_dash_sched_a_${timestamp}`;
-const DASHBOARD_B = `test_dash_sched_b_${timestamp}`;
+const DASH_PREFIX = 'test_dash_sched_';
+const DASHBOARD_A = `${DASH_PREFIX}a_${timestamp}`;
+const DASHBOARD_B = `${DASH_PREFIX}b_${timestamp}`;
 const REPORT_FOLDER = `test_folder_sched_${timestamp}`;
 const REPORT_DEFAULT_FOLDER = `test_report_sched_default_${timestamp}`;
 const REPORT_CUSTOM_FOLDER = `test_report_sched_custom_${timestamp}`;
@@ -276,7 +277,16 @@ test.describe("Dashboard Scheduled Reports Drawer", () => {
     }
 
     await pm.apiCleanup.cleanupReportFolders(['test_folder_sched_']);
-    await pm.apiCleanup.cleanupDashboards();
+    // Delete only the dashboards this spec created. cleanupDashboards() removes
+    // every dashboard owned by the automation user — under fullyParallel that is
+    // every other spec's too, and deleting a dashboard also makes any report
+    // bound to it vanish. Mirrors the scoped report/folder cleanups above.
+    const dashboards = await pm.apiCleanup.fetchDashboardsInFolder('default');
+    const ourDashboards = dashboards.filter(d => d.title && d.title.startsWith(DASH_PREFIX));
+    for (const dash of ourDashboards) {
+      await pm.apiCleanup.deleteDashboard(dash.dashboard_id, dash.folder_id || 'default');
+      testLogger.info(`Deleted test dashboard: ${dash.title}`);
+    }
 
     testLogger.info('Cleanup completed');
   });


### PR DESCRIPTION
## Problem

`reportFolders.spec.js` failed intermittently in CI. `P2: Move button disabled
when source equals destination` failed on all 3 retries with a freshly-created
report each time — the signature of poisoned shared state, not timing flake.

## Root causes

Four independent test-side defects, all rooted in specs sharing one org, one
user, and one `default` folder under `fullyParallel: true, workers: 5`:

1. **Reports bound to a stranger's dashboard.** `createReportViaApi` ignored the
   dashboard the test had just created and attached to `dashboards[0]` — whichever
   dashboard sorted first alphabetically in the shared folder. Deleting a
   dashboard removes its reports, so a neighbouring spec's cleanup made the
   report vanish mid-test.

2. **Blanket cleanups.** `cleanupDashboards()` deletes *every* dashboard owned by
   the automation user — every other spec's included (16 in one observed run).
   `reportFolders` also deleted every report matching `test_report_`, which swept
   up `scheduledReportsDrawer`'s `test_report_sched_*`.

3. **Bulk select-all across the shared folder.** `reports-bulk-operations` did
   "select all in `default` → bulk move/delete". Under parallel load that
   captured other specs' reports. Confirmed on a live server: `reportFolders`'
   report was found sitting in `bulk_test_folder_*`, created 78ms apart.

4. **A retry that could never succeed.** `expectReportVisibleInTable` retried by
   re-typing the same value into the search box. The Vue model never changed, and
   the in-folder search is a client-side filter over already-fetched rows — it
   cannot pull in a report the page hasn't loaded. The poll burned its full 45s
   doing nothing. Separately, `clickMove()` swallowed its dialog-close wait, so a
   move that never landed passed silently and failed a *later* test instead.

## Changes
