### PR TITLE
fix: wait for WAL settle window before merging the previous hour

### DIFF
--- a/src/compaction/src/lib.rs
+++ b/src/compaction/src/lib.rs
@@ -448,40 +448,8 @@ pub async fn run_delay_deletion() -> Result<(), anyhow::Error> {
 }
 
 pub(crate) fn is_past_hour(offset: i64) -> bool {
-    is_past_hour_at(offset, now_micros())
-}
-
-fn is_past_hour_at(offset: i64, now: i64) -> bool {
-    // the hour of `offset` must have ended at least 3 * max_file_retention_time ago,
-    // so data still buffered in ingester WAL when the hour closed has landed:
-    // -- first period: the last hour local file upload to storage, write file list
-    // -- second period, the last hour file list upload to storage
-    // -- third period, we can do the merge, so, at least 3 times of
-    // max_file_retention_time
-    let offset_hour_end = offset - offset % hour_micros(1) + hour_micros(1);
+    let now = now_micros();
+    let hour = hour_micros(1);
+    let offset_hour_end = offset - offset % hour + hour;
     now - offset_hour_end > second_micros(get_config().limit.max_file_retention_time as i64) * 3
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_past_hour_at() {
-        let settle = second_micros(get_config().limit.max_file_retention_time as i64) * 3;
-        let hour = hour_micros(1);
-        let offset = 1_755_590_400_000_000; // 2025-08-19 08:00:00 UTC
-        let hour_end = offset + hour;
-
-        // right at the top of the next hour: not yet
-        assert!(!is_past_hour_at(offset, hour_end + 1));
-        // within the settle window after the hour ends: not yet
-        assert!(!is_past_hour_at(offset, hour_end + settle));
-        // past the settle window: ready
-        assert!(is_past_hour_at(offset, hour_end + settle + 1));
-        // mid-hour offsets are floored to their hour
-        assert!(is_past_hour_at(offset + hour / 2, hour_end + settle + 1));
-        // old hours are always ready
-        assert!(is_past_hour_at(offset - hour * 24, hour_end));
-    }
 }

