### PR TITLE
fix(metrics): bound indexed merge output memory

### DIFF
--- a/src/compaction/src/merge/file.rs
+++ b/src/compaction/src/merge/file.rs
@@ -38,9 +38,9 @@ use metrics_index::MetricsFileLayout;
 use schema::generate_schema_for_defined_schema_fields;
 use search::datafusion::{
     exec::TableBuilder,
-    merge::{self, MergeMode, MergeOutput, MergeParquetResult, MergedFile},
+    merge::{self, MergeMode, MergeOutput, MergeResult},
 };
-use tantivy_utils::index_builder::create_tantivy_index;
+use tantivy_utils::index_builder::{TantivyIndexOptions, create_tantivy_index};
 use tokio::sync::Semaphore;
 
 // merge small files into big file, upload to storage, returns the big file key and merged files
@@ -281,7 +281,13 @@ pub async fn merge_files(
         log::debug!("skip index generation for stream: {org_id}/{stream_type}/{stream_name}");
     }
 
-    let MergeParquetResult {
+    let storage_tier = if cfg.s3.feature_force_infrequent_access && storage_type.is_compliance() {
+        storage::StorageTier::InfrequentAccess
+    } else {
+        storage::StorageTier::Default
+    };
+
+    let MergeResult {
         files: merged_files,
         file_format,
     } = buf;
@@ -292,13 +298,11 @@ pub async fn merge_files(
         ));
     }
     let mut new_files = Vec::with_capacity(merged_files.len());
