### PR TITLE
fix(promql): preserve mixed-case WAL metric names

### DIFF
--- a/src/promql_service/src/search/grpc/wal.rs
+++ b/src/promql_service/src/search/grpc/wal.rs
@@ -22,6 +22,7 @@ use config::{
 };
 use datafusion::{
     arrow::datatypes::Schema,
+    common::TableReference,
     datasource::MemTable,
     error::{DataFusionError, Result},
     physical_plan::visit_execution_plan,
@@ -111,6 +112,26 @@ pub(crate) async fn create_context(
     Ok(resp)
 }
 
+/// Register a placeholder metrics table for a distributed WAL search.
+///
+/// The table name embedded in the physical plan must be a quoted SQL reference;
+/// otherwise DataFusion lowercases mixed-case metric names when the receiving
+/// search node parses the plan.
+fn register_remote_metric_table(
+    ctx: &SessionContext,
+    stream_name: &str,
+    schema: Arc<Schema>,
+) -> Result<TableReference> {
+    let table_ref = TableReference::bare(stream_name);
+    let plan_table_name = table_ref.to_quoted_string();
+    let table = Arc::new(
+        NewEmptyTable::new(&plan_table_name, schema)
+            .with_partitions(ctx.state().config().target_partitions()),
+    );
+    ctx.register_table(table_ref.clone(), table)?;
+    Ok(table_ref)
+}
+
 /// get file list from local cache, no need match_source, each file will be
 /// searched
 #[allow(clippy::too_many_arguments)]
@@ -136,15 +157,11 @@ async fn get_wal_batches(
         .stream_type(StreamType::Metrics)
         .build(cfg.limit.cpu_num)
         .await?;
-    let table = Arc::new(
-        NewEmptyTable::new(stream_name, Arc::clone(&schema))
-            .with_partitions(ctx.state().config().target_partitions()),
-    );
-    ctx.register_table(stream_name, table)?;
+    let table_ref = register_remote_metric_table(&ctx, stream_name, Arc::clone(&schema))?;
 
     // create physical plan
     let (start, end) = time_range;
-    let mut df = match ctx.table(stream_name).await {
+    let mut df = match ctx.table(table_ref).await {
         Ok(df) => df.filter(
             col(TIMESTAMP_COL_NAME)
                 .gt_eq(lit(start))
@@ -226,4 +243,43 @@ async fn get_wal_batches(
         )?);
     }
     Ok((stats, new_batches, schema))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::datatypes::{DataType, Field},
+        common::tree_node::TreeNode,
+    };
+    use search::datafusion::distributed_plan::NewEmptyExecVisitor;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_remote_metric_table_preserves_stream_name_in_physical_plan() -> Result<()> {
+        for stream_name in [
+            "node_cpu_seconds_total",
+            "node_memory_MemTotal_bytes",
+            "namespace:MixedMetric",
+        ] {
+            let ctx = SessionContext::new();
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "value",
+                DataType::Float64,
+                false,
+            )]));
+            let table_ref = register_remote_metric_table(&ctx, stream_name, schema)?;
+            let df = ctx.table(table_ref).await?;
+            let physical_plan = ctx.state().create_physical_plan(df.logical_plan()).await?;
+
+            let mut visitor = NewEmptyExecVisitor::default();
+            physical_plan.visit(&mut visitor)?;
+            assert!(visitor.has_empty_exec());
+
+            let plan_table_name = visitor.plan().name();
+            let decoded_table_ref = TableReference::from(plan_table_name);
+            assert_eq!(decoded_table_ref, TableReference::bare(stream_name));
+        }
+        Ok(())
+    }
 }

--- a/src/search/src/datafusion/distributed_plan/codec/empty_exec.rs
+++ b/src/search/src/datafusion/distributed_plan/codec/empty_exec.rs
@@ -94,7 +94,10 @@ pub fn try_encode(node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()>
 
 #[cfg(test)]
 mod tests {
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::{
+        arrow::datatypes::{DataType, Field, Schema},
+        common::TableReference,
+    };
     use datafusion_proto::bytes::{
         physical_plan_from_bytes_with_extension_codec, physical_plan_to_bytes_with_extension_codec,
     };
@@ -103,9 +106,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_datafusion_codec() -> Result<()> {
+        let stream_name = "node_memory_MemTotal_bytes";
+        let plan_table_name = TableReference::bare(stream_name).to_quoted_string();
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
         let plan: Arc<dyn ExecutionPlan> = Arc::new(NewEmptyExec::new(
-            "test",
+            &plan_table_name,
             Arc::clone(&schema),
             Some(&vec![0]),
             &[],
@@ -133,6 +138,10 @@ mod tests {
         assert_eq!(plan.limit(), plan2.limit());
         assert_eq!(plan.full_schema(), plan2.full_schema());
         assert_eq!(plan.sort_order(), plan2.sort_order());
+        assert_eq!(
+            TableReference::from(plan2.name()),
+            TableReference::bare(stream_name)
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #13926

## Problem

With `ZO_FORMAT_STREAM_NAME_TO_LOWERCASE=false`, ingestion keeps the original metric name, but the PromQL WAL distributed plan sent it as an unquoted SQL table name. DataFusion lowercased it in the Flight receiver before schema lookup, so an exact mixed-case query returned no data.

## Fix

Represent the metric as a case-preserving `TableReference::bare` and serialize its quoted form in the placeholder physical plan. The existing receiver and normal SQL paths remain unchanged. Regression coverage now checks physical-plan creation and distributed codec round-tripping.

## Verification

- `cargo fmt --package promql-service --package search -- --check`
- `cargo test -p promql-service` (18 passed)
- `cargo test -p search datafusion_codec` (8 passed)
- `cargo build`