### PR TITLE
fix: always create file_list_dump_stats table

### DIFF
--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -2797,11 +2797,8 @@ async fn apply_column_width_compat(pool: &sqlx::Pool<Postgres>) -> Result<()> {
 async fn handle_partitioned_tables(pool: &sqlx::Pool<Postgres>) -> Result<()> {
     let cfg = get_config();
 
-    // Handle file_list, file_list_history, and (only when enabled) file_list_dump_stats
-    let mut tables = vec!["file_list", "file_list_history"];
-    if cfg.compact.file_list_dump_enabled {
-        tables.push("file_list_dump_stats");
-    }
+    // Handle file_list, file_list_history, and file_list_dump_stats
+    let tables = vec!["file_list", "file_list_history", "file_list_dump_stats"];
     for table in &tables {
         let relkind = get_table_relkind(pool, table).await?;
         match relkind.as_deref() {


### PR DESCRIPTION
Currently observed on v0.92.x , when file list dump is not enabled we do not create the dump stats table, but for some reason compactor tries to use the table and fails. Apart from this, even in the case when someone has not initially setup the dump enabled, and later enables it, the table will be missing as migration will not be run if db schema version matches.

We should always create all the table schemas, as plain schema and indices will not take much db resources, but would be problematic to later debug and fix if missing. Thus this pr always created the file_list_dump_stats table irrespective of the env value.