-    for MergedFile {
-        buf,
-        meta: mut new_file_meta,
-        layout,
-        metrics_index,
-    } in merged_files
-    {
+    for file in merged_files {
+        let id = ider::generate_file_name();
+        let new_file_key = format!("{prefix}/{}", file.file_name(&id, file_format));
+        let (data, mut new_file_meta, metrics_index_path) = file.into_upload_parts().await?;
+        let buf = Bytes::from(data);
         new_file_meta.compressed_size = buf.len() as i64;
         if new_file_meta.compressed_size == 0 {
             return Err(anyhow::anyhow!(
@@ -306,11 +310,7 @@ pub async fn merge_files(
             ));
         }
 
-        let id = ider::generate_file_name();
-        let new_file_key = format!("{prefix}/{}", layout.file_name(&id, file_format));
-
         // upload file to storage
-        let buf = Bytes::from(buf);
         if cfg.cache_latest_files.enabled
             && cfg.cache_latest_files.cache_parquet
             && cfg.cache_latest_files.download_from_node
@@ -319,29 +319,24 @@ pub async fn merge_files(
             log::debug!("merge_files {new_file_key} file_data::disk::set success");
         }
 
-        // TODO: check how compliance will interact with org storage
         let account = storage::get_account(org_id, &new_file_key).unwrap_or_default();
-        let compliance = cfg.s3.feature_force_infrequent_access && storage_type.is_compliance();
-        if compliance {
-            storage::put_with_compliance(&account, &new_file_key, buf.clone()).await?;
-        } else {
-            storage::put(&account, &new_file_key, buf.clone()).await?;
-        }
+        storage::put_with_tier(&account, &new_file_key, buf.clone(), storage_tier).await?;
 
         // Indexed metrics files own a `.midx` metrics index; it is not tracked in
         // file_list and is deleted together with the data file
-        if let Some(metrics_index) = metrics_index {
+        if let Some(metrics_index_path) = metrics_index_path {
             let metrics_index_key = MetricsFileLayout::metrics_index_path(&new_file_key)
                 .ok_or_else(|| {
                     anyhow::anyhow!("metrics index for a non-indexed metrics file: {new_file_key}")
                 })?;
-            let metrics_index = Bytes::from(metrics_index);
-            if compliance {
-                storage::put_with_compliance(&account, &metrics_index_key, metrics_index.clone())
-                    .await?;
-            } else {
-                storage::put(&account, &metrics_index_key, metrics_index.clone()).await?;
-            }
+            let metrics_index = Bytes::from(tokio::fs::read(&metrics_index_path).await?);
+            storage::put_with_tier(
+                &account,
+                &metrics_index_key,
+                metrics_index.clone(),
+                storage_tier,
+            )
+            .await?;
             log::debug!(
                 "[COMPACTOR:WORKER:{thread_id}] wrote metrics index {metrics_index_key}, size: {}",
                 metrics_index.len()
@@ -358,6 +353,7 @@ pub async fn merge_files(
                 &mut new_file_meta,
                 latest_schema.clone(),
                 buf,
+                storage_tier,
             )
             .await?;
         }
@@ -389,11 +385,15 @@ async fn generate_inverted_index(
     new_file_meta: &mut FileMeta,
     latest_schema: Arc<Schema>,
     buf: Bytes,
+    storage_tier: storage::StorageTier,
 ) -> Result<(), anyhow::Error> {
     let index_size = create_tantivy_index(
-        "COMPACTOR",
-        org_id,
-        new_file_key,
+        TantivyIndexOptions {
+            caller: "COMPACTOR",
+            org_id,
+            data_file_name: new_file_key,
+            storage_tier,
+        },
         fts_fields,
         index_fields,
         latest_schema, // Use stream schema to include all configured fields

--- a/src/compaction/src/merge/metrics.rs
+++ b/src/compaction/src/merge/metrics.rs
@@ -47,7 +47,7 @@ pub(super) fn metrics_index_merge_scope(
 ) -> MetricsIndexMergeScope {
     let indexed_files = files
         .iter()
-        .filter(|f| MetricsFileLayout::of(&f.key) == MetricsFileLayout::Indexed)
+        .filter(|f| MetricsFileLayout::of(&f.key) == Some(MetricsFileLayout::Indexed))
         .count();
     let total_original_size: i64 = files.iter().map(|f| f.meta.original_size.max(0)).sum();
     let ideal_file_count = (total_original_size as usize).div_ceil(max_file_size.max(1));

--- a/src/compaction/src/merge/stream.rs
+++ b/src/compaction/src/merge/stream.rs
@@ -179,7 +179,7 @@ pub async fn merge_by_stream(
                     MetricsIndexMergeScope::Skip => return Ok(vec![]),
                     MetricsIndexMergeScope::LateFilesOnly => {
                         files_with_size.retain(|f| {
-                            MetricsFileLayout::of(&f.key) != MetricsFileLayout::Indexed
+                            MetricsFileLayout::of(&f.key) != Some(MetricsFileLayout::Indexed)
                         });
                         log::debug!(
                             "[COMPACTOR] merge_by_stream [{org_id}/{stream_type}/{stream_name}] metrics_indexed late merge of {} files, indexed files untouched",

--- a/src/infra/src/storage/mod.rs
+++ b/src/infra/src/storage/mod.rs
@@ -47,6 +47,15 @@ pub const CONCURRENT_REQUESTS: usize = 1000;
 
 static MULTI_ACCOUNTS: Lazy<Box<dyn ObjectStoreExt>> = Lazy::new(accounts::default);
 
+/// Storage tier applied consistently to every object that belongs to one
+/// logical data file, including its metrics and Tantivy indexes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum StorageTier {
+    #[default]
+    Default,
+    InfrequentAccess,
+}
+
 // Create a wrapper trait that extends ObjectStore
 #[async_trait]
 pub trait ObjectStoreExt: std::fmt::Display + Send + Sync + Debug + 'static {
@@ -202,6 +211,18 @@ pub async fn put(account: &str, file: &str, data: bytes::Bytes) -> Result<()> {
     Ok(())
 }
 
+pub async fn put_with_tier(
+    account: &str,
+    file: &str,
+    data: bytes::Bytes,
+    tier: StorageTier,
+) -> Result<()> {
+    match tier {
+        StorageTier::Default => put(account, file, data).await,
+        StorageTier::InfrequentAccess => put_infrequent_access(account, file, data).await,
+    }
+}
+
 async fn put_multipart(account: &str, file: &str, data: bytes::Bytes) -> Result<()> {
     let path = Path::from(file);
     let upload = MULTI_ACCOUNTS.put_multipart(account, &path).await?;
@@ -211,7 +232,7 @@ async fn put_multipart(account: &str, file: &str, data: bytes::Bytes) -> Result<
     Ok(())
 }
 
-pub async fn put_with_compliance(account: &str, file: &str, data: bytes::Bytes) -> Result<()> {
+async fn put_infrequent_access(account: &str, file: &str, data: bytes::Bytes) -> Result<()> {
     let cfg = get_config();
     let attrs = match cfg.s3.provider.as_str() {
         "aws" | "s3" => Attributes::from_iter([(

--- a/src/jobs/src/job/files/pack.rs
+++ b/src/jobs/src/job/files/pack.rs
@@ -41,10 +41,9 @@ use infra::{
     storage,
 };
 use ingester::{PackSegment, PendingStreamStats};
-use metrics_index::MetricsFileLayout;
 use schema::generate_schema_for_defined_schema_fields;
-use search::datafusion::merge::{self, MergeMode, MergeOutput};
-use tantivy_utils::index_builder::create_tantivy_index;
+use search::datafusion::merge::{self, MergeMode, MergeOutput, MergedFile};
+use tantivy_utils::index_builder::{TantivyIndexOptions, create_tantivy_index};
 use tokio::sync::{Mutex, RwLock};
 
 static PROCESSING_STREAMS: std::sync::LazyLock<RwLock<HashSet<String>>> =
@@ -392,23 +391,24 @@ async fn upload_chunk(
     // Segments are persisted in arrival order. A hash-sorted layout must be
     // produced by the merge, so it never takes the as-is fast path.
     let mode = MergeMode::for_ingester(stream_type, stream_name, &latest_schema);
-    let single_segment_as_is = chunk.len() == 1 && mode.file_layout() == MetricsFileLayout::Legacy;
-    let (buf, mut new_file_meta, file_format, layout) = if single_segment_as_is {
+    let single_segment_as_is = chunk.len() == 1 && mode.metrics_file_layout().is_none();
+    let (merged_file, file_format) = if single_segment_as_is {
         // fast path: upload the parquet bytes as-is, no decode/re-encode
-        let buf = Bytes::from(bufs.pop().unwrap());
+        let data = bufs.pop().unwrap();
         let file_meta = FileMeta {
             min_ts,
             max_ts,
             records: total_records,
             original_size: total_original_size,
-            compressed_size: buf.len() as i64,
+            compressed_size: data.len() as i64,
             ..Default::default()
         };
         (
-            buf,
-            file_meta,
+            MergedFile::Standard {
+                data,
+                meta: file_meta,
+            },
             FileFormat::Parquet,
-            MetricsFileLayout::Legacy,
         )
     } else {
         // merge multiple segments in memory
@@ -452,34 +452,28 @@ async fn upload_chunk(
         )
         .await?;
         // the ingester always merges into exactly one file
-        let (merged, file_format) = merge_result.into_single()?;
-        (
-            Bytes::from(merged.buf),
-            merged.meta,
-            file_format,
-            merged.layout,
-        )
+        merge_result.into_single()?
     };
+
+    let new_file_key = merged_file.mark_file_key(&super::generate_ingester_storage_file_key(
+        org_id,
+        stream_type,
+        stream_name,
+        &format!(
+            "0/{}/{}",
+            chunk[0].meta.partition_key,
+            generate_filename_with_time_range(min_ts, max_ts, 0)
+        ),
+        file_format,
+    ));
+    let (data, mut new_file_meta) = merged_file.into_buffered()?;
+    let buf = Bytes::from(data);
 
     if new_file_meta.compressed_size == 0 {
         return Err(anyhow::anyhow!(
             "upload_chunk error: compressed_size is 0 for stream [{org_id}/{stream_type}/{stream_name}]"
         ));
     }
-
-    // the synthetic wal-like name keeps the segments' partition path
-    let wal_like_name = format!(
-        "0/{}/{}",
-        chunk[0].meta.partition_key,
-        generate_filename_with_time_range(min_ts, max_ts, 0)
-    );
-    let new_file_key = layout.mark_file_key(&super::generate_ingester_storage_file_key(
-        org_id,
-        stream_type,
-        stream_name,
-        &wal_like_name,
-        file_format,
-    ));
 
     log::info!(
         "[INGESTER:PACK:JOB:{thread_id}] uploading {} segments into a new file: {new_file_key}, original_size: {}, compressed_size: {}, took: {} ms",
@@ -524,9 +518,12 @@ async fn upload_chunk(
             .any(|f| index_schema_fields.contains(f));
         if need_index {
             let index_size = create_tantivy_index(
-                "INGESTER:PACK",
-                org_id,
-                &new_file_key,
+                TantivyIndexOptions {
+                    caller: "INGESTER:PACK",
+                    org_id,
+                    data_file_name: &new_file_key,
+                    storage_tier: storage::StorageTier::Default,
+                },
                 &full_text_search_fields,
                 &index_fields,
                 index_schema.clone(),

--- a/src/jobs/src/job/files/parquet.rs
+++ b/src/jobs/src/job/files/parquet.rs
@@ -52,7 +52,7 @@ use search::datafusion::{
     merge::{self, MergeMode, MergeOutput},
     sort_order::FileSortOrder,
 };
-use tantivy_utils::index_builder::create_tantivy_index;
+use tantivy_utils::index_builder::{TantivyIndexOptions, create_tantivy_index};
 use tokio::{
     fs::remove_file,
     sync::{Mutex, RwLock},
@@ -809,21 +809,22 @@ async fn merge_files(
     };
 
     // the ingester always merges into exactly one file
-    let (merged, file_format) = buf.into_single()?;
-    let (buf, mut new_file_meta, layout) = (merged.buf, merged.meta, merged.layout);
+    let (merged_file, file_format) = buf.into_single()?;
 
-    if new_file_meta.compressed_size == 0 {
-        return Err(anyhow::anyhow!(
-            "merge_parquet_files error: compressed_size is 0"
-        ));
-    }
-    let new_file_key = layout.mark_file_key(&super::generate_ingester_storage_file_key(
+    let new_file_key = merged_file.mark_file_key(&super::generate_ingester_storage_file_key(
         &org_id,
         stream_type,
         &stream_name,
         &file_name,
         file_format,
     ));
+    let (data, mut new_file_meta) = merged_file.into_buffered()?;
+
+    if new_file_meta.compressed_size == 0 {
+        return Err(anyhow::anyhow!(
+            "merge_parquet_files error: compressed_size is 0"
+        ));
+    }
     log::info!(
         "[INGESTER:JOB:{thread_id}] merged {} files into a new file: {new_file_key}, original_size: {}, compressed_size: {}, took: {} ms",
         retain_file_list.len(),
@@ -833,7 +834,7 @@ async fn merge_files(
     );
 
     // upload file
-    let buf = Bytes::from(buf);
+    let buf = Bytes::from(data);
     if cfg.cache_latest_files.enabled
         && cfg.cache_latest_files.cache_parquet
         && cfg.cache_latest_files.download_from_node
@@ -879,9 +880,12 @@ async fn merge_files(
     }
 
     let index_size = create_tantivy_index(
-        "INGESTER",
-        &org_id,
-        &new_file_key,
+        TantivyIndexOptions {
+            caller: "INGESTER",
+            org_id: &org_id,
+            data_file_name: &new_file_key,
+            storage_tier: storage::StorageTier::Default,
+        },
         &full_text_search_fields,
         &index_fields,
         latest_schema.clone(), // Use stream schema to include all configured fields

--- a/src/metrics_index/src/layout.rs
+++ b/src/metrics_index/src/layout.rs
@@ -46,17 +46,15 @@ pub fn metrics_index_enabled(stream_type: StreamType) -> bool {
         && cfg.common.file_format.for_stream(stream_type) == FileFormat::Parquet
 }
 
-/// Physical layout of a metrics data file, encoded in its file-name prefix so
-/// readers and later merges know the row order without opening the file.
+/// Metrics-specific physical layout encoded in a file-name prefix so readers
+/// and later merges know the row order without opening the file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetricsFileLayout {
-    /// Classic `_timestamp DESC` file (`{id}.parquet` / `{id}.vortex`).
-    Legacy,
-    /// Parquet ordered by `(__hash__ ASC, _timestamp ASC)` but not finalized:
+    /// File ordered by `(__hash__ ASC, _timestamp ASC)` but not finalized:
     /// written by the ingester and by incremental compactor merges of the
     /// still-open hour (`hash-sorted-v1-{id}.parquet`).
     HashSorted,
-    /// Size-bounded Parquet ordered by `(__hash__ ASC, _timestamp ASC)` with a
+    /// Size-bounded file ordered by `(__hash__ ASC, _timestamp ASC)` with a
     /// `.midx` metrics index (see [`MetricsFileLayout::metrics_index_path`]);
     /// written by the compactor's hour-end merge
     /// (`indexed-v1-{id}.parquet`).
@@ -70,42 +68,33 @@ impl MetricsFileLayout {
     const METRICS_INDEX_EXT: &'static str = ".midx";
 
     /// Layout of the file at `path` (a full object key or a bare file name).
-    pub fn of(path: &str) -> Self {
+    pub fn of(path: &str) -> Option<Self> {
         let file_name = path.rsplit('/').next().unwrap_or(path);
         for (prefix, layout) in [
             (Self::HASH_SORTED_PREFIX, Self::HashSorted),
             (Self::INDEXED_PREFIX, Self::Indexed),
         ] {
             if let Some(id) = file_name.strip_prefix(prefix)
-                && let Some(id) = id.strip_suffix(".parquet")
+                && let Some(file_format) = FileFormat::from_extension(id)
+                && let Some(id) = id.strip_suffix(file_format.extension())
                 && !id.is_empty()
             {
-                return layout;
+                return Some(layout);
             }
         }
-        Self::Legacy
+        None
     }
 
     fn prefix(self) -> &'static str {
         match self {
-            Self::Legacy => "",
             Self::HashSorted => Self::HASH_SORTED_PREFIX,
             Self::Indexed => Self::INDEXED_PREFIX,
         }
     }
 
-    /// True when the rows are ordered by `(__hash__, _timestamp)`.
-    pub fn is_hash_ordered(self) -> bool {
-        !matches!(self, Self::Legacy)
-    }
-
-    /// File name for a new file of this layout. Marked layouts are always
-    /// Parquet; `Legacy` keeps the extension of `file_format`.
+    /// File name for a new file of this layout.
     pub fn file_name(self, id: &str, file_format: FileFormat) -> String {
-        match self {
-            Self::Legacy => format!("{id}{}", file_format.extension()),
-            _ => format!("{}{id}.parquet", self.prefix()),
-        }
+        format!("{}{id}{}", self.prefix(), file_format.extension())
     }
 
     /// Add this layout's marker to the file name of an existing key
@@ -124,7 +113,7 @@ impl MetricsFileLayout {
     /// `files/{org}/metrics/{stream}/{date}/{hour}/indexed-v1-{id}.parquet`
     /// -> `files/{org}/midx/{stream}/{date}/{hour}/indexed-v1-{id}.midx`.
     pub fn metrics_index_path(path: &str) -> Option<String> {
-        if Self::of(path) != Self::Indexed {
+        if Self::of(path) != Some(Self::Indexed) {
             return None;
         }
         let mut parts: Vec<&str> = path.split('/').collect();
@@ -134,7 +123,8 @@ impl MetricsFileLayout {
         }
         parts[2] = Self::METRICS_INDEX_DIR;
         let file_name_pos = parts.len() - 1;
-        let file_name = parts[file_name_pos].strip_suffix(".parquet")?;
+        let file_format = FileFormat::from_extension(parts[file_name_pos])?;
+        let file_name = parts[file_name_pos].strip_suffix(file_format.extension())?;
         let file_name = format!("{file_name}{}", Self::METRICS_INDEX_EXT);
         parts[file_name_pos] = &file_name;
         Some(parts.join("/"))
@@ -151,43 +141,39 @@ mod metrics_file_layout_tests {
     fn recognizes_layouts_from_file_names() {
         assert_eq!(
             MetricsFileLayout::of("files/default/metrics/cpu/2026/08/18/10/7099.parquet"),
-            MetricsFileLayout::Legacy
+            None
         );
-        assert_eq!(
-            MetricsFileLayout::of("7099.vortex"),
-            MetricsFileLayout::Legacy
-        );
+        assert_eq!(MetricsFileLayout::of("7099.vortex"), None);
         assert_eq!(
             MetricsFileLayout::of(
                 "files/default/metrics/cpu/2026/08/18/10/hash-sorted-v1-7099.parquet"
             ),
-            MetricsFileLayout::HashSorted
+            Some(MetricsFileLayout::HashSorted)
         );
         assert_eq!(
             MetricsFileLayout::of(
                 "files/default/metrics/test/2026/08/13/10/indexed-v1-456.parquet"
             ),
-            MetricsFileLayout::Indexed
+            Some(MetricsFileLayout::Indexed)
         );
-        // wrong format, empty id, other versions, marker in a directory name
+        assert_eq!(
+            MetricsFileLayout::of("hash-sorted-v1-7099.vortex"),
+            Some(MetricsFileLayout::HashSorted)
+        );
+        assert_eq!(
+            MetricsFileLayout::of("indexed-v1-456.vortex"),
+            Some(MetricsFileLayout::Indexed)
+        );
+        // empty id, other versions, marker in a directory name
         for name in [
-            "indexed-v1-x.vortex",
-            "hash-sorted-v1-1.vortex",
             "indexed-v1-.parquet",
             "hash-sorted-v1-.parquet",
             "metrics-indexed-v2-x.parquet",
             "metrics-range-v1-b04-p000a-x.parquet",
             "files/hash-sorted-v1-dir/1.parquet",
         ] {
-            assert_eq!(
-                MetricsFileLayout::of(name),
-                MetricsFileLayout::Legacy,
-                "{name}"
-            );
+            assert_eq!(MetricsFileLayout::of(name), None, "{name}");
         }
-        assert!(MetricsFileLayout::HashSorted.is_hash_ordered());
-        assert!(MetricsFileLayout::Indexed.is_hash_ordered());
-        assert!(!MetricsFileLayout::Legacy.is_hash_ordered());
     }
 
     #[test]
@@ -201,8 +187,8 @@ mod metrics_file_layout_tests {
             "hash-sorted-v1-456.parquet"
         );
         assert_eq!(
-            MetricsFileLayout::Legacy.file_name("456", FileFormat::Vortex),
-            "456.vortex"
+            MetricsFileLayout::Indexed.file_name("456", FileFormat::Vortex),
+            "indexed-v1-456.vortex"
         );
         let key = "files/default/metrics/cpu/2026/08/18/10/7099.parquet";
         let marked = MetricsFileLayout::HashSorted.mark_file_key(key);
@@ -212,9 +198,8 @@ mod metrics_file_layout_tests {
         );
         assert_eq!(
             MetricsFileLayout::of(&marked),
-            MetricsFileLayout::HashSorted
+            Some(MetricsFileLayout::HashSorted)
         );
-        assert_eq!(MetricsFileLayout::Legacy.mark_file_key(key), key);
         assert_eq!(
             MetricsFileLayout::HashSorted.mark_file_key("1.parquet"),
             "hash-sorted-v1-1.parquet"
@@ -226,6 +211,12 @@ mod metrics_file_layout_tests {
         assert_eq!(
             MetricsFileLayout::metrics_index_path(
                 "files/default/metrics/cpu/2026/08/19/07/indexed-v1-456.parquet"
+            ),
+            Some("files/default/midx/cpu/2026/08/19/07/indexed-v1-456.midx".to_string())
+        );
+        assert_eq!(
+            MetricsFileLayout::metrics_index_path(
+                "files/default/metrics/cpu/2026/08/19/07/indexed-v1-456.vortex"
             ),
             Some("files/default/midx/cpu/2026/08/19/07/indexed-v1-456.midx".to_string())
         );

--- a/src/metrics_index/src/pruner.rs
+++ b/src/metrics_index/src/pruner.rs
@@ -72,7 +72,7 @@ pub async fn search(
     let mut index_files = BTreeMap::new();
     for file in files.iter() {
         // only indexed metrics files own a sidecar; other layouts stay as they are
-        if MetricsFileLayout::of(&file.key) != MetricsFileLayout::Indexed {
+        if MetricsFileLayout::of(&file.key) != Some(MetricsFileLayout::Indexed) {
             continue;
         }
         let Some(sidecar_path) = MetricsFileLayout::metrics_index_path(&file.key) else {

--- a/src/search/Cargo.toml
+++ b/src/search/Cargo.toml
@@ -55,6 +55,7 @@ serde_json.workspace = true
 sqlparser.workspace = true
 tantivy.workspace = true
 tantivy_utils.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
@@ -66,6 +67,3 @@ utoipa.workspace = true
 vortex = { workspace = true }
 vortex-btrblocks = { workspace = true }
 vortex-datafusion = { workspace = true }
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/src/search/src/datafusion/merge/downsampling.rs
+++ b/src/search/src/datafusion/merge/downsampling.rs
@@ -28,7 +28,6 @@ use datafusion::{
     arrow::datatypes::Schema,
     error::{DataFusionError, Result},
 };
-use metrics_index::MetricsFileLayout;
 use vortex::{
     VortexSessionDefault,
     array::ArrayRef,
@@ -73,12 +72,7 @@ pub(super) async fn write_files(
     Ok(bufs
         .into_iter()
         .zip(file_metas)
-        .map(|(buf, meta)| MergedFile {
-            buf,
-            meta,
-            layout: MetricsFileLayout::Legacy,
-            metrics_index: None,
-        })
+        .map(|(buf, meta)| MergedFile::Standard { data: buf, meta })
         .collect())
 }
 

--- a/src/search/src/datafusion/merge/merged_file.rs
+++ b/src/search/src/datafusion/merge/merged_file.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use config::{FileFormat, meta::stream::FileMeta};
+use datafusion::error::{DataFusionError, Result};
+use metrics_index::MetricsFileLayout;
+
+pub struct MergeResult {
+    pub files: Vec<MergedFile>,
+    pub file_format: FileFormat,
+}
+
+impl MergeResult {
+    /// The output for callers that always merge into exactly one file.
+    pub fn into_single(self) -> Result<(MergedFile, FileFormat)> {
+        let Self {
+            mut files,
+            file_format,
+        } = self;
+        if files.len() != 1 {
+            return Err(DataFusionError::Execution(format!(
+                "merge_parquet_files produced {} files, expected exactly one",
+                files.len()
+            )));
+        }
+        Ok((files.pop().unwrap(), file_format))
+    }
+}
+
+/// One file written by [`super::merge_parquet_files`].
+pub enum MergedFile {
+    /// Ordinary output, including logs, traces and downsampled metrics.
+    Standard { data: Vec<u8>, meta: FileMeta },
+    /// Metrics output ordered by `(__hash__, _timestamp)` and retained in memory.
+    MetricsHashSorted { data: Vec<u8>, meta: FileMeta },
+    /// Finalized indexed metrics output spooled to local disk.
+    MetricsIndexed {
+        data_path: tempfile::TempPath,
+        metrics_index_path: tempfile::TempPath,
+        meta: FileMeta,
+    },
+}
+
+impl MergedFile {
+    fn metrics_layout(&self) -> Option<MetricsFileLayout> {
+        match self {
+            Self::Standard { .. } => None,
+            Self::MetricsHashSorted { .. } => Some(MetricsFileLayout::HashSorted),
+            Self::MetricsIndexed { .. } => Some(MetricsFileLayout::Indexed),
+        }
+    }
+
+    /// Name this output without exposing a metrics layout to ordinary files.
+    pub fn file_name(&self, id: &str, file_format: FileFormat) -> String {
+        match self.metrics_layout() {
+            Some(layout) => layout.file_name(id, file_format),
+            None => format!("{id}{}", file_format.extension()),
+        }
+    }
+
+    /// Mark an existing object key when this is a metrics-specific layout.
+    pub fn mark_file_key(&self, key: &str) -> String {
+        match self.metrics_layout() {
+            Some(layout) => layout.mark_file_key(key),
+            None => key.to_string(),
+        }
+    }
+
+    /// Consume the single buffered output used by ingester movers.
+    pub fn into_buffered(self) -> Result<(Vec<u8>, FileMeta)> {
+        match self {
+            Self::Standard { data, meta } | Self::MetricsHashSorted { data, meta } => {
+                Ok((data, meta))
+            }
+            Self::MetricsIndexed { .. } => Err(DataFusionError::Execution(
+                "ingester cannot consume indexed metrics output".to_string(),
+            )),
+        }
+    }
+
+    /// Materialize an output immediately before the compactor uploads it.
+    pub async fn into_upload_parts(
+        self,
+    ) -> Result<(Vec<u8>, FileMeta, Option<tempfile::TempPath>)> {
+        match self {
+            Self::Standard { data, meta } | Self::MetricsHashSorted { data, meta } => {
+                Ok((data, meta, None))
+            }
+            Self::MetricsIndexed {
+                data_path,
+                metrics_index_path,
+                meta,
+            } => Ok((
+                tokio::fs::read(&data_path).await?,
+                meta,
+                Some(metrics_index_path),
+            )),
+        }
+    }
+}

--- a/src/search/src/datafusion/merge/metrics.rs
+++ b/src/search/src/datafusion/merge/metrics.rs
@@ -24,8 +24,9 @@ use datafusion::{
     arrow::datatypes::Schema,
     error::{DataFusionError, Result},
 };
-use metrics_index::{MetricsFileLayout, MetricsIndexWriter};
+use metrics_index::MetricsIndexWriter;
 use parquet::arrow::AsyncArrowWriter;
+use tokio::io::AsyncWriteExt;
 
 use super::{MergedFile, append_metadata};
 
@@ -89,7 +90,8 @@ pub(super) async fn write_files(
 /// One output file in progress: the Parquet writer, its `.midx` metrics-index
 /// writer and the running file meta.
 struct ActiveIndexedMetricsWriter {
-    writer: AsyncArrowWriter<Vec<u8>>,
+    writer: AsyncArrowWriter<tokio::fs::File>,
+    data_path: tempfile::TempPath,
     metrics_index: MetricsIndexWriter,
     file_meta: FileMeta,
     timestamp_index: usize,
@@ -102,16 +104,11 @@ impl ActiveIndexedMetricsWriter {
         metadata: &FileMeta,
         timestamp_index: usize,
     ) -> Result<Self> {
-        let writer = new_parquet_writer(
-            Vec::new(),
-            schema,
-            bloom_filter_fields,
-            metadata,
-            false,
-            None,
-        );
+        let (file, data_path) = new_temp_file()?;
+        let writer = new_parquet_writer(file, schema, bloom_filter_fields, metadata, false, None);
         Ok(Self {
             writer,
+            data_path,
             metrics_index: MetricsIndexWriter::try_new(schema)?,
             file_meta: FileMeta::default(),
             timestamp_index,
@@ -149,6 +146,7 @@ impl ActiveIndexedMetricsWriter {
     async fn finish(self, source_meta: &FileMeta, max_file_size: i64) -> Result<MergedFile> {
         let Self {
             mut writer,
+            data_path,
             metrics_index,
             mut file_meta,
             ..
@@ -159,16 +157,28 @@ impl ActiveIndexedMetricsWriter {
             proportional_original_size(source_meta, file_meta.records).min(max_file_size - 1);
         append_metadata(&mut writer, &file_meta)?;
         writer.finish().await?;
+        drop(writer.into_inner());
 
-        let buf = writer.into_inner();
-        file_meta.compressed_size = buf.len() as i64;
-        Ok(MergedFile {
-            buf,
+        file_meta.compressed_size =
+            i64::try_from(tokio::fs::metadata(&data_path).await?.len()).unwrap_or(i64::MAX);
+        Ok(MergedFile::MetricsIndexed {
+            data_path,
+            metrics_index_path: write_temp_file(metrics_index.finish()?).await?,
             meta: file_meta,
-            layout: MetricsFileLayout::Indexed,
-            metrics_index: Some(metrics_index.finish()?),
         })
     }
+}
+
+fn new_temp_file() -> Result<(tokio::fs::File, tempfile::TempPath)> {
+    let (file, path) = tempfile::NamedTempFile::new()?.into_parts();
+    Ok((tokio::fs::File::from_std(file), path))
+}
+
+async fn write_temp_file(buf: Vec<u8>) -> Result<tempfile::TempPath> {
+    let (mut file, path) = new_temp_file()?;
+    file.write_all(&buf).await?;
+    file.shutdown().await?;
+    Ok(path)
 }
 
 /// The share of the source `original_size` that `records` rows carry.
@@ -254,31 +264,68 @@ mod tests {
         .unwrap();
 
         assert_eq!(files.len(), 3);
-        assert_eq!(files.iter().map(|f| f.meta.records).sum::<i64>(), 6);
         assert_eq!(
             files
                 .iter()
-                .map(|f| f.meta.original_size)
+                .map(|file| match file {
+                    MergedFile::MetricsIndexed { meta, .. } => meta.records,
+                    _ => unreachable!(),
+                })
+                .sum::<i64>(),
+            6
+        );
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| match file {
+                    MergedFile::MetricsIndexed { meta, .. } => meta.original_size,
+                    _ => unreachable!(),
+                })
                 .collect::<Vec<_>>(),
             vec![150, 150, 100]
         );
-        assert!(files.iter().all(|f| {
-            f.layout == MetricsFileLayout::Indexed
-                && f.metrics_index.is_some()
-                && f.meta.original_size < max_file_size as i64
-                && f.meta.compressed_size == f.buf.len() as i64
+        assert!(files.iter().all(|file| {
+            let MergedFile::MetricsIndexed {
+                data_path,
+                metrics_index_path,
+                meta,
+            } = file
+            else {
+                return false;
+            };
+            data_path.is_file()
+                && metrics_index_path.is_file()
+                && meta.original_size < max_file_size as i64
+                && meta.compressed_size == std::fs::metadata(data_path).unwrap().len() as i64
         }));
 
         let mut file_hashes = Vec::new();
         for file in files {
-            let bytes = bytes::Bytes::from(file.buf);
+            let MergedFile::MetricsIndexed {
+                data_path,
+                metrics_index_path,
+                meta,
+            } = file
+            else {
+                unreachable!()
+            };
+            let persisted_data_path = data_path.to_path_buf();
+            let persisted_metrics_index_path = metrics_index_path.to_path_buf();
+            let bytes = bytes::Bytes::from(tokio::fs::read(&data_path).await.unwrap());
+            drop(data_path);
+            assert!(!persisted_data_path.exists());
             let footer = config::utils::parquet::read_metadata_from_bytes(&bytes)
                 .await
                 .unwrap();
-            assert_eq!(footer.min_ts, file.meta.min_ts);
-            assert_eq!(footer.max_ts, file.meta.max_ts);
-            assert_eq!(footer.records, file.meta.records);
-            assert_eq!(footer.original_size, file.meta.original_size);
+            assert_eq!(footer.min_ts, meta.min_ts);
+            assert_eq!(footer.max_ts, meta.max_ts);
+            assert_eq!(footer.records, meta.records);
+            assert_eq!(footer.original_size, meta.original_size);
+
+            let metrics_index = tokio::fs::read(&metrics_index_path).await.unwrap();
+            drop(metrics_index_path);
+            assert!(!metrics_index.is_empty());
+            assert!(!persisted_metrics_index_path.exists());
 
             let reader = ParquetRecordBatchReaderBuilder::try_new(bytes)
                 .unwrap()

--- a/src/search/src/datafusion/merge/metrics.rs
+++ b/src/search/src/datafusion/merge/metrics.rs
@@ -159,8 +159,7 @@ impl ActiveIndexedMetricsWriter {
         writer.finish().await?;
         drop(writer.into_inner());
 
-        file_meta.compressed_size =
-            i64::try_from(tokio::fs::metadata(&data_path).await?.len()).unwrap_or(i64::MAX);
+        // compressed_size is set by the compactor when it uploads the file
         Ok(MergedFile::MetricsIndexed {
             data_path,
             metrics_index_path: write_temp_file(metrics_index.finish()?).await?,
@@ -170,7 +169,11 @@ impl ActiveIndexedMetricsWriter {
 }
 
 fn new_temp_file() -> Result<(tokio::fs::File, tempfile::TempPath)> {
-    let (file, path) = tempfile::NamedTempFile::new()?.into_parts();
+    // spool under data_tmp_dir, not the OS temp dir (often a RAM-backed
+    // tmpfs); it is wiped at startup, reclaiming files a crash orphaned
+    let tmp_dir = &config::get_config().common.data_tmp_dir;
+    std::fs::create_dir_all(tmp_dir)?;
+    let (file, path) = tempfile::NamedTempFile::new_in(tmp_dir)?.into_parts();
     Ok((tokio::fs::File::from_std(file), path))
 }
 
@@ -296,7 +299,6 @@ mod tests {
             data_path.is_file()
                 && metrics_index_path.is_file()
                 && meta.original_size < max_file_size as i64
-                && meta.compressed_size == std::fs::metadata(data_path).unwrap().len() as i64
         }));
 
         let mut file_hashes = Vec::new();

--- a/src/search/src/datafusion/merge/mod.rs
+++ b/src/search/src/datafusion/merge/mod.rs
@@ -28,7 +28,6 @@ use datafusion::{
     physical_plan::execute_stream,
 };
 use futures::TryStreamExt;
-use metrics_index::MetricsFileLayout;
 use parquet::{
     arrow::{AsyncArrowWriter, async_writer::AsyncFileWriter},
     file::metadata::KeyValue,
@@ -52,43 +51,12 @@ use crate::datafusion::{
 
 #[cfg(feature = "enterprise")]
 pub mod downsampling;
+mod merged_file;
 mod metrics;
 pub mod mode;
 
+pub use merged_file::{MergeResult, MergedFile};
 pub use mode::{MergeMode, MergeOutput};
-
-/// One file written by [`merge_parquet_files`].
-pub struct MergedFile {
-    pub buf: Vec<u8>,
-    pub meta: FileMeta,
-    /// Physical layout the file was written in; decides its file name.
-    pub layout: MetricsFileLayout,
-    /// `.midx` metrics index of a [`MetricsFileLayout::Indexed`] file.
-    pub metrics_index: Option<Vec<u8>>,
-}
-
-pub struct MergeParquetResult {
-    pub files: Vec<MergedFile>,
-    pub file_format: FileFormat,
-}
-
-impl MergeParquetResult {
-    /// The merged file, for callers that always merge into exactly one file
-    /// (the ingester movers).
-    pub fn into_single(self) -> Result<(MergedFile, FileFormat)> {
-        let Self {
-            mut files,
-            file_format,
-        } = self;
-        if files.len() != 1 {
-            return Err(DataFusionError::Execution(format!(
-                "merge_parquet_files produced {} files, expected exactly one",
-                files.len()
-            )));
-        }
-        Ok((files.pop().unwrap(), file_format))
-    }
-}
 
 /// Merge `tables` (the union of the input files) into one or more files
 /// according to `mode`, written as `output` says.
@@ -99,7 +67,7 @@ pub async fn merge_parquet_files(
     mut metadata: FileMeta,
     mode: &MergeMode,
     output: MergeOutput,
-) -> Result<MergeParquetResult> {
+) -> Result<MergeResult> {
     let start = std::time::Instant::now();
     let sql = mode.sql(&schema);
     log::debug!("merge_parquet_files [{mode}] sql: {sql}");
@@ -146,11 +114,15 @@ pub async fn merge_parquet_files(
                 FileFormat::Vortex => write_vortex(schema, &metadata, rx, read_task).await?,
             };
             metadata.compressed_size = buf.len() as i64;
-            vec![MergedFile {
-                buf,
-                meta: metadata,
-                layout: mode.file_layout(),
-                metrics_index: None,
+            vec![match mode {
+                MergeMode::MetricsHashSorted => MergedFile::MetricsHashSorted {
+                    data: buf,
+                    meta: metadata,
+                },
+                _ => MergedFile::Standard {
+                    data: buf,
+                    meta: metadata,
+                },
             }]
         }
     };
@@ -160,7 +132,7 @@ pub async fn merge_parquet_files(
         files.len(),
         start.elapsed().as_millis()
     );
-    Ok(MergeParquetResult {
+    Ok(MergeResult {
         files,
         file_format: output.file_format,
     })
@@ -339,13 +311,38 @@ mod tests {
 
     use arrow::array::{Array, Int64Array, StringArray};
     use arrow_schema::{DataType, Field, Schema};
-    use bytes::Bytes;
     use config::{TIMESTAMP_COL_NAME, meta::stream::StreamType};
     use datafusion::datasource::MemTable;
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use vortex::file::OpenOptionsSessionExt;
 
     use super::*;
+
+    #[test]
+    fn merged_file_names_only_mark_metrics_layouts() {
+        let standard = MergedFile::Standard {
+            data: Vec::new(),
+            meta: FileMeta::default(),
+        };
+        assert_eq!(standard.file_name("1", FileFormat::Vortex), "1.vortex");
+        assert_eq!(
+            standard.mark_file_key("files/o/logs/s/1.parquet"),
+            "files/o/logs/s/1.parquet"
+        );
+
+        let metrics = MergedFile::MetricsHashSorted {
+            data: Vec::new(),
+            meta: FileMeta::default(),
+        };
+        assert_eq!(
+            metrics.file_name("1", FileFormat::Parquet),
+            "hash-sorted-v1-1.parquet"
+        );
+        assert_eq!(
+            metrics.mark_file_key("files/o/metrics/s/1.parquet"),
+            "files/o/metrics/s/hash-sorted-v1-1.parquet"
+        );
+    }
 
     fn create_test_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![
@@ -417,7 +414,8 @@ mod tests {
         .await
         .unwrap();
         let (merged, _) = merged.into_single().unwrap();
-        let batches = ParquetRecordBatchReaderBuilder::try_new(Bytes::from(merged.buf))
+        let (data, _) = merged.into_buffered().unwrap();
+        let batches = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(data))
             .unwrap()
             .build()
             .unwrap()

--- a/src/search/src/datafusion/merge/mode.rs
+++ b/src/search/src/datafusion/merge/mode.rs
@@ -150,25 +150,21 @@ impl MergeMode {
     /// sort. Any mix with other layouts declares no order; otherwise the
     /// classic `_timestamp DESC`.
     pub fn input_sort_order(&self, files: &[FileKey]) -> FileSortOrder {
+        let hash_ordered = files
+            .iter()
+            .filter(|f| MetricsFileLayout::of(&f.key).is_some())
+            .count();
         match self {
             Self::MetricsHashSorted | Self::MetricsIndexed => {
-                if files
-                    .iter()
-                    .all(|f| MetricsFileLayout::of(&f.key).is_some())
-                {
+                if hash_ordered == files.len() {
                     FileSortOrder::HashTimestampAsc
                 } else {
                     FileSortOrder::None
                 }
             }
-            #[cfg(feature = "enterprise")]
-            Self::Downsampling(_)
-                if files
-                    .iter()
-                    .any(|f| MetricsFileLayout::of(&f.key).is_some()) =>
-            {
-                FileSortOrder::None
-            }
+            // hash-ordered files under any other mode: declare no order so
+            // the merge re-sorts instead of trusting `_timestamp DESC`
+            _ if hash_ordered > 0 => FileSortOrder::None,
             _ => FileSortOrder::TimestampDesc,
         }
     }
@@ -328,9 +324,17 @@ mod tests {
                 FileSortOrder::None
             );
         }
-        // ordinary modes never interpret metrics layout markers
+        // classic merge over hash-ordered files (layout switched off): no order
         assert_eq!(
-            MergeMode::Classic.input_sort_order(&[legacy, sorted]),
+            MergeMode::Classic.input_sort_order(&[legacy.clone(), sorted.clone()]),
+            FileSortOrder::None
+        );
+        assert_eq!(
+            MergeMode::Classic.input_sort_order(std::slice::from_ref(&sorted)),
+            FileSortOrder::None
+        );
+        assert_eq!(
+            MergeMode::Classic.input_sort_order(std::slice::from_ref(&legacy)),
             FileSortOrder::TimestampDesc
         );
     }

--- a/src/search/src/datafusion/merge/mode.rs
+++ b/src/search/src/datafusion/merge/mode.rs
@@ -42,7 +42,7 @@ use crate::datafusion::sort_order::FileSortOrder;
 #[derive(Debug, Clone)]
 pub enum MergeMode {
     /// `SELECT * FROM tbl ORDER BY _timestamp DESC` into one file: logs,
-    /// traces, plain metrics — the ingester and the compactor default.
+    /// traces and plain metrics — the default merge.
     Classic,
     /// The trace time-index metadata stream: one row per `trace_id`
     /// (`MIN(_timestamp)`, `MIN(min_ts)`, `MAX(max_ts)`, …), one file.
@@ -134,12 +134,12 @@ impl MergeMode {
         }
     }
 
-    /// Layout of the file(s) the merge writes.
-    pub fn file_layout(&self) -> MetricsFileLayout {
+    /// Metrics-specific layout of the file(s) the merge writes.
+    pub fn metrics_file_layout(&self) -> Option<MetricsFileLayout> {
         match self {
-            Self::MetricsHashSorted => MetricsFileLayout::HashSorted,
-            Self::MetricsIndexed => MetricsFileLayout::Indexed,
-            _ => MetricsFileLayout::Legacy,
+            Self::MetricsHashSorted => Some(MetricsFileLayout::HashSorted),
+            Self::MetricsIndexed => Some(MetricsFileLayout::Indexed),
+            _ => None,
         }
     }
 
@@ -150,16 +150,25 @@ impl MergeMode {
     /// sort. Any mix with other layouts declares no order; otherwise the
     /// classic `_timestamp DESC`.
     pub fn input_sort_order(&self, files: &[FileKey]) -> FileSortOrder {
-        let hash_ordered = files
-            .iter()
-            .filter(|f| MetricsFileLayout::of(&f.key).is_hash_ordered())
-            .count();
         match self {
-            Self::MetricsHashSorted | Self::MetricsIndexed if hash_ordered == files.len() => {
-                FileSortOrder::HashTimestampAsc
+            Self::MetricsHashSorted | Self::MetricsIndexed => {
+                if files
+                    .iter()
+                    .all(|f| MetricsFileLayout::of(&f.key).is_some())
+                {
+                    FileSortOrder::HashTimestampAsc
+                } else {
+                    FileSortOrder::None
+                }
             }
-            _ if hash_ordered > 0 => FileSortOrder::None,
-            Self::MetricsHashSorted | Self::MetricsIndexed => FileSortOrder::None,
+            #[cfg(feature = "enterprise")]
+            Self::Downsampling(_)
+                if files
+                    .iter()
+                    .any(|f| MetricsFileLayout::of(&f.key).is_some()) =>
+            {
+                FileSortOrder::None
+            }
             _ => FileSortOrder::TimestampDesc,
         }
     }
@@ -272,6 +281,10 @@ mod tests {
             MergeMode::Classic
         ));
         assert!(matches!(
+            MergeMode::for_ingester(StreamType::Metrics, "cpu", &schema),
+            MergeMode::Classic
+        ));
+        assert!(matches!(
             MergeMode::for_compactor(StreamType::Filelist, "x", &schema, 0, false),
             MergeMode::FileList
         ));
@@ -282,10 +295,10 @@ mod tests {
             MergeMode::Classic.input_sort_order(&[]),
             FileSortOrder::TimestampDesc
         );
-        assert_eq!(MergeMode::Classic.file_layout(), MetricsFileLayout::Legacy);
+        assert_eq!(MergeMode::Classic.metrics_file_layout(), None);
         assert_eq!(
-            MergeMode::MetricsHashSorted.file_layout(),
-            MetricsFileLayout::HashSorted
+            MergeMode::MetricsHashSorted.metrics_file_layout(),
+            Some(MetricsFileLayout::HashSorted)
         );
         assert_eq!(
             MergeMode::MetricsIndexed.output_sort_order(),
@@ -315,13 +328,9 @@ mod tests {
                 FileSortOrder::None
             );
         }
-        // classic merge over hash-ordered files (layout switched off): no order
+        // ordinary modes never interpret metrics layout markers
         assert_eq!(
-            MergeMode::Classic.input_sort_order(&[legacy.clone(), sorted.clone()]),
-            FileSortOrder::None
-        );
-        assert_eq!(
-            MergeMode::Classic.input_sort_order(std::slice::from_ref(&legacy)),
+            MergeMode::Classic.input_sort_order(&[legacy, sorted]),
             FileSortOrder::TimestampDesc
         );
     }

--- a/src/tantivy_utils/src/index_builder/mod.rs
+++ b/src/tantivy_utils/src/index_builder/mod.rs
@@ -29,14 +29,20 @@ use config::{
     get_config, tantivy::tokenizer::O2_TOKENIZER, utils::inverted_index::to_tantivy_name,
 };
 use hashbrown::HashSet;
-use infra::storage;
+use infra::storage::{self, StorageTier};
 
 use crate::puffin_directory::{PROP_ROW_GROUP_SIZE, writer::PuffinDirWriter};
 
+#[derive(Debug, Clone, Copy)]
+pub struct TantivyIndexOptions<'a> {
+    pub caller: &'a str,
+    pub org_id: &'a str,
+    pub data_file_name: &'a str,
+    pub storage_tier: StorageTier,
+}
+
 pub async fn create_tantivy_index(
-    caller: &str,
-    org_id: &str,
-    parquet_file_name: &str,
+    options: TantivyIndexOptions<'_>,
     fts_fields: &[String],
     index_fields: &[String],
     schema: Arc<Schema>,
@@ -44,8 +50,8 @@ pub async fn create_tantivy_index(
 ) -> Result<usize, anyhow::Error> {
     let start = std::time::Instant::now();
     let cfg = get_config();
-    let caller = format!("[{caller}:JOB]");
-    let file_format = FileFormat::from_extension(parquet_file_name).unwrap_or_default();
+    let caller = format!("[{}:JOB]", options.caller);
+    let file_format = FileFormat::from_extension(options.data_file_name).unwrap_or_default();
     let thread_num = cfg.compact.tantivy_builder_thread_num;
 
     let Some(index_schema) = build_tantivy_schema(fts_fields, index_fields, &schema) else {
@@ -69,7 +75,7 @@ pub async fn create_tantivy_index(
     let index_size = puffin_bytes.len();
 
     // write fst bytes into disk
-    let Some(idx_file_name) = to_tantivy_name(parquet_file_name) else {
+    let Some(idx_file_name) = to_tantivy_name(options.data_file_name) else {
         return Ok(0);
     };
 
@@ -82,9 +88,9 @@ pub async fn create_tantivy_index(
         log::info!("file: {idx_file_name} file_data::disk::set success");
     }
 
-    // the index file is stored in the same account as the parquet file
-    let account = storage::get_account(org_id, parquet_file_name).unwrap_or_default();
-    match storage::put(&account, &idx_file_name, buf).await {
+    // the index file is stored in the same account and tier as the data file
+    let account = storage::get_account(options.org_id, options.data_file_name).unwrap_or_default();
+    match storage::put_with_tier(&account, &idx_file_name, buf, options.storage_tier).await {
         Ok(_) => {
             log::info!(
                 "{caller} generated tantivy index file: {idx_file_name}, size {index_size}, took: {} ms",
@@ -389,9 +395,12 @@ pub(super) mod tests {
 
         // Test that create_tantivy_index returns 0 for empty data
         let result = create_tantivy_index(
-            "test_caller",
-            "default",
-            "test_file.parquet",
+            TantivyIndexOptions {
+                caller: "test_caller",
+                org_id: "default",
+                data_file_name: "test_file.parquet",
+                storage_tier: StorageTier::Default,
+            },
             &["content".to_string()],
             &["status".to_string()],
             empty_batch.schema(),
@@ -410,9 +419,12 @@ pub(super) mod tests {
 
         // Test that create_tantivy_index returns 0 when no fields to index
         let result = create_tantivy_index(
-            "test_caller",
-            "default",
-            "test_file.parquet",
+            TantivyIndexOptions {
+                caller: "test_caller",
+                org_id: "default",
+                data_file_name: "test_file.parquet",
+                storage_tier: StorageTier::Default,
+            },
             &[], // No FTS fields
             &[], // No index fields
             batch.schema(),
@@ -431,9 +443,12 @@ pub(super) mod tests {
 
         // Test with an invalid parquet filename that won't convert to tantivy filename
         let result = create_tantivy_index(
-            "test_caller",
-            "default",
-            "invalid_filename", // This won't convert to a valid tantivy filename
+            TantivyIndexOptions {
+                caller: "test_caller",
+                org_id: "default",
+                data_file_name: "invalid_filename", // won't convert to a Tantivy name
+                storage_tier: StorageTier::Default,
+            },
             &["content".to_string()],
             &["status".to_string()],
             batch.schema(),


### PR DESCRIPTION
## Summary

- spool finalized indexed metrics Parquet and midx output to temporary files, materializing one data file only when it is uploaded
- keep MetricsFileLayout limited to metrics-specific HashSorted and Indexed layouts while standard files carry no metrics layout
- apply one StorageTier consistently to compacted Parquet/Vortex data, midx sidecars, and Tantivy indexes
- preserve the ingester upload tier behavior as Default

## Validation

- cargo fmt --check
- git diff HEAD --check
- cargo check -p infra -p tantivy_utils -p compaction -p openobserve-jobs
- cargo test -p tantivy_utils index_builder::tests
- cargo test -p compaction merge::
- cargo test -p openobserve-jobs job::files
- cargo clippy -p infra -p tantivy_utils -p compaction -p openobserve-jobs --all-targets -- -D warnings

Follow-up to #13882.