### PR TITLE
refactor(merge): decide the merge kind once (MergeMode) and share the DataFusion pipeline

### DIFF
--- a/src/cli/basic/test.rs
+++ b/src/cli/basic/test.rs
@@ -38,6 +38,7 @@ pub async fn file_list(
         stream_name,
         hour,
         hour,
+        infra::file_list::merge_max_original_size(),
     )
     .await?;
     println!("get files: {}", file_list.len());

--- a/src/compaction/src/deleted.rs
+++ b/src/compaction/src/deleted.rs
@@ -15,6 +15,8 @@
 
 //! Delayed deletion of compacted files.
 
+use std::borrow::Cow;
+
 use config::{
     meta::stream::{FileKey, FileListDeleted, FileMeta},
     utils::inverted_index::to_tantivy_name,
@@ -24,32 +26,25 @@ use infra::{file_list as infra_file_list, storage};
 // Batch size for deleting files from file_list_deleted table
 const BATCH_SIZE: i64 = 10000;
 
-/// `(account, derived object key)` pairs of the files for which `derive`
-/// returns a key.
-fn derived_files(
-    files: &[FileListDeleted],
-    derive: impl Fn(&FileListDeleted) -> Option<String>,
-) -> Vec<(String, String)> {
-    files
-        .iter()
-        .filter_map(|file| derive(file).map(|key| (file.account.clone(), key)))
-        .collect()
-}
-
-/// Delete objects from storage, ignoring `not found` (already deleted, or a
-/// derived object that was never written).
-async fn delete_from_storage(
+/// Delete the objects `key` maps the files to from storage, ignoring
+/// `not found` (already deleted, or a derived object that was never written).
+async fn delete_from_storage<'a>(
     kind: &str,
-    files: Vec<(String, String)>,
+    files: &'a [FileListDeleted],
+    key: impl Fn(&'a FileListDeleted) -> Option<Cow<'a, str>>,
 ) -> Result<(), anyhow::Error> {
-    if files.is_empty() {
+    let objects = files
+        .iter()
+        .filter_map(|file| key(file).map(|key| (file.account.as_str(), key)))
+        .collect::<Vec<_>>();
+    if objects.is_empty() {
         return Ok(());
     }
     if let Err(e) = storage::del(
-        files
+        objects
             .iter()
-            .map(|(account, key)| (account.as_str(), key.as_str()))
-            .collect::<Vec<_>>(),
+            .map(|(account, key)| (*account, key.as_ref()))
+            .collect(),
     )
     .await
         && !e.to_string().to_lowercase().contains("not found")
@@ -68,34 +63,23 @@ pub async fn delete(org_id: &str, time_max: i64) -> Result<i64, anyhow::Error> {
     let files_num = files.len() as i64;
 
     // delete files from storage
-    delete_from_storage(
-        "data",
-        files
-            .iter()
-            .filter(|file| !ingester::is_wal_file(&file.file))
-            .map(|file| (file.account.clone(), file.file.clone()))
-            .collect(),
-    )
+    delete_from_storage("data", &files, |file| {
+        (!ingester::is_wal_file(&file.file)).then_some(Cow::Borrowed(file.file.as_str()))
+    })
     .await?;
 
     // derived objects are not tracked in file_list: delete them together with
     // their parent data file
-    delete_from_storage(
-        "inverted index",
-        derived_files(&files, |file| {
-            file.index_file
-                .then(|| to_tantivy_name(&file.file))
-                .flatten()
-        }),
-    )
+    delete_from_storage("inverted index", &files, |file| {
+        file.index_file
+            .then(|| to_tantivy_name(&file.file).map(Cow::Owned))
+            .flatten()
+    })
     .await?;
-    delete_from_storage(
-        "flattened",
-        derived_files(&files, |file| {
-            file.flattened
-                .then(|| super::flatten::generate_flatten_file_key(&file.file))
-        }),
-    )
+    delete_from_storage("flattened", &files, |file| {
+        file.flattened
+            .then(|| Cow::Owned(super::flatten::generate_flatten_file_key(&file.file)))
+    })
     .await?;
 
     // delete files from file_list_deleted table

--- a/src/compaction/src/merge.rs
+++ b/src/compaction/src/merge.rs
@@ -59,6 +59,36 @@ use tokio::{
 
 use super::worker::{MergeBatch, MergeSender};
 
+/// The time range one merge job covers: the hour of `offset` (aligned down),
+/// or the whole day for daily-partitioned streams.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct JobTimeRange {
+    /// `%Y/%m/%d/%H` bounds for the file_list query (inclusive)
+    date_start: String,
+    date_end: String,
+    /// Last microsecond of the range: no file of the job can be newer, so
+    /// "is the range old enough" is decided against this.
+    end_ts: i64,
+}
+
+fn job_time_range(offset: i64, partition_time_level: PartitionTimeLevel) -> JobTimeRange {
+    let offset = offset - offset % hour_micros(1);
+    let offset_time: DateTime<Utc> = Utc.timestamp_nanos(offset * 1000);
+    if partition_time_level == PartitionTimeLevel::Daily {
+        JobTimeRange {
+            date_start: offset_time.format("%Y/%m/%d/00").to_string(),
+            date_end: offset_time.format("%Y/%m/%d/23").to_string(),
+            end_ts: offset - offset % day_micros(1) + day_micros(1) - 1,
+        }
+    } else {
+        JobTimeRange {
+            date_start: offset_time.format("%Y/%m/%d/%H").to_string(),
+            date_end: offset_time.format("%Y/%m/%d/%H").to_string(),
+            end_ts: offset + hour_micros(1) - 1,
+        }
+    }
+}
+
 /// Generate merging job by stream
 /// 1. get offset from db
 /// 2. check if other node is processing
@@ -308,6 +338,11 @@ pub async fn generate_downsampling_job_by_stream_and_rule(
     // -- third period, we can do the merge, so, at least 3 times of
     // -- 1 day, downsampling is in day level
     // max_file_retention_time
+    // The job merges the hour of `offset` and decides the downsampling rule
+    // against the end of that hour (see merge_by_stream), so only enqueue it
+    // once the whole hour is older than the rule's offset; otherwise the job
+    // would run as a plain merge and the advanced offset would skip the hour.
+    let job_end_ts = job_time_range(offset, get_partition_time_level(stream_type)).end_ts;
     if offset >= time_now_day
         || time_now.timestamp_micros() - offset
             <= Duration::try_seconds(cfg.limit.max_file_retention_time as i64)
@@ -316,7 +351,7 @@ pub async fn generate_downsampling_job_by_stream_and_rule(
                 .unwrap()
                 * 3
                 + day_micros(1)
-        || time_now.timestamp_micros() - rule.0 * 1_000_000 < offset
+        || time_now.timestamp_micros() - rule.0 * 1_000_000 < job_end_ts
     {
         return Ok(()); // the time is future, just wait
     }
@@ -392,27 +427,14 @@ pub async fn merge_by_stream(
     let is_incremental = !super::is_past_hour(offset);
 
     // check offset
-    let partition_time_level = get_partition_time_level(stream_type);
-    let offset_time: DateTime<Utc> = Utc.timestamp_nanos(offset * 1000);
-    let (date_start, date_end) = if partition_time_level == PartitionTimeLevel::Daily {
-        (
-            offset_time.format("%Y/%m/%d/00").to_string(),
-            offset_time.format("%Y/%m/%d/23").to_string(),
-        )
-    } else {
-        (
-            offset_time.format("%Y/%m/%d/%H").to_string(),
-            offset_time.format("%Y/%m/%d/%H").to_string(),
-        )
-    };
+    let JobTimeRange {
+        date_start,
+        date_end,
+        end_ts: range_end_ts,
+    } = job_time_range(offset, get_partition_time_level(stream_type));
     // What this hour of files turns into. Decided once here — the workers and
-    // the merge only read it — from the end of the date range, so a
-    // whole-hour mode applies to the hour as a unit.
-    let range_end_ts = if partition_time_level == PartitionTimeLevel::Daily {
-        offset - offset % day_micros(1) + day_micros(1) - 1
-    } else {
-        offset + hour_micros(1) - 1
-    };
+    // the merge only read it — from the end of the range, so a whole-hour
+    // mode applies to the hour as a unit.
     let mode = MergeMode::for_compactor(stream_type, stream_name, range_end_ts, !is_incremental);
     // a whole-hour merge needs every file of the hour, even those already
     // above the size target that a normal merge would leave alone
@@ -1202,6 +1224,36 @@ mod tests {
     use config::meta::stream::{FileKey, FileMeta};
 
     use super::*;
+
+    #[test]
+    fn test_job_time_range_hourly_and_daily() {
+        // 2026-08-18 10:10:00 UTC
+        let offset = Utc
+            .with_ymd_and_hms(2026, 8, 18, 10, 10, 0)
+            .unwrap()
+            .timestamp_micros();
+        let hourly = job_time_range(offset, PartitionTimeLevel::Hourly);
+        assert_eq!(hourly.date_start, "2026/08/18/10");
+        assert_eq!(hourly.date_end, "2026/08/18/10");
+        assert_eq!(
+            hourly.end_ts,
+            Utc.with_ymd_and_hms(2026, 8, 18, 11, 0, 0)
+                .unwrap()
+                .timestamp_micros()
+                - 1
+        );
+
+        let daily = job_time_range(offset, PartitionTimeLevel::Daily);
+        assert_eq!(daily.date_start, "2026/08/18/00");
+        assert_eq!(daily.date_end, "2026/08/18/23");
+        assert_eq!(
+            daily.end_ts,
+            Utc.with_ymd_and_hms(2026, 8, 19, 0, 0, 0)
+                .unwrap()
+                .timestamp_micros()
+                - 1
+        );
+    }
 
     // Helper function to create test FileKey
     fn create_file_key(key: &str, min_ts: i64, max_ts: i64, original_size: i64) -> FileKey {

--- a/src/compaction/src/merge.rs
+++ b/src/compaction/src/merge.rs
@@ -405,10 +405,32 @@ pub async fn merge_by_stream(
             offset_time.format("%Y/%m/%d/%H").to_string(),
         )
     };
-    let files =
-        file_list::query_for_merge(org_id, stream_type, stream_name, &date_start, &date_end)
-            .await
-            .map_err(|e| anyhow::anyhow!("query file list failed: {e}"))?;
+    // What this hour of files turns into. Decided once here — the workers and
+    // the merge only read it — from the end of the date range, so a
+    // whole-hour mode applies to the hour as a unit.
+    let range_end_ts = if partition_time_level == PartitionTimeLevel::Daily {
+        offset - offset % day_micros(1) + day_micros(1) - 1
+    } else {
+        offset + hour_micros(1) - 1
+    };
+    let mode = MergeMode::for_compactor(stream_type, stream_name, range_end_ts, !is_incremental);
+    // a whole-hour merge needs every file of the hour, even those already
+    // above the size target that a normal merge would leave alone
+    let max_original_size = if mode.merges_whole_batch() {
+        i64::MAX
+    } else {
+        infra_file_list::merge_max_original_size()
+    };
+    let files = file_list::query_for_merge(
+        org_id,
+        stream_type,
+        stream_name,
+        &date_start,
+        &date_end,
+        max_original_size,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("query file list failed: {e}"))?;
 
     log::debug!(
         "[COMPACTOR] merge_by_stream [{org_id}/{stream_type}/{stream_name}] date range: [{date_start},{date_end}], files: {}",
@@ -438,6 +460,7 @@ pub async fn merge_by_stream(
     for (prefix, mut files_with_size) in partition_files_with_size.into_iter() {
         let org_id = org_id.to_string();
         let stream_name = stream_name.to_string();
+        let mode = mode.clone();
         let permit = semaphore.clone().acquire_owned().await.unwrap();
         let worker_tx = worker_tx.clone();
         let task: JoinHandle<Result<Vec<i64>, anyhow::Error>> = tokio::task::spawn(async move {
@@ -455,11 +478,6 @@ pub async fn merge_by_stream(
                     files_with_size = sort_by_time_range(files_with_size);
                 }
             }
-
-            // what this batch of files turns into; decided once here, the
-            // worker and the merge only read it
-            let max_ts = files_with_size.iter().map(|f| f.meta.max_ts).max().unwrap();
-            let mode = MergeMode::for_compactor(stream_type, &stream_name, max_ts);
 
             if files_with_size.len() <= 1 && !mode.merges_whole_batch() {
                 return Ok(vec![]);

--- a/src/compaction/src/merge.rs
+++ b/src/compaction/src/merge.rs
@@ -45,13 +45,10 @@ use infra::{
     },
     storage,
 };
-#[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::common::downsampling::get_largest_downsampling_rule;
 use schema::generate_schema_for_defined_schema_fields;
 use search::datafusion::{
     exec::TableBuilder,
-    merge::{self, MergeParquetResult, MergedFile},
-    sort_order::FileSortOrder,
+    merge::{self, MergeMode, MergeOutput, MergeParquetResult, MergedFile},
 };
 use search_service::file_list;
 use tantivy_utils::index_builder::create_tantivy_index;
@@ -459,24 +456,18 @@ pub async fn merge_by_stream(
                 }
             }
 
-            #[cfg(feature = "enterprise")]
-            let skip_group_files = stream_type == StreamType::Metrics
-                && get_largest_downsampling_rule(
-                    &stream_name,
-                    files_with_size.iter().map(|f| f.meta.max_ts).max().unwrap(),
-                )
-                .is_some();
+            // what this batch of files turns into; decided once here, the
+            // worker and the merge only read it
+            let max_ts = files_with_size.iter().map(|f| f.meta.max_ts).max().unwrap();
+            let mode = MergeMode::for_compactor(stream_type, &stream_name, max_ts);
 
-            #[cfg(not(feature = "enterprise"))]
-            let skip_group_files = false;
-
-            if files_with_size.len() <= 1 && !skip_group_files {
+            if files_with_size.len() <= 1 && !mode.merges_whole_batch() {
                 return Ok(vec![]);
             }
 
             // group files need to merge
             let mut batch_groups = Vec::new();
-            if skip_group_files {
+            if mode.merges_whole_batch() {
                 batch_groups.push(MergeBatch {
                     batch_id: 0,
                     org_id: org_id.clone(),
@@ -484,6 +475,7 @@ pub async fn merge_by_stream(
                     stream_name: stream_name.clone(),
                     prefix: prefix.clone(),
                     files: files_with_size.clone(),
+                    mode: mode.clone(),
                 });
             } else {
                 let mut new_file_list = Vec::new();
@@ -509,6 +501,7 @@ pub async fn merge_by_stream(
                             stream_name: stream_name.clone(),
                             prefix: prefix.clone(),
                             files: new_file_list.clone(),
+                            mode: mode.clone(),
                         });
                         new_file_size = 0;
                         new_file_list.clear();
@@ -529,6 +522,7 @@ pub async fn merge_by_stream(
                         stream_name: stream_name.clone(),
                         prefix: prefix.clone(),
                         files: new_file_list.clone(),
+                        mode: mode.clone(),
                     });
                 }
 
@@ -670,6 +664,7 @@ pub async fn merge_by_stream(
 // - stream_name: the name of the stream
 // - prefix: the prefix of the files
 // - files_with_size: the files to merge
+// - mode: what the merge produces (decided by the scheduler)
 // returns:
 // - new_files: the files that are merged
 // - retain_file_list: the files that are not merged
@@ -680,19 +675,13 @@ pub async fn merge_files(
     stream_name: &str,
     prefix: &str,
     files_with_size: &[FileKey],
+    mode: &MergeMode,
 ) -> Result<(Vec<FileKey>, Vec<FileKey>), anyhow::Error> {
     let start = std::time::Instant::now();
-    #[cfg(feature = "enterprise")]
-    let is_match_downsampling_rule = get_largest_downsampling_rule(
-        stream_name,
-        files_with_size.iter().map(|f| f.meta.max_ts).max().unwrap(),
-    )
-    .is_some();
-
-    #[cfg(not(feature = "enterprise"))]
-    let is_match_downsampling_rule = false;
-
-    if files_with_size.len() <= 1 && !is_match_downsampling_rule {
+    // a whole-batch mode (downsampling) merges everything it is given, even a
+    // single file; otherwise 0/1 files means nothing to do
+    let merge_whole_batch = mode.merges_whole_batch();
+    if files_with_size.len() <= 1 && !merge_whole_batch {
         return Ok((Vec::new(), Vec::new()));
     }
 
@@ -704,7 +693,7 @@ pub async fn merge_files(
         if (new_file_size + file.meta.original_size > cfg.compact.max_file_size as i64
             || new_compressed_file_size + file.meta.compressed_size
                 > cfg.compact.max_file_size as i64)
-            && !is_match_downsampling_rule
+            && !merge_whole_batch
         {
             break;
         }
@@ -720,7 +709,7 @@ pub async fn merge_files(
             .inc_by(file.meta.original_size as u64);
     }
     // no files need to merge
-    if new_file_list.len() <= 1 && !is_match_downsampling_rule {
+    if new_file_list.len() <= 1 && !merge_whole_batch {
         return Ok((Vec::new(), Vec::new()));
     }
 
@@ -736,7 +725,7 @@ pub async fn merge_files(
     if !deleted_files.is_empty() {
         new_file_list.retain(|f| !deleted_files.contains(&f.key));
     }
-    if new_file_list.len() <= 1 && !is_match_downsampling_rule {
+    if new_file_list.len() <= 1 && !merge_whole_batch {
         return Ok((Vec::new(), retain_file_list));
     }
 
@@ -847,7 +836,7 @@ pub async fn merge_files(
     };
 
     let tables = match TableBuilder::new()
-        .sort_order(FileSortOrder::TimestampDesc)
+        .sort_order(mode.input_sort_order())
         .build(session, files.clone(), schema.clone())
         .await
     {
@@ -859,17 +848,16 @@ pub async fn merge_files(
     };
 
     let merge_result = {
-        let stream_name = stream_name.to_string();
+        let mode = mode.clone();
         DATAFUSION_RUNTIME
             .spawn(async move {
                 merge::merge_parquet_files(
-                    stream_type,
-                    &stream_name,
                     schema,
                     tables,
                     &bloom_filter_fields,
                     new_file_meta,
-                    false,
+                    &mode,
+                    MergeOutput::for_compactor(stream_type),
                 )
                 .await
             })

--- a/src/compaction/src/merge.rs
+++ b/src/compaction/src/merge.rs
@@ -911,6 +911,12 @@ pub async fn merge_files(
         files: merged_files,
         file_format,
     } = buf;
+    // an empty result would delete the source files without a replacement
+    if merged_files.is_empty() {
+        return Err(anyhow::anyhow!(
+            "merge_parquet_files error: produced no files"
+        ));
+    }
     let mut new_files = Vec::with_capacity(merged_files.len());
     for MergedFile {
         buf,

--- a/src/compaction/src/merge.rs
+++ b/src/compaction/src/merge.rs
@@ -59,33 +59,15 @@ use tokio::{
 
 use super::worker::{MergeBatch, MergeSender};
 
-/// The time range one merge job covers: the hour of `offset` (aligned down),
-/// or the whole day for daily-partitioned streams.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct JobTimeRange {
-    /// `%Y/%m/%d/%H` bounds for the file_list query (inclusive)
-    date_start: String,
-    date_end: String,
-    /// Last microsecond of the range: no file of the job can be newer, so
-    /// "is the range old enough" is decided against this.
-    end_ts: i64,
-}
-
-fn job_time_range(offset: i64, partition_time_level: PartitionTimeLevel) -> JobTimeRange {
+/// Last microsecond of the range a merge job at `offset` covers: the hour of
+/// `offset`, or the whole day for daily-partitioned streams. No file of the
+/// job can be newer, so "is the range old enough" is decided against this.
+fn job_range_end(offset: i64, partition_time_level: PartitionTimeLevel) -> i64 {
     let offset = offset - offset % hour_micros(1);
-    let offset_time: DateTime<Utc> = Utc.timestamp_nanos(offset * 1000);
     if partition_time_level == PartitionTimeLevel::Daily {
-        JobTimeRange {
-            date_start: offset_time.format("%Y/%m/%d/00").to_string(),
-            date_end: offset_time.format("%Y/%m/%d/23").to_string(),
-            end_ts: offset - offset % day_micros(1) + day_micros(1) - 1,
-        }
+        offset - offset % day_micros(1) + day_micros(1) - 1
     } else {
-        JobTimeRange {
-            date_start: offset_time.format("%Y/%m/%d/%H").to_string(),
-            date_end: offset_time.format("%Y/%m/%d/%H").to_string(),
-            end_ts: offset + hour_micros(1) - 1,
-        }
+        offset + hour_micros(1) - 1
     }
 }
 
@@ -342,7 +324,7 @@ pub async fn generate_downsampling_job_by_stream_and_rule(
     // against the end of that hour (see merge_by_stream), so only enqueue it
     // once the whole hour is older than the rule's offset; otherwise the job
     // would run as a plain merge and the advanced offset would skip the hour.
-    let job_end_ts = job_time_range(offset, get_partition_time_level(stream_type)).end_ts;
+    let job_end_ts = job_range_end(offset, get_partition_time_level(stream_type));
     if offset >= time_now_day
         || time_now.timestamp_micros() - offset
             <= Duration::try_seconds(cfg.limit.max_file_retention_time as i64)
@@ -427,14 +409,23 @@ pub async fn merge_by_stream(
     let is_incremental = !super::is_past_hour(offset);
 
     // check offset
-    let JobTimeRange {
-        date_start,
-        date_end,
-        end_ts: range_end_ts,
-    } = job_time_range(offset, get_partition_time_level(stream_type));
+    let partition_time_level = get_partition_time_level(stream_type);
+    let offset_time: DateTime<Utc> = Utc.timestamp_nanos(offset * 1000);
+    let (date_start, date_end) = if partition_time_level == PartitionTimeLevel::Daily {
+        (
+            offset_time.format("%Y/%m/%d/00").to_string(),
+            offset_time.format("%Y/%m/%d/23").to_string(),
+        )
+    } else {
+        (
+            offset_time.format("%Y/%m/%d/%H").to_string(),
+            offset_time.format("%Y/%m/%d/%H").to_string(),
+        )
+    };
     // What this hour of files turns into. Decided once here — the workers and
     // the merge only read it — from the end of the range, so a whole-hour
     // mode applies to the hour as a unit.
+    let range_end_ts = job_range_end(offset, partition_time_level);
     let mode = MergeMode::for_compactor(stream_type, stream_name, range_end_ts, !is_incremental);
     // a whole-hour merge needs every file of the hour, even those already
     // above the size target that a normal merge would leave alone
@@ -1226,28 +1217,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_job_time_range_hourly_and_daily() {
+    fn test_job_range_end_hourly_and_daily() {
         // 2026-08-18 10:10:00 UTC
         let offset = Utc
             .with_ymd_and_hms(2026, 8, 18, 10, 10, 0)
             .unwrap()
             .timestamp_micros();
-        let hourly = job_time_range(offset, PartitionTimeLevel::Hourly);
-        assert_eq!(hourly.date_start, "2026/08/18/10");
-        assert_eq!(hourly.date_end, "2026/08/18/10");
         assert_eq!(
-            hourly.end_ts,
+            job_range_end(offset, PartitionTimeLevel::Hourly),
             Utc.with_ymd_and_hms(2026, 8, 18, 11, 0, 0)
                 .unwrap()
                 .timestamp_micros()
                 - 1
         );
-
-        let daily = job_time_range(offset, PartitionTimeLevel::Daily);
-        assert_eq!(daily.date_start, "2026/08/18/00");
-        assert_eq!(daily.date_end, "2026/08/18/23");
         assert_eq!(
-            daily.end_ts,
+            job_range_end(offset, PartitionTimeLevel::Daily),
             Utc.with_ymd_and_hms(2026, 8, 19, 0, 0, 0)
                 .unwrap()
                 .timestamp_micros()

--- a/src/compaction/src/worker.rs
+++ b/src/compaction/src/worker.rs
@@ -19,6 +19,7 @@ use config::{
     cluster::is_offline,
     meta::stream::{FileKey, StreamType},
 };
+use search::datafusion::merge::MergeMode;
 use tokio::sync::{Mutex, mpsc};
 
 #[derive(Clone)]
@@ -29,6 +30,8 @@ pub struct MergeBatch {
     pub stream_name: String,
     pub prefix: String,
     pub files: Vec<FileKey>,
+    /// What the merge produces; decided by the scheduler, read by the worker.
+    pub mode: MergeMode,
 }
 
 pub struct MergeResult {
@@ -212,6 +215,7 @@ impl MergeWorker {
                                 &msg.stream_name,
                                 &msg.prefix,
                                 &msg.files,
+                                &msg.mode,
                             )
                             .await
                             {

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -113,12 +113,15 @@ pub trait FileList: Sync + Send + 'static {
         time_range: (i64, i64),
         flattened: Option<bool>,
     ) -> Result<Vec<FileKey>>;
+    /// Files of `date_range` with `original_size <= max_original_size`, the
+    /// compactor's merge candidates.
     async fn query_for_merge(
         &self,
         org_id: &str,
         stream_type: StreamType,
         stream_name: &str,
         date_range: (String, String),
+        max_original_size: i64,
     ) -> Result<Vec<FileKey>>;
     async fn query_for_dump(
         &self,
@@ -402,15 +405,29 @@ pub async fn query(
 }
 
 #[inline]
+/// Classic upper bound on `original_size` for merge candidates: files at or
+/// above ~95% of `ZO_COMPACT_MAX_FILE_SIZE` are already "big enough" and are
+/// not merged again.
+pub fn merge_max_original_size() -> i64 {
+    get_config().compact.max_file_size as i64 * 95 / 100
+}
+
 #[tracing::instrument(name = "infra:file_list:db:query_for_merge")]
 pub async fn query_for_merge(
     org_id: &str,
     stream_type: StreamType,
     stream_name: &str,
     date_range: (String, String),
+    max_original_size: i64,
 ) -> Result<Vec<FileKey>> {
     CLIENT
-        .query_for_merge(org_id, stream_type, stream_name, date_range)
+        .query_for_merge(
+            org_id,
+            stream_type,
+            stream_name,
+            date_range,
+            max_original_size,
+        )
         .await
 }
 

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -528,6 +528,7 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
         stream_type: StreamType,
         stream_name: &str,
         date_range: (String, String),
+        max_original_size: i64,
     ) -> Result<Vec<FileKey>> {
         let start = std::time::Instant::now();
         let (date_start, date_end) = date_range;
@@ -541,8 +542,6 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
             .with_label_values(&["query_for_merge", "file_list"])
             .inc();
 
-        let cfg = get_config();
-        let max_size = cfg.compact.max_file_size as i64 * 95 / 100;
         let sql = r#"
 SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, compressed_size, index_size, bloom_ver, flattened
     FROM file_list
@@ -552,7 +551,7 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
             .bind(stream_key)
             .bind(date_start)
             .bind(date_end)
-            .bind(max_size)
+            .bind(max_original_size)
             .fetch_all(&pool)
             .await;
         let time = start.elapsed().as_secs_f64();

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -440,6 +440,7 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
         stream_type: StreamType,
         stream_name: &str,
         date_range: (String, String),
+        max_original_size: i64,
     ) -> Result<Vec<FileKey>> {
         let (date_start, date_end) = date_range;
         if date_start.is_empty() && date_end.is_empty() {
@@ -447,8 +448,6 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
         }
         let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
 
-        let cfg = get_config();
-        let max_size = cfg.compact.max_file_size as i64 * 95 / 100;
         let pool = CLIENT_RO.clone();
         let ret = sqlx::query_as::<_, super::FileRecord>(
                 r#"
@@ -460,7 +459,7 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
             .bind(stream_key)
             .bind(date_start)
             .bind(date_end)
-            .bind(max_size)
+            .bind(max_original_size)
             .fetch_all(&pool)
             .await;
         Ok(ret?.iter().map(|r| r.into()).collect())

--- a/src/jobs/src/job/files/pack.rs
+++ b/src/jobs/src/job/files/pack.rs
@@ -42,7 +42,7 @@ use infra::{
 };
 use ingester::{PackSegment, PendingStreamStats};
 use schema::generate_schema_for_defined_schema_fields;
-use search::datafusion::merge;
+use search::datafusion::merge::{self, MergeMode, MergeOutput};
 use tantivy_utils::index_builder::create_tantivy_index;
 use tokio::sync::{Mutex, RwLock};
 
@@ -433,13 +433,12 @@ async fn upload_chunk(
             ..Default::default()
         };
         let merge_result = merge::merge_parquet_files(
-            stream_type,
-            stream_name,
             union_schema,
             tables,
             &bloom_filter_fields,
             new_file_meta,
-            true,
+            &MergeMode::for_ingester(stream_type, stream_name),
+            MergeOutput::for_ingester(stream_type),
         )
         .await?;
         // the ingester always merges into exactly one file

--- a/src/jobs/src/job/files/parquet.rs
+++ b/src/jobs/src/job/files/parquet.rs
@@ -47,7 +47,11 @@ use infra::{
 };
 use ingester::WAL_PARQUET_METADATA;
 use schema::generate_schema_for_defined_schema_fields;
-use search::datafusion::{exec::TableBuilder, merge, sort_order::FileSortOrder};
+use search::datafusion::{
+    exec::TableBuilder,
+    merge::{self, MergeMode, MergeOutput},
+    sort_order::FileSortOrder,
+};
 use tantivy_utils::index_builder::create_tantivy_index;
 use tokio::{
     fs::remove_file,
@@ -781,13 +785,12 @@ async fn merge_files(
 
     let start = std::time::Instant::now();
     let merge_result = merge::merge_parquet_files(
-        stream_type,
-        &stream_name,
         schema,
         tables,
         &bloom_filter_fields,
         new_file_meta,
-        true,
+        &MergeMode::for_ingester(stream_type, &stream_name),
+        MergeOutput::for_ingester(stream_type),
     )
     .await;
 

--- a/src/search/src/datafusion/merge/downsampling.rs
+++ b/src/search/src/datafusion/merge/downsampling.rs
@@ -26,11 +26,8 @@ use config::{
 };
 use datafusion::{
     arrow::datatypes::Schema,
-    catalog::TableProvider,
     error::{DataFusionError, Result},
-    physical_plan::execute_stream,
 };
-use futures::TryStreamExt;
 use vortex::{
     VortexSessionDefault,
     array::ArrayRef,
@@ -42,75 +39,25 @@ use vortex::{
 };
 
 use crate::datafusion::{
-    exec::DataFusionContextBuilder,
-    merge::{MergeParquetResult, MergedFile, append_metadata},
-    sort_order::FileSortOrder,
-    table_provider::uniontable::NewUnionTable,
+    merge::{MergedFile, append_metadata},
     vortex::{VORTEX_RUNTIME, vortex_write_strategy},
 };
 
 const TIMESTAMP_ALIAS: &str = "_timestamp_alias";
 
-pub async fn merge_parquet_files_with_downsampling(
-    schema: Arc<Schema>,
-    tables: Vec<Arc<dyn TableProvider>>,
+/// Write the downsampled batches into size-split files of `file_format`.
+pub(super) async fn write_files(
+    schema: &Arc<Schema>,
     bloom_filter_fields: &[String],
-    rule: &DownsamplingRule,
     metadata: &FileMeta,
     file_format: FileFormat,
-) -> Result<MergeParquetResult> {
-    let start = std::time::Instant::now();
+    rx: tokio::sync::mpsc::Receiver<RecordBatch>,
+    read_task: tokio::task::JoinHandle<Result<()>>,
+) -> Result<Vec<MergedFile>> {
     let cfg = get_config();
-    let sql = generate_downsampling_sql(&schema, rule);
-
-    log::debug!("merge_parquet_files_with_downsampling sql: {sql}");
-
-    // create datafusion context
-    let ctx = DataFusionContextBuilder::new()
-        .trace_id("merge_parquet_files_with_downsampling")
-        .sort_order(FileSortOrder::TimestampDesc)
-        .build(get_config().limit.datafusion_min_partition_num)
-        .await?;
-    // register union table
-    let union_table = Arc::new(NewUnionTable::new(schema.clone(), tables));
-    ctx.register_table("tbl", union_table)?;
-
-    let plan = ctx.state().create_logical_plan(&sql).await?;
-    let physical_plan = ctx.state().create_physical_plan(&plan).await?;
-    let schema = physical_plan.schema();
-
-    // write result to parquet or vortex file based on config
-    let mut batch_stream = execute_stream(physical_plan, ctx.task_ctx())?;
-
-    // Create a shared channel for streaming batches
-    let (tx, rx) = tokio::sync::mpsc::channel::<RecordBatch>(2);
-
-    // Spawn task to read from batch_stream and send to channel
-    let read_task = tokio::task::spawn(async move {
-        loop {
-            match batch_stream.try_next().await {
-                Ok(None) => break,
-                Ok(Some(batch)) => {
-                    if let Err(e) = tx.send(batch).await {
-                        log::error!(
-                            "merge_parquet_files_with_downsampling send to channel error: {e}"
-                        );
-                        return Err(DataFusionError::External(Box::new(e)));
-                    }
-                }
-                Err(e) => {
-                    log::error!("merge_parquet_files_with_downsampling execute stream error: {e}");
-                    return Err(e);
-                }
-            }
-        }
-        Ok(())
-    });
-
-    // Write batches to the appropriate format
     let (bufs, file_metas) = match file_format {
         FileFormat::Parquet => {
-            write_downsampled_parquet(rx, &schema, bloom_filter_fields, metadata, &cfg).await?
+            write_downsampled_parquet(rx, schema, bloom_filter_fields, metadata, &cfg).await?
         }
         FileFormat::Vortex => {
             write_downsampled_vortex(rx, schema.clone(), cfg.compact.max_file_size as i64).await?
@@ -122,17 +69,11 @@ pub async fn merge_parquet_files_with_downsampling(
         .await
         .map_err(|e| DataFusionError::External(Box::new(e)))??;
 
-    log::debug!(
-        "merge_parquet_files_with_downsampling took {} ms",
-        start.elapsed().as_millis()
-    );
-
-    let files = bufs
+    Ok(bufs
         .into_iter()
         .zip(file_metas)
         .map(|(buf, meta)| MergedFile { buf, meta })
-        .collect();
-    Ok(MergeParquetResult { files, file_format })
+        .collect())
 }
 
 async fn write_downsampled_parquet(
@@ -284,7 +225,7 @@ async fn write_downsampled_vortex(
         .map_err(|e| DataFusionError::Execution(format!("Failed to write vortex file: {e}")))
 }
 
-fn generate_downsampling_sql(schema: &Arc<Schema>, rule: &DownsamplingRule) -> String {
+pub(super) fn generate_downsampling_sql(schema: &Schema, rule: &DownsamplingRule) -> String {
     let step = rule.step;
     let fields = schema
         .fields()

--- a/src/search/src/datafusion/merge/mod.rs
+++ b/src/search/src/datafusion/merge/mod.rs
@@ -17,12 +17,9 @@ use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use config::{
-    FileFormat, FileFormatConfig, TIMESTAMP_COL_NAME, get_config,
-    meta::stream::{FileMeta, StreamType},
-    utils::{
-        parquet::{VORTEX_FILE_META_KEY, encode_vortex_file_meta, new_parquet_writer},
-        util::is_trace_time_index_stream,
-    },
+    FileFormat, get_config,
+    meta::stream::FileMeta,
+    utils::parquet::{VORTEX_FILE_META_KEY, encode_vortex_file_meta, new_parquet_writer},
 };
 use datafusion::{
     arrow::datatypes::Schema,
@@ -54,11 +51,9 @@ use crate::datafusion::{
 
 #[cfg(feature = "enterprise")]
 pub mod downsampling;
-#[cfg(feature = "enterprise")]
-use {
-    crate::datafusion::merge::downsampling::merge_parquet_files_with_downsampling,
-    o2_enterprise::enterprise::common::downsampling::get_largest_downsampling_rule,
-};
+pub mod mode;
+
+pub use mode::{MergeMode, MergeOutput};
 
 /// One file written by [`merge_parquet_files`].
 pub struct MergedFile {
@@ -89,69 +84,92 @@ impl MergeParquetResult {
     }
 }
 
+/// Merge `tables` (the union of the input files) into one or more files
+/// according to `mode`, written as `output` says.
 pub async fn merge_parquet_files(
-    stream_type: StreamType,
-    stream_name: &str,
     schema: Arc<Schema>,
     tables: Vec<Arc<dyn TableProvider>>,
     bloom_filter_fields: &[String],
     mut metadata: FileMeta,
-    is_ingester: bool,
+    mode: &MergeMode,
+    output: MergeOutput,
 ) -> Result<MergeParquetResult> {
     let start = std::time::Instant::now();
-    let cfg = get_config();
+    let sql = mode.sql(&schema);
+    log::debug!("merge_parquet_files [{mode}] sql: {sql}");
+    let (schema, mut rx, read_task) =
+        run_merge_query(&sql, mode.input_sort_order(), schema, tables).await?;
 
-    let file_format = merge_output_file_format(stream_type, is_ingester, cfg.common.file_format);
-
-    #[cfg(feature = "enterprise")]
-    if stream_type == StreamType::Metrics && !is_ingester {
-        let rule = get_largest_downsampling_rule(stream_name, metadata.max_ts);
-        if let Some(rule) = rule {
-            log::info!(
-                "merge_parquet_files: stream_type={stream_type}, stream_name={stream_name}, downsampling rule={rule:?}"
-            );
-            return merge_parquet_files_with_downsampling(
-                schema,
-                tables,
+    let files = match mode {
+        #[cfg(feature = "enterprise")]
+        MergeMode::Downsampling(_) => {
+            downsampling::write_files(
+                &schema,
                 bloom_filter_fields,
-                rule,
                 &metadata,
-                file_format,
+                output.file_format,
+                rx,
+                read_task,
             )
-            .await;
+            .await?
         }
-    }
-
-    // get all sorted data
-    let sql = if stream_type == StreamType::Metadata && is_trace_time_index_stream(stream_name) {
-        // Files whose records all had a null session_id were persisted without the
-        // column (all-null columns are pruned), so only select it when present.
-        let session_id_col = if schema.column_with_name("session_id").is_some() {
-            ", MAX(session_id) AS session_id"
-        } else {
-            ""
-        };
-        format!(
-            "SELECT MIN({TIMESTAMP_COL_NAME}) AS {TIMESTAMP_COL_NAME}, trace_id{session_id_col}, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts FROM tbl GROUP BY trace_id ORDER BY {TIMESTAMP_COL_NAME} DESC"
-        )
-    } else if stream_type == StreamType::Filelist {
-        // for file list we do not have timestamp, so we instead sort by min ts of entries
-        "SELECT * FROM tbl ORDER BY min_ts DESC".to_string()
-    } else {
-        format!("SELECT * FROM tbl ORDER BY {TIMESTAMP_COL_NAME} DESC")
+        _ => {
+            let buf = match output.file_format {
+                FileFormat::Parquet => {
+                    write_parquet(
+                        &schema,
+                        bloom_filter_fields,
+                        &metadata,
+                        output.parquet_compression,
+                        &mut rx,
+                        read_task,
+                    )
+                    .await?
+                }
+                FileFormat::Vortex => write_vortex(schema, &metadata, rx, read_task).await?,
+            };
+            metadata.compressed_size = buf.len() as i64;
+            vec![MergedFile {
+                buf,
+                meta: metadata,
+            }]
+        }
     };
-    log::debug!("merge_parquet_files sql: {sql}");
 
+    log::debug!(
+        "merge_parquet_files [{mode}] wrote {} file(s) in {} ms",
+        files.len(),
+        start.elapsed().as_millis()
+    );
+    Ok(MergeParquetResult {
+        files,
+        file_format: output.file_format,
+    })
+}
+
+/// Plan and start `sql` over the union of `tables`; the record batches arrive
+/// on the returned channel, the task reports the stream's completion / error.
+async fn run_merge_query(
+    sql: &str,
+    input_sort_order: FileSortOrder,
+    schema: Arc<Schema>,
+    tables: Vec<Arc<dyn TableProvider>>,
+) -> Result<(
+    Arc<Schema>,
+    tokio::sync::mpsc::Receiver<RecordBatch>,
+    tokio::task::JoinHandle<Result<()>>,
+)> {
+    let cfg = get_config();
     let ctx = DataFusionContextBuilder::new()
         .trace_id("merge_parquet_files")
-        .sort_order(FileSortOrder::TimestampDesc)
-        .build(get_config().limit.datafusion_min_partition_num)
+        .sort_order(input_sort_order)
+        .build(cfg.limit.datafusion_min_partition_num)
         .await?;
     // register union table
-    let union_table = Arc::new(NewUnionTable::new(schema.clone(), tables));
+    let union_table = Arc::new(NewUnionTable::new(schema, tables));
     ctx.register_table("tbl", union_table)?;
 
-    let plan = ctx.state().create_logical_plan(&sql).await?;
+    let plan = ctx.state().create_logical_plan(sql).await?;
     let physical_plan = ctx.state().create_physical_plan(&plan).await?;
     let schema = physical_plan.schema();
 
@@ -167,7 +185,7 @@ pub async fn merge_parquet_files(
     }
 
     let mut batch_stream = execute_stream(physical_plan, ctx.task_ctx())?;
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<RecordBatch>(2);
+    let (tx, rx) = tokio::sync::mpsc::channel::<RecordBatch>(2);
     let read_task = tokio::task::spawn(async move {
         loop {
             match batch_stream.try_next().await {
@@ -188,65 +206,18 @@ pub async fn merge_parquet_files(
         }
         Ok(())
     });
-
-    let buf = match file_format {
-        FileFormat::Parquet => {
-            write_parquet(
-                &schema,
-                bloom_filter_fields,
-                &metadata,
-                is_ingester,
-                &mut rx,
-                read_task,
-            )
-            .await?
-        }
-        FileFormat::Vortex => write_vortex(schema, &metadata, rx, read_task).await?,
-    };
-
-    log::debug!(
-        "merge_parquet_files took {} ms",
-        start.elapsed().as_millis()
-    );
-
-    metadata.compressed_size = buf.len() as i64;
-    Ok(MergeParquetResult {
-        files: vec![MergedFile {
-            buf,
-            meta: metadata,
-        }],
-        file_format,
-    })
-}
-
-fn merge_output_file_format(
-    stream_type: StreamType,
-    is_ingester: bool,
-    configured: FileFormatConfig,
-) -> FileFormat {
-    let configured = configured.for_stream(stream_type);
-    if is_ingester {
-        FileFormat::for_ingester_stream(stream_type, configured)
-    } else {
-        configured
-    }
+    Ok((schema, rx, read_task))
 }
 
 async fn write_parquet(
     schema: &Arc<Schema>,
     bloom_filter_fields: &[String],
     metadata: &FileMeta,
-    is_ingester: bool,
+    compression: Option<&str>,
     rx: &mut tokio::sync::mpsc::Receiver<RecordBatch>,
     read_task: tokio::task::JoinHandle<Result<()>>,
 ) -> Result<Vec<u8>> {
-    let cfg = get_config();
     let mut buf = Vec::new();
-    let compression = if is_ingester && cfg.common.feature_ingester_none_compression {
-        Some("none")
-    } else {
-        None
-    };
     let mut writer = new_parquet_writer(
         &mut buf,
         schema,
@@ -348,6 +319,7 @@ mod tests {
     use arrow::array::{Array, Int64Array, StringArray};
     use arrow_schema::{DataType, Field, Schema};
     use bytes::Bytes;
+    use config::{TIMESTAMP_COL_NAME, meta::stream::StreamType};
     use datafusion::datasource::MemTable;
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use vortex::file::OpenOptionsSessionExt;
@@ -362,35 +334,6 @@ mod tests {
         ]))
     }
 
-    #[test]
-    fn test_merge_output_file_format_uses_parquet_for_ingester_metrics() {
-        let configured = "parquet,metrics=vortex"
-            .parse::<FileFormatConfig>()
-            .unwrap();
-        assert_eq!(
-            merge_output_file_format(StreamType::Metrics, true, configured),
-            FileFormat::Parquet
-        );
-        assert_eq!(
-            merge_output_file_format(StreamType::Logs, true, configured),
-            FileFormat::Parquet
-        );
-        assert_eq!(
-            merge_output_file_format(StreamType::Metrics, false, configured),
-            FileFormat::Vortex
-        );
-        assert_eq!(
-            merge_output_file_format(StreamType::Traces, false, configured),
-            FileFormat::Parquet
-        );
-
-        let configured = FileFormatConfig::new(FileFormat::Vortex);
-        assert_eq!(
-            merge_output_file_format(StreamType::Logs, true, configured),
-            FileFormat::Vortex
-        );
-    }
-
     #[tokio::test]
     async fn test_merge_parquet_files_error_handling() {
         // Test with empty tables vector
@@ -399,13 +342,12 @@ mod tests {
         let metadata = FileMeta::default();
 
         let result = merge_parquet_files(
-            StreamType::Logs,
-            "test_stream",
             schema,
             empty_tables,
             &[],
             metadata,
-            false,
+            &MergeMode::Classic,
+            MergeOutput::for_compactor(StreamType::Logs),
         )
         .await;
 
@@ -436,9 +378,9 @@ mod tests {
         .unwrap();
         let table = Arc::new(MemTable::try_new(schema.clone(), vec![vec![batch]]).unwrap());
 
+        let mode = MergeMode::for_ingester(StreamType::Metadata, "trace_time_index_test");
+        assert!(matches!(mode, MergeMode::TraceTimeIndex));
         let merged = merge_parquet_files(
-            StreamType::Metadata,
-            "trace_time_index_test",
             schema,
             vec![table],
             &[],
@@ -448,7 +390,8 @@ mod tests {
                 records: 4,
                 ..Default::default()
             },
-            true,
+            &mode,
+            MergeOutput::for_ingester(StreamType::Metadata),
         )
         .await
         .unwrap();

--- a/src/search/src/datafusion/merge/mode.rs
+++ b/src/search/src/datafusion/merge/mode.rs
@@ -1,0 +1,267 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! What a merge produces.
+//!
+//! The kind of merge (plain time-ordered file, trace time-index aggregation,
+//! file-list ordering, metrics downsampling) used to be re-derived at every
+//! layer — batching in the compactor, `merge_files`, and again inside
+//! `merge_parquet_files` — from stream type, stream name, config and the batch
+//! time range. [`MergeMode`] is decided once by the caller and passed down;
+//! every layer only asks it questions.
+
+use std::fmt;
+
+use arrow_schema::Schema;
+#[cfg(feature = "enterprise")]
+use config::meta::promql::DownsamplingRule;
+use config::{
+    FileFormat, FileFormatConfig, TIMESTAMP_COL_NAME, get_config, meta::stream::StreamType,
+    utils::util::is_trace_time_index_stream,
+};
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::common::downsampling::get_largest_downsampling_rule;
+
+use crate::datafusion::sort_order::FileSortOrder;
+
+/// The kind of merge, decided once per batch.
+#[derive(Debug, Clone)]
+pub enum MergeMode {
+    /// `SELECT * FROM tbl ORDER BY _timestamp DESC` into one file: logs,
+    /// traces, plain metrics — the ingester and the compactor default.
+    Classic,
+    /// The trace time-index metadata stream: one row per `trace_id`
+    /// (`MIN(_timestamp)`, `MIN(min_ts)`, `MAX(max_ts)`, …), one file.
+    TraceTimeIndex,
+    /// The file-list stream has no `_timestamp`; order by `min_ts DESC`.
+    FileList,
+    /// Metrics downsampling (enterprise): aggregate every series by the rule's
+    /// step, size-split output files. The whole batch is one merge.
+    #[cfg(feature = "enterprise")]
+    Downsampling(DownsamplingRule),
+}
+
+impl MergeMode {
+    /// Mode for a compactor batch of `stream_name` files whose newest sample
+    /// is `max_ts` (metrics downsampling rules select by time).
+    pub fn for_compactor(stream_type: StreamType, stream_name: &str, max_ts: i64) -> Self {
+        #[cfg(feature = "enterprise")]
+        if stream_type == StreamType::Metrics
+            && let Some(rule) = get_largest_downsampling_rule(stream_name, max_ts)
+        {
+            return Self::Downsampling(rule.clone());
+        }
+        #[cfg(not(feature = "enterprise"))]
+        let _ = max_ts;
+        Self::for_stream(stream_type, stream_name)
+    }
+
+    /// Mode for the ingester movers: never downsamples.
+    pub fn for_ingester(stream_type: StreamType, stream_name: &str) -> Self {
+        Self::for_stream(stream_type, stream_name)
+    }
+
+    fn for_stream(stream_type: StreamType, stream_name: &str) -> Self {
+        match stream_type {
+            StreamType::Metadata if is_trace_time_index_stream(stream_name) => Self::TraceTimeIndex,
+            StreamType::Filelist => Self::FileList,
+            _ => Self::Classic,
+        }
+    }
+
+    /// True when the batch must be merged as a whole regardless of
+    /// `ZO_COMPACT_MAX_FILE_SIZE` (the writer splits the output itself).
+    pub fn merges_whole_batch(&self) -> bool {
+        match self {
+            #[cfg(feature = "enterprise")]
+            Self::Downsampling(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Physical order of the input files the merge query may rely on.
+    pub fn input_sort_order(&self) -> FileSortOrder {
+        FileSortOrder::TimestampDesc
+    }
+
+    /// The merge query over the union table `tbl`.
+    pub(super) fn sql(&self, schema: &Schema) -> String {
+        match self {
+            Self::Classic => format!("SELECT * FROM tbl ORDER BY {TIMESTAMP_COL_NAME} DESC"),
+            Self::TraceTimeIndex => {
+                // Files whose records all had a null session_id were persisted
+                // without the column (all-null columns are pruned), so only
+                // select it when present.
+                let session_id_col = if schema.column_with_name("session_id").is_some() {
+                    ", MAX(session_id) AS session_id"
+                } else {
+                    ""
+                };
+                format!(
+                    "SELECT MIN({TIMESTAMP_COL_NAME}) AS {TIMESTAMP_COL_NAME}, trace_id{session_id_col}, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts FROM tbl GROUP BY trace_id ORDER BY {TIMESTAMP_COL_NAME} DESC"
+                )
+            }
+            Self::FileList => "SELECT * FROM tbl ORDER BY min_ts DESC".to_string(),
+            #[cfg(feature = "enterprise")]
+            Self::Downsampling(rule) => {
+                super::downsampling::generate_downsampling_sql(schema, rule)
+            }
+        }
+    }
+}
+
+impl fmt::Display for MergeMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Classic => write!(f, "classic"),
+            Self::TraceTimeIndex => write!(f, "trace_time_index"),
+            Self::FileList => write!(f, "file_list"),
+            #[cfg(feature = "enterprise")]
+            Self::Downsampling(rule) => write!(f, "downsampling(step={}s)", rule.step),
+        }
+    }
+}
+
+/// Where the merged file goes: file format and Parquet compression depend on
+/// whether the ingester or the compactor is writing.
+#[derive(Debug, Clone, Copy)]
+pub struct MergeOutput {
+    pub file_format: FileFormat,
+    /// Parquet compression override (`None` = configured default).
+    pub parquet_compression: Option<&'static str>,
+}
+
+impl MergeOutput {
+    /// Ingester movers: metrics always stay Parquet, optional no-compression.
+    pub fn for_ingester(stream_type: StreamType) -> Self {
+        let cfg = get_config();
+        Self {
+            file_format: output_file_format(stream_type, true, cfg.common.file_format),
+            parquet_compression: cfg
+                .common
+                .feature_ingester_none_compression
+                .then_some("none"),
+        }
+    }
+
+    /// Compactor: the configured format for the stream.
+    pub fn for_compactor(stream_type: StreamType) -> Self {
+        Self {
+            file_format: output_file_format(stream_type, false, get_config().common.file_format),
+            parquet_compression: None,
+        }
+    }
+}
+
+fn output_file_format(
+    stream_type: StreamType,
+    is_ingester: bool,
+    configured: FileFormatConfig,
+) -> FileFormat {
+    let configured = configured.for_stream(stream_type);
+    if is_ingester {
+        FileFormat::for_ingester_stream(stream_type, configured)
+    } else {
+        configured
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_schema::{DataType, Field};
+
+    use super::*;
+
+    #[test]
+    fn mode_by_stream() {
+        assert!(matches!(
+            MergeMode::for_ingester(StreamType::Logs, "app"),
+            MergeMode::Classic
+        ));
+        assert!(matches!(
+            MergeMode::for_compactor(StreamType::Traces, "app", 0),
+            MergeMode::Classic
+        ));
+        assert!(matches!(
+            MergeMode::for_compactor(StreamType::Filelist, "x", 0),
+            MergeMode::FileList
+        ));
+        assert!(!MergeMode::Classic.merges_whole_batch());
+        assert_eq!(
+            MergeMode::Classic.input_sort_order(),
+            FileSortOrder::TimestampDesc
+        );
+    }
+
+    #[test]
+    fn output_file_format_uses_parquet_for_ingester_metrics() {
+        let configured = "parquet,metrics=vortex"
+            .parse::<FileFormatConfig>()
+            .unwrap();
+        assert_eq!(
+            output_file_format(StreamType::Metrics, true, configured),
+            FileFormat::Parquet
+        );
+        assert_eq!(
+            output_file_format(StreamType::Logs, true, configured),
+            FileFormat::Parquet
+        );
+        assert_eq!(
+            output_file_format(StreamType::Metrics, false, configured),
+            FileFormat::Vortex
+        );
+        assert_eq!(
+            output_file_format(StreamType::Traces, false, configured),
+            FileFormat::Parquet
+        );
+
+        let configured = FileFormatConfig::new(FileFormat::Vortex);
+        assert_eq!(
+            output_file_format(StreamType::Logs, true, configured),
+            FileFormat::Vortex
+        );
+    }
+
+    #[test]
+    fn sql_by_mode() {
+        let with_session = Schema::new(vec![
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new("trace_id", DataType::Utf8, false),
+            Field::new("session_id", DataType::Utf8, true),
+        ]);
+        let without_session = Schema::new(vec![
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new("trace_id", DataType::Utf8, false),
+        ]);
+        assert_eq!(
+            MergeMode::Classic.sql(&without_session),
+            "SELECT * FROM tbl ORDER BY _timestamp DESC"
+        );
+        assert_eq!(
+            MergeMode::FileList.sql(&without_session),
+            "SELECT * FROM tbl ORDER BY min_ts DESC"
+        );
+        assert!(
+            MergeMode::TraceTimeIndex
+                .sql(&with_session)
+                .contains("MAX(session_id) AS session_id")
+        );
+        assert!(
+            !MergeMode::TraceTimeIndex
+                .sql(&without_session)
+                .contains("session_id")
+        );
+    }
+}

--- a/src/search/src/datafusion/merge/mode.rs
+++ b/src/search/src/datafusion/merge/mode.rs
@@ -48,23 +48,33 @@ pub enum MergeMode {
     /// The file-list stream has no `_timestamp`; order by `min_ts DESC`.
     FileList,
     /// Metrics downsampling (enterprise): aggregate every series by the rule's
-    /// step, size-split output files. The whole batch is one merge.
+    /// step, size-split output files. Only for a closed hour, which is merged
+    /// as a whole.
     #[cfg(feature = "enterprise")]
     Downsampling(DownsamplingRule),
 }
 
 impl MergeMode {
-    /// Mode for a compactor batch of `stream_name` files whose newest sample
-    /// is `max_ts` (metrics downsampling rules select by time).
-    pub fn for_compactor(stream_type: StreamType, stream_name: &str, max_ts: i64) -> Self {
+    /// Mode for the compactor's merge of one `stream_name` hour (or day) that
+    /// ends at `max_ts`. `finalize` is true once that hour is closed; only then
+    /// may the whole hour be rewritten (metrics downsampling, whose rules
+    /// select by how old `max_ts` is). Incremental merges of the still-open
+    /// hour always use the plain per-stream mode.
+    pub fn for_compactor(
+        stream_type: StreamType,
+        stream_name: &str,
+        max_ts: i64,
+        finalize: bool,
+    ) -> Self {
         #[cfg(feature = "enterprise")]
-        if stream_type == StreamType::Metrics
+        if finalize
+            && stream_type == StreamType::Metrics
             && let Some(rule) = get_largest_downsampling_rule(stream_name, max_ts)
         {
             return Self::Downsampling(rule.clone());
         }
         #[cfg(not(feature = "enterprise"))]
-        let _ = max_ts;
+        let _ = (max_ts, finalize);
         Self::for_stream(stream_type, stream_name)
     }
 
@@ -81,8 +91,9 @@ impl MergeMode {
         }
     }
 
-    /// True when the batch must be merged as a whole regardless of
-    /// `ZO_COMPACT_MAX_FILE_SIZE` (the writer splits the output itself).
+    /// True when the whole hour must be merged as one batch — every file of
+    /// the hour, including ones already above the size target, and regardless
+    /// of `ZO_COMPACT_MAX_FILE_SIZE` (the writer splits the output itself).
     pub fn merges_whole_batch(&self) -> bool {
         match self {
             #[cfg(feature = "enterprise")]
@@ -191,11 +202,11 @@ mod tests {
             MergeMode::Classic
         ));
         assert!(matches!(
-            MergeMode::for_compactor(StreamType::Traces, "app", 0),
+            MergeMode::for_compactor(StreamType::Traces, "app", 0, true),
             MergeMode::Classic
         ));
         assert!(matches!(
-            MergeMode::for_compactor(StreamType::Filelist, "x", 0),
+            MergeMode::for_compactor(StreamType::Filelist, "x", 0, false),
             MergeMode::FileList
         ));
         assert!(!MergeMode::Classic.merges_whole_batch());

--- a/src/search/src/datafusion/storage/file_list.rs
+++ b/src/search/src/datafusion/storage/file_list.rs
@@ -104,8 +104,15 @@ pub fn clear(trace_id: &str) {
     drop(w);
 }
 
+/// Look up the selection registered by [`set`] for an object location of the
+/// form `{trace_key}/$$/[{account}/::/]{file.key}`.
 pub fn get_scan_selection(file_key: &str) -> Option<ScanSelection> {
     let (trace_id, filename) = file_key.split_once("/$$/")?;
+    // `set` keys selections by the bare `file.key`; strip the account prefix
+    // it inserts into the object location for multi-account storage
+    let filename = filename
+        .split_once("/::/")
+        .map_or(filename, |(_, filename)| filename);
     let r = SCAN_SELECTIONS.read();
     let data = r.get(trace_id)?;
     data.get(filename).cloned()
@@ -137,5 +144,42 @@ mod tests {
     fn test_get_scan_selection_no_separator_returns_none() {
         let result = get_scan_selection("no-separator-here");
         assert!(result.is_none());
+    }
+
+    /// The selection must be found through the object location `set` builds,
+    /// both without and with a storage account prefix.
+    #[tokio::test]
+    async fn test_get_scan_selection_round_trip_with_account() {
+        let trace_id = "trace_scan_selection_round_trip";
+        let mut plain = FileKey::from_file_name("files/org/logs/s/2024/01/01/00/plain.parquet");
+        plain.with_selection(
+            FileSelection::RowGroups(std::sync::Arc::new(vec![1])),
+            Some(1024),
+        );
+        let mut multi = FileKey::from_file_name("files/org/logs/s/2024/01/01/00/multi.parquet");
+        multi.account = "acct".to_string();
+        multi.with_selection(
+            FileSelection::RowGroups(std::sync::Arc::new(vec![2])),
+            Some(2048),
+        );
+        set(trace_id, "schema", "parquet", vec![plain, multi]).await;
+
+        let locations: Vec<String> = get(&format!("{trace_id}/schema=schema/format=parquet"))
+            .unwrap()
+            .into_iter()
+            .map(|m| m.location.to_string())
+            .collect();
+        assert_eq!(locations.len(), 2);
+        for location in &locations {
+            let selection = get_scan_selection(location)
+                .unwrap_or_else(|| panic!("no selection for {location}"));
+            if location.contains("/acct/::/") {
+                assert_eq!(selection.row_group_size, Some(2048));
+            } else {
+                assert!(!location.contains("::"));
+                assert_eq!(selection.row_group_size, Some(1024));
+            }
+        }
+        clear(trace_id);
     }
 }

--- a/src/search_service/src/file_list.rs
+++ b/src/search_service/src/file_list.rs
@@ -71,12 +71,14 @@ pub async fn query_for_merge(
     stream_name: &str,
     date_start: &str,
     date_end: &str,
+    max_original_size: i64,
 ) -> Result<Vec<FileKey>> {
     infra_file_list::query_for_merge(
         org_id,
         stream_type,
         stream_name,
         (date_start.to_string(), date_end.to_string()),
+        max_original_size,
     )
     .await
 }


### PR DESCRIPTION
## Why

The kind of merge — plain time-ordered file, trace time-index aggregation, file-list ordering, enterprise metrics downsampling — was re-derived at every layer, each from stream type / stream name / config / batch time range:

- compactor scheduler (`merge_by_stream`): `skip_group_files` (downsampling rule lookup #1) → whole-hour batch vs size groups
- `merge_files`: `is_match_downsampling_rule` (lookup #2) → early returns, size-limit bypass
- `merge_parquet_files`: lookup #3 + SQL selection by stream type, with `is_ingester: bool` standing in for the writer's role

`merge_parquet_files` and `merge_parquet_files_with_downsampling` also carried two copies of the DataFusion context / union table / plan / execute-stream / channel / read-task plumbing. Reading the code meant reconciling three derivations of the same fact to know what a batch would produce.

## What

- **`search::datafusion::merge::mode::MergeMode { Classic, TraceTimeIndex, FileList, Downsampling(rule) }`** — decided once: `MergeMode::for_compactor(stream_type, stream_name, max_ts)` by the scheduler (carried in `MergeBatch.mode`), `MergeMode::for_ingester(stream_type, stream_name)` by the movers. Every layer only asks it questions: `merges_whole_batch()`, `input_sort_order()`, `sql(schema)`.
- **`MergeOutput { file_format, parquet_compression }`** (`for_ingester` / `for_compactor`) replaces the `is_ingester` bool.
- **`merge_parquet_files(schema, tables, bloom, meta, &mode, output)`**: one `run_merge_query()` pipeline for every mode, then the mode's writer. Downsampling is a `MergeMode` arm calling `downsampling::write_files` instead of an early-return second implementation (`merge_parquet_files_with_downsampling` removed, −81 lines).
- Compactor: `skip_group_files` / `is_match_downsampling_rule` and their `cfg(enterprise)` twin declarations are gone; `compaction` no longer imports `get_largest_downsampling_rule`.

Commit 1 (`672ab315a1`) is pure refactor, no behavior change.

## Behavior change (commit 2, `8030eefd04`): whole-hour merges only for a closed hour, over every file of the hour

Metrics downsampling used to merge the whole batch whenever the rule matched the batch's newest sample — including incremental rounds on the still-open hour — and it only ever saw the files below the 95%-of-`ZO_COMPACT_MAX_FILE_SIZE` bound of `query_for_merge`: files already above the bound were never downsampled, and small outputs were re-aggregated round after round.

- `MergeMode::for_compactor(stream_type, stream_name, range_end_ts, finalize)` is decided **once per hour, before the file_list query**, from the end of the job's date range; a whole-hour mode (downsampling) is only chosen when `finalize` (the hour is closed). Incremental merges of a matching hour use the plain per-stream mode and leave the aggregation to the hour-end pass.
- `query_for_merge` takes the `original_size` bound from the caller (`infra::file_list::merge_max_original_size()` = the classic 95% rule); a whole-hour merge asks for **every** file of the hour (`i64::MAX`), the same input range the TSID-major hour-end merge in #13839 uses.
- Rule matching uses the hour's end instead of the batch's max `max_ts` (≤ 1h difference; the hour is decided as a unit).

## Guards (commit 3, cherry-picked from #13839)

- compactor: fail the merge instead of deleting the sources when `merge_parquet_files` produced no files
- search storage `file_list::get_scan_selection` strips the multi-account `{account}/::/` prefix so selections registered by `set` are found again (+ round-trip test)
- `deleted.rs`: `delete_from_storage` takes the file slice and a key closure (`Cow`) instead of a pre-collected `Vec`

## Not in this PR

The write stage still dispatches to four writers (`write_parquet`, `write_vortex`, `write_downsampled_parquet`, `write_downsampled_vortex`) that share the open / write / rotate / close skeleton and differ only in the rotation policy and how `FileMeta` is derived. Unifying them into one rotating writer is a follow-up (needs a decision on deriving `min_ts/max_ts` from the output batches for the classic path too).

## Validation

- `cargo fmt --check`; `cargo clippy -p search -p compaction -p openobserve-jobs --tests` clean
- `cargo test -p search --lib -- merge::` 6 passed (new: `mode_by_stream`, `sql_by_mode`, `output_file_format_uses_parquet_for_ingester_metrics`; trace-time-index merge test now goes through `MergeMode::for_ingester` and asserts `TraceTimeIndex`)
- `cargo test -p compaction --lib -- merge` 30 passed; `cargo test -p infra --lib -- file_list` 49 passed
- `downsampling.rs` is enterprise-only and not compilable locally; `write_files` / `pub(super) generate_downsampling_sql` were edited by hand and need the enterprise CI.

