### PR TITLE
fix: annotation_queues item hydration intermittent 500s

### DIFF
--- a/src/api/management/src/models/annotation_queues/mod.rs
+++ b/src/api/management/src/models/annotation_queues/mod.rs
@@ -198,11 +198,22 @@ pub struct AnnotationQueueMachineScoreResponseBody {
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct QueueReviewSubmissionResponseBody {
+    pub submission_id: String,
+    pub reviewer: Option<String>,
+    pub comments: Option<String>,
+    pub submitted_at: i64,
+    pub scores: Vec<AnnotationQueueMachineScoreResponseBody>,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct AnnotationQueueItemDetailResponseBody {
     pub item: AnnotationQueueItemResponseBody,
     pub source_stream: String,
     pub content: AnnotationQueueItemContentResponseBody,
     pub machine_scores: Vec<AnnotationQueueMachineScoreResponseBody>,
+    pub reviews: Vec<QueueReviewSubmissionResponseBody>,
 }
 
 impl From<CreateAnnotationQueueRequestBody> for CreateAnnotationQueue {
@@ -372,6 +383,18 @@ impl From<LlmScoreRecord> for AnnotationQueueMachineScoreResponseBody {
     }
 }
 
+impl From<QueueReviewSubmission> for QueueReviewSubmissionResponseBody {
+    fn from(value: QueueReviewSubmission) -> Self {
+        Self {
+            submission_id: value.submission_id,
+            reviewer: value.reviewer,
+            comments: value.comments,
+            submitted_at: value.submitted_at,
+            scores: value.scores.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
 impl From<AnnotationQueueItemDetail> for AnnotationQueueItemDetailResponseBody {
     fn from(value: AnnotationQueueItemDetail) -> Self {
         Self {
@@ -379,6 +402,7 @@ impl From<AnnotationQueueItemDetail> for AnnotationQueueItemDetailResponseBody {
             source_stream: value.source_stream,
             content: value.content.into(),
             machine_scores: value.machine_scores.into_iter().map(Into::into).collect(),
+            reviews: value.reviews.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -512,6 +536,22 @@ mod tests {
                 _timestamp: 200,
                 ..LlmScoreRecord::default()
             }],
+            reviews: vec![QueueReviewSubmission {
+                submission_id: "submission-1".to_string(),
+                reviewer: Some("reviewer@example.com".to_string()),
+                comments: None,
+                submitted_at: 300,
+                scores: vec![LlmScoreRecord {
+                    id: "score-2".to_string(),
+                    name: "faithfulness".to_string(),
+                    value_numeric: Some(1.0),
+                    data_type: LlmScoreDataType::Numeric,
+                    source_type: LlmScoreDataSourceType::Annotation,
+                    source_stream: Some("traces".to_string()),
+                    _timestamp: 300,
+                    ..LlmScoreRecord::default()
+                }],
+            }],
         };
         let value =
             serde_json::to_value(AnnotationQueueItemDetailResponseBody::from(detail)).unwrap();
@@ -520,6 +560,8 @@ mod tests {
         assert_eq!(value["content"]["input"]["question"], "hello");
         assert_eq!(value["machineScores"][0]["sourceType"], "llm_judge");
         assert_eq!(value["machineScores"][0]["valueNumeric"], 0.9);
+        assert_eq!(value["reviews"][0]["submissionId"], "submission-1");
+        assert_eq!(value["reviews"][0]["scores"][0]["valueNumeric"], 1.0);
     }
 
     #[test]

--- a/src/api/management/src/request/annotation_queues/mod.rs
+++ b/src/api/management/src/request/annotation_queues/mod.rs
@@ -38,6 +38,20 @@ use crate::{
     },
 };
 
+/// If `err`'s root cause is a retryable search-admission error (cancellation or
+/// ratelimit), return the 429 response it should map to instead of a 500.
+fn retryable_search_error_response(err: &anyhow::Error) -> Option<Response> {
+    let infra::errors::Error::ErrorCode(code) = err.downcast_ref::<infra::errors::Error>()? else {
+        return None;
+    };
+    matches!(
+        code,
+        infra::errors::ErrorCodes::SearchCancelQuery(_)
+            | infra::errors::ErrorCodes::RatelimitExceeded(_)
+    )
+    .then(|| MetaHttpResponse::too_many_requests(code.get_message()))
+}
+
 fn annotation_queue_error_response(value: AnnotationQueueError) -> Response {
     match value {
         AnnotationQueueError::Database(err) => {
@@ -49,6 +63,12 @@ fn annotation_queue_error_response(value: AnnotationQueueError) -> Response {
             MetaHttpResponse::internal_error("Failed to publish review Scores")
         }
         AnnotationQueueError::Search(err) => {
+            if let Some(response) = retryable_search_error_response(&err) {
+                log::warn!(
+                    "[AnnotationQueue] Workbench Scores query cancelled/rate-limited: {err}"
+                );
+                return response;
+            }
             log::error!("[AnnotationQueue] failed to query Workbench Scores: {err}");
             MetaHttpResponse::internal_error("Failed to query Workbench Scores")
         }
@@ -69,6 +89,10 @@ fn annotation_queue_error_response(value: AnnotationQueueError) -> Response {
             MetaHttpResponse::internal_error("Queue Item source stream is ambiguous")
         }
         AnnotationQueueError::Hydration(err) => {
+            if let Some(response) = retryable_search_error_response(&err) {
+                log::warn!("[AnnotationQueue] Queue Item hydration cancelled/rate-limited: {err}");
+                return response;
+            }
             log::error!("[AnnotationQueue] failed to hydrate Queue Item: {err}");
             MetaHttpResponse::internal_error("Failed to hydrate Queue Item")
         }
@@ -757,6 +781,39 @@ mod tests {
                 .status()
                 .as_u16(),
             409
+        );
+    }
+
+    #[test]
+    fn maps_search_cancellation_to_too_many_requests() {
+        let cancelled = || {
+            anyhow::anyhow!(infra::errors::Error::ErrorCode(
+                infra::errors::ErrorCodes::SearchCancelQuery("canceled".to_string())
+            ))
+        };
+        assert_eq!(
+            annotation_queue_error_response(AnnotationQueueError::Search(cancelled()))
+                .status()
+                .as_u16(),
+            429
+        );
+        assert_eq!(
+            annotation_queue_error_response(AnnotationQueueError::Hydration(cancelled()))
+                .status()
+                .as_u16(),
+            429
+        );
+    }
+
+    #[test]
+    fn maps_other_search_errors_to_internal_error() {
+        assert_eq!(
+            annotation_queue_error_response(AnnotationQueueError::Search(anyhow::anyhow!(
+                "unexpected SQL error"
+            )))
+            .status()
+            .as_u16(),
+            500
         );
     }
 }

--- a/src/jobs/src/job/mod.rs
+++ b/src/jobs/src/job/mod.rs
@@ -754,10 +754,15 @@ pub async fn init() -> Result<(), anyhow::Error> {
                         ..Default::default()
                     };
                     let stream_type = config::meta::stream::StreamType::from(stream_type.as_str());
-                    let count_response =
-                        search_service::search("", &org_id, stream_type, None, &count_req)
-                            .await
-                            .map_err(|e| anyhow::anyhow!(e))?;
+                    let count_response = search_service::search(
+                        &config::ider::generate_trace_id(),
+                        &org_id,
+                        stream_type,
+                        None,
+                        &count_req,
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))?;
                     if count_response.is_partial || !count_response.function_error.is_empty() {
                         return Ok(o2_enterprise::enterprise::llm_evaluations::eval_jobs::scheduler::SchedulerSearchResult {
                             total: count_response.total,
@@ -797,18 +802,24 @@ pub async fn init() -> Result<(), anyhow::Error> {
                         use_cache: false,
                         ..Default::default()
                     };
-                    search_service::search("", &org_id, stream_type, None, &data_req)
-                        .await
-                        .map(|response| {
-                            o2_enterprise::enterprise::llm_evaluations::eval_jobs::scheduler::SchedulerSearchResult {
-                                hits: response.hits,
-                                total,
-                                is_partial: response.is_partial,
-                                function_error: response.function_error,
-                                over_limit,
-                            }
-                        })
-                        .map_err(|e| anyhow::anyhow!(e))
+                    search_service::search(
+                        &config::ider::generate_trace_id(),
+                        &org_id,
+                        stream_type,
+                        None,
+                        &data_req,
+                    )
+                    .await
+                    .map(|response| {
+                        o2_enterprise::enterprise::llm_evaluations::eval_jobs::scheduler::SchedulerSearchResult {
+                            hits: response.hits,
+                            total,
+                            is_partial: response.is_partial,
+                            function_error: response.function_error,
+                            over_limit,
+                        }
+                    })
+                    .map_err(|e| anyhow::anyhow!(e))
                 })
             },
         );
@@ -832,7 +843,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
                         ..Default::default()
                     };
                     search_service::search(
-                        "",
+                        &config::ider::generate_trace_id(),
                         &request.org_id,
                         stream_type,
                         None,

--- a/src/search_service/src/work_group.rs
+++ b/src/search_service/src/work_group.rs
@@ -212,18 +212,24 @@ pub async fn work_group_checking(
     caller: &str,
 ) -> Result<()> {
     let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
-    if SEARCH_SERVER
+    if let Err(err) = SEARCH_SERVER
         .insert_sender(trace_id, abort_sender, false)
         .await
-        .is_err()
     {
         metrics::QUERY_PENDING_NUMS
             .with_label_values(&[org_id])
             .dec();
         dist_lock::unlock_with_trace_id(trace_id, locker).await?;
-        log::warn!("[trace_id {trace_id}] search->cluster: request canceled before enter queue");
+        // Not a queue-capacity rejection: this means the entry `search()`'s own
+        // top-level registration should have created for `trace_id` is missing
+        // (never registered, or already removed by a concurrent/finished query
+        // that shares the same trace_id). Real capacity waits/timeouts are a
+        // separate branch below (`work_group_need_wait`).
+        log::warn!(
+            "[trace_id {trace_id}] search->cluster: request canceled, missing work-group registration: {err}"
+        );
         return Err(Error::ErrorCode(ErrorCodes::SearchCancelQuery(format!(
-            "[trace_id {trace_id}] search->cluster: request canceled before enter queue"
+            "[trace_id {trace_id}] search->cluster: request canceled, missing work-group registration: {err}"
         ))));
     }
     tokio::select! {

--- a/src/search_service/src/work_group.rs
+++ b/src/search_service/src/work_group.rs
@@ -220,11 +220,6 @@ pub async fn work_group_checking(
             .with_label_values(&[org_id])
             .dec();
         dist_lock::unlock_with_trace_id(trace_id, locker).await?;
-        // Not a queue-capacity rejection: this means the entry `search()`'s own
-        // top-level registration should have created for `trace_id` is missing
-        // (never registered, or already removed by a concurrent/finished query
-        // that shares the same trace_id). Real capacity waits/timeouts are a
-        // separate branch below (`work_group_need_wait`).
         log::warn!(
             "[trace_id {trace_id}] search->cluster: request canceled, missing work-group registration: {err}"
         );

--- a/web/src/enterprise/views/AIObservability/QueueWorkbenchPage.vue
+++ b/web/src/enterprise/views/AIObservability/QueueWorkbenchPage.vue
@@ -967,19 +967,17 @@ async function loadCurrentItem() {
   if (!item) return;
 
   detailLoading.value = true;
-  const [detailResult, reviewsResult] = await Promise.allSettled([
-    llmQueuesService.getItemDetail(orgId.value, queueId.value, item.id),
-    llmQueuesService.listReviews(orgId.value, queueId.value, item.id),
-  ]);
-  if (request !== detailRequest) return;
-
-  if (detailResult.status === "fulfilled") {
-    currentDetail.value = detailResult.value;
-    currentReviews.value = reviewsResult.status === "fulfilled" ? reviewsResult.value : [];
-  } else {
+  try {
+    const detail = await llmQueuesService.getItemDetail(orgId.value, queueId.value, item.id);
+    if (request !== detailRequest) return;
+    currentDetail.value = detail;
+    currentReviews.value = detail.reviews;
+  } catch {
+    if (request !== detailRequest) return;
     toast({ variant: "error", message: t("aiObservability.queues.detail.loadError") });
+  } finally {
+    if (request === detailRequest) detailLoading.value = false;
   }
-  detailLoading.value = false;
 }
 
 function selectItem(index: number) {

--- a/web/src/services/llm-queues.service.spec.ts
+++ b/web/src/services/llm-queues.service.spec.ts
@@ -145,6 +145,15 @@ describe("llmQueuesService Workbench contracts", () => {
             timestamp: 456,
           },
         ],
+        reviews: [
+          {
+            submissionId: "submission-1",
+            reviewer: "reviewer@example.com",
+            comments: null,
+            submittedAt: 789,
+            scores: [{ name: "faithfulness", value_numeric: 1 }],
+          },
+        ],
       },
     });
 
@@ -157,6 +166,11 @@ describe("llmQueuesService Workbench contracts", () => {
       name: "faithfulness",
       value: 0.8,
       sourceType: "llm_judge",
+    });
+    expect(detail.reviews).toHaveLength(1);
+    expect(detail.reviews[0]).toMatchObject({
+      submissionId: "submission-1",
+      scores: [{ name: "faithfulness", value: 1 }],
     });
   });
 

--- a/web/src/services/llm-queues.service.ts
+++ b/web/src/services/llm-queues.service.ts
@@ -110,6 +110,7 @@ export interface LlmQueueItemDetail {
     trace: Record<string, unknown>[];
   };
   machineScores: LlmQueueMachineScore[];
+  reviews: LlmQueueReview[];
 }
 
 export interface LlmQueueReviewScore {
@@ -265,6 +266,7 @@ function normalizeItemDetail(detail: any): LlmQueueItemDetail {
     machineScores: unwrapList(detail.machine_scores ?? detail.machineScores).map(
       normalizeMachineScore,
     ),
+    reviews: unwrapList(detail.reviews).map(normalizeReview),
   };
 }
 


### PR DESCRIPTION
## Summary

RCA (2026-08-19, 08:20-08:22 UTC): `GET /api/{org}/annotation_queues/{queue_id}/items/{item_id}` (and its `/reviews` sibling) intermittently returned 500. Originally attributed to search work-group admission capacity exhaustion; tracing the actual code found a different root cause.

**Real mechanism**: `eval_jobs::search::execute()`'s registered executors (in `src/jobs/src/job/mod.rs`) called `search_service::search("", ...)` with a hardcoded empty `trace_id`. With no propagated OTel span in that detached task, `search_service::search()` falls back to OpenTelemetry's *invalid* trace ID for every such call - the same `000...000` seen in every failing log line. Every concurrent internal search therefore shared one `QueryManager` map key: one query's cleanup (`SEARCH_SERVER.remove`) deleted another's still in-flight registration, so the next `insert_sender` failed with "trace_id not found" -> `SearchCancelQuery` -> 500. `work_group_checking` never reached the real concurrency-wait branch in this failure mode - "work-group capacity" was never the actual mechanism.

## Changes (3 commits)

1. **`fix(annotation-queues): merge item detail and reviews into one call`** - the Queue Workbench always fetches item detail + reviews together (confirmed: no caller ever needs one without the other, including after review submission); fold them into one backend call, cutting the per-item load from 2 HTTP round trips to 1. See companion PR openobserve/o2-enterprise#2473 for the response-shape change this depends on.
2. **`fix(annotation-queues): map search admission cancellation to 429`** - `annotation_queue_error_response` unconditionally 500'd on `AnnotationQueueError::Search`/`Hydration`, even when the underlying cause already has a defined 429 `http_status()` (`SearchCancelQuery` / `RatelimitExceeded`). Downcast and map correctly instead.
3. **`fix(search): stop colliding on trace_id in internal eval searches`** - the actual root-cause fix: generate a real per-call `trace_id` via `config::ider::generate_trace_id()` at all three internal `search_service::search("", ...)` call sites instead of passing `""`.

## Dependency

This PR's enterprise build depends on openobserve/o2-enterprise#2473 (same branch name `ud/fix-annotation-queue-hydration-500s`) via the path dependency in `Cargo.toml.openobserve` - that PR adds the `reviews` field on `AnnotationQueueItemDetail` this PR's merge (commit 1) consumes.

## Test plan

- [x] `cargo build --features enterprise`
- [x] `cargo test -p openobserve-api-management --lib --features enterprise annotation_queue` - 11 passed (incl. 2 new tests for the 429 mapping), no regressions
- [x] `cargo test -p o2_enterprise --lib annotation_queues` (companion repo) - 16 passed, no regressions
- [x] `cargo clippy --features enterprise -p openobserve-jobs -p search_service -p openobserve-api-management --no-deps` - clean (no warnings in touched files)
- [x] `cargo fmt --check` - clean
- [x] Frontend: `npx vitest run` on `llm-queues.service.spec.ts` + `QueueWorkbenchPage.backTarget.spec.ts` - 9 passed
- [x] `vue-tsc --noEmit` (`type-check:app`) - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)