### PR TITLE
fix(rum): restore RUM-traces correlation for zero-stripped trace ids

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@joakimono/echarts-extension-leaflet": "^1.1.0",
-        "@openobserve/browser-logs": "0.4.2-beta.2",
-        "@openobserve/browser-rum": "0.4.2-beta.2",
+        "@openobserve/browser-logs": "0.4.2-beta.3",
+        "@openobserve/browser-rum": "0.4.2-beta.3",
         "@openobserve/node-sql-parser": "^0.1.5",
         "@openobserve/rrweb-player": "^0.2.1",
         "@rudderstack/analytics-js": "3.6.0",
@@ -2735,25 +2735,25 @@
       "license": "MIT"
     },
     "node_modules/@openobserve/browser-core": {
-      "version": "0.4.2-beta.2",
-      "resolved": "https://registry.npmjs.org/@openobserve/browser-core/-/browser-core-0.4.2-beta.2.tgz",
-      "integrity": "sha512-vXEMd7yERi5u5UQ0zkX1fiaBAlK1C6IJhGhg0xS60MTQTeG+c2qmzNKI7msG8IH6IO6ZjL4LQiPj7Sz/VbHu+w==",
+      "version": "0.4.2-beta.3",
+      "resolved": "https://registry.npmjs.org/@openobserve/browser-core/-/browser-core-0.4.2-beta.3.tgz",
+      "integrity": "sha512-aXV4HgaXRrPeWE4ZyyMx/NaeJLzv/yyW9B4wONGwdAdLX9+S1IWNuMfPbuJpJO7rybYBFTwOMVY0hox818Dt6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openobserve/js-core": "0.4.2-beta.2"
+        "@openobserve/js-core": "0.4.2-beta.3"
       }
     },
     "node_modules/@openobserve/browser-logs": {
-      "version": "0.4.2-beta.2",
-      "resolved": "https://registry.npmjs.org/@openobserve/browser-logs/-/browser-logs-0.4.2-beta.2.tgz",
-      "integrity": "sha512-PSzlLapxcJE1XIF4R81kqVfUEfK5RzcJVkHiysl7XIjTdpWImxSjOVwGP1dgRPOeP+XRwZ19Ym+l93QIK9QuSw==",
+      "version": "0.4.2-beta.3",
+      "resolved": "https://registry.npmjs.org/@openobserve/browser-logs/-/browser-logs-0.4.2-beta.3.tgz",
+      "integrity": "sha512-mx6R5c6M7pThXhwJWoqrLHi1E03LU4KqMWzBB2xW9wGYtLzThEhbdgwOLR84WXLH82MruyLWLo4jxsoHjbNXbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openobserve/browser-core": "0.4.2-beta.2",
-        "@openobserve/js-core": "0.4.2-beta.2"
+        "@openobserve/browser-core": "0.4.2-beta.3",
+        "@openobserve/js-core": "0.4.2-beta.3"
       },
       "peerDependencies": {
-        "@openobserve/browser-rum": "0.4.2-beta.2"
+        "@openobserve/browser-rum": "0.4.2-beta.3"
       },
       "peerDependenciesMeta": {
         "@openobserve/browser-rum": {
@@ -2762,17 +2762,17 @@
       }
     },
     "node_modules/@openobserve/browser-rum": {
-      "version": "0.4.2-beta.2",
-      "resolved": "https://registry.npmjs.org/@openobserve/browser-rum/-/browser-rum-0.4.2-beta.2.tgz",
-      "integrity": "sha512-NUxn5byBorDtSQ+LaOp2EqLpJfDcRPD8BVgzxFdMsL/HgeYp82TyR+lwoLp2Buzz5kESFZ3Cmws9wzDd4ZHIIQ==",
+      "version": "0.4.2-beta.3",
+      "resolved": "https://registry.npmjs.org/@openobserve/browser-rum/-/browser-rum-0.4.2-beta.3.tgz",
+      "integrity": "sha512-Jjt/gtjrSLPLD8Zhof5B6VfmUWmWCsR+MjItV8H0lRYOwGo6w2GXTJ5Z1OmXMkeiUs1dCBBMoH3M+Lqf9yUQDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openobserve/browser-core": "0.4.2-beta.2",
-        "@openobserve/browser-rum-core": "0.4.2-beta.2",
-        "@openobserve/js-core": "0.4.2-beta.2"
+        "@openobserve/browser-core": "0.4.2-beta.3",
+        "@openobserve/browser-rum-core": "0.4.2-beta.3",
+        "@openobserve/js-core": "0.4.2-beta.3"
       },
       "peerDependencies": {
-        "@openobserve/browser-logs": "0.4.2-beta.2"
+        "@openobserve/browser-logs": "0.4.2-beta.3"
       },
       "peerDependenciesMeta": {
         "@openobserve/browser-logs": {
@@ -2781,19 +2781,19 @@
       }
     },
     "node_modules/@openobserve/browser-rum-core": {
-      "version": "0.4.2-beta.2",
-      "resolved": "https://registry.npmjs.org/@openobserve/browser-rum-core/-/browser-rum-core-0.4.2-beta.2.tgz",
-      "integrity": "sha512-QZMgu0bEHkjHByEZt1mvAzlNNr88ZlTCFODn52GAsv/KOdevE87vGz0cU6yoGPfppP187KHgKNuJOkgWMkRuYQ==",
+      "version": "0.4.2-beta.3",
+      "resolved": "https://registry.npmjs.org/@openobserve/browser-rum-core/-/browser-rum-core-0.4.2-beta.3.tgz",
+      "integrity": "sha512-ssWgUCS+Y/N4vhQ/TAEQp4Xj2fh5G8vZiSmgnakUbdS0tzrBD/VDkVbW3Bvz4ETzPeq2QgHJQwpzi5S/auLEkQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openobserve/browser-core": "0.4.2-beta.2",
-        "@openobserve/js-core": "0.4.2-beta.2"
+        "@openobserve/browser-core": "0.4.2-beta.3",
+        "@openobserve/js-core": "0.4.2-beta.3"
       }
     },
     "node_modules/@openobserve/js-core": {
-      "version": "0.4.2-beta.2",
-      "resolved": "https://registry.npmjs.org/@openobserve/js-core/-/js-core-0.4.2-beta.2.tgz",
-      "integrity": "sha512-Rn/o79iiG2bTtnIwD8b/AuPiHs/11Tp+ejD7vHRI5FzLI51hbP7t49/fqBxk6ewrNlZm+rHDvh8Tm6GWqsZe4Q==",
+      "version": "0.4.2-beta.3",
+      "resolved": "https://registry.npmjs.org/@openobserve/js-core/-/js-core-0.4.2-beta.3.tgz",
+      "integrity": "sha512-3hwDzBPj0ZTpBleqJL0ZgRw+EBN7Jx1wRQFX/jgKRANbCUsII8y0EsdBS6zLZpTNDUWH1Nmv+8uQ5S5+wLFeMg==",
       "license": "Apache-2.0"
     },
     "node_modules/@openobserve/node-sql-parser": {
@@ -11641,6 +11641,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/entities": {

--- a/web/package.json
+++ b/web/package.json
@@ -42,8 +42,8 @@
   "dependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@joakimono/echarts-extension-leaflet": "^1.1.0",
-    "@openobserve/browser-logs": "0.4.2-beta.2",
-    "@openobserve/browser-rum": "0.4.2-beta.2",
+    "@openobserve/browser-logs": "0.4.2-beta.3",
+    "@openobserve/browser-rum": "0.4.2-beta.3",
     "@openobserve/node-sql-parser": "^0.1.5",
     "@openobserve/rrweb-player": "^0.2.1",
     "@rudderstack/analytics-js": "3.6.0",

--- a/web/src/components/rum/EventDetailDrawerContent.spec.ts
+++ b/web/src/components/rum/EventDetailDrawerContent.spec.ts
@@ -783,6 +783,53 @@ describe("EventDetailDrawerContent", () => {
       windowOpenSpy.mockRestore();
     });
 
+    it("pads a legacy zero-stripped trace_id before navigating to traceDetails", async () => {
+      // Arrange — a resource whose id SDK 0.4.x stored zero-stripped (31 hex chars)
+      const legacyResource = createMockResource({
+        _oo_trace_id: "1a034c1aabc72f78880daf6c9755cff",
+      });
+      if (globalThis.server) {
+        globalThis.server.use(
+          http.post(
+            `${store.state.API_ENDPOINT}/api/${store.state.selectedOrganization.identifier}/_search`,
+            async ({ request }) => {
+              const body = (await request.json()) as any;
+              if (body?.query?.sql?.includes("action_id")) {
+                return HttpResponse.json({ took: 0, hits: [legacyResource], total: 1 });
+              }
+              return HttpResponse.json({ took: 0, hits: [], total: 0 });
+            },
+          ),
+        );
+      }
+      wrapper.unmount();
+      wrapper = mountComponent();
+      await flushPromises();
+      await waitForRelatedResources(wrapper);
+
+      const routerResolveSpy = vi.spyOn(router, "resolve");
+      const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+      const traceButtons = wrapper.findAll('[data-test="view-trace-btn"]');
+      expect(traceButtons.length).toBeGreaterThan(0);
+
+      // Act
+      await traceButtons[0].trigger("click");
+      await flushPromises();
+
+      // Assert — route carries the padded 32-char id the traces stream stores
+      expect(routerResolveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "traceDetails",
+          query: expect.objectContaining({
+            trace_id: "01a034c1aabc72f78880daf6c9755cff",
+            stream: "default",
+          }),
+        }),
+      );
+
+      windowOpenSpy.mockRestore();
+    });
+
     it("opens trace in a new browser tab when view-trace-btn is clicked", async () => {
       // Arrange
       await waitForRelatedResources(wrapper);

--- a/web/src/components/rum/EventDetailDrawerContent.spec.ts
+++ b/web/src/components/rum/EventDetailDrawerContent.spec.ts
@@ -88,6 +88,13 @@ function createMockError(overrides: Record<string, any> = {}) {
 // Mock related resources
 const mockRelatedResources = [createMockResource(), createMockError()];
 
+// Stream discovery: defaults to the constant so the padded-navigation tests
+// keep their `stream: "default"` shape; tests override for custom streams.
+const mockResolveTracesStream = vi.fn().mockResolvedValue("default");
+vi.mock("@/composables/rum/useCorrelatedTracesStream", () => ({
+  default: () => ({ resolveTracesStream: mockResolveTracesStream }),
+}));
+
 // ============================================================================
 // TEST HELPERS
 // ============================================================================
@@ -826,6 +833,33 @@ describe("EventDetailDrawerContent", () => {
           }),
         }),
       );
+
+      windowOpenSpy.mockRestore();
+    });
+
+    it("opens the tab synchronously (popup-safe) and points it at the resolved stream", async () => {
+      // The user-gesture context dies at the first await: window.open must be
+      // called BEFORE the resolver settles, then the window is pointed at the
+      // resolved-stream route.
+      await waitForRelatedResources(wrapper);
+
+      const fakeWin: any = { location: { href: "" } };
+      const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => fakeWin);
+      let openedBeforeResolve = false;
+      mockResolveTracesStream.mockImplementationOnce(async () => {
+        openedBeforeResolve = windowOpenSpy.mock.calls.length > 0;
+        return "payments_traces";
+      });
+
+      const traceButtons = wrapper.findAll('[data-test="view-trace-btn"]');
+      expect(traceButtons.length).toBeGreaterThan(0);
+      await traceButtons[0].trigger("click");
+      await flushPromises();
+
+      expect(windowOpenSpy).toHaveBeenCalledWith("", "_blank");
+      expect(openedBeforeResolve).toBe(true);
+      expect(fakeWin.location.href).toContain("stream=payments_traces");
+      expect(fakeWin.location.href).toContain("trace_id=");
 
       windowOpenSpy.mockRestore();
     });

