### PR TITLE
test(logs): E2E cover for Build tab stream list with no stream selected  

### DIFF
--- a/tests/ui-testing/ci-matrix/ci_matrix.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix.json
@@ -303,7 +303,8 @@
     "browser": "chrome",
     "quick_mode_enabled": "true",
     "run_files": [
-      "logsVisualizeSelectStar.spec.js"
+      "logsVisualizeSelectStar.spec.js",
+      "logsBuildStreamList.spec.js"
     ],
     "disabled": []
   },

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -9497,33 +9497,83 @@ export class LogsPage {
     // ── Build tab: panel field list stream selectors ────────────────────────
     // PanelFieldList (pageKey "build") owns these. Unlike the Visualize tab's
     // copy (pageKey "logs", read-only), both selects here are the user's own.
+    // All locator work and every assertion lives here — specs call the semantic
+    // methods only, matching the other Logs specs.
 
-    /** Selected stream on the LOGS page's own picker; '' when nothing is picked. */
-    async getLogsSelectedStream() {
+    /**
+     * Assert the LOGS page has no stream selected.
+     *
+     * Asserts the count too, and deliberately fails CLOSED: this selector also
+     * exists in JsonPreview.vue (rendered when a log row is expanded), so a bare
+     * .first() could silently read the wrong control and report '' for a page
+     * that does have a stream. A second match is a broken precondition, not a
+     * detail to skip past.
+     */
+    async expectNoLogsStreamSelected() {
         const trigger = this.page.locator('[data-test="log-search-index-list-select-stream-trigger"]');
-        await trigger.first().waitFor({ state: 'visible', timeout: 20000 });
-        return (await trigger.first().getAttribute('data-test-selected-value')) ?? '';
+        await expect(
+            trigger,
+            'expected exactly one logs stream select — a second match means the locator is ambiguous'
+        ).toHaveCount(1, { timeout: 20000 });
+        await expect(
+            trigger,
+            'logs page must start with no stream selected — the Build tab inherits that blank stream'
+        ).toHaveAttribute('data-test-selected-value', '', { timeout: 20000 });
+        testLogger.info('Verified logs page has no stream selected');
     }
 
-    /** Selected stream on the Build tab's field list; '' when nothing is picked. */
-    async getBuildSelectedStream() {
-        const trigger = this.page.locator(this.buildStreamTrigger);
-        await trigger.waitFor({ state: 'visible', timeout: 20000 });
-        return (await trigger.getAttribute('data-test-selected-value')) ?? '';
+    /** Assert the Build tab's stream type. Retries — the model settles a tick late. */
+    async expectBuildStreamType(type) {
+        await expect(this.page.locator(this.buildStreamTypeTrigger))
+            .toHaveAttribute('data-test-selected-value', type, { timeout: 20000 });
+        testLogger.info(`Verified Build tab stream type: ${type}`);
     }
 
-    /** Selected stream type on the Build tab's field list. */
-    async getBuildSelectedStreamType() {
-        const trigger = this.page.locator(this.buildStreamTypeTrigger);
-        await trigger.waitFor({ state: 'visible', timeout: 20000 });
-        return (await trigger.getAttribute('data-test-selected-value')) ?? '';
+    /** Assert which stream the Build tab's field list has selected. */
+    async expectBuildStreamSelected(name) {
+        await expect(this.page.locator(this.buildStreamTrigger))
+            .toHaveAttribute('data-test-selected-value', name, { timeout: 20000 });
+        testLogger.info(`Verified Build tab selected stream: ${name}`);
     }
 
-    /** True when the Build tab's stream select accepts input (it must not be read-only). */
-    async isBuildStreamDropdownEnabled() {
-        const trigger = this.page.locator(this.buildStreamTrigger);
-        await trigger.waitFor({ state: 'visible', timeout: 20000 });
-        return await trigger.isEnabled();
+    /** The stream select must be the user's own control, not read-only. */
+    async expectBuildStreamDropdownEditable() {
+        await expect(
+            this.page.locator(this.buildStreamTrigger),
+            'Build tab stream select must be user-editable'
+        ).toBeEnabled({ timeout: 20000 });
+    }
+
+    /** The open dropdown offers real streams instead of OSelect's empty state. */
+    async expectBuildStreamListPopulated() {
+        await expect(
+            this.page.locator(this.buildStreamPopover).getByText('No options found', { exact: true }),
+            'stream list never loaded — dropdown fell through to its empty state'
+        ).toHaveCount(0, { timeout: 15000 });
+        await expect(this.page.locator(this.buildStreamOptions).first())
+            .toBeVisible({ timeout: 15000 });
+    }
+
+    /** Assert a stream IS offered. Filters first — the option list is virtualised. */
+    async expectBuildStreamOptionVisible(name) {
+        await this.filterBuildStreamOptions(name);
+        await expect(this.page.locator(this.buildStreamOption(name)).first())
+            .toBeVisible({ timeout: 15000 });
+    }
+
+    /** Assert a stream is NOT offered (e.g. a logs stream under stream type traces). */
+    async expectBuildStreamOptionAbsent(name) {
+        await this.filterBuildStreamOptions(name);
+        await expect(this.page.locator(this.buildStreamOption(name)))
+            .toHaveCount(0, { timeout: 15000 });
+    }
+
+    /** Field rows render for the selected stream. Any row — this shard runs with
+     *  ZO_QUICK_MODE_ENABLED, which narrows which fields are listed. */
+    async expectBuildFieldListPopulated() {
+        await expect(
+            this.page.locator('[data-test="logs-build-query-page"] [data-test^="o-field-list-row-"]').first()
+        ).toBeVisible({ timeout: 20000 });
     }
 
     async openBuildStreamDropdown() {
@@ -9552,6 +9602,13 @@ export class LogsPage {
         await search.fill(text);
     }
 
+    /** Click an offered stream and wait for the dropdown to commit the pick. */
+    async clickBuildStreamOption(name) {
+        await this.page.locator(this.buildStreamOption(name)).first().click();
+        await expect(this.page.locator(this.buildStreamPopover)).toBeHidden({ timeout: 10000 });
+        testLogger.info(`Picked Build tab stream: ${name}`);
+    }
+
     /** Change the Build tab's Stream Type. Clears the stream by design. */
     async selectBuildStreamType(type) {
         await this.page.locator(this.buildStreamTypeDropdown).click();
@@ -9560,19 +9617,6 @@ export class LogsPage {
         await popover.locator(`[data-test="index-dropdown-stream_type-option"][data-test-value="${type}"]`).first().click();
         await popover.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {});
         testLogger.info(`Selected Build tab stream type: ${type}`);
-    }
-
-    /** Pick a stream from the Build tab's field list (opens, filters, clicks). */
-    async selectBuildStream(name) {
-        await this.openBuildStreamDropdown();
-        await this.filterBuildStreamOptions(name);
-        const option = this.page.locator(this.buildStreamOption(name)).first();
-        await option.waitFor({ state: 'visible', timeout: 15000 });
-        await option.click();
-        await this.page.locator(this.buildStreamPopover)
-            .waitFor({ state: 'hidden', timeout: 10000 })
-            .catch(() => {});
-        testLogger.info(`Selected Build tab stream: ${name}`);
     }
 
     /**

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -281,7 +281,23 @@ export class LogsPage {
         this.xAxisItemsAny = `${this.xAxisLayout} [data-test^="dashboard-x-item-"]`;
         this.yAxisItemsAny = `${this.yAxisLayout} [data-test^="dashboard-y-item-"]`;
 
-        // Field list for builder
+        // Field list for builder.
+        // Scoped under [data-test="logs-build-query-page"]: the Visualize tab mounts a
+        // SECOND PanelEditor (pageType="logs") that Index.vue keeps in the DOM with
+        // v-show, so both tabs render an `index-dropdown-stream` and an unscoped
+        // locator is a strict-mode violation.
+        this.buildStreamTypeDropdown = '[data-test="logs-build-query-page"] [data-test="index-dropdown-stream_type"]';
+        this.buildStreamTypeTrigger = '[data-test="logs-build-query-page"] [data-test="index-dropdown-stream_type-trigger"]';
+        this.buildStreamDropdown = '[data-test="logs-build-query-page"] [data-test="index-dropdown-stream"]';
+        this.buildStreamTrigger = '[data-test="logs-build-query-page"] [data-test="index-dropdown-stream-trigger"]';
+        // OSelect popovers teleport to <body>, so popover/option/search locators are
+        // NOT scoped to the build page — only one popover is ever open at a time.
+        this.buildStreamPopover = '[data-test="index-dropdown-stream-popover"]';
+        this.buildStreamSearch = '[data-test="index-dropdown-stream-search"]';
+        this.buildStreamOptions = '[data-test="index-dropdown-stream-popover"] [data-test="index-dropdown-stream-option"]';
+        this.buildStreamOption = (name) => `[data-test="index-dropdown-stream-option"][data-test-value="${name}"]`;
+        this.buildStreamTypePopover = '[data-test="index-dropdown-stream_type-popover"]';
+        this.buildStreamTypeOption = (type) => `[data-test="index-dropdown-stream_type-popover"] [data-test="index-dropdown-stream_type-option"][data-test-value="${type}"]`;
         this.streamTypeDropdown = '[data-test="index-dropdown-stream_type"]';
         this.streamDropdown = '[data-test="index-dropdown-stream"]';
         this.addToXAxis = '[data-test="dashboard-add-x-data"]';
@@ -9476,6 +9492,87 @@ export class LogsPage {
     async clickBuildToggle() {
         await this.page.locator(this.buildToggle).click();
         testLogger.info('Clicked Build tab toggle');
+    }
+
+    // ── Build tab: panel field list stream selectors ────────────────────────
+    // PanelFieldList (pageKey "build") owns these. Unlike the Visualize tab's
+    // copy (pageKey "logs", read-only), both selects here are the user's own.
+
+    /** Selected stream on the LOGS page's own picker; '' when nothing is picked. */
+    async getLogsSelectedStream() {
+        const trigger = this.page.locator('[data-test="log-search-index-list-select-stream-trigger"]');
+        await trigger.first().waitFor({ state: 'visible', timeout: 20000 });
+        return (await trigger.first().getAttribute('data-test-selected-value')) ?? '';
+    }
+
+    /** Selected stream on the Build tab's field list; '' when nothing is picked. */
+    async getBuildSelectedStream() {
+        const trigger = this.page.locator(this.buildStreamTrigger);
+        await trigger.waitFor({ state: 'visible', timeout: 20000 });
+        return (await trigger.getAttribute('data-test-selected-value')) ?? '';
+    }
+
+    /** Selected stream type on the Build tab's field list. */
+    async getBuildSelectedStreamType() {
+        const trigger = this.page.locator(this.buildStreamTypeTrigger);
+        await trigger.waitFor({ state: 'visible', timeout: 20000 });
+        return (await trigger.getAttribute('data-test-selected-value')) ?? '';
+    }
+
+    /** True when the Build tab's stream select accepts input (it must not be read-only). */
+    async isBuildStreamDropdownEnabled() {
+        const trigger = this.page.locator(this.buildStreamTrigger);
+        await trigger.waitFor({ state: 'visible', timeout: 20000 });
+        return await trigger.isEnabled();
+    }
+
+    async openBuildStreamDropdown() {
+        const dropdown = this.page.locator(this.buildStreamDropdown);
+        await dropdown.waitFor({ state: 'visible', timeout: 20000 });
+        await dropdown.click();
+        await this.page.locator(this.buildStreamPopover).waitFor({ state: 'visible', timeout: 15000 });
+        testLogger.info('Opened Build tab stream dropdown');
+    }
+
+    async closeBuildStreamDropdown() {
+        await this.page.keyboard.press('Escape');
+        await this.page.locator(this.buildStreamPopover)
+            .waitFor({ state: 'hidden', timeout: 10000 })
+            .catch(() => {});
+    }
+
+    /**
+     * Filter the open stream dropdown. The option list is virtualised, so
+     * filtering — not scrolling — is the only reliable way to assert that a
+     * specific stream is present or absent.
+     */
+    async filterBuildStreamOptions(text) {
+        const search = this.page.locator(this.buildStreamSearch);
+        await search.waitFor({ state: 'visible', timeout: 10000 });
+        await search.fill(text);
+    }
+
+    /** Change the Build tab's Stream Type. Clears the stream by design. */
+    async selectBuildStreamType(type) {
+        await this.page.locator(this.buildStreamTypeDropdown).click();
+        const popover = this.page.locator(this.buildStreamTypePopover);
+        await popover.waitFor({ state: 'visible', timeout: 10000 });
+        await popover.locator(`[data-test="index-dropdown-stream_type-option"][data-test-value="${type}"]`).first().click();
+        await popover.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {});
+        testLogger.info(`Selected Build tab stream type: ${type}`);
+    }
+
+    /** Pick a stream from the Build tab's field list (opens, filters, clicks). */
+    async selectBuildStream(name) {
+        await this.openBuildStreamDropdown();
+        await this.filterBuildStreamOptions(name);
+        const option = this.page.locator(this.buildStreamOption(name)).first();
+        await option.waitFor({ state: 'visible', timeout: 15000 });
+        await option.click();
+        await this.page.locator(this.buildStreamPopover)
+            .waitFor({ state: 'hidden', timeout: 10000 })
+            .catch(() => {});
+        testLogger.info(`Selected Build tab stream: ${name}`);
     }
 
     /**

--- a/tests/ui-testing/playwright-tests/Logs/logsBuildStreamList.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/logsBuildStreamList.spec.js
@@ -1,0 +1,149 @@
+/**
+ * Logs Build tab — stream list loads without a preselected stream
+ *
+ * Regression cover for openobserve/openobserve#13812
+ * ("fix(logs): load the stream list on Visualize when no stream is selected").
+ *
+ * The Build toggle mounts BuildQueryPage → PanelEditor(editMode: true) →
+ * PanelFieldList with pageKey "build". PanelFieldList deferred its stream-list
+ * fetch until a stream was already set, because edit mode is normally reached
+ * from a saved panel whose data arrives asynchronously.
+ *
+ * The Build tab is not that. `ZO_QUERY_ON_STREAM_SELECTION` defaults to true, so
+ * the logs page selects nothing until the user does — Build therefore mounts with
+ * a blank stream, and its Stream select is the user's own (read-only only when the
+ * page key is "logs", i.e. the Visualize tab). Deferring left that select enabled,
+ * openable and permanently empty on "No options found", with no way to pick a
+ * stream and so no way out.
+ *
+ * The fix adds "build" to STREAM_LIST_WITHOUT_STREAM alongside "metrics". Arming
+ * that initial load also arms the stream_type watcher (it is gated on
+ * `initialStreamsLoaded`), so changing Stream Type with a blank stream refetches
+ * instead of silently no-op'ing.
+ *
+ * Neither test picks a stream on the logs page first — that IS the precondition
+ * the bug needed.
+ *
+ * @tags @logs @queryBuilder @all
+ */
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+const { ingestForQueryBuilderTest } = require('../utils/queryBuilder-helpers.js');
+
+const STREAM_NAME = 'e2e_automate';
+
+test.describe("Logs Build Tab - Stream List Without A Preselected Stream", () => {
+    test.describe.configure({ mode: 'parallel' });
+    let pm;
+
+    test.beforeAll(async ({ request }) => {
+        // The Build tab's stream dropdown must have a real logs stream to offer.
+        await ingestForQueryBuilderTest(request);
+    });
+
+    test.beforeEach(async ({ page }, testInfo) => {
+        testLogger.testStart(testInfo.title, testInfo.file);
+        await navigateToBase(page);
+        pm = new PageManager(page);
+
+        await page.goto(`/web/logs?org_identifier=${process.env["ORGNAME"] ?? "default"}`);
+        await page.waitForLoadState('domcontentloaded');
+
+        // Deliberately NO selectStream() call here. Guard the precondition instead:
+        // if an environment ever pre-seeds a stream on the logs page, Build would
+        // mount with a stream already set and both tests below would pass against
+        // the buggy build without exercising anything.
+        const preselected = await pm.logsPage.getLogsSelectedStream();
+        expect(
+            preselected,
+            'logs page must start with no stream selected — the Build tab inherits that blank stream'
+        ).toBe('');
+    });
+
+    test("Build tab stream dropdown is populated and usable when no stream is selected on the logs page", {
+        tag: ['@queryBuilder', '@functional', '@P0', '@all', '@logs']
+    }, async ({ page }) => {
+        await pm.logsPage.clickBuildToggle();
+        await pm.logsPage.waitForBuildTabLoaded();
+
+        // The select defaults to logs and is the user's own control here — the bug
+        // was an enabled, openable, permanently empty dropdown, not a disabled one.
+        expect(await pm.logsPage.getBuildSelectedStreamType()).toBe('logs');
+        expect(
+            await pm.logsPage.isBuildStreamDropdownEnabled(),
+            'Build tab stream select must be user-editable'
+        ).toBe(true);
+
+        await pm.logsPage.openBuildStreamDropdown();
+
+        // The regression itself: the list never loaded, so OSelect fell through to
+        // its empty state.
+        await expect(
+            page.locator(pm.logsPage.buildStreamPopover).getByText('No options found', { exact: true })
+        ).toHaveCount(0);
+        await expect(page.locator(pm.logsPage.buildStreamOptions).first()).toBeVisible({ timeout: 15000 });
+        expect(await page.locator(pm.logsPage.buildStreamOptions).count()).toBeGreaterThan(0);
+
+        // The ingested stream is actually offered, not just "some" options.
+        await pm.logsPage.filterBuildStreamOptions(STREAM_NAME);
+        const option = page.locator(pm.logsPage.buildStreamOption(STREAM_NAME)).first();
+        await expect(option).toBeVisible({ timeout: 15000 });
+
+        // "no way to pick one" was the user-visible symptom, so assert the pick
+        // lands rather than stopping at the list being non-empty.
+        await option.click();
+        await expect(page.locator(pm.logsPage.buildStreamPopover)).toBeHidden({ timeout: 10000 });
+        expect(await pm.logsPage.getBuildSelectedStream()).toBe(STREAM_NAME);
+
+        // And the selection propagates: the field list loads that stream's schema.
+        // Asserted on "any field row" rather than a named field — this shard runs
+        // with ZO_QUICK_MODE_ENABLED, which narrows which fields are listed.
+        const fieldRows = page.locator('[data-test="logs-build-query-page"] [data-test^="o-field-list-row-"]');
+        await expect(fieldRows.first()).toBeVisible({ timeout: 20000 });
+
+        testLogger.info('Build tab stream list loaded and selectable without a preselected stream');
+    });
+
+    test("Build tab stream list refreshes when the stream type changes with no stream selected", {
+        tag: ['@queryBuilder', '@functional', '@P1', '@all', '@logs']
+    }, async ({ page }) => {
+        await pm.logsPage.clickBuildToggle();
+        await pm.logsPage.waitForBuildTabLoaded();
+
+        // Baseline: under "logs" the ingested stream is listed.
+        await pm.logsPage.openBuildStreamDropdown();
+        await pm.logsPage.filterBuildStreamOptions(STREAM_NAME);
+        await expect(page.locator(pm.logsPage.buildStreamOption(STREAM_NAME)).first())
+            .toBeVisible({ timeout: 15000 });
+        await pm.logsPage.closeBuildStreamDropdown();
+
+        // Switching type must refetch. `e2e_automate` is ingested as a LOGS stream,
+        // so a traces list that still offers it means the list was never refreshed —
+        // this is what the un-armed stream_type watcher used to do.
+        await pm.logsPage.selectBuildStreamType('traces');
+        expect(await pm.logsPage.getBuildSelectedStreamType()).toBe('traces');
+
+        await pm.logsPage.openBuildStreamDropdown();
+        // A real traces list arrived — not merely an empty one. Global setup ingests
+        // traces for every shard, so this pins "refetched" rather than "cleared".
+        await expect(page.locator(pm.logsPage.buildStreamOptions).first())
+            .toBeVisible({ timeout: 15000 });
+        await pm.logsPage.filterBuildStreamOptions(STREAM_NAME);
+        await expect(page.locator(pm.logsPage.buildStreamOption(STREAM_NAME)))
+            .toHaveCount(0, { timeout: 15000 });
+        await pm.logsPage.closeBuildStreamDropdown();
+
+        // Switching back restores it — the watcher fires on every change, not once.
+        await pm.logsPage.selectBuildStreamType('logs');
+        expect(await pm.logsPage.getBuildSelectedStreamType()).toBe('logs');
+
+        await pm.logsPage.openBuildStreamDropdown();
+        await pm.logsPage.filterBuildStreamOptions(STREAM_NAME);
+        await expect(page.locator(pm.logsPage.buildStreamOption(STREAM_NAME)).first())
+            .toBeVisible({ timeout: 15000 });
+
+        testLogger.info('Build tab stream list refreshed on every stream type change');
+    });
+});

--- a/tests/ui-testing/playwright-tests/Logs/logsBuildStreamList.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/logsBuildStreamList.spec.js
@@ -27,7 +27,7 @@
  * @tags @logs @queryBuilder @all
  */
 
-const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const { test, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
 const testLogger = require('../utils/test-logger.js');
 const PageManager = require('../../pages/page-manager.js');
 const { ingestForQueryBuilderTest } = require('../utils/queryBuilder-helpers.js');
@@ -55,94 +55,70 @@ test.describe("Logs Build Tab - Stream List Without A Preselected Stream", () =>
         // if an environment ever pre-seeds a stream on the logs page, Build would
         // mount with a stream already set and both tests below would pass against
         // the buggy build without exercising anything.
-        const preselected = await pm.logsPage.getLogsSelectedStream();
-        expect(
-            preselected,
-            'logs page must start with no stream selected — the Build tab inherits that blank stream'
-        ).toBe('');
+        await pm.logsPage.expectNoLogsStreamSelected();
     });
 
     test("Build tab stream dropdown is populated and usable when no stream is selected on the logs page", {
         tag: ['@queryBuilder', '@functional', '@P0', '@all', '@logs']
-    }, async ({ page }) => {
+    }, async () => {
         await pm.logsPage.clickBuildToggle();
         await pm.logsPage.waitForBuildTabLoaded();
 
         // The select defaults to logs and is the user's own control here — the bug
         // was an enabled, openable, permanently empty dropdown, not a disabled one.
-        expect(await pm.logsPage.getBuildSelectedStreamType()).toBe('logs');
-        expect(
-            await pm.logsPage.isBuildStreamDropdownEnabled(),
-            'Build tab stream select must be user-editable'
-        ).toBe(true);
+        await pm.logsPage.expectBuildStreamType('logs');
+        await pm.logsPage.expectBuildStreamDropdownEditable();
 
         await pm.logsPage.openBuildStreamDropdown();
 
         // The regression itself: the list never loaded, so OSelect fell through to
         // its empty state.
-        await expect(
-            page.locator(pm.logsPage.buildStreamPopover).getByText('No options found', { exact: true })
-        ).toHaveCount(0);
-        await expect(page.locator(pm.logsPage.buildStreamOptions).first()).toBeVisible({ timeout: 15000 });
-        expect(await page.locator(pm.logsPage.buildStreamOptions).count()).toBeGreaterThan(0);
+        await pm.logsPage.expectBuildStreamListPopulated();
 
         // The ingested stream is actually offered, not just "some" options.
-        await pm.logsPage.filterBuildStreamOptions(STREAM_NAME);
-        const option = page.locator(pm.logsPage.buildStreamOption(STREAM_NAME)).first();
-        await expect(option).toBeVisible({ timeout: 15000 });
+        await pm.logsPage.expectBuildStreamOptionVisible(STREAM_NAME);
 
         // "no way to pick one" was the user-visible symptom, so assert the pick
         // lands rather than stopping at the list being non-empty.
-        await option.click();
-        await expect(page.locator(pm.logsPage.buildStreamPopover)).toBeHidden({ timeout: 10000 });
-        expect(await pm.logsPage.getBuildSelectedStream()).toBe(STREAM_NAME);
+        await pm.logsPage.clickBuildStreamOption(STREAM_NAME);
+        await pm.logsPage.expectBuildStreamSelected(STREAM_NAME);
 
         // And the selection propagates: the field list loads that stream's schema.
-        // Asserted on "any field row" rather than a named field — this shard runs
-        // with ZO_QUICK_MODE_ENABLED, which narrows which fields are listed.
-        const fieldRows = page.locator('[data-test="logs-build-query-page"] [data-test^="o-field-list-row-"]');
-        await expect(fieldRows.first()).toBeVisible({ timeout: 20000 });
+        await pm.logsPage.expectBuildFieldListPopulated();
 
         testLogger.info('Build tab stream list loaded and selectable without a preselected stream');
     });
 
     test("Build tab stream list refreshes when the stream type changes with no stream selected", {
         tag: ['@queryBuilder', '@functional', '@P1', '@all', '@logs']
-    }, async ({ page }) => {
+    }, async () => {
         await pm.logsPage.clickBuildToggle();
         await pm.logsPage.waitForBuildTabLoaded();
 
         // Baseline: under "logs" the ingested stream is listed.
         await pm.logsPage.openBuildStreamDropdown();
-        await pm.logsPage.filterBuildStreamOptions(STREAM_NAME);
-        await expect(page.locator(pm.logsPage.buildStreamOption(STREAM_NAME)).first())
-            .toBeVisible({ timeout: 15000 });
+        await pm.logsPage.expectBuildStreamOptionVisible(STREAM_NAME);
         await pm.logsPage.closeBuildStreamDropdown();
 
         // Switching type must refetch. `e2e_automate` is ingested as a LOGS stream,
         // so a traces list that still offers it means the list was never refreshed —
         // this is what the un-armed stream_type watcher used to do.
         await pm.logsPage.selectBuildStreamType('traces');
-        expect(await pm.logsPage.getBuildSelectedStreamType()).toBe('traces');
+        await pm.logsPage.expectBuildStreamType('traces');
 
         await pm.logsPage.openBuildStreamDropdown();
         // A real traces list arrived — not merely an empty one. Global setup ingests
         // traces for every shard, so this pins "refetched" rather than "cleared".
-        await expect(page.locator(pm.logsPage.buildStreamOptions).first())
-            .toBeVisible({ timeout: 15000 });
-        await pm.logsPage.filterBuildStreamOptions(STREAM_NAME);
-        await expect(page.locator(pm.logsPage.buildStreamOption(STREAM_NAME)))
-            .toHaveCount(0, { timeout: 15000 });
+        await pm.logsPage.expectBuildStreamListPopulated();
+        await pm.logsPage.expectBuildStreamOptionAbsent(STREAM_NAME);
         await pm.logsPage.closeBuildStreamDropdown();
 
         // Switching back restores it — the watcher fires on every change, not once.
         await pm.logsPage.selectBuildStreamType('logs');
-        expect(await pm.logsPage.getBuildSelectedStreamType()).toBe('logs');
+        await pm.logsPage.expectBuildStreamType('logs');
 
         await pm.logsPage.openBuildStreamDropdown();
-        await pm.logsPage.filterBuildStreamOptions(STREAM_NAME);
-        await expect(page.locator(pm.logsPage.buildStreamOption(STREAM_NAME)).first())
-            .toBeVisible({ timeout: 15000 });
+        await pm.logsPage.expectBuildStreamOptionVisible(STREAM_NAME);
 
         testLogger.info('Build tab stream list refreshed on every stream type change');
     });


### PR DESCRIPTION
Adds E2E regression cover for the fix in #13812.

The Logs → Build toggle mounts PanelFieldList with pageKey "build" in edit
mode, which deferred its stream-list fetch until a stream was already set.
Since ZO_QUERY_ON_STREAM_SELECTION defaults to true, the logs page selects
nothing, so Build mounted blank and its Stream dropdown was left enabled,
openable and permanently empty on "No options found" — no way to pick a
stream, no way out.

## Tests (Logs-SelectStar shard)

- **P0** — with no stream selected on the logs page, the Build tab's Stream
  dropdown is populated and a stream can actually be picked: no empty state,
  options render, `e2e_automate` is offered, selecting it lands, and the
  field list loads that stream's schema.
- **P1** — changing Stream Type with a blank stream refetches the list:
  logs → traces drops `e2e_automate` (a logs stream) and loads a real traces
  list, switching back restores it. Covers the stream_type watcher, which is
  gated on the same `initialStreamsLoaded` flag the fix arms.

`beforeEach` asserts the logs page starts with no stream selected — without
that precondition both tests would pass against the buggy build.

## Notes

- Page-object locators are scoped to `[data-test="logs-build-query-page"]`:
  the Visualize tab mounts a second PanelEditor that stays in the DOM under
  `v-show`, so an unscoped `index-dropdown-stream` is a strict-mode violation.
- Verified 6/6 green over 3 repeats locally. The shard runs the backend with
  ZO_QUICK_MODE_ENABLED=true, which the local instance does not — assertions
  avoid named fields so quick mode's field narrowing can't affect them.
