### PR TITLE
fix(promql): resolve .sidx projection and matcher filter by name per sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9096,6 +9096,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "async-trait",
+ "bytes",
  "config",
  "datafusion",
  "db",

--- a/src/promql_service/Cargo.toml
+++ b/src/promql_service/Cargo.toml
@@ -21,6 +21,7 @@ vectorscan = ["search/vectorscan", "search_service/vectorscan"]
 [dependencies]
 arrow.workspace = true
 async-trait.workspace = true
+bytes.workspace = true
 config.workspace = true
 datafusion.workspace = true
 db.workspace = true

--- a/src/promql_service/src/search/grpc/tsid_series_index.rs
+++ b/src/promql_service/src/search/grpc/tsid_series_index.rs
@@ -119,9 +119,10 @@ pub(super) async fn search(
     matchers: &Matchers,
     target_partitions: usize,
 ) -> Result<Option<usize>> {
-    let Some(sidecar_projection) = series_index_projection(table_schema, matchers) else {
+    let Some(matcher_labels) = series_index_labels(table_schema, matchers) else {
         return Ok(None);
     };
+    let matcher_labels = Arc::new(matcher_labels);
     if files.is_empty() {
         return Ok(None);
     }
@@ -165,9 +166,9 @@ pub(super) async fn search(
     let concurrency = target_partitions.max(1).saturating_mul(2).min(64);
     let loaded = stream::iter(misses.into_iter().map(
         |(data_path, account, sidecar_path, cache_key)| {
-            let projection = sidecar_projection.clone();
+            let labels = Arc::clone(&matcher_labels);
             async move {
-                load_series_index_file(&account, &sidecar_path, projection)
+                load_series_index_file(&account, &sidecar_path, labels)
                     .await
                     .map(|data| (data_path, cache_key, data))
             }
@@ -178,18 +179,17 @@ pub(super) async fn search(
     .await;
 
     let loaded_files = loaded.into_iter().collect::<Result<Vec<_>>>()?;
-    let newly_evaluated = if let Some((_, _, first)) = loaded_files.first() {
-        let physical_filter = create_physical_filter(first.schema.as_ref(), matchers)?;
-        loaded_files
-            .into_par_iter()
-            .map(|(path, cache_key, data)| {
-                evaluate_series_index(&data, physical_filter.as_ref())
-                    .map(|ranges| (path, cache_key, Arc::new(ranges)))
-            })
-            .collect::<Result<Vec<_>>>()?
-    } else {
-        Vec::new()
-    };
+    // Sidecars written at different times can carry different label sets and
+    // column orders, so the physical filter is resolved by name against each
+    // file's own schema instead of being shared across files.
+    let newly_evaluated = loaded_files
+        .into_par_iter()
+        .map(|(path, cache_key, data)| {
+            let physical_filter = create_physical_filter(data.schema.as_ref(), matchers)?;
+            evaluate_series_index(&data, physical_filter.as_deref())
+                .map(|ranges| (path, cache_key, Arc::new(ranges)))
+        })
+        .collect::<Result<Vec<_>>>()?;
     {
         let mut cache = SERIES_SELECTION_CACHE.lock();
         for (path, cache_key, ranges) in newly_evaluated {
@@ -231,22 +231,10 @@ pub(super) async fn search(
     Ok(Some(took))
 }
 
-fn series_index_projection(table_schema: &Schema, matchers: &Matchers) -> Option<Vec<usize>> {
-    let mut sidecar_fields = vec![TSID_SERIES_INDEX_ROW_START, TSID_SERIES_INDEX_ROW_COUNT];
-    sidecar_fields.extend(
-        table_schema
-            .fields()
-            .iter()
-            .filter(|field| {
-                !matches!(
-                    field.name().as_str(),
-                    TIMESTAMP_COL_NAME | VALUE_LABEL | EXEMPLARS_LABEL
-                )
-            })
-            .map(|field| field.name().as_str()),
-    );
-
-    let mut projection = vec![0, 1];
+/// Labels referenced by the matchers that the sidecar can answer. `None`
+/// when no matcher can be evaluated on the series index.
+fn series_index_labels(table_schema: &Schema, matchers: &Matchers) -> Option<Vec<String>> {
+    let mut labels: Vec<String> = Vec::new();
     for matcher in &matchers.matchers {
         if matches!(
             matcher.name.as_str(),
@@ -255,78 +243,110 @@ fn series_index_projection(table_schema: &Schema, matchers: &Matchers) -> Option
         {
             continue;
         }
-        let index = sidecar_fields
-            .iter()
-            .position(|field| *field == matcher.name)?;
-        if !projection.contains(&index) {
-            projection.push(index);
+        if !labels.contains(&matcher.name) {
+            labels.push(matcher.name.clone());
         }
     }
-    if projection.len() == 2 {
-        return None;
-    }
-    projection.sort_unstable();
-    Some(projection)
+    (!labels.is_empty()).then_some(labels)
 }
 
 async fn load_series_index_file(
     account: &str,
     path: &str,
-    projection: Vec<usize>,
+    labels: Arc<Vec<String>>,
 ) -> Result<SeriesIndexData> {
     let bytes = infra::cache::file_data::get(account, path, None)
         .await
         .map_err(|error| DataFusionError::External(Box::new(error)))?;
-    tokio::task::spawn_blocking(move || -> Result<SeriesIndexData> {
-        let reader = ArrowFileReaderBuilder::new()
-            .with_projection(projection)
-            .build(Cursor::new(bytes))?;
-        let reader_schema = reader.schema();
-        let batches = reader.collect::<std::result::Result<Vec<_>, _>>()?;
-        let schema = batches
-            .first()
-            .map(RecordBatch::schema)
-            .unwrap_or(reader_schema);
-        Ok(SeriesIndexData { schema, batches })
-    })
-    .await
-    .map_err(|error| DataFusionError::External(Box::new(error)))?
+    let path = path.to_string();
+    tokio::task::spawn_blocking(move || decode_series_index(&path, bytes, &labels))
+        .await
+        .map_err(|error| DataFusionError::External(Box::new(error)))?
 }
 
+/// Read the row-range columns plus the requested labels from a sidecar.
+///
+/// The projection is resolved by name against the sidecar's own schema: the
+/// label set and column order of a sidecar depend on the schema at compaction
+/// time and differ between files. A requested label that the sidecar does not
+/// have is skipped, which over-selects that file; the final PromQL filter keeps
+/// the query result exact.
+fn decode_series_index(
+    path: &str,
+    bytes: bytes::Bytes,
+    labels: &[String],
+) -> Result<SeriesIndexData> {
+    let file_schema = ArrowFileReaderBuilder::new()
+        .build(Cursor::new(bytes.clone()))?
+        .schema();
+    let mut projection = vec![
+        file_schema.index_of(TSID_SERIES_INDEX_ROW_START)?,
+        file_schema.index_of(TSID_SERIES_INDEX_ROW_COUNT)?,
+    ];
+    for label in labels {
+        match file_schema.index_of(label) {
+            Ok(index) => projection.push(index),
+            Err(_) => log::debug!(
+                "TSID series index {path} has no label {label}, evaluating the remaining matchers only"
+            ),
+        }
+    }
+    let reader = ArrowFileReaderBuilder::new()
+        .with_projection(projection)
+        .build(Cursor::new(bytes))?;
+    let reader_schema = reader.schema();
+    let batches = reader.collect::<std::result::Result<Vec<_>, _>>()?;
+    let schema = batches
+        .first()
+        .map(RecordBatch::schema)
+        .unwrap_or(reader_schema);
+    Ok(SeriesIndexData { schema, batches })
+}
+
+/// Physical filter over the sidecar columns. `None` when none of the matchers
+/// can be evaluated on this sidecar (all matched labels are missing): every
+/// series of the file must then be scanned.
 fn create_physical_filter(
     sidecar_schema: &Schema,
     matchers: &Matchers,
-) -> Result<Arc<dyn PhysicalExpr>> {
-    let filter = promql::utils::matcher_predicates(sidecar_schema, matchers)
+) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+    let Some(filter) = promql::utils::matcher_predicates(sidecar_schema, matchers)
         .into_iter()
         .reduce(Expr::and)
-        .ok_or_else(|| {
-            DataFusionError::Plan("TSID series index has no usable label matcher".to_string())
-        })?;
+    else {
+        return Ok(None);
+    };
     let df_schema = DFSchema::try_from(sidecar_schema.clone())?;
     SessionContext::new()
         .state()
         .create_physical_expr(filter, &df_schema)
+        .map(Some)
 }
 
 fn evaluate_series_index(
     data: &SeriesIndexData,
-    filter: &dyn PhysicalExpr,
+    filter: Option<&dyn PhysicalExpr>,
 ) -> Result<Vec<Range<usize>>> {
     let start_index = data.schema.index_of(TSID_SERIES_INDEX_ROW_START)?;
     let count_index = data.schema.index_of(TSID_SERIES_INDEX_ROW_COUNT)?;
     let mut ranges: Vec<Range<usize>> = Vec::new();
 
     for batch in &data.batches {
-        let mask = filter.evaluate(batch)?.into_array(batch.num_rows())?;
-        let mask = mask
-            .as_any()
-            .downcast_ref::<BooleanArray>()
-            .ok_or_else(|| {
-                DataFusionError::Execution(
-                    "TSID series-index filter did not produce a boolean array".to_string(),
-                )
-            })?;
+        let mask = match filter {
+            Some(filter) => {
+                let mask = filter.evaluate(batch)?.into_array(batch.num_rows())?;
+                mask.as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(
+                            "TSID series-index filter did not produce a boolean array".to_string(),
+                        )
+                    })?
+                    .clone()
+            }
+            None => BooleanArray::from(vec![true; batch.num_rows()]),
+        };
+        let mask = &mask;
         let starts = batch
             .column(start_index)
             .as_any()
@@ -376,13 +396,15 @@ mod tests {
     use arrow::{
         array::{StringViewArray, UInt32Array, UInt64Array},
         datatypes::{DataType, Field},
+        ipc::writer::FileWriter as ArrowFileWriter,
     };
+    use bytes::Bytes;
     use promql_parser::label::{MatchOp, Matcher};
 
     use super::*;
 
     #[test]
-    fn projection_keeps_offsets_and_requested_labels() {
+    fn labels_keep_only_matchable_table_labels() {
         let schema = Schema::new(vec![
             Field::new("__hash__", DataType::UInt64, false),
             Field::new("__name__", DataType::Utf8View, false),
@@ -391,13 +413,20 @@ mod tests {
             Field::new("path", DataType::Utf8View, true),
             Field::new(VALUE_LABEL, DataType::Float64, false),
         ]);
-        let matchers = Matchers::new(vec![Matcher::new(MatchOp::Equal, "path", "a")]);
-
-        // sidecar schema is: start, count, __hash__, __name__, instance, path
+        let matchers = Matchers::new(vec![
+            Matcher::new(MatchOp::Equal, "path", "a"),
+            Matcher::new(MatchOp::Equal, "path", "b"),
+            Matcher::new(MatchOp::NotEqual, VALUE_LABEL, "1"),
+            Matcher::new(MatchOp::Equal, "missing_label", "x"),
+            Matcher::new(MatchOp::NotEqual, "instance", "i1"),
+        ]);
         assert_eq!(
-            series_index_projection(&schema, &matchers),
-            Some(vec![0, 1, 5])
+            series_index_labels(&schema, &matchers),
+            Some(vec!["path".to_string(), "instance".to_string()])
         );
+
+        let only_value = Matchers::new(vec![Matcher::new(MatchOp::Equal, VALUE_LABEL, "1")]);
+        assert_eq!(series_index_labels(&schema, &only_value), None);
     }
 
     #[test]
@@ -422,10 +451,112 @@ mod tests {
         };
         let matchers = Matchers::new(vec![Matcher::new(MatchOp::Equal, "path", "a")]);
         let filter = create_physical_filter(&schema, &matchers).unwrap();
+        assert!(filter.is_some());
 
         assert_eq!(
-            evaluate_series_index(&data, filter.as_ref()).unwrap(),
+            evaluate_series_index(&data, filter.as_deref()).unwrap(),
             vec![0..2, 4..8]
+        );
+
+        // no evaluable matcher: every series is selected
+        assert_eq!(
+            evaluate_series_index(&data, None).unwrap(),
+            vec![Range { start: 0, end: 8 }]
+        );
+    }
+
+    /// Serialize a sidecar with the given label columns (in this order).
+    fn sidecar_bytes(labels: &[(&str, Vec<&str>)], starts: Vec<u64>, counts: Vec<u32>) -> Bytes {
+        let mut fields = vec![
+            Field::new(TSID_SERIES_INDEX_ROW_START, DataType::UInt64, false),
+            Field::new(TSID_SERIES_INDEX_ROW_COUNT, DataType::UInt32, false),
+        ];
+        let mut columns: Vec<Arc<dyn Array>> = vec![
+            Arc::new(UInt64Array::from(starts)),
+            Arc::new(UInt32Array::from(counts)),
+        ];
+        for (name, values) in labels {
+            fields.push(Field::new(*name, DataType::Utf8View, true));
+            columns.push(Arc::new(StringViewArray::from(values.clone())));
+        }
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), columns).unwrap();
+        let mut writer = ArrowFileWriter::try_new(Vec::new(), &schema).unwrap();
+        writer.write(&batch).unwrap();
+        Bytes::from(writer.into_inner().unwrap())
+    }
+
+    #[test]
+    fn projects_by_name_across_sidecars_with_different_layouts() {
+        let labels = vec!["path".to_string(), "instance".to_string()];
+        let matchers = Matchers::new(vec![
+            Matcher::new(MatchOp::Equal, "path", "a"),
+            Matcher::new(MatchOp::Equal, "instance", "i1"),
+        ]);
+
+        // file 1: [.., instance, job, path]; file 2: [.., path, instance] —
+        // same labels, different positions
+        let file1 = sidecar_bytes(
+            &[
+                ("instance", vec!["i1", "i2", "i1"]),
+                ("job", vec!["j", "j", "j"]),
+                ("path", vec!["a", "a", "b"]),
+            ],
+            vec![0, 3, 5],
+            vec![3, 2, 4],
+        );
+        let file2 = sidecar_bytes(
+            &[("path", vec!["b", "a"]), ("instance", vec!["i1", "i1"])],
+            vec![0, 7],
+            vec![7, 1],
+        );
+        for (name, bytes, expected) in [
+            ("f1", file1, vec![Range { start: 0, end: 3 }]),
+            ("f2", file2, vec![Range { start: 7, end: 8 }]),
+        ] {
+            let data = decode_series_index(name, bytes, &labels).unwrap();
+            assert_eq!(data.schema.fields().len(), 4, "{name}");
+            let filter = create_physical_filter(&data.schema, &matchers).unwrap();
+            assert_eq!(
+                evaluate_series_index(&data, filter.as_deref()).unwrap(),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_label_over_selects_instead_of_dropping() {
+        let labels = vec!["path".to_string(), "instance".to_string()];
+        let matchers = Matchers::new(vec![
+            Matcher::new(MatchOp::Equal, "path", "a"),
+            Matcher::new(MatchOp::Equal, "instance", "i1"),
+        ]);
+
+        // sidecar without `instance`: only the `path` matcher is evaluated
+        let partial = sidecar_bytes(
+            &[("path", vec!["a", "b", "a"])],
+            vec![0, 2, 6],
+            vec![2, 4, 1],
+        );
+        let data = decode_series_index("partial", partial, &labels).unwrap();
+        assert_eq!(data.schema.fields().len(), 3);
+        let filter = create_physical_filter(&data.schema, &matchers).unwrap();
+        assert!(filter.is_some());
+        assert_eq!(
+            evaluate_series_index(&data, filter.as_deref()).unwrap(),
+            vec![0..2, 6..7]
+        );
+
+        // sidecar with none of the matched labels: the whole file is selected
+        let none = sidecar_bytes(&[("job", vec!["j", "j"])], vec![0, 4], vec![4, 2]);
+        let data = decode_series_index("none", none, &labels).unwrap();
+        assert_eq!(data.schema.fields().len(), 2);
+        let filter = create_physical_filter(&data.schema, &matchers).unwrap();
+        assert!(filter.is_none());
+        assert_eq!(
+            evaluate_series_index(&data, filter.as_deref()).unwrap(),
+            vec![Range { start: 0, end: 6 }]
         );
     }
 }


### PR DESCRIPTION
Follow-up to #13839 (targets its branch `codex/metrics-tsid-major-pocs`).

## Problem

`tsid_series_index.rs` projected sidecar columns **by position** computed from the query-time table schema, and built **one** physical filter from the first loaded sidecar's schema and reused it for every file.

A sidecar's label set / column order is `latest_schema.retain(fields present in that hour's inputs)` at compaction time (`compaction/merge.rs`), so it differs between files and from the current table schema whenever an earlier label is absent in a given hour. Consequences:

- position out of range → `Err` → whole query falls back to Tantivy/full scan (safe, but the pruning is lost)
- position hits another column, or the shared `Column(index)` filter is evaluated on a file with a different layout → a matcher is applied to the wrong label → series wrongly excluded → **rows dropped, wrong PromQL result** (the final filter can only remove rows, never add them back)

## Fix

- `decode_series_index`: read the sidecar's own schema first, project `row_start`/`row_count` + matched labels **by name**
- `create_physical_filter` per sidecar (returns `None` when no matcher applies)
- a matched label missing from a sidecar is skipped → that file is over-selected; the final PromQL filter keeps the result exact. When no matcher applies the whole file is selected (`[0..rows)`) instead of erroring the query.

## Tests

`cargo test -p promql-service --lib -- tsid_series_index` — 4 passed:
- labels derived from matchers/table schema
- coalescing + "no filter selects everything"
- two sidecars with the same labels in different positions
- sidecar missing one / all matched labels

`cargo clippy -p promql-service --tests` clean, `cargo fmt --check` clean.