### PR TITLE
fix(api): stop unprintable error messages collapsing responses into a bare 500

### DIFF
--- a/src/common/src/meta/http.rs
+++ b/src/common/src/meta/http.rs
@@ -15,7 +15,7 @@
 
 use axum::{
     Json,
-    http::StatusCode,
+    http::{HeaderValue, StatusCode},
     response::{IntoResponse, Response},
 };
 use infra::errors;
@@ -243,6 +243,18 @@ impl HttpResponse {
             .into_response()
     }
 
+    /// Send an error response in json format that also reports the message through
+    /// [`ERROR_HEADER`] for the audit log.
+    pub fn error_with_header(code: StatusCode, error: impl ToString) -> Response {
+        let error = error.to_string();
+        (
+            code,
+            [(ERROR_HEADER, error_header_value(&error))],
+            Json(Self::error(code, &error)),
+        )
+            .into_response()
+    }
+
     /// Send a response in json format, status code is 200.
     /// The payload should be serde-serializable.
     pub fn json<T: Serialize>(payload: T) -> Response {
@@ -268,6 +280,31 @@ impl IntoResponse for HttpResponse {
         };
         (status, Json(self)).into_response()
     }
+}
+
+/// Build an [`ERROR_HEADER`] value out of an error message.
+///
+/// These messages interpolate user-supplied names (org, stream, field type), so they can hold
+/// anything. Control bytes make `HeaderValue` construction fail, which costs the whole response:
+/// axum replaces it with a bare 500 that hides the real status and message. Non-ascii bytes are
+/// accepted but then `HeaderValue::to_str` refuses to read them back, so the audit log silently
+/// drops the message. Escaping everything outside visible ascii avoids both.
+pub fn error_header_value(message: &str) -> HeaderValue {
+    let needs_escape = |c: char| !matches!(c, ' '..='~' | '\t');
+    let value = if message.contains(needs_escape) {
+        let mut escaped = String::with_capacity(message.len());
+        for c in message.chars() {
+            if needs_escape(c) {
+                escaped.extend(c.escape_default());
+            } else {
+                escaped.push(c);
+            }
+        }
+        HeaderValue::from_str(&escaped)
+    } else {
+        HeaderValue::from_str(message)
+    };
+    value.unwrap_or_else(|_| HeaderValue::from_static("error"))
 }
 
 #[cfg(test)]
