### PR TITLE
fix(deps): add missing @noble/hashes@2.3.0 to web lockfile (npm 10 npm ci)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11632,6 +11632,21 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/jsdom/node_modules/entities": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",


### PR DESCRIPTION
## Problem

Every frontend build is red on `npm ci` in `web/`:

```
npm error `npm ci` can only install packages when your package.json and
          package-lock.json ... are in sync.
npm error Missing: @noble/hashes@2.3.0 from lock file
```

## Root cause (not a feature change)

- `web/package-lock.json` was last regenerated with **npm 11**, whose resolver **omits** the explicit `@noble/hashes@2.3.0` entry that `jsdom`'s transitive `@exodus/bytes@1.15.1` **peer-requires** (`^1.8.0 || ^2.0.0`).
- The **Playwright build pins `node-version: 22` → npm 10** (`.github/workflows/playwright.yml`). npm 10's `npm ci` recomputes the ideal tree, needs that entry, finds it missing, and hard-fails.
- Reproduced locally: `npm@10 ci` **fails**, `npm@11 ci` **passes**, on the exact committed lock. So it's a **toolchain mismatch**, independent of any PR — it breaks `main` and every open PR building the frontend.

## Fix

Regenerated the lock with `npm@10 install --package-lock-only` → adds the nested `node_modules/jsdom/node_modules/@noble/hashes@2.3.0` entry. **+15 lines, lockfile only**, `lockfileVersion` unchanged (3).

Verified `npm ci` now passes under **both npm 10 and npm 11**.

## Note

The durable fix is aligning the Playwright build to **Node 24 / npm 11** (matching the AI-review workflow and the Node 20/22 runner deprecation). This PR is the minimal unblock; the Node bump can follow separately.