### PR TITLE
fix(search): tie wal search file locks to guards so cancelled queries release them [v0.80]

### DIFF
--- a/src/common/infra/wal.rs
+++ b/src/common/infra/wal.rs
@@ -15,7 +15,7 @@
 
 use std::sync::LazyLock as Lazy;
 
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 
 // SEARCHING_FILES for searching files, in use, should not move to s3
 static SEARCHING_FILES: Lazy<parking_lot::RwLock<SearchingFileLocker>> =
@@ -27,6 +27,13 @@ static SEARCHING_REQUESTS: Lazy<parking_lot::RwLock<HashMap<String, Vec<String>>
 
 struct SearchingFileLocker {
     inner: HashMap<String, usize>,
+}
+
+/// Owns the `SEARCHING_FILES` locks of one search, releasing them on drop so a cancelled
+/// search cannot pin wal files for the life of the process.
+pub struct SearchingFiles {
+    trace_id: String,
+    files: HashSet<String>,
 }
 
 impl SearchingFileLocker {
@@ -68,22 +75,69 @@ impl SearchingFileLocker {
     }
 }
 
+impl SearchingFiles {
+    /// An empty guard, for the paths that return before any lock is taken.
+    pub fn empty(trace_id: &str) -> Self {
+        Self {
+            trace_id: trace_id.to_string(),
+            files: HashSet::new(),
+        }
+    }
+
+    pub fn lock(trace_id: &str, files: &[String]) -> Self {
+        // a set, so release_one is O(1) over a file list that can run to thousands
+        let files: HashSet<String> = files.iter().cloned().collect();
+        lock_files(&files);
+        Self {
+            trace_id: trace_id.to_string(),
+            files,
+        }
+    }
+
+    /// Release one file now and stop tracking it.
+    pub fn release_one(&mut self, file: &str) {
+        if self.files.remove(file) {
+            release_files(std::iter::once(file));
+        }
+    }
+
+    /// Hand the remaining locks to the trace id; `release_request` releases them from there.
+    pub fn into_request(mut self) {
+        let files: Vec<String> = self.files.drain().collect();
+        lock_request(&self.trace_id, files);
+    }
+}
+
+impl Drop for SearchingFiles {
+    fn drop(&mut self) {
+        if self.files.is_empty() {
+            return;
+        }
+        log::debug!(
+            "[trace_id {}] wal->search: released {} file locks on drop",
+            self.trace_id,
+            self.files.len()
+        );
+        release_files(&self.files);
+    }
+}
+
 pub fn init() -> Result<(), anyhow::Error> {
     _ = SEARCHING_FILES.read().len();
     Ok(())
 }
 
