### PR TITLE
fix(infra): fail startup when the NATS queue backend is unreachable

### DIFF
--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -51,7 +51,10 @@ const SUPER_CLUSTER_PREFIX: &str = "super_cluster_kv_";
 static NATS_CLIENT: OnceCell<Client> = OnceCell::const_new();
 
 pub async fn get_nats_client() -> &'static Client {
-    NATS_CLIENT.get_or_init(connect).await
+    NATS_CLIENT
+        .get_or_try_init(connect)
+        .await
+        .unwrap_or_else(|e| panic!("{e}"))
 }
 
 async fn get_bucket_by_key<'a>(
@@ -107,8 +110,9 @@ async fn get_bucket_by_key<'a>(
     Ok((kv, key.trim_start_matches(bucket_name)))
 }
 
-pub async fn init() {
-    _ = get_nats_client().await;
+pub async fn init() -> Result<()> {
+    NATS_CLIENT.get_or_try_init(connect).await?;
+    Ok(())
 }
 
 pub struct NatsDb {
@@ -639,7 +643,7 @@ pub async fn create_table() -> Result<()> {
     Ok(())
 }
 
-pub async fn connect() -> async_nats::Client {
+async fn connect() -> Result<async_nats::Client> {
     let cfg = get_config();
     if cfg.common.print_key_config {
         log::info!("Nats init get_config(): {:?}", cfg.nats);
@@ -657,15 +661,16 @@ pub async fn connect() -> async_nats::Client {
         .nats
         .addr
         .split(',')
-        .map(|a| a.parse().unwrap())
-        .collect::<Vec<ServerAddr>>();
-    match async_nats::connect_with_options(addrs.clone(), opts).await {
-        Ok(client) => client,
-        Err(e) => {
-            log::error!("NATS connect failed for address(es): {addrs:?}, err: {e}");
-            panic!("NATS connect failed");
-        }
-    }
+        .map(|a| a.parse())
+        .collect::<std::result::Result<Vec<ServerAddr>, _>>()
+        .map_err(|e| Error::Message(format!("invalid NATS address {}: {e}", cfg.nats.addr)))?;
+    async_nats::connect_with_options(addrs.clone(), opts)
+        .await
+        .map_err(|e| {
+            Error::Message(format!(
+                "NATS connect failed for address(es): {addrs:?}, err: {e}"
+            ))
+        })
 }
 
 async fn keys(kv: &jetstream::kv::Store, prefix: &str) -> Result<Vec<String>> {

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -112,6 +112,11 @@ pub async fn db_init() -> Result<(), anyhow::Error> {
 }
 
 pub async fn init() -> Result<(), anyhow::Error> {
+    // runs for every node role; db_init() is skipped when migrations are
+    // up-to-date, so this is the call that keeps an unreachable queue
+    // backend from booting
+    queue::init().await?;
+
     if !config::cluster::LOCAL_NODE.is_ingester()
         && !config::cluster::LOCAL_NODE.is_querier()
         && !config::cluster::LOCAL_NODE.is_compactor()

--- a/src/infra/src/queue/memory.rs
+++ b/src/infra/src/queue/memory.rs
@@ -45,6 +45,11 @@ use tokio::{
 use super::{DeliverPolicy, QueueConfig, StorageType, format_key};
 use crate::errors::{QueueError, Result};
 
+pub async fn init() -> Result<()> {
+    // process-local queue, nothing to check at startup
+    Ok(())
+}
+
 /// Fixed accounting overhead charged for every entry in addition to its
 /// payload bytes: sequence, timestamps, ack state, deque/map nodes, and
 /// shared-pointer metadata. Empty payloads therefore still consume budget.

--- a/src/infra/src/queue/mod.rs
+++ b/src/infra/src/queue/mod.rs
@@ -105,7 +105,11 @@ pub async fn get_super_cluster() -> &'static Box<dyn Queue> {
 }
 
 pub async fn init() -> Result<()> {
-    nats::init().await
+    match QueueStore::try_from(config::get_config().common.queue_store.as_str()) {
+        Ok(QueueStore::Nats) => nats::init().await,
+        Ok(QueueStore::Memory) => memory::init().await,
+        Err(e) => Err(Error::Message(e)),
+    }
 }
 
 async fn default() -> Box<dyn Queue> {

--- a/src/infra/src/queue/nats.rs
+++ b/src/infra/src/queue/nats.rs
@@ -25,7 +25,7 @@ use tokio::{sync::mpsc, task::JoinHandle};
 use crate::{db::nats::get_nats_client, errors::*, queue, queue::format_key};
 
 pub async fn init() -> Result<()> {
-    Ok(())
+    crate::db::nats::init().await
 }
 
 pub struct NatsQueue {


### PR DESCRIPTION
## What

With `ZO_QUEUE_STORE=nats` and no reachable NATS server, the process used to boot successfully. The first NATS connection happened lazily inside background tasks (pipeline execution etc.), whose panics tokio swallows, so the node kept running but could not serve queue-backed features — an error state users easily miss.

Now an unreachable NATS fails boot with a clear error and exit code 1:

```
infra init failed: Error# NATS connect failed for address(es): [...], err: IO error: Connection refused (os error 61)
Error: backend job init failed, exiting
```

## How

- Implement the missing queue backend init hook: `queue::init()` dispatches by `queue_store` — `nats::init()` establishes the connection at startup and fails boot on error, `memory::init()` is a no-op.
- Call `queue::init()` from `infra::init()` as well: `db_init()` runs only when migrations are needed, so on a normal boot (schema version matches) it is skipped entirely and cannot carry the check alone.
- Make `db::nats::connect()` return `Result` so the startup path gets a clean error instead of a panic. `get_nats_client()` keeps its `&'static Client` panic-on-failure contract for existing lazy callers (with the full error now in the panic message); after this change every NATS-configured boot connects during startup, so that panic path is effectively dead.

The meta store already had an equivalent startup check: `migration::init_db()` reads the schema version on every boot with a 5-attempt retry and aborts on an unreachable database.

## Verified

Ran the debug binary in local mode against each scenario:

| scenario | result |
|---|---|
| fresh db, `queue_store=nats`, NATS down | exit 1 with clear error |
| migrated db (skips `db_init`), NATS down | exit 1 with clear error |
| NATS up (docker, JetStream) | boots, healthz ok, no panics |
| `queue_store=memory` | boots, never touches NATS |