### PR TITLE
fix(metrics): preserve timestamp sorting for hash-ordered queries

### DIFF
--- a/src/search/src/datafusion/optimizer/logical_optimizer/add_sort_and_limit.rs
+++ b/src/search/src/datafusion/optimizer/logical_optimizer/add_sort_and_limit.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use config::meta::stream::StreamType;
 use datafusion::{
     common::{
         Result,
@@ -28,11 +29,16 @@ use crate::datafusion::optimizer::utils::{AddSortAndLimit, is_empty_relation};
 pub struct AddSortAndLimitRule {
     limit: usize,
     offset: usize,
+    stream_type: StreamType,
 }
 
 impl AddSortAndLimitRule {
-    pub fn new(limit: usize, offset: usize) -> Self {
-        Self { limit, offset }
+    pub fn new(limit: usize, offset: usize, stream_type: StreamType) -> Self {
+        Self {
+            limit,
+            offset,
+            stream_type,
+        }
     }
 }
 
@@ -57,7 +63,11 @@ impl OptimizerRule for AddSortAndLimitRule {
         if self.limit == 0 || is_empty_relation(&plan) {
             return Ok(Transformed::new(plan, false, TreeNodeRecursion::Stop));
         }
-        let mut plan = plan.rewrite(&mut AddSortAndLimit::new(self.limit, self.offset))?;
+        let mut plan = plan.rewrite(&mut AddSortAndLimit::new(
+            self.limit,
+            self.offset,
+            self.stream_type,
+        ))?;
         plan.tnr = TreeNodeRecursion::Stop;
         Ok(plan)
     }
@@ -67,14 +77,22 @@ impl OptimizerRule for AddSortAndLimitRule {
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{Int64Array, StringArray};
+    use arrow::array::{Int64Array, StringArray, UInt64Array};
     use arrow_schema::{DataType, Field, Schema};
+    use config::meta::stream::StreamType;
     use datafusion::{
-        arrow::record_batch::RecordBatch, assert_batches_eq, datasource::MemTable,
+        arrow::record_batch::RecordBatch,
+        assert_batches_eq,
+        common::tree_node::TreeNode,
+        datasource::{MemTable, TableProvider},
+        physical_plan::{collect, displayable},
         prelude::SessionContext,
     };
 
     use super::AddSortAndLimitRule;
+    use crate::datafusion::{
+        distributed_plan::ReplaceTableScanExec, table_provider::empty_table::NewEmptyTable,
+    };
 
     #[tokio::test]
     async fn test_real_sql_for_timestamp() {
@@ -195,7 +213,7 @@ mod tests {
         let ctx = SessionContext::new();
         let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
         ctx.register_table("t", Arc::new(provider)).unwrap();
-        ctx.add_optimizer_rule(Arc::new(AddSortAndLimitRule::new(2, 0)));
+        ctx.add_optimizer_rule(Arc::new(AddSortAndLimitRule::new(2, 0, StreamType::Logs)));
 
         for item in sqls {
             let df = ctx.sql(item.0).await.unwrap();
@@ -204,10 +222,129 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn test_metrics_default_sort_over_hash_ordered_input() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("_timestamp", DataType::Int64, false),
+            Field::new("__hash__", DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![10, 30, 20, 40])),
+                Arc::new(UInt64Array::from(vec![1, 1, 2, 2])),
+            ],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        let placeholder = NewEmptyTable::new("metrics", schema.clone());
+        ctx.register_table("metrics", Arc::new(placeholder))
+            .unwrap();
+        ctx.add_optimizer_rule(Arc::new(AddSortAndLimitRule::new(
+            2,
+            0,
+            StreamType::Metrics,
+        )));
+
+        let data = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let data_scan = data.scan(&ctx.state(), None, &[], None).await.unwrap();
+        let expected = [
+            "+------------+----------+",
+            "| _timestamp | __hash__ |",
+            "+------------+----------+",
+            "| 40         | 2        |",
+            "| 30         | 1        |",
+            "+------------+----------+",
+        ];
+
+        for sql in [
+            "SELECT * FROM metrics",
+            "SELECT * FROM metrics ORDER BY _timestamp DESC",
+        ] {
+            let logical_plan = ctx.state().create_logical_plan(sql).await.unwrap();
+            let physical_plan = ctx
+                .state()
+                .create_physical_plan(&logical_plan)
+                .await
+                .unwrap();
+            let plan = displayable(physical_plan.as_ref()).indent(true).to_string();
+            assert!(
+                plan.contains("SortExec:"),
+                "hash-ordered input still needs a timestamp sort:\n{plan}"
+            );
+
+            let mut rewriter = ReplaceTableScanExec::new(data_scan.clone());
+            let executable_plan = physical_plan.rewrite(&mut rewriter).unwrap().data;
+            let batches = collect(executable_plan, ctx.task_ctx()).await.unwrap();
+            assert_batches_eq!(expected, &batches);
+        }
+
+        let logical_plan = ctx
+            .state()
+            .create_logical_plan("SELECT __hash__ FROM metrics")
+            .await
+            .unwrap();
+        let physical_plan = ctx
+            .state()
+            .create_physical_plan(&logical_plan)
+            .await
+            .unwrap();
+        let plan = displayable(physical_plan.as_ref()).indent(true).to_string();
+        assert!(plan.contains("SortExec:"), "{plan}");
+
+        let projection = vec![1, 0];
+        let projected_data_scan = data
+            .scan(&ctx.state(), Some(&projection), &[], None)
+            .await
+            .unwrap();
+        let mut rewriter = ReplaceTableScanExec::new(projected_data_scan);
+        let executable_plan = physical_plan.rewrite(&mut rewriter).unwrap().data;
+        let batches = collect(executable_plan, ctx.task_ctx()).await.unwrap();
+        assert_batches_eq!(
+            [
+                "+----------+",
+                "| __hash__ |",
+                "+----------+",
+                "| 2        |",
+                "| 1        |",
+                "+----------+",
+            ],
+            &batches
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_sort_keeps_timestamp_order_optimization_for_logs() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("_timestamp", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ctx = SessionContext::new();
+        ctx.register_table("logs", Arc::new(NewEmptyTable::new("logs", schema)))
+            .unwrap();
+        ctx.add_optimizer_rule(Arc::new(AddSortAndLimitRule::new(2, 0, StreamType::Logs)));
+
+        let logical_plan = ctx
+            .state()
+            .create_logical_plan("SELECT * FROM logs")
+            .await
+            .unwrap();
+        let physical_plan = ctx
+            .state()
+            .create_physical_plan(&logical_plan)
+            .await
+            .unwrap();
+        let plan = displayable(physical_plan.as_ref()).indent(true).to_string();
+
+        assert!(plan.contains("sort_order=timestamp_desc"), "{plan}");
+        assert!(!plan.contains("SortExec:"), "{plan}");
+    }
+
     #[test]
     fn test_add_sort_and_limit_rule_new_metadata() {
         use datafusion::optimizer::OptimizerRule;
-        let rule = AddSortAndLimitRule::new(10, 5);
+        let rule = AddSortAndLimitRule::new(10, 5, StreamType::Logs);
         assert_eq!(rule.name(), "add_sort_and_limit");
         assert_eq!(
             rule.apply_order(),
@@ -217,7 +354,7 @@ mod tests {
 
     #[test]
     fn test_add_sort_and_limit_rule_new_zero_limit() {
-        let rule = AddSortAndLimitRule::new(0, 0);
+        let rule = AddSortAndLimitRule::new(0, 0, StreamType::Logs);
         use datafusion::optimizer::OptimizerRule;
         assert_eq!(rule.name(), "add_sort_and_limit");
     }

--- a/src/search/src/datafusion/optimizer/logical_optimizer/limit_join_right_side.rs
+++ b/src/search/src/datafusion/optimizer/logical_optimizer/limit_join_right_side.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use config::TIMESTAMP_COL_NAME;
+use config::{TIMESTAMP_COL_NAME, meta::stream::StreamType};
 use datafusion::{
     common::{
         Column, Result,
@@ -35,11 +35,12 @@ use crate::datafusion::{
 #[derive(Default, Debug)]
 pub struct LimitJoinRightSide {
     limit: usize,
+    stream_type: StreamType,
 }
 
 impl LimitJoinRightSide {
-    pub fn new(limit: usize) -> Self {
-        Self { limit }
+    pub fn new(limit: usize, stream_type: StreamType) -> Self {
+        Self { limit, stream_type }
     }
 }
 
@@ -80,7 +81,7 @@ impl OptimizerRule for LimitJoinRightSide {
                 // limit the right side output size
                 let mut plan = (*join.right)
                     .clone()
-                    .rewrite(&mut AddSortAndLimit::new(self.limit, 0))?
+                    .rewrite(&mut AddSortAndLimit::new(self.limit, 0, self.stream_type))?
                     .data;
                 if !right_column.is_empty() {
                     // deduplication on join key
@@ -182,6 +183,7 @@ mod tests {
 
     use arrow::array::{Int64Array, StringArray};
     use arrow_schema::{DataType, Field, Schema};
+    use config::meta::stream::StreamType;
     use datafusion::{
         arrow::record_batch::RecordBatch,
         common::Result,
@@ -193,18 +195,21 @@ mod tests {
     };
 
     use super::LimitJoinRightSide;
-    use crate::datafusion::planner::extension_planner::OpenobserveQueryPlanner;
+    use crate::datafusion::{
+        planner::extension_planner::OpenobserveQueryPlanner,
+        table_provider::empty_table::NewEmptyTable,
+    };
 
     #[test]
     fn test_limit_join_right_side_name() {
-        let rule = LimitJoinRightSide::new(10);
+        let rule = LimitJoinRightSide::new(10, StreamType::Logs);
         assert_eq!(rule.name(), "limit_join_right_side");
     }
 
     #[test]
     fn test_limit_join_right_side_apply_order() {
         use datafusion::optimizer::optimizer::ApplyOrder;
-        let rule = LimitJoinRightSide::new(10);
+        let rule = LimitJoinRightSide::new(10, StreamType::Logs);
         assert_eq!(rule.apply_order(), Some(ApplyOrder::TopDown));
     }
 
@@ -233,7 +238,7 @@ mod tests {
             .with_query_planner(Arc::new(OpenobserveQueryPlanner::new()))
             .build();
         let ctx = SessionContext::new_with_state(state);
-        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000)));
+        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000, StreamType::Logs)));
         let provider1 = MemTable::try_new(schema.clone(), vec![vec![batch.clone()]]).unwrap();
         ctx.register_table("t1", Arc::new(provider1)).unwrap();
 
@@ -288,7 +293,7 @@ mod tests {
             .with_default_features()
             .build();
         let ctx = SessionContext::new_with_state(state);
-        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000)));
+        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000, StreamType::Logs)));
         let provider1 = MemTable::try_new(schema.clone(), vec![vec![batch.clone()]]).unwrap();
         let provider2 = MemTable::try_new(schema, vec![vec![batch.clone()], vec![batch]]).unwrap();
         ctx.register_table("t1", Arc::new(provider1)).unwrap();
@@ -327,6 +332,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_metrics_join_right_side_keeps_timestamp_sort() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("_timestamp", DataType::Int64, false),
+        ]));
+        let state = SessionStateBuilder::new()
+            .with_config(SessionConfig::new().with_target_partitions(12))
+            .with_runtime_env(Arc::new(RuntimeEnvBuilder::new().build().unwrap()))
+            .with_query_planner(Arc::new(OpenobserveQueryPlanner::new()))
+            .with_default_features()
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(
+            50_000,
+            StreamType::Metrics,
+        )));
+        ctx.register_table(
+            "t1",
+            Arc::new(NewEmptyTable::new("t1", schema.clone()).with_partitions(12)),
+        )?;
+        ctx.register_table(
+            "t2",
+            Arc::new(NewEmptyTable::new("t2", schema).with_partitions(12)),
+        )?;
+
+        let logical_plan = ctx
+            .state()
+            .create_logical_plan("SELECT t1.id FROM t1 JOIN t2 ON t1.id = t2.id")
+            .await?;
+        let physical_plan = ctx.state().create_physical_plan(&logical_plan).await?;
+        let plan = get_plan_string(&physical_plan);
+
+        assert!(
+            plan.iter()
+                .any(|line| { line.contains("SortExec: TopK(fetch=50000), expr=[_timestamp") }),
+            "metrics join right side must retain its timestamp sort:\n{}",
+            plan.join("\n")
+        );
+        assert!(
+            plan.iter()
+                .all(|line| !line.contains("sort_order=timestamp_desc")),
+            "metrics scans must not claim timestamp-descending input:\n{}",
+            plan.join("\n")
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_join_three_table() -> Result<()> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("usr_id", DataType::Int64, false),
@@ -351,7 +405,7 @@ mod tests {
             .with_default_features()
             .build();
         let ctx = SessionContext::new_with_state(state);
-        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000)));
+        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000, StreamType::Logs)));
         let provider1 = MemTable::try_new(schema.clone(), vec![vec![batch.clone()]]).unwrap();
         let provider2 = MemTable::try_new(
             schema.clone(),
@@ -399,7 +453,7 @@ mod tests {
     #[test]
     fn test_limit_join_right_side_rule_metadata() {
         use datafusion::optimizer::OptimizerRule;
-        let rule = LimitJoinRightSide::new(100);
+        let rule = LimitJoinRightSide::new(100, StreamType::Logs);
         assert_eq!(rule.name(), "limit_join_right_side");
         assert_eq!(
             rule.apply_order(),

--- a/src/search/src/datafusion/optimizer/mod.rs
+++ b/src/search/src/datafusion/optimizer/mod.rs
@@ -129,7 +129,11 @@ pub fn generate_optimizer_rules(sql: &Sql) -> Vec<Arc<dyn OptimizerRule + Send +
         sql.timezone.clone(),
     )));
     if let Some(limit) = limit {
-        rules.push(Arc::new(AddSortAndLimitRule::new(limit, offset)));
+        rules.push(Arc::new(AddSortAndLimitRule::new(
+            limit,
+            offset,
+            sql.stream_type,
+        )));
     };
     #[cfg(feature = "enterprise")]
     rules.push(Arc::new(RewriteCipherCall::new()));
@@ -156,6 +160,7 @@ pub fn generate_optimizer_rules(sql: &Sql) -> Vec<Arc<dyn OptimizerRule + Send +
     {
         rules.push(Arc::new(LimitJoinRightSide::new(
             cfg.search.feature_join_right_side_max_rows,
+            sql.stream_type,
         )));
     }
     // ************************************

--- a/src/search/src/datafusion/optimizer/physical_optimizer/join_reorder.rs
+++ b/src/search/src/datafusion/optimizer/physical_optimizer/join_reorder.rs
@@ -98,6 +98,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_schema::{DataType, Field, Schema};
+    use config::meta::stream::StreamType;
     use datafusion::{
         common::Result,
         execution::{runtime_env::RuntimeEnvBuilder, session_state::SessionStateBuilder},
@@ -251,7 +252,7 @@ mod tests {
             .with_config(SessionConfig::new().with_target_partitions(12))
             .with_runtime_env(Arc::new(RuntimeEnvBuilder::new().build().unwrap()))
             .with_default_features()
-            .with_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000)))
+            .with_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000, StreamType::Logs)))
             .with_physical_optimizer_rule(Arc::new(JoinReorderRule::new()))
             .with_query_planner(Arc::new(OpenobserveQueryPlanner::new()))
             .build();
