### PR TITLE
fix: session detail output message fixed

### DIFF
--- a/web/src/plugins/traces/SessionDetails.vue
+++ b/web/src/plugins/traces/SessionDetails.vue
@@ -903,9 +903,8 @@ import {
   type SessionDetail,
   type SessionTraceRow,
   type TurnDetail,
-  type TurnMessage,
 } from "./composables/useSessions";
-import { messagesFromInput, messagesFromOutput, getModel } from "./threadView.utils";
+import { buildTurnDetail } from "./threadView.utils";
 import OButton from "@/lib/core/Button/OButton.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OPageLayout from "@/lib/core/PageLayout/OPageLayout.vue";
@@ -1288,10 +1287,9 @@ const expandedTurns = reactive<Record<string, boolean>>({});
 // Per-turn detail is DERIVED from the session spans we already fetch eagerly
 // (`sessionSpans`) — the SAME single source that powers the Pretty view and the
 // Tool Hotspots. This guarantees the collapsed turn body, the tool hotspots, and
-// the transcript can never disagree. Spans are grouped by `trace_id` and
-// classified exactly like ThreadView.
-const LLM_OPS = new Set(["chat", "text_completion", "generate_content", "embeddings"]);
-
+// the transcript can never disagree. Spans are grouped by `trace_id`; the
+// per-trace projection lives in `threadView.utils` alongside ThreadView's, so
+// the two views classify spans identically.
 const turnDetailsByTrace = computed<Record<string, TurnDetail>>(() => {
   const byTrace: Record<string, any[]> = {};
   for (const s of sessionSpans.value) {
@@ -1302,72 +1300,7 @@ const turnDetailsByTrace = computed<Record<string, TurnDetail>>(() => {
 
   const out: Record<string, TurnDetail> = {};
   for (const tid of Object.keys(byTrace)) {
-    const spans = byTrace[tid]
-      .slice()
-      .sort((a, b) => (Number(a.start_time) || 0) - (Number(b.start_time) || 0));
-
-    let llmCalls = 0;
-    let toolCalls = 0;
-    let otherCalls = 0;
-    const otherOps = new Set<string>();
-    for (const sp of spans) {
-      const op = String(sp.gen_ai_operation_name || "").toLowerCase();
-      if (LLM_OPS.has(op)) llmCalls += 1;
-      else if (op === "execute_tool") toolCalls += 1;
-      else {
-        otherCalls += 1;
-        if (op) otherOps.add(op);
-      }
-    }
-
-    // user question = last user-role entry of a span's full prompt; model = the
-    // first span that carries one.
-    let userMessage: TurnMessage | null = null;
-    let model: string | null = null;
-    for (const sp of spans) {
-      if (!model) {
-        const m = getModel(sp);
-        if (m) model = m;
-      }
-      if (!userMessage) {
-        const inputMsgs = messagesFromInput(sp.gen_ai_input_messages);
-        for (let i = inputMsgs.length - 1; i >= 0; i--) {
-          if (inputMsgs[i].role === "user" && inputMsgs[i].content) {
-            userMessage = { role: "user", content: raw(inputMsgs[i].content) };
-            break;
-          }
-        }
-      }
-      if (userMessage && model) break;
-    }
-
-    // assistant reply = final non-empty assistant message (walk newest → oldest).
-    let assistantMessage: TurnMessage | null = null;
-    for (let s = spans.length - 1; s >= 0; s--) {
-      const outputMsgs = messagesFromOutput(spans[s].gen_ai_output_messages);
-      let a: any = null;
-      for (let i = outputMsgs.length - 1; i >= 0; i--) {
-        if (outputMsgs[i].role === "assistant" && outputMsgs[i].content) {
-          a = outputMsgs[i];
-          break;
-        }
-      }
-      if (a) {
-        assistantMessage = { role: "assistant", content: a.content };
-        break;
-      }
-    }
-
-    out[tid] = {
-      traceId: tid,
-      userMessage,
-      assistantMessage,
-      model,
-      llmCalls,
-      toolCalls,
-      otherCalls,
-      otherOps: [...otherOps].sort(),
-    };
+    out[tid] = buildTurnDetail(tid, byTrace[tid]);
   }
   return out;
 });

--- a/web/src/plugins/traces/composables/useSessions.ts
+++ b/web/src/plugins/traces/composables/useSessions.ts
@@ -445,10 +445,10 @@ export function useSessions() {
    * Fetch the message payload for a single turn (one trace). Used by
    * the SessionDetails accordion when a turn row is expanded.
    *
-   * Pulls only the LLM-turn spans for that trace (the ones carrying
-   * `gen_ai.input.messages` / `gen_ai.output.messages`), then picks
-   * the first user message and last assistant message from the
-   * normalised list — same convention used by `ThreadView`.
+   * Fetches every `gen_ai` span of the trace in one query — tool spans
+   * included, so the LLM/tool call badges can be counted client-side rather
+   * than via a second COUNT query — and hands them to `buildTurnDetail`,
+   * the same projection the session-detail turn cards use.
    */
   async function fetchTurnDetail(
     streamName: string,
@@ -489,89 +489,13 @@ export function useSessions() {
       LIMIT 50
     `);
 
-    const LLM_OPS = new Set(["chat", "text_completion", "generate_content", "embeddings"]);
-
     const hits = await executeQuery(sql, startTime, endTime);
 
-    let llmCalls = 0;
-    let toolCalls = 0;
-    let otherCalls = 0;
-    const otherOpsSet = new Set<string>();
-    for (const row of hits || []) {
-      const op = String(row.gen_ai_operation_name || "").toLowerCase();
-      if (LLM_OPS.has(op)) llmCalls += 1;
-      else if (op === "execute_tool") toolCalls += 1;
-      else {
-        otherCalls += 1;
-        otherOpsSet.add(op);
-      }
-    }
-    const otherOps = [...otherOpsSet].sort();
-    // Lazy-import the message parser so this composable stays light
-    // when only the list view is in use.
-    const { messagesFromInput, messagesFromOutput, getModel } = await import("../threadView.utils");
-
-    let userMessage: TurnMessage | null = null;
-    let assistantMessage: TurnMessage | null = null;
-    let model: string | null = null;
-
-    // First pass — forward — pick model and the user question for THIS
-    // turn. `gen_ai.input.messages` carries the FULL prompt sent to
-    // the model (system + every prior turn + the current question),
-    // so the *last* user-role entry of the *first* span is the
-    // current turn's question, not turn 1's.
-    for (const span of hits || []) {
-      if (!model) {
-        const m = getModel(span);
-        if (m) model = m;
-      }
-      if (!userMessage) {
-        const inputMsgs = messagesFromInput(span.gen_ai_input_messages);
-        let u: any = null;
-        for (let i = inputMsgs.length - 1; i >= 0; i--) {
-          if (inputMsgs[i].role === "user" && inputMsgs[i].content) {
-            u = inputMsgs[i];
-            break;
-          }
-        }
-        if (u) userMessage = { role: "user", content: u.content };
-      }
-      if (userMessage && model) break;
-    }
-
-    // Second pass — reverse — pick the FINAL assistant reply for this
-    // turn. An agent may make multiple LLM calls (LLM → tool → LLM
-    // → tool → … → final answer). The first chat span's output is
-    // usually an intermediate "I should call tool X" reply; the user
-    // wants the answer at the end, not the planning step. Walking
-    // from the latest span back gives us the final non-empty
-    // assistant message.
-    for (let s = (hits || []).length - 1; s >= 0; s--) {
-      const span = hits[s];
-      const outputMsgs = messagesFromOutput(span.gen_ai_output_messages);
-      let a: any = null;
-      for (let i = outputMsgs.length - 1; i >= 0; i--) {
-        if (outputMsgs[i].role === "assistant" && outputMsgs[i].content) {
-          a = outputMsgs[i];
-          break;
-        }
-      }
-      if (a) {
-        assistantMessage = { role: "assistant", content: a.content };
-        break;
-      }
-    }
-
-    return {
-      traceId,
-      userMessage,
-      assistantMessage,
-      model,
-      llmCalls,
-      toolCalls,
-      otherCalls,
-      otherOps,
-    };
+    // Lazy-import the projection so this composable stays light when only the
+    // list view is in use. Shared with the session-detail turn cards and
+    // ThreadView so all three classify spans identically.
+    const { buildTurnDetail } = await import("../threadView.utils");
+    return buildTurnDetail(traceId, hits || []);
   }
 
   /**

--- a/web/src/plugins/traces/threadView.utils.spec.ts
+++ b/web/src/plugins/traces/threadView.utils.spec.ts
@@ -25,6 +25,7 @@ import {
   messagesFromOutput,
   looksLikeAgentInjection,
   buildTraceGroup,
+  buildTurnDetail,
 } from "./threadView.utils";
 
 // ===========================================================================
@@ -983,5 +984,108 @@ describe("buildTraceGroup", () => {
     ];
     const g = buildTraceGroup(spans)!;
     expect(g.userQuery).toBe("EXPLICIT QUESTION");
+  });
+});
+
+// ===========================================================================
+// buildTurnDetail
+// ===========================================================================
+
+describe("buildTurnDetail", () => {
+  // Real capture: one agent turn where the `chat` span WRAPS the tool call it
+  // makes, so the `execute_tool` span is the newest span by start_time.
+  // ns timestamps are kept as strings — they exceed Number precision, and
+  // `buildTurnDetail` coerces with Number() anyway.
+  const chatSpan = {
+    span_id: "9c7e26618777ec86",
+    trace_id: "01a013ea454b703bbda018c5c5a0175f",
+    gen_ai_operation_name: "chat",
+    gen_ai_request_model: "deepseek-v4-pro",
+    gen_ai_response_model: "deepseek-v4-pro",
+    start_time: "1787040515717940269",
+    gen_ai_input_messages: JSON.stringify([{ role: "user", content: "how many streams are there" }]),
+    gen_ai_output_messages: JSON.stringify([
+      { role: "assistant", content: "There are **3,647 streams** in the `default` organization." },
+    ]),
+  };
+  const toolSpan = {
+    span_id: "dc20fb56909bd06c",
+    trace_id: "01a013ea454b703bbda018c5c5a0175f",
+    gen_ai_operation_name: "execute_tool",
+    gen_ai_tool_name: "o2_StreamList",
+    start_time: "1787040518081711486",
+    gen_ai_input_messages: JSON.stringify({ org_id: "default", limit: 10, offset: 0 }),
+    gen_ai_output_messages: JSON.stringify({
+      total: 3647,
+      items: [{ name: "_agent_signals", stream_type: "logs" }],
+    }),
+  };
+  const wrapperSpan = {
+    span_id: "a491937f8c278d4e",
+    trace_id: "01a013ea454b703bbda018c5c5a0175f",
+    gen_ai_operation_name: "span",
+    start_time: "1787040515717926621",
+  };
+
+  it("uses the chat span's reply, not the tool result, when the tool span is newest", () => {
+    const d = buildTurnDetail("t1", [chatSpan, toolSpan, wrapperSpan]);
+    expect(d.assistantMessage?.content).toBe(
+      "There are **3,647 streams** in the `default` organization.",
+    );
+    expect(d.assistantMessage?.content).not.toContain("_agent_signals");
+  });
+
+  it("does not mistake tool arguments for the user question", () => {
+    // Tool span sorted FIRST — the forward walk must still skip it.
+    const d = buildTurnDetail("t1", [{ ...toolSpan, start_time: 1 }, chatSpan]);
+    expect(d.userMessage?.content).toBe("how many streams are there");
+  });
+
+  it("still counts tool and LLM spans it excludes from messages", () => {
+    const d = buildTurnDetail("t1", [chatSpan, toolSpan, wrapperSpan]);
+    expect(d.llmCalls).toBe(1);
+    expect(d.toolCalls).toBe(1);
+    expect(d.otherCalls).toBe(1);
+    expect(d.otherOps).toEqual(["span"]);
+    expect(d.model).toBe("deepseek-v4-pro");
+    expect(d.traceId).toBe("t1");
+  });
+
+  it("takes the LAST assistant reply across a multi-call turn", () => {
+    const planning = {
+      ...chatSpan,
+      span_id: "plan",
+      start_time: 100,
+      gen_ai_output_messages: JSON.stringify([
+        { role: "assistant", content: "I should call o2_StreamList." },
+      ]),
+    };
+    const answer = { ...chatSpan, span_id: "answer", start_time: 300 };
+    const tool = { ...toolSpan, start_time: 200 };
+    const d = buildTurnDetail("t1", [planning, tool, answer]);
+    expect(d.assistantMessage?.content).toBe(
+      "There are **3,647 streams** in the `default` organization.",
+    );
+  });
+
+  it("returns null messages for a trace with no chat spans", () => {
+    const d = buildTurnDetail("t1", [toolSpan]);
+    expect(d.userMessage).toBeNull();
+    expect(d.assistantMessage).toBeNull();
+    expect(d.toolCalls).toBe(1);
+  });
+
+  it("handles an empty span list", () => {
+    const d = buildTurnDetail("t1", []);
+    expect(d).toEqual({
+      traceId: "t1",
+      userMessage: null,
+      assistantMessage: null,
+      model: null,
+      llmCalls: 0,
+      toolCalls: 0,
+      otherCalls: 0,
+      otherOps: [],
+    });
   });
 });

--- a/web/src/plugins/traces/threadView.utils.ts
+++ b/web/src/plugins/traces/threadView.utils.ts
@@ -21,6 +21,9 @@
  * No Vue imports. No DOM. No vuex. Just data-in / data-out.
  */
 
+import { raw } from "@/types/i18n";
+import type { TurnDetail, TurnMessage } from "./composables/useSessions";
+
 // ---------------------------------------------------------------------------
 // Field resolvers — read OTEL gen_ai_* attributes.
 // ---------------------------------------------------------------------------
@@ -104,6 +107,13 @@ export function hasLLMPayload(span: any): boolean {
  *   - server span with no parent                → root
  *   - everything else                           → other
  */
+/**
+ * Operation names that count as a model call for the per-turn call badges.
+ * Deliberately broader than `classify`'s `llm_turn` set — an `embeddings`
+ * span is a real LLM call even though it carries no chat transcript.
+ */
+const LLM_CALL_OPS = new Set(["chat", "text_completion", "generate_content", "embeddings"]);
+
 export function classify(span: any): SpanKind {
   const obs = getOp(span);
   const LLM_TURN_OPS = new Set(["chat", "text_completion", "generate_content"]);
@@ -526,5 +536,98 @@ export function buildTraceGroup(spans: any[]): TraceGroup | null {
     totalCost,
     totalDurationNs,
     errorCount,
+  };
+}
+
+/**
+ * Per-turn summary — the user question, the final assistant reply, the model
+ * and the call counts — derived from one trace's `gen_ai` spans. Backs the
+ * session-detail turn cards, and shares this module's parsers with
+ * `buildTraceGroup` so a turn card and the transcript can't disagree.
+ *
+ * Tool-execution spans are excluded from message extraction: their
+ * `gen_ai_input_messages` / `gen_ai_output_messages` hold the tool's arguments
+ * and its raw JSON result, not chat messages, and `messagesFromOutput` will
+ * happily stringify such a payload into an `assistant` message. This matters
+ * because an agent's chat span typically *wraps* the tool calls it makes — so
+ * the tool span is the newest span in the trace by `start_time`, and the
+ * newest → oldest walk below would otherwise surface the raw tool JSON where
+ * the assistant's answer belongs.
+ *
+ * Tool spans are filtered by exclusion rather than by an `LLM_CALL_OPS`
+ * allow-list on purpose: an SDK that tags its model calls with a non-standard
+ * operation name should still get its answer rendered.
+ *
+ * @param traceId trace the spans belong to
+ * @param spans   that trace's `gen_ai` spans, in any order
+ */
+export function buildTurnDetail(traceId: string, spans: any[]): TurnDetail {
+  const ordered = (spans || [])
+    .slice()
+    .sort((a, b) => (Number(a.start_time) || 0) - (Number(b.start_time) || 0));
+
+  let llmCalls = 0;
+  let toolCalls = 0;
+  let otherCalls = 0;
+  const otherOps = new Set<string>();
+  for (const sp of ordered) {
+    const op = getOp(sp).toLowerCase();
+    if (LLM_CALL_OPS.has(op)) llmCalls += 1;
+    else if (op === "execute_tool") toolCalls += 1;
+    else {
+      otherCalls += 1;
+      if (op) otherOps.add(op);
+    }
+  }
+
+  const chatSpans = ordered.filter((sp) => getOp(sp).toLowerCase() !== "execute_tool");
+
+  // user question = last user-role entry of a span's prompt. The prompt carries
+  // the full history (system + every prior turn + the current question), so the
+  // LAST user entry is this turn's question, not turn 1's.
+  // model = the first span that carries one.
+  let userMessage: TurnMessage | null = null;
+  let model: string | null = null;
+  for (const sp of chatSpans) {
+    if (!model) {
+      const m = getModel(sp);
+      if (m) model = m;
+    }
+    if (!userMessage) {
+      const inputMsgs = messagesFromInput(sp.gen_ai_input_messages);
+      for (let i = inputMsgs.length - 1; i >= 0; i--) {
+        if (inputMsgs[i].role === "user" && inputMsgs[i].content) {
+          userMessage = { role: "user", content: raw(inputMsgs[i].content) };
+          break;
+        }
+      }
+    }
+    if (userMessage && model) break;
+  }
+
+  // assistant reply = final non-empty assistant message (walk newest → oldest).
+  // An agent makes several model calls per turn (LLM → tool → LLM → … → answer);
+  // the earlier outputs are planning steps, the last one is the answer.
+  let assistantMessage: TurnMessage | null = null;
+  for (let s = chatSpans.length - 1; s >= 0; s--) {
+    const outputMsgs = messagesFromOutput(chatSpans[s].gen_ai_output_messages);
+    for (let i = outputMsgs.length - 1; i >= 0; i--) {
+      if (outputMsgs[i].role === "assistant" && outputMsgs[i].content) {
+        assistantMessage = { role: "assistant", content: raw(outputMsgs[i].content) };
+        break;
+      }
+    }
+    if (assistantMessage) break;
+  }
+
+  return {
+    traceId,
+    userMessage,
+    assistantMessage,
+    model,
+    llmCalls,
+    toolCalls,
+    otherCalls,
+    otherOps: [...otherOps].sort(),
   };
 }


### PR DESCRIPTION
## Summary

Cherry-picked from the prior `fix/session-detail-sql` branch (commit 66c88f084f, authored by @nikhilkethe) onto a clean branch off current `main` so it has its own PR.

- web/src/plugins/traces/SessionDetails.vue
- web/src/plugins/traces/composables/useSessions.ts
- web/src/plugins/traces/threadView.utils.ts (new)
- web/src/plugins/traces/threadView.utils.spec.ts (new)

## Test plan

- [x] `npx vitest run` on `threadView.utils.spec.ts` - 114 passed
- [x] `vue-tsc --noEmit` (`type-check:app`) - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)