@@ -499,6 +536,43 @@ mod tests {
     fn test_http_response_too_many_requests() {
         let response = HttpResponse::too_many_requests("slow down");
         assert_eq!(response.status(), http::StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[test]
+    fn test_error_header_value_passes_ascii_through_unchanged() {
+        let message = "stream 'my-stream' is reserved\tand cannot be created";
+        assert_eq!(error_header_value(message).to_str().unwrap(), message);
+    }
+
+    #[test]
+    fn test_error_header_value_escapes_unreadable_chars() {
+        // Control bytes make `HeaderValue::from_str` fail outright; non-ascii ones make
+        // `to_str` fail, which is what the audit middleware reads the header with.
+        for (message, expected) in [
+            (
+                "invalid data type: v^\u{11}0K",
+                "invalid data type: v^\\u{11}0K",
+            ),
+            ("org Q\u{b4}\u{ed}\u{cd}j", "org Q\\u{b4}\\u{ed}\\u{cd}j"),
+            ("a\u{7f}b", "a\\u{7f}b"),
+        ] {
+            assert_eq!(error_header_value(message).to_str().unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn test_error_with_header_keeps_status_for_unprintable_message() {
+        // A control byte in the message used to fail header construction, which made axum
+        // replace the whole response with a bare 500 "failed to parse header value".
+        let response = HttpResponse::error_with_header(
+            StatusCode::BAD_REQUEST,
+            "invalid data type: v^\u{11}0K",
+        );
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.headers().get(ERROR_HEADER).unwrap(),
+            "invalid data type: v^\\u{11}0K"
+        );
     }
 
     #[test]

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -37,7 +37,7 @@ use transform::compile_vrl_function;
 use crate::{
     common::meta::{
         authz::Authz,
-        http::{ERROR_HEADER, HttpResponse as MetaHttpResponse},
+        http::{ERROR_HEADER, HttpResponse as MetaHttpResponse, error_header_value},
     },
     http::map_error_to_http_response,
 };
@@ -376,7 +376,7 @@ pub async fn update_function(
             {
                 return Ok((
                     http::StatusCode::INTERNAL_SERVER_ERROR,
-                    [(ERROR_HEADER, e.to_string())],
+                    [(ERROR_HEADER, error_header_value(&e.to_string()))],
                     Json(MetaHttpResponse::message(
                         http::StatusCode::INTERNAL_SERVER_ERROR,
                         format!(

--- a/src/core/src/organization.rs
+++ b/src/core/src/organization.rs
@@ -750,6 +750,25 @@ pub async fn create_org(
     }
 }
 
+/// Auto-provisioned orgs take their identifier verbatim from a URL path or an IdP claim, unlike
+/// [`create_org`] which validates the name and assigns a generated identifier. The identifier then
+/// flows into object store keys, headers and log lines, so restrict it to the same character set
+/// the rest of the system can carry safely.
+fn validate_auto_created_org_id(org_id: &str) -> Result<(), anyhow::Error> {
+    if org_id.is_empty() {
+        return Err(anyhow::anyhow!("Organization identifier cannot be empty"));
+    }
+    if !org_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(anyhow::anyhow!(
+            "Organization identifier can only contain alphanumeric characters (A-Z, a-z, 0-9), hyphens, and underscores"
+        ));
+    }
+    Ok(())
+}
+
 /// Checks if the org exists, otherwise creates the org. Does not associate any user
 /// with the org, only saves the org in the meta and creates org tuples.
 pub async fn check_and_create_org(org_id: &str) -> Result<Organization, anyhow::Error> {
@@ -757,6 +776,7 @@ pub async fn check_and_create_org(org_id: &str) -> Result<Organization, anyhow::
     if let Some(org) = get_org(org_id).await {
         return Ok(org);
     }
+    validate_auto_created_org_id(org_id)?;
 
     let org = &Organization {
         identifier: org_id.to_owned(),
@@ -814,6 +834,7 @@ pub async fn check_and_create_org_without_ofga(
     if let Some(org) = get_org(org_id).await {
         return Ok(org);
     }
+    validate_auto_created_org_id(org_id)?;
 
     let org = &Organization {
         identifier: org_id.to_owned(),
@@ -1476,5 +1497,27 @@ mod tests {
     fn test_should_mask_token_no_org() {
         // Without an org context, masking is never applied
         assert!(!should_mask_token(None, "user@example.com"));
+    }
+
+    #[test]
+    fn test_validate_auto_created_org_id_accepts_identifiers() {
+        for org_id in ["default", "_meta", "acme-corp", "team_1", "Org2"] {
+            assert!(
+                validate_auto_created_org_id(org_id).is_ok(),
+                "expected {org_id} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_auto_created_org_id_rejects_unsafe_identifiers() {
+        // Non-ascii, control bytes, path separators and spaces all reach object store keys,
+        // headers and log lines verbatim when an org is auto-provisioned.
+        for org_id in ["", "Q\u{b4}\u{ed}\u{cd}j", "a\u{11}b", "a/b", "a b", "a.b"] {
+            assert!(
+                validate_auto_created_org_id(org_id).is_err(),
+                "expected {org_id:?} to be rejected"
+            );
+        }
     }
 }

--- a/src/core/src/stream.rs
+++ b/src/core/src/stream.rs
@@ -21,7 +21,7 @@ use axum::{
     Json, http,
     response::{IntoResponse, Response},
 };
-use common::meta::http::{ERROR_HEADER, HttpResponse as MetaHttpResponse};
+use common::meta::http::{ERROR_HEADER, HttpResponse as MetaHttpResponse, error_header_value};
 use config::meta::stream::{StreamParams, StreamType};
 
 #[tracing::instrument(skip(cleanup_enrichment_table_resources))]
@@ -75,7 +75,10 @@ async fn cleanup_related_resources(
         if let Err(e) = crate::pipeline::db::delete(&pipeline.id).await {
             return Err((
                 http::StatusCode::INTERNAL_SERVER_ERROR,
-                [(ERROR_HEADER, format!("failed to delete stream: {e}"))],
+                [(
+                    ERROR_HEADER,
+                    error_header_value(&format!("failed to delete stream: {e}")),
+                )],
                 Json(MetaHttpResponse::error(
                     http::StatusCode::INTERNAL_SERVER_ERROR,
                     format!(

--- a/src/core/src/traces/mod.rs
+++ b/src/core/src/traces/mod.rs
@@ -67,7 +67,7 @@ use config::utils::schema::format_stream_name;
 use crate::{
     alerts::alert::AlertExt,
     common::meta::{
-        http::{ERROR_HEADER, HttpResponse as MetaHttpResponse},
+        http::{ERROR_HEADER, HttpResponse as MetaHttpResponse, error_header_value},
         stream::SchemaRecords,
         traces::{Event, Span, SpanLink, SpanLinkContext, SpanRefType},
     },
@@ -798,9 +798,9 @@ pub async fn handle_otlp_request(
                         http::StatusCode::INTERNAL_SERVER_ERROR,
                         [(
                             ERROR_HEADER,
-                            format!(
+                            error_header_value(&format!(
                                 "[trace_id: {trace_id}] stream did not receive a valid json object"
-                            ),
+                            )),
                         )],
                         Json(MetaHttpResponse::error(
                             http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -873,18 +873,10 @@ pub async fn handle_otlp_request(
                                     log::error!(
                                         "[TRACES:OTLP] stream did not receive a valid json object"
                                     );
-                                    return Ok((
+                                    return Ok(MetaHttpResponse::error_with_header(
                                         http::StatusCode::INTERNAL_SERVER_ERROR,
-                                        [(
-                                            ERROR_HEADER,
-                                            "stream did not receive a valid json object",
-                                        )],
-                                        Json(MetaHttpResponse::error(
-                                            http::StatusCode::INTERNAL_SERVER_ERROR,
-                                            "stream did not receive a valid json object",
-                                        )),
-                                    )
-                                        .into_response());
+                                        "stream did not receive a valid json object",
+                                    ));
                                 }
                             };
                             normalize_llm_field_types(&mut record_val);
@@ -1036,15 +1028,10 @@ pub async fn handle_otlp_request(
         } else {
             http::StatusCode::INTERNAL_SERVER_ERROR
         };
-        return Ok((
+        return Ok(MetaHttpResponse::error_with_header(
             status_code,
-            [(ERROR_HEADER, format!("error while writing trace data: {e}"))],
-            Json(MetaHttpResponse::error(
-                status_code,
-                format!("error while writing trace data: {e}"),
-            )),
-        )
-            .into_response());
+            format!("error while writing trace data: {e}"),
+        ));
     }
 
     #[cfg(feature = "enterprise")]
@@ -1253,9 +1240,9 @@ pub async fn ingest_json(
                     http::StatusCode::INTERNAL_SERVER_ERROR,
                     [(
                         ERROR_HEADER,
-                        format!(
+                        error_header_value(&format!(
                             "[trace_id: {trace_id}] stream did not receive a valid json object"
-                        ),
+                        )),
                     )],
                     Json(MetaHttpResponse::error(
                         http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -1401,15 +1388,10 @@ pub async fn ingest_json(
         } else {
             http::StatusCode::INTERNAL_SERVER_ERROR
         };
-        return Ok((
+        return Ok(MetaHttpResponse::error_with_header(
             status_code,
-            [(ERROR_HEADER, format!("error while writing trace data: {e}"))],
-            Json(MetaHttpResponse::error(
-                status_code,
-                format!("error while writing trace data: {e}"),
-            )),
-        )
-            .into_response());
+            format!("error while writing trace data: {e}"),
+        ));
     }
 
     #[cfg(feature = "enterprise")]

--- a/src/enrichment_data/src/enrichment_table/mod.rs
+++ b/src/enrichment_data/src/enrichment_table/mod.rs
@@ -16,14 +16,10 @@
 use std::{collections::HashMap, io::Error, sync::Arc};
 
 use arrow_schema::Schema;
-use axum::{
-    extract::Multipart,
-    http::{self, StatusCode},
-    response::Response as HttpResponse,
-};
+use axum::{extract::Multipart, http::StatusCode, response::Response as HttpResponse};
 use bytes::Bytes;
 use chrono::Utc;
-use common::meta::http::{ERROR_HEADER, HttpResponse as MetaHttpResponse};
+use common::meta::http::{ERROR_HEADER, HttpResponse as MetaHttpResponse, error_header_value};
 use config::{
     SIZE_IN_MB, TIMESTAMP_COL_NAME,
     cluster::LOCAL_NODE,
@@ -70,12 +66,10 @@ pub async fn save_enrichment_data(
     let stream_name = format_stream_name(table_name.to_string());
 
     if !LOCAL_NODE.is_ingester() {
-        let mut resp = MetaHttpResponse::internal_error("not an ingester");
-        resp.headers_mut().insert(
-            ERROR_HEADER,
-            http::HeaderValue::from_str("not an ingester").unwrap(),
-        );
-        return Ok(resp);
+        return Ok(MetaHttpResponse::error_with_header(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "not an ingester",
+        ));
     }
 
     // check if we are allowed to ingest
@@ -85,13 +79,10 @@ pub async fn save_enrichment_data(
         &stream_name,
         None,
     ) {
-        let error_msg = format!("enrichment table [{stream_name}] is being deleted");
-        let mut resp = MetaHttpResponse::bad_request(&error_msg);
-        resp.headers_mut().insert(
-            ERROR_HEADER,
-            http::HeaderValue::from_str(&error_msg).unwrap(),
-        );
-        return Ok(resp);
+        return Ok(MetaHttpResponse::error_with_header(
+            StatusCode::BAD_REQUEST,
+            format!("enrichment table [{stream_name}] is being deleted"),
+        ));
     }
 
     // Estimate the size of the payload in json format in bytes
@@ -189,13 +180,10 @@ pub async fn save_enrichment_data(
         .unwrap_or(Schema::empty());
     if !db_schema.fields().is_empty() && db_schema.fields().ne(inferred_schema.fields()) {
         log::error!("Schema mismatch for enrichment table {org_id}/{stream_name}");
-        let error_msg = format!("Schema mismatch for enrichment table {org_id}/{stream_name}");
-        let mut resp = MetaHttpResponse::internal_error(&error_msg);
-        resp.headers_mut().insert(
-            ERROR_HEADER,
-            http::HeaderValue::from_str(&error_msg).unwrap(),
-        );
-        return Ok(resp);
+        return Ok(MetaHttpResponse::error_with_header(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Schema mismatch for enrichment table {org_id}/{stream_name}"),
+        ));
     }
 
     // check for schema evolution
@@ -236,12 +224,11 @@ pub async fn save_enrichment_data(
                 .await
         {
             log::error!("Error writing enrichment table to database: {e}");
-            let error_msg = format!("Error writing enrichment table to database: {e}");
             let mut resp =
                 MetaHttpResponse::internal_error("Error writing enrichment table to database");
             resp.headers_mut().insert(
                 ERROR_HEADER,
-                http::HeaderValue::from_str(&error_msg).unwrap(),
+                error_header_value(&format!("Error writing enrichment table to database: {e}")),
             );
             return Ok(resp);
         }

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -16,14 +16,11 @@
 use std::{future::Future, io::Error};
 
 use arrow_schema::{DataType, Field, Schema};
-use axum::{
-    Json, http,
-    response::{IntoResponse, Response as HttpResponse},
-};
+use axum::{http, response::Response as HttpResponse};
 use chrono::{TimeZone, Timelike, Utc};
 use common::meta::{
     authz::Authz,
-    http::{ERROR_HEADER, HttpResponse as MetaHttpResponse},
+    http::HttpResponse as MetaHttpResponse,
     stream::{FieldUpdate, Stream, StreamCreate},
 };
 // Reserved self-reporting stream guards are a Cloud-only concern (Cloud manages
@@ -248,42 +245,27 @@ pub async fn create_stream(
     // Cloud-only: OSS / self-hosted may legitimately use these stream names.
     #[cfg(feature = "cloud")]
     if is_reserved_internal_stream(stream_name) {
-        return Ok((
+        return Ok(MetaHttpResponse::error_with_header(
             http::StatusCode::BAD_REQUEST,
-            [(ERROR_HEADER, "stream name is reserved")],
-            Json(MetaHttpResponse::error(
-                http::StatusCode::BAD_REQUEST,
-                format!("stream name '{stream_name}' is reserved and cannot be created"),
-            )),
-        )
-            .into_response());
+            format!("stream name '{stream_name}' is reserved and cannot be created"),
+        ));
     }
 
     // check if the stream already exists
     let schema = match infra::schema::get(org_id, stream_name, stream_type).await {
         Ok(schema) => schema,
         Err(e) => {
-            return Ok((
+            return Ok(MetaHttpResponse::error_with_header(
                 http::StatusCode::INTERNAL_SERVER_ERROR,
-                [(ERROR_HEADER, format!("error in getting schema: {e}"))],
-                Json(MetaHttpResponse::error(
-                    http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("error in getting schema: {e}"),
-                )),
-            )
-                .into_response());
+                format!("error in getting schema: {e}"),
+            ));
         }
     };
     if !schema.fields().is_empty() {
-        return Ok((
+        return Ok(MetaHttpResponse::error_with_header(
             http::StatusCode::BAD_REQUEST,
-            [(ERROR_HEADER, "stream already exists")],
-            Json(MetaHttpResponse::error(
-                http::StatusCode::BAD_REQUEST,
-                "stream already exists",
-            )),
-        )
-            .into_response());
+            "stream already exists",
+        ));
     }
 
     // create the stream
@@ -292,15 +274,10 @@ pub async fn create_stream(
     let mut has_timestamp = false;
     for f in schema {
         let Ok(data_type) = f.r#type.parse::<DataType>() else {
-            return Ok((
+            return Ok(MetaHttpResponse::error_with_header(
                 http::StatusCode::BAD_REQUEST,
-                [(ERROR_HEADER, format!("invalid data type: {}", f.r#type))],
-                Json(MetaHttpResponse::error(
-                    http::StatusCode::BAD_REQUEST,
-                    format!("invalid data type: {}", f.r#type),
-                )),
-            )
-                .into_response());
+                format!("invalid data type: {}", f.r#type),
+            ));
         };
         let name = format_label_name(&f.name);
         if name == TIMESTAMP_COL_NAME {
@@ -322,29 +299,16 @@ pub async fn create_stream(
         match infra::schema::merge(org_id, stream_name, stream_type, &schema, Some(min_ts)).await {
             Ok(Some((s, _))) => s,
             Ok(None) => {
-                return Ok((
+                return Ok(MetaHttpResponse::error_with_header(
                     http::StatusCode::INTERNAL_SERVER_ERROR,
-                    [(
-                        ERROR_HEADER,
-                        "error in creating stream: created schema is empty",
-                    )],
-                    Json(MetaHttpResponse::error(
-                        http::StatusCode::INTERNAL_SERVER_ERROR,
-                        "error in creating stream: created schema is empty",
-                    )),
-                )
-                    .into_response());
+                    "error in creating stream: created schema is empty",
+                ));
             }
             Err(e) => {
-                return Ok((
+                return Ok(MetaHttpResponse::error_with_header(
                     http::StatusCode::INTERNAL_SERVER_ERROR,
-                    [(ERROR_HEADER, format!("error in creating stream: {e}"))],
-                    Json(MetaHttpResponse::error(
-                        http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("error in creating stream: {e}"),
-                    )),
-                )
-                    .into_response());
+                    format!("error in creating stream: {e}"),
+                ));
             }
         };
 
@@ -386,15 +350,10 @@ pub async fn save_stream_settings(
     {
         Ok(saved) => saved,
         Err(schema::StreamSettingsError::StreamDeleting(message)) => {
-            return Ok((
+            return Ok(MetaHttpResponse::error_with_header(
                 http::StatusCode::BAD_REQUEST,
-                [(ERROR_HEADER, message.clone())],
-                Json(MetaHttpResponse::error(
-                    http::StatusCode::BAD_REQUEST,
-                    message,
-                )),
-            )
-                .into_response());
+                message,
+            ));
         }
         Err(schema::StreamSettingsError::BadRequest(message)) => {
             return Ok(MetaHttpResponse::bad_request(message));
@@ -641,15 +600,10 @@ pub async fn update_stream_settings(
             let usage = match check_field_use(org_id, stream_name, stream_type.as_str(), f).await {
                 Ok(entry) => entry,
                 Err(e) => {
-                    return Ok((
+                    return Ok(MetaHttpResponse::error_with_header(
                         http::StatusCode::INTERNAL_SERVER_ERROR,
-                        [(ERROR_HEADER, format!("error in updating settings : {e}"))],
-                        Json(MetaHttpResponse::error(
-                            http::StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("error in updating settings : {e}"),
-                        )),
-                    )
-                        .into_response());
+                        format!("error in updating settings : {e}"),
+                    ));
                 }
             };
             // if there are multiple uses, we cannot allow it to be removed
@@ -696,15 +650,10 @@ pub async fn update_stream_settings(
                 f,
             );
             if let Err(e) = distinct_values::add(record).await {
-                return Ok((
+                return Ok(MetaHttpResponse::error_with_header(
                     http::StatusCode::INTERNAL_SERVER_ERROR,
-                    [(ERROR_HEADER, format!("error in updating settings : {e}"))],
-                    Json(MetaHttpResponse::error(
-                        http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("error in updating settings : {e}"),
-                    )),
-                )
-                    .into_response());
+                    format!("error in updating settings : {e}"),
+                ));
             }
             // we cannot allow duplicate entries here
             let temp = DistinctField {
@@ -809,15 +758,10 @@ where
     // delete is safe and preserves billing/usage accounting. Cloud-only.
     #[cfg(feature = "cloud")]
     if is_reserved_internal_stream(stream_name) {
-        return Ok((
+        return Ok(MetaHttpResponse::error_with_header(
             http::StatusCode::BAD_REQUEST,
-            [(ERROR_HEADER, "stream name is reserved")],
-            Json(MetaHttpResponse::error(
-                http::StatusCode::BAD_REQUEST,
-                format!("stream '{stream_name}' is reserved and cannot be deleted"),
-            )),
-        )
-            .into_response());
+            format!("stream '{stream_name}' is reserved and cannot be deleted"),
+        ));
     }
 
     let schema = infra::schema::get_versions(org_id, stream_name, stream_type, None)
@@ -863,15 +807,10 @@ where
 
     // delete stream schema
     if let Err(e) = db::schema::delete(org_id, stream_name, Some(stream_type)).await {
-        return Ok((
+        return Ok(MetaHttpResponse::error_with_header(
             http::StatusCode::INTERNAL_SERVER_ERROR,
-            [(ERROR_HEADER, format!("failed to delete stream schema: {e}"))],
-            Json(MetaHttpResponse::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("failed to delete stream schema: {e}"),
-            )),
-        )
-            .into_response());
+            format!("failed to delete stream schema: {e}"),
+        ));
     }
 
     // create delete for compactor
@@ -881,30 +820,20 @@ where
         log::error!(
             "Failed to create retention job for stream: {org_id}/{stream_type}/{stream_name}, error: {e}"
         );
-        return Ok((
+        return Ok(MetaHttpResponse::error_with_header(
             http::StatusCode::INTERNAL_SERVER_ERROR,
-            [(ERROR_HEADER, format!("failed to delete stream: {e}"))],
-            Json(MetaHttpResponse::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("failed to delete stream: {e}"),
-            )),
-        )
-            .into_response());
+            format!("failed to delete stream: {e}"),
+        ));
     }
 
     delete_associated_metadata_streams(org_id, stream_name, stream_type).await;
 
     // delete related resource
     if let Err(e) = stream_delete_inner(org_id, stream_type, stream_name).await {
-        return Ok((
+        return Ok(MetaHttpResponse::error_with_header(
             http::StatusCode::INTERNAL_SERVER_ERROR,
-            [(ERROR_HEADER, format!("failed to delete stream: {e}"))],
-            Json(MetaHttpResponse::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("failed to delete stream: {e}"),
-            )),
-        )
-            .into_response());
+            format!("failed to delete stream: {e}"),
+        ));
     }
 
     if stream_type == StreamType::EnrichmentTables {


### PR DESCRIPTION
## Problem

`api_fuzz_tests` (schemathesis) intermittently reported a 500 on
`POST /api/{org_id}/streams/{stream_name}` with the body
`failed to parse header value`.

That string is not ours — it is the `http` crate's `InvalidHeaderValue`
display. The chain:

- ~20 sites return `(StatusCode, [(ERROR_HEADER, format!(...))], Json(...))`,
  where the message interpolates user-supplied names (org, stream, **field
  type**).
- The failing payload carried `"type": "v^0K…"`. `HeaderValue` accepts
  only `b >= 32 && b != 127 || b == b'\t'`, so the control byte makes header
  construction fail.
- axum's `TryIntoHeaderError` then **discards the whole response** and
  substitutes `(500, inner.to_string())`.

So the handler's real 400 and its JSON body never reached the client. The
status code was not chosen by the handler at all — axum overwrote it.

The org name was never the trigger; it only had to exist so the request got
past the auth check. The field type was the poison.

A second, quieter bug sits in the same place: non-ascii bytes *are* accepted
into a header, but `HeaderValue::to_str()` only reads back `32..127`, and the
audit middleware reads this header with exactly `to_str().ok()`. Any error
mentioning a non-ascii stream name was being silently dropped from the audit
log.

## Approach

Route every `X-Error-Message` write through one chokepoint in
`common::meta::http`:

- `error_header_value()` escapes anything outside visible ascii via
  `char::escape_default`, which fixes both failure modes at once — the header
  always builds, and it always reads back.
- `HttpResponse::error_with_header()` sets the header and the JSON body from a
  single message, replacing the hand-built tuples.

Most sites were formatting the identical message twice (once for the header,
once for the body), so this removes that duplication as well.

`enrichment_table` additionally had four `HeaderValue::from_str(..).unwrap()`
calls — outright panics, not 500s, on the same class of input. Those are gone.
Other `HeaderValue` construction sites (router `user_email`, `x-api-node`)
already guard with `unwrap_or_else` and are untouched.

## Organization identifier validation

Investigating how such an org existed at all: `create_org` validates the
display name and assigns a uuid identifier, but
`core::organization::check_and_create_org` takes the identifier **verbatim from
the URL path** with no validation. It is reachable from any root-authenticated
ingestion write (`ZO_CREATE_ORG_THROUGH_INGESTION`, default true), which is how
the fuzzer provisioned it.

`validate_auto_created_org_id` (ascii alphanumeric plus `-` and `_`) now guards
both auto-create entry points. It runs **after** the existing-org lookup, so it
only gates new creation: no deployment loses an org it already has, and SSO
auto-provisioning from IdP group names keeps working for normal identifiers.

## Verification

Against a local server with the CI payload:

- stream create → `400 {"code":400,"message":"invalid data type: v^0K"}`
  instead of the 500
- ingestion to the exotic org → 404; `autoorg-1` still auto-creates and ingests
- valid create, duplicate create, settings update, settings on a missing stream,
  delete, enrichment upload → correct codes, no panics

Two edits sit under `#[cfg(feature = "cloud")]` and cannot be compiled here:
swapping in `Cargo.toml.openobserve` fails inside o2-enterprise itself, whose
`main` has not yet picked up the `get_orm_client_rw` split from #13927. They
were verified by temporarily un-gating them and stubbing the cloud-only
predicate.
