### PR TITLE
fix(ofga): migrate annotation queue and dataset permissions

### DIFF
--- a/src/core/src/ofga/mod.rs
+++ b/src/core/src/ofga/mod.rs
@@ -76,6 +76,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     let mut need_workflows_migration = false;
     let mut need_synthetics_migration = false;
     let mut need_stream_names_migration = false;
+    let mut need_annotation_queues_datasets_migration = false;
 
     let existing_meta: Option<o2_openfga::meta::mapping::OFGAModel> =
         match db::ofga::get_ofga_model().await {
@@ -262,6 +263,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
                 let v0_0_36 = version_compare::Version::from("0.0.36").unwrap();
                 let v0_0_37 = version_compare::Version::from("0.0.37").unwrap();
                 let v0_0_38 = version_compare::Version::from("0.0.38").unwrap();
+                let v0_0_39 = version_compare::Version::from("0.0.39").unwrap();
 
                 if meta_version > v0_0_5 && existing_model_version < v0_0_6 {
                     need_pipeline_migration = true;
@@ -347,6 +349,12 @@ pub async fn init() -> Result<(), anyhow::Error> {
                 if existing_model_version < v0_0_38 {
                     log::info!("[OFGA:Local] stream names migration needed");
                     need_stream_names_migration = true;
+                }
+                if existing_model_version < v0_0_39 {
+                    log::info!(
+                        "[OFGA:Local] annotation queues and datasets permissions migration needed"
+                    );
+                    need_annotation_queues_datasets_migration = true;
                 }
             }
 
@@ -491,6 +499,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
                     }
                     if need_workflows_migration {
                         get_ownership_all_org_tuple(org_name, "workflows", &mut tuples);
+                    }
+                    if need_annotation_queues_datasets_migration {
+                        get_ownership_all_org_tuple(org_name, "annotation_queues", &mut tuples);
+                        get_ownership_all_org_tuple(org_name, "datasets", &mut tuples);
                     }
                 }
                 if need_alert_folders_migration {


### PR DESCRIPTION
## What

Adds the OpenFGA migration for the `annotation_queues` and `datasets` resources, gated on model version `0.0.39`, following the pattern used for every other resource in `init()`:

- a `need_annotation_queues_datasets_migration` flag
- a `v0_0_39` version constant
- an `existing_model_version < v0_0_39` gate
- `get_ownership_all_org_tuple(org_name, "annotation_queues", …)` and `…"datasets"…` in the per-org loop

Those two strings are the `OFGA_MODELS` map keys added in o2-enterprise, which resolve to the `annotation_queue` and `dataset` object types.

## Why

`annotation_queue` and `dataset` were added to the OpenFGA model without a migration, so existing deployments never receive the `_all_<org>` ownership tuples for them.

## Depends on

o2-enterprise#2477, which adds the two types to `model.json` and bumps `o2_version` to `0.0.39`. Without it this migration never fires, since the version gate is never crossed.

## Verification

Verified on a local enterprise instance running both changes:

```
[OFGA:Local] model version changed: 0.0.38 -> 0.0.39
[OFGA:Local] annotation queues and datasets permissions migration needed
[OFGA:Local] Data migrated to openfga
```

- `org:<org> owningOrg annotation_queue:_all_<org>` and `… dataset:_all_<org>` are written, with no errors in the batch.
- Creating a role and saving `annotation_queue` / `dataset` permissions returns 200 and reads back correctly.
- OpenFGA `check`, with the `org_context` contextual tuple the app sends, resolves correctly: `AllowAll` on `annotation_queue` permits GET/POST/DELETE; `AllowList` only on `dataset` permits LIST and denies DELETE.
- `cargo check -p openobserve-core --features enterprise` is clean.

No frontend change is needed — the roles edit page builds its resource list from the `/resources` endpoint, and the entity fetchers for both resources already shipped in #13719.