--- a/src/compaction/src/lib.rs
+++ b/src/compaction/src/lib.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
+use chrono::{Datelike, Duration, TimeZone, Timelike, Utc};
 use config::{
     COMPACT_OLD_DATA_STREAM_SET,
     cluster::LOCAL_NODE,
@@ -22,6 +22,7 @@ use config::{
         cluster::{CompactionJobType, Role},
         stream::{PartitionTimeLevel, StreamType},
     },
+    utils::time::{hour_micros, now_micros, second_micros},
 };
 use infra::{
     cluster::get_node_from_consistent_hash,
@@ -447,28 +448,40 @@ pub async fn run_delay_deletion() -> Result<(), anyhow::Error> {
 }
 
 pub(crate) fn is_past_hour(offset: i64) -> bool {
-    let time_now: DateTime<Utc> = Utc::now();
-    let time_now_hour = Utc
-        .with_ymd_and_hms(
-            time_now.year(),
-            time_now.month(),
-            time_now.day(),
-            time_now.hour(),
-            0,
-            0,
-        )
-        .unwrap()
-        .timestamp_micros();
-    // must wait for at least 3 * max_file_retention_time
+    is_past_hour_at(offset, now_micros())
+}
+
+fn is_past_hour_at(offset: i64, now: i64) -> bool {
+    // the hour of `offset` must have ended at least 3 * max_file_retention_time ago,
+    // so data still buffered in ingester WAL when the hour closed has landed:
     // -- first period: the last hour local file upload to storage, write file list
     // -- second period, the last hour file list upload to storage
     // -- third period, we can do the merge, so, at least 3 times of
     // max_file_retention_time
-    offset < time_now_hour
-        && time_now.timestamp_micros() - offset
-            > Duration::try_seconds(get_config().limit.max_file_retention_time as i64)
-                .unwrap()
-                .num_microseconds()
-                .unwrap()
-                * 3
+    let offset_hour_end = offset - offset % hour_micros(1) + hour_micros(1);
+    now - offset_hour_end > second_micros(get_config().limit.max_file_retention_time as i64) * 3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_past_hour_at() {
+        let settle = second_micros(get_config().limit.max_file_retention_time as i64) * 3;
+        let hour = hour_micros(1);
+        let offset = 1_755_590_400_000_000; // 2025-08-19 08:00:00 UTC
+        let hour_end = offset + hour;
+
+        // right at the top of the next hour: not yet
+        assert!(!is_past_hour_at(offset, hour_end + 1));
+        // within the settle window after the hour ends: not yet
+        assert!(!is_past_hour_at(offset, hour_end + settle));
+        // past the settle window: ready
+        assert!(is_past_hour_at(offset, hour_end + settle + 1));
+        // mid-hour offsets are floored to their hour
+        assert!(is_past_hour_at(offset + hour / 2, hour_end + settle + 1));
+        // old hours are always ready
+        assert!(is_past_hour_at(offset - hour * 24, hour_end));
+    }
 }

--- a/src/compaction/src/merge.rs
+++ b/src/compaction/src/merge.rs
@@ -401,10 +401,11 @@ pub async fn merge_by_stream(
         "[COMPACTOR] merge_by_stream [{org_id}/{stream_type}/{stream_name}] offset: {offset}"
     );
 
-    // A job whose offset hour has not yet fully passed is an incremental round on the
-    // still-open current hour (enqueued by the ingester, see service::compaction::incremental):
-    // only seal full-size groups and carry the remainder, so each file is merged into a
-    // sealed output exactly once. The scheduled hour-end pass seals whatever is left.
+    // A job whose offset hour has not yet settled (hour end + 3 * max_file_retention_time,
+    // see is_past_hour) is an incremental round on a hour that can still receive files
+    // (enqueued by the ingester, see service::compaction::incremental): only seal full-size
+    // groups and carry the remainder, so each file is merged into a sealed output exactly
+    // once. The scheduled hour-end pass seals whatever is left.
     let offset = offset - offset % hour_micros(1);
     let is_incremental = !super::is_past_hour(offset);
 


### PR DESCRIPTION
## What

The compactor's hour-merge gate (`is_past_hour`) now measures the 3 × `ZO_MAX_FILE_RETENTION_TIME` settle window from the **end** of the offset hour instead of its start.

## Why

The original design delayed merging the previous hour until the current hour's top plus 3 × `ZO_MAX_FILE_RETENTION_TIME` (default 30 min), giving data still buffered in ingester WAL when the hour closed time to upload. Since the multi-worker compactor refactor (#3526), the gate compared `now - offset` (offset = start of the hour to merge) against the window — a condition that is always already satisfied the moment the hour passes (1 h > 30 min), so the check was dead code and the merge fired right at the top of the hour. Files uploaded afterwards for that hour arrived as small files that the normal path never re-merged; the old-data fallback only picks an hour up once it has ≥ 10 small files, so a handful of stragglers stayed unmerged forever.

## How

- `is_past_hour` rounds `offset` up to its hour's end and requires `now - hour_end > 3 * max_file_retention_time`. One fix covers all three call sites: scheduled job generation, the incremental-mode decision in `merge_by_stream` (jobs inside the settle window now correctly run incrementally: seal full-size groups only, carry the remainder), and the file_list dump gate.
- Catch-up of older hours is unaffected — their hour end is long past the window, so they pass immediately (the behavior #3526 wanted to preserve).

## Reviewer notes

The behavior change operators will see: the previous hour's final merge now starts ~30 minutes (3 × retention) after the hour closes instead of immediately, matching the pre-#3526 design. Streams with the ingester incremental trigger enabled keep getting intra-hour merges during that window.