### PR TITLE
fix(infra): serialize every remaining sqlite write path

### DIFF
--- a/src/core/src/alerts/composite/service.rs
+++ b/src/core/src/alerts/composite/service.rs
@@ -21,6 +21,7 @@ use infra::{
     table::{
         alert_composites,
         entity::{alert_composite_children, alert_composites as composite_entity},
+        get_lock,
     },
 };
 #[cfg(feature = "enterprise")]
@@ -151,6 +152,8 @@ pub async fn set_composite_enabled(
     }
     use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, sea_query::Expr};
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     let result = composite_entity::Entity::update_many()
         .col_expr(composite_entity::Column::Enabled, Expr::value(enabled))
         .col_expr(
@@ -161,6 +164,8 @@ pub async fn set_composite_enabled(
         .filter(composite_entity::Column::Id.eq(id))
         .exec(db)
         .await?;
+    // released before the scheduler follow-ups below, which take this lock themselves
+    drop(_lock);
     if result.rows_affected != 1 {
         return Err(CompositeServiceError::NotFound);
     }
@@ -242,6 +247,8 @@ pub async fn move_composite(
     {
         return Err(CompositeServiceError::PermissionDenied);
     }
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     let result = composite_entity::Entity::update_many()
         .col_expr(composite_entity::Column::FolderId, Expr::value(folder_id))
         .col_expr(composite_entity::Column::LastEditedBy, Expr::value(editor))
@@ -257,6 +264,8 @@ pub async fn move_composite(
         .filter(composite_entity::Column::Id.eq(id))
         .exec(db)
         .await?;
+    // released before the OpenFGA relation rewrites below
+    drop(_lock);
     #[cfg(feature = "enterprise")]
     if get_openfga_config().enabled {
         set_parent_relation(

--- a/src/core/src/alerts/deduplication.rs
+++ b/src/core/src/alerts/deduplication.rs
@@ -25,7 +25,7 @@ use config::{
     },
     utils::json::{Map, Value},
 };
-use infra::table::entity::alert_dedup_state;
+use infra::table::{entity::alert_dedup_state, get_lock};
 use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
 
 /// Append the evaluated level to a fingerprint for MULTI-LEVEL alerts.
@@ -161,6 +161,8 @@ pub async fn confirm_notification_sent(
     if fingerprints.is_empty() {
         return Ok(());
     }
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     alert_dedup_state::Entity::update_many()
         .col_expr(
             alert_dedup_state::Column::NotificationSent,
@@ -197,6 +199,8 @@ pub async fn save_dedup_state(
     db: &DatabaseConnection,
     params: DedupStateParams<'_>,
 ) -> Result<alert_dedup_state::Model, sea_orm::DbErr> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     // Try to find existing record
     if let Some(existing) = get_dedup_state(db, params.fingerprint).await? {
         // Update existing
@@ -237,6 +241,8 @@ pub async fn cleanup_expired_state(
     let cutoff_time = o2_enterprise::enterprise::alerts::dedup::current_timestamp_micros()
         - (older_than_minutes * 60 * 1_000_000);
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     let query = alert_dedup_state::Entity::delete_many()
         .filter(alert_dedup_state::Column::LastSeenAt.lt(cutoff_time));
 

--- a/src/core/src/alerts/scheduler/handlers.rs
+++ b/src/core/src/alerts/scheduler/handlers.rs
@@ -40,6 +40,7 @@ use cron::Schedule;
 use infra::{
     db::{ORM_CLIENT, connect_to_orm},
     scheduler::get_scheduler_max_retries,
+    table::get_lock,
 };
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::recommendations::service::QueryRecommendationService;
@@ -815,6 +816,8 @@ async fn handle_composite_alert_trigger(
     use sea_orm::{
         ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QuerySelect, TransactionTrait,
     };
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     let transaction = db.begin().await?;
     let lease_deadline = now + config::get_config().limit.alert_schedule_timeout * 1_000_000;
     if !infra::scheduler::renew_claim_in_transaction(
@@ -840,6 +843,8 @@ async fn handle_composite_alert_trigger(
             || current.evaluation_generation != definition.definition.evaluation_generation
     }) {
         transaction.rollback().await?;
+        // released before complete_claim, which takes this lock itself on sqlite
+        drop(_lock);
         trigger.status = db::scheduler::TriggerStatus::Waiting;
         trigger.next_run_at = now + composite_debounce_secs() * 1_000_000;
         let _ = infra::scheduler::complete_claim(trigger).await?;
@@ -847,6 +852,8 @@ async fn handle_composite_alert_trigger(
     }
     infra::table::alert_states::persist_update_in_transaction(&transaction, &update).await?;
     transaction.commit().await?;
+    // released before delivery and complete_claim below, which take this lock themselves
+    drop(_lock);
 
     let mut delivery_retry_at = None;
     if evaluated.result {
@@ -1277,6 +1284,8 @@ async fn handle_anomaly_detection_triggers(
             let mut active = config.into_active_model();
             active.status = Set(AnomalyStatus::Active.to_i32());
             active.updated_at = Set(run_end_us);
+            // make sure only one client is writing to the database(only for sqlite)
+            let _lock = get_lock().await;
             if let Err(e) = active.update(db).await {
                 log::warn!(
                     "[anomaly_detection] failed to reset status to Active for {anomaly_id}: {e}"

--- a/src/core/src/anomaly_detection.rs
+++ b/src/core/src/anomaly_detection.rs
@@ -25,7 +25,10 @@ use config::{
     utils::time::now_micros,
 };
 use db::authz::{remove_ownership, set_ownership};
-use infra::{db::ORM_CLIENT, table::anomaly_detection::config as anomaly_config_table};
+use infra::{
+    db::ORM_CLIENT,
+    table::{anomaly_detection::config as anomaly_config_table, get_lock},
+};
 use sea_orm::{ActiveModelTrait, IntoActiveModel, Set};
 use search_service as search;
 use serde::{Deserialize, Serialize};
@@ -692,7 +695,11 @@ pub async fn update_config(
 
     active_model.updated_at = Set(Utc::now().timestamp_micros());
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     let updated = active_model.update(db).await?;
+    // released before the retrain/scheduler follow-ups below, which take this lock themselves
+    drop(_lock);
 
     // Evict any cached model for this config — training params may have changed,
     // so the next detection run should load a fresh model from S3.
@@ -1078,7 +1085,10 @@ async fn force_retrain_for_threshold(org_id: &str, anomaly_id: &str) -> Result<(
     active.status = Set(0i32);
     active.is_trained = Set(false);
     active.updated_at = Set(Utc::now().timestamp_micros());
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     active.update(db).await?;
+    drop(_lock);
 
     // Nudge the training scheduler so the retrain fires promptly rather than on its next
     // periodic sweep.
@@ -1111,6 +1121,8 @@ pub async fn cancel_training(org_id: &str, anomaly_id: &str) -> Result<()> {
     active.training_started_at = Set(None);
     active.last_error = Set(Some("Training cancelled by user.".to_string()));
     active.updated_at = Set(Utc::now().timestamp_micros());
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     active.update(db).await?;
 
     log::info!("[anomaly_detection {anomaly_id}] training cancelled by user");

--- a/src/db/src/pipeline_errors.rs
+++ b/src/db/src/pipeline_errors.rs
@@ -33,6 +33,8 @@ pub async fn upsert(
     timestamp: i64,
     error_data: &PipelineError,
 ) -> Result<(), infra::errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = infra::table::get_lock().await;
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
     // Serialize node_errors to JSON
@@ -129,6 +131,8 @@ pub async fn batch_upsert(
     let errors = dedup_and_sort(errors);
 
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = infra::table::get_lock().await;
     let txn = client.begin().await?;
 
     // Collect all pipeline_ids to check which exist
@@ -225,6 +229,8 @@ pub async fn get_by_pipeline_id(
 
 /// Deletes a pipeline error record by pipeline_id.
 pub async fn delete(pipeline_id: &str) -> Result<(), infra::errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = infra::table::get_lock().await;
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
     PipelineLastErrors::delete_many()
@@ -237,6 +243,8 @@ pub async fn delete(pipeline_id: &str) -> Result<(), infra::errors::Error> {
 
 /// Deletes all pipeline error records for an organization.
 pub async fn delete_by_org(org_id: &str) -> Result<(), infra::errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = infra::table::get_lock().await;
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
     PipelineLastErrors::delete_many()

--- a/src/db/src/pipeline_errors.rs
+++ b/src/db/src/pipeline_errors.rs
@@ -33,16 +33,18 @@ pub async fn upsert(
     timestamp: i64,
     error_data: &PipelineError,
 ) -> Result<(), infra::errors::Error> {
-    // make sure only one client is writing to the database(only for sqlite)
-    let _lock = infra::table::get_lock().await;
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
-    // Serialize node_errors to JSON
+    // Serialize node_errors to JSON before taking the write lock
     let node_errors_json = if !error_data.node_errors.is_empty() {
         Some(serde_json::to_value(&error_data.node_errors)?)
     } else {
         None
     };
+
+    // make sure only one client is writing to the database(only for sqlite);
+    // taken before the existence check so the read-modify-write is serialized
+    let _lock = infra::table::get_lock().await;
 
     // Check if record exists
     let existing = PipelineLastErrors::find_by_id(pipeline_id)
@@ -130,13 +132,32 @@ pub async fn batch_upsert(
     // Collapse repeats and fix the row order so concurrently flushing nodes can't deadlock
     let errors = dedup_and_sort(errors);
 
+    // Serialize node_errors to JSON before taking the write lock: pure CPU
+    // work has no business inside the serialized critical section
+    let mut errors_json = Vec::with_capacity(errors.len());
+    for (pipeline_id, pipeline_name, org_id, timestamp, error_data) in errors {
+        let node_errors_json = if !error_data.node_errors.is_empty() {
+            Some(serde_json::to_value(&error_data.node_errors)?)
+        } else {
+            None
+        };
+        errors_json.push((
+            pipeline_id,
+            pipeline_name,
+            org_id,
+            timestamp,
+            error_data,
+            node_errors_json,
+        ));
+    }
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     // make sure only one client is writing to the database(only for sqlite)
     let _lock = infra::table::get_lock().await;
     let txn = client.begin().await?;
 
     // Collect all pipeline_ids to check which exist
-    let pipeline_ids: Vec<&str> = errors.iter().map(|(id, ..)| id.as_str()).collect();
+    let pipeline_ids: Vec<&str> = errors_json.iter().map(|(id, ..)| id.as_str()).collect();
 
     let existing_records = PipelineLastErrors::find()
         .filter(pipeline_last_errors::Column::PipelineId.is_in(pipeline_ids))
@@ -152,14 +173,8 @@ pub async fn batch_upsert(
 
     let now = now_micros();
 
-    for (pipeline_id, pipeline_name, org_id, timestamp, error_data) in errors {
-        // Serialize node_errors to JSON
-        let node_errors_json = if !error_data.node_errors.is_empty() {
-            Some(serde_json::to_value(&error_data.node_errors)?)
-        } else {
-            None
-        };
-
+    for (pipeline_id, pipeline_name, org_id, timestamp, error_data, node_errors_json) in errors_json
+    {
         if let Some(existing) = existing_map.get(&pipeline_id) {
             // Check if error content has actually changed
             let error_changed = existing.error_summary != error_data.error

--- a/src/infra/src/db/mod.rs
+++ b/src/infra/src/db/mod.rs
@@ -50,8 +50,10 @@ pub async fn connect_to_orm() -> DatabaseConnection {
             SqlxPostgresConnector::from_sqlx_postgres_pool(pool)
         }
         _ => {
-            let pool = { sqlite::CLIENT_RW.lock().await.clone() };
-            SqlxSqliteConnector::from_sqlx_sqlite_pool(pool)
+            // clone the pool handle directly, NOT through the CLIENT_RW mutex:
+            // callers may lazily initialize ORM_CLIENT while already holding
+            // `table::get_lock()`, and locking here again would self-deadlock
+            SqlxSqliteConnector::from_sqlx_sqlite_pool(sqlite::CLIENT_RW_POOL.clone())
         }
     }
 }
@@ -64,8 +66,7 @@ pub async fn connect_to_orm_ddl() -> DatabaseConnection {
         }
         _ => {
             // for sqlite, there is no separate ddl client, use the common one
-            let pool = { sqlite::CLIENT_RW.lock().await.clone() };
-            SqlxSqliteConnector::from_sqlx_sqlite_pool(pool)
+            SqlxSqliteConnector::from_sqlx_sqlite_pool(sqlite::CLIENT_RW_POOL.clone())
         }
     }
 }
@@ -451,5 +452,17 @@ mod tests {
         db.put("/foo/del/bar3", hello, false, None).await.unwrap();
         assert_eq!(db.list_keys("/foo/del/").await.unwrap().len(), 3);
         assert_eq!(db.list_values("/foo/del/").await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn connect_to_orm_never_takes_the_sqlite_write_mutex() {
+        // Regression: a task may lazily initialize ORM_CLIENT while already
+        // holding table::get_lock() (the CLIENT_RW mutex). connect_to_orm must
+        // clone the pool handle without locking CLIENT_RW itself, or the first
+        // cold-start write from any entry point self-deadlocks forever.
+        let _guard = sqlite::CLIENT_RW.lock().await;
+        tokio::time::timeout(std::time::Duration::from_secs(5), connect_to_orm())
+            .await
+            .expect("connect_to_orm deadlocked on the held CLIENT_RW mutex");
     }
 }

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -40,11 +40,8 @@ use crate::{
 };
 
 pub static CLIENT_RO: Lazy<Pool<Sqlite>> = Lazy::new(connect_ro);
-/// The shared RW pool. sqlx pools are cheap Arc-style handles, so this and the
-/// clone inside [`CLIENT_RW`] are the same underlying pool. Cloning this never
-/// touches the write mutex — `connect_to_orm` must use this so that a task
-/// already holding [`CLIENT_RW`] (via `table::get_lock()`) can lazily
-/// initialize the ORM client without deadlocking on its own guard.
+/// Same pool as [`CLIENT_RW`], cloneable without taking the mutex — so the ORM
+/// can be lazily initialized while `table::get_lock()` is held.
 pub static CLIENT_RW_POOL: Lazy<Pool<Sqlite>> = Lazy::new(connect_rw);
 pub static CLIENT_RW: Lazy<Arc<Mutex<Pool<Sqlite>>>> =
     Lazy::new(|| Arc::new(Mutex::new(CLIENT_RW_POOL.clone())));

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -40,8 +40,14 @@ use crate::{
 };
 
 pub static CLIENT_RO: Lazy<Pool<Sqlite>> = Lazy::new(connect_ro);
+/// The shared RW pool. sqlx pools are cheap Arc-style handles, so this and the
+/// clone inside [`CLIENT_RW`] are the same underlying pool. Cloning this never
+/// touches the write mutex — `connect_to_orm` must use this so that a task
+/// already holding [`CLIENT_RW`] (via `table::get_lock()`) can lazily
+/// initialize the ORM client without deadlocking on its own guard.
+pub static CLIENT_RW_POOL: Lazy<Pool<Sqlite>> = Lazy::new(connect_rw);
 pub static CLIENT_RW: Lazy<Arc<Mutex<Pool<Sqlite>>>> =
-    Lazy::new(|| Arc::new(Mutex::new(connect_rw())));
+    Lazy::new(|| Arc::new(Mutex::new(CLIENT_RW_POOL.clone())));
 static INDICES: OnceCell<HashSet<DBIndex>> = OnceCell::const_new();
 
 pub static CHANNEL: Lazy<SqliteDbChannel> = Lazy::new(SqliteDbChannel::new);

--- a/src/infra/src/table/alert_composites.rs
+++ b/src/infra/src/table/alert_composites.rs
@@ -11,7 +11,10 @@ use sea_orm::{
     sea_query::{Expr, LockType},
 };
 
-use super::entity::{alert_composite_children, alert_composites, alerts};
+use super::{
+    entity::{alert_composite_children, alert_composites, alerts},
+    get_lock,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(i16)]
@@ -47,6 +50,10 @@ where
 {
     let id = active_string(&definition.id, "composite id")?;
     validate_child_ownership(&children, &id)?;
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = conn.begin().await?;
     let definition = definition.insert(&txn).await?;
     if !children.is_empty() {
@@ -73,6 +80,10 @@ where
     let id = active_string(&replacement.id, "composite id")?;
     let org = active_string(&replacement.org, "composite org")?;
     validate_child_ownership(&children, &id)?;
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = conn.begin().await?;
     let mut current_query =
         alert_composites::Entity::find_by_id(&id).filter(alert_composites::Column::Org.eq(&org));
@@ -305,6 +316,9 @@ pub async fn increment_evaluation_generation<C: ConnectionTrait>(
     org: &str,
     id: &str,
 ) -> Result<i64, sea_orm::DbErr> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let backend = conn.get_database_backend();
     let sql = match backend {
         sea_orm::DatabaseBackend::Postgres => {
@@ -352,6 +366,9 @@ pub async fn delete_by_id<C>(conn: &C, org: &str, id: &str) -> Result<(), sea_or
 where
     C: ConnectionTrait + TransactionTrait,
 {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = conn.begin().await?;
     let exists = alert_composites::Entity::find_by_id(id)
         .filter(alert_composites::Column::Org.eq(org))
@@ -381,6 +398,9 @@ pub async fn delete_by_org<C>(conn: &C, org: &str) -> Result<(), sea_orm::DbErr>
 where
     C: ConnectionTrait + TransactionTrait,
 {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = conn.begin().await?;
     let ids = alert_composites::Entity::find()
         .select_only()

--- a/src/infra/src/table/alert_eval_intervals.rs
+++ b/src/infra/src/table/alert_eval_intervals.rs
@@ -28,7 +28,7 @@
 use config::meta::alerts::{level::AlertLevel, state::EvalLedgerWrite};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
 
-use super::entity::alert_eval_intervals;
+use super::{entity::alert_eval_intervals, get_lock};
 use crate::{
     db::{ORM_CLIENT, connect_to_orm},
     errors,
@@ -241,6 +241,9 @@ pub async fn earliest_from_us_with<C: sea_orm::ConnectionTrait>(
 /// cutoff but began long before it — survives. Deleting on `from_us` would
 /// delete the interval an alert has been sitting in for months.
 pub async fn delete_before(cutoff_us: i64) -> Result<u64, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     delete_before_with(client, cutoff_us).await
 }
@@ -260,6 +263,9 @@ pub async fn delete_before_with<C: sea_orm::ConnectionTrait>(
 /// Remove an alert's whole ledger. Called when the alert is deleted — these
 /// rows are owned by the alert's lifecycle, exactly like its state rows.
 pub async fn delete_by_alert(alert_id: &str) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     delete_by_alert_with(client, alert_id).await
 }

--- a/src/infra/src/table/alert_incidents.rs
+++ b/src/infra/src/table/alert_incidents.rs
@@ -19,7 +19,8 @@
 
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect, Set, TransactionTrait, sea_query::LockType,
+    QuerySelect, Set, TransactionTrait,
+    sea_query::{Expr, LockType},
 };
 use svix_ksuid::KsuidLike;
 
@@ -664,39 +665,54 @@ pub async fn upgrade_incident_group_values(
 pub async fn auto_resolve_stale(
     stale_threshold_micros: i64,
 ) -> Result<(u64, Vec<(String, String)>), errors::Error> {
+    const PAGE_SIZE: u64 = 500;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
     let cutoff = now - stale_threshold_micros;
 
-    // make sure only one client is writing to the database(only for sqlite)
-    let _lock = get_lock().await;
+    let mut resolved_ids = Vec::new();
+    loop {
+        // make sure only one client is writing to the database(only for sqlite).
+        // Re-acquired per page so a large backlog doesn't monopolize the global
+        // write lock; each pass shrinks the non-resolved candidate set.
+        let _lock = get_lock().await;
 
-    // Find all open/acknowledged incidents with last_alert_at older than threshold
-    let stale_incidents = alert_incidents::Entity::find()
-        .filter(alert_incidents::Column::Status.ne("resolved"))
-        .filter(alert_incidents::Column::LastAlertAt.lt(cutoff))
-        .all(client)
-        .await
-        .map_err(|e| Error::DbError(DbError::SeaORMError(e.to_string())))?;
+        // Find open/acknowledged incidents with last_alert_at older than threshold
+        let stale_incidents = alert_incidents::Entity::find()
+            .filter(alert_incidents::Column::Status.ne("resolved"))
+            .filter(alert_incidents::Column::LastAlertAt.lt(cutoff))
+            .limit(PAGE_SIZE)
+            .all(client)
+            .await
+            .map_err(|e| Error::DbError(DbError::SeaORMError(e.to_string())))?;
+        if stale_incidents.is_empty() {
+            break;
+        }
+        let page_full = stale_incidents.len() as u64 == PAGE_SIZE;
 
-    let count = stale_incidents.len() as u64;
-    let mut resolved_ids = Vec::with_capacity(stale_incidents.len());
+        let page_ids: Vec<String> = stale_incidents.iter().map(|i| i.id.clone()).collect();
+        alert_incidents::Entity::update_many()
+            .col_expr(alert_incidents::Column::Status, Expr::value("resolved"))
+            .col_expr(alert_incidents::Column::ResolvedAt, Expr::value(Some(now)))
+            .col_expr(alert_incidents::Column::UpdatedAt, Expr::value(now))
+            .filter(alert_incidents::Column::Id.is_in(page_ids))
+            .filter(alert_incidents::Column::Status.ne("resolved"))
+            .exec(client)
+            .await
+            .map_err(|e| Error::DbError(DbError::SeaORMError(e.to_string())))?;
 
-    for incident in stale_incidents {
-        let org_id = incident.org_id.clone();
-        let incident_id = incident.id.clone();
-        let mut active: alert_incidents::ActiveModel = incident.into();
-        active.status = Set("resolved".to_string());
-        active.resolved_at = Set(Some(now));
-        active.updated_at = Set(now);
-
-        if let Err(e) = active.update(client).await {
-            log::warn!("[incidents] Failed to auto-resolve incident: {}", e);
-        } else {
-            resolved_ids.push((org_id, incident_id));
+        resolved_ids.extend(
+            stale_incidents
+                .into_iter()
+                .map(|incident| (incident.org_id, incident.id)),
+        );
+        if !page_full {
+            break;
         }
     }
 
+    let count = resolved_ids.len() as u64;
     Ok((count, resolved_ids))
 }
 

--- a/src/infra/src/table/alert_incidents.rs
+++ b/src/infra/src/table/alert_incidents.rs
@@ -23,7 +23,10 @@ use sea_orm::{
 };
 use svix_ksuid::KsuidLike;
 
-use super::entity::{alert_incident_alerts, alert_incidents};
+use super::{
+    entity::{alert_incident_alerts, alert_incidents},
+    get_lock,
+};
 use crate::{
     db::{ORM_CLIENT, connect_to_orm},
     errors::{self, DbError, Error},
@@ -71,6 +74,9 @@ pub async fn create(
         updated_at: Set(now),
     };
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     model
         .insert(client)
         .await
@@ -93,6 +99,9 @@ pub async fn add_alert_to_incident(
 ) -> Result<bool, errors::Error> {
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
 
     // Use transaction for atomic update
     let txn = client
@@ -165,6 +174,9 @@ pub async fn update_status(
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let incident = get(org_id, id)
         .await?
         .ok_or_else(|| Error::DbError(DbError::SeaORMError("Incident not found".to_string())))?;
@@ -192,6 +204,9 @@ pub async fn update_title(
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let incident = get(org_id, id)
         .await?
         .ok_or_else(|| Error::DbError(DbError::SeaORMError("Incident not found".to_string())))?;
@@ -214,6 +229,9 @@ pub async fn update_severity(
 ) -> Result<alert_incidents::Model, errors::Error> {
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
 
     let incident = get(org_id, id)
         .await?
@@ -465,6 +483,9 @@ pub async fn update_topology(
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let incident = get(org_id, id)
         .await?
         .ok_or_else(|| Error::DbError(DbError::SeaORMError("Incident not found".to_string())))?;
@@ -505,6 +526,9 @@ pub async fn update_incident_metadata(
 ) -> Result<(), errors::Error> {
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
 
     let incident = get(org_id, id)
         .await?
@@ -604,6 +628,9 @@ pub async fn upgrade_incident_group_values(
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let incident = get(org_id, id)
         .await?
         .ok_or_else(|| Error::DbError(DbError::SeaORMError("Incident not found".to_string())))?;
@@ -641,6 +668,9 @@ pub async fn auto_resolve_stale(
     let now = chrono::Utc::now().timestamp_micros();
     let cutoff = now - stale_threshold_micros;
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     // Find all open/acknowledged incidents with last_alert_at older than threshold
     let stale_incidents = alert_incidents::Entity::find()
         .filter(alert_incidents::Column::Status.ne("resolved"))
@@ -672,6 +702,9 @@ pub async fn auto_resolve_stale(
 
 /// Deletes all alert incidents belonging to the given org.
 pub async fn delete_by_org(org_id: &str) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     alert_incidents::Entity::delete_many()
         .filter(alert_incidents::Column::OrgId.eq(org_id))

--- a/src/infra/src/table/alert_states.rs
+++ b/src/infra/src/table/alert_states.rs
@@ -33,7 +33,10 @@ use sea_orm::{
     TransactionTrait,
 };
 
-use super::entity::{alert_state_transitions, alert_states, alerts};
+use super::{
+    entity::{alert_state_transitions, alert_states, alerts},
+    get_lock,
+};
 use crate::{
     db::{ORM_CLIENT, connect_to_orm},
     errors,
@@ -161,6 +164,10 @@ pub async fn persist_with<C: sea_orm::ConnectionTrait + TransactionTrait>(
     if update.state.is_none() && ledger.is_none() {
         return Ok(());
     }
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = conn.begin().await?;
     write_update(&txn, update).await?;
     if let Some(write) = ledger {
@@ -195,6 +202,9 @@ pub async fn persist_group_plan_with<C: sea_orm::ConnectionTrait + TransactionTr
     plan: &GroupPlan,
     alert_id: &str,
 ) -> Result<bool, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = conn.begin().await?;
 
     // §5.3 opt-out race: this evaluation may have read the alert BEFORE a save
@@ -260,6 +270,9 @@ pub async fn advance_delivery_state_with<C: sea_orm::ConnectionTrait + Transacti
     episode: DeliveryEpisode,
     outcome: DeliveryOutcome,
 ) -> Result<bool, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = conn.begin().await?;
 
     let Some(current) =
@@ -445,6 +458,10 @@ pub async fn delete_groups_with<C: sea_orm::ConnectionTrait>(
     if group_keys.is_empty() {
         return Ok(());
     }
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     alert_states::Entity::delete_many()
         .filter(alert_states::Column::AlertId.eq(alert_id))
         .filter(alert_states::Column::GroupKey.is_in(group_keys.to_vec()))
@@ -512,6 +529,9 @@ pub async fn delete_all_groups_with<C: sea_orm::ConnectionTrait>(
     conn: &C,
     alert_id: &str,
 ) -> Result<u64, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let res = alert_states::Entity::delete_many()
         .filter(alert_states::Column::AlertId.eq(alert_id))
         .filter(alert_states::Column::GroupKey.ne(ROLLUP_GROUP_KEY))
@@ -806,6 +826,9 @@ pub async fn delete_by_alert_with<C: sea_orm::ConnectionTrait + TransactionTrait
     conn: &C,
     alert_id: &str,
 ) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = conn.begin().await?;
     alert_states::Entity::delete_many()
         .filter(alert_states::Column::AlertId.eq(alert_id))
@@ -822,6 +845,9 @@ pub async fn delete_by_alert_with<C: sea_orm::ConnectionTrait + TransactionTrait
 /// Retention for the append-only transition log. Governed by audit needs, set
 /// independently of the `triggers` stream retention.
 pub async fn delete_transitions_before(cutoff: i64) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     alert_state_transitions::Entity::delete_many()
         .filter(alert_state_transitions::Column::At.lt(cutoff))

--- a/src/infra/src/table/compactor_manual_jobs.rs
+++ b/src/infra/src/table/compactor_manual_jobs.rs
@@ -159,6 +159,9 @@ pub async fn add(job: CompactorManualJob) -> Result<(), errors::Error> {
 }
 
 pub async fn update(ksuid: &str, ended_at: i64, status: Status) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let res = Entity::update_many()
         .col_expr(Column::EndedAt, Expr::value(ended_at))
@@ -174,6 +177,9 @@ pub async fn update(ksuid: &str, ended_at: i64, status: Status) -> Result<(), er
 }
 
 pub async fn bulk_update(jobs: Vec<CompactorManualJob>) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let tx = client.begin().await?;
 

--- a/src/infra/src/table/dashboards.rs
+++ b/src/infra/src/table/dashboards.rs
@@ -34,6 +34,7 @@ use super::{
     distinct_values::{self, OriginType},
     entity::{dashboards, folders, reports},
     folders::folder_type_into_i16,
+    get_lock,
 };
 use crate::{
     db::{ORM_CLIENT, connect_to_orm},
@@ -221,6 +222,9 @@ pub async fn put(
     let updated_at = dashboard.updated_at;
     let data = inner_data_as_json(dashboard)?;
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     // Try to get the new folder if the dashboard is being moved to a new folder.
     let maybe_new_folder_model = if let Some(new_folder_id) = new_folder_id {
         let new_folder_model = folders::Entity::find()
@@ -305,6 +309,9 @@ pub async fn delete_from_folder(
     folder_id: &str,
     dashboard_id: &str,
 ) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = ORM_CLIENT.get_or_init(connect_to_orm).await.begin().await?;
     let maybe_dashboard_model = get_model_from_folder(&txn, org_id, folder_id, dashboard_id)
         .await?
@@ -341,6 +348,10 @@ pub async fn delete_all() -> Result<(), errors::Error> {
     for id in ids {
         distinct_values::batch_remove(OriginType::Dashboard, id).await?;
     }
+
+    // make sure only one client is writing to the database(only for sqlite)
+    // NOTE: acquired after batch_remove() calls above, which take this lock internally
+    let _lock = get_lock().await;
 
     dashboards::Entity::delete_many().exec(client).await?;
     Ok(())
@@ -532,6 +543,9 @@ fn inner_data_as_json(dashboard: Dashboard) -> Result<JsonValue, errors::Error> 
 
 /// Deletes all dashboards belonging to the given org (via folder join).
 pub async fn delete_by_org(org_id: &str) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     // Collect folder PKs for this org
     let folder_ids: Vec<String> = folders::Entity::find()

--- a/src/infra/src/table/folders.rs
+++ b/src/infra/src/table/folders.rs
@@ -20,7 +20,10 @@ use sea_orm::{
 };
 use svix_ksuid::{Ksuid, KsuidLike};
 
-use super::entity::folders::{ActiveModel, Column, Entity, Model};
+use super::{
+    entity::folders::{ActiveModel, Column, Entity, Model},
+    get_lock,
+};
 use crate::{
     db::{ORM_CLIENT, connect_to_orm},
     errors::{self, FromStrError},
@@ -104,6 +107,8 @@ pub async fn put(
     folder: Folder,
     folder_type: FolderType,
 ) -> Result<(Ksuid, Folder), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
     let model = match get_model(client, org_id, &folder.folder_id, folder_type).await? {
@@ -150,6 +155,8 @@ pub async fn delete(
     folder_id: &str,
     folder_type: FolderType,
 ) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let model = get_model(client, org_id, folder_id, folder_type).await?;
 
@@ -248,6 +255,8 @@ async fn list_models(
 
 /// Deletes all folders belonging to the given org.
 pub async fn delete_by_org(org_id: &str) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     Entity::delete_many()
         .filter(Column::Org.eq(org_id))

--- a/src/infra/src/table/incident_events.rs
+++ b/src/infra/src/table/incident_events.rs
@@ -16,6 +16,7 @@
 use config::meta::alerts::incidents::IncidentEvent;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set, TransactionTrait};
 
+use super::get_lock;
 use crate::{
     db::{ORM_CLIENT, connect_to_orm},
     table::entity::incident_events,
@@ -114,6 +115,9 @@ pub async fn init(org_id: &str, incident_id: &str) -> Result<(), sea_orm::DbErr>
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let event = IncidentEvent::created();
     let events_json = encode_events(&[event])?;
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
 
     let model = incident_events::ActiveModel {
         org_id: Set(org_id.to_string()),
@@ -223,6 +227,10 @@ pub async fn reconstruct_if_empty(
     incident_id: &str,
 ) -> Result<Option<usize>, sea_orm::DbErr> {
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
 
     let row = incident_events::Entity::find()
@@ -296,6 +304,10 @@ pub async fn append(
     event: IncidentEvent,
 ) -> Result<(), sea_orm::DbErr> {
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
 
     let row = incident_events::Entity::find()
@@ -342,6 +354,10 @@ pub async fn record_alert(
     triggered_at: i64,
 ) -> Result<(), sea_orm::DbErr> {
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
 
     let row = incident_events::Entity::find()
@@ -398,6 +414,10 @@ pub async fn record_alert(
 /// Deletes all incident event entries belonging to the given org.
 pub async fn delete_by_org(org_id: &str) -> Result<(), sea_orm::DbErr> {
     use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
     incident_events::Entity::delete_many()
         .filter(incident_events::Column::OrgId.eq(org_id))

--- a/src/infra/src/table/mod.rs
+++ b/src/infra/src/table/mod.rs
@@ -143,6 +143,14 @@ pub async fn create_user_tables() -> Result<(), anyhow::Error> {
 
 /// Acquires a lock on the SQLite client if SQLite is configured as the meta store.
 ///
+/// The guard wraps one process-wide, non-reentrant mutex serializing every
+/// SQLite write (raw meta-store puts, the coordinator, scheduler backends, and
+/// all ORM table writers). Acquire it at most once per call chain: the function
+/// that owns the write or transaction takes it; helpers that receive an open
+/// transaction must not. Drop the guard before calling anything that acquires
+/// it internally (coordinator emits, `db::scheduler` calls, other table write
+/// functions) — a nested acquisition deadlocks the process.
+///
 /// # Returns
 /// - `Some(MutexGuard)` if SQLite is configured
 /// - `None` if a different store is configured

--- a/src/infra/src/table/mod.rs
+++ b/src/infra/src/table/mod.rs
@@ -13,12 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::get_config;
+use config::{get_config, meta::meta_store::MetaStore};
 use migration::Migrator;
 use sea_orm_migration::MigratorTrait;
 
 use crate::{
-    db::{ORM_CLIENT_DDL, SQLITE_STORE, connect_to_orm_ddl, sqlite::CLIENT_RW},
+    db::{ORM_CLIENT_DDL, connect_to_orm_ddl, sqlite::CLIENT_RW},
     dist_lock,
 };
 
@@ -141,7 +141,12 @@ pub async fn create_user_tables() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Acquires a lock on the SQLite client if SQLite is configured as the meta store.
+/// Acquires a lock on the SQLite client if the ORM runs on SQLite.
+///
+/// `connect_to_orm` uses the shared SQLite pool for every meta store except
+/// PostgreSQL, so the predicate here must match it — keying off
+/// `ZO_META_STORE=sqlite` alone would silently disable every lock site for
+/// other non-postgres values while the ORM still writes SQLite.
 ///
 /// The guard wraps one process-wide, non-reentrant mutex serializing every
 /// SQLite write (raw meta-store puts, the coordinator, scheduler backends, and
@@ -152,14 +157,10 @@ pub async fn create_user_tables() -> Result<(), anyhow::Error> {
 /// functions) — a nested acquisition deadlocks the process.
 ///
 /// # Returns
-/// - `Some(MutexGuard)` if SQLite is configured
-/// - `None` if a different store is configured
+/// - `Some(MutexGuard)` if the ORM runs on SQLite
+/// - `None` if PostgreSQL is configured
 pub async fn get_lock() -> Option<tokio::sync::MutexGuard<'static, sqlx::Pool<sqlx::Sqlite>>> {
-    if get_config()
-        .common
-        .meta_store
-        .eq_ignore_ascii_case(SQLITE_STORE)
-    {
+    if MetaStore::from(get_config().common.meta_store.as_str()) != MetaStore::PostgreSQL {
         Some(CLIENT_RW.lock().await)
     } else {
         None

--- a/src/infra/src/table/org_ingestion_tokens.rs
+++ b/src/infra/src/table/org_ingestion_tokens.rs
@@ -296,6 +296,7 @@ pub async fn get_by_name(
 
 /// Rotate (regenerate) a token's value. Returns the new token.
 pub async fn rotate_token(org_id: &str, name: &str) -> Result<String, errors::Error> {
+    let _lock = get_lock().await;
     let new_token = generate_token();
     let now = chrono::Utc::now().timestamp_micros();
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;

--- a/src/infra/src/table/org_users.rs
+++ b/src/infra/src/table/org_users.rs
@@ -292,6 +292,9 @@ pub async fn update(
     token: &str,
     rum_token: Option<String>,
 ) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     // There can be only one record with one org_id and email.
     // Hence the below updates only one record.
@@ -317,6 +320,9 @@ pub async fn update_rum_token(
     email: &str,
     rum_token: &str,
 ) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     // There can be only one record with one org_id and email.
     // Hence the below updates only one record.
@@ -336,6 +342,9 @@ pub async fn update_rum_token(
 }
 
 pub async fn update_token(org_id: &str, email: &str, token: &str) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     // There can be only one record with one org_id and email.
     // Hence the below updates only one record.

--- a/src/infra/src/table/organizations.rs
+++ b/src/infra/src/table/organizations.rs
@@ -359,6 +359,9 @@ pub async fn batch_remove(org_ids: Vec<String>) -> Result<(), errors::Error> {
 }
 
 pub async fn set_status(org_id: &str, status: &str) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = config::utils::time::now_micros();
     Entity::update_many()
@@ -380,6 +383,9 @@ pub async fn set_status_if(
     expected_status: &str,
     new_status: &str,
 ) -> Result<bool, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = config::utils::time::now_micros();
     let result = Entity::update_many()
@@ -407,6 +413,9 @@ pub async fn set_status_if_with_deleted_at(
     new_status: &str,
     deleted_at: Option<i64>,
 ) -> Result<bool, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = config::utils::time::now_micros();
     let result = Entity::update_many()

--- a/src/infra/src/table/ratelimit.rs
+++ b/src/infra/src/table/ratelimit.rs
@@ -25,6 +25,7 @@ use sea_orm::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::get_lock;
 use crate::{
     db::{ORM_CLIENT, connect_to_orm},
     orm_err,
@@ -112,6 +113,9 @@ pub async fn fetch_rules_by_id(rule_id: &str) -> Result<Option<RatelimitRule>, a
 }
 
 pub async fn add(rule: RuleEntry) -> Result<(), anyhow::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     match rule {
         RuleEntry::Single(rule) => add_single(rule).await,
         RuleEntry::Batch(rules) => add_batch(rules).await,
@@ -350,6 +354,9 @@ async fn add_single(rule: RatelimitRule) -> Result<(), anyhow::Error> {
 }
 
 pub async fn update(rule: RuleEntry) -> Result<(), anyhow::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     match rule {
         RuleEntry::Single(rule) => update_single(rule).await,
         RuleEntry::Batch(rules) => update_batch(rules).await,
@@ -499,6 +506,9 @@ async fn update_batch(rules: Vec<RatelimitRule>) -> Result<(), anyhow::Error> {
 }
 
 pub async fn delete(rule_id: String) -> Result<(), anyhow::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     match fetch_rules_by_id(rule_id.as_str()).await {
         Ok(Some(_)) => {
             let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
@@ -755,10 +765,10 @@ mod tests {
 
     async fn setup_test_db(mock_db: sea_orm::DatabaseConnection) {
         INIT.call_once(|| {
-            // Initialize ORM_CLIENT only once
-            ORM_CLIENT
-                .set(mock_db)
-                .expect("Failed to set mock database");
+            // Another test in the shared process may already have initialized
+            // ORM_CLIENT; the validation paths under test never reach a query,
+            // so losing the race is fine.
+            let _ = ORM_CLIENT.set(mock_db);
         });
     }
 

--- a/src/infra/src/table/search_job/search_job_partitions.rs
+++ b/src/infra/src/table/search_job/search_job_partitions.rs
@@ -139,7 +139,7 @@ pub async fn submit_partitions(job_id: &str, jobs: Vec<Model>) -> Result<(), err
     let status = Entity::find()
         .filter(Column::JobId.eq(job_id))
         .lock(LockType::Update)
-        .one(client)
+        .one(&tx)
         .await;
 
     match status {

--- a/src/infra/src/table/search_job/search_jobs.rs
+++ b/src/infra/src/table/search_job/search_jobs.rs
@@ -601,6 +601,9 @@ pub async fn set_job_start(
     node: &str,
     updated_at: i64,
 ) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
     let res = Entity::update_many()

--- a/src/infra/src/table/sessions.rs
+++ b/src/infra/src/table/sessions.rs
@@ -15,7 +15,10 @@
 
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set, sea_query::OnConflict};
 
-use super::entity::sessions::{ActiveModel, Column, Entity, Model};
+use super::{
+    entity::sessions::{ActiveModel, Column, Entity, Model},
+    get_lock,
+};
 use crate::{
     db::{ORM_CLIENT, connect_to_orm},
     errors,
@@ -43,6 +46,9 @@ pub async fn set_with_expiry(
     access_token: &str,
     expires_at: i64,
 ) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
 
@@ -75,6 +81,9 @@ pub async fn set_with_expiry(
 
 /// Deletes a session by session_id
 pub async fn delete(session_id: &str) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     Entity::delete_many()
         .filter(Column::SessionId.eq(session_id))
@@ -93,6 +102,9 @@ pub async fn list() -> Result<Vec<Model>, errors::Error> {
 /// Deletes all expired sessions from the database
 /// This is more efficient than deleting one at a time
 pub async fn delete_expired() -> Result<u64, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp();
 

--- a/src/infra/src/table/slo.rs
+++ b/src/infra/src/table/slo.rs
@@ -44,7 +44,7 @@ use sea_orm::{
     sea_query::{Expr, Func, SimpleExpr},
 };
 
-use super::entity::slo_status;
+use super::{entity::slo_status, get_lock};
 use crate::errors;
 
 /// `COALESCE(col, 0) + delta` — the increment applied in SQL rather than
@@ -122,6 +122,9 @@ pub async fn apply_status(
     db: &DatabaseConnection,
     write: &StatusWrite,
 ) -> Result<WriteOutcome, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
     let outcome = match apply_status_in_txn(&txn, write).await {
         Ok(outcome) => outcome,
@@ -294,6 +297,9 @@ pub async fn init_generation(
     slo_id: &str,
     definition_generation: i32,
 ) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     slo_status::ActiveModel {
         slo_id: Set(slo_id.to_string()),
         group_key: Set(slo_status::ROLLUP_GROUP_KEY.to_string()),
@@ -312,6 +318,9 @@ pub async fn bump_generation(
     slo_id: &str,
     new_generation: i32,
 ) -> Result<(), errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
     // Delete rather than null out: the group set itself belongs to the old
     // definition, so a group that no longer exists under the new one must not
@@ -344,6 +353,10 @@ pub async fn reconcile_from_slices(
     recomputed: (f64, f64, i32),
 ) -> Result<(), errors::Error> {
     let (good, total, covered) = recomputed;
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     // Assignment, not increment: this is a rebuild from the source of truth,
     // and the watermark is deliberately untouched — reconciliation repairs the
     // aggregate, not the read clamp.
@@ -367,6 +380,10 @@ pub async fn delete_by_org(db: &DatabaseConnection, org: &str) -> Result<(), err
     if slo_ids.is_empty() {
         return Ok(());
     }
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     slo_status::Entity::delete_many()
         .filter(slo_status::Column::SloId.is_in(slo_ids))
         .exec(db)

--- a/src/infra/src/table/slo_backfill_jobs.rs
+++ b/src/infra/src/table/slo_backfill_jobs.rs
@@ -25,7 +25,7 @@ use sea_orm::{
     Set,
 };
 
-use super::entity::slo_backfill_jobs;
+use super::{entity::slo_backfill_jobs, get_lock};
 use crate::errors::Error;
 
 pub const STATE_QUEUED: i32 = 1;
@@ -59,6 +59,10 @@ pub async fn queue(
     if get(db, slo_id, generation).await?.is_some() {
         return Ok(());
     }
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     slo_backfill_jobs::ActiveModel {
         slo_id: Set(slo_id.to_string()),
         definition_generation: Set(generation),
@@ -87,6 +91,10 @@ pub async fn record_progress(
     let Some(model) = get(db, slo_id, generation).await? else {
         return Ok(());
     };
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let previous = model.rows_written;
     let mut active = model.into_active_model();
     active.state = Set(STATE_RUNNING);
@@ -127,6 +135,10 @@ async fn set_state(
     let Some(model) = get(db, slo_id, generation).await? else {
         return Ok(());
     };
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let mut active = model.into_active_model();
     active.state = Set(state);
     if let Some(e) = error {
@@ -138,6 +150,9 @@ async fn set_state(
 
 /// Drop every job for an SLO — used when the SLO itself is deleted.
 pub async fn delete_all(db: &DatabaseConnection, slo_id: &str) -> Result<(), Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     slo_backfill_jobs::Entity::delete_many()
         .filter(slo_backfill_jobs::Column::SloId.eq(slo_id))
         .exec(db)
@@ -155,6 +170,10 @@ pub async fn delete_by_org(db: &DatabaseConnection, org: &str) -> Result<(), Err
     if slo_ids.is_empty() {
         return Ok(());
     }
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     slo_backfill_jobs::Entity::delete_many()
         .filter(slo_backfill_jobs::Column::SloId.is_in(slo_ids))
         .exec(db)

--- a/src/infra/src/table/slo_budget.rs
+++ b/src/infra/src/table/slo_budget.rs
@@ -31,7 +31,10 @@ use sea_orm::{
     TransactionTrait,
 };
 
-use super::entity::{slo_budget, slo_budget_charges};
+use super::{
+    entity::{slo_budget, slo_budget_charges},
+    get_lock,
+};
 use crate::errors::Error;
 
 /// Charge states, as stored.
@@ -102,6 +105,9 @@ pub async fn charge(
     rows: i64,
     cap: i64,
 ) -> Result<(), ChargeError> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     for _ in 0..CAS_RETRIES {
         let current = get(db, org).await?;
         let (version, active, residual) = match &current {
@@ -198,6 +204,9 @@ pub async fn retire(
     generation: i32,
     expires_at: i64,
 ) -> Result<(), ChargeError> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     for _ in 0..CAS_RETRIES {
         let Some(budget) = get(db, org).await? else {
             return Ok(());
@@ -256,6 +265,9 @@ pub async fn expire_residuals(
     org: &str,
     now: i64,
 ) -> Result<i64, ChargeError> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     for _ in 0..CAS_RETRIES {
         let Some(budget) = get(db, org).await? else {
             return Ok(0);
@@ -309,6 +321,9 @@ pub async fn expire_residuals(
 /// No CAS: the org is going away, so there is no concurrent charge whose
 /// arithmetic this could invalidate.
 pub async fn delete_by_org(db: &DatabaseConnection, org: &str) -> Result<(), Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
     slo_budget_charges::Entity::delete_many()
         .filter(slo_budget_charges::Column::Org.eq(org))

--- a/src/infra/src/table/slos.rs
+++ b/src/infra/src/table/slos.rs
@@ -32,7 +32,10 @@ use sea_orm::{
     PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, TransactionTrait, sea_query::Expr,
 };
 
-use super::entity::{slo_status, slos};
+use super::{
+    entity::{slo_status, slos},
+    get_lock,
+};
 use crate::errors::{DbError, Error};
 
 /// What an update did to the writing epoch.
@@ -138,6 +141,9 @@ pub async fn create(
     now: i64,
     editor: Option<&str>,
 ) -> Result<(), Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
     let mut model = to_model(slo, now)?;
     model.created_at = Set(now);
@@ -168,6 +174,9 @@ pub async fn update(
     now: i64,
     editor: Option<&str>,
 ) -> Result<GenerationEffect, Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
 
     let Some(existing) = slos::Entity::find_by_id(slo.id.clone())
@@ -285,6 +294,9 @@ pub async fn bump_generation(
     id: &str,
     now: i64,
 ) -> Result<Option<(i32, i32)>, Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
     let Some(existing) = slos::Entity::find_by_id(id.to_string())
         .filter(slos::Column::Org.eq(org))
@@ -329,6 +341,9 @@ pub async fn bump_generation(
 /// does not instantly free the storage its slices occupy, and pretending
 /// otherwise would let an org delete-and-recreate its way past the cap.
 pub async fn delete(db: &DatabaseConnection, org: &str, id: &str) -> Result<bool, Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let txn = db.begin().await?;
     let Some(model) = slos::Entity::find_by_id(id.to_string())
         .filter(slos::Column::Org.eq(org))
@@ -367,6 +382,9 @@ pub(crate) async fn ids_in_org(db: &DatabaseConnection, org: &str) -> Result<Vec
 /// modules, which resolve their org through `ids_in_org` and therefore run
 /// BEFORE this (`org_cleanup::step_delete_db_resources`).
 pub async fn delete_by_org(db: &DatabaseConnection, org: &str) -> Result<(), Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     slos::Entity::delete_many()
         .filter(slos::Column::Org.eq(org))
         .exec(db)
@@ -389,6 +407,10 @@ pub async fn set_enabled(
     else {
         return Ok(false);
     };
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let mut active = model.into_active_model();
     active.enabled = Set(enabled);
     active.updated_at = Set(now);
@@ -422,6 +444,10 @@ pub async fn move_to_folder(
     if ids.is_empty() {
         return Ok(0);
     }
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let res = slos::Entity::update_many()
         .col_expr(slos::Column::FolderId, Expr::value(dst_folder_id))
         .col_expr(slos::Column::UpdatedAt, Expr::value(now))

--- a/src/infra/src/table/synthetics_agents.rs
+++ b/src/infra/src/table/synthetics_agents.rs
@@ -159,6 +159,7 @@ pub async fn register(record: &SyntheticsAgentRecord) -> Result<(), errors::Erro
 /// lease, which is exactly the rate of the reads the cache serves. Callers that
 /// need a current `last_seen_at` use [`get`], not [`get_cached`].
 pub async fn touch(agent_id: &str, now_us: i64) -> Result<(), errors::Error> {
+    let _lock = get_lock().await;
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     Entity::update_many()
         .col_expr(Column::LastSeenAt, Expr::value(now_us))

--- a/src/infra/src/table/synthetics_checks.rs
+++ b/src/infra/src/table/synthetics_checks.rs
@@ -800,6 +800,7 @@ pub async fn advance_schedule<C: ConnectionTrait>(
     last_triggered_at: i64,
     next_run_at: i64,
 ) -> Result<(), errors::Error> {
+    let _lock = super::get_lock().await;
     Entity::update_many()
         .col_expr(Column::LastTriggeredAt, Expr::value(last_triggered_at))
         .col_expr(Column::NextRunAt, Expr::value(next_run_at))
@@ -829,6 +830,7 @@ pub async fn update_last_check_status<C: ConnectionTrait>(
     id: &str,
     status: i32,
 ) -> Result<bool, errors::Error> {
+    let _lock = super::get_lock().await;
     let res = Entity::update_many()
         .col_expr(Column::LastCheckStatus, Expr::value(status))
         .filter(Column::Id.eq(id))
@@ -905,6 +907,7 @@ pub async fn update_alert_state_if<C: ConnectionTrait>(
     expected: AlertState,
     state: AlertState,
 ) -> Result<bool, errors::Error> {
+    let _lock = super::get_lock().await;
     let res = Entity::update_many()
         .col_expr(
             Column::ConsecutiveFailures,

--- a/src/infra/src/table/synthetics_jobs.rs
+++ b/src/infra/src/table/synthetics_jobs.rs
@@ -284,7 +284,8 @@ pub async fn lease_batch<C: ConnectionTrait>(
     let limit = limit.clamp(1, MAX_LEASE_BATCH);
 
     // make sure only one client is writing to the database(only for sqlite).
-    // One lock across all three steps — the guard drops at fn end.
+    // One lock across the candidate pick and the claim; released before the
+    // read-back, which only reads rows pinned by our own stamp.
     let _lock = get_lock().await;
 
     // Step 1: pick candidate IDs.
@@ -341,6 +342,7 @@ pub async fn lease_batch<C: ConnectionTrait>(
         .filter(Column::Status.eq(0i32))
         .exec(conn)
         .await?;
+    drop(_lock);
 
     // Step 3: return ONLY the rows THIS call actually won — pinned by our
     // (claimed_by, claimed_at) stamp. A racing agent that lost the guard above

--- a/src/infra/src/table/synthetics_jobs.rs
+++ b/src/infra/src/table/synthetics_jobs.rs
@@ -549,8 +549,14 @@ pub async fn dead_letter_expired<C: ConnectionTrait>(
     now_us: i64,
     max_attempts: i32,
 ) -> Result<Vec<DeadLetteredRow>, errors::Error> {
+    // Bounds one reaper pass so the global write lock below is never held
+    // across an unbounded backlog; the reaper runs periodically and picks up
+    // the remainder on its next tick.
+    const MAX_DEAD_LETTER_BATCH: i64 = 500;
+
     // make sure only one client is writing to the database(only for sqlite).
-    // One lock across the SELECT and the per-row CAS updates — drops at fn end.
+    // One lock across the bounded SELECT and the per-row CAS updates — drops
+    // at fn end.
     let _lock = get_lock().await;
 
     // Step 1: find candidates before marking them dead. `status` comes back so
@@ -560,12 +566,17 @@ pub async fn dead_letter_expired<C: ConnectionTrait>(
         FROM synthetics_jobs
         WHERE (status = 1 AND lease_expires_at < $1 AND (dispatch_attempts >= $2 OR valid_until < $1))
            OR (status = 0 AND valid_until < $1)
+        LIMIT $3
     "#;
     let rows = conn
         .query_all(Statement::from_sql_and_values(
             conn.get_database_backend(),
             select_sql,
-            [Value::from(now_us), Value::from(max_attempts)],
+            [
+                Value::from(now_us),
+                Value::from(max_attempts),
+                Value::from(MAX_DEAD_LETTER_BATCH),
+            ],
         ))
         .await?;
 

--- a/src/infra/src/table/synthetics_jobs.rs
+++ b/src/infra/src/table/synthetics_jobs.rs
@@ -27,7 +27,10 @@ use sea_orm::{
 use serde::Serialize;
 use svix_ksuid::KsuidLike as _;
 
-use super::entity::synthetics_jobs::{Column, Entity};
+use super::{
+    entity::synthetics_jobs::{Column, Entity},
+    get_lock,
+};
 use crate::errors;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -151,6 +154,9 @@ pub async fn enqueue<C: ConnectionTrait>(
         ON CONFLICT (synthetics_id, location, scheduled_ts) DO NOTHING
     "#;
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     conn.execute(Statement::from_sql_and_values(
         conn.get_database_backend(),
         sql,
@@ -221,6 +227,9 @@ pub async fn drain_check<C: ConnectionTrait>(
     conn: &C,
     synthetics_id: &str,
 ) -> Result<u64, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let sql = "DELETE FROM synthetics_jobs WHERE synthetics_id = $1";
     let res = conn
         .execute(Statement::from_sql_and_values(
@@ -273,6 +282,10 @@ pub async fn lease_batch<C: ConnectionTrait>(
     // Reachable from a single mistyped env var, so it is clamped here rather than
     // trusted: a probe does not get to decide how much of the queue it may take.
     let limit = limit.clamp(1, MAX_LEASE_BATCH);
+
+    // make sure only one client is writing to the database(only for sqlite).
+    // One lock across all three steps — the guard drops at fn end.
+    let _lock = get_lock().await;
 
     // Step 1: pick candidate IDs.
     //
@@ -434,6 +447,10 @@ pub async fn ack_complete<C: ConnectionTrait>(
         "UPDATE synthetics_jobs SET status = $1, result = $2, completed_at = $3 \
          WHERE id = $4 AND status = 1{owner_clause}"
     );
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let applied = conn
         .execute(Statement::from_sql_and_values(
             conn.get_database_backend(),
@@ -491,6 +508,10 @@ pub async fn requeue_expired<C: ConnectionTrait>(
           AND valid_until >= $1
           AND dispatch_attempts < $2
     "#;
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let res = conn
         .execute(Statement::from_sql_and_values(
             conn.get_database_backend(),
@@ -526,6 +547,10 @@ pub async fn dead_letter_expired<C: ConnectionTrait>(
     now_us: i64,
     max_attempts: i32,
 ) -> Result<Vec<DeadLetteredRow>, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite).
+    // One lock across the SELECT and the per-row CAS updates — drops at fn end.
+    let _lock = get_lock().await;
+
     // Step 1: find candidates before marking them dead. `status` comes back so
     // the CAS can require the row not to have moved under us.
     let select_sql = r#"
@@ -630,6 +655,9 @@ pub async fn fail_dispatch<C: ConnectionTrait>(
     current_attempts: i32,
     max_attempts: i32,
 ) -> Result<DispatchFailureOutcome, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     if current_attempts < max_attempts {
         // `AND status = 1` is what keeps this from resurrecting finished work. A
         // dispatch can be judged failed after the probe has already acked — a
@@ -828,6 +856,9 @@ pub async fn pending_backlog<C: ConnectionTrait>(
 /// count here is a bug signal, not routine housekeeping — the reaper logs it at
 /// warn for that reason.
 pub async fn prune_stale<C: ConnectionTrait>(conn: &C, now_us: i64) -> Result<u64, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let sql = r#"
         DELETE FROM synthetics_jobs
         WHERE status = 0 AND valid_until < $1

--- a/src/infra/src/table/synthetics_runs.rs
+++ b/src/infra/src/table/synthetics_runs.rs
@@ -21,6 +21,7 @@
 
 use sea_orm::{ConnectionTrait, Statement, Value};
 
+use super::get_lock;
 use crate::errors;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -67,6 +68,10 @@ pub async fn insert_run<C: ConnectionTrait>(
              run_result, created_at, completed_at)
         VALUES ($1, $2, $3, $4, $5, $6, 0, NULL, $7, NULL)
     "#;
+
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     conn.execute(Statement::from_sql_and_values(
         conn.get_database_backend(),
         sql,
@@ -263,6 +268,10 @@ pub async fn increment_jobs_done<C: ConnectionTrait>(
     job_result: i32,
     now_us: i64,
 ) -> Result<Option<(i32, i32)>, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite).
+    // One lock across all three steps — the guard drops at fn end.
+    let _lock = get_lock().await;
+
     // Step 1: count this job and fold its severity in.
     //
     // `jobs_done < job_count` stops a duplicate or replayed ack from pushing the

--- a/src/infra/src/table/system_settings.rs
+++ b/src/infra/src/table/system_settings.rs
@@ -29,6 +29,7 @@ use sea_orm::{
     ColumnTrait, EntityTrait, QueryFilter, QueryOrder,
 };
 
+use super::get_lock;
 use crate::{
     db::{ORM_CLIENT, connect_to_orm},
     table::entity::system_settings::{ActiveModel, Column, Entity, Model},
@@ -181,6 +182,9 @@ pub async fn list_resolved(
 pub async fn set(setting: &SystemSetting) -> Result<SystemSetting, anyhow::Error> {
     setting.validate().map_err(|e| anyhow!(e))?;
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let now = chrono::Utc::now().timestamp_micros();
 
@@ -283,6 +287,9 @@ pub async fn delete(
         }
     }
 
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let result = query
         .exec(client)
         .await
@@ -293,6 +300,9 @@ pub async fn delete(
 
 /// Delete all settings for an organization
 pub async fn delete_org_settings(org_id: &str) -> Result<u64, anyhow::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
     let result = Entity::delete_many()
@@ -306,6 +316,9 @@ pub async fn delete_org_settings(org_id: &str) -> Result<u64, anyhow::Error> {
 
 /// Delete all settings for a user in an organization
 pub async fn delete_user_settings(org_id: &str, user_id: &str) -> Result<u64, anyhow::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
     let result = Entity::delete_many()

--- a/src/infra/src/table/trial_quota_usage.rs
+++ b/src/infra/src/table/trial_quota_usage.rs
@@ -27,8 +27,14 @@ use crate::{
 /// Upserts: if the row exists, adds delta to usage_count; otherwise inserts with
 /// usage_count = delta. Uses sea_orm's on_conflict for atomic upserts.
 pub async fn batch_increment(records: Vec<(String, String, i64)>) -> Result<(), sea_orm::DbErr> {
+    if records.is_empty() {
+        return Ok(());
+    }
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let _lock = super::get_lock().await;
+    // one transaction for the whole batch so the write lock is held for a
+    // single commit instead of one autocommit round-trip per record
+    let txn = db.begin().await?;
     let now = config::utils::time::now_micros();
 
     for (org_id, feature, delta) in records {
@@ -58,9 +64,10 @@ pub async fn batch_increment(records: Vec<(String, String, i64)>) -> Result<(), 
                 .value(trial_quota_usage::Column::UpdatedAt, Expr::value(now))
                 .to_owned(),
             )
-            .exec(db)
+            .exec(&txn)
             .await?;
     }
+    txn.commit().await?;
     Ok(())
 }
 

--- a/src/infra/src/table/trial_quota_usage.rs
+++ b/src/infra/src/table/trial_quota_usage.rs
@@ -28,6 +28,7 @@ use crate::{
 /// usage_count = delta. Uses sea_orm's on_conflict for atomic upserts.
 pub async fn batch_increment(records: Vec<(String, String, i64)>) -> Result<(), sea_orm::DbErr> {
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
+    let _lock = super::get_lock().await;
     let now = config::utils::time::now_micros();
 
     for (org_id, feature, delta) in records {
@@ -203,6 +204,7 @@ pub async fn update_notified_checkpoint(
     checkpoint: i16,
 ) -> Result<bool, sea_orm::DbErr> {
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
+    let _lock = super::get_lock().await;
     let result = trial_quota_usage::Entity::update_many()
         .filter(trial_quota_usage::Column::OrgId.eq(org_id))
         .filter(trial_quota_usage::Column::NotifiedCheckpoint.lt(checkpoint))
@@ -255,6 +257,7 @@ pub async fn load_all_checkpoints() -> Result<Vec<(String, i16)>, sea_orm::DbErr
 pub async fn delete_by_org(org_id: &str) -> Result<(), sea_orm::DbErr> {
     use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
     let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
+    let _lock = super::get_lock().await;
     trial_quota_usage::Entity::delete_many()
         .filter(trial_quota_usage::Column::OrgId.eq(org_id))
         .exec(db)

--- a/src/infra/src/table/users.rs
+++ b/src/infra/src/table/users.rs
@@ -167,6 +167,9 @@ pub async fn update(
     password: &str,
     password_ext: Option<String>,
 ) -> Result<u64, errors::Error> {
+    // make sure only one client is writing to the database(only for sqlite)
+    let _lock = get_lock().await;
+
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
     let result = Entity::update_many()


### PR DESCRIPTION
## Problem

In local mode with the default sqlite meta store, concurrent metadata writes fail with:

```
Execution Error: error returned from database: (code: 517) database is locked
```

517 is `SQLITE_BUSY_SNAPSHOT`: a deferred sqlite transaction pins its read snapshot at the first SELECT, and when it later performs its first write the upgrade fails immediately if any other connection committed in between — `busy_timeout` never retries it. The codebase convention is to serialize sqlite writes with `infra::table::get_lock()`, but a full audit found ~100 write functions that never take it, concentrated in the newer subsystems.

## What changed (31 files)

- **Table layer, previously zero locks**: `alert_states`, `alert_incidents`, `incident_events`, `dashboards`, `folders`, `ratelimit`, `sessions`, `system_settings`, `alert_composites`, `slo` / `slos` / `slo_budget` / `slo_backfill_jobs`, `synthetics_jobs` / `synthetics_runs`.
- **Partially covered modules**: the specific unlocked writers in `users`, `org_users`, `organizations`, `org_ingestion_tokens`, `synthetics_agents`, `synthetics_checks`, `compactor_manual_jobs`, `trial_quota_usage`, `alert_eval_intervals`, `search_job/search_jobs`.
- **Service layer**: `db/pipeline_errors` (self-reporting flush), alert deduplication state, the composite-alert scheduler transaction in `core/alerts/scheduler/handlers.rs`, raw anomaly-detection config updates, and two direct writes in `core/alerts/composite/service.rs`.
- **Bonus fixes**: `search_job_partitions::submit_partitions` ran its `FOR UPDATE` probe on the pool instead of its open transaction (on Postgres that row lock was not tied to the transaction at all); a ratelimit unit test raced the global `ORM_CLIENT` OnceCell and failed depending on suite ordering.

## Lock-placement rules (why some functions deliberately do NOT lock)

The mutex is not reentrant, so the diff enforces **exactly one acquisition per call chain**:
- The function that owns the transaction locks before `begin()`; helpers that receive an open transaction (`persist_update_in_transaction`, `apply_status_in_txn`, `record_evaluation_with`, the `alert_states` public wrappers, …) never lock.
- Guards are dropped before coordinator emits, `db::scheduler` calls, and helpers that lock internally (e.g. `dashboards::delete_all` locks only after `distinct_values::batch_remove`, which takes the lock itself).

## Verification

- Full workspace `cargo check` + clippy clean; 928 infra table tests pass (run twice for ordering stability).
- Combined build with the enterprise crate passes; **companion enterprise PR uses the same branch name** `fix/sqlite-lock-remaining` per paired-CI convention.
- Live smoke on a sqlite local-mode instance: 40 concurrent folder creations (previously an unlocked path) plus mixed ingestion/metadata load — all requests succeed, zero locked errors in the log.

## Note for reviewers

This is the per-call-site fix consistent with the existing convention. A structural alternative (single-connection sqlite RW pool, which makes 517 impossible and would let the ~330 manual lock sites retire) was prototyped separately and can follow as its own change.