### PR TITLE
chore: write-access probe (will be closed immediately)

### DIFF
--- a/.github/write-probe.tmp
+++ b/.github/write-probe.tmp
@@ -1,0 +1,1 @@
+temporary write-access probe; will be deleted


### PR DESCRIPTION
Temporary probe to verify fork PR permissions. Closing now; no review needed.