--- a/web/src/components/rum/EventDetailDrawerContent.vue
+++ b/web/src/components/rum/EventDetailDrawerContent.vue
@@ -443,7 +443,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup lang="ts">
-import { rumField } from "@/utils/rum/fields";
+import { rumField, normalizeTraceId, RUM_CORRELATION_TRACES_STREAM } from "@/utils/rum/fields";
 import OTabs from "@/lib/navigation/Tabs/OTabs.vue";
 import OTab from "@/lib/navigation/Tabs/OTab.vue";
 import OTabPanels from "@/lib/navigation/Tabs/OTabPanels.vue";
@@ -610,10 +610,16 @@ const viewResourceDetails = (resource: any) => {
  * Opens in a new tab
  */
 const navigateToSpecificTrace = (traceId: string) => {
-  if (!traceId) return;
+  // Canonicalize: SDK 0.4.x stored ids zero-stripped, but the traces stream
+  // (and therefore the trace-details page) uses the padded 32-char form.
+  const canonicalTraceId = normalizeTraceId(traceId) || traceId;
+  if (!canonicalTraceId) return;
 
   // Find the resource with this trace_id to get timing information
-  const resource = relatedResources.value.find((r: any) => rumField(r, "trace_id") === traceId);
+  const resource = relatedResources.value.find(
+    (r: any) =>
+      (normalizeTraceId(rumField(r, "trace_id")) || rumField(r, "trace_id")) === canonicalTraceId,
+  );
 
   // Use resource timing if available, otherwise use event timing
   const startTime = resource?.date
@@ -627,8 +633,8 @@ const navigateToSpecificTrace = (traceId: string) => {
   const route = router.resolve({
     name: "traceDetails",
     query: {
-      stream: "default", // RUM traces stream
-      trace_id: traceId,
+      stream: RUM_CORRELATION_TRACES_STREAM,
+      trace_id: canonicalTraceId,
       from: startTime,
       to: endTime,
       org_identifier: store.state.selectedOrganization.identifier,

--- a/web/src/components/rum/EventDetailDrawerContent.vue
+++ b/web/src/components/rum/EventDetailDrawerContent.vue
@@ -326,6 +326,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       :title="t('common.viewTraceDetails')"
                       data-test="view-trace-btn"
                       class="ml-2 h-5! px-1.5"
+                      :loading="isResolvingTraceNav"
                       @click.stop="navigateToSpecificTrace(rumField(item, 'trace_id'))"
                     >
                       <OIcon name="account-tree" size="xs" />
@@ -443,7 +444,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup lang="ts">
-import { rumField, normalizeTraceId, RUM_CORRELATION_TRACES_STREAM } from "@/utils/rum/fields";
+import { rumField, normalizeTraceId } from "@/utils/rum/fields";
+import useCorrelatedTracesStream from "@/composables/rum/useCorrelatedTracesStream";
 import OTabs from "@/lib/navigation/Tabs/OTabs.vue";
 import OTab from "@/lib/navigation/Tabs/OTab.vue";
 import OTabPanels from "@/lib/navigation/Tabs/OTabPanels.vue";
@@ -500,6 +502,7 @@ const emit = defineEmits(["update:open", "resource-selected"]);
 const store = useStore();
 const router = useRouter();
 const { t } = useI18nTyped();
+const { resolveTracesStream } = useCorrelatedTracesStream(t);
 const relatedResources = ref<any[]>([]);
 const isLoadingRelatedResources = ref(false);
 const selectedResourceWithTrace = ref<any>(null);
@@ -609,7 +612,8 @@ const viewResourceDetails = (resource: any) => {
  * Used when clicking on individual trace icons
  * Opens in a new tab
  */
-const navigateToSpecificTrace = (traceId: string) => {
+const isResolvingTraceNav = ref(false);
+const navigateToSpecificTrace = async (traceId: string) => {
   // Canonicalize: SDK 0.4.x stored ids zero-stripped, but the traces stream
   // (and therefore the trace-details page) uses the padded 32-char form.
   const canonicalTraceId = normalizeTraceId(traceId) || traceId;
@@ -629,20 +633,29 @@ const navigateToSpecificTrace = (traceId: string) => {
     ? resource.date * 1000 + 10000000 // 10 seconds after
     : props.rawEvent?.date * 1000 + 10000000;
 
-  // Build the route object
-  const route = router.resolve({
-    name: "traceDetails",
-    query: {
-      stream: RUM_CORRELATION_TRACES_STREAM,
-      trace_id: canonicalTraceId,
-      from: startTime,
-      to: endTime,
-      org_identifier: store.state.selectedOrganization.identifier,
-    },
-  });
-
-  // Open in new tab
-  window.open(route.href, "_blank");
+  // Popup-safe: window.open after an await loses the user-gesture context and
+  // popup blockers kill the tab — open synchronously, then point the window at
+  // whichever traces stream actually contains the trace (discovered + cached;
+  // falls back to the default correlation stream).
+  const win = window.open("", "_blank");
+  isResolvingTraceNav.value = true;
+  try {
+    const stream = await resolveTracesStream(canonicalTraceId, startTime, endTime);
+    const route = router.resolve({
+      name: "traceDetails",
+      query: {
+        stream,
+        trace_id: canonicalTraceId,
+        from: startTime,
+        to: endTime,
+        org_identifier: store.state.selectedOrganization.identifier,
+      },
+    });
+    if (win) win.location.href = route.href;
+    else window.open(route.href, "_blank");
+  } finally {
+    isResolvingTraceNav.value = false;
+  }
 };
 
 defineExpose({

--- a/web/src/components/rum/PlayerEventsSidebar.spec.ts
+++ b/web/src/components/rum/PlayerEventsSidebar.spec.ts
@@ -243,6 +243,42 @@ describe("PlayerEventsSidebar", () => {
 
       expect(wrapper.find('[data-test="search-input"]').exists()).toBe(false);
     });
+
+    it("keeps the Traces tab alive across toggles — mounts it exactly once", async () => {
+      // Every toggle used to destroy PlayerTracesTab and refire its whole fetch
+      // pipeline via onMounted. KeepAlive must preserve the instance instead.
+      let mountCount = 0;
+      const CountingTracesTab = {
+        name: "PlayerTracesTab",
+        template: '<div data-test="counting-traces-tab" />',
+        props: ["sessionId", "currentTime", "startTime", "endTime"],
+        mounted() {
+          mountCount++;
+        },
+      };
+      wrapper.unmount();
+      wrapper = mount(PlayerEventsSidebar, {
+        attachTo: "#app",
+        props: { events: mockEvents, sessionDetails: mockSessionDetails },
+        global: { plugins: [i18n], stubs: { ...stubs, PlayerTracesTab: CountingTracesTab } },
+      });
+      await wrapper.vm.$nextTick();
+      const appTabs = wrapper.findComponent({ name: "AppTabs" });
+
+      await appTabs.vm.$emit("update:active-tab", "traces");
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-test="counting-traces-tab"]').exists()).toBe(true);
+
+      await appTabs.vm.$emit("update:active-tab", "breadcrumbs");
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-test="counting-traces-tab"]').exists()).toBe(false);
+
+      await appTabs.vm.$emit("update:active-tab", "traces");
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-test="counting-traces-tab"]').exists()).toBe(true);
+
+      expect(mountCount).toBe(1);
+    });
   });
 
   // ==========================================================================

--- a/web/src/components/rum/PlayerEventsSidebar.vue
+++ b/web/src/components/rum/PlayerEventsSidebar.vue
@@ -44,16 +44,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </div>
     </template>
-    <template v-else-if="activeTab === 'traces'">
+    <!-- KeepAlive sits OUTSIDE the tab branch chain so toggling deactivates the
+    traces tab instead of destroying it — a remount used to refire the whole
+    fetch pipeline (rum query + stream resolution + metadata) on every
+    Breadcrumbs↔Traces switch. The sidebar dies with SessionViewer, so nothing
+    leaks across sessions. -->
+    <KeepAlive>
       <PlayerTracesTab
+        v-if="activeTab === 'traces'"
         :session-id="sessionId"
         :current-time="currentTime"
         :start-time="startTime"
         :end-time="endTime"
         @event-emitted="(type, payload) => emit('event-emitted', type, payload)"
       />
-    </template>
-    <template v-else>
+    </KeepAlive>
+    <template v-if="activeTab !== 'tags' && activeTab !== 'traces'">
       <div class="flex w-full items-center justify-between px-1.5 pt-2">
         <div class="w-[60%] pr-1">
           <OInput

--- a/web/src/components/rum/PlayerTracesTab.spec.ts
+++ b/web/src/components/rum/PlayerTracesTab.spec.ts
@@ -297,6 +297,28 @@ describe("PlayerTracesTab", () => {
       expect(wrapper.text()).toContain("/products");
     });
 
+    it("joins legacy zero-stripped RUM ids with padded traces-stream metadata", async () => {
+      // SDK 0.4.x stored the id zero-stripped (31 hex chars) in _rumdata while
+      // the traces stream stores the padded 32-char form — the join must still hit.
+      setupSuccessfulMocks(
+        [createRumHit({ _trace_id: "1a034c1aabc72f78880daf6c9755cff" })],
+        [createTraceMetadata({ trace_id: "01a034c1aabc72f78880daf6c9755cff" })],
+      );
+      wrapper.unmount();
+      wrapper = mountComponent();
+      await flushPromises();
+
+      // Row survives the metadata filter (previously dropped: raw 31-char key
+      // never matched the 32-char metadata key)
+      expect(wrapper.find('[data-test="rum-player-traces-tab-table"]').exists()).toBe(true);
+      expect(wrapper.text()).toContain("/products");
+
+      // The traces-stream metadata query was filtered on the padded id
+      const queryReq = mockFetchQueryDataWithHttpStream.mock.calls[0][0].queryReq;
+      expect(queryReq.filter).toContain("01a034c1aabc72f78880daf6c9755cff");
+      expect(queryReq.stream_name).toBe("default");
+    });
+
     it("should display trace count badge in filter bar", () => {
       const badge = wrapper.find('[data-test="rum-player-traces-tab-count-badge"]');
       expect(badge.exists()).toBe(true);

--- a/web/src/components/rum/PlayerTracesTab.spec.ts
+++ b/web/src/components/rum/PlayerTracesTab.spec.ts
@@ -57,6 +57,14 @@ vi.mock("@/composables/useStreamingSearch", () => ({
   }),
 }));
 
+// Stream discovery: default resolves nothing so every row falls back to the
+// default stream and the pre-discovery tests keep their single-call shape;
+// individual tests override with per-id streams.
+const mockResolveTracesStreamsBulk = vi.fn().mockResolvedValue({});
+vi.mock("@/composables/rum/useCorrelatedTracesStream", () => ({
+  default: () => ({ resolveTracesStreamsBulk: mockResolveTracesStreamsBulk }),
+}));
+
 // ---------------------------------------------------------------------------
 // Test data factories
 // ---------------------------------------------------------------------------
@@ -295,6 +303,67 @@ describe("PlayerTracesTab", () => {
 
     it("should display the route path in the table row", () => {
       expect(wrapper.text()).toContain("/products");
+    });
+
+    it("gives each row its own stream and fetches metadata per distinct stream", async () => {
+      const P1 = "01a034c1aabc72f78880daf6c9755cff"; // → payments_traces
+      const C1 = "01a038ddccc770b9bba3b2df20c12415"; // → checkout_traces
+      mockResolveTracesStreamsBulk.mockResolvedValueOnce({
+        [P1]: "payments_traces",
+        [C1]: "checkout_traces",
+      });
+
+      // RUM hits for both ids; metadata mock answers per queried stream.
+      mockSearch.mockReset();
+      mockFetchQueryDataWithHttpStream.mockReset();
+      mockSearch.mockImplementation((_params: any, source: string) =>
+        Promise.resolve(
+          source === "RUM"
+            ? {
+                data: {
+                  hits: [
+                    createRumHit({ _trace_id: P1, _view_url: "https://example.com/pay" }),
+                    createRumHit({ _trace_id: C1, _view_url: "https://example.com/checkout" }),
+                  ],
+                },
+              }
+            : { data: { hits: [] } },
+        ),
+      );
+      mockFetchQueryDataWithHttpStream.mockImplementation((args: any, handlers: any) => {
+        const stream = args.queryReq.stream_name;
+        const id = stream === "payments_traces" ? P1 : C1;
+        handlers.data(null, {
+          content: { results: { hits: [createTraceMetadata({ trace_id: id })] } },
+        });
+        handlers.complete();
+      });
+
+      wrapper.unmount();
+      wrapper = mountComponent();
+      await flushPromises();
+
+      // metadata fetched once per distinct stream
+      const streamsQueried = mockFetchQueryDataWithHttpStream.mock.calls.map(
+        ([args]: any[]) => args.queryReq.stream_name,
+      );
+      expect(streamsQueried.sort()).toEqual(["checkout_traces", "payments_traces"]);
+
+      // both rows render, each carrying its own stream context
+      expect(wrapper.text()).toContain("/pay");
+      expect(wrapper.text()).toContain("/checkout");
+
+      // clicking the checkout row opens the embedded view against ITS stream
+      const rows = wrapper.findAll('[data-test^="table-row-"]');
+      const checkoutRow = rows.find((r: any) => r.text().includes("/checkout"));
+      expect(checkoutRow).toBeDefined();
+      await checkoutRow!.trigger("click");
+      await flushPromises();
+
+      const traceDetails = wrapper.findComponent({ name: "TraceDetails" });
+      expect(traceDetails.exists()).toBe(true);
+      expect(traceDetails.props("streamNameProp")).toBe("checkout_traces");
+      expect(traceDetails.props("traceIdProp")).toBe(C1);
     });
 
     it("joins legacy zero-stripped RUM ids with padded traces-stream metadata", async () => {

--- a/web/src/components/rum/PlayerTracesTab.vue
+++ b/web/src/components/rum/PlayerTracesTab.vue
@@ -125,7 +125,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           ref="traceDetailsRef"
           mode="embedded"
           :trace-id-prop="selectedTrace.traceId"
-          stream-name-prop="default"
+          :stream-name-prop="RUM_CORRELATION_TRACES_STREAM"
           :span-list-prop="[]"
           :start-time-prop="selectedTraceStartTime"
           :end-time-prop="selectedTraceEndTime"
@@ -212,7 +212,12 @@ import { useStore } from "vuex";
 import { useI18nTyped } from "@/types/i18n";
 import searchService from "@/services/search";
 import useStreams from "@/composables/useStreams";
-import { rumFieldSql, rumFieldNotNullSql } from "@/utils/rum/fields";
+import {
+  rumFieldSql,
+  rumFieldNotNullSql,
+  normalizeTraceId,
+  RUM_CORRELATION_TRACES_STREAM,
+} from "@/utils/rum/fields";
 import { formatTimeWithSuffix, formatLargeNumber, generateTraceContext } from "@/utils/zincutils";
 import useHttpStreaming from "@/composables/useStreamingSearch";
 import OButton from "@/lib/core/Button/OButton.vue";
@@ -374,7 +379,7 @@ async function fetchTraceMetadata(traceIds: string[]): Promise<Record<string, an
     fetchQueryDataWithHttpStream(
       {
         queryReq: {
-          stream_name: "default",
+          stream_name: RUM_CORRELATION_TRACES_STREAM,
           filter,
           start_time: searchStartTime,
           end_time: searchEndTime,
@@ -481,10 +486,13 @@ async function fetchTraces() {
       return;
     }
 
-    // Deduplicate by trace_id, keep first occurrence for view context
+    // Deduplicate by trace_id, keep first occurrence for view context.
+    // Canonicalize the id: SDK 0.4.x stored it zero-stripped, while the traces
+    // stream stores the padded 32-char form — the metadata join and the embedded
+    // trace view both need the stream's form.
     const traceMap = new Map<string, any>();
     for (const hit of rumHits) {
-      const traceId = hit._trace_id;
+      const traceId = normalizeTraceId(hit._trace_id) || hit._trace_id;
       if (!traceId || traceMap.has(traceId)) continue;
       const viewUrl = hit._view_url || hit.view_url || "";
       traceMap.set(traceId, {

--- a/web/src/components/rum/PlayerTracesTab.vue
+++ b/web/src/components/rum/PlayerTracesTab.vue
@@ -125,7 +125,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           ref="traceDetailsRef"
           mode="embedded"
           :trace-id-prop="selectedTrace.traceId"
-          :stream-name-prop="RUM_CORRELATION_TRACES_STREAM"
+          :stream-name-prop="selectedTrace.stream || RUM_CORRELATION_TRACES_STREAM"
           :span-list-prop="[]"
           :start-time-prop="selectedTraceStartTime"
           :end-time-prop="selectedTraceEndTime"
@@ -220,6 +220,7 @@ import {
 } from "@/utils/rum/fields";
 import { formatTimeWithSuffix, formatLargeNumber, generateTraceContext } from "@/utils/zincutils";
 import useHttpStreaming from "@/composables/useStreamingSearch";
+import useCorrelatedTracesStream from "@/composables/rum/useCorrelatedTracesStream";
 import OButton from "@/lib/core/Button/OButton.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
@@ -232,6 +233,7 @@ import TraceDetails from "@/plugins/traces/TraceDetails.vue";
 const { t } = useI18nTyped();
 const store = useStore();
 const { getStream } = useStreams(t);
+const { resolveTracesStreamsBulk } = useCorrelatedTracesStream(t);
 
 const props = defineProps({
   sessionId: {
@@ -357,7 +359,10 @@ function traceTimeOffset(startTimeNs: number): string {
 }
 
 // ── Data fetching ───────────────────────────────────────────
-async function fetchTraceMetadata(traceIds: string[]): Promise<Record<string, any>> {
+async function fetchTraceMetadata(
+  traceIds: string[],
+  streamName: string,
+): Promise<Record<string, any>> {
   if (traceIds.length === 0) return {};
 
   const orgId = store.state.selectedOrganization.identifier;
@@ -379,7 +384,7 @@ async function fetchTraceMetadata(traceIds: string[]): Promise<Record<string, an
     fetchQueryDataWithHttpStream(
       {
         queryReq: {
-          stream_name: RUM_CORRELATION_TRACES_STREAM,
+          stream_name: streamName,
           filter,
           start_time: searchStartTime,
           end_time: searchEndTime,
@@ -515,7 +520,31 @@ async function fetchTraces() {
     if (views.length > 0) {
       metadataLoading.value = true;
       try {
-        const metadata = await fetchTraceMetadata(views.map((v) => v.traceId));
+        // Which stream holds each trace (one bulk request; cached in the store).
+        // Every row keeps ITS OWN stream so multi-stream sessions list fully and
+        // each click opens against the right stream; unresolved ids fall back to
+        // the default correlation stream — today's behavior.
+        const streamById = await resolveTracesStreamsBulk(
+          views.map((v) => v.traceId),
+          searchStartTime,
+          searchEndTime,
+        );
+        for (const view of views as any[]) {
+          view.stream = streamById[view.traceId] ?? RUM_CORRELATION_TRACES_STREAM;
+        }
+
+        // Metadata is fetched per distinct stream (usually one, at most a few).
+        const idsByStream = new Map<string, string[]>();
+        for (const view of views as any[]) {
+          const ids = idsByStream.get(view.stream) ?? [];
+          ids.push(view.traceId);
+          idsByStream.set(view.stream, ids);
+        }
+        const metadata: Record<string, any> = {};
+        const metadataPerStream = await Promise.all(
+          [...idsByStream.entries()].map(([stream, ids]) => fetchTraceMetadata(ids, stream)),
+        );
+        for (const part of metadataPerStream) Object.assign(metadata, part);
 
         // Only keep views whose trace_id exists in the traces stream, sorted by start time
         filteredViews = views

--- a/web/src/composables/rum/useCorrelatedTracesStream.spec.ts
+++ b/web/src/composables/rum/useCorrelatedTracesStream.spec.ts
@@ -1,0 +1,278 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import useCorrelatedTracesStream from "@/composables/rum/useCorrelatedTracesStream";
+import i18nInstance from "@/locales";
+const t = (i18nInstance.global as any).t;
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+const mockFetchQueryDataWithHttpStream = vi.fn();
+vi.mock("@/composables/useStreamingSearch", () => ({
+  default: () => ({
+    fetchQueryDataWithHttpStream: (...args: any[]) => mockFetchQueryDataWithHttpStream(...args),
+  }),
+}));
+
+const mockGetStreams = vi.fn();
+vi.mock("@/composables/useStreams", () => ({
+  default: () => ({ getStreams: mockGetStreams }),
+}));
+
+vi.mock("@/utils/zincutils", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return { ...actual, generateTraceContext: () => ({ traceId: "mock-trace-context-id" }) };
+});
+
+// A store mock whose commit REALLY mutates state, mirroring the production
+// setCorrelatedTracesStream mutation, so caching behavior is observable.
+const mockStoreState = {
+  selectedOrganization: { identifier: "test-org" },
+  organizationData: {
+    correlatedTracesStreams: {
+      byTraceId: {} as Record<string, string>,
+      knownStreams: [] as string[],
+    },
+  },
+};
+const mockCommit = vi.fn((type: string, payload: any) => {
+  if (type !== "setCorrelatedTracesStream") return;
+  const cache = mockStoreState.organizationData.correlatedTracesStreams;
+  if (Object.keys(cache.byTraceId).length >= 1000) cache.byTraceId = {};
+  cache.byTraceId[payload.traceId] = payload.stream;
+  if (!cache.knownStreams.includes(payload.stream)) cache.knownStreams.push(payload.stream);
+});
+vi.mock("vuex", () => ({
+  useStore: () => ({ state: mockStoreState, commit: mockCommit }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const T1 = "01a034c1aabc72f78880daf6c9755cff";
+const T2 = "0badc0ffee0ddf00dd15ea5eba5eba11";
+const T3 = "01a038ddccc770b9bba3b2df20c12415";
+
+function streamOfSql(sql: string): string {
+  return sql.match(/from "([^"]+)"/)?.[1] ?? "";
+}
+
+function idsOfSql(sql: string): string[] {
+  return [...sql.matchAll(/[0-9a-f]{32}/g)].map((m) => m[0]);
+}
+
+/**
+ * Configure the batched client: for each sub-query, emit hit chunks (tagged
+ * with query_index) for ids present in `hitsByStream`, then complete. Chunks
+ * are emitted in REVERSE sub-query order to simulate nondeterministic arrival.
+ */
+function mockBatch(hitsByStream: Record<string, string[]>) {
+  mockFetchQueryDataWithHttpStream.mockImplementation((args: any, handlers: any) => {
+    const sqls: string[] = args.queryReq.query.sql;
+    const chunks: any[] = [];
+    sqls.forEach((sql, queryIndex) => {
+      const stream = streamOfSql(sql);
+      const wanted = idsOfSql(sql);
+      const present = (hitsByStream[stream] ?? []).filter((id) => wanted.includes(id));
+      if (present.length) {
+        chunks.push({
+          type: "search_response_hits",
+          content: {
+            results: { hits: present.map((id) => ({ trace_id: id })), query_index: queryIndex },
+          },
+        });
+      }
+    });
+    // reversed: later sub-queries "arrive" first
+    for (const chunk of chunks.reverse()) handlers.data(null, chunk);
+    handlers.complete();
+    return Promise.resolve();
+  });
+}
+
+function batchCalls(): string[][] {
+  return mockFetchQueryDataWithHttpStream.mock.calls.map(([args]: any[]) =>
+    args.queryReq.query.sql.map(streamOfSql),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("useCorrelatedTracesStream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStoreState.organizationData.correlatedTracesStreams = { byTraceId: {}, knownStreams: [] };
+    mockGetStreams.mockResolvedValue({
+      list: [{ name: "payments_traces" }, { name: "default" }, { name: "checkout_traces" }],
+    });
+  });
+
+  it("① first-ever id: one batch over all streams, default ordered first, seeds knownStreams", async () => {
+    mockBatch({ payments_traces: [T1] });
+    const { resolveTracesStream } = useCorrelatedTracesStream(t);
+
+    expect(await resolveTracesStream(T1, 1_000, 2_000)).toBe("payments_traces");
+    expect(batchCalls()).toEqual([["default", "payments_traces", "checkout_traces"]]);
+    expect(mockStoreState.organizationData.correlatedTracesStreams.knownStreams).toEqual([
+      "payments_traces",
+    ]);
+  });
+
+  it("①b second new id probes ONLY knownStreams — no full batch", async () => {
+    mockBatch({ payments_traces: [T1, T2] });
+    const { resolveTracesStream } = useCorrelatedTracesStream(t);
+    await resolveTracesStream(T1, 1_000, 2_000);
+    mockFetchQueryDataWithHttpStream.mockClear();
+
+    expect(await resolveTracesStream(T2, 1_000, 2_000)).toBe("payments_traces");
+    expect(batchCalls()).toEqual([["payments_traces"]]);
+  });
+
+  it("② single-stream org: that stream is the answer, zero probes", async () => {
+    mockGetStreams.mockResolvedValue({ list: [{ name: "only_traces" }] });
+    const { resolveTracesStream } = useCorrelatedTracesStream(t);
+
+    expect(await resolveTracesStream(T1, 1_000, 2_000)).toBe("only_traces");
+    expect(mockFetchQueryDataWithHttpStream).not.toHaveBeenCalled();
+  });
+
+  it("③ same id in two streams: first in stream order wins regardless of arrival order", async () => {
+    // T1 exists in default AND checkout; chunks arrive reversed (checkout first)
+    mockBatch({ default: [T1], checkout_traces: [T1] });
+    const { resolveTracesStream } = useCorrelatedTracesStream(t);
+
+    expect(await resolveTracesStream(T1, 1_000, 2_000)).toBe("default");
+  });
+
+  it("④ second resolve of the same id reads the cache: zero queries", async () => {
+    mockBatch({ payments_traces: [T1] });
+    const { resolveTracesStream } = useCorrelatedTracesStream(t);
+    await resolveTracesStream(T1, 1_000, 2_000);
+    mockFetchQueryDataWithHttpStream.mockClear();
+    mockGetStreams.mockClear();
+
+    expect(await resolveTracesStream(T1, 1_000, 2_000)).toBe("payments_traces");
+    expect(mockFetchQueryDataWithHttpStream).not.toHaveBeenCalled();
+    expect(mockGetStreams).not.toHaveBeenCalled();
+  });
+
+  it("⑤ all-miss returns default and caches nothing", async () => {
+    mockBatch({});
+    const { resolveTracesStream } = useCorrelatedTracesStream(t);
+
+    expect(await resolveTracesStream(T1, 1_000, 2_000)).toBe("default");
+    expect(mockStoreState.organizationData.correlatedTracesStreams.byTraceId).toEqual({});
+    expect(mockCommit).not.toHaveBeenCalled();
+  });
+
+  it("⑥ errors everywhere: returns default, never rejects", async () => {
+    mockGetStreams.mockRejectedValue(new Error("boom"));
+    mockFetchQueryDataWithHttpStream.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const { resolveTracesStream } = useCorrelatedTracesStream(t);
+
+    await expect(resolveTracesStream(T1, 1_000, 2_000)).resolves.toBe("default");
+  });
+
+  it("⑦ legacy 31-char input probes the padded canonical id", async () => {
+    mockBatch({ default: [T1] });
+    const { resolveTracesStream } = useCorrelatedTracesStream(t);
+
+    // T1 minus its leading zero, as SDK 0.4.x stored it
+    expect(await resolveTracesStream(T1.slice(1), 1_000, 2_000)).toBe("default");
+    const sql = mockFetchQueryDataWithHttpStream.mock.calls[0][0].queryReq.query.sql[0];
+    expect(sql).toContain(`'${T1}'`);
+    expect(sql).not.toContain(`'${T1.slice(1)}'`);
+  });
+
+  it("⑧ two concurrent resolves of one id share a single probe pass", async () => {
+    mockBatch({ payments_traces: [T1] });
+    const { resolveTracesStream } = useCorrelatedTracesStream(t);
+
+    const [a, b] = await Promise.all([
+      resolveTracesStream(T1, 1_000, 2_000),
+      resolveTracesStream(T1, 1_000, 2_000),
+    ]);
+
+    expect(a).toBe("payments_traces");
+    expect(b).toBe("payments_traces");
+    expect(mockFetchQueryDataWithHttpStream).toHaveBeenCalledTimes(1);
+  });
+
+  describe("resolveTracesStreamsBulk", () => {
+    it("resolves the whole id-set in one request and returns id→stream pairs", async () => {
+      mockBatch({ payments_traces: [T1, T2], checkout_traces: [T3] });
+      const { resolveTracesStreamsBulk } = useCorrelatedTracesStream(t);
+
+      const result = await resolveTracesStreamsBulk([T1, T2, T3], 1_000, 2_000);
+
+      expect(result).toEqual({
+        [T1]: "payments_traces",
+        [T2]: "payments_traces",
+        [T3]: "checkout_traces",
+      });
+      // cold: knownStreams empty → step 1 covers ALL streams → no second request
+      expect(mockFetchQueryDataWithHttpStream).toHaveBeenCalledTimes(1);
+    });
+
+    it("escalates only unresolved ids to unprobed streams (step 2)", async () => {
+      mockBatch({ payments_traces: [T1], checkout_traces: [T3] });
+      const { resolveTracesStream, resolveTracesStreamsBulk } = useCorrelatedTracesStream(t);
+      // learn payments first so step 1 probes only knownStreams
+      await resolveTracesStream(T1, 1_000, 2_000);
+      mockFetchQueryDataWithHttpStream.mockClear();
+
+      const result = await resolveTracesStreamsBulk([T2, T3], 1_000, 2_000);
+
+      // T3 found in checkout via escalation; T2 exists nowhere → absent
+      expect(result).toEqual({ [T3]: "checkout_traces" });
+      const calls = batchCalls();
+      expect(calls[0]).toEqual(["payments_traces"]); // step 1: knownStreams only
+      expect(calls[1]).toEqual(["default", "checkout_traces"]); // step 2: the rest
+      // step 2 asked only for the unresolved ids
+      const step2Sql: string[] =
+        mockFetchQueryDataWithHttpStream.mock.calls[1][0].queryReq.query.sql;
+      for (const sql of step2Sql) {
+        expect(idsOfSql(sql).sort()).toEqual([T3, T2].sort());
+      }
+      expect(mockStoreState.organizationData.correlatedTracesStreams.knownStreams).toContain(
+        "checkout_traces",
+      );
+    });
+
+    it("merges already-cached ids without probing them", async () => {
+      mockBatch({ payments_traces: [T1, T2] });
+      const { resolveTracesStream, resolveTracesStreamsBulk } = useCorrelatedTracesStream(t);
+      await resolveTracesStream(T1, 1_000, 2_000);
+      mockFetchQueryDataWithHttpStream.mockClear();
+
+      const result = await resolveTracesStreamsBulk([T1, T2], 1_000, 2_000);
+
+      expect(result[T1]).toBe("payments_traces");
+      expect(result[T2]).toBe("payments_traces");
+      const probedIds = mockFetchQueryDataWithHttpStream.mock.calls.flatMap(([args]: any[]) =>
+        args.queryReq.query.sql.flatMap(idsOfSql),
+      );
+      expect(probedIds).not.toContain(T1);
+    });
+  });
+});

--- a/web/src/composables/rum/useCorrelatedTracesStream.spec.ts
+++ b/web/src/composables/rum/useCorrelatedTracesStream.spec.ts
@@ -78,29 +78,39 @@ function idsOfSql(sql: string): string[] {
 }
 
 /**
- * Configure the batched client: for each sub-query, emit hit chunks (tagged
- * with query_index) for ids present in `hitsByStream`, then complete. Chunks
- * are emitted in REVERSE sub-query order to simulate nondeterministic arrival.
+ * Configure the batched client modeling the REAL wire shape (verified live):
+ * each sub-query emits a `search_response_metadata` event whose results carry
+ * `query_index`, followed by a separate `search_response_hits` event that has
+ * ONLY `{hits}` — no query_index. Pairs are emitted in REVERSE sub-query order
+ * to simulate nondeterministic arrival, and hits duplicate per span row (the
+ * probe scans span rows, not distinct traces).
  */
 function mockBatch(hitsByStream: Record<string, string[]>) {
   mockFetchQueryDataWithHttpStream.mockImplementation((args: any, handlers: any) => {
     const sqls: string[] = args.queryReq.query.sql;
-    const chunks: any[] = [];
+    const pairs: any[][] = [];
     sqls.forEach((sql, queryIndex) => {
       const stream = streamOfSql(sql);
       const wanted = idsOfSql(sql);
       const present = (hitsByStream[stream] ?? []).filter((id) => wanted.includes(id));
-      if (present.length) {
-        chunks.push({
+      // every sub-query emits its metadata event, hits or not (as on the wire)
+      pairs.push([
+        {
+          type: "search_response_metadata",
+          content: { results: { hits: [], total: present.length, query_index: queryIndex } },
+        },
+        {
           type: "search_response_hits",
           content: {
-            results: { hits: present.map((id) => ({ trace_id: id })), query_index: queryIndex },
+            // duplicate rows: real traces have many spans per id
+            results: { hits: present.flatMap((id) => [{ trace_id: id }, { trace_id: id }]) },
           },
-        });
-      }
+        },
+      ]);
     });
-    // reversed: later sub-queries "arrive" first
-    for (const chunk of chunks.reverse()) handlers.data(null, chunk);
+    for (const pair of pairs.reverse()) {
+      for (const chunk of pair) handlers.data(null, chunk);
+    }
     handlers.complete();
     return Promise.resolve();
   });
@@ -202,6 +212,9 @@ describe("useCorrelatedTracesStream", () => {
     const sql = mockFetchQueryDataWithHttpStream.mock.calls[0][0].queryReq.query.sql[0];
     expect(sql).toContain(`'${T1}'`);
     expect(sql).not.toContain(`'${T1.slice(1)}'`);
+    // probes must count distinct traces, not span rows — a single trace's
+    // spans would otherwise consume the whole limit (found live on pentest)
+    expect(sql.toLowerCase()).toContain("select distinct trace_id");
   });
 
   it("⑧ two concurrent resolves of one id share a single probe pass", async () => {

--- a/web/src/composables/rum/useCorrelatedTracesStream.ts
+++ b/web/src/composables/rum/useCorrelatedTracesStream.ts
@@ -88,9 +88,12 @@ export default function useCorrelatedTracesStream(t: TranslateFn) {
   ): Promise<Record<string, string>> => {
     if (!streams.length || !traceIds.length) return {};
     const idList = traceIds.map((id) => `'${id}'`).join(",");
+    // DISTINCT is load-bearing: the probe scans span rows, and one trace's
+    // spans would otherwise consume the whole limit, leaving sibling ids
+    // unresolved (observed live).
     const sqls = streams.map(
       (stream) =>
-        `select trace_id from "${stream}" where trace_id IN (${idList}) limit ${traceIds.length}`,
+        `select distinct trace_id from "${stream}" where trace_id IN (${idList}) limit ${traceIds.length}`,
     );
 
     // hits[streamIndex] = set of ids found in that stream
@@ -116,17 +119,34 @@ export default function useCorrelatedTracesStream(t: TranslateFn) {
             searchType: "UI",
           },
           {
-            data: (_payload: any, response: any) => {
-              const results = response?.content?.results;
-              const queryIndex = results?.query_index;
-              const hits = results?.hits;
-              if (typeof queryIndex !== "number" || !Array.isArray(hits)) return;
-              const bucket = hitsByStreamIndex[queryIndex];
-              if (!bucket) return;
-              for (const hit of hits) {
-                if (typeof hit?.trace_id === "string") bucket.add(hit.trace_id);
-              }
-            },
+            // Wire shape (verified live): each sub-query emits a
+            // `search_response_metadata` event whose results carry
+            // `query_index`, followed by a separate `search_response_hits`
+            // event that has ONLY `{hits}`. Events arrive strictly paired in
+            // SSE order, so the last metadata's index attributes the hits
+            // that follow it.
+            data: (() => {
+              let lastQueryIndex: number | null = null;
+              const harvest = (hits: unknown, queryIndex: number | null) => {
+                if (queryIndex === null || !Array.isArray(hits)) return;
+                const bucket = hitsByStreamIndex[queryIndex];
+                if (!bucket) return;
+                for (const hit of hits) {
+                  if (typeof hit?.trace_id === "string") bucket.add(hit.trace_id);
+                }
+              };
+              return (_payload: any, response: any) => {
+                const results = response?.content?.results;
+                const ownIndex =
+                  typeof results?.query_index === "number" ? results.query_index : null;
+                if (response?.type === "search_response_metadata") {
+                  lastQueryIndex = ownIndex;
+                  harvest(results?.hits, ownIndex);
+                } else {
+                  harvest(results?.hits, ownIndex ?? lastQueryIndex);
+                }
+              };
+            })(),
             error: () => resolve(), // a failed sub-query is a miss, not an error
             complete: () => resolve(),
             reset: () => {},

--- a/web/src/composables/rum/useCorrelatedTracesStream.ts
+++ b/web/src/composables/rum/useCorrelatedTracesStream.ts
@@ -1,0 +1,241 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { useStore } from "vuex";
+import type { TranslateFn } from "@/types/i18n";
+import useStreams from "@/composables/useStreams";
+import useHttpStreaming from "@/composables/useStreamingSearch";
+import { generateTraceContext } from "@/utils/zincutils";
+import { normalizeTraceId, RUM_CORRELATION_TRACES_STREAM } from "@/utils/rum/fields";
+
+// Probes look up a trace by id, but the caller's window is event-derived and
+// ingestion can lag it — widen like useRumSpanBuilder's RUM_TIME_BUFFER_US,
+// but generously: probes are `limit 1` point lookups, so the wider window is
+// effectively free.
+const PROBE_TIME_BUFFER_US = 300_000_000; // ±5 min
+
+// Deduplicates concurrent resolves of the same id (e.g. the error card and the
+// Traces tab racing on page load). Transient in-progress work, deliberately
+// NOT in the Vuex store: entries delete themselves on settle, so org-switch
+// staleness cannot apply.
+const inFlight = new Map<string, Promise<string>>();
+
+/**
+ * Discovers which traces stream contains a given trace id.
+ *
+ * The RUM correlation surfaces (error card, session Traces tab, event-drawer
+ * navigation) have no stream picker, and assuming the backend's OTLP default
+ * silently breaks every flow for orgs exporting traces to a named stream. A
+ * trace id is globally unique, so probing streams for it is unambiguous: a
+ * probe can only miss, never match the wrong trace.
+ *
+ * Layers (see the discovery spec):
+ * - `byTraceId` (store): per-trace answers, shared across surfaces/remounts.
+ * - `knownStreams` (store): the org-level learned fact — probe only streams
+ *   that have ever contained a correlated trace; a miss escalates to the full
+ *   stream list and the newly found stream is learned.
+ * Every failure path returns RUM_CORRELATION_TRACES_STREAM, reproducing the
+ * pre-discovery behavior; misses are never cached so ingestion lag self-heals.
+ */
+export default function useCorrelatedTracesStream(t: TranslateFn) {
+  const store = useStore();
+  const { getStreams } = useStreams(t);
+  const { fetchQueryDataWithHttpStream } = useHttpStreaming();
+
+  const cache = () => store.state.organizationData.correlatedTracesStreams;
+
+  const listTracesStreams = async (): Promise<string[]> => {
+    try {
+      const res = (await getStreams("traces", false)) as { list: { name: string }[] };
+      const names = (res?.list ?? []).map((option) => option.name);
+      // Deterministic probe order: default first, then the list order.
+      names.sort((a, b) => {
+        if (a === RUM_CORRELATION_TRACES_STREAM) return -1;
+        if (b === RUM_CORRELATION_TRACES_STREAM) return 1;
+        return 0;
+      });
+      return names;
+    } catch (err: unknown) {
+      console.error("Failed to get traces streams", err);
+      return [];
+    }
+  };
+
+  /**
+   * One `_search_multi_stream` request probing `streams` for `traceIds`.
+   * Returns id → stream for every id found. Chunks are attributed via
+   * `results.query_index` (the sub-query's position in the sql array) and
+   * collected until `complete`; ties resolve to the FIRST stream in `streams`
+   * order — never to arrival order, which is nondeterministic.
+   */
+  const probeBatch = async (
+    streams: string[],
+    traceIds: string[],
+    startTimeUs: number,
+    endTimeUs: number,
+  ): Promise<Record<string, string>> => {
+    if (!streams.length || !traceIds.length) return {};
+    const idList = traceIds.map((id) => `'${id}'`).join(",");
+    const sqls = streams.map(
+      (stream) =>
+        `select trace_id from "${stream}" where trace_id IN (${idList}) limit ${traceIds.length}`,
+    );
+
+    // hits[streamIndex] = set of ids found in that stream
+    const hitsByStreamIndex: Array<Set<string>> = streams.map(() => new Set());
+
+    try {
+      await new Promise<void>((resolve) => {
+        fetchQueryDataWithHttpStream(
+          {
+            queryReq: {
+              query: {
+                sql: sqls, // string[] → auto-routes to _search_multi_stream
+                sql_mode: "full",
+                start_time: startTimeUs - PROBE_TIME_BUFFER_US,
+                end_time: endTimeUs + PROBE_TIME_BUFFER_US,
+                size: traceIds.length,
+              },
+            },
+            type: "search",
+            traceId: generateTraceContext()?.traceId ?? "",
+            org_id: store.state.selectedOrganization.identifier,
+            pageType: "traces",
+            searchType: "UI",
+          },
+          {
+            data: (_payload: any, response: any) => {
+              const results = response?.content?.results;
+              const queryIndex = results?.query_index;
+              const hits = results?.hits;
+              if (typeof queryIndex !== "number" || !Array.isArray(hits)) return;
+              const bucket = hitsByStreamIndex[queryIndex];
+              if (!bucket) return;
+              for (const hit of hits) {
+                if (typeof hit?.trace_id === "string") bucket.add(hit.trace_id);
+              }
+            },
+            error: () => resolve(), // a failed sub-query is a miss, not an error
+            complete: () => resolve(),
+            reset: () => {},
+          },
+        )?.catch?.(() => resolve());
+      });
+    } catch {
+      return {};
+    }
+
+    // First stream in probe order wins ties (edge case 16).
+    const found: Record<string, string> = {};
+    streams.forEach((stream, index) => {
+      for (const id of hitsByStreamIndex[index]) {
+        if (!(id in found)) found[id] = stream;
+      }
+    });
+    return found;
+  };
+
+  const record = (traceId: string, stream: string) => {
+    store.commit("setCorrelatedTracesStream", { traceId, stream });
+  };
+
+  /**
+   * id → stream for every id found (absent = found nowhere; callers fall back
+   * to RUM_CORRELATION_TRACES_STREAM per id). Two-step escalation: probe
+   * `knownStreams` for the whole set first; only unresolved ids go on to the
+   * remaining streams. Never rejects.
+   */
+  const resolveTracesStreamsBulk = async (
+    traceIds: string[],
+    startTimeUs: number,
+    endTimeUs: number,
+  ): Promise<Record<string, string>> => {
+    try {
+      const result: Record<string, string> = {};
+      const toResolve: string[] = [];
+      for (const rawId of traceIds) {
+        const canonical = normalizeTraceId(rawId);
+        if (!canonical) continue;
+        const cached = cache().byTraceId[canonical];
+        if (cached) result[canonical] = cached;
+        else if (!toResolve.includes(canonical)) toResolve.push(canonical);
+      }
+      if (!toResolve.length) return result;
+
+      const allStreams = await listTracesStreams();
+      if (!allStreams.length) return result;
+      if (allStreams.length === 1) {
+        for (const id of toResolve) {
+          result[id] = allStreams[0];
+          record(id, allStreams[0]);
+        }
+        return result;
+      }
+
+      const known: string[] = cache().knownStreams.filter((s: string) => allStreams.includes(s));
+      const step1Streams = known.length ? known : allStreams;
+      const step1 = await probeBatch(step1Streams, toResolve, startTimeUs, endTimeUs);
+      for (const [id, stream] of Object.entries(step1)) {
+        result[id] = stream;
+        record(id, stream);
+      }
+
+      // Step 2: only unresolved ids, only unprobed streams.
+      const unresolved = toResolve.filter((id) => !(id in result));
+      const unprobed = allStreams.filter((s) => !step1Streams.includes(s));
+      if (unresolved.length && unprobed.length) {
+        const step2 = await probeBatch(unprobed, unresolved, startTimeUs, endTimeUs);
+        for (const [id, stream] of Object.entries(step2)) {
+          result[id] = stream;
+          record(id, stream);
+        }
+      }
+      return result;
+    } catch (err: unknown) {
+      console.error("Failed to resolve traces streams", err);
+      return {};
+    }
+  };
+
+  /**
+   * The stream containing `traceId`, else RUM_CORRELATION_TRACES_STREAM.
+   * Never rejects.
+   */
+  const resolveTracesStream = async (
+    traceId: string,
+    startTimeUs: number,
+    endTimeUs: number,
+  ): Promise<string> => {
+    const canonical = normalizeTraceId(traceId);
+    if (!canonical) return RUM_CORRELATION_TRACES_STREAM;
+
+    const cached = cache().byTraceId[canonical];
+    if (cached) return cached;
+
+    const pending = inFlight.get(canonical);
+    if (pending) return pending;
+
+    const promise = (async () => {
+      const found = await resolveTracesStreamsBulk([canonical], startTimeUs, endTimeUs);
+      return found[canonical] ?? RUM_CORRELATION_TRACES_STREAM;
+    })().finally(() => {
+      inFlight.delete(canonical);
+    });
+    inFlight.set(canonical, promise);
+    return promise;
+  };
+
+  return { resolveTracesStream, resolveTracesStreamsBulk };
+}

--- a/web/src/composables/rum/useRumSpanBuilder.spec.ts
+++ b/web/src/composables/rum/useRumSpanBuilder.spec.ts
@@ -342,6 +342,37 @@ describe("useRumSpanBuilder", () => {
   });
 
   // =========================================================================
+  // fetchRumEventsForTrace — padded/legacy trace-id variants
+  // =========================================================================
+
+  describe("fetchRumEventsForTrace — trace-id variants", () => {
+    it("should query both padded and legacy zero-stripped trace ids", async () => {
+      vi.mocked(searchService.search).mockResolvedValue(makeSearchResponse([]));
+
+      const { fetchRumEventsForTrace } = buildComposable(["_rumdata"]);
+      // 32-char canonical id as it arrives from the traces page; SDK 0.4.x
+      // stored the same id zero-stripped (31 chars) in _rumdata
+      await fetchRumEventsForTrace("01a034c1aabc72f78880daf6c9755cff", 1_000_000, 2_000_000);
+
+      const sql: string = vi.mocked(searchService.search).mock.calls[0][0].query.query
+        .sql as string;
+      expect(sql).toContain("= '01a034c1aabc72f78880daf6c9755cff'");
+      expect(sql).toContain("= '1a034c1aabc72f78880daf6c9755cff'");
+    });
+
+    it("should keep exact matching for non-hex ids", async () => {
+      vi.mocked(searchService.search).mockResolvedValue(makeSearchResponse([]));
+
+      const { fetchRumEventsForTrace } = buildComposable(["_rumdata"]);
+      await fetchRumEventsForTrace("trace-abc", 1_000_000, 2_000_000);
+
+      const sql: string = vi.mocked(searchService.search).mock.calls[0][0].query.query
+        .sql as string;
+      expect(sql).toContain("= 'trace-abc'");
+    });
+  });
+
+  // =========================================================================
   // fetchRumEventsForTrace — successful full flow
   // =========================================================================
 

--- a/web/src/composables/rum/useRumSpanBuilder.ts
+++ b/web/src/composables/rum/useRumSpanBuilder.ts
@@ -19,7 +19,13 @@ import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import useStreams from "@/composables/useStreams";
 import searchService from "@/services/search";
-import { rumField, hasRumField, rumFieldEqualsSql } from "@/utils/rum/fields";
+import {
+  rumField,
+  hasRumField,
+  rumFieldEqualsAnySql,
+  normalizeTraceId,
+  traceIdLookupVariants,
+} from "@/utils/rum/fields";
 import { SPAN_KIND_CLIENT, SPAN_KIND_UNSPECIFIED } from "@/utils/traces/constants";
 
 const ACTION_PROXIMITY_MS = 10_000; // ±10s — actions beyond this are collapsed
@@ -170,11 +176,15 @@ export default function useRumSpanBuilder(
       const rumStream = await getStream("_rumdata", "logs", true);
       // Match the trace id under whichever spellings this stream actually carries.
       // Naming a column the stream lacks fails the entire query, so the predicate is
-      // built from the schema rather than assuming one namespace.
-      const traceIdPredicate = rumFieldEqualsSql(
+      // built from the schema rather than assuming one namespace. The id is matched
+      // in both its padded canonical form and the zero-stripped form SDK 0.4.x
+      // stored; non-hex ids fall back to an exact match.
+      const sanitized = sanitizeTraceId(traceId);
+      const idVariants = traceIdLookupVariants(sanitized);
+      const traceIdPredicate = rumFieldEqualsAnySql(
         rumStream?.schema,
         "trace_id",
-        sanitizeTraceId(traceId),
+        idVariants.length ? idVariants : [sanitized],
       );
       if (!traceIdPredicate) return empty;
 
@@ -284,7 +294,8 @@ export default function useRumSpanBuilder(
         ? String(rumField(event, "span_id"))
         : `rum_${event.type}_${event[`${event.type}_id`] || event.date}`,
       reference_parent_span_id: parentSpanId,
-      trace_id: rumField(event, "trace_id") || undefined,
+      trace_id:
+        normalizeTraceId(rumField(event, "trace_id")) || rumField(event, "trace_id") || undefined,
       operation_name: operationName,
       service_name: event.service || "Frontend",
       span_status:
@@ -563,7 +574,8 @@ export default function useRumSpanBuilder(
     if (!allViewEvents.length) return [];
 
     const firstTracedResource = tracedResources[0];
-    const traceId = rumField<string>(firstTracedResource, "trace_id") || "";
+    const rawTraceId = rumField<string>(firstTracedResource, "trace_id") || "";
+    const traceId = normalizeTraceId(rawTraceId) || rawTraceId;
     const tracedTimestamp = firstTracedResource?.date || 0;
 
     const { staticAssets, apiCalls, errors, longTasks } = classifyLeafEvents(allViewEvents);

--- a/web/src/composables/rum/useTraceCorrelation.spec.ts
+++ b/web/src/composables/rum/useTraceCorrelation.spec.ts
@@ -40,6 +40,13 @@ vi.mock("@/services/search", () => ({
   },
 }));
 
+// Stream discovery: defaults to the constant so existing tests keep their
+// `from "default"` shape; individual tests override to a custom stream.
+const mockResolveTracesStream = vi.fn().mockResolvedValue("default");
+vi.mock("@/composables/rum/useCorrelatedTracesStream", () => ({
+  default: () => ({ resolveTracesStream: mockResolveTracesStream }),
+}));
+
 // Mock vuex store
 const mockStore = {
   state: {
@@ -259,6 +266,25 @@ describe("useTraceCorrelation", () => {
       const sql: string = apmCall[0].query.query.sql;
       expect(sql).toContain('from "default"');
       expect(sql).toContain("trace_id = '01a034c1aabc72f78880daf6c9755cff'");
+    });
+
+    it("queries the discovered stream when the trace lives outside default", async () => {
+      const traceId = ref("01a034c1aabc72f78880daf6c9755cff");
+      mockResolveTracesStream.mockResolvedValueOnce("payments_traces");
+
+      mockSuccessfulSearch([createMockRumEvent()], [createMockBackendSpan()]);
+
+      const { fetchCorrelation } = useTraceCorrelation(traceId, t);
+      await fetchCorrelation();
+
+      expect(mockResolveTracesStream).toHaveBeenCalledWith(
+        "01a034c1aabc72f78880daf6c9755cff",
+        expect.any(Number),
+        expect.any(Number),
+      );
+      const apmCall = vi.mocked(searchService.search).mock.calls[1];
+      const sql: string = apmCall[0].query.query.sql;
+      expect(sql).toContain('from "payments_traces"');
     });
 
     it("reports the canonical padded id in correlationData", async () => {

--- a/web/src/composables/rum/useTraceCorrelation.spec.ts
+++ b/web/src/composables/rum/useTraceCorrelation.spec.ts
@@ -231,6 +231,47 @@ describe("useTraceCorrelation", () => {
       expect(sql).toContain("_oo_trace_id = 'trace-abc-999'");
     });
 
+    it("matches both padded and legacy zero-stripped ids in the RUM query", async () => {
+      // Legacy 31-char id as SDK 0.4.x stored it on the RUM event
+      const traceId = ref("1a034c1aabc72f78880daf6c9755cff");
+
+      mockSuccessfulSearch([], []);
+
+      const { fetchCorrelation } = useTraceCorrelation(traceId, t);
+      await fetchCorrelation();
+
+      const sql: string = vi.mocked(searchService.search).mock.calls[0][0].query.query.sql;
+      expect(sql).toContain("= '01a034c1aabc72f78880daf6c9755cff'");
+      expect(sql).toContain("= '1a034c1aabc72f78880daf6c9755cff'");
+    });
+
+    it("queries the default traces stream with the zero-padded id as page_type traces", async () => {
+      const traceId = ref("1a034c1aabc72f78880daf6c9755cff");
+
+      mockSuccessfulSearch([createMockRumEvent()], [createMockBackendSpan()]);
+
+      const { fetchCorrelation } = useTraceCorrelation(traceId, t);
+      await fetchCorrelation();
+
+      const apmCall = vi.mocked(searchService.search).mock.calls[1];
+      expect(apmCall[1]).toBe("APM");
+      expect(apmCall[0].page_type).toBe("traces");
+      const sql: string = apmCall[0].query.query.sql;
+      expect(sql).toContain('from "default"');
+      expect(sql).toContain("trace_id = '01a034c1aabc72f78880daf6c9755cff'");
+    });
+
+    it("reports the canonical padded id in correlationData", async () => {
+      const traceId = ref("1a034c1aabc72f78880daf6c9755cff");
+
+      mockSuccessfulSearch([createMockRumEvent()], [createMockBackendSpan()]);
+
+      const { fetchCorrelation, correlationData } = useTraceCorrelation(traceId, t);
+      await fetchCorrelation();
+
+      expect(correlationData.value?.trace_id).toBe("01a034c1aabc72f78880daf6c9755cff");
+    });
+
     it("should fetch trace data after RUM data", async () => {
       const traceId = ref("test-trace-123");
 

--- a/web/src/composables/rum/useTraceCorrelation.ts
+++ b/web/src/composables/rum/useTraceCorrelation.ts
@@ -18,12 +18,8 @@ import type { TranslateFn } from "@/types/i18n";
 import { useStore } from "vuex";
 import searchService from "@/services/search";
 import useStreams from "@/composables/useStreams";
-import {
-  normalizeTraceId,
-  rumFieldEqualsAnySql,
-  traceIdLookupVariants,
-  RUM_CORRELATION_TRACES_STREAM,
-} from "@/utils/rum/fields";
+import useCorrelatedTracesStream from "@/composables/rum/useCorrelatedTracesStream";
+import { normalizeTraceId, rumFieldEqualsAnySql, traceIdLookupVariants } from "@/utils/rum/fields";
 
 export interface TraceCorrelationData {
   trace_id: string;
@@ -53,6 +49,7 @@ export default function useTraceCorrelation(
 ) {
   const store = useStore();
   const { getStream } = useStreams(t);
+  const { resolveTracesStream } = useCorrelatedTracesStream(t);
   const correlationData = ref<TraceCorrelationData | null>(null);
   const isLoading = ref(false);
   const error = ref<Error | null>(null);
@@ -135,16 +132,23 @@ export default function useTraceCorrelation(
 
       const rumEvents = rumResponse.data.hits || [];
 
-      // Try to query backend trace data from the traces stream RUM correlates
-      // against, using the canonical padded id — the traces stream always stores
-      // the full 32-char form.
+      // Try to query backend trace data from whichever traces stream actually
+      // contains this trace (discovered + cached; falls back to the default
+      // stream), using the canonical padded id — the traces stream always
+      // stores the full 32-char form.
       let backendSpans: any[] = [];
       let hasTrace = false;
+
+      const tracesStream = await resolveTracesStream(
+        canonicalTraceId,
+        range.startTime,
+        range.endTime,
+      );
 
       try {
         const traceQuery = {
           query: {
-            sql: `select * from "${RUM_CORRELATION_TRACES_STREAM}" where trace_id = '${canonicalTraceId}' order by start_time`,
+            sql: `select * from "${tracesStream}" where trace_id = '${canonicalTraceId}' order by start_time`,
             start_time: range.startTime,
             end_time: range.endTime,
             from: 0,

--- a/web/src/composables/rum/useTraceCorrelation.ts
+++ b/web/src/composables/rum/useTraceCorrelation.ts
@@ -18,7 +18,12 @@ import type { TranslateFn } from "@/types/i18n";
 import { useStore } from "vuex";
 import searchService from "@/services/search";
 import useStreams from "@/composables/useStreams";
-import { rumFieldEqualsSql } from "@/utils/rum/fields";
+import {
+  normalizeTraceId,
+  rumFieldEqualsAnySql,
+  traceIdLookupVariants,
+  RUM_CORRELATION_TRACES_STREAM,
+} from "@/utils/rum/fields";
 
 export interface TraceCorrelationData {
   trace_id: string;
@@ -91,12 +96,17 @@ export default function useTraceCorrelation(
       // The trace-id column exists under two namespaces (`_o2_` on newer SDKs, `_oo_`
       // on older ones and on everything already ingested). Ask the schema which are
       // present: referencing a column the stream lacks fails the whole query, so a
-      // hardcoded name would break correlation for one SDK or the other.
+      // hardcoded name would break correlation for one SDK or the other. The id is
+      // matched in both its padded canonical form and the zero-stripped form SDK
+      // 0.4.x stored; non-hex ids fall back to an exact match.
+      const sanitized = String(traceId.value).replace(/'/g, "''");
+      const canonicalTraceId = normalizeTraceId(traceId.value) || sanitized;
+      const idVariants = traceIdLookupVariants(traceId.value);
       const rumStream = await getStream("_rumdata", "logs", true);
-      const traceIdPredicate = rumFieldEqualsSql(
+      const traceIdPredicate = rumFieldEqualsAnySql(
         rumStream?.schema,
         "trace_id",
-        String(traceId.value).replace(/'/g, "''"),
+        idVariants.length ? idVariants : [sanitized],
       );
       if (!traceIdPredicate) {
         correlationData.value = null;
@@ -125,16 +135,16 @@ export default function useTraceCorrelation(
 
       const rumEvents = rumResponse.data.hits || [];
 
-      // Try to query backend trace data
-      // Note: This assumes traces are stored in a stream like "_traces" or similar
-      // Adjust the stream name based on your actual trace storage
+      // Try to query backend trace data from the traces stream RUM correlates
+      // against, using the canonical padded id — the traces stream always stores
+      // the full 32-char form.
       let backendSpans: any[] = [];
       let hasTrace = false;
 
       try {
         const traceQuery = {
           query: {
-            sql: `select * from _traces where trace_id = '${traceId.value}' order by start_time`,
+            sql: `select * from "${RUM_CORRELATION_TRACES_STREAM}" where trace_id = '${canonicalTraceId}' order by start_time`,
             start_time: range.startTime,
             end_time: range.endTime,
             from: 0,
@@ -146,7 +156,7 @@ export default function useTraceCorrelation(
           {
             org_identifier: store.state.selectedOrganization.identifier,
             query: traceQuery,
-            page_type: "logs",
+            page_type: "traces",
           },
           "APM",
         );
@@ -183,7 +193,7 @@ export default function useTraceCorrelation(
       }
 
       correlationData.value = {
-        trace_id: traceId.value,
+        trace_id: canonicalTraceId,
         session_id: rumEvents[0]?.session_id || null,
         rum_events: rumEvents,
         backend_spans: backendSpans,

--- a/web/src/stores/index.spec.ts
+++ b/web/src/stores/index.spec.ts
@@ -175,4 +175,52 @@ describe("root store", () => {
       expect(store.state.alertLibrary.fileCache).toEqual({});
     });
   });
+
+  describe("correlated traces stream cache", () => {
+    const cache = () => store.state.organizationData.correlatedTracesStreams;
+
+    it("records a resolved trace and learns its stream", () => {
+      store.commit("resetOrganizationData");
+      store.commit("setCorrelatedTracesStream", {
+        traceId: "01a034c1aabc72f78880daf6c9755cff",
+        stream: "payments_traces",
+      });
+
+      expect(cache().byTraceId["01a034c1aabc72f78880daf6c9755cff"]).toBe("payments_traces");
+      expect(cache().knownStreams).toEqual(["payments_traces"]);
+    });
+
+    it("does not duplicate a stream already learned", () => {
+      store.commit("resetOrganizationData");
+      store.commit("setCorrelatedTracesStream", { traceId: "a1", stream: "payments_traces" });
+      store.commit("setCorrelatedTracesStream", { traceId: "b2", stream: "payments_traces" });
+
+      expect(cache().knownStreams).toEqual(["payments_traces"]);
+      expect(Object.keys(cache().byTraceId)).toHaveLength(2);
+    });
+
+    it("clears byTraceId past the 1000-entry cap but keeps knownStreams", () => {
+      store.commit("resetOrganizationData");
+      for (let i = 0; i < 1000; i++) {
+        store.commit("setCorrelatedTracesStream", {
+          traceId: `id-${i}`,
+          stream: "payments_traces",
+        });
+      }
+      expect(Object.keys(cache().byTraceId)).toHaveLength(1000);
+
+      store.commit("setCorrelatedTracesStream", { traceId: "overflow", stream: "checkout_traces" });
+
+      expect(Object.keys(cache().byTraceId)).toEqual(["overflow"]);
+      expect(cache().knownStreams).toEqual(["payments_traces", "checkout_traces"]);
+    });
+
+    it("is wiped by resetOrganizationData (org switch)", () => {
+      store.commit("setCorrelatedTracesStream", { traceId: "a1", stream: "payments_traces" });
+      store.commit("resetOrganizationData");
+
+      expect(cache().byTraceId).toEqual({});
+      expect(cache().knownStreams).toEqual([]);
+    });
+  });
 });

--- a/web/src/stores/index.ts
+++ b/web/src/stores/index.ts
@@ -46,6 +46,15 @@ const organizationObj = {
   rumToken: {
     rum_token: "",
   },
+  // Which traces stream contains a given (canonical 32-char) trace id, learned
+  // by probing — see useCorrelatedTracesStream. knownStreams is the org-level
+  // fact ("streams that have ever contained a correlated trace") that keeps
+  // steady-state resolution at one point lookup regardless of stream count.
+  // Lives here so resetOrganizationData wipes it on org switch.
+  correlatedTracesStreams: {
+    byTraceId: {} as Record<string, string>,
+    knownStreams: [] as string[],
+  },
   quotaThresholdMsg: "",
   functions: [],
   actions: [],
@@ -201,6 +210,15 @@ export default createStore({
     },
     setRUMToken(state, payload) {
       state.organizationData.rumToken = payload;
+    },
+    setCorrelatedTracesStream(state, payload: { traceId: string; stream: string }) {
+      const cache = state.organizationData.correlatedTracesStreams;
+      // Bounded: past the cap, clear and restart. knownStreams survives, so a
+      // re-resolution of any dropped id is a single point lookup — LRU would
+      // be bookkeeping for ~100KB of strings.
+      if (Object.keys(cache.byTraceId).length >= 1000) cache.byTraceId = {};
+      cache.byTraceId[payload.traceId] = payload.stream;
+      if (!cache.knownStreams.includes(payload.stream)) cache.knownStreams.push(payload.stream);
     },
     setOrgTokens(state, payload) {
       state.organizationData.orgTokens = payload;

--- a/web/src/test/unit/helpers/store.ts
+++ b/web/src/test/unit/helpers/store.ts
@@ -22,6 +22,11 @@ const organizationObj = {
   rumToken: {
     rum_token: "",
   },
+  // Mirror of the production organizationObj — see src/stores/index.ts.
+  correlatedTracesStreams: {
+    byTraceId: {} as Record<string, string>,
+    knownStreams: [] as string[],
+  },
   quotaThresholdMsg: "",
   functions: [],
   streams: {},
@@ -238,6 +243,12 @@ const store = createStore({
     },
     setRUMToken(state, payload) {
       state.organizationData.rumToken = payload;
+    },
+    setCorrelatedTracesStream(state, payload: { traceId: string; stream: string }) {
+      const cache = state.organizationData.correlatedTracesStreams;
+      if (Object.keys(cache.byTraceId).length >= 1000) cache.byTraceId = {};
+      cache.byTraceId[payload.traceId] = payload.stream;
+      if (!cache.knownStreams.includes(payload.stream)) cache.knownStreams.push(payload.stream);
     },
     // setAllCurrentDashboards(state, payload) {
     //   state.allCurrentDashboards = payload;

--- a/web/src/utils/rum/fields.spec.ts
+++ b/web/src/utils/rum/fields.spec.ts
@@ -1,0 +1,123 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, it, expect } from "vitest";
+import {
+  normalizeTraceId,
+  traceIdLookupVariants,
+  rumFieldEqualsAnySql,
+  rumFieldEqualsSql,
+  TRACE_ID_HEX_LENGTH,
+} from "@/utils/rum/fields";
+
+describe("normalizeTraceId", () => {
+  it("pads a 31-char legacy id to 32 chars", () => {
+    expect(normalizeTraceId("1a034c1aabc72f78880daf6c9755cff")).toBe(
+      "01a034c1aabc72f78880daf6c9755cff",
+    );
+  });
+
+  it("returns a 32-char id unchanged", () => {
+    expect(normalizeTraceId("01a034c1aabc72f78880daf6c9755cff")).toBe(
+      "01a034c1aabc72f78880daf6c9755cff",
+    );
+  });
+
+  it("pads shorter legacy forms (multiple stripped zeros)", () => {
+    // BigInt.toString(16) strips ALL leading zeros, not just one
+    expect(normalizeTraceId("1234567890abcdef")).toBe("00000000000000001234567890abcdef");
+  });
+
+  it("lowercases", () => {
+    expect(normalizeTraceId("ABC")).toBe("0".repeat(29) + "abc");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeTraceId("  1a034c1aabc72f78880daf6c9755cff ")).toBe(
+      "01a034c1aabc72f78880daf6c9755cff",
+    );
+  });
+
+  it("rejects non-hex, empty, too-long and non-string junk", () => {
+    expect(normalizeTraceId("xyz")).toBe("");
+    expect(normalizeTraceId("")).toBe("");
+    expect(normalizeTraceId("a".repeat(TRACE_ID_HEX_LENGTH + 1))).toBe("");
+    expect(normalizeTraceId(null)).toBe("");
+    expect(normalizeTraceId(undefined)).toBe("");
+  });
+});
+
+describe("traceIdLookupVariants", () => {
+  it("returns canonical + zero-stripped legacy variant", () => {
+    expect(traceIdLookupVariants("01a034c1aabc72f78880daf6c9755cff")).toEqual([
+      "01a034c1aabc72f78880daf6c9755cff",
+      "1a034c1aabc72f78880daf6c9755cff",
+    ]);
+  });
+
+  it("accepts a legacy short id and still produces both forms", () => {
+    expect(traceIdLookupVariants("1a034c1aabc72f78880daf6c9755cff")).toEqual([
+      "01a034c1aabc72f78880daf6c9755cff",
+      "1a034c1aabc72f78880daf6c9755cff",
+    ]);
+  });
+
+  it("strips all leading zeros for the legacy variant", () => {
+    expect(traceIdLookupVariants("00000000000000001234567890abcdef")).toEqual([
+      "00000000000000001234567890abcdef",
+      "1234567890abcdef",
+    ]);
+  });
+
+  it("dedupes when the id has no leading zero", () => {
+    const id = "f".repeat(32);
+    expect(traceIdLookupVariants(id)).toEqual([id]);
+  });
+
+  it("returns [] for invalid input", () => {
+    expect(traceIdLookupVariants("not-hex")).toEqual([]);
+    expect(traceIdLookupVariants(null)).toEqual([]);
+  });
+});
+
+describe("rumFieldEqualsAnySql", () => {
+  const schema = [{ name: "_oo_trace_id" }, { name: "_o2_trace_id" }];
+
+  it("crosses spellings with values", () => {
+    expect(rumFieldEqualsAnySql(schema, "trace_id", ["a", "b"])).toBe(
+      "(_o2_trace_id = 'a' OR _o2_trace_id = 'b' OR _oo_trace_id = 'a' OR _oo_trace_id = 'b')",
+    );
+  });
+
+  it("uses only the spelling the stream has", () => {
+    expect(rumFieldEqualsAnySql([{ name: "_oo_trace_id" }], "trace_id", ["a"])).toBe(
+      "(_oo_trace_id = 'a')",
+    );
+  });
+
+  it("matches rumFieldEqualsSql for a single value", () => {
+    expect(rumFieldEqualsAnySql(schema, "trace_id", ["a"])).toBe(
+      rumFieldEqualsSql(schema, "trace_id", "a"),
+    );
+  });
+
+  it("returns null when the stream has neither spelling", () => {
+    expect(rumFieldEqualsAnySql([{ name: "other" }], "trace_id", ["a"])).toBeNull();
+  });
+
+  it("returns null for an empty value list", () => {
+    expect(rumFieldEqualsAnySql(schema, "trace_id", [])).toBeNull();
+  });
+});

--- a/web/src/utils/rum/fields.ts
+++ b/web/src/utils/rum/fields.ts
@@ -119,3 +119,63 @@ export function rumFieldNotNullSql(
   if (present.length === 0) return null;
   return `(${present.map((n) => `${n} IS NOT NULL`).join(" OR ")})`;
 }
+
+/** Canonical trace-id width in the traces stream: 16 bytes, hex-encoded. */
+export const TRACE_ID_HEX_LENGTH = 32;
+
+/**
+ * Traces stream RUM correlates against. Matches the backend's OTLP default
+ * (ingestion without an explicit stream name writes to "default") and the
+ * existing navigation/metadata sites in EventDetailDrawerContent and
+ * PlayerTracesTab. Orgs ingesting traces into custom-named streams do not
+ * correlate — a known limitation shared by every RUM→traces flow, tracked
+ * separately.
+ */
+export const RUM_CORRELATION_TRACES_STREAM = "default";
+
+/**
+ * Canonicalize a trace id read off a RUM event.
+ *
+ * SDK 0.4.0-beta.7 through 0.4.2-beta.2 serialize the id with BigInt
+ * `toString(16)`, which drops leading zeros; ids are UUIDv7 (timestamp-topped),
+ * so effectively every stored id is short. The traces stream always stores the
+ * full 32-char form (the traceparent header is padded), so anything shorter can
+ * never exact-match. Returns "" when the input is not plausible hex, so callers
+ * can fall back rather than query garbage.
+ */
+export function normalizeTraceId(id: unknown): string {
+  const s = String(id ?? "")
+    .trim()
+    .toLowerCase();
+  if (!/^[0-9a-f]{1,32}$/.test(s)) return "";
+  return s.padStart(TRACE_ID_HEX_LENGTH, "0");
+}
+
+/**
+ * The stored spellings a trace id may have in `_rumdata`: the correct padded
+ * form (SDK ≤0.3.2 and ≥ the padding fix) and the zero-stripped legacy form
+ * (0.4.0-beta.7 … 0.4.2-beta.2). Query both; data from the broken window is
+ * never rewritten.
+ */
+export function traceIdLookupVariants(id: unknown): string[] {
+  const canonical = normalizeTraceId(id);
+  if (!canonical) return [];
+  const legacy = canonical.replace(/^0+/, "") || "0";
+  return legacy === canonical ? [canonical] : [canonical, legacy];
+}
+
+/**
+ * Like `rumFieldEqualsSql`, but matching any of several values — used to hit
+ * both trace-id spellings AND both stored id forms in one indexed predicate.
+ * Values MUST already be sanitized/hex-validated.
+ */
+export function rumFieldEqualsAnySql(
+  schema: any[] | undefined,
+  field: RumInternalField | string,
+  sanitizedValues: string[],
+): string | null {
+  const present = presentRumFields(schema, field);
+  if (present.length === 0 || sanitizedValues.length === 0) return null;
+  const clauses = present.flatMap((col) => sanitizedValues.map((v) => `${col} = '${v}'`));
+  return `(${clauses.join(" OR ")})`;
+}

--- a/web/src/views/RUM/ErrorViewer.spec.ts
+++ b/web/src/views/RUM/ErrorViewer.spec.ts
@@ -313,14 +313,16 @@ describe("ErrorViewer.vue", () => {
     it("shows the trace correlation card when the error carries _oo_trace_id", async () => {
       await seedErrorDetails({
         error_id: "err-1",
-        _oo_trace_id: "trace-abc",
+        // Legacy zero-stripped id as SDK 0.4.x stored it (31 hex chars) — the
+        // card must receive the padded 32-char form the traces stream stores.
+        _oo_trace_id: "1a034c1aabc72f78880daf6c9755cff",
         session_id: "session-1",
         _timestamp: 1640995200000000,
       });
 
       const card = wrapper.findComponent({ name: "TraceCorrelationCard" });
       expect(card.exists()).toBe(true);
-      expect(card.props("traceId")).toBe("trace-abc");
+      expect(card.props("traceId")).toBe("01a034c1aabc72f78880daf6c9755cff");
       expect(card.props("timestamp")).toBe(1640995200000000);
     });
 
@@ -330,13 +332,27 @@ describe("ErrorViewer.vue", () => {
         _timestamp: 1640995200000000,
         events: [
           { type: "action", action_type: "click" },
-          { type: "resource", resource_type: "xhr", _oo_trace_id: "trace-xhr" },
+          {
+            type: "resource",
+            resource_type: "xhr",
+            _oo_trace_id: "0badc0ffee0ddf00dd15ea5eba5eba11",
+          },
         ],
       });
 
       const card = wrapper.findComponent({ name: "TraceCorrelationCard" });
       expect(card.exists()).toBe(true);
-      expect(card.props("traceId")).toBe("trace-xhr");
+      expect(card.props("traceId")).toBe("0badc0ffee0ddf00dd15ea5eba5eba11");
+    });
+
+    it("hides the card when the stored trace id is not plausible hex", async () => {
+      await seedErrorDetails({
+        error_id: "err-1",
+        _oo_trace_id: "not-a-trace-id",
+        _timestamp: 1640995200000000,
+      });
+
+      expect(wrapper.findComponent({ name: "TraceCorrelationCard" }).exists()).toBe(false);
     });
 
     it("hides the card when neither the error nor its events carry a trace id", async () => {

--- a/web/src/views/RUM/ErrorViewer.vue
+++ b/web/src/views/RUM/ErrorViewer.vue
@@ -95,7 +95,7 @@ import useErrorTracking from "@/composables/useErrorTracking";
 import useErrorDetail from "@/composables/rum/useErrorDetail";
 import useStreams from "@/composables/useStreams";
 import searchService from "@/services/search";
-import { rumField } from "@/utils/rum/fields";
+import { rumField, normalizeTraceId } from "@/utils/rum/fields";
 import { buildBreadcrumbsSql, type ErrorDetailContext } from "@/utils/rum/errorDetailQueries";
 import { useI18nTyped } from "@/types/i18n";
 import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
@@ -148,15 +148,17 @@ const getTimestamp = computed(() => {
 });
 
 // Trace id linking this error to a backend trace: on the error itself, or
-// on the nearest xhr/fetch event captured around the failure.
+// on the nearest xhr/fetch event captured around the failure. Canonicalized
+// to the padded 32-char form the traces stream stores — SDK 0.4.x wrote the
+// id zero-stripped on RUM events.
 const errorTraceId = computed(() => {
   if (rumField(errorDetails.value, "trace_id")) {
-    return rumField<string>(errorDetails.value, "trace_id");
+    return normalizeTraceId(rumField<string>(errorDetails.value, "trace_id"));
   }
   const xhrWithTrace = (errorDetails.value?.events || []).find(
     (event: any) => event.type === "resource" && rumField(event, "trace_id"),
   );
-  return rumField<string>(xhrWithTrace, "trace_id") || "";
+  return normalizeTraceId(rumField<string>(xhrWithTrace, "trace_id"));
 });
 
 /**


### PR DESCRIPTION
## Problem

RUM-to-traces correlation stopped working after the browser SDK 0.4.x line. The SDK's identifiers became plain `BigInt`, so the unchanged `toString(16)` serialization silently started dropping leading zeros. Trace ids are UUIDv7-shaped (48-bit ms timestamp in the top bits), so the leading hex nibble is always zero today — effectively every RUM event stored a 31-char `_oo_trace_id`/`_o2_trace_id` while the traces stream stores the padded 32-char `trace_id` (the `traceparent` header was padded correctly, so backend traces have the full id). Exact-match correlation could never hit, in either direction.

Verified against live data: for sampled traced requests, `'0' + stored_id` found the backend trace every time; the stored id never did.

## Fix (frontend compatibility layer)

Works for the already-ingested short ids **and** for correct ids from the fixed SDK:

- `utils/rum/fields.ts`: `normalizeTraceId` (pads to canonical 32-char hex), `traceIdLookupVariants` (padded + legacy zero-stripped forms), `rumFieldEqualsAnySql` (matches both namespace spellings x both id forms), and a shared `RUM_CORRELATION_TRACES_STREAM` constant replacing four scattered "default" literals.
- `useRumSpanBuilder`: trace→RUM lookup queries both id forms; canonical id stamped on generated RUM spans.
- `useTraceCorrelation`: backend-span query now targets the real `default` traces stream (was a nonexistent `_traces` stream) as `page_type: "traces"` (was `"logs"`), with the padded id.
- `EventDetailDrawerContent`: trace navigation pads the id before building the route.
- `PlayerTracesTab`: the session Traces tab canonicalizes ids before the traces-stream metadata join (rows were silently dropped).
- `ErrorViewer`: error correlation card receives the padded id; implausible (non-hex) ids hide the card instead of showing a misleading empty state.
- `package.json`: browser SDK bumped to 0.4.2-beta.3, which serializes trace/span ids as fixed-width canonical hex at the source (resolved `browser-rum-core` verified at 0.4.2-beta.3).

## Testing

- New unit coverage: `fields.spec.ts` (16 tests) plus regression tests in each touched spec (legacy 31-char id fixtures asserting padded 32-char behavior); full RUM/traces suites green (53 files, 1971 passed).
- Live-verified against real data: a trace from the broken window renders the full RUM hierarchy (Session→View→Action→Resource + backend spans) where the old code showed backend spans only; pre-regression sessions still correlate (no behavior change for correct ids).
- `npm run lint` and `npm run type-check` clean.