-pub fn lock_files(files: &[String]) {
+fn lock_files<I: IntoIterator<Item = S>, S: AsRef<str>>(files: I) {
     let mut locker = SEARCHING_FILES.write();
-    for file in files.iter() {
-        locker.lock(file.clone());
+    for file in files {
+        locker.lock(file.as_ref().to_string());
     }
 }
 
-pub fn release_files(files: &[String]) {
+fn release_files<I: IntoIterator<Item = S>, S: AsRef<str>>(files: I) {
     let mut locker = SEARCHING_FILES.write();
-    for file in files.iter() {
-        locker.release(file);
+    for file in files {
+        locker.release(file.as_ref());
     }
     locker.shrink_to_fit();
 }
@@ -92,27 +146,31 @@ pub fn lock_files_exists(file: &str) -> bool {
     SEARCHING_FILES.read().exist(file)
 }
 
+pub fn lock_files_len() -> usize {
+    SEARCHING_FILES.read().len()
+}
+
 pub fn clean_lock_files() {
     let mut locker = SEARCHING_FILES.write();
     locker.clean();
 }
 
-pub fn lock_request(trace_id: &str, files: &[String]) {
+fn lock_request(trace_id: &str, files: Vec<String>) {
     log::info!("[trace_id: {trace_id}] lock_request for wal files");
     let mut locker = SEARCHING_REQUESTS.write();
-    locker.insert(trace_id.to_string(), files.to_vec());
+    locker
+        .entry(trace_id.to_string())
+        .or_default()
+        .extend(files);
 }
 
 pub fn release_request(trace_id: &str) {
-    if !config::cluster::LOCAL_NODE.is_ingester() {
-        return;
-    }
-    log::info!("[trace_id: {trace_id}] release_request for wal files");
     let mut locker = SEARCHING_REQUESTS.write();
     let files = locker.remove(trace_id);
     locker.shrink_to_fit();
     drop(locker);
     if let Some(files) = files {
+        log::info!("[trace_id: {trace_id}] release_request for wal files");
         release_files(&files);
     }
 }
@@ -122,8 +180,14 @@ mod tests {
 
     use super::*;
 
+    // tests below mutate the shared global SEARCHING_FILES map; serialize the
+    // ones that assert on lock presence so clean_lock_files() from a parallel
+    // test cannot clear locks mid-assertion
+    static TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
     #[tokio::test]
     async fn test_wal_file_locking() {
+        let _guard = TEST_LOCK.lock();
         let files = vec![
             "files/test_org/logs/test_stream/1/2025/06/06/01/1/md5/test_key1.json".to_string(),
             "files/test_org/logs/test_stream/1/2025/06/06/01/1/md5/test_key2.json".to_string(),
@@ -142,6 +206,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_wal_request_locking() {
+        let _guard = TEST_LOCK.lock();
         let trace_id = "test_trace_1234";
         let files = vec![
             "files/test_org/logs/test_stream/1/2025/06/06/01/1/md5/test_key3.json".to_string(),
@@ -150,13 +215,113 @@ mod tests {
 
         // Test locking request
         lock_files(&files);
-        lock_request(trace_id, &files);
+        lock_request(trace_id, files.clone());
         assert!(lock_files_exists(&files[0]));
         assert!(lock_files_exists(&files[1]));
 
-        // Test releasing request
         release_request(trace_id);
         assert!(!lock_files_exists(&files[0]));
         assert!(!lock_files_exists(&files[1]));
+    }
+
+    #[test]
+    fn test_init_succeeds() {
+        assert!(init().is_ok());
+    }
+
+    #[test]
+    fn test_file_not_locked_initially() {
+        assert!(!lock_files_exists(
+            "files/org/logs/stream/1/md5/never_locked.json"
+        ));
+    }
+
+    #[test]
+    fn test_clean_lock_files_clears_all() {
+        let _guard = TEST_LOCK.lock();
+        let files = vec![
+            "files/org/logs/stream/1/md5/clean_test_a.json".to_string(),
+            "files/org/logs/stream/1/md5/clean_test_b.json".to_string(),
+        ];
+        lock_files(&files);
+        assert!(lock_files_exists(&files[0]));
+        clean_lock_files();
+        assert!(!lock_files_exists(&files[0]));
+        assert!(!lock_files_exists(&files[1]));
+    }
+
+    #[test]
+    fn test_file_lock_reference_counting() {
+        let _guard = TEST_LOCK.lock();
+        let files = vec!["files/org/logs/stream/1/md5/refcount_test.json".to_string()];
+        lock_files(&files);
+        lock_files(&files);
+        // one release - still locked
+        release_files(&files);
+        assert!(lock_files_exists(&files[0]));
+        // second release - now free
+        release_files(&files);
+        assert!(!lock_files_exists(&files[0]));
+    }
+
+    #[test]
+    fn test_searching_files_releases_on_drop() {
+        let _guard = TEST_LOCK.lock();
+        let files = vec![
+            "files/org/logs/stream/1/md5/guard_drop_a.json".to_string(),
+            "files/org/logs/stream/1/md5/guard_drop_b.json".to_string(),
+        ];
+        {
+            let _locks = SearchingFiles::lock("trace_drop", &files);
+            assert!(lock_files_exists(&files[0]));
+            assert!(lock_files_exists(&files[1]));
+        }
+        assert!(!lock_files_exists(&files[0]));
+        assert!(!lock_files_exists(&files[1]));
+    }
+
+    #[test]
+    fn test_searching_files_locks_duplicates_once() {
+        let _guard = TEST_LOCK.lock();
+        let file = "files/org/logs/stream/1/md5/guard_dup.json".to_string();
+        {
+            let _locks = SearchingFiles::lock("trace_dup", &[file.clone(), file.clone()]);
+            assert!(lock_files_exists(&file));
+        }
+        assert!(!lock_files_exists(&file));
+    }
+
+    #[test]
+    fn test_searching_files_release_one() {
+        let _guard = TEST_LOCK.lock();
+        let files = vec![
+            "files/org/logs/stream/1/md5/guard_one_a.json".to_string(),
+            "files/org/logs/stream/1/md5/guard_one_b.json".to_string(),
+        ];
+        {
+            let mut locks = SearchingFiles::lock("trace_one", &files);
+            locks.release_one(&files[0]);
+            assert!(!lock_files_exists(&files[0]));
+            assert!(lock_files_exists(&files[1]));
+            // releasing an untracked file is a no-op
+            locks.release_one(&files[0]);
+            assert!(lock_files_exists(&files[1]));
+        }
+        assert!(!lock_files_exists(&files[1]));
+    }
+
+    #[test]
+    fn test_searching_files_into_request_keeps_locks() {
+        let _guard = TEST_LOCK.lock();
+        let trace_id = "trace_into_request";
+        let files = vec!["files/org/logs/stream/1/md5/guard_into.json".to_string()];
+        {
+            let locks = SearchingFiles::lock(trace_id, &files);
+            locks.into_request();
+        }
+        // ownership moved to SEARCHING_REQUESTS, so the guard's drop released nothing
+        assert!(lock_files_exists(&files[0]));
+        release_request(trace_id);
+        assert!(!lock_files_exists(&files[0]));
     }
 }

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -163,6 +163,33 @@ pub static INGEST_PARQUET_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .expect("Metric created")
 });
+pub static INGEST_WAL_SEARCHING_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "ingest_wal_searching_files",
+            "Number of wal files locked by in-flight searches on the ingester.".to_owned()
+                + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static INGEST_WAL_PENDING_DELETE_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "ingest_wal_pending_delete_files",
+            "Number of uploaded wal files on the ingester still awaiting local deletion."
+                .to_owned()
+                + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
 pub static INGEST_WAL_WRITE_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
@@ -1847,6 +1874,12 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(INGEST_PARQUET_FILES.clone()))
         .expect("Metric registered");
     registry
+        .register(Box::new(INGEST_WAL_SEARCHING_FILES.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(INGEST_WAL_PENDING_DELETE_FILES.clone()))
+        .expect("Metric registered");
+    registry
         .register(Box::new(INGEST_WAL_WRITE_BYTES.clone()))
         .expect("Metric registered");
     registry
@@ -2397,6 +2430,8 @@ mod tests {
         let _ = INGEST_ERRORS.clone();
         let _ = INGEST_WAL_USED_BYTES.clone();
         let _ = INGEST_PARQUET_FILES.clone();
+        let _ = INGEST_WAL_SEARCHING_FILES.clone();
+        let _ = INGEST_WAL_PENDING_DELETE_FILES.clone();
         let _ = INGEST_WAL_WRITE_BYTES.clone();
         let _ = INGEST_WAL_READ_BYTES.clone();
         let _ = INGEST_MEMTABLE_BYTES.clone();

--- a/src/handler/grpc/flight/mod.rs
+++ b/src/handler/grpc/flight/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     handler::grpc::{
         MetadataMap,
         flight::{
-            stream::FlightEncoderStreamBuilder,
+            stream::{FlightEncoderStreamBuilder, MAX_FLIGHT_DATA_SIZE},
             visitor::{
                 get_cluster_metrics, get_partial_err, get_peak_memory, get_peak_memory_from_ctx,
                 get_scan_stats,
@@ -64,6 +64,12 @@ pub mod visitor;
 
 #[derive(Default)]
 pub struct FlightServiceImpl;
+
+/// Releases the wal locks and datafusion file list registered under this trace id on drop, so
+/// a request cancelled before it can produce a response stream cannot leave them pinned.
+pub(crate) struct SessionGuard {
+    trace_id: String,
+}
 
 #[tonic::async_trait]
 impl FlightService for FlightServiceImpl {
@@ -100,6 +106,7 @@ impl FlightService for FlightServiceImpl {
             "{}-{}",
             req.query_identifier.trace_id, req.query_identifier.job_id
         );
+        let session_guard = SessionGuard::new(trace_id.clone());
         let is_super_cluster = req.super_cluster_info.is_super_cluster;
         let timeout = req.search_info.timeout as u64;
         log::info!("[trace_id {trace_id}] flight->search: do_get, timeout: {timeout}s",);
@@ -154,7 +161,6 @@ impl FlightService for FlightServiceImpl {
         let (ctx, physical_plan, lock, scan_stats) = match result {
             Ok(v) => v,
             Err(e) => {
-                clear_session_data(&trace_id);
                 #[cfg(feature = "enterprise")]
                 if get_o2_config().work_group.max_nodes_per_query > 0 {
                     o2_enterprise::enterprise::search::admission::ledger::release(&trace_id);
@@ -184,8 +190,6 @@ impl FlightService for FlightServiceImpl {
         let write_options: IpcWriteOptions = IpcWriteOptions::default()
             .try_with_compression(Some(CompressionType::ZSTD))
             .map_err(|e| {
-                // clear session data
-                clear_session_data(&trace_id);
                 log::error!(
                     "[trace_id {trace_id}] flight->search: do_get create IPC write options error: {e:?}",
                 );
@@ -210,7 +214,6 @@ impl FlightService for FlightServiceImpl {
         let partial_err_ref = get_partial_err(&physical_plan);
 
         let stream = execute_stream(physical_plan, ctx.task_ctx().clone()).map_err(|e| {
-            clear_session_data(&trace_id);
             #[cfg(feature = "enterprise")]
             if get_o2_config().work_group.max_nodes_per_query > 0 {
                 o2_enterprise::enterprise::search::admission::ledger::release(&trace_id);
@@ -221,22 +224,23 @@ impl FlightService for FlightServiceImpl {
             Status::internal(e.to_string())
         })?;
 
-        let mut stream = FlightEncoderStreamBuilder::new(write_options, 33554432)
-            .with_trace_id(trace_id.to_string())
-            .with_is_super(is_super_cluster)
-            .with_defer_lock(lock)
-            .with_start(start)
-            .with_custom_message(PreCustomMessage::ScanStats(scan_stats))
-            .with_custom_message(PreCustomMessage::ScanStatsRef(scan_stats_ref))
-            .with_custom_message(PreCustomMessage::Metrics(metrics))
-            .with_custom_message(PreCustomMessage::MetricsRef(metrics_ref))
-            .with_custom_message(PreCustomMessage::PeakMemoryRef(Some(peak_memory)))
-            .with_custom_message(PreCustomMessage::PeakMemoryRef(peak_memory_ref))
-            .with_custom_message(PreCustomMessage::PartialErrRefEarly(
-                partial_err_ref.clone(),
-            ))
-            .with_custom_message(PreCustomMessage::PartialErrRef(partial_err_ref))
-            .build(stream, span);
+        let mut stream =
+            FlightEncoderStreamBuilder::new(write_options, MAX_FLIGHT_DATA_SIZE, session_guard)
+                .with_trace_id(trace_id.to_string())
+                .with_is_super(is_super_cluster)
+                .with_defer_lock(lock)
+                .with_start(start)
+                .with_custom_message(PreCustomMessage::ScanStats(scan_stats))
+                .with_custom_message(PreCustomMessage::ScanStatsRef(scan_stats_ref))
+                .with_custom_message(PreCustomMessage::Metrics(metrics))
+                .with_custom_message(PreCustomMessage::MetricsRef(metrics_ref))
+                .with_custom_message(PreCustomMessage::PeakMemoryRef(Some(peak_memory)))
+                .with_custom_message(PreCustomMessage::PeakMemoryRef(peak_memory_ref))
+                .with_custom_message(PreCustomMessage::PartialErrRefEarly(
+                    partial_err_ref.clone(),
+                ))
+                .with_custom_message(PreCustomMessage::PartialErrRef(partial_err_ref))
+                .build(stream, span);
 
         let stream = async_stream::stream! {
             let timeout = tokio::time::sleep(tokio::time::Duration::from_secs(timeout));
@@ -322,6 +326,18 @@ impl FlightService for FlightServiceImpl {
         _request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
         Err(Status::unimplemented("Implement do_exchange"))
+    }
+}
+
+impl SessionGuard {
+    fn new(trace_id: String) -> Self {
+        Self { trace_id }
+    }
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        clear_session_data(&self.trace_id);
     }
 }
 

--- a/src/handler/grpc/flight/stream.rs
+++ b/src/handler/grpc/flight/stream.rs
@@ -27,7 +27,11 @@ use o2_enterprise::enterprise::common::config::get_config as get_o2_config;
 use tracing::info_span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::{handler::grpc::flight::clear_session_data, service::search::work_group::DeferredLock};
+use crate::{handler::grpc::flight::SessionGuard, service::search::work_group::DeferredLock};
+
+/// Cap on one encoded FlightData message. Mirrors the `ZO_GRPC_MAX_MESSAGE_SIZE` default,
+/// which is what the receiving channel accepts.
+pub(crate) const MAX_FLIGHT_DATA_SIZE: usize = 32 * 1024 * 1024;
 
 pub struct FlightEncoderStreamBuilder {
     encoder: FlightDataEncoder,
@@ -37,11 +41,16 @@ pub struct FlightEncoderStreamBuilder {
     trace_id: String,
     is_super: bool,
     defer_lock: Option<DeferredLock>,
+    session_guard: Option<SessionGuard>,
     start: std::time::Instant,
 }
 
 impl FlightEncoderStreamBuilder {
-    pub fn new(options: IpcWriteOptions, max_flight_data_size: usize) -> Self {
+    pub(crate) fn new(
+        options: IpcWriteOptions,
+        max_flight_data_size: usize,
+        session_guard: SessionGuard,
+    ) -> Self {
         Self {
             encoder: FlightDataEncoder::new(options, max_flight_data_size),
             queue: VecDeque::new(),
@@ -49,6 +58,7 @@ impl FlightEncoderStreamBuilder {
             trace_id: String::new(),
             is_super: false,
             defer_lock: None,
+            session_guard: Some(session_guard),
             start: std::time::Instant::now(),
         }
     }
@@ -94,6 +104,7 @@ impl FlightEncoderStreamBuilder {
             trace_id: self.trace_id,
             is_super: self.is_super,
             defer_lock: self.defer_lock,
+            session_guard: self.session_guard,
             start: self.start,
             first_batch: true,
             span,
@@ -116,6 +127,8 @@ pub struct FlightEncoderStream {
     trace_id: String,
     is_super: bool,
     defer_lock: Option<DeferredLock>,
+    /// releases the wal locks and the datafusion file list of this request.
+    session_guard: Option<SessionGuard>,
     start: std::time::Instant,
     span: tracing::Span,
     child_span: tracing::Span,
@@ -289,15 +302,11 @@ impl Drop for FlightEncoderStream {
             log::info!("[trace_id {trace_id}] flight->search: releasing slot");
         }
 
-        // defer is only set for super cluster follower leader
-        if let Some(defer) = self.defer_lock.take() {
-            drop(defer);
-        } else {
-            // clear session data
-            clear_session_data(&self.trace_id);
-            log::info!(
-                "[trace_id {trace_id}] flight->search: drop FlightEncoderStream, is_super: {is_super}",
-            );
-        }
+        // the defer only covers the work group slot, so it never gates the session release
+        drop(self.defer_lock.take());
+        drop(self.session_guard.take());
+        log::info!(
+            "[trace_id {trace_id}] flight->search: drop FlightEncoderStream, is_super: {is_super}",
+        );
     }
 }

--- a/src/job/metrics.rs
+++ b/src/job/metrics.rs
@@ -262,6 +262,13 @@ async fn update_parquet_metrics() -> Result<(), anyhow::Error> {
     ingester::collect_wal_parquet_metrics()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to collect parquet metrics: {}", e))?;
+    // and the wal search locks, plus the deletions they are holding back
+    metrics::INGEST_WAL_SEARCHING_FILES
+        .with_label_values::<&str>(&[])
+        .set(crate::common::infra::wal::lock_files_len() as i64);
+    metrics::INGEST_WAL_PENDING_DELETE_FILES
+        .with_label_values::<&str>(&[])
+        .set(crate::service::db::file_list::local::pending_delete_len().await as i64);
     Ok(())
 }
 

--- a/src/service/db/file_list/local.rs
+++ b/src/service/db/file_list/local.rs
@@ -64,6 +64,10 @@ pub async fn get_pending_delete() -> Vec<String> {
     PENDING_DELETE_FILES.read().await.iter().cloned().collect()
 }
 
+pub async fn pending_delete_len() -> usize {
+    PENDING_DELETE_FILES.read().await.len()
+}
+
 pub async fn filter_by_pending_delete(mut files: Vec<String>) -> Vec<String> {
     // Acquire locks in a consistent order to prevent deadlocks
     let pending = PENDING_DELETE_FILES.read().await;

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -52,7 +52,7 @@ pub struct QueryParams {
 /// - Files completely within the query time range: no timestamp filter applied
 /// - Files partially overlapping with the query time range: timestamp filter applied
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn create_tables_from_files<F>(
+pub(crate) async fn create_tables_from_files(
     files: Vec<FileKey>,
     session: config::meta::search::Session,
     query: Arc<QueryParams>,
@@ -61,11 +61,7 @@ pub(crate) async fn create_tables_from_files<F>(
     file_stat_cache: Option<Arc<dyn FileStatisticsCache>>,
     index_condition: Option<IndexCondition>,
     fst_fields: Vec<String>,
-    on_error: F,
-) -> Result<Vec<Arc<dyn TableProvider>>>
-where
-    F: Fn() + Clone,
-{
+) -> Result<Vec<Arc<dyn TableProvider>>> {
     let mut tables: Vec<Arc<dyn TableProvider>> = Vec::new();
     let schema_ref = Arc::new(
         schema_ref
@@ -83,7 +79,6 @@ where
         let file_stat_cache = file_stat_cache.clone();
         let index_condition = index_condition.clone();
         let fst_fields = fst_fields.clone();
-        let on_error = on_error.clone();
 
         async move {
             let mut builder = TableBuilder::new()
@@ -96,10 +91,7 @@ where
                 builder = builder.timestamp_filter(time_range);
             }
 
-            builder
-                .build(session, files, schema_ref)
-                .await
-                .inspect_err(|_| on_error())
+            builder.build(session, files, schema_ref).await
         }
     };
 

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -263,7 +263,6 @@ pub async fn search(
         file_stat_cache,
         index_condition,
         fst_fields,
-        || {},
     )
     .await?;
 

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -84,7 +84,7 @@ pub async fn search_parquet(
             .await
             .unwrap_or_default();
     let partition_time_level = get_partition_time_level(query.stream_type);
-    let files = get_file_list(
+    let (files, mut locks) = get_file_list(
         query.clone(),
         &stream_settings.partition_keys,
         Some(query.time_range),
@@ -102,7 +102,6 @@ pub async fn search_parquet(
         return Ok((vec![], ScanStats::new(), HashSet::new()));
     }
 
-    let mut lock_files = files.iter().map(|f| f.key.clone()).collect::<Vec<_>>();
     let cfg = get_config();
     // get file metadata to build file_list
     let files_num = files.len();
@@ -131,8 +130,7 @@ pub async fn search_parquet(
         .await;
     for file in files_metadata {
         if file.meta.is_empty() {
-            wal::release_files(std::slice::from_ref(&file.key));
-            lock_files.retain(|f| f != &file.key);
+            locks.release_one(&file.key);
             continue;
         }
         let (min_ts, max_ts) = query.time_range;
@@ -143,8 +141,7 @@ pub async fn search_parquet(
                 file.meta.min_ts,
                 file.meta.max_ts
             );
-            wal::release_files(std::slice::from_ref(&file.key));
-            lock_files.retain(|f| f != &file.key);
+            locks.release_one(&file.key);
             continue;
         }
         new_files.push(file);
@@ -154,16 +151,12 @@ pub async fn search_parquet(
     let mut scan_stats = ScanStats::new();
     scan_stats.files = files.len() as i64;
     if scan_stats.files == 0 {
-        // release all files
-        wal::release_files(&lock_files);
         return Ok((vec![], scan_stats, HashSet::new()));
     }
 
     let scan_stats = match file_list::calculate_files_size(&files).await {
         Ok(size) => size,
         Err(err) => {
-            // release all files
-            wal::release_files(&lock_files);
             log::error!("[trace_id {trace_id}] calculate files size error: {err}",);
             return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(
                 "calculate files size error".to_string(),
@@ -198,8 +191,6 @@ pub async fn search_parquet(
 
     // check memory circuit breaker
     if let Err(e) = ingester::check_memory_circuit_breaker() {
-        // release all files
-        wal::release_files(&lock_files);
         return Err(Error::ResourceError(e.to_string()));
     }
 
@@ -220,14 +211,11 @@ pub async fn search_parquet(
         file_stat_cache,
         index_condition,
         fst_fields,
-        || {
-            wal::release_files(&lock_files);
-        },
     )
     .await?;
 
-    // lock these files for this request
-    wal::lock_request(&query.trace_id, &lock_files);
+    // hand the locks to the request; released by wal::release_request on stream teardown
+    locks.into_request();
 
     log::info!(
         "{}",
@@ -488,7 +476,7 @@ async fn get_file_list(
     search_partition_keys: &[(String, String)],
     partition_time_level: PartitionTimeLevel,
     memtable_ids: HashSet<u64>,
-) -> Result<Vec<FileKey>, Error> {
+) -> Result<(Vec<FileKey>, wal::SearchingFiles), Error> {
     let wal_dir = match Path::new(&get_config().common.data_wal_dir).canonicalize() {
         Ok(path) => {
             let mut path = path.to_str().unwrap().to_string();
@@ -499,7 +487,7 @@ async fn get_file_list(
             path
         }
         Err(_) => {
-            return Ok(vec![]);
+            return Ok((vec![], wal::SearchingFiles::empty(&query.trace_id)));
         }
     };
 
@@ -564,13 +552,13 @@ async fn get_file_list(
         .collect::<Vec<_>>();
 
     if files.is_empty() {
-        return Ok(vec![]);
+        return Ok((vec![], wal::SearchingFiles::empty(&query.trace_id)));
     }
 
     // filter by pending delete
     let mut files = crate::service::db::file_list::local::filter_by_pending_delete(files).await;
     if files.is_empty() {
-        return Ok(vec![]);
+        return Ok((vec![], wal::SearchingFiles::empty(&query.trace_id)));
     }
 
     let files_num = files.len();
@@ -585,7 +573,7 @@ async fn get_file_list(
     }
 
     // lock theses files
-    wal::lock_files(&files);
+    let mut locks = wal::SearchingFiles::lock(&query.trace_id, &files);
 
     let stream_params = Arc::new(StreamParams::new(
         &query.org_id,
@@ -616,7 +604,7 @@ async fn get_file_list(
                     "[trace_id {}] skip wal parquet file: {file} time_range: [{file_min_ts},{file_max_ts}]",
                     query.trace_id,
                 );
-                wal::release_files(std::slice::from_ref(file));
+                locks.release_one(file);
                 continue;
             }
         }
@@ -624,10 +612,10 @@ async fn get_file_list(
         if match_source(stream_params.clone(), time_range, &filters, &file_key).await {
             result.push(file_key);
         } else {
-            wal::release_files(std::slice::from_ref(file));
+            locks.release_one(file);
         }
     }
-    Ok(result)
+    Ok((result, locks))
 }
 
 fn adapt_batch(


### PR DESCRIPTION
Backport of #13953 to `branch-v0.80.0`. Fixes o2-enterprise#2491, which was
reported against a build from this line.

## Problem

Local wal parquet files that had already been merged and uploaded to object
storage stayed on disk forever, because their `SEARCHING_FILES` refcount never
returned to zero. Post-merge cleanup defers deletion while a search holds the
file and re-checks every `ZO_FILE_PUSH_INTERVAL` — forever, if the lock is
never released. Queries stayed correct; the symptom was disk.

Release depended on control flow reaching a line, while the only thing that can
cancel the request guarantees no further line runs. `SEARCHING_FILES` and
`SEARCHING_REQUESTS` are global maps with no owner, so nothing releases an entry
automatically, and the whole of plan generation sat unprotected — from
`lock_files()` in `get_file_list` all the way to the `FlightEncoderStream` that
is the first object with a `Drop`.

Both gRPC cancellation paths fire only *before* `do_get` returns a response, so
the set of cancellable moments and the set of unowned moments coincided:

- hyper polls `poll_reset` only on the `Poll::Pending` branch — "check if the
  client has sent a RST_STREAM frame which would cancel the current request" —
  and drops the service future.
- tonic's `GrpcTimeout` reads the client's `grpc-timeout` header and drops the
  inner future on expiry. Every flight request sets that header.

Routine triggers, all of which drop in-flight `do_get` calls to ingesters:
`query_task.abort()` on leader timeout or user cancel, client disconnect, and
the ingester `grpc-timeout` itself. None are visible — the leader treats
`Cancelled` / `DeadlineExceeded` from a node as an empty partial result, so the
query still succeeds.

## Approach

Identical in shape to #13953: give the locks an owner for every instant they
exist.

- **`wal::SearchingFiles`** owns the raw locks from acquisition until
  `into_request` hands them to `SEARCHING_REQUESTS`; `Drop` releases whatever is
  left. `get_file_list` returns it alongside the file list, so the type forces
  every early return to account for it.
- **`flight::SessionGuard`** is armed on the first line of `do_get` — before
  anything can be locked — and moves into `FlightEncoderStream`, whose `Drop`
  already performed the teardown. It is a required argument of
  `FlightEncoderStreamBuilder::new`, so a future call site cannot forget it.

`lock_files`, `release_files` and `lock_request` are module-private now: the
guard is the only way to take a wal lock.

Also on the same chain: `release_request` no longer early-returns on
non-ingesters and logs only a release that actually happened, so
`lock_request` / `release_request` pair one-to-one per trace id;
`lock_request` merges instead of overwriting; and `FlightEncoderStream::drop`
releases session data unconditionally rather than letting "am I a super-cluster
follower leader?" decide whether wal locks are released.

Two gauges, `ingest_wal_searching_files` and `ingest_wal_pending_delete_files`,
publish the lock table size and the deferred-deletion backlog from the existing
60s ingester collector. A backlog that rises and never drains is the leak.

## Differences from the main-branch change

The port is close to mechanical — `do_get` and `FlightEncoderStream` have the same shape here, and this branch's `SEARCHING_FILES` differs from main's only by a `shrink_to_fit`, which is preserved. Adapted:

- `FlightEncoderStream` is still a flat struct (no `StreamContext`), so the guard is a field on it directly, and `execute_stream` yields one stream rather than partitions
- `create_tables_from_files` keeps its `pub(crate)` visibility; only the `on_error` parameter is dropped
- `get_file_list` keeps `memtable_ids: HashSet<u64>` by value
- the pending-delete set lives in `service::db::file_list::local`, so the O(1) `pending_delete_len` accessor goes there
- the admission `ledger::release` calls in `do_get` are left alone; folding those into the guard is the follow-up in #13954, which will be backported separately

## Verification

- `cargo fmt --all`: clean
- `cargo clippy --workspace -- -D warnings` (this branch's CI scope): clean.
  `--all-targets` additionally surfaces 29 pre-existing errors in
  `src/infra/src/table/ratelimit.rs` test code, untouched by this change and
  outside what CI lints here
- `cargo check --all-targets`: clean
- `cargo test --lib common::infra::wal`: 10/10, including 4 new tests covering
  drop-release, duplicate collapse, `release_one`, and the `into_request`
  handoff
