### PR TITLE
fix: skip session_id in trace time index merge when files lack the column

### DIFF
--- a/src/search/src/datafusion/merge/mod.rs
+++ b/src/search/src/datafusion/merge/mod.rs
@@ -106,8 +106,15 @@ pub async fn merge_parquet_files(
 
     // get all sorted data
     let sql = if stream_type == StreamType::Metadata && is_trace_time_index_stream(stream_name) {
+        // Files whose records all had a null session_id were persisted without the
+        // column (all-null columns are pruned), so only select it when present.
+        let session_id_col = if schema.column_with_name("session_id").is_some() {
+            ", MAX(session_id) AS session_id"
+        } else {
+            ""
+        };
         format!(
-            "SELECT MIN({TIMESTAMP_COL_NAME}) AS {TIMESTAMP_COL_NAME}, trace_id, MAX(session_id) AS session_id, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts FROM tbl GROUP BY trace_id ORDER BY {TIMESTAMP_COL_NAME} DESC"
+            "SELECT MIN({TIMESTAMP_COL_NAME}) AS {TIMESTAMP_COL_NAME}, trace_id{session_id_col}, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts FROM tbl GROUP BY trace_id ORDER BY {TIMESTAMP_COL_NAME} DESC"
         )
     } else if stream_type == StreamType::Filelist {
         // for file list we do not have timestamp, so we instead sort by min ts of entries


### PR DESCRIPTION
## Problem

Ingester merge jobs fail repeatedly for trace time index streams:

```
merge_parquet_files error for stream: default/metadata/trace_time_index__evaluator, ...
err: Schema error: No field named session_id. Valid fields are tbl._timestamp, tbl.max_ts, tbl.min_ts, tbl.trace_id.
```

The failing file can never merge, so the job retries it forever and the file stays stuck in the WAL, never uploaded to object storage.

## Root cause

- The trace time index write path only inserts a `session_id` value when the trace actually carries one; the field is nullable in the schema.
- When the ingester persists WAL files, `merge_record_batches` prunes columns that are entirely null — so a file whose records all lack a session is written **without the `session_id` column at all**. Since most traces have no session id, this is the common case, not an edge case.
- The ingester merge job builds the DataFusion table schema from the files' own fields (intentionally, to avoid the wide latest schema), and `merge_parquet_files` hardcoded `MAX(session_id) AS session_id` in the merge SQL for trace time index streams — planning fails when the column is absent.

## Fix

Only include `MAX(session_id) AS session_id` in the merge SQL when the resolved schema actually contains the field. Files without the column merge with the original 4-column shape (matching what search already handles via schema adaptation); when any file in the batch has the column, the union schema null-fills the rest and the full query works. This also covers files written before `session_id` was added to the index schema.

## Testing

Existing `test_trace_time_index_merge_aggregates_by_trace_id` covers the with-session path through the conditional SQL; verified the module's tests pass.