### PR TITLE
fix: reduce db calls for realtime alerts

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2321,12 +2321,6 @@ pub struct Limit {
     #[env_config(name = "ZO_ALERT_SCHEDULE_TIMEOUT", default = 90)] // seconds
     pub alert_schedule_timeout: i64,
     #[env_config(
-        name = "ZO_ALERT_REALTIME_MIN_SILENCE_SECS",
-        default = 30,
-        help = "Minimum silence period (seconds) applied to a realtime alert after each notification, even when the alert's own silence is 0 — without a floor, every matching ingestion request sends a notification and its DB writes. 0 disables the floor."
-    )]
-    pub alert_realtime_min_silence_secs: i64,
-    #[env_config(
         name = "ZO_ALERT_PREVIEW_TIMERANGE_MINUTES",
         default = 0,
         help = "Time range in minutes for alert preview. If set to 0 (default), uses the alert's period value. If greater than 0, overrides period for preview."

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2321,6 +2321,12 @@ pub struct Limit {
     #[env_config(name = "ZO_ALERT_SCHEDULE_TIMEOUT", default = 90)] // seconds
     pub alert_schedule_timeout: i64,
     #[env_config(
+        name = "ZO_ALERT_REALTIME_MIN_SILENCE_SECS",
+        default = 30,
+        help = "Minimum silence period (seconds) applied to a realtime alert after each notification, even when the alert's own silence is 0 — without a floor, every matching ingestion request sends a notification and its DB writes. 0 disables the floor."
+    )]
+    pub alert_realtime_min_silence_secs: i64,
+    #[env_config(
         name = "ZO_ALERT_PREVIEW_TIMERANGE_MINUTES",
         default = 0,
         help = "Time range in minutes for alert preview. If set to 0 (default), uses the alert's period value. If greater than 0, overrides period for preview."

--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -341,6 +341,15 @@ impl TriggerCondition {
             )
         }
     }
