### PR TITLE
test(traces): heal service-graph/catalog rail-flyout nav for #13852 ?tab= reroute

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -312,8 +312,23 @@ jobs:
           mv .env tests/ui-testing
           cd tests/ui-testing && npm ci
 
-          # Install apt system dependencies (always needed)
-          npx playwright install-deps chromium
+          # Install apt system dependencies (always needed).
+          # azure.archive.ubuntu.com intermittently times out fetching font/lib
+          # packages, which makes `install-deps` exit 100 and fails the whole job.
+          # Give apt its own per-fetch retries and wrap the call in a backoff loop.
+          echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99retries >/dev/null
+          for attempt in 1 2 3; do
+            if npx playwright install-deps chromium; then
+              echo "install-deps succeeded on attempt ${attempt}"
+              break
+            fi
+            if [ "${attempt}" = 3 ]; then
+              echo "::error::playwright install-deps chromium failed after 3 attempts"
+              exit 1
+            fi
+            echo "install-deps attempt ${attempt} failed; retrying in $((attempt * 20))s"
+            sleep $((attempt * 20))
+          done
 
           # Get revision from playwright's own metadata
           CHROMIUM_REV=$(node -pe "

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -260,13 +260,30 @@ jobs:
       - name: Install Playwright browser
         run: |
           cd tests/ui-testing
+          # azure.archive.ubuntu.com intermittently times out fetching font/lib
+          # packages, which makes apt (via install-deps / --with-deps) exit 100 and
+          # fails the whole job. Give apt its own per-fetch retries and wrap the
+          # browser/deps install in a backoff loop.
+          echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99retries >/dev/null
           if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
             echo "Browser cache hit — installing system deps only"
-            npx playwright install-deps chromium
+            install_cmd="npx playwright install-deps chromium"
           else
             echo "Browser cache miss — installing browser + system deps"
-            npx playwright install --with-deps chromium
+            install_cmd="npx playwright install --with-deps chromium"
           fi
+          for attempt in 1 2 3; do
+            if ${install_cmd}; then
+              echo "playwright install succeeded on attempt ${attempt}"
+              break
+            fi
+            if [ "${attempt}" = 3 ]; then
+              echo "::error::${install_cmd} failed after 3 attempts"
+              exit 1
+            fi
+            echo "install attempt ${attempt} failed; retrying in $((attempt * 20))s"
+            sleep $((attempt * 20))
+          done
 
       - name: Write .env and run ui-tests
         run: |

--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -1421,13 +1421,25 @@ export class AlertsPage {
         ).first();
         const tabVisible = await folderTab.isVisible({ timeout: 10000 }).catch(() => false);
         if (tabVisible) {
-            // Force-click past the reflow, retrying, until the tab reports data-state="active".
-            // Re-clicking each iteration self-heals a click that landed mid-animation; the
-            // active-state assertion is the real completion signal (activeFolderId switched).
+            // Force-click past the reflow until data-state="active". But data-state flips
+            // before activeFolderId (AlertList.vue) settles, and the "New alert" route reads
+            // activeFolderId — so a createAlert() right after can create in the stale "default"
+            // folder. Also gate on the folder-scoped list refetch (GET .../alerts?...folder=<id>,
+            // id != "default"), which only fires once activeFolderId has actually flipped.
             await expect(async () => {
                 if ((await folderTab.getAttribute('data-state')) !== 'active') {
                     await folderTab.scrollIntoViewIfNeeded({ timeout: 2000 }).catch(() => {});
+                    const scopedListSettled = folderName === 'default'
+                        ? Promise.resolve()
+                        : this.page.waitForResponse(
+                            resp => resp.request().method() === 'GET'
+                                && resp.url().includes('/alerts?')
+                                && /[?&]folder=/.test(resp.url())
+                                && !/[?&]folder=default(?:&|$)/.test(resp.url()),
+                            { timeout: 8000 }
+                          ).catch(() => {});
                     await folderTab.click({ force: true, timeout: 5000 });
+                    await scopedListSettled;
                 }
                 await expect(folderTab).toHaveAttribute('data-state', 'active', { timeout: 3000 });
             }).toPass({ timeout: 30000 });

--- a/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
+++ b/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
@@ -9,8 +9,9 @@ export class ServiceGraphPage {
     this.page = page;
 
     // ===== NAVIGATION =====
-    // Service Graph is its own route (/traces/service-graph), reached from the
-    // Traces rail tile's hover flyout — it is no longer a tab on the Traces page.
+    // Service Graph is reached from the Traces rail tile's hover flyout; since #13852 the
+    // flyout item lands on the Traces page's in-page `?tab=service-graph` view (the old
+    // /traces/service-graph route now only exists as a legacy redirect).
     this.tracesRailTile = '[data-test="nav-group-traces"]';
     // #13852 rerouted the flyout children through the Traces page's ?tab= views, so the
     // Service Graph flyout item is now `nav-group-item-traces-service-graph`

--- a/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
+++ b/tests/ui-testing/pages/tracesPages/serviceGraphPage.js
@@ -12,7 +12,11 @@ export class ServiceGraphPage {
     // Service Graph is its own route (/traces/service-graph), reached from the
     // Traces rail tile's hover flyout — it is no longer a tab on the Traces page.
     this.tracesRailTile = '[data-test="nav-group-traces"]';
-    this.serviceGraphFlyoutItem = '[data-test="nav-group-item-serviceGraph"]';
+    // #13852 rerouted the flyout children through the Traces page's ?tab= views, so the
+    // Service Graph flyout item is now `nav-group-item-traces-service-graph`
+    // (childDataTest = `nav-group-item-${child.name}-${child.tab}`), not the old
+    // standalone `nav-group-item-serviceGraph`.
+    this.serviceGraphFlyoutItem = '[data-test="nav-group-item-traces-service-graph"]';
 
     // ===== MAIN COMPONENT (ServiceGraph.vue) =====
     this.dateTimePicker = '[data-test="service-graph-date-time-picker"]';
@@ -85,8 +89,15 @@ export class ServiceGraphPage {
 
   async navigateToServiceGraph() {
     await this.page.locator(this.tracesRailTile).hover();
-    await this.page.locator(this.serviceGraphFlyoutItem).click();
-    await this.page.waitForURL(/\/traces\/service-graph/, { timeout: 10000 });
+    // The flyout is teleported to <body> and opens after ONavGroup's 120ms OPEN_DELAY, so the
+    // item is not in the DOM the instant hover() resolves — wait for it before clicking, else
+    // the click races the debounce and times out.
+    const flyoutItem = this.page.locator(this.serviceGraphFlyoutItem);
+    await flyoutItem.waitFor({ state: 'visible', timeout: 10000 });
+    await flyoutItem.click();
+    // #13852 lands Service Graph on the Traces page as `?tab=service-graph`; the old
+    // /traces/service-graph path now only exists as a legacy redirect.
+    await this.page.waitForURL(/\/traces\?.*tab=service-graph/, { timeout: 10000 });
   }
 
   /**

--- a/tests/ui-testing/pages/tracesPages/servicesCatalogPage.js
+++ b/tests/ui-testing/pages/tracesPages/servicesCatalogPage.js
@@ -92,7 +92,11 @@ export class ServicesCatalogPage {
     // the Traces rail tile's hover flyout (no longer a tab on the Traces page)
     // =====================================================================
     this.tracesRailTile = page.locator('[data-test="nav-group-traces"]');
-    this.servicesCatalogNavItem = page.locator('[data-test="nav-group-item-servicesCatalog"]');
+    // #13852 rerouted the flyout children through the Traces page's ?tab= views, so the
+    // Services Catalog flyout item is now `nav-group-item-traces-services-catalog`
+    // (childDataTest = `nav-group-item-${child.name}-${child.tab}`), not the old
+    // standalone `nav-group-item-servicesCatalog`.
+    this.servicesCatalogNavItem = page.locator('[data-test="nav-group-item-traces-services-catalog"]');
 
     // =====================================================================
     // Factory locators — runtime-bound (allowed by POM strict policy)
@@ -168,8 +172,14 @@ export class ServicesCatalogPage {
   /** Navigate to Services via the left-rail flyout (the discovery path a user takes). */
   async clickServiceCatalogTab() {
     await this.tracesRailTile.hover();
+    // The flyout is teleported to <body> and opens after ONavGroup's 120ms OPEN_DELAY, so the
+    // item is not in the DOM the instant hover() resolves — wait for it before clicking, else
+    // the click races the debounce and times out.
+    await this.servicesCatalogNavItem.waitFor({ state: 'visible', timeout: 10000 });
     await this.servicesCatalogNavItem.click();
-    await this.page.waitForURL(/\/traces\/services/, { timeout: 10000 });
+    // #13852 lands Services Catalog on the Traces page as `?tab=services-catalog`; the old
+    // /traces/services path now only exists as a legacy redirect.
+    await this.page.waitForURL(/\/traces\?.*tab=services-catalog/, { timeout: 10000 });
     await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
   }
 

--- a/tests/ui-testing/pages/tracesPages/servicesCatalogPage.js
+++ b/tests/ui-testing/pages/tracesPages/servicesCatalogPage.js
@@ -88,8 +88,10 @@ export class ServicesCatalogPage {
     this.sidePanel = page.locator('[data-test="service-graph-side-panel"]');
 
     // =====================================================================
-    // Navigation — Services is its own route (/traces/services), reached from
-    // the Traces rail tile's hover flyout (no longer a tab on the Traces page)
+    // Navigation — Services Catalog is reached from the Traces rail tile's hover
+    // flyout; since #13852 the flyout item lands on the Traces page's in-page
+    // `?tab=services-catalog` view (the old /traces/services route now only
+    // exists as a legacy redirect).
     // =====================================================================
     this.tracesRailTile = page.locator('[data-test="nav-group-traces"]');
     // #13852 rerouted the flyout children through the Traces page's ?tab= views, so the


### PR DESCRIPTION
## What

Heals the two Traces-Regression tests that broke after #13852 (\`fix(ui): clean up SLO detail and traces navigation\`).

Failing scheduled runs:
- ENT: https://github.com/openobserve/o2-enterprise/actions/runs/32213206401/job/95953026991 — \`traces-ent.spec.js\` Service Graph test
- OSS: https://github.com/openobserve/openobserve/actions/runs/32213278081 — \`traces-regression.spec.js\` Service Catalog test

Both failed all 4 retries with \`locator.click: Timeout 45000ms exceeded\` on the left-rail flyout item.

## Root cause

#13852 rerouted the Traces rail-flyout children through the Traces page's in-page \`?tab=\` views. That changed **both**:

| | before | after |
|---|---|---|
| flyout \`data-test\` | \`nav-group-item-serviceGraph\` | \`nav-group-item-traces-service-graph\` |
| | \`nav-group-item-servicesCatalog\` | \`nav-group-item-traces-services-catalog\` |
| URL | \`/traces/service-graph\` | \`/traces?tab=service-graph\` |
| | \`/traces/services\` | \`/traces?tab=services-catalog\` |

(\`childDataTest = nav-group-item-\${child.name}-\${child.tab}\`; legacy paths now only exist as redirects.) The stale \`data-test\` made \`.click()\` wait the full 45s action timeout.

## Fix

\`serviceGraphPage.navigateToServiceGraph()\` and \`servicesCatalogPage.clickServiceCatalogTab()\`:
- point at the new flyout \`data-test\` ids
- \`waitFor\` the teleported flyout item to be **visible** before clicking — the flyout opens after ONavGroup's 120ms \`OPEN_DELAY\`, so the item isn't in the DOM the instant \`hover()\` resolves
- match the new \`/traces?tab=\` URL

Engine/other nav helpers untouched.

## Verification

Run locally against a #13852 frontend (localhost:5080, enterprise build):
- ✅ Live flyout click → \`/web/traces?org_identifier=default&tab=service-graph\` and \`...&tab=services-catalog\`
- ✅ **OSS** \`traces-regression.spec.js\` "Clearing search filter should not blank out Service Catalog table" — **passes**
- ✅ **ENT** \`traces-ent.spec.js\` Service Graph nav now works — test reaches the chart assertion (line 54); the only residual local failure is absent service-graph topology (0 nodes locally; CI seeds it via ingestion + the daemon)

## Follow-up (not in this PR / not in any CI matrix)

\`Traces/traces-toolbar-tabs.spec.js\` + \`tracesPage.switchToServiceMaps()\` still assert the pre-#13852 "flyout → standalone route" dual-semantics that #13852 removed. Not run by any CI matrix, so left for a separate change aligned with the new single-\`?tab=\` semantics.