### PR TITLE
refactor(search): drop FileSortOrder from the distributed plan wire format

### DIFF
--- a/src/proto/proto/cluster/plan.proto
+++ b/src/proto/proto/cluster/plan.proto
@@ -26,24 +26,14 @@ message Uint64List {
     repeated uint64 values = 1;
 }
 
-// Physical sort order of the files behind a table.
-enum FileSortOrder {
-    FILE_SORT_ORDER_NONE               = 0;
-    FILE_SORT_ORDER_TIMESTAMP_DESC     = 1;
-    FILE_SORT_ORDER_HASH_TIMESTAMP_ASC = 2;
-}
-
 message NewEmptyExecNode {
     string                                 name = 1;
     datafusion_common.Schema             schema = 2;
     optional Uint64List              projection = 3;
     repeated datafusion.LogicalExprNode filters = 4;
     optional uint64                       limit = 5;
-    // Legacy flag, kept for rolling upgrades: true == FILE_SORT_ORDER_TIMESTAMP_DESC.
-    // Readers prefer `sort_order` when it is set to anything but NONE.
     bool                         sorted_by_time = 6;
     datafusion_common.Schema        full_schema = 7;
-    FileSortOrder                    sort_order = 8;
 }
 
 message TmpExecNode {

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -3306,14 +3306,10 @@ pub struct NewEmptyExecNode {
     pub filters: ::prost::alloc::vec::Vec<::datafusion_proto::protobuf::LogicalExprNode>,
     #[prost(uint64, optional, tag = "5")]
     pub limit: ::core::option::Option<u64>,
-    /// Legacy flag, kept for rolling upgrades: true == FILE_SORT_ORDER_TIMESTAMP_DESC.
-    /// Readers prefer `sort_order` when it is set to anything but NONE.
     #[prost(bool, tag = "6")]
     pub sorted_by_time: bool,
     #[prost(message, optional, tag = "7")]
     pub full_schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
-    #[prost(enumeration = "FileSortOrder", tag = "8")]
-    pub sort_order: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TmpExecNode {
@@ -3492,36 +3488,6 @@ pub struct KvItem {
     pub key: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub value: ::prost::alloc::string::String,
-}
-/// Physical sort order of the files behind a table.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum FileSortOrder {
-    None = 0,
-    TimestampDesc = 1,
-    HashTimestampAsc = 2,
-}
-impl FileSortOrder {
-    /// String value of the enum field names used in the ProtoBuf definition.
-    ///
-    /// The values are not transformed in any way and thus are considered stable
-    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn as_str_name(&self) -> &'static str {
-        match self {
-            Self::None => "FILE_SORT_ORDER_NONE",
-            Self::TimestampDesc => "FILE_SORT_ORDER_TIMESTAMP_DESC",
-            Self::HashTimestampAsc => "FILE_SORT_ORDER_HASH_TIMESTAMP_ASC",
-        }
-    }
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "FILE_SORT_ORDER_NONE" => Some(Self::None),
-            "FILE_SORT_ORDER_TIMESTAMP_DESC" => Some(Self::TimestampDesc),
-            "FILE_SORT_ORDER_HASH_TIMESTAMP_ASC" => Some(Self::HashTimestampAsc),
-            _ => None,
-        }
-    }
 }
 /// Response message for GetNodes
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/search/src/datafusion/distributed_plan/codec/empty_exec.rs
+++ b/src/search/src/datafusion/distributed_plan/codec/empty_exec.rs
@@ -57,18 +57,11 @@ pub fn try_decode(
         projection.as_ref(),
         &filters,
         node.limit.map(|v| v as usize),
-        decode_sort_order(&node),
+        // only the classic `_timestamp DESC` order travels with distributed
+        // plans; the hash order is a compactor-merge concern
+        FileSortOrder::from_sorted_by_time(node.sorted_by_time),
         full_schema,
     )))
