### PR TITLE
test(dashboards): cover CTE/subquery match_all queries through the pa…[v0.80.0]

### DIFF
--- a/tests/api-testing/support/endpoints/dashboards.py
+++ b/tests/api-testing/support/endpoints/dashboards.py
@@ -23,3 +23,81 @@ class DashboardsAPI:
 
     def delete(self, dashboard_id: str, *, org: str | None = None) -> requests.Response:
         return self.c.delete(f"dashboards/{dashboard_id}", org=org)
+
+    def hash(self, dashboard_id: str, *, org: str | None = None) -> str:
+        """Current optimistic-concurrency hash, read from the GET response.
+
+        Every panel mutation consumes a hash and mints a new one, so callers
+        must re-read (or chain the `hash` from the previous response) before
+        the next write — a stale hash is a 409, not a retryable error.
+        """
+        r = self.get(dashboard_id, org=org)
+        r.raise_for_status()
+        return r.json()["hash"]
+
+    # ----- panel operations (v8 dashboards only) -----
+
+    def add_panel(
+        self,
+        dashboard_id: str,
+        panel: dict[str, Any],
+        *,
+        hash: str,
+        tab_id: str | None = None,
+        folder: str | None = None,
+        org: str | None = None,
+    ) -> requests.Response:
+        """POST /api/{org}/dashboards/{id}/panels — `hash` is a query param, not body."""
+        params: dict[str, str] = {"hash": hash}
+        if folder is not None:
+            params["folder"] = folder
+        body: dict[str, Any] = {"panel": panel}
+        if tab_id is not None:
+            body["tabId"] = tab_id
+        return self.c.post(f"dashboards/{dashboard_id}/panels", params=params, json=body, org=org)
+
+    def update_panel(
+        self,
+        dashboard_id: str,
+        panel_id: str,
+        panel: dict[str, Any],
+        *,
+        hash: str,
+        tab_id: str | None = None,
+        folder: str | None = None,
+        org: str | None = None,
+    ) -> requests.Response:
+        """PUT /api/{org}/dashboards/{id}/panels/{panel_id}."""
+        params: dict[str, str] = {"hash": hash}
+        if folder is not None:
+            params["folder"] = folder
+        body: dict[str, Any] = {"panel": panel}
+        if tab_id is not None:
+            body["tabId"] = tab_id
+        return self.c.put(
+            f"dashboards/{dashboard_id}/panels/{panel_id}", params=params, json=body, org=org
+        )
+
+    def delete_panel(
+        self,
+        dashboard_id: str,
+        panel_id: str,
+        *,
+        hash: str,
+        tab_id: str | None = None,
+        folder: str | None = None,
+        org: str | None = None,
+    ) -> requests.Response:
+        """DELETE /api/{org}/dashboards/{id}/panels/{panel_id}."""
+        params: dict[str, str] = {"hash": hash}
+        if folder is not None:
+            params["folder"] = folder
+        if tab_id is not None:
+            params["tabId"] = tab_id
+        return self.c.delete(f"dashboards/{dashboard_id}/panels/{panel_id}", params=params, org=org)
+
+    def panels(self, dashboard_id: str, *, org: str | None = None) -> list[dict[str, Any]]:
+        """Flatten every panel across every tab of a v8 dashboard."""
+        r = self.get(dashboard_id, org=org)
+        r.raise_for_status()
+        return [p for tab in r.json()["v8"].get("tabs", []) for p in tab.get("panels", [])]

--- a/tests/api-testing/support/endpoints/search.py
+++ b/tests/api-testing/support/endpoints/search.py
@@ -31,6 +31,42 @@ class SearchAPI:
             raise_for_status=raise_for_status,
         )
 
+    def dashboard_panel(
+        self,
+        sql: str,
+        *,
+        dashboard_id: str,
+        start_time: int,
+        end_time: int,
+        size: int = 500,
+        use_cache: bool = False,
+        org: str | None = None,
+        raise_for_status: bool = False,
+    ) -> requests.Response:
+        """Run a panel query the way the dashboard UI does.
+
+        Hits `_search?type=logs&search_type=dashboards&dashboard_id=…`, which is
+        a distinct code path from the Logs page (`search_type=ui`): it carries the
+        dashboard context and defaults `use_cache` on. A query that works in Logs
+        can still regress here, so panel tests must exercise this variant.
+
+        `use_cache` defaults to False so repeated assertions read the engine, not
+        a cached result set.
+        """
+        body = search_payload(sql, start_time=start_time, end_time=end_time, size=size)
+        return self.c.post(
+            "_search",
+            params={
+                "type": "logs",
+                "search_type": "dashboards",
+                "use_cache": str(use_cache).lower(),
+                "dashboard_id": dashboard_id,
+            },
+            json=body,
+            org=org,
+            raise_for_status=raise_for_status,
+        )
+
     def hits(self, sql: str, **kw) -> list[dict[str, Any]]:
         """Convenience: run SQL and return just the hits list."""
         return self.sql(sql, **kw).json().get("hits", [])

--- a/tests/api-testing/support/factories.py
+++ b/tests/api-testing/support/factories.py
@@ -116,6 +116,79 @@ def dashboard_payload(
     }
 
 
