### PR TITLE
test(mobile): P0 session-replay upload assertion

### DIFF
--- a/tests/mobile-testing/specs/ios-native.masking.spec.js
+++ b/tests/mobile-testing/specs/ios-native.masking.spec.js
@@ -10,5 +10,6 @@ maskingSuite({
   pii: ['alex.morgan@example.com', '4242 4242 4242 4242'],
   flows: ['ios-native/masking.yaml'],
   device: cfg.IOS_SIM_UDID,
-  requireReplay: false, // iOS mobile replay is not always rendered in CI → skip-with-reason, don't false-fail
+  // NOTE: the NATIVE iOS SDK uses OpenObserve's correct /replay endpoint, so this uploads + renders and
+  // runs as a hard P0 (unlike RN iOS — see rn-ios.masking / openobserve#13942).
 });

--- a/tests/mobile-testing/specs/rn-ios.masking.spec.js
+++ b/tests/mobile-testing/specs/rn-ios.masking.spec.js
@@ -1,7 +1,11 @@
 const { maskingSuite } = require('../utils/rumChecks');
 const cfg = require('../utils/config');
 
-// Same RN app as RN-Android, built with Session Replay MASK_ALL — no on-screen PII may appear.
+// KNOWN BUG — openobserve#13942: on iOS the RN Session-Replay bridge posts segments to Datadog's
+// `/api/v2/replay` instead of OpenObserve's `/replay`, so they are rejected (401) and ZERO segments
+// reach `_sessionreplay` — session replay silently records nothing on RN iOS. The P0 upload assertion
+// in maskingSuite therefore fails here; test.fixme documents it and flips green once the SDK is fixed.
+// (RN Android is unaffected — see rn-android.masking. Fix lives in openobserve-react-native-rum.)
 maskingSuite({
   name: 'RN iOS · Session Replay privacy masking',
   tags: ['@mobile', '@rn-ios'],
@@ -9,5 +13,5 @@ maskingSuite({
   pii: ['alex.morgan@example.com', '4242 4242 4242 4242'],
   flows: ['ios-react-native/masking.yaml'],
   device: cfg.IOS_SIM_UDID,
-  requireReplay: false, // iOS mobile replay is not always rendered in CI → skip-with-reason, don't false-fail
+  knownReplayBug: 'openobserve#13942',
 });

--- a/tests/mobile-testing/specs/rn-ios.masking.spec.js
+++ b/tests/mobile-testing/specs/rn-ios.masking.spec.js
@@ -1,12 +1,12 @@
 const { maskingSuite } = require('../utils/rumChecks');
 const cfg = require('../utils/config');
 
-// KNOWN BUG — openobserve#13942: on iOS the RN Session-Replay bridge posts segments to Datadog's
-// `/api/v2/replay` instead of OpenObserve's `/replay`, so they are rejected (401) and ZERO segments
-// reach `_sessionreplay` — session replay silently records nothing on RN iOS. This test still RUNS and
-// is marked EXPECTED-TO-FAIL (test.fail) on the P0 upload assertion — it is NOT skipped: it reports as
-// a known failure and the run goes RED (unexpected pass) the day the SDK is fixed, so this marker gets
-// removed. (RN Android is unaffected — see rn-android.masking. Fix lives in openobserve-react-native-rum.)
+// This test currently FAILS by design, until openobserve#13942 is fixed: on iOS the RN Session-Replay
+// bridge posts segments to Datadog's `/api/v2/replay` instead of OpenObserve's `/replay`, so they are
+// rejected (401) and ZERO segments reach `_sessionreplay` — session replay silently records nothing on
+// RN iOS. The P0 upload assertion in maskingSuite therefore fails (0 segments) and will PASS on its own
+// the moment the SDK is fixed. No skip / no expected-fail marker — a real red until it's fixed.
+// (RN Android is unaffected — see rn-android.masking. The fix lives in openobserve-react-native-rum.)
 maskingSuite({
   name: 'RN iOS · Session Replay privacy masking',
   tags: ['@mobile', '@rn-ios'],
@@ -14,5 +14,4 @@ maskingSuite({
   pii: ['alex.morgan@example.com', '4242 4242 4242 4242'],
   flows: ['ios-react-native/masking.yaml'],
   device: cfg.IOS_SIM_UDID,
-  knownReplayBug: 'openobserve#13942',
 });

--- a/tests/mobile-testing/specs/rn-ios.masking.spec.js
+++ b/tests/mobile-testing/specs/rn-ios.masking.spec.js
@@ -3,9 +3,10 @@ const cfg = require('../utils/config');
 
 // KNOWN BUG — openobserve#13942: on iOS the RN Session-Replay bridge posts segments to Datadog's
 // `/api/v2/replay` instead of OpenObserve's `/replay`, so they are rejected (401) and ZERO segments
-// reach `_sessionreplay` — session replay silently records nothing on RN iOS. The P0 upload assertion
-// in maskingSuite therefore fails here; test.fixme documents it and flips green once the SDK is fixed.
-// (RN Android is unaffected — see rn-android.masking. Fix lives in openobserve-react-native-rum.)
+// reach `_sessionreplay` — session replay silently records nothing on RN iOS. This test still RUNS and
+// is marked EXPECTED-TO-FAIL (test.fail) on the P0 upload assertion — it is NOT skipped: it reports as
+// a known failure and the run goes RED (unexpected pass) the day the SDK is fixed, so this marker gets
+// removed. (RN Android is unaffected — see rn-android.masking. Fix lives in openobserve-react-native-rum.)
 maskingSuite({
   name: 'RN iOS · Session Replay privacy masking',
   tags: ['@mobile', '@rn-ios'],

--- a/tests/mobile-testing/utils/rumChecks.js
+++ b/tests/mobile-testing/utils/rumChecks.js
@@ -142,11 +142,16 @@ function networkSuite({ name, tags, service, urlSubstring, flows, device = '' })
 // regression can't hide. iOS specs pass requireReplay:false because the mobile replay is not always
 // rendered for iOS in CI (observed); there it skips-with-reason instead of a false fail. Scoping the
 // skip this way keeps enforcement on the platforms where the replay does render.
-function maskingSuite({ name, tags, service, pii, flows, device = '', requireReplay = true }) {
+// knownReplayBug: pass a tracking-issue reference for a platform whose Session Replay is known-broken
+// upstream (in the SDK) — the test is then `test.fixme`, documenting the bug and flipping green when the
+// SDK is fixed (same pattern as the o2-enterprise#2289 skips). Do NOT use it to hide an unexplained
+// non-upload: a missing replay with no filed bug must FAIL here (that is the whole point of the P0).
+function maskingSuite({ name, tags, service, pii, flows, device = '', knownReplayBug = null }) {
   test.describe(name, () => {
-    test(
-      'PII is masked in the session replay (MASK_ALL)',
-      { tag: [...tags, '@replay', '@masking', '@P1'] },
+    const runner = knownReplayBug ? test.fixme : test;
+    runner(
+      'session replay uploads segments and PII is masked (MASK_ALL)',
+      { tag: [...tags, '@replay', '@masking', '@P0'] },
       async ({ page }) => {
         const start = Date.now() - 30000;
         for (const f of flows) runFlow(f, { device });
@@ -154,21 +159,30 @@ function maskingSuite({ name, tags, service, pii, flows, device = '', requireRep
         const sessionId = await q.sessionForService(service, start, { tries: 20, delayMs: 5000 });
         expect(sessionId, 'a session was ingested for the masking flow').toBeTruthy();
 
+        // P0 — DATA LAYER: Session Replay segments actually reached OpenObserve's `_sessionreplay`
+        // stream. This is the check that would have caught openobserve#13942 — RN iOS posted replay to
+        // Datadog's `/api/v2/replay` (rejected, 401, no error surfaced) → ZERO segments. A rendered
+        // dashboard is NOT sufficient proof; the segments must land in the stream.
+        const segments = await q.bySql(
+          `SELECT session_id FROM _sessionreplay WHERE session_id='${sessionId}'`,
+          start,
+          { minHits: 1, tries: 20, delayMs: 5000 },
+        );
+        expect(
+          segments.length,
+          'session replay segments uploaded to _sessionreplay (see openobserve#13942)',
+        ).toBeGreaterThan(0);
+
+        // P1 — PRIVACY: no PII in the rendered replay DOM. The upload above is the hard gate; the
+        // dashboard player render is secondary (segments-landed-but-player-didn't-paint is a dashboard
+        // flake, not an SDK bug), so scan for PII only when the player actually renders.
         const dash = new RumDashboardPage(page);
         await dash.ensureServedOrSkip(test);
         await dash.login();
         await dash.openSession(sessionId);
-        // POSITIVE CONTROL: only assert "no PII" if the replay actually rendered — otherwise a
-        // not-rendered player has zero text nodes and the check would pass vacuously.
-        const rendered = await dash.replayRendered();
-        if (requireReplay) {
-          // Android: the replay renders, so a non-render is a real regression → FAIL.
-          expect(rendered, 'session replay must render before masking can be verified').toBe(true);
-        } else {
-          // iOS: the replay is not always rendered in CI → skip-with-reason rather than false-fail.
-          test.skip(!rendered, 'session replay did not render (no playback bar) — cannot verify masking');
+        if (await dash.replayRendered()) {
+          await dash.expectNoPiiInReplay(pii);
         }
-        await dash.expectNoPiiInReplay(pii);
       },
     );
   });

--- a/tests/mobile-testing/utils/rumChecks.js
+++ b/tests/mobile-testing/utils/rumChecks.js
@@ -142,17 +142,23 @@ function networkSuite({ name, tags, service, urlSubstring, flows, device = '' })
 // regression can't hide. iOS specs pass requireReplay:false because the mobile replay is not always
 // rendered for iOS in CI (observed); there it skips-with-reason instead of a false fail. Scoping the
 // skip this way keeps enforcement on the platforms where the replay does render.
-// knownReplayBug: pass a tracking-issue reference for a platform whose Session Replay is known-broken
-// upstream (in the SDK) — the test is then `test.fixme`, documenting the bug and flipping green when the
-// SDK is fixed (same pattern as the o2-enterprise#2289 skips). Do NOT use it to hide an unexplained
-// non-upload: a missing replay with no filed bug must FAIL here (that is the whole point of the P0).
+// knownReplayBug: a tracking-issue reference for a platform whose Session Replay is known-broken
+// UPSTREAM (in the SDK). The test is marked EXPECTED-TO-FAIL (test.fail) — NOT skipped: it still runs
+// the real path and reports as a known failure (never a false green), and the run turns RED the day
+// the SDK is fixed and it starts passing, forcing this marker to be removed. Do NOT use it to hide an
+// unexplained non-upload — a missing replay with no filed bug must fail outright (that is the P0's job).
 function maskingSuite({ name, tags, service, pii, flows, device = '', knownReplayBug = null }) {
   test.describe(name, () => {
-    const runner = knownReplayBug ? test.fixme : test;
-    runner(
+    test(
       'session replay uploads segments and PII is masked (MASK_ALL)',
       { tag: [...tags, '@replay', '@masking', '@P0'] },
       async ({ page }) => {
+        if (knownReplayBug) {
+          test.fail(
+            true,
+            `known upstream bug ${knownReplayBug}: session replay does not upload — remove this marker when the SDK is fixed`,
+          );
+        }
         const start = Date.now() - 30000;
         for (const f of flows) runFlow(f, { device });
 

--- a/tests/mobile-testing/utils/rumChecks.js
+++ b/tests/mobile-testing/utils/rumChecks.js
@@ -142,23 +142,12 @@ function networkSuite({ name, tags, service, urlSubstring, flows, device = '' })
 // regression can't hide. iOS specs pass requireReplay:false because the mobile replay is not always
 // rendered for iOS in CI (observed); there it skips-with-reason instead of a false fail. Scoping the
 // skip this way keeps enforcement on the platforms where the replay does render.
-// knownReplayBug: a tracking-issue reference for a platform whose Session Replay is known-broken
-// UPSTREAM (in the SDK). The test is marked EXPECTED-TO-FAIL (test.fail) — NOT skipped: it still runs
-// the real path and reports as a known failure (never a false green), and the run turns RED the day
-// the SDK is fixed and it starts passing, forcing this marker to be removed. Do NOT use it to hide an
-// unexplained non-upload — a missing replay with no filed bug must fail outright (that is the P0's job).
-function maskingSuite({ name, tags, service, pii, flows, device = '', knownReplayBug = null }) {
+function maskingSuite({ name, tags, service, pii, flows, device = '' }) {
   test.describe(name, () => {
     test(
       'session replay uploads segments and PII is masked (MASK_ALL)',
       { tag: [...tags, '@replay', '@masking', '@P0'] },
       async ({ page }) => {
-        if (knownReplayBug) {
-          test.fail(
-            true,
-            `known upstream bug ${knownReplayBug}: session replay does not upload — remove this marker when the SDK is fixed`,
-          );
-        }
         const start = Date.now() - 30000;
         for (const f of flows) runFlow(f, { device });
 


### PR DESCRIPTION
## What

Adds a **P0 data-layer assertion** to the mobile RUM masking suite: after driving the replay flow, it queries the **`_sessionreplay`** stream and requires that segments actually landed. A rendered dashboard is no longer accepted as proof that Session Replay works.

This is the check that catches **#13942** — on iOS the RN Session-Replay bridge posts segments to Datadog's `/api/v2/replay` instead of OpenObserve's `/replay`, so they're rejected (401, no error surfaced) and **zero** segments reach `_sessionreplay`. RN iOS session replay silently records nothing.

## RC

The masking suite verified Session Replay **only through the dashboard UI** (does the player render + is PII masked). It had no data-layer check that segments actually reached OpenObserve. So a broken upload showed only as "the replay didn't render" — ambiguous (a benign dashboard-render flake *or* a real non-upload) — and that non-render had been scoped to a skip. The bug slipped through the ambiguity.

## The fix

- **P0 (data):** `maskingSuite` asserts `_sessionreplay` received segments for the session (`> 0`). Non-upload → hard fail. Platform-agnostic; catches this whole class of bug.
- **P1 (privacy):** the dashboard render + PII scan stays, run only when the player paints (segments-landed-but-player-didn't = dashboard flake, not an SDK bug).
- Removed the `requireReplay` skip hack. **`ios-native` masking unskipped** → runs as hard P0 (native iOS SDK uses the correct `/replay` endpoint).
- **`rn-ios` masking is a plain test that hard-FAILS until #13942 is fixed** — **no skip, no expected-fail marker.** The P0 assertion sees 0 segments → red; it **passes on its own** the moment the SDK starts uploading. The fix lives in `openobserve-react-native-rum`.

## Expected result per platform

| Platform | Masking (P0 upload + PII) | Why |
|---|:-:|---|
| rn-android | ✅ pass | RN replay works on Android |
| **rn-ios** | ❌ **fail** | **#13942** — 0 replay segments |
| android-native | ✅ pass | native SDK, correct endpoint |
| ios-native | ✅ pass | native SDK, correct endpoint |

So whenever iOS runs (the `mobile-e2e` label / an SDK dispatch), the iOS job is **red until the SDK fix lands** — an intentional, self-healing signal.

## Validation (local, real device/data runs)

- `android-native` + `ios-native` masking **pass** the new P0 (segments present in `_sessionreplay`).
- A non-uploading session returns **0 segments → P0 correctly fails** — the exact rn-ios symptom.

Scope: only `tests/mobile-testing/` — 3 files.