-}
-
-/// Prefer the explicit `sort_order`; fall back to the legacy `sorted_by_time`
-/// flag written by nodes that predate the enum.
-fn decode_sort_order(node: &cluster_rpc::NewEmptyExecNode) -> FileSortOrder {
-    match FileSortOrder::from_proto(node.sort_order()) {
-        FileSortOrder::None => FileSortOrder::from_sorted_by_time(node.sorted_by_time),
-        order => order,
-    }
 }
 
 pub fn try_encode(node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
@@ -85,10 +78,8 @@ pub fn try_encode(node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()>
         }),
         filters,
         limit: node.limit().map(|v| v as u64),
-        // keep the legacy flag populated so older nodes still see the time order
         sorted_by_time: node.sort_order().is_timestamp_desc(),
         full_schema: Some(node.full_schema().as_ref().try_into()?),
-        sort_order: node.sort_order().to_proto() as i32,
     };
     let proto = cluster_rpc::PhysicalPlanNode {
         plan: Some(cluster_rpc::physical_plan_node::Plan::EmptyExec(plan_node)),
@@ -148,17 +139,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_datafusion_codec_sort_order_roundtrip() -> Result<()> {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new(config::meta::promql::HASH_LABEL, DataType::UInt64, false),
-            Field::new(config::TIMESTAMP_COL_NAME, DataType::Int64, false),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            config::TIMESTAMP_COL_NAME,
+            DataType::Int64,
+            false,
+        )]));
         let proto = super::super::get_physical_extension_codec();
         let ctx = datafusion::prelude::SessionContext::new();
-        for order in [
-            FileSortOrder::None,
-            FileSortOrder::TimestampDesc,
-            FileSortOrder::HashTimestampAsc,
-        ] {
+        for order in [FileSortOrder::None, FileSortOrder::TimestampDesc] {
             let plan: Arc<dyn ExecutionPlan> = Arc::new(NewEmptyExec::new(
                 "test",
                 Arc::clone(&schema),
@@ -175,19 +163,5 @@ mod tests {
             assert_eq!(decoded.sort_order(), order);
         }
         Ok(())
-    }
-
-    #[test]
-    fn test_decode_sort_order_prefers_enum_then_legacy_flag() {
-        let mut node = cluster_rpc::NewEmptyExecNode::default();
-        assert_eq!(decode_sort_order(&node), FileSortOrder::None);
-
-        // legacy sender: only the bool is populated
-        node.sorted_by_time = true;
-        assert_eq!(decode_sort_order(&node), FileSortOrder::TimestampDesc);
-
-        // new sender: enum wins over the bool
-        node.sort_order = cluster_rpc::FileSortOrder::HashTimestampAsc as i32;
-        assert_eq!(decode_sort_order(&node), FileSortOrder::HashTimestampAsc);
     }
 }

--- a/src/search/src/datafusion/distributed_plan/empty_exec.rs
+++ b/src/search/src/datafusion/distributed_plan/empty_exec.rs
@@ -266,10 +266,10 @@ mod tests {
 
     #[test]
     fn test_output_ordering_follows_sort_order() {
-        use config::{TIMESTAMP_COL_NAME, meta::promql::HASH_LABEL};
+        use config::TIMESTAMP_COL_NAME;
 
         let schema = Arc::new(Schema::new(vec![
-            Field::new(HASH_LABEL, DataType::UInt64, false),
+            Field::new("k", DataType::UInt64, false),
             Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
             Field::new("v", DataType::Float64, true),
         ]));
@@ -288,28 +288,17 @@ mod tests {
             ordering(FileSortOrder::TimestampDesc),
             Some(vec![("_timestamp@1".to_string(), true)])
         );
-        assert_eq!(
-            ordering(FileSortOrder::HashTimestampAsc),
-            Some(vec![
-                ("__hash__@0".to_string(), false),
-                ("_timestamp@1".to_string(), false)
-            ])
-        );
 
-        // a sort column missing from the projected schema: no ordering is declared
-        let no_hash = Arc::new(Schema::new(vec![Field::new(
-            TIMESTAMP_COL_NAME,
-            DataType::Int64,
-            false,
-        )]));
+        // the sort column missing from the projected schema: no ordering is declared
+        let no_ts = Arc::new(Schema::new(vec![Field::new("v", DataType::Float64, true)]));
         let exec = NewEmptyExec::new(
             "t",
-            no_hash.clone(),
+            no_ts.clone(),
             None,
             &[],
             None,
-            FileSortOrder::HashTimestampAsc,
-            no_hash,
+            FileSortOrder::TimestampDesc,
+            no_ts,
         );
         assert!(exec.properties().output_ordering().is_none());
     }

--- a/src/search/src/datafusion/sort_order.rs
+++ b/src/search/src/datafusion/sort_order.rs
@@ -80,7 +80,8 @@ pub enum FileSortOrder {
     /// compactor for logs, traces and (non TSID-major) metrics.
     TimestampDesc,
     /// `__hash__ ASC, _timestamp ASC` — TSID-major metrics layout: all samples of
-    /// one series are contiguous and time-ordered inside a file.
+    /// one series are contiguous and time-ordered inside a file. Only used by
+    /// the compactor merge; distributed query plans never carry it.
     HashTimestampAsc,
 }
 
@@ -154,23 +155,6 @@ impl FileSortOrder {
             });
         }
         LexOrdering::new(exprs)
-    }
-
-    /// Wire representation used by the distributed plan protobuf.
-    pub fn to_proto(&self) -> proto::cluster_rpc::FileSortOrder {
-        match self {
-            Self::None => proto::cluster_rpc::FileSortOrder::None,
-            Self::TimestampDesc => proto::cluster_rpc::FileSortOrder::TimestampDesc,
-            Self::HashTimestampAsc => proto::cluster_rpc::FileSortOrder::HashTimestampAsc,
-        }
-    }
-
-    pub fn from_proto(value: proto::cluster_rpc::FileSortOrder) -> Self {
-        match value {
-            proto::cluster_rpc::FileSortOrder::None => Self::None,
-            proto::cluster_rpc::FileSortOrder::TimestampDesc => Self::TimestampDesc,
-            proto::cluster_rpc::FileSortOrder::HashTimestampAsc => Self::HashTimestampAsc,
-        }
     }
 }
 