+def axis_item(alias: str, *, label: str | None = None, column: str | None = None) -> dict[str, Any]:
+    """One entry for a panel's `x` / `y` / `breakdown` array.
+
+    `label` is a required String in the v8 schema (not optional) — omitting it
+    is a 422. For `customQuery` panels the `alias` must match the SELECT alias
+    verbatim, or the axis renders blank.
+    """
+    return {
+        "label": label if label is not None else alias,
+        "alias": alias,
+        "column": column if column is not None else alias,
+        "color": None,
+    }
+
+
+def panel_payload(
+    *,
+    stream: str,
+    sql: str,
+    x_alias: str,
+    y_alias: str,
+    panel_id: str | None = None,
+    title: str | None = None,
+    description: str = "",
+    panel_type: str = "bar",
+    stream_type: str = "logs",
+    layout: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """A v8 `Panel` carrying hand-written SQL, for the AddPanel/UpdatePanel APIs.
+
+    `customQuery` is hard-coded True: with False, OO discards `sql` and rebuilds
+    the query from the field config, which silently defeats any test asserting on
+    the SQL it supplied.
+
+    Note `config` (PanelConfig) is snake_case while `fields`/`queries` are
+    camelCase — the v8 schema genuinely mixes both.
+    """
+    return {
+        "id": panel_id or unique_name("panel"),
+        "type": panel_type,
+        "title": title or unique_name("Panel"),
+        "description": description,
+        "config": {
+            "show_legends": True,
+            "legends_position": None,
+        },
+        "queryType": "sql",
+        "queries": [
+            {
+                "query": sql,
+                "vrlFunctionQuery": None,
+                "customQuery": True,
+                "fields": {
+                    "stream": stream,
+                    "stream_type": stream_type,
+                    "x": [axis_item(x_alias)],
+                    "y": [axis_item(y_alias)],
+                    "z": [],
+                    # A bare [] is rejected: PanelFilter is an untagged enum and
+                    # the empty list matches neither variant. It must be a group.
+                    "filter": {
+                        "filterType": "group",
+                        "logicalOperator": "AND",
+                        "conditions": [],
+                    },
+                },
+                "config": {"promql_legend": ""},
+            }
+        ],
+        "layout": layout if layout is not None else {"x": 0, "y": 0, "w": 24, "h": 9, "i": 1},
+    }
+
+
 def alert_template_payload(
     *,
     name: str | None = None,

--- a/tests/api-testing/support/panel_queries.py
+++ b/tests/api-testing/support/panel_queries.py
@@ -1,0 +1,304 @@
+"""Discovery and execution helpers for dashboard-panel query tests.
+
+The query corpus lives in `tests/test-data/query-agent/queries/*.json` and is
+owned by the query-agent suite, which verifies it through the Logs search path.
+This module lets the dashboard tests reuse the exact same corpus — same SQL,
+same time windows, same DuckDB-computed expectations — through the *dashboard*
+panel path instead, so the two suites cannot drift apart.
+
+Queries are discovered by shape rather than listed by ID. A hand-maintained list
+of 70-odd IDs goes stale the moment someone adds a query; classifying the SQL
+means new CTE combinations are picked up on their own.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("o2-api.panel-queries")
+
+# support/ -> api-testing/ -> tests/
+QUERY_AGENT_DIR = Path(__file__).resolve().parents[2] / "test-data" / "query-agent"
+QUERIES_DIR = QUERY_AGENT_DIR / "queries"
+
+# The corpus generator lives next to the queries it generates data for. Re-exported
+# here so test modules have a single import site for both halves of the corpus.
+sys.path.insert(0, str(QUERY_AGENT_DIR))
+from data_gen import BASE_TS, build_dataset  # noqa: E402
+
+__all__ = [
+    "BASE_TS",
+    "QUERIES_DIR",
+    "QUERY_AGENT_DIR",
+    "add_panel",
+    "build_dataset",
+    "classify",
+    "discover_nested_match_all",
+    "drop_panel",
+    "expected_non_null_columns",
+    "load_queries",
+    "panel_axes",
+    "panel_type_for",
+    "query_window",
+    "render_sql",
+    "result_set_mismatch",
+    "row_count_is_comparable",
+    "values_equal",
+    "write_with_fresh_hash",
+]
+
+# A CTE head is `WITH x AS (` or a continuation `, y AS (`; a derived table is a
+# parenthesised SELECT in FROM position. Either one puts the match_all inside a
+# nested query block, which is the case this module exists to cover.
+_CTE_RE = re.compile(r"(?:WITH|,)\s+\w+\s+AS\s*\(", re.IGNORECASE)
+_DERIVED_RE = re.compile(r"FROM\s*\(\s*SELECT", re.IGNORECASE)
+
+
+def write_with_fresh_hash(client, dashboard_id: str, op, attempts: int = 3):
+    """Run a panel write with a freshly read hash, retrying if it goes stale.
+
+    Returns `(response, hash_used)`.
+
+    Every panel write consumes the dashboard's hash and mints a new one. When a
+    module drives many writes against one shared dashboard, the GET that reads
+    the hash can occasionally return a version the store has already moved past,
+    and the write comes back 409 through no fault of the test. Retrying with a
+    re-read hash makes setup writes deterministic.
+
+    This is only for writes that are *supposed* to succeed. Tests asserting
+    conflict behaviour must call the endpoint directly, or the retry would paper
+    over the very thing they check.
+    """
+    resp = None
+    hash_used = ""
+    for attempt in range(attempts):
+        hash_used = client.dashboards.hash(dashboard_id)
+        resp = op(hash_used)
+        if resp.status_code != 409:
+            return resp, hash_used
+        log.warning(
+            "panel write on %s hit a stale hash (attempt %d/%d)",
+            dashboard_id,
+            attempt + 1,
+            attempts,
+        )
+    return resp, hash_used
+
+
+def add_panel(client, dashboard_id: str, panel: dict) -> dict:
+    """Add a panel and return the response body, retrying past stale hashes."""
+    resp, _ = write_with_fresh_hash(
+        client, dashboard_id, lambda h: client.dashboards.add_panel(dashboard_id, panel, hash=h)
+    )
+    assert resp.status_code == 200, f"AddPanel failed: {resp.status_code} {resp.text}"
+    return resp.json()
+
+
+def drop_panel(client, dashboard_id: str, panel_id: str) -> None:
+    """Best-effort panel removal, for tests that add a panel mid-assertion."""
+    try:
+        write_with_fresh_hash(
+            client,
+            dashboard_id,
+            lambda h: client.dashboards.delete_panel(dashboard_id, panel_id, hash=h),
+        )
+    except Exception as e:
+        log.warning("panel cleanup failed for %s: %s", panel_id, e)
+
+
+def load_queries(category: str) -> list[dict[str, Any]]:
+    """Every query in one `queries/<category>.json` file, or [] if absent.
+
+    Absent is normal, not an error: a branch that predates a query-set PR simply
+    has fewer categories, and callers skip rather than fail.
+    """
+    path = QUERIES_DIR / f"{category}.json"
+    if not path.exists():
+        log.warning("query catalog %s not found", path)
+        return []
+    with open(path) as f:
+        return json.load(f).get("queries", [])
+
+
+def classify(sql: str) -> str | None:
+    """Compact family label for a nested-query shape, or None if it isn't one.
+
+    The label is what makes a parametrised failure legible — `Q1022-cte1_union_cdist_4ma`
+    says which combination broke without opening the catalog.
+    """
+    nested = len(_CTE_RE.findall(sql))
+    derived = bool(_DERIVED_RE.search(sql))
+    if not nested and not derived:
+        return None
+
+    upper = sql.upper()
+    tags = []
+    if nested:
+        tags.append(f"cte{nested}")
+    if derived:
+        tags.append("derived")
+    if "UNION ALL" in upper:
+        tags.append("union")
+    if " JOIN " in upper:
+        tags.append("join")
+    if "{stream2}" in sql:
+        tags.append("xstream")
+    if "OVER (" in upper or "OVER(" in upper:
+        tags.append("window")
+    if "NOT MATCH_ALL" in upper:
+        tags.append("not")
+    if "HISTOGRAM(" in upper:
+        tags.append("hist")
+    if "COUNT(DISTINCT" in upper:
+        tags.append("cdist")
+    if "CASE WHEN" in upper:
+        tags.append("case")
+    if "HAVING" in upper:
+        tags.append("having")
+    tags.append(f"{len(re.findall('match_all', sql))}ma")
+    return "_".join(tags)
+
+
+def discover_nested_match_all(categories: tuple[str, ...]) -> list[tuple[str, str, dict]]:
+    """(query_id, family, query) for every match_all query inside a CTE or subquery.
+
+    Sorted by ID so parametrised runs are reproducible.
+    """
+    found: list[tuple[str, str, dict]] = []
+    for category in categories:
+        for query in load_queries(category):
+            sql = query.get("sql", "")
+            if "match_all" not in sql:
+                continue
+            family = classify(sql)
+            if family is None:
+                continue
+            if "results" not in query.get("expected", {}):
+                # No oracle result set — nothing meaningful to assert against.
+                continue
+            found.append((query["id"], family, query))
+    return sorted(found, key=lambda t: t[0])
+
+
+def panel_type_for(family: str, query: dict) -> str:
+    """Pick a plausible chart type so the panel resembles something a user builds."""
+    if "hist" in family:
+        return "line"
+    if len(query["expected"]["columns"]) == 1 or "window" in family or "join" in family:
+        return "table"
+    return "bar"
+
+
+def render_sql(query: dict, stream: str, stream2: str) -> str:
+    """Substitute the corpus stream placeholders with real stream names."""
+    return query["sql"].replace("{stream}", stream).replace("{stream2}", stream2)
+
+
+def query_window(query: dict, base_ts: int) -> tuple[int, int]:
+    """Absolute search window, from the query's BASE_TS-relative offsets."""
+    off = query["time_offset"]
+    return base_ts + off["start_offset"], base_ts + off["end_offset"]
+
+
+def panel_axes(query: dict) -> tuple[str, str]:
+    """(x_alias, y_alias) taken from the oracle's own column list.
+
+    Derived rather than hand-written so a panel can never disagree with the query
+    it carries. Single-column queries reuse the one column for both axes.
+    """
+    cols = query["expected"]["columns"]
+    return cols[0], cols[1] if len(cols) > 1 else cols[0]
+
+
+def expected_non_null_columns(query: dict) -> list[str]:
+    """Columns the oracle shows holding a real value in at least one row.
+
+    OpenObserve omits NULL-valued keys from a hit rather than emitting them as
+    null, so a column can legitimately be absent from some rows — or from every
+    row, if the query's correct answer is NULL throughout. Asserting on the raw
+    column list therefore produces false "dropped projection" failures; the
+    query-agent comparator sidesteps this by reading cells with `.get(col, "")`.
+
+    Restricting the projection assertion to columns the oracle proves are
+    non-NULL somewhere keeps the check meaningful: a genuinely dropped
+    projection makes the column vanish from every row, which this still catches.
+
+    DuckDB renders NULL as "None" and OpenObserve as "", so both count as empty.
+    """
+    columns = query["expected"]["columns"]
+    results = query["expected"]["results"]
+    return [
+        col
+        for i, col in enumerate(columns)
+        if any(str(row[i]) not in ("", "None") for row in results)
+    ]
+
+
+def values_equal(a: str, b: str, rel_tol: float = 0.05) -> bool:
+    """Compare two result cells the way the query-agent comparator does.
+
+    Cross-engine float aggregates (AVG, STDDEV) differ in their least-significant
+    digits because summation order differs, so numerics compare within a relative
+    tolerance while strings, integers and timestamps compare exactly.
+
+    NULL renders as "" from OpenObserve and "None" from DuckDB; both mean empty.
+    """
+    if a == b:
+        return True
+    if (a == "" and b == "None") or (a == "None" and b == ""):
+        return True
+    try:
+        fa, fb = float(a), float(b)
+    except (TypeError, ValueError):
+        return False
+    return abs(fa - fb) / max(abs(fa), abs(fb), 1.0) < rel_tol
+
+
+def result_set_mismatch(hits: list[dict], query: dict, rel_tol: float = 0.05) -> str | None:
+    """First disagreement between live hits and the oracle, or None if they agree.
+
+    Both sides are sorted before comparison, matching the query-agent comparator:
+    the corpus pins the result *multiset*, not row order, so a query whose ORDER BY
+    ties arbitrarily does not fail spuriously.
+
+    Returns a message rather than raising, so the caller owns the assertion and can
+    add its own context.
+    """
+    columns = query["expected"]["columns"]
+    got = sorted([str(hit.get(col, "")) for col in columns] for hit in hits)
+    want = sorted([str(cell) for cell in row] for row in query["expected"]["results"])
+
+    if len(got) != len(want):
+        return f"row count {len(got)} != oracle {len(want)}"
+
+    for i, (got_row, want_row) in enumerate(zip(got, want, strict=True)):
+        # Checked explicitly rather than left to zip: a short oracle row would
+        # otherwise truncate the comparison and hide a real mismatch.
+        if len(got_row) != len(want_row):
+            return (
+                f"row {i} has {len(got_row)} columns, oracle row has {len(want_row)}"
+            )
+        for j, (got_cell, want_cell) in enumerate(zip(got_row, want_row, strict=True)):
+            if not values_equal(got_cell, want_cell, rel_tol):
+                return (
+                    f"row {i} column {j} ('{columns[j]}'): "
+                    f"got {got_cell!r}, oracle {want_cell!r}"
+                )
+    return None
+
+
+def row_count_is_comparable(query_id: str, query: dict) -> bool:
+    """Whether the oracle's row count can be asserted against a live run.
+
+    Histogram queries bucket against a BASE_TS that moves between the oracle run
+    and this one, and anything carrying `skip_sqllogictest` has results the
+    query-agent suite itself does not treat as authoritative.
+    """
+    expected = query["expected"]
+    if expected.get("skip_sqllogictest"):
+        return False
+    return "histogram(" not in query["sql"].lower()

--- a/tests/api-testing/tests/dashboards/conftest.py
+++ b/tests/api-testing/tests/dashboards/conftest.py
@@ -1,0 +1,167 @@
+"""Shared fixtures for the dashboard panel test modules.
+
+The warehouse dataset is ingested once per session and shared by every panel
+module — it is 10 000 records across two streams, and re-ingesting per module
+would dominate the run time for no added coverage.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from support.client import OpenObserveClient
+from support.factories import unique_name
+from support.panel_queries import BASE_TS, build_dataset
+from support.wait import wait_until
+
+logger = logging.getLogger(__name__)
+
+
+def _ingest(client: OpenObserveClient, stream: str, records: list[dict]) -> None:
+    resp = client.post(
+        f"{stream}/_json",
+        data=json.dumps(records),
+        headers={"Content-Type": "application/json"},
+    )
+    if resp.status_code != 200:
+        pytest.fail(f"Ingestion into {stream} failed: {resp.status_code} — {resp.text[:300]}")
+    logger.info("Ingested %d records into %s", len(records), stream)
+
+
+@pytest.fixture(scope="session")
+def panel_streams(client: OpenObserveClient) -> Generator[tuple[str, str], None, None]:
+    """Two streams holding the query-agent warehouse dataset: (primary, secondary).
+
+    Uses `build_dataset()` at its default size on purpose: the expected row counts
+    in the query JSON were computed by the DuckDB oracle against exactly that
+    dataset. A smaller one shifts which records fall inside a query's time window
+    at the boundary, and the counts stop matching.
+
+    The secondary stream carries `stream_offset=7` — same timestamps, rotated
+    field values — which is what the corpus's cross-stream CTE joins expect.
+
+    Both streams are dropped on teardown. The PID suffix only prevents *collisions*
+    between concurrent runs — without an explicit delete, every run would strand
+    10 000 records on the server, which adds up fast on a shared environment.
+    """
+    stream = f"dashboard_panel_{BASE_TS}_{os.getpid()}"
+    stream2 = f"dashboard_panel2_{BASE_TS}_{os.getpid()}"
+
+    records = build_dataset()
+    records2 = build_dataset(stream_offset=7)
+    _ingest(client, stream, records)
+    _ingest(client, stream2, records2)
+
+    max_ts = max(r["_timestamp"] for r in records)
+
+    def _count(target: str) -> int:
+        now = datetime.now(UTC)
+        # Records run forward of BASE_TS into the future; widen the ceiling past
+        # max_ts or the vortex engine (which enforces end_time strictly) sees none.
+        end_us = max(int(now.timestamp() * 1_000_000), max_ts) + 3_600_000_000
+        start_us = int((now - timedelta(weeks=4)).timestamp() * 1_000_000)
+        r = client.post(
+            "_search?type=logs",
+            json={
+                "query": {
+                    "sql": f'SELECT COUNT(*) AS c FROM "{target}"',
+                    "start_time": start_us,
+                    "end_time": end_us,
+                    "from": 0,
+                    "size": 1,
+                }
+            },
+        )
+        if r.status_code != 200:
+            return 0
+        hits = r.json().get("hits", [])
+        return int(hits[0].get("c", 0)) if hits else 0
+
+    # Vortex nodes serve nothing until data leaves the memtable. Probe briefly,
+    # then flush once rather than waiting out the full timeout for nothing.
+    memtable_visible = False
+    for _ in range(3):
+        if _count(stream) > 0:
+            memtable_visible = True
+            break
+        time.sleep(1.0)
+    if not memtable_visible:
+        client.put("node/flush", prefix="")
+        logger.info("No memtable visibility after 3s — flushed")
+
+    # Each stream is checked independently so a cross-stream join never runs
+    # against a half-ready secondary.
+    for target, expected in ((stream, len(records)), (stream2, len(records2))):
+        wait_until(
+            lambda t=target, n=expected: _count(t) >= n,
+            timeout=90,
+            interval=1.0,
+            msg=f"{target}: ingested records never became searchable",
+        )
+    logger.info("%s and %s are searchable", stream, stream2)
+
+    yield stream, stream2
+
+    for target in (stream, stream2):
+        try:
+            resp = client.streams.delete(target)
+            if resp.status_code not in (200, 204, 404):
+                logger.warning(
+                    "stream cleanup for %s returned %s: %s",
+                    target,
+                    resp.status_code,
+                    resp.text[:200],
+                )
+        except Exception as e:
+            logger.warning("stream cleanup failed for %s: %s", target, e)
+
+
+@pytest.fixture(scope="session")
+def panel_stream(panel_streams: tuple[str, str]) -> str:
+    """The primary warehouse stream, for tests that need only one."""
+    return panel_streams[0]
+
+
+@pytest.fixture(scope="module")
+def panel_dashboard(client: OpenObserveClient) -> Generator[str, None, None]:
+    """A v8 dashboard with one empty tab, deleted at module teardown.
+
+    Panel operations are v8-only and need a tab to land in — AddPanel with no
+    `tabId` targets the first tab and 404s on a dashboard that has none.
+
+    Module-scoped so each test module gets a clean dashboard: panels are added
+    and removed constantly here, and a leaked panel should not follow the suite
+    into the next file.
+    """
+    resp = client.post(
+        "dashboards",
+        json={
+            "version": 8,
+            "title": unique_name("panel_dash"),
+            "description": "Dashboard panel API tests",
+            "folder_id": "default",
+            "tabs": [{"tabId": "default", "name": "Default", "panels": []}],
+        },
+    )
+    assert resp.status_code in (200, 201), f"Dashboard setup failed: {resp.status_code} {resp.text}"
+    dashboard_id = resp.json()["v8"]["dashboardId"]
+    yield dashboard_id
+    try:
+        # A non-2xx delete leaks a dashboard just as surely as an exception does,
+        # so check the status too rather than only catching throws.
+        resp = client.dashboards.delete(dashboard_id)
+        if resp.status_code not in (200, 204, 404):
+            logger.warning(
+                "dashboard cleanup for %s returned %s: %s",
+                dashboard_id,
+                resp.status_code,
+                resp.text[:200],
+            )
+    except Exception as e:
+        logger.warning("panel_dashboard cleanup failed for %s: %s", dashboard_id, e)

--- a/tests/api-testing/tests/dashboards/test_dashboard_cte_panels.py
+++ b/tests/api-testing/tests/dashboards/test_dashboard_cte_panels.py
@@ -1,0 +1,243 @@
+"""Dashboard panels running CTE / subquery queries that contain `match_all`.
+
+Scope is deliberately narrow: every case here puts a `match_all` predicate
+*inside* a nested query block — a `WITH … AS (…)` body or a derived table in
+FROM position — and then runs it as a real dashboard panel.
+
+Why that shape specifically. The `match_all` + FST projection rewrite fixed in
+#13808 has to preserve the projection of the block the predicate sits in. When
+that block is the whole statement, the projection is obvious. When it is a CTE
+body feeding a JOIN, a window, or a four-branch UNION ALL, the rewrite has to
+preserve the *CTE's* output schema while the outer query reads different columns
+from it — and that is where it went wrong. #13824 added 70 sentinel queries to
+pin the behaviour down; 65 of them are nested-query shapes, and this module runs
+every one of them through the dashboard panel path.
+
+The corpus is shared with the query-agent suite, which verifies the same SQL via
+the Logs path (`search_type=ui`). This module verifies the dashboard path
+(`search_type=dashboards`), so a rewrite that fires on only one of the two
+routes shows up as a diff rather than passing quietly on both.
+
+Cases are discovered by classifying the SQL, not by a hand-written ID list, so a
+new CTE combination added to the corpus is picked up without touching this file.
+Runs on a branch without #13824 simply discover fewer cases.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from support.factories import panel_payload
+from support.panel_queries import (
+    BASE_TS,
+    add_panel,
+    discover_nested_match_all,
+    drop_panel,
+    expected_non_null_columns,
+    panel_axes,
+    panel_type_for,
+    query_window,
+    render_sql,
+    result_set_mismatch,
+    row_count_is_comparable,
+)
+
+logger = logging.getLogger(__name__)
+
+# full_text_search holds the #13824 sentinels; cte_subquery holds the older
+# nested-query cases that also happen to use match_all.
+_CATEGORIES = ("full_text_search", "cte_subquery")
+
+_CASES = discover_nested_match_all(_CATEGORIES)
+
+# id reads as e.g. `Q1022-cte1_union_cdist_4ma`, so a failure names the
+# combination without anyone opening the corpus.
+_IDS = [f"{qid}-{family}" for qid, family, _ in _CASES]
+
+
+def _query_number(query_id: str) -> int:
+    """Numeric part of a `Qnnn` id, or -1 for anything that does not parse."""
+    try:
+        return int(query_id.lstrip("Qq"))
+    except ValueError:
+        return -1
+
+
+# #13824 adds Q1003–Q1072. Q1000–Q1002 predate it, so the threshold is 1003.
+# Used to gate the corpus-breadth guard: on a branch without the sentinels the
+# corpus genuinely lacks whole families, and that is not a regression.
+_HAS_SENTINELS = any(_query_number(qid) >= 1003 for qid, _, _ in _CASES)
+
+
+
+def test_corpus_is_present():
+    """Guard: a silently empty corpus would turn this whole module into a no-op.
+
+    Skips (rather than fails) when the catalog predates #13824, but never lets
+    an all-green run be mistaken for coverage that did not happen.
+    """
+    if not _CASES:
+        pytest.skip("no nested match_all queries in the catalog — predates PR #13824")
+    logger.info("discovered %d nested match_all queries", len(_CASES))
+
+
+def test_all_nested_families_represented():
+    """The discovered set spans every combination this module claims to cover.
+
+    If a corpus change quietly drops, say, every cross-stream CTE join, the
+    per-query tests all still pass — this is what notices.
+    """
+    if not _HAS_SENTINELS:
+        pytest.skip(
+            f"catalog predates PR #13824 ({len(_CASES)} nested cases, no Q1003+) — "
+            "whole combination families are legitimately absent"
+        )
+
+    families = {family for _, family, _ in _CASES}
+    tags = {tag for family in families for tag in family.split("_")}
+
+    for required in ("union", "join", "window", "not", "hist", "cdist", "case"):
+        assert required in tags, (
+            f"no nested match_all query combines with '{required}' — "
+            f"corpus coverage regressed; found tags: {sorted(tags)}"
+        )
+    assert any(f.startswith("cte") for f in families), "no CTE-based cases discovered"
+    assert any("derived" in f for f in families), "no derived-table cases discovered"
+
+
+@pytest.mark.parametrize(("query_id", "family", "query"), _CASES, ids=_IDS)
+def test_nested_match_all_panel(
+    client, panel_dashboard, panel_streams, query_id, family, query
+):
+    """A CTE/subquery `match_all` query runs correctly as a dashboard panel.
+
+    Three assertions carry the weight:
+
+    * the cardinality matches the DuckDB oracle exactly;
+    * every cell matches the oracle (float-tolerant, order-insensitive) — without
+      this, a regression returning right-shaped rows with wrong values passes;
+    * the projection survives — every column the oracle proves is non-NULL appears
+      somewhere in the result set. This is what #13808 broke: 200 OK, columns
+      silently dropped.
+
+    Histogram cases skip the first two: their bucket timestamps are anchored to a
+    BASE_TS that differs between the oracle run and this one.
+    """
+    stream, stream2 = panel_streams
+    sql = render_sql(query, stream, stream2)
+    start_time, end_time = query_window(query, BASE_TS)
+    x_alias, y_alias = panel_axes(query)
+
+    panel = panel_payload(
+        stream=stream,
+        sql=sql,
+        x_alias=x_alias,
+        y_alias=y_alias,
+        title=f"{query_id} — {family}",
+        panel_type=panel_type_for(family, query),
+    )
+    add_panel(client, panel_dashboard, panel)
+
+    try:
+        resp = client.search.dashboard_panel(
+            sql, dashboard_id=panel_dashboard, start_time=start_time, end_time=end_time
+        )
+        assert resp.status_code == 200, (
+            f"{query_id} ({family}) failed via search_type=dashboards: "
+            f"{resp.status_code} {resp.text[:500]}"
+        )
+
+        hits = resp.json().get("hits", [])
+        expected_rows = len(query["expected"]["results"])
+
+        if row_count_is_comparable(query_id, query):
+            assert len(hits) == expected_rows, (
+                f"{query_id} ({family}): dashboard path returned {len(hits)} rows, "
+                f"oracle expects {expected_rows}"
+            )
+            # Row count and projection alone would pass a regression that returned
+            # correctly-shaped rows holding wrong values — which is the bug class
+            # this corpus exists to pin down. Compare the cells too.
+            mismatch = result_set_mismatch(hits, query)
+            assert mismatch is None, (
+                f"{query_id} ({family}): dashboard path disagrees with the oracle — {mismatch}"
+            )
+        elif expected_rows:
+            assert hits, f"{query_id} ({family}) returned no rows through the dashboard path"
+
+        # Projection is a property of the result set, not of each row: OO drops
+        # NULL-valued keys per row, so a column legitimately missing from some
+        # rows is not a dropped projection. It is dropped only if it is absent
+        # from every row.
+        if hits:
+            present = set().union(*(set(hit) for hit in hits))
+            missing = [c for c in expected_non_null_columns(query) if c not in present]
+            assert not missing, (
+                f"{query_id} ({family}): projection dropped {missing} — "
+                f"result set carried only {sorted(present)}"
+            )
+    finally:
+        drop_panel(client, panel_dashboard, panel["id"])
+
+
+@pytest.mark.parametrize(
+    ("query_id", "family", "query"),
+    # The dashboard-vs-Logs comparison is the expensive assertion (two searches
+    # per case), so it runs on the combinations most likely to diverge rather
+    # than on all of them: anything where the CTE feeds a second operator.
+    [c for c in _CASES if any(t in c[1] for t in ("union", "join", "window", "not"))],
+    ids=[
+        f"{qid}-{family}"
+        for qid, family, _ in _CASES
+        if any(t in family for t in ("union", "join", "window", "not"))
+    ],
+)
+def test_nested_match_all_agrees_with_logs_path(
+    client, panel_dashboard, panel_streams, query_id, family, query
+):
+    """The same nested query returns identical rows via Logs and via a dashboard.
+
+    `search_type=ui` and `search_type=dashboards` take different routes into the
+    engine. If the FST rewrite fires on one and not the other, the result sets
+    diverge here even though both calls return 200.
+    """
+    stream, stream2 = panel_streams
+    sql = render_sql(query, stream, stream2)
+    start_time, end_time = query_window(query, BASE_TS)
+
+    body = {
+        "query": {
+            "sql": sql,
+            "start_time": start_time,
+            "end_time": end_time,
+            "from": 0,
+            "size": 500,
+        }
+    }
+    logs_resp = client.post("_search?type=logs&search_type=ui", json=body)
+    assert logs_resp.status_code == 200, (
+        f"{query_id} ({family}) failed on the Logs path: "
+        f"{logs_resp.status_code} {logs_resp.text[:300]}"
+    )
+
+    dash_resp = client.search.dashboard_panel(
+        sql, dashboard_id=panel_dashboard, start_time=start_time, end_time=end_time
+    )
+    assert dash_resp.status_code == 200, (
+        f"{query_id} ({family}) failed on the dashboard path: "
+        f"{dash_resp.status_code} {dash_resp.text[:300]}"
+    )
+
+    columns = query["expected"]["columns"]
+
+    def _normalise(hits: list[dict]) -> list[list[str]]:
+        return sorted([str(h.get(c, "")) for c in columns] for h in hits)
+
+    logs_rows = _normalise(logs_resp.json().get("hits", []))
+    dash_rows = _normalise(dash_resp.json().get("hits", []))
+    assert logs_rows == dash_rows, (
+        f"{query_id} ({family}): results diverge between search_type=ui and "
+        f"search_type=dashboards — Logs returned {len(logs_rows)} rows, "
+        f"dashboard returned {len(dash_rows)}"
+    )

--- a/tests/api-testing/tests/dashboards/test_dashboard_panels.py
+++ b/tests/api-testing/tests/dashboards/test_dashboard_panels.py
@@ -1,0 +1,327 @@
+"""Dashboard panel API tests — AddPanel / UpdatePanel / DeletePanel.
+
+Covers the three panel endpoints (`/dashboards/{id}/panels[/{panel_id}]`), which
+had no pytest coverage at all. They are the only dashboard endpoints that take
+`hash` as a *query* parameter and mint a fresh one on every write, so their
+optimistic-concurrency semantics need tests of their own.
+
+Panel *query execution* — running real SQL through the dashboard search path —
+lives in test_dashboard_cte_panels.py. This module deliberately uses one trivial
+query throughout, so a failure here means the panel API is broken rather than
+the query engine.
+
+Shared fixtures (`panel_streams`, `panel_stream`, `panel_dashboard`) come from
+conftest.py in this directory.
+"""
+from __future__ import annotations
+
+import logging
+import time
+
+from support.factories import panel_payload
+from support.panel_queries import add_panel, drop_panel, write_with_fresh_hash
+
+logger = logging.getLogger(__name__)
+
+# A query that depends on nothing but the ingested fixture: this module is about
+# the panel endpoints, not about what the panel runs.
+_BASELINE_SQL = (
+    'SELECT facility_zone, COUNT(*) AS cnt FROM "{stream}" '
+    "WHERE match_all('warehouse') AND facility_zone IS NOT NULL "
+    "GROUP BY facility_zone ORDER BY cnt DESC, facility_zone ASC LIMIT 10"
+)
+
+# ── contract ───────────────────────────────────────────────────────────────
+
+
+class TestDashboardPanelContract:
+    """Response schemas for the panel endpoints, per the Utoipa decorators."""
+
+    def test_add_panel_response_schema(self, client, panel_dashboard, panel_stream):
+        """POST /dashboards/{id}/panels -> PanelResponseBody {panel, hash, tabId}."""
+        panel = panel_payload(
+            stream=panel_stream,
+            sql=_BASELINE_SQL.format(stream=panel_stream),
+            x_alias="facility_zone",
+            y_alias="cnt",
+        )
+
+        body = add_panel(client, panel_dashboard, panel)
+        try:
+            for field in ("panel", "hash", "tabId"):
+                assert field in body, f"PanelResponseBody missing '{field}': {body}"
+            assert body["hash"], "A panel write must return the next hash"
+            assert body["tabId"] == "default", f"Expected the panel in tab 'default': {body['tabId']}"
+
+            returned = body["panel"]
+            assert returned["id"] == panel["id"], "Panel id should echo back unchanged"
+            for field in ("type", "title", "description", "config", "queries", "layout"):
+                assert field in returned, f"Panel missing required field '{field}'"
+            assert returned["queries"][0]["customQuery"] is True, (
+                "customQuery must survive the round trip — if it flips to false, "
+                "OO rebuilds the SQL from field config and the panel stops running our query"
+            )
+        finally:
+            drop_panel(client, panel_dashboard, panel["id"])
+
+    def test_panel_sql_round_trips_unmodified(self, client, panel_dashboard, panel_stream):
+        """The stored panel SQL must be byte-identical to what was submitted.
+
+        A match_all query that gets normalised, re-quoted or projection-rewritten
+        on the way into storage would come back subtly different and run as a
+        different query on the next dashboard load.
+        """
+        sql = _BASELINE_SQL.format(stream=panel_stream)
+        panel = panel_payload(
+            stream=panel_stream, sql=sql, x_alias="facility_zone", y_alias="cnt"
+        )
+
+        add_panel(client, panel_dashboard, panel)
+        try:
+            stored = [p for p in client.dashboards.panels(panel_dashboard) if p["id"] == panel["id"]]
+            assert stored, f"Panel {panel['id']} not found on the dashboard after AddPanel"
+            assert stored[0]["queries"][0]["query"] == sql, (
+                "Stored panel SQL differs from the submitted SQL"
+            )
+        finally:
+            drop_panel(client, panel_dashboard, panel["id"])
+
+
+# ── CRUD lifecycle ─────────────────────────────────────────────────────────
+
+
+class TestDashboardPanelCRUD:
+    """Add -> read -> update -> delete -> verify, against one dashboard."""
+
+    _panel_id: str | None = None
+    _panel: dict | None = None
+
+    def test_01_add_panel(self, client, panel_dashboard, panel_stream):
+        """AddPanel returns the panel and the next hash."""
+        panel = panel_payload(
+            stream=panel_stream,
+            sql=_BASELINE_SQL.format(stream=panel_stream),
+            x_alias="facility_zone",
+            y_alias="cnt",
+            title="CRUD panel",
+        )
+        body = add_panel(client, panel_dashboard, panel)
+
+        TestDashboardPanelCRUD._panel = panel
+        TestDashboardPanelCRUD._panel_id = body["panel"]["id"]
+        assert TestDashboardPanelCRUD._panel_id, "AddPanel must return a panel id"
+
+    def test_02_read_panel(self, client, panel_dashboard):
+        """The added panel is present on the dashboard with its title intact."""
+        assert TestDashboardPanelCRUD._panel_id, "Prerequisite: panel must be added first"
+
+        panels = client.dashboards.panels(panel_dashboard)
+        match = [p for p in panels if p["id"] == TestDashboardPanelCRUD._panel_id]
+        assert match, f"Panel {TestDashboardPanelCRUD._panel_id} missing from dashboard"
+        assert match[0]["title"] == "CRUD panel", "Panel title should match what was submitted"
+
+    def test_03_update_panel(self, client, panel_dashboard, panel_stream):
+        """UpdatePanel swaps the SQL and title, and returns a fresh hash."""
+        assert TestDashboardPanelCRUD._panel_id, "Prerequisite: panel must be added first"
+
+        new_sql = (
+            "SELECT histogram(_timestamp, '5 minute') AS bucket, COUNT(*) AS hits "
+            f'FROM "{panel_stream}" '
+            "WHERE match_all('warehouse') GROUP BY bucket ORDER BY bucket ASC LIMIT 20"
+        )
+        updated = panel_payload(
+            stream=panel_stream,
+            sql=new_sql,
+            x_alias="bucket",
+            y_alias="hits",
+            panel_id=TestDashboardPanelCRUD._panel_id,
+            title="CRUD panel (updated)",
+            panel_type="line",
+        )
+
+        resp = client.dashboards.update_panel(
+            panel_dashboard,
+            TestDashboardPanelCRUD._panel_id,
+            updated,
+            hash=client.dashboards.hash(panel_dashboard),
+        )
+        assert resp.status_code == 200, f"UpdatePanel failed: {resp.status_code} {resp.text}"
+
+        stored = [
+            p
+            for p in client.dashboards.panels(panel_dashboard)
+            if p["id"] == TestDashboardPanelCRUD._panel_id
+        ]
+        assert stored, "Panel disappeared after update"
+        assert stored[0]["title"] == "CRUD panel (updated)", "Updated title not persisted"
+        assert stored[0]["queries"][0]["query"] == new_sql, "Updated SQL not persisted"
+        assert stored[0]["type"] == "line", "Updated panel type not persisted"
+
+    def test_04_delete_panel(self, client, panel_dashboard):
+        """DeletePanel returns the deleted id and the next hash."""
+        assert TestDashboardPanelCRUD._panel_id, "Prerequisite: panel must be added first"
+
+        resp = client.dashboards.delete_panel(
+            panel_dashboard,
+            TestDashboardPanelCRUD._panel_id,
+            hash=client.dashboards.hash(panel_dashboard),
+        )
+        assert resp.status_code == 200, f"DeletePanel failed: {resp.status_code} {resp.text}"
+
+        body = resp.json()
+        assert body["panelId"] == TestDashboardPanelCRUD._panel_id, (
+            f"DeletePanel echoed the wrong id: {body}"
+        )
+        assert body["hash"], "DeletePanel must return the next hash"
+
+    def test_05_verify_panel_deleted(self, client, panel_dashboard):
+        """The panel is gone from the dashboard, and deleting it again 404s."""
+        assert TestDashboardPanelCRUD._panel_id, "Prerequisite: panel must be added first"
+
+        panel_ids = [p["id"] for p in client.dashboards.panels(panel_dashboard)]
+        assert TestDashboardPanelCRUD._panel_id not in panel_ids, (
+            "Deleted panel still present on the dashboard"
+        )
+
+        resp = client.dashboards.delete_panel(
+            panel_dashboard,
+            TestDashboardPanelCRUD._panel_id,
+            hash=client.dashboards.hash(panel_dashboard),
+        )
+        assert resp.status_code == 404, (
+            f"Expected 404 deleting an already-deleted panel, got {resp.status_code}: {resp.text}"
+        )
+
+
+# ── error paths ────────────────────────────────────────────────────────────
+
+
+class TestDashboardPanelErrors:
+    """Error paths derived from `DashboardError` in src/core/src/dashboards/mod.rs."""
+
+    def test_add_panel_missing_hash(self, client, panel_dashboard, panel_stream):
+        """No `hash` query param -> 400 (handler rejects before reaching the store)."""
+        panel = panel_payload(
+            stream=panel_stream,
+            sql=_BASELINE_SQL.format(stream=panel_stream),
+            x_alias="facility_zone",
+            y_alias="cnt",
+        )
+        resp = client.post(f"dashboards/{panel_dashboard}/panels", json={"panel": panel})
+        assert resp.status_code == 400, (
+            f"Expected 400 for a missing hash param, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_add_panel_stale_hash(self, client, panel_dashboard, panel_stream):
+        """DashboardError::UpdateConflictingHash -> 409.
+
+        Reuse a hash that a prior write already consumed; the second write must
+        be rejected rather than silently overwriting the first.
+        """
+        first = panel_payload(
+            stream=panel_stream,
+            sql=_BASELINE_SQL.format(stream=panel_stream),
+            x_alias="facility_zone",
+            y_alias="cnt",
+        )
+        # Take the stale hash from the write that actually consumed it, rather
+        # than from a separate read: this module shares one dashboard across many
+        # writes, so a hash read moments earlier can already be a version behind
+        # and the setup write would 409 for the wrong reason.
+        resp, stale_hash = write_with_fresh_hash(
+            client,
+            panel_dashboard,
+            lambda h: client.dashboards.add_panel(panel_dashboard, first, hash=h),
+        )
+        assert resp.status_code == 200, f"Setup write failed: {resp.status_code} {resp.text}"
+
+        try:
+            second = panel_payload(
+                stream=panel_stream,
+                sql=_BASELINE_SQL.format(stream=panel_stream),
+                x_alias="facility_zone",
+                y_alias="cnt",
+            )
+            conflict = client.dashboards.add_panel(panel_dashboard, second, hash=stale_hash)
+            assert conflict.status_code == 409, (
+                f"Expected 409 for a stale hash, got {conflict.status_code}: {conflict.text}"
+            )
+        finally:
+            drop_panel(client, panel_dashboard, first["id"])
+
+    def test_add_duplicate_panel_id(self, client, panel_dashboard, panel_stream):
+        """DashboardError::PanelAlreadyExists -> 409."""
+        panel = panel_payload(
+            stream=panel_stream,
+            sql=_BASELINE_SQL.format(stream=panel_stream),
+            x_alias="facility_zone",
+            y_alias="cnt",
+        )
+        add_panel(client, panel_dashboard, panel)
+
+        try:
+            resp = client.dashboards.add_panel(
+                panel_dashboard, panel, hash=client.dashboards.hash(panel_dashboard)
+            )
+            assert resp.status_code == 409, (
+                f"Expected 409 for a duplicate panel id, got {resp.status_code}: {resp.text}"
+            )
+        finally:
+            drop_panel(client, panel_dashboard, panel["id"])
+
+    def test_add_panel_unknown_tab(self, client, panel_dashboard, panel_stream):
+        """DashboardError::TabNotFound -> 404."""
+        panel = panel_payload(
+            stream=panel_stream,
+            sql=_BASELINE_SQL.format(stream=panel_stream),
+            x_alias="facility_zone",
+            y_alias="cnt",
+        )
+        resp = client.dashboards.add_panel(
+            panel_dashboard,
+            panel,
+            hash=client.dashboards.hash(panel_dashboard),
+            tab_id=f"no_such_tab_{int(time.time() * 1000)}",
+        )
+        assert resp.status_code == 404, (
+            f"Expected 404 for an unknown tab, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_add_panel_unknown_dashboard(self, client, panel_stream):
+        """DashboardError::DashboardNotFound -> 404."""
+        panel = panel_payload(
+            stream=panel_stream,
+            sql=_BASELINE_SQL.format(stream=panel_stream),
+            x_alias="facility_zone",
+            y_alias="cnt",
+        )
+        resp = client.dashboards.add_panel(
+            f"nonexistent_{int(time.time() * 1000)}", panel, hash="0"
+        )
+        assert resp.status_code == 404, (
+            f"Expected 404 for an unknown dashboard, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_update_unknown_panel(self, client, panel_dashboard, panel_stream):
+        """DashboardError::PanelNotFound -> 404."""
+        missing_id = f"nonexistent_{int(time.time() * 1000)}"
+        panel = panel_payload(
+            stream=panel_stream,
+            sql=_BASELINE_SQL.format(stream=panel_stream),
+            x_alias="facility_zone",
+            y_alias="cnt",
+            panel_id=missing_id,
+        )
+        resp = client.dashboards.update_panel(
+            panel_dashboard, missing_id, panel, hash=client.dashboards.hash(panel_dashboard)
+        )
+        assert resp.status_code == 404, (
+            f"Expected 404 updating an unknown panel, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_delete_panel_missing_hash(self, client, panel_dashboard):
+        """DeletePanel without a `hash` query param -> 400."""
+        resp = client.delete(f"dashboards/{panel_dashboard}/panels/some_panel_id")
+        assert resp.status_code == 400, (
+            f"Expected 400 for a missing hash param, got {resp.status_code}: {resp.text}"
+        )


### PR DESCRIPTION
…nel search path (#13838)

## What

First test coverage for the dashboard **panel** endpoints and the **dashboard
search path**, running CTE/subquery `match_all` queries as real dashboard panels.

Nothing in the repo previously touched either:
`grep -rn "/panels\|search_type=dashboards" tests/api-testing/` returned zero hits.

## Why

Panels query `_search?type=logs&search_type=dashboards&dashboard_id=…` — a
different route into the engine than the Logs page (`search_type=ui`). The
`match_all` + FST projection rewrite fixed in #13808 runs inside it, so a query
that passes via Logs can still regress on a dashboard.

The rewrite has to preserve the projection of the block the predicate sits in.
When that block is the whole statement, the projection is obvious. When it's a
CTE body feeding a JOIN, a window, or a four-branch UNION ALL, it has to preserve
the *CTE's* output schema while the outer query reads different columns from it —
which is where it went wrong.

## Coverage

**71 distinct queries across 29 combination families**, all with `match_all`
inside a `WITH …` body or a derived table:

| Axis | Variants |
|---|---|
| Nesting depth | 1, 2, 3, and 5-level CTE chains | | Nesting kind | CTEs and derived tables (and one query using both) | | UNION ALL | 2, 3, and 4 separate `match_all` branches | | JOIN | CTE⋈CTE, derived⋈derived, cross-stream |
| Window | `ROW_NUMBER`, `RANK`, `DENSE_RANK`, partitioned aggregates | | Negation | `NOT match_all`, and mixed with positive `match_all` | | Combined with | `COUNT(DISTINCT)`, `CASE`, `HAVING`, `histogram()` |

Each case creates a real panel, runs it via the dashboard search path, then
asserts row count against the DuckDB oracle and that no expected column was
dropped from the projection. A further 30 cases run the same SQL through **both**
Logs and dashboard and diff the results — that's what catches a rewrite firing on
only one path.

Queries are reused from the existing query-agent corpus rather than duplicated,
so the two suites can't drift: query-agent verifies the values via the Logs path,
this verifies the same SQL survives the dashboard path.

Cases are **discovered by classifying the SQL**, not from a hand-written ID list,
so new combinations added to the corpus are picked up automatically. Test ids
name the shape (`Q1022-cte1_union_cdist_4ma`), so a failure identifies the
combination without opening the corpus.

Plus 14 tests for the panel endpoints themselves — AddPanel / UpdatePanel /
DeletePanel, contract + CRUD lifecycle + 7 error paths derived from `DashboardError` in `src/core/src/http.rs`.

## Changes

| File | |
|---|---|
| `tests/dashboards/test_dashboard_cte_panels.py` | new — 103 tests | | `tests/dashboards/test_dashboard_panels.py` | new — 14 tests | | `tests/dashboards/conftest.py` | new — shared fixtures | | `support/panel_queries.py` | new — discovery + panel helpers | | `support/endpoints/dashboards.py` | +78, additive | | `support/endpoints/search.py` | +36, additive |
| `support/factories.py` | +73, additive |

The three shared-file edits are **187 added lines, 0 modified** — nothing
existing can break.

## Results

168 tests in tests/api-testing/tests/dashboards/ (117 new + 51 pre-existing)
166 passed, 1 skipped, 1 xfailed     # full nested-query corpus present
74 passed, 2 skipped, 1 xfailed     # current corpus on main

Repeated 2× and 4× respectively, no flakes.

Discovery scales with the corpus: on main it finds 8 nested `match_all` cases,
and 71 once the larger sentinel set is present. Cases that aren't in the corpus
skip with an explanatory message instead of failing, so this is safe to merge in
either order.

(cherry picked from commit 33c6e9e0e1c31560982d8c266fadd248e2ed6277)