### PR TITLE
perf(promql): avoid repeated parsing, lookup, and sorting in histogram_quantile

### DIFF
--- a/src/promql/src/engine.rs
+++ b/src/promql/src/engine.rs
@@ -1045,7 +1045,8 @@ impl Engine {
             }
         };
 
-        Ok(match func_name {
+        let start = std::time::Instant::now();
+        let result = match func_name {
             Func::Abs => functions::abs(input)?,
             Func::Absent => functions::absent(input, &self.eval_ctx)?,
             Func::AbsentOverTime => functions::absent_over_time(input, &self.eval_ctx)?,
@@ -1276,7 +1277,14 @@ impl Engine {
             Func::Timestamp => functions::timestamp(input)?,
             Func::Vector => functions::vector(input, &self.eval_ctx)?,
             Func::Year => functions::year(input)?,
-        })
+        };
+        log::info!(
+            "[trace_id: {}] [PromQL Timing] call_expr({}) execution took: {:?}",
+            self.trace_id,
+            func.name,
+            start.elapsed()
+        );
+        Ok(result)
     }
 }
 

--- a/src/promql/src/functions/histogram.rs
+++ b/src/promql/src/functions/histogram.rs
@@ -54,53 +54,62 @@ pub(crate) fn histogram_quantile(phi: f64, data: Value, eval_ctx: &EvalContext) 
     // Always use range query path - compute all timestamps at once
     let timestamps = eval_ctx.timestamps();
 
-    // Group metrics by their signature (without bucket label)
-    let mut metrics_by_sig: HashMap<u64, Vec<RangeValue>> = HashMap::default();
+    // Parse each upper bound once and group metrics by their signature (without
+    // bucket label). The previous implementation reparsed every bound for every
+    // evaluation timestamp.
+    let mut metrics_by_sig: HashMap<u64, Vec<(f64, RangeValue)>> = HashMap::default();
 
     for rv in in_matrix {
         // Verify this metric has a bucket label
-        if rv.labels.get_value(BUCKET_LABEL).parse::<f64>().is_err() {
+        let Ok(upper_bound) = rv.labels.get_value(BUCKET_LABEL).parse::<f64>() else {
             continue;
-        }
+        };
 
         let sig = signature_without_labels(&rv.labels, &[HASH_LABEL, NAME_LABEL, BUCKET_LABEL]);
-        metrics_by_sig.entry(sig).or_default().push(rv);
+        metrics_by_sig
+            .entry(sig)
+            .or_default()
+            .push((upper_bound, rv));
     }
 
-    let mut range_values = Vec::new();
+    let group_count = metrics_by_sig.len();
+    let mut range_values = Vec::with_capacity(group_count);
 