@@ -296,7 +297,7 @@ mod tests {
             .with_config(SessionConfig::new().with_target_partitions(12))
             .with_runtime_env(Arc::new(RuntimeEnvBuilder::new().build().unwrap()))
             .with_default_features()
-            .with_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000)))
+            .with_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000, StreamType::Logs)))
             .with_physical_optimizer_rule(Arc::new(JoinReorderRule::new()))
             .with_query_planner(Arc::new(OpenobserveQueryPlanner::new()))
             .build();
@@ -339,7 +340,7 @@ mod tests {
             .with_config(SessionConfig::new().with_target_partitions(12))
             .with_runtime_env(Arc::new(RuntimeEnvBuilder::new().build().unwrap()))
             .with_default_features()
-            .with_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000)))
+            .with_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000, StreamType::Logs)))
             .with_physical_optimizer_rule(Arc::new(JoinReorderRule::new()))
             .with_query_planner(Arc::new(OpenobserveQueryPlanner::new()))
             .build();

--- a/src/search/src/datafusion/optimizer/utils.rs
+++ b/src/search/src/datafusion/optimizer/utils.rs
@@ -15,7 +15,10 @@
 
 use std::sync::Arc;
 
-use config::TIMESTAMP_COL_NAME;
+use config::{
+    TIMESTAMP_COL_NAME,
+    meta::{sql::TableReferenceExt, stream::StreamType},
+};
 use datafusion::{
     common::{
         DFSchema, Result,
@@ -50,11 +53,16 @@ pub fn is_complex_query(plan: &LogicalPlan) -> bool {
 pub struct AddSortAndLimit {
     pub limit: usize,
     pub offset: usize,
+    pub stream_type: StreamType,
 }
 
 impl AddSortAndLimit {
-    pub fn new(limit: usize, offset: usize) -> Self {
-        Self { limit, offset }
+    pub fn new(limit: usize, offset: usize, stream_type: StreamType) -> Self {
+        Self {
+            limit,
+            offset,
+            stream_type,
+        }
     }
 }
 
@@ -87,7 +95,8 @@ impl TreeNodeRewriter for AddSortAndLimit {
                         // the add sort plan should reflect the limit
                         let fetch = get_int_from_expr(&limit.fetch);
                         let skip = get_int_from_expr(&limit.skip);
-                        let (sort, schema) = generate_sort_plan(limit.input.clone(), fetch + skip);
+                        let (sort, schema) =
+                            generate_sort_plan(limit.input.clone(), fetch + skip, self.stream_type);
                         limit.input = Arc::new(sort);
                         (Transformed::yes(LogicalPlan::Limit(limit)), schema)
                     }
@@ -116,8 +125,12 @@ impl TreeNodeRewriter for AddSortAndLimit {
                         None,
                     )
                 } else {
-                    let (plan, schema) =
-                        generate_limit_and_sort_plan(Arc::new(node), self.limit, self.offset);
+                    let (plan, schema) = generate_limit_and_sort_plan(
+                        Arc::new(node),
+                        self.limit,
+                        self.offset,
+                        self.stream_type,
+                    );
                     (Transformed::yes(plan), schema)
                 }
             }
@@ -152,6 +165,7 @@ fn generate_limit_plan(input: Arc<LogicalPlan>, limit: usize, skip: usize) -> Lo
 fn generate_sort_plan(
     input: Arc<LogicalPlan>,
     limit: usize,
+    stream_type: StreamType,
 ) -> (LogicalPlan, Option<Arc<DFSchema>>) {
     let timestamp = SortExpr {
         expr: col(TIMESTAMP_COL_NAME),
@@ -162,7 +176,7 @@ fn generate_sort_plan(
     if schema.field_with_name(None, TIMESTAMP_COL_NAME).is_err() {
         let mut input = input.as_ref().clone();
         input = input
-            .rewrite(&mut ChangeTableScanSchema::new())
+            .rewrite(&mut ChangeTableScanSchema::new(stream_type))
             .data()
             .unwrap();
         (
@@ -175,7 +189,10 @@ fn generate_sort_plan(
         )
     } else {
         let mut input = input.as_ref().clone();
-        input = input.rewrite(&mut SortByTime::new()).data().unwrap();
+        input = input
+            .rewrite(&mut SortByTime::new(stream_type))
+            .data()
+            .unwrap();
         (
             LogicalPlan::Sort(Sort {
                 expr: vec![timestamp],
@@ -191,8 +208,9 @@ fn generate_limit_and_sort_plan(
     input: Arc<LogicalPlan>,
     limit: usize,
     skip: usize,
+    stream_type: StreamType,
 ) -> (LogicalPlan, Option<Arc<DFSchema>>) {
-    let (sort, schema) = generate_sort_plan(input, limit + skip);
+    let (sort, schema) = generate_sort_plan(input, limit + skip, stream_type);
     (
         LogicalPlan::Limit(Limit {
             skip: Some(Box::new(Expr::Literal(
@@ -219,11 +237,13 @@ fn get_int_from_expr(expr: &Option<Box<Expr>>) -> usize {
     }
 }
 
-struct ChangeTableScanSchema {}
+struct ChangeTableScanSchema {
+    stream_type: StreamType,
+}
 
 impl ChangeTableScanSchema {
-    fn new() -> Self {
-        Self {}
+    fn new(stream_type: StreamType) -> Self {
+        Self { stream_type }
     }
 }
 
@@ -233,6 +253,8 @@ impl TreeNodeRewriter for ChangeTableScanSchema {
     fn f_up(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
         let mut transformed = match node {
             LogicalPlan::TableScan(scan) => {
+                let is_metrics =
+                    scan.table_name.get_stream_type(self.stream_type) == StreamType::Metrics;
                 let schema = scan.source.schema();
                 let timestamp_idx = schema.index_of(TIMESTAMP_COL_NAME)?;
                 let projection = scan.projection.clone().map(|mut p| {
@@ -246,9 +268,11 @@ impl TreeNodeRewriter for ChangeTableScanSchema {
                     scan.filters,
                     scan.fetch,
                 )?;
-                // add sorted by time to the table source
-                let source = generate_table_source_with_sorted_by_time(table_scan.source);
-                table_scan.source = source;
+                if !is_metrics {
+                    // non-metrics files are timestamp-descending.
+                    table_scan.source =
+                        generate_table_source_with_sorted_by_time(table_scan.source);
+                }
                 Transformed::yes(LogicalPlan::TableScan(table_scan))
             }
             _ => Transformed::no(node),
@@ -258,11 +282,13 @@ impl TreeNodeRewriter for ChangeTableScanSchema {
     }
 }
 
-struct SortByTime {}
+struct SortByTime {
+    stream_type: StreamType,
+}
 
 impl SortByTime {
-    fn new() -> Self {
-        Self {}
+    fn new(stream_type: StreamType) -> Self {
+        Self { stream_type }
     }
 }
 
@@ -271,10 +297,10 @@ impl TreeNodeRewriter for SortByTime {
 
     fn f_up(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
         let mut transformed = match node {
-            LogicalPlan::TableScan(mut scan) => {
-                // add sorted by time to the table source
-                let source = generate_table_source_with_sorted_by_time(scan.source);
-                scan.source = source;
+            LogicalPlan::TableScan(mut scan)
+                if scan.table_name.get_stream_type(self.stream_type) != StreamType::Metrics =>
+            {
+                scan.source = generate_table_source_with_sorted_by_time(scan.source);
                 Transformed::yes(LogicalPlan::TableScan(scan))
             }
             _ => Transformed::no(node),

--- a/src/search_service/src/grpc/flight.rs
+++ b/src/search_service/src/grpc/flight.rs
@@ -198,6 +198,7 @@ pub async fn search(
         physical_plan,
         &ctx,
         &latest_schema,
+        stream_type,
         (req.search_info.start_time, req.search_info.end_time),
         fst_fields.clone(),
         index_fields,
@@ -628,6 +629,7 @@ fn optimizer_physical_plan(
     plan: Arc<dyn ExecutionPlan>,
     ctx: &SessionContext,
     schema: &Schema,
+    stream_type: StreamType,
     time_range: (i64, i64),
     fst_fields: Vec<String>,
     index_fields: Vec<String>,
@@ -658,6 +660,12 @@ fn optimizer_physical_plan(
         let _ = index_optimizer_rule.optimize(original_plan, ctx.state().config_options())?;
     }
 
+    {
+        let mut index_optimizer_rule = index_optimizer_rule_ref.lock();
+        *index_optimizer_rule =
+            index_optimize_mode_for_stream(stream_type, index_optimizer_rule.take());
+    }
+
     let rewrite_match_rule = RewriteMatchPhysical::new(
         fst_fields
             .clone()
@@ -682,6 +690,20 @@ fn optimizer_physical_plan(
     }
 
     Ok(plan)
+}
+
+fn index_optimize_mode_for_stream(
+    stream_type: StreamType,
+    mode: Option<IndexOptimizeMode>,
+) -> Option<IndexOptimizeMode> {
+    // Metrics files may be hash-ordered, so Tantivy doc IDs do not guarantee timestamp order.
+    if stream_type == StreamType::Metrics
+        && matches!(mode, Some(IndexOptimizeMode::SimpleSelect(..)))
+    {
+        None
+    } else {
+        mode
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -963,6 +985,7 @@ mod tests {
             physical_plan,
             &ctx,
             &schema,
+            StreamType::Logs,
             (start_time, end_time),
             vec![],
             vec!["kubernetes_namespace_name".to_string()],
@@ -984,5 +1007,81 @@ mod tests {
             index_optimizer_rule_ref.lock().clone(),
             Some(IndexOptimizeMode::SimpleHistogram(..))
         ));
+    }
+
+    #[test]
+    fn test_index_optimize_mode_for_stream_disables_metrics_simple_select() {
+        let simple_select = Some(IndexOptimizeMode::SimpleSelect(10, false));
+
+        assert_eq!(
+            index_optimize_mode_for_stream(StreamType::Metrics, simple_select.clone()),
+            None
+        );
+        assert_eq!(
+            index_optimize_mode_for_stream(StreamType::Logs, simple_select.clone()),
+            simple_select
+        );
+        assert_eq!(
+            index_optimize_mode_for_stream(
+                StreamType::Metrics,
+                Some(IndexOptimizeMode::SimpleCount),
+            ),
+            Some(IndexOptimizeMode::SimpleCount)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimizer_physical_plan_disables_detected_metrics_simple_select() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("_timestamp", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let state = SessionStateBuilder::new()
+            .with_config(SessionConfig::new().with_target_partitions(12))
+            .with_runtime_env(Arc::new(RuntimeEnvBuilder::new().build().unwrap()))
+            .with_default_features()
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+        let provider = NewEmptyTable::new("default", schema.clone()).with_partitions(12);
+        ctx.register_table("default", Arc::new(provider)).unwrap();
+
+        let logical_plan = ctx
+            .state()
+            .create_logical_plan("SELECT * FROM default ORDER BY _timestamp DESC LIMIT 10")
+            .await
+            .unwrap();
+        let physical_plan = ctx
+            .state()
+            .create_physical_plan(&logical_plan)
+            .await
+            .unwrap();
+
+        for (stream_type, expected_mode) in [
+            (
+                StreamType::Logs,
+                Some(IndexOptimizeMode::SimpleSelect(10, false)),
+            ),
+            (StreamType::Metrics, None),
+        ] {
+            let index_condition_ref = Arc::new(Mutex::new(None));
+            let index_optimizer_rule_ref = Arc::new(Mutex::new(None));
+            let is_metrics = stream_type == StreamType::Metrics;
+
+            optimizer_physical_plan(
+                physical_plan.clone(),
+                &ctx,
+                &schema,
+                stream_type,
+                (0, 100),
+                vec![],
+                vec![],
+                index_condition_ref.clone(),
+                index_optimizer_rule_ref.clone(),
+            )
+            .unwrap();
+
+            assert_eq!(index_optimizer_rule_ref.lock().clone(), expected_mode);
+            assert_eq!(index_condition_ref.lock().is_none(), is_metrics);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- keep the required `_timestamp DESC` result order independent from the physical input order for metrics queries
- preserve the existing `TimestampDesc` source-order optimization for non-metrics streams, including join right-side limits
- disable Tantivy `SimpleSelect` optimization for metrics while leaving other stream types and index modes unchanged
- add explicit, implicit, projected-field, and join regression coverage for hash-ordered metrics input

## Context

Follow-up to the query-correctness TODO in #13882. This PR does not include the separate TSID-major merge-memory or WAL-ordering follow-ups.

## Testing

- `cargo test -p search --lib -- datafusion::optimizer::` (152 passed)
- `cargo test -p search_service --lib -- --test-threads=1` (200 passed)
- `cargo clippy -p search -p search_service --tests -- -D warnings`
- `cargo fmt --all -- --check`