+
+    /// Effective realtime-alert silence in microseconds: the alert's own
+    /// silence (minutes) floored by `min_silence_secs`.
+    pub fn effective_silence_micros(&self, min_silence_secs: i64) -> i64 {
+        self.silence
+            .saturating_mul(60)
+            .max(min_silence_secs)
+            .saturating_mul(1_000_000)
+    }
 }
 
 impl TriggerCondition {

--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -44,6 +44,11 @@ pub mod state;
 pub mod state_level;
 pub mod tags;
 
+/// Minimum silence applied to a realtime alert after each notification, even
+/// when the alert's own silence is 0 — without a floor, every matching
+/// ingestion request sends a notification and its db writes.
+const REALTIME_MIN_SILENCE_SECS: i64 = 30;
+
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq, Default)]
 #[serde(default)]
 pub struct TriggerCondition {
@@ -343,11 +348,11 @@ impl TriggerCondition {
     }
 
     /// Effective realtime-alert silence in microseconds: the alert's own
-    /// silence (minutes) floored by `min_silence_secs`.
-    pub fn effective_silence_micros(&self, min_silence_secs: i64) -> i64 {
+    /// silence (minutes) floored by [`REALTIME_MIN_SILENCE_SECS`].
+    pub fn effective_silence_micros(&self) -> i64 {
         self.silence
             .saturating_mul(60)
-            .max(min_silence_secs)
+            .max(REALTIME_MIN_SILENCE_SECS)
             .saturating_mul(1_000_000)
     }
 }

--- a/src/core/src/ingestion/mod.rs
+++ b/src/core/src/ingestion/mod.rs
@@ -138,7 +138,6 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
     if triggers.is_empty() {
         return;
     }
-    let cfg = config::get_config();
     let mut trigger_usage_reports = vec![];
     for (alert, val) in triggers.iter() {
         let module_key = scheduler_key(alert.id);
@@ -194,9 +193,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
                 }
                 // enforce a minimum silence floor so a high-volume stream cannot
                 // fire (and write to the db) once per matching request
-                let silence_micros = alert
-                    .trigger_condition
-                    .effective_silence_micros(cfg.limit.alert_realtime_min_silence_secs);
+                let silence_micros = alert.trigger_condition.effective_silence_micros();
                 if silence_micros > 0 {
                     log::debug!(
                         "Realtime alert {}/{}/{}/{} triggered successfully, hence applying silence period",

--- a/src/core/src/ingestion/mod.rs
+++ b/src/core/src/ingestion/mod.rs
@@ -22,7 +22,7 @@ use std::{
     },
 };
 
-use chrono::{Duration, TimeZone, Utc};
+use chrono::{TimeZone, Utc};
 use config::{
     SIZE_IN_MB, TIMESTAMP_COL_NAME,
     cluster::{LOCAL_NODE, LOCAL_NODE_ID},
@@ -128,7 +128,7 @@ pub async fn get_stream_alerts(
             })
             .collect::<Vec<_>>();
         if alerts.is_empty() {
-            return;
+            continue;
         }
         stream_alerts_map.insert(key, alerts);
     }
@@ -138,6 +138,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
     if triggers.is_empty() {
         return;
     }
+    let cfg = config::get_config();
     let mut trigger_usage_reports = vec![];
     for (alert, val) in triggers.iter() {
         let module_key = scheduler_key(alert.id);
@@ -191,7 +192,12 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
                 if !success_msg.is_empty() {
                     trigger_data_stream.success_response = Some(success_msg);
                 }
-                if alert.trigger_condition.silence > 0 {
+                // enforce a minimum silence floor so a high-volume stream cannot
+                // fire (and write to the db) once per matching request
+                let silence_micros = alert
+                    .trigger_condition
+                    .effective_silence_micros(cfg.limit.alert_realtime_min_silence_secs);
+                if silence_micros > 0 {
                     log::debug!(
                         "Realtime alert {}/{}/{}/{} triggered successfully, hence applying silence period",
                         alert.org_id,
@@ -200,11 +206,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
                         alert.name
                     );
 
-                    let next_run_at = Utc::now().timestamp_micros()
-                        + Duration::try_minutes(alert.trigger_condition.silence)
-                            .unwrap()
-                            .num_microseconds()
-                            .unwrap();
+                    let next_run_at = Utc::now().timestamp_micros() + silence_micros;
                     // After the notification is sent successfully, we need to update
                     // the silence period of the trigger
                     if let Err(e) = db::scheduler::update_trigger(

--- a/src/core/src/logs/mod.rs
+++ b/src/core/src/logs/mod.rs
@@ -539,7 +539,7 @@ async fn write_logs(
 
     // only one trigger per request
     if !triggers.is_empty() {
-        tokio::spawn(async move { evaluate_trigger(triggers).await });
+        tokio::spawn(evaluate_trigger(triggers));
     }
 
     Ok(req_stats)

--- a/src/core/src/metrics/json.rs
+++ b/src/core/src/metrics/json.rs
@@ -659,10 +659,10 @@ pub async fn ingest(
         ])
         .inc();
 
-    // only one trigger per request
+    // only one trigger per request; notification/db work must not block ingestion
     for (_, entry) in stream_trigger_map {
         if let Some(entry) = entry {
-            evaluate_trigger(entry).await;
+            tokio::spawn(evaluate_trigger(entry));
         }
     }
 

--- a/src/core/src/metrics/otlp.rs
+++ b/src/core/src/metrics/otlp.rs
@@ -706,10 +706,10 @@ pub async fn handle_otlp_request(
         .with_label_values(&[ep, "200", org_id, StreamType::Metrics.as_str(), "", ""])
         .inc();
 
-    // only one trigger per request
+    // only one trigger per request; notification/db work must not block ingestion
     for (_, entry) in stream_trigger_map {
         if let Some(entry) = entry {
-            evaluate_trigger(entry).await;
+            tokio::spawn(evaluate_trigger(entry));
         }
     }
 

--- a/src/core/src/metrics/prom.rs
+++ b/src/core/src/metrics/prom.rs
@@ -800,10 +800,10 @@ pub async fn remote_write(
         ])
         .inc();
 
-    // only one trigger per request
+    // only one trigger per request; notification/db work must not block ingestion
     for (_, entry) in stream_trigger_map {
         if let Some(entry) = entry {
-            evaluate_trigger(entry).await;
+            tokio::spawn(evaluate_trigger(entry));
         }
     }
 

--- a/src/core/src/short_url.rs
+++ b/src/core/src/short_url.rs
@@ -13,12 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use anyhow::anyhow;
 use chrono::Utc;
 use config::{get_config, utils::md5};
-use infra::{
-    errors::{DbError, Error},
-    table::short_urls::ShortUrlRecord,
-};
+use infra::table::short_urls::ShortUrlRecord;
 
 use crate::db;
 
@@ -40,14 +38,14 @@ pub fn construct_short_url(org_id: &str, short_id: &str) -> String {
     )
 }
 
+/// Returns `false` when a row with the same short id already exists.
 async fn store_short_url(
     org_id: &str,
     short_id: &str,
     original_url: &str,
-) -> Result<String, anyhow::Error> {
+) -> Result<bool, anyhow::Error> {
     let entry = ShortUrlRecord::new(short_id, original_url, org_id);
-    db::short_url::set(short_id, entry).await?;
-    Ok(construct_short_url(org_id, short_id))
+    db::short_url::set(short_id, entry).await
 }
 
 fn generate_short_id(original_url: &str, timestamp: Option<i64>) -> String {
@@ -62,31 +60,32 @@ fn generate_short_id(original_url: &str, timestamp: Option<i64>) -> String {
 
 /// Shortens the given original URL and stores it in the database
 pub async fn shorten(org_id: &str, original_url: &str) -> Result<String, anyhow::Error> {
-    let mut short_id = generate_short_id(original_url, None);
+    let short_id = generate_short_id(original_url, None);
 
+    // fast path for already-shortened urls: cache only, no db read
+    if db::short_url::get_cached(&short_id, org_id).is_some_and(|url| url == original_url) {
+        return Ok(construct_short_url(org_id, &short_id));
+    }
+
+    // insert first (ON CONFLICT DO NOTHING): most urls are previously unseen,
+    // so a lookup before insert would be a wasted db call
+    if store_short_url(org_id, &short_id, original_url).await? {
+        return Ok(construct_short_url(org_id, &short_id));
+    }
+
+    // conflict: either the same url was already stored, or the short id
+    // belongs to a different url (hash collision or another org's row)
     if let Ok(existing_url) = db::short_url::get(&short_id, org_id).await
         && existing_url == original_url
     {
         return Ok(construct_short_url(org_id, &short_id));
     }
-
-    let result = store_short_url(org_id, &short_id, original_url).await;
-    match result {
-        Ok(url) => Ok(url),
-        Err(e) => {
-            if let Some(infra_error) = e.downcast_ref::<Error>() {
-                match infra_error {
-                    Error::DbError(DbError::UniqueViolation) => {
-                        let timestamp = Utc::now().timestamp_micros();
-                        short_id = generate_short_id(original_url, Some(timestamp));
-                        store_short_url(org_id, &short_id, original_url).await
-                    }
-                    _ => Err(e),
-                }
-            } else {
-                Err(e)
-            }
-        }
+    let timestamp = Utc::now().timestamp_micros();
+    let short_id = generate_short_id(original_url, Some(timestamp));
+    if store_short_url(org_id, &short_id, original_url).await? {
+        Ok(construct_short_url(org_id, &short_id))
+    } else {
+        Err(anyhow!("Short URL id collision for {short_id}"))
     }
 }
 

--- a/src/core/src/traces/mod.rs
+++ b/src/core/src/traces/mod.rs
@@ -1554,8 +1554,10 @@ async fn write_traces(
         std::io::Error::other(e.to_string())
     })?;
 
-    // only one trigger per request
-    evaluate_trigger(triggers).await;
+    // only one trigger per request; notification/db work must not block ingestion
+    if !triggers.is_empty() {
+        tokio::spawn(evaluate_trigger(triggers));
+    }
 
     Ok(req_stats)
 }

--- a/src/db/src/short_url.rs
+++ b/src/db/src/short_url.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use anyhow::{Context, anyhow};
 use chrono::Utc;
 use common::infra::config::SHORT_URLS;
-use config::get_config;
+use config::{get_config, utils::json};
 use infra::{db::Event, table::short_urls};
 
 use crate as db;
@@ -30,12 +30,10 @@ const SHORT_URL_GC_INTERVAL: i64 = 1; // days
 const SHORT_URL_CACHE_LIMIT: i64 = 10_000; // records
 
 pub async fn get(short_id: &str, org_id: &str) -> Result<String, anyhow::Error> {
-    // Check cache first; re-validate org_id ownership (legacy rows have empty org_id).
-    if let Some(v) = SHORT_URLS.get(short_id) {
-        if v.org_id.is_empty() || v.org_id == org_id {
-            return Ok(v.original_url.to_string());
-        }
-        return Err(anyhow!("Short URL not found"));
+    // Check cache first; a cached row that fails the org check must not fall
+    // through to the db.
+    if SHORT_URLS.contains_key(short_id) {
+        return get_cached(short_id, org_id).ok_or_else(|| anyhow!("Short URL not found"));
     }
 
     let val = short_urls::get(short_id, org_id)
@@ -46,19 +44,30 @@ pub async fn get(short_id: &str, org_id: &str) -> Result<String, anyhow::Error> 
     Ok(original_url)
 }
 
-pub async fn set(short_id: &str, entry: short_urls::ShortUrlRecord) -> Result<(), anyhow::Error> {
-    if let Err(e) = short_urls::add(short_id, &entry.original_url, &entry.org_id).await {
-        log::error!("Failed to add short URL to DB : {e}");
-        return Err(e).context("Failed to add short URL to DB");
+/// Cache-only lookup; re-validates org_id ownership (legacy rows have empty org_id).
+pub fn get_cached(short_id: &str, org_id: &str) -> Option<String> {
+    let v = SHORT_URLS.get(short_id)?;
+    (v.org_id.is_empty() || v.org_id == org_id).then(|| v.original_url.to_string())
+}
+
+/// Returns `false` when a row with the same `short_id` already exists (nothing
+/// written, no events emitted).
+pub async fn set(short_id: &str, entry: short_urls::ShortUrlRecord) -> Result<bool, anyhow::Error> {
+    let inserted = short_urls::add(short_id, &entry.original_url, &entry.org_id)
+        .await
+        .inspect_err(|e| log::error!("Failed to add short URL to DB : {e}"))
+        .context("Failed to add short URL to DB")?;
+    if !inserted {
+        return Ok(false);
     }
 
     // trigger watch event cluster coordinator
-    cluster::emit_put_event(short_id).await?;
+    cluster::emit_put_event(short_id, &entry).await?;
     // trigger watch event super cluster
     #[cfg(feature = "enterprise")]
     super_cluster::emit_put_event(short_id, entry).await?;
 
-    Ok(())
+    Ok(true)
 }
 
 pub async fn watch() -> Result<(), anyhow::Error> {
@@ -87,12 +96,26 @@ pub async fn watch() -> Result<(), anyhow::Error> {
         match ev {
             Event::Put(ev) => {
                 let item_key = ev.key.strip_prefix(key).unwrap();
-                // Load with empty org_id so the lookup succeeds regardless of tenant.
-                let item_value = match short_urls::get(item_key, "").await {
-                    Ok(val) => val,
-                    Err(e) => {
-                        log::error!("Error getting value: {e}");
-                        continue;
+                // Prefer the record carried in the event body; fall back to a
+                // db read for events from nodes that send an empty body.
+                let item_value = if let Some(val) = &ev.value
+                    && !val.is_empty()
+                {
+                    match json::from_slice::<short_urls::ShortUrlRecord>(val) {
+                        Ok(val) => val,
+                        Err(e) => {
+                            log::error!("Error parsing short URL event value: {e}");
+                            continue;
+                        }
+                    }
+                } else {
+                    // Load with empty org_id so the lookup succeeds regardless of tenant.
+                    match short_urls::get(item_key, "").await {
+                        Ok(val) => val,
+                        Err(e) => {
+                            log::error!("Error getting value: {e}");
+                            continue;
+                        }
                     }
                 };
                 SHORT_URLS.insert(item_key.to_string(), item_value);
@@ -194,13 +217,18 @@ mod tests {
 
 /// Helper functions for sending events to cache watchers in the cluster.
 mod cluster {
-    use super::SHORT_URL_KEY;
+    use config::utils::json;
+
+    use super::{SHORT_URL_KEY, short_urls};
 
     /// Sends event to the cluster cache watchers indicating that a new short URL entry has been
-    /// added.
-    pub async fn emit_put_event(short_id: &str) -> Result<(), infra::errors::Error> {
+    /// added. The record rides in the event body so watchers can cache it without a db read.
+    pub async fn emit_put_event(
+        short_id: &str,
+        entry: &short_urls::ShortUrlRecord,
+    ) -> Result<(), infra::errors::Error> {
         let key = short_url_key(short_id);
-        let value = bytes::Bytes::new();
+        let value = bytes::Bytes::from(json::to_vec(entry).unwrap());
         let cluster_coordinator = infra::db::get_coordinator().await;
         cluster_coordinator
             .put(&key, value, infra::db::NEED_WATCH, None)

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -16,9 +16,12 @@
 use std::sync::LazyLock as Lazy;
 
 use async_trait::async_trait;
-use config::meta::{
-    meta_store::MetaStore,
-    triggers::{Trigger, TriggerModule, TriggerStatus},
+use config::{
+    meta::{
+        meta_store::MetaStore,
+        triggers::{Trigger, TriggerModule, TriggerStatus},
+    },
+    utils::json,
 };
 use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
 
@@ -308,6 +311,22 @@ pub async fn clear() -> Result<()> {
 pub fn get_scheduler_max_retries() -> (bool, i32) {
     let max_retries = config::get_config().limit.scheduler_max_retries;
     (max_retries > 0, max_retries.unsigned_abs() as i32)
+}
+
+/// Realtime alert triggers are cached on every node; the trigger rides in the
+/// event body so watchers can update their cache without a db read.
+async fn emit_realtime_trigger_event(trigger: &Trigger) -> Result<()> {
+    if trigger.module != TriggerModule::Alert || !trigger.is_realtime {
+        return Ok(());
+    }
+    let key = format!(
+        "{TRIGGERS_KEY}{}/{}/{}",
+        trigger.module, trigger.org, trigger.module_key
+    );
+    let cluster_coordinator = crate::db::get_coordinator().await;
+    cluster_coordinator
+        .put(&key, json::to_vec(trigger).unwrap().into(), true, None)
+        .await
 }
 
 #[cfg(test)]

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -14,7 +14,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use chrono::Duration;
 use config::{
     metrics::DB_QUERY_NUMS,
@@ -282,17 +281,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
             return Err(e.into());
         }
 
-        // For now, only send realtime alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, trigger.org, trigger.module_key
-            );
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, Bytes::from(""), true, None)
-                .await?;
-        }
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 
@@ -380,7 +369,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     SET status = $1, start_time = $2, end_time = $3, retries = $4, next_run_at = $5, is_realtime = $6, is_silenced = $7, data = $8
     WHERE org = $9 AND module_key = $10 AND module = $11;"#,
             )
-            .bind(trigger.status)
+            .bind(&trigger.status)
             .bind(trigger.start_time)
             .bind(trigger.end_time)
             .bind(trigger.retries)
@@ -397,7 +386,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
     WHERE org = $7 AND module_key = $8 AND module = $9;"#,
             )
-            .bind(trigger.status)
+            .bind(&trigger.status)
             .bind(trigger.retries)
             .bind(trigger.next_run_at)
             .bind(trigger.is_realtime)
@@ -410,17 +399,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
 
         query.execute(&pool).await?;
 
-        // For now, only send realtime alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, trigger.org, trigger.module_key
-            );
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, Bytes::from(""), true, None)
-                .await?;
-        }
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 
@@ -488,20 +467,12 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
                     .inc();
                 // Handle cluster coordinator for realtime alerts
                 for trigger in &triggers {
-                    if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-                        let key = format!(
-                            "{TRIGGERS_KEY}{}/{}/{}",
-                            trigger.module, trigger.org, trigger.module_key
+                    if let Err(e) = super::emit_realtime_trigger_event(trigger).await {
+                        log::error!(
+                            "Error updating cluster coordinator for trigger {}/{}: {e}",
+                            trigger.org,
+                            trigger.module_key
                         );
-                        let cluster_coordinator = db::get_coordinator().await;
-                        if let Err(e) = cluster_coordinator
-                            .put(&key, Bytes::from(""), true, None)
-                            .await
-                        {
-                            log::error!(
-                                "Error updating cluster coordinator for trigger {key}: {e}",
-                            );
-                        }
                     }
                 }
                 Ok(())

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -15,7 +15,7 @@
 
 use async_trait::async_trait;
 use chrono::Duration;
-use config::utils::{json, time::now_micros};
+use config::utils::time::now_micros;
 use sqlx::Row;
 
 use super::{TRIGGERS_KEY, Trigger, TriggerModule, TriggerStatus, get_scheduler_max_retries};
@@ -213,22 +213,11 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         // release lock
         drop(client);
 
-        // For now, only send realtime alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, trigger.org, trigger.module_key
-            );
-
-            // TODO: For sqlite cluster coordinator, the alert triggers are put
-            // into the sqlite meta database to send watch events. Hence, there is a
-            // redundancy of alert triggers stored both in scheduled_jobs and meta
-            // tables. How to remove this redundancy?
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, json::to_vec(&trigger).unwrap().into(), true, None)
-                .await?;
-        }
+        // TODO: For sqlite cluster coordinator, the alert triggers are put
+        // into the sqlite meta database to send watch events. Hence, there is a
+        // redundancy of alert triggers stored both in scheduled_jobs and meta
+        // tables. How to remove this redundancy?
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 
@@ -346,17 +335,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         // release lock
         drop(client);
 
-        // For now, only send alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, trigger.org, trigger.module_key
-            );
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, json::to_vec(&trigger).unwrap().into(), true, None)
-                .await?;
-        }
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 

--- a/src/infra/src/table/short_urls.rs
+++ b/src/infra/src/table/short_urls.rs
@@ -127,7 +127,8 @@ pub async fn create_table_index() -> Result<(), errors::Error> {
     Ok(())
 }
 
-pub async fn add(short_id: &str, original_url: &str, org_id: &str) -> Result<(), errors::Error> {
+/// Returns `false` when a row with the same `short_id` already exists.
+pub async fn add(short_id: &str, original_url: &str, org_id: &str) -> Result<bool, errors::Error> {
     let record = ActiveModel {
         short_id: Set(short_id.to_string()),
         original_url: Set(original_url.to_string()),
@@ -140,9 +141,16 @@ pub async fn add(short_id: &str, original_url: &str, org_id: &str) -> Result<(),
     let _lock = get_lock().await;
 
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
-    Entity::insert(record).exec(client).await?;
+    let inserted = Entity::insert(record)
+        .on_conflict(
+            sea_orm::sea_query::OnConflict::column(Column::ShortId)
+                .do_nothing()
+                .to_owned(),
+        )
+        .exec_without_returning(client)
+        .await?;
 
-    Ok(())
+    Ok(inserted > 0)
 }
 
 pub async fn remove(short_id: &str) -> Result<(), errors::Error> {
@@ -200,17 +208,6 @@ pub async fn list(limit: Option<i64>) -> Result<Vec<ShortUrlRecord>, errors::Err
     let records = res.into_model::<ShortUrlRecord>().all(client).await?;
 
     Ok(records)
-}
-
-pub async fn contains(short_id: &str) -> Result<bool, errors::Error> {
-    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
-    let record = Entity::find()
-        .filter(Column::ShortId.eq(short_id))
-        .into_model::<ShortUrlRecord>()
-        .one(client)
-        .await?;
-
-    Ok(record.is_some())
 }
 
 pub async fn len() -> usize {

--- a/src/super_cluster_queue/src/short_urls.rs
+++ b/src/super_cluster_queue/src/short_urls.rs
@@ -27,13 +27,10 @@ pub(crate) async fn process(msg: Message) -> Result<()> {
             if original_url.is_empty() {
                 return Err(Error::Message("Invalid message value".to_string()));
             }
-            if infra::table::short_urls::contains(&short_id).await? {
-                return Ok(());
-            }
             // The super-cluster queue only carries the original_url, not the
             // org_id, so store an empty org_id. This matches the legacy
             // semantics in `short_urls::get`, where empty-org rows are accepted
-            // from any org.
+            // from any org. `add` is a no-op if the short id already exists.
             infra::table::short_urls::add(&short_id, &original_url, "").await?;
         }
         MessageType::ShortUrlDelete => {


### PR DESCRIPTION
Closes #13910

## What changed

Realtime alerts made a burst of metadata db calls on every firing — and with `silence = 0`, on every matching ingestion request:

- short URL creation: 1 SELECT (always a miss, since the alert URL embeds row timestamps and is unique per firing) + 1 INSERT + a coordinator event whose empty body forced a SELECT on **every** watcher node
- silence update: 1 UPDATE + a coordinator event with an empty body (Postgres only) forcing a `scheduler::get` SELECT per watcher node
- with `silence = 0`, nothing throttled at all, so a high-volume stream repeated all of this per matching request

This PR cuts a firing down to 1 INSERT + 1 UPDATE with zero watcher fan-out, and bounds the firing rate:

1. **Coordinator events carry the body.** The Postgres scheduler backend now serializes the trigger into the event (SQLite already did — the two backends had silently drifted). The five copy-pasted emit blocks across both backends are collapsed into one `emit_realtime_trigger_event` helper in `infra::scheduler`, so the event-body wire contract lives in one place. Short URL put events likewise carry the `ShortUrlRecord`. Both watchers use the body when non-empty and keep the db-read fallback for empty-body events from old nodes, so rolling upgrades are safe.
2. **Short URL uses `INSERT … ON CONFLICT DO NOTHING`** instead of select-then-insert; `add` reports whether a row was written, no-op writes emit no events, and the redundant `contains()` pre-check in the super-cluster queue (plus the now-dead helper) is gone. The old `UniqueViolation` downcast in `shorten()` was dead code — `add` never produced that variant, so an md5 collision used to fail the notification; collisions are now genuinely handled.
3. **Fixed 30s minimum silence for realtime alerts.** The effective silence is `max(alert's silence, 30s)`, computed by `TriggerCondition::effective_silence_micros`. A realtime alert can no longer fire once per matching request, even with its silence set to 0.
4. **Bug fix in `get_stream_alerts`:** an early `return` (instead of `continue`) when one stream's alerts all filtered out silently dropped alerts for the remaining streams of the request — this hit the multi-stream metrics/traces callers.
5. **Traces and metrics ingestion spawn `evaluate_trigger`** like the logs path already did, instead of awaiting notification + db work inline on the ingest request path.

## Notes for review

- The event-body watcher fallback means mixed-version clusters degrade to today's behavior (one SELECT per event) rather than breaking.
- Enterprise verified: `cargo check --all-targets` passes with the enterprise feature (via `Cargo.toml.openobserve` swap); no enterprise-side changes needed.
- `cargo fmt`, the CI clippy command, and unit tests for the touched crates pass.
- Known remaining gap, out of scope here: silence takes effect on a node only after the coordinator event round-trips into the `REALTIME_ALERT_TRIGGERS` cache, so requests landing in that (now shorter) window can still fire duplicates. A synchronous local cache write in `evaluate_trigger` would close it and composes cleanly with this PR.