@@ -282,16 +266,5 @@ mod tests {
                 .physical_ordering(&schema)
                 .is_some()
         );
-    }
-
-    #[test]
-    fn test_proto_roundtrip() {
-        for order in [
-            FileSortOrder::None,
-            FileSortOrder::TimestampDesc,
-            FileSortOrder::HashTimestampAsc,
-        ] {
-            assert_eq!(FileSortOrder::from_proto(order.to_proto()), order);
-        }
     }
 }


### PR DESCRIPTION
Follow-up to #13853. The `(__hash__, _timestamp)` order is only relevant to the compactor merge; distributed query plans never carry it, so the wire-level `FileSortOrder` is unnecessary.

## Changes

- `plan.proto` / generated: remove `enum FileSortOrder` and `NewEmptyExecNode.sort_order = 8`; `NewEmptyExecNode` keeps only the legacy `bool sorted_by_time = 6`.
- `codec/empty_exec.rs`: encode/decode with the bool only (`FileSortOrder::from_sorted_by_time`); drop the enum-first/legacy-fallback logic and its test.
- `sort_order.rs`: drop `to_proto` / `from_proto` and the round-trip test; `HashTimestampAsc` is documented as compactor-merge only.
- `empty_exec.rs` tests: cover `None` / `TimestampDesc` output ordering only.

Rolling upgrade: #13853 nodes still write and read `sorted_by_time`, nodes with this change only use `sorted_by_time` — no incompatibility.

## Validation

- `cargo check -p search -p search_service --tests`, `cargo fmt --check`
- `cargo test -p search --lib -- sort_order empty_exec` 26 passed