### PR TITLE
fix(traces): preserve inferred service identity in catalog

### DIFF
--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
@@ -613,6 +613,57 @@ describe("ServiceGraphNodeSidePanel", () => {
       expect(sql).toContain("service_name as caller_service");
       expect(sql).not.toContain("LEFT JOIN");
     });
+
+    it("filters catalog-origin inferred dependencies by type and system", async () => {
+      vi.mocked(searchService.search).mockClear();
+      vi.mocked(searchService.search).mockResolvedValue({ data: { hits: [] } } as any);
+      wrapper = mountPanel({
+        streamFilter: "default",
+        selectedNode: {
+          ...baseNode,
+          id: '["sso","sso","database","mysql"]',
+          name: "sso",
+          service_type: "database",
+          service_system: "mysql",
+        },
+      });
+      await flushPromises();
+
+      const sql = vi.mocked(searchService.search).mock.calls[0][0].query.query.sql;
+      expect(sql).toContain("infer_service_name = 'sso'");
+      expect(sql).toContain("infer_service_type = 'database'");
+      expect(sql).toContain("infer_service_system = 'mysql'");
+    });
+
+    it("does not add a catalog system to graph-origin navigation", async () => {
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, name: "postgres", service_type: "database" },
+      });
+
+      await wrapper.vm.viewRelatedTraces();
+
+      const payload = wrapper.emitted("view-traces")?.[0]?.[0] as Record<string, any>;
+      expect(payload).not.toHaveProperty("serviceSystem");
+    });
+
+    it("adds the catalog system to catalog-origin navigation", async () => {
+      wrapper = mountPanel({
+        selectedNode: {
+          ...baseNode,
+          name: "sso",
+          service_type: "database",
+          service_system: "mysql",
+        },
+      });
+
+      await wrapper.vm.viewRelatedTraces();
+
+      expect(wrapper.emitted("view-traces")?.[0]?.[0]).toMatchObject({
+        serviceName: "sso",
+        serviceType: "database",
+        serviceSystem: "mysql",
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -1062,13 +1062,31 @@ export default defineComponent({
     // is a plain `FROM "{stream}"` with no join.
     const serviceNameField = computed(() => identityField());
 
+    const hasCatalogServiceIdentity = computed(
+      () =>
+        Boolean(props.selectedNode?.service_type) &&
+        Object.prototype.hasOwnProperty.call(props.selectedNode ?? {}, "service_system"),
+    );
+
+    const serviceFilter = (alias = ""): string => {
+      const serviceName = buildServiceName();
+      let filter = `${identityField(alias)} = '${serviceName}'`;
+      if (!hasCatalogServiceIdentity.value) return filter;
+
+      filter += ` AND ${alias}infer_service_type = '${escapeSingleQuotes(props.selectedNode.service_type)}'`;
+      const serviceSystem = props.selectedNode.service_system;
+      if (serviceSystem) {
+        return `${filter} AND ${alias}infer_service_system = '${escapeSingleQuotes(serviceSystem)}'`;
+      }
+      return `${filter} AND (${alias}infer_service_system IS NULL OR ${alias}infer_service_system = '')`;
+    };
+
     const loadDashboard = () => {
       if (!props.selectedNode || props.streamFilter === "all") {
         dashboardData.value = {};
         return;
       }
 
-      const serviceName = buildServiceName();
       const streamName = props.streamFilter;
 
       selectedTimeObj.value = {
@@ -1084,15 +1102,15 @@ export default defineComponent({
       };
 
       const convertedDashboard = convertDashboardSchemaVersion(deepCopy(metrics));
-      const serviceFilter = `${serviceNameField.value} = '${serviceName}'`;
+      const catalogServiceFilter = serviceFilter();
 
       convertedDashboard.tabs[0].panels.forEach((panel: any, index: number) => {
         let whereClause: string;
 
         if (panel.title === "Errors") {
-          whereClause = `WHERE span_status = 'ERROR' AND ${serviceFilter}`;
+          whereClause = `WHERE span_status = 'ERROR' AND ${catalogServiceFilter}`;
         } else {
-          whereClause = `WHERE ${serviceFilter}`;
+          whereClause = `WHERE ${catalogServiceFilter}`;
         }
 
         panel.layout.h = 10;
@@ -1341,7 +1359,6 @@ export default defineComponent({
 
     // Fetch the most recent span for this service to extract rich semantic dimensions
     const fetchLatestSpan = async (): Promise<Record<string, any> | null> => {
-      const serviceName = buildServiceName();
       const streamName = props.streamFilter || "default";
       const org = store.state.selectedOrganization.identifier;
 
@@ -1350,7 +1367,7 @@ export default defineComponent({
           org_identifier: org,
           query: {
             query: {
-              sql: `SELECT * FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' ORDER BY _timestamp DESC`,
+              sql: `SELECT * FROM "${streamName}" WHERE ${serviceFilter()} ORDER BY _timestamp DESC`,
               start_time: props.timeRange.startTime,
               end_time: props.timeRange.endTime,
               from: 0,
@@ -1965,7 +1982,6 @@ export default defineComponent({
       recentOperations.value = [];
 
       try {
-        const serviceName = buildServiceName();
         const streamName = props.streamFilter || "default";
         const st = props.selectedNode?.service_type;
         // A tool/model node's caller is its OWNING AGENT, which usually sits on an
@@ -1981,16 +1997,13 @@ export default defineComponent({
         let sql: string;
         if (isGenAiChild) {
           const { callerExpr, joins } = genAiCallerClimb(streamName);
-          // The identity field, built already aliased to the child table `c`
-          // (no post-processing of the expression string).
-          const childField = identityField("c.");
-          sql = `SELECT ${callerExpr} as caller_service, c.operation_name, ${metrics} FROM "${streamName}" AS c ${joins} WHERE ${childField} = '${serviceName}' GROUP BY ${callerExpr}, c.operation_name`;
+          sql = `SELECT ${callerExpr} as caller_service, c.operation_name, ${metrics} FROM "${streamName}" AS c ${joins} WHERE ${serviceFilter("c.")} GROUP BY ${callerExpr}, c.operation_name`;
         } else {
           const selectCols = isInf
             ? "service_name as caller_service, operation_name"
             : "operation_name";
           const groupCols = isInf ? "service_name, operation_name" : "operation_name";
-          sql = `SELECT ${selectCols}, ${metrics} FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' GROUP BY ${groupCols}`;
+          sql = `SELECT ${selectCols}, ${metrics} FROM "${streamName}" WHERE ${serviceFilter()} GROUP BY ${groupCols}`;
         }
 
         const response = await searchService.search({
@@ -2035,7 +2048,6 @@ export default defineComponent({
       recentSpanData.value = { errorSpans: [], slowSpans: [] };
 
       try {
-        const serviceName = buildServiceName();
         const streamName = props.streamFilter || "default";
         const org = store.state.selectedOrganization.identifier;
         const timeParams = {
@@ -2049,7 +2061,7 @@ export default defineComponent({
             org_identifier: org,
             query: {
               query: {
-                sql: `SELECT operation_name, duration, start_time FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' AND span_status = 'ERROR' ORDER BY start_time DESC`,
+                sql: `SELECT operation_name, duration, start_time FROM "${streamName}" WHERE ${serviceFilter()} AND span_status = 'ERROR' ORDER BY start_time DESC`,
                 ...timeParams,
                 size: 5,
               },
@@ -2060,7 +2072,7 @@ export default defineComponent({
             org_identifier: org,
             query: {
               query: {
-                sql: `SELECT operation_name, duration FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' ORDER BY duration DESC`,
+                sql: `SELECT operation_name, duration FROM "${streamName}" WHERE ${serviceFilter()} ORDER BY duration DESC`,
                 ...timeParams,
                 size: 20,
               },
@@ -2129,7 +2141,6 @@ export default defineComponent({
       resourceTabData.value = { ...resourceTabData.value, [config.id]: [] };
 
       try {
-        const serviceName = buildServiceName();
         const streamName = props.streamFilter || "default";
         const groupField = config.groupField;
         const alias = config.colId + "_name";
@@ -2140,7 +2151,7 @@ export default defineComponent({
           ? `(${buildNullCheck(config.fields)})`
           : `${groupField} IS NOT NULL`;
 
-        const sql = `SELECT ${groupField} as ${alias}, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' AND ${nullClause} GROUP BY ${alias} ORDER BY request_count DESC`;
+        const sql = `SELECT ${groupField} as ${alias}, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE ${serviceFilter()} AND ${nullClause} GROUP BY ${alias} ORDER BY request_count DESC`;
 
         const response = await searchService.search({
           org_identifier: store.state.selectedOrganization.identifier,
@@ -2344,6 +2355,9 @@ export default defineComponent({
         serviceName:
           props.selectedNode?.name || props.selectedNode?.label || props.selectedNode?.id,
         serviceType: props.selectedNode?.service_type,
+        ...(hasCatalogServiceIdentity.value
+          ? { serviceSystem: props.selectedNode?.service_system }
+          : {}),
         operationName: params.operationName,
         callerService: params.callerService,
         nodeName: params.nodeName,

--- a/web/src/plugins/traces/ServicesCatalog.spec.ts
+++ b/web/src/plugins/traces/ServicesCatalog.spec.ts
@@ -1812,6 +1812,73 @@ describe("ServicesCatalog", () => {
         );
         expect(decodedSql).toContain('FROM "production-stream"');
       });
+
+      it("keeps inferred dependencies with the same name but different identities separate", async () => {
+        mockStreamSchema.mockResolvedValueOnce({
+          data: { schema: [{ name: "infer_service_name" }] },
+        });
+        mockFetchQueryDataWithHttpStream.mockImplementation((_req: any, callbacks: any) => {
+          callbacks.data(null, {
+            type: "search_response_hits",
+            content: {
+              results: {
+                hits: [
+                  {
+                    service_name: "sso",
+                    _infer_service_name: "sso",
+                    _infer_service_type: "database",
+                    _infer_service_system: "mysql",
+                    total_requests: 1,
+                  },
+                  {
+                    service_name: "sso",
+                    _infer_service_name: "sso",
+                    _infer_service_type: "external",
+                    _infer_service_system: "http",
+                    total_requests: 1,
+                  },
+                ],
+              },
+            },
+          });
+          callbacks.complete(null, {});
+        });
+
+        wrapper = mountServicesCatalog();
+        await flushPromises();
+
+        expect(wrapper.vm.services).toHaveLength(2);
+        expect(wrapper.vm.services.map((row: any) => row.id)).toEqual([
+          '["sso","sso","database","mysql"]',
+          '["sso","sso","external","http"]',
+        ]);
+        expect(wrapper.vm.services.map((row: any) => row.infer_service_type)).toEqual([
+          "database",
+          "external",
+        ]);
+
+        wrapper.vm.handleRowClick(wrapper.vm.services[0]);
+        expect(wrapper.vm.selectedServiceNode).toMatchObject({
+          name: "sso",
+          service_type: "database",
+          service_system: "mysql",
+        });
+        wrapper.vm.handleRowClick(wrapper.vm.services[1]);
+        expect(wrapper.vm.selectedServiceNode).toMatchObject({
+          name: "sso",
+          service_type: "external",
+          service_system: "http",
+        });
+
+        const request = mockFetchQueryDataWithHttpStream.mock.calls[0][0];
+        const decodedSql = atob(
+          request.queryReq.query.sql.replace(/-/g, "+").replace(/_/g, "/").replace(/\./g, "="),
+        );
+        const groupBy = decodedSql.split("GROUP BY")[1].split("ORDER BY")[0];
+        expect(groupBy).toContain("NULLIF(infer_service_name, '')");
+        expect(groupBy).toContain("NULLIF(infer_service_system, '')");
+        expect(groupBy).toContain("NULLIF(infer_service_type, '')");
+      });
     });
   });
 

--- a/web/src/plugins/traces/ServicesCatalog.vue
+++ b/web/src/plugins/traces/ServicesCatalog.vue
@@ -294,7 +294,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :data="sortedServices"
             :columns="tableColumns"
             :column-visibility="columnVisibility"
-            row-key="service_name"
+            row-key="id"
             :loading="isLoading"
             :frame="false"
             :default-columns="false"
@@ -482,6 +482,7 @@ const streamFilter = ref(tracesStream || storedStreamFilter || "default");
 const availableStreams = ref<string[]>([]);
 
 interface ServiceRow {
+  id: string;
   service_name: string;
   status: "healthy" | "degraded" | "warning" | "critical";
   total_requests: number;
@@ -521,6 +522,20 @@ const TYPE_FILTER_ORDER: TypeFilter[] = ["all", ...CATEGORY_ORDER];
  */
 function categoryOf(row: ServiceRow): EntityCategory {
   return classifyEntity(Boolean(row.is_real_service), row.infer_service_type) as EntityCategory;
+}
+
+function serviceRowId(row: {
+  service_name: string;
+  infer_service_name?: string;
+  infer_service_system?: string;
+  infer_service_type?: string;
+}): string {
+  return JSON.stringify([
+    row.service_name,
+    row.infer_service_name ?? null,
+    row.infer_service_type ?? null,
+    row.infer_service_system ?? null,
+  ]);
 }
 
 const isLoading = ref(false);
@@ -577,9 +592,10 @@ const showSidePanel = ref(false);
 const selectedServiceNode = computed(() =>
   selectedServiceRow.value
     ? {
-        id: selectedServiceRow.value.service_name,
+        id: selectedServiceRow.value.id,
         name: selectedServiceRow.value.service_name,
         service_type: selectedServiceRow.value.infer_service_type,
+        service_system: selectedServiceRow.value.infer_service_system,
       }
     : null,
 );
@@ -886,7 +902,7 @@ function formatLat(us: number): string {
 }
 
 function handleRowClick(row: ServiceRow) {
-  if (selectedServiceRow.value?.service_name === row.service_name) {
+  if (selectedServiceRow.value?.id === row.id) {
     showSidePanel.value = false;
     selectedServiceRow.value = null;
   } else {
@@ -964,9 +980,9 @@ async function loadServicesCatalog() {
   const sql = useInfer
     ? `SELECT
   COALESCE(NULLIF(infer_service_name, ''), service_name) AS service_name,
-  MAX(infer_service_name) AS _infer_service_name,
-  MAX(infer_service_system) AS _infer_service_system,
-  MAX(infer_service_type) AS _infer_service_type,
+  NULLIF(infer_service_name, '') AS _infer_service_name,
+  CASE WHEN NULLIF(infer_service_name, '') IS NULL THEN NULL ELSE NULLIF(infer_service_system, '') END AS _infer_service_system,
+  CASE WHEN NULLIF(infer_service_name, '') IS NULL THEN NULL ELSE NULLIF(infer_service_type, '') END AS _infer_service_type,
   MAX(CASE WHEN service_name IS NOT NULL AND (infer_service_name IS NULL OR infer_service_name = '') THEN 1 ELSE 0 END) AS _is_real_service,
   COUNT(*) AS total_requests,
   SUM(CASE WHEN span_status = 'ERROR' THEN 1 ELSE 0 END) AS error_count,
@@ -977,7 +993,11 @@ async function loadServicesCatalog() {
   approx_percentile_cont(duration, 0.95) AS p95_latency_ns,
   approx_percentile_cont(duration, 0.99) AS p99_latency_ns
 FROM "${streamName}"
-GROUP BY COALESCE(NULLIF(infer_service_name, ''), service_name)
+GROUP BY
+  COALESCE(NULLIF(infer_service_name, ''), service_name),
+  NULLIF(infer_service_name, ''),
+  CASE WHEN NULLIF(infer_service_name, '') IS NULL THEN NULL ELSE NULLIF(infer_service_system, '') END,
+  CASE WHEN NULLIF(infer_service_name, '') IS NULL THEN NULL ELSE NULLIF(infer_service_type, '') END
 ORDER BY total_requests DESC`
     : `SELECT
   service_name,
@@ -1020,10 +1040,20 @@ ORDER BY total_requests DESC`;
           response.type === "search_response_metadata"
         ) {
           const hits: any[] = response.content?.results?.hits ?? [];
-          const serviceMap = new Map(services.value.map((s) => [s.service_name, s]));
+          const serviceMap = new Map(services.value.map((s) => [s.id, s]));
           for (const hit of hits) {
             const name = hit.service_name ?? "";
-            serviceMap.set(name, {
+            const inferredName = hit._infer_service_name ?? undefined;
+            const inferredSystem = hit._infer_service_system ?? undefined;
+            const inferredType = hit._infer_service_type ?? undefined;
+            const id = serviceRowId({
+              service_name: name,
+              infer_service_name: inferredName,
+              infer_service_system: inferredSystem,
+              infer_service_type: inferredType,
+            });
+            serviceMap.set(id, {
+              id,
               service_name: name,
               total_requests: hit.total_requests ?? 0,
               error_count: hit.error_count ?? 0,
@@ -1035,9 +1065,9 @@ ORDER BY total_requests DESC`;
               p99_latency_ns: hit.p99_latency_ns ?? 0,
               status: deriveStatus(hit.error_rate ?? 0),
               is_real_service: hit._is_real_service ?? 0,
-              infer_service_name: hit._infer_service_name ?? undefined,
-              infer_service_system: hit._infer_service_system ?? undefined,
-              infer_service_type: hit._infer_service_type ?? undefined,
+              infer_service_name: inferredName,
+              infer_service_system: inferredSystem,
+              infer_service_type: inferredType,
             });
           }
           // RPC entities are kept as their own category (matching the Service

--- a/web/src/plugins/traces/components/TraceServiceCell.spec.ts
+++ b/web/src/plugins/traces/components/TraceServiceCell.spec.ts
@@ -134,6 +134,44 @@ describe("TraceServiceCell", () => {
       );
     });
 
+    it("should prefer inferred service system when available", () => {
+      wrapper = mount(TraceServiceCell, {
+        props: {
+          item: makeItem({
+            service_name: "sso",
+            infer_service_system: "mysql",
+            infer_service_type: "database",
+          }),
+        },
+        global: { plugins: [store] },
+      });
+
+      expect(vi.mocked(getServiceIconDataUrl)).toHaveBeenCalledWith(
+        "mysql",
+        expect.any(Boolean),
+        "#9e9e9e",
+      );
+    });
+
+    it("should use inferred service type when system is unavailable", () => {
+      wrapper = mount(TraceServiceCell, {
+        props: {
+          item: makeItem({
+            service_name: "sso",
+            infer_service_type: "database",
+          }),
+        },
+        global: { plugins: [store] },
+      });
+
+      expect(vi.mocked(getServiceIconDataUrl)).toHaveBeenCalledWith(
+        "sso",
+        expect.any(Boolean),
+        "#9e9e9e",
+        "database",
+      );
+    });
+
     it("should use fallback color #9e9e9e for unknown service", () => {
       wrapper = mount(TraceServiceCell, {
         props: { item: makeItem({ service_name: "unknown-svc" }) },

--- a/web/src/plugins/traces/components/TraceServiceCell.vue
+++ b/web/src/plugins/traces/components/TraceServiceCell.vue
@@ -55,7 +55,20 @@ const { getOrSetServiceColor } = useTraces();
 
 const rootColor = computed(() => getOrSetServiceColor(props.item.service_name) ?? "#9e9e9e");
 
-const serviceIconUrl = computed(() =>
-  getServiceIconDataUrl(props.item.service_name, isDark.value, rootColor.value),
-);
+const serviceIconUrl = computed(() => {
+  if (props.item.infer_service_system) {
+    return getServiceIconDataUrl(props.item.infer_service_system, isDark.value, rootColor.value);
+  }
+
+  if (props.item.infer_service_type) {
+    return getServiceIconDataUrl(
+      props.item.service_name,
+      isDark.value,
+      rootColor.value,
+      props.item.infer_service_type,
+    );
+  }
+
+  return getServiceIconDataUrl(props.item.service_name, isDark.value, rootColor.value);
+});
 </script>

--- a/web/src/plugins/traces/viewTracesHandoff.spec.ts
+++ b/web/src/plugins/traces/viewTracesHandoff.spec.ts
@@ -32,6 +32,30 @@ describe("buildViewTracesFilter", () => {
     );
   });
 
+  it("uses the complete inferred identity when a catalog system is provided", () => {
+    expect(
+      buildViewTracesFilter({
+        serviceName: "sso",
+        serviceType: "database",
+        serviceSystem: "mysql",
+      }),
+    ).toBe(
+      "infer_service_name = 'sso' AND infer_service_type = 'database' AND infer_service_system = 'mysql'",
+    );
+  });
+
+  it("matches normalized empty systems for catalog dependencies", () => {
+    expect(
+      buildViewTracesFilter({
+        serviceName: "sso",
+        serviceType: "external",
+        serviceSystem: null,
+      }),
+    ).toBe(
+      "infer_service_name = 'sso' AND infer_service_type = 'external' AND (infer_service_system IS NULL OR infer_service_system = '')",
+    );
+  });
+
   it("escapes single quotes in the service name", () => {
     // escapeSingleQuotes uses SQL-style escaping: ' → ''
     expect(buildViewTracesFilter({ serviceName: "it's" })).toBe("service_name = 'it''s'");

--- a/web/src/plugins/traces/viewTracesHandoff.ts
+++ b/web/src/plugins/traces/viewTracesHandoff.ts
@@ -23,6 +23,7 @@ import { escapeSingleQuotes } from "@/utils/zincutils";
 export interface ViewTracesPayload {
   serviceName?: string;
   serviceType?: string;
+  serviceSystem?: string | null;
   operationName?: string;
   nodeName?: string;
   podName?: string;
@@ -52,6 +53,15 @@ export function buildViewTracesFilter(data: ViewTracesPayload): string {
   const escapedServiceName = escapeSingleQuotes(data.serviceName);
   const serviceField = data.serviceType ? "infer_service_name" : "service_name";
   let filterQuery = `${serviceField} = '${escapedServiceName}'`;
+
+  if (data.serviceType && Object.prototype.hasOwnProperty.call(data, "serviceSystem")) {
+    filterQuery += ` AND infer_service_type = '${escapeSingleQuotes(data.serviceType)}'`;
+    if (data.serviceSystem) {
+      filterQuery += ` AND infer_service_system = '${escapeSingleQuotes(data.serviceSystem)}'`;
+    } else {
+      filterQuery += " AND (infer_service_system IS NULL OR infer_service_system = '')";
+    }
+  }
 
   if (data.operationName) {
     filterQuery += ` AND operation_name = '${escapeSingleQuotes(data.operationName)}'`;


### PR DESCRIPTION
## Summary

- preserve inferred service identity using service name, type, and system
- keep Catalog rows distinct when inferred services share a display name
- apply the same identity to side panel queries and trace navigation
- retain existing name-only behavior for service graph nodes

Closes #13908

## Runtime evidence

Tested against a fresh OpenObserve v0.92.2 backend with the frontend built from this branch.

Before the fix, two inferred `sso` spans were merged into one Catalog row:

```json
{"service_name":"sso","_infer_service_system":"mysql","_infer_service_type":"external","total_requests":2}
```

After the fix, the live UI search response returned two rows:

```json
{"service_name":"sso","_infer_service_system":"http","_infer_service_type":"external","total_requests":1}
{"service_name":"sso","_infer_service_system":"mysql","_infer_service_type":"database","total_requests":1}
```

The rendered Catalog showed two `sso` rows, one datastore and one external service. Opening the external row produced an exact filter:

```sql
WHERE infer_service_name = 'sso'
  AND infer_service_type = 'external'
  AND infer_service_system = 'http'
```

A repeated MySQL ingestion changed only the database row from 1 to 2 requests. The external row remained at 1 and the Catalog still returned 2 rows.

## Validation

- practical browser and API verification against a running backend
- production frontend build passed
- format, lint, design token, and type checks passed
- changed trace suites passed: 182 tests, 3 skipped
- full coverage run: 42,554 passed, 405 skipped, 1 unrelated alert list test timed out
- isolated rerun of the timed out alert list test passed in 1.19 seconds