-    for (_sig, bucket_series) in metrics_by_sig {
+    for (_sig, mut bucket_series) in metrics_by_sig {
+        // Sort bucket bounds once per output series. `bucket_quantile_sorted`
+        // can then consume them directly for every timestamp.
+        bucket_series.sort_by(|a, b| sort_float(&a.0, &b.0));
         // Get the labels (without bucket label) from the first series
-        let mut base_labels = bucket_series[0].labels.clone();
+        let mut base_labels = bucket_series[0].1.labels.clone();
         base_labels
             .retain(|l| l.name != HASH_LABEL && l.name != NAME_LABEL && l.name != BUCKET_LABEL);
 
         let mut samples = Vec::with_capacity(timestamps.len());
+        let mut cursors = vec![0usize; bucket_series.len()];
 
         // For each timestamp, compute histogram_quantile
         for &eval_ts in &timestamps {
-            let mut buckets = Vec::new();
+            let mut buckets = Vec::with_capacity(bucket_series.len());
 
             // Collect bucket values at this timestamp
-            for bucket_rv in &bucket_series {
-                let upper_bound: f64 = match bucket_rv.labels.get_value(BUCKET_LABEL).parse() {
-                    Ok(u) => u,
-                    Err(_) => continue,
-                };
-
-                // Find the sample closest to eval_ts
-                if let Some(sample) = bucket_rv
-                    .samples
-                    .iter()
-                    .find(|s| s.timestamp == eval_ts)
-                    .or_else(|| bucket_rv.samples.first())
+            for ((upper_bound, bucket_rv), cursor) in bucket_series.iter().zip(cursors.iter_mut()) {
+                while *cursor < bucket_rv.samples.len()
+                    && bucket_rv.samples[*cursor].timestamp < eval_ts
                 {
-                    buckets.push(Bucket::new(upper_bound, sample.value));
+                    *cursor += 1;
+                }
+                let sample = bucket_rv
+                    .samples
+                    .get(*cursor)
+                    .filter(|sample| sample.timestamp == eval_ts)
+                    .or_else(|| bucket_rv.samples.first());
+                if let Some(sample) = sample {
+                    buckets.push(Bucket::new(*upper_bound, sample.value));
                 }
             }
 
             if !buckets.is_empty() {
-                let quantile_value = bucket_quantile(phi, buckets);
+                let quantile_value = bucket_quantile_sorted(phi, buckets);
                 samples.push(Sample::new(eval_ts, quantile_value));
             }
         }
@@ -119,7 +128,8 @@ pub(crate) fn histogram_quantile(phi: f64, data: Value, eval_ctx: &EvalContext) 
 }
 
 // cf. https://github.com/prometheus/prometheus/blob/cf1bea344a3c390a90c35ea8764c4a468b345d5e/promql/quantile.go#L76
-fn bucket_quantile(phi: f64, mut buckets: Vec<Bucket>) -> f64 {
+/// Compute a classic histogram quantile from buckets already sorted by upper bound.
+fn bucket_quantile_sorted(phi: f64, buckets: Vec<Bucket>) -> f64 {
     if phi.is_nan() || buckets.is_empty() {
         return f64::NAN;
     }
@@ -129,8 +139,7 @@ fn bucket_quantile(phi: f64, mut buckets: Vec<Bucket>) -> f64 {
     if phi > 1.0 {
         return f64::INFINITY;
     }
-    buckets.sort_by(|a, b| sort_float(&a.upper_bound, &b.upper_bound));
-    // The caller of `bucket_quantile` guarantees that `buckets` is non-empty.
+    // The caller guarantees that `buckets` is non-empty.
     let highest_bucket = &buckets[buckets.len() - 1];
     if !(highest_bucket.upper_bound.is_infinite() && highest_bucket.upper_bound.is_sign_positive())
     {
@@ -217,9 +226,47 @@ fn ensure_monotonic(buckets: &mut [Bucket]) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use config::meta::promql::value::Label;
     use expect_test::expect;
 
     use super::*;
+
+    #[test]
+    fn test_histogram_quantile_handles_unsorted_buckets_and_sparse_timestamps() {
+        let eval_ctx = EvalContext::new(1, 3, 1, "test".to_string());
+        let series = |le: &str, samples: Vec<Sample>| RangeValue {
+            labels: vec![
+                Arc::new(Label::new("__name__", "request_duration_bucket")),
+                Arc::new(Label::new("path", "/api")),
+                Arc::new(Label::new("le", le)),
+            ],
+            samples,
+            exemplars: None,
+            time_window: None,
+        };
+        let input = Value::Matrix(vec![
+            // Intentionally put +Inf before the finite bound. Timestamp 2 is
+            // absent, so the established fallback-to-first-sample behavior is
+            // exercised as well as the cursor fast path.
+            series("+Inf", vec![Sample::new(1, 10.0), Sample::new(3, 30.0)]),
+            series("1", vec![Sample::new(1, 5.0), Sample::new(3, 15.0)]),
+        ]);
+
+        let Value::Matrix(result) = histogram_quantile(0.5, input, &eval_ctx).unwrap() else {
+            panic!("expected matrix");
+        };
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0]
+                .samples
+                .iter()
+                .map(|sample| (sample.timestamp, sample.value))
+                .collect::<Vec<_>>(),
+            vec![(1, 1.0), (2, 1.0), (3, 1.0)],
+        );
+    }
 
     #[test]
     fn test_coalesce_buckets() {

--- a/src/promql/src/functions/histogram.rs
+++ b/src/promql/src/functions/histogram.rs
@@ -38,6 +38,9 @@ impl Bucket {
 
 /// Enhanced version that processes all timestamps at once for range queries
 pub(crate) fn histogram_quantile(phi: f64, data: Value, eval_ctx: &EvalContext) -> Result<Value> {
+    let start = std::time::Instant::now();
+    let trace_id = &eval_ctx.trace_id;
+
     // Handle input data - convert to matrix format if needed
     let in_matrix = match data {
         Value::Matrix(m) => m,
@@ -53,6 +56,11 @@ pub(crate) fn histogram_quantile(phi: f64, data: Value, eval_ctx: &EvalContext) 
 
     // Always use range query path - compute all timestamps at once
     let timestamps = eval_ctx.timestamps();
+    log::info!(
+        "[trace_id: {trace_id}] [PromQL Timing] histogram_quantile({phi}) started with {} series and {} time points",
+        in_matrix.len(),
+        timestamps.len()
+    );
 
     // Parse each upper bound once and group metrics by their signature (without
     // bucket label). The previous implementation reparsed every bound for every
@@ -124,6 +132,11 @@ pub(crate) fn histogram_quantile(phi: f64, data: Value, eval_ctx: &EvalContext) 
         }
     }
 
+    log::info!(
+        "[trace_id: {trace_id}] [PromQL Timing] histogram_quantile({phi}) completed in {:?}, folded {group_count} groups into {} series",
+        start.elapsed(),
+        range_values.len()
+    );
     Ok(Value::Matrix(range_values))
 }
 


### PR DESCRIPTION
## Summary

Remove the per-timestamp repeated work in `histogram_quantile`:

- parse each `le` upper bound once per input series instead of once per series per evaluation timestamp
- sort buckets once per output series (`bucket_quantile_sorted`) instead of sorting the collected buckets inside every `bucket_quantile` call
- find each bucket's sample for an evaluation timestamp by advancing a per-bucket cursor instead of a linear `find` over the series' samples per timestamp, making the whole per-series scan O(samples) amortized instead of O(timestamps × samples)

Also add the `[PromQL Timing]` logs this path was missing:

- `histogram_quantile` logs started (input series and time-point counts) and completed (duration, groups folded, series produced), matching the `eval_range` logs that already cover `rate`-style functions
- `call_expr` logs one dispatch-level duration per function call, covering the remaining functions that go through neither `eval_range` nor the aggregation paths (math and time operations, `clamp`/`clamp_min`/`clamp_max`, `label_join`, `label_replace`, `absent`, `scalar`, `vector`, `timestamp`)

Behavior is unchanged, including the established fallback-to-first-sample semantics when a timestamp has no exact match. The cursor relies on two invariants that hold for every input the engine can produce: evaluation timestamps are ascending (`EvalContext::timestamps`), and each series' samples are sorted by timestamp (the engine sorts all selector output in `selector_load_data_owned`, and range functions emit samples in evaluation order).

## Verification

- New unit test covering unsorted bucket input, a missing evaluation timestamp (fallback path), and the cursor fast path.
- A differential test (run locally, not committed) compared this implementation bit-for-bit against the previous one over 200 randomized seeds × 7 phi values (negative, 0, 0.5, 0.9, 1, >1, NaN), with inputs covering multiple groups, duplicate `le` values, `+Inf`/`NaN`/unparsable bounds, sparse and duplicated timestamps, and empty series. All outputs matched (f64 compared by bits).

## History

This branch originally contained a broader set of hash-sorted metrics optimizations. Series-capacity preallocation, fused aggregation, and counter-reset prefix scans have since landed on main as #13971, #13989, and #13997; the hash-run repartitioning of sample loading was split out to be submitted separately with fresh benchmarks. This PR now carries only the `histogram_quantile` change.

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p promql --lib` (390 passed)
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings`
