### PR TITLE
fix(infra): take the sqlite write lock for every non-postgres meta store

### DIFF
--- a/src/infra/src/table/mod.rs
+++ b/src/infra/src/table/mod.rs
@@ -13,12 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::get_config;
+use config::{get_config, meta::meta_store::MetaStore};
 use migration::Migrator;
 use sea_orm_migration::MigratorTrait;
 
 use crate::{
-    db::{ORM_CLIENT_DDL, SQLITE_STORE, connect_to_orm_ddl, sqlite::CLIENT_RW},
+    db::{ORM_CLIENT_DDL, connect_to_orm_ddl, sqlite::CLIENT_RW},
     dist_lock,
 };
 
@@ -141,17 +141,17 @@ pub async fn create_user_tables() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Acquires a lock on the SQLite client if SQLite is configured as the meta store.
+/// Acquires a lock on the SQLite client if the ORM runs on SQLite.
+///
+/// `connect_to_orm` uses the shared SQLite pool for every meta store except
+/// PostgreSQL, so the write lock must match that, not just
+/// `ZO_META_STORE=sqlite`.
 ///
 /// # Returns
-/// - `Some(MutexGuard)` if SQLite is configured
-/// - `None` if a different store is configured
+/// - `Some(MutexGuard)` if the ORM runs on SQLite
+/// - `None` if PostgreSQL is configured
 pub async fn get_lock() -> Option<tokio::sync::MutexGuard<'static, sqlx::Pool<sqlx::Sqlite>>> {
-    if get_config()
-        .common
-        .meta_store
-        .eq_ignore_ascii_case(SQLITE_STORE)
-    {
+    if MetaStore::from(get_config().common.meta_store.as_str()) != MetaStore::PostgreSQL {
         Some(CLIENT_RW.lock().await)
     } else {
         None


### PR DESCRIPTION
## What

`infra::table::get_lock()` now engages for every meta store except PostgreSQL, matching `connect_to_orm`'s pool selection, instead of only for `ZO_META_STORE=sqlite`.

## Why

`connect_to_orm` falls back to the shared SQLite pool for every non-postgres meta store. With `ZO_META_STORE=nats` the ORM therefore still writes to `metadata.sqlite`, but every one of the ~250 `get_lock()` call sites returned `None` and became a no-op — leaving concurrent ORM writes unserialized. In WAL mode a deferred read-then-write transaction whose snapshot went stale fails immediately with `(code: 517) database is locked` (`SQLITE_BUSY_SNAPSHOT`); `busy_timeout` never retries that error, so affected endpoints returned 500s under any concurrent write.

## Notes for reviewers

- No behavior change for `ZO_META_STORE=sqlite` (lock still taken) or `postgres`/`postgresql` (still `None`). Only non-postgres, non-sqlite values — which the ORM already routes to SQLite — gain the serialization they were always supposed to have.
- `MetaStore::from` maps unknown values to `Sqlite`, so the fallback arm matches `connect_to_orm`'s `_ =>` arm exactly.
- A paired enterprise-side fix serializes the annotation-queue write paths themselves (the module that surfaced this).