### PR TITLE
fix(i18n): send key-path context and a term glossary to the translation model

### DIFF
--- a/scripts/translations/README.md
+++ b/scripts/translations/README.md
@@ -77,8 +77,15 @@ RTL languages (Arabic, Persian) are deliberately excluded until the web app has
 2. **Translation**: New/changed keys are translated by DeepSeek, in batches, with
    interpolation placeholders (`{count}`, `%s`, `@:linked.key`) and vue-i18n
    literal escapes (`{'{'}`, `{'@'}`) validated per string
-3. **Preservation**: Existing translations are never overwritten unless their English source changed
-4. **Nested Support**: Handles nested JSON structures correctly
+3. **Context**: every string is sent together with its i18n key path (so a bare
+   "Open" under `alerts.incidents.statusOpen` translates as a status, not a verb)
+   and the prompt carries the `TERMS` glossary (an "event" is a record, not a
+   party; a "stream" is a data stream, not a brook — plus per-locale pinned
+   renderings like zh-CN `event` → `事件`) and the locale's own established
+   module names mined from its `menu.*` translations (zh-CN: Alerts → 告警,
+   Pipelines → 流水线, Dashboards → 仪表盘)
+4. **Preservation**: Existing translations are never overwritten unless their English source changed
+5. **Nested Support**: Handles nested JSON structures correctly
 
 A translation is rejected (and retried on the next run) when it is empty, drops or
 adds an interpolation token, changes the `|` plural-form count, or is something
@@ -482,6 +489,12 @@ ModuleNotFoundError: No module named 'openai'
 - Review translations before merging PRs
 - Consider manual review for critical UI text
 - Native speakers should review translations
+- An ambiguous or unstable term belongs in the `TERMS` table in `translator.py`:
+  its `sense` line fixes the meaning for every language at once, and an optional
+  per-locale entry (zh-CN `event` → `事件`) pins one language's rendering. This
+  only affects future translations; an already-translated key is re-sent only
+  when its English source changes (edit the existing translation by hand, or
+  remove the key's hash from `.translation_state.json` to force a re-run)
 
 ### Build Has Old Translations
 

--- a/scripts/translations/main.py
+++ b/scripts/translations/main.py
@@ -32,6 +32,7 @@ import sys
 from translator import (
     SOURCE_LOCALE,
     build_locale,
+    build_module_glossary,
     build_state,
     collect_pending_leaves,
     find_duplicate_keys,
@@ -140,7 +141,11 @@ def main():
         pending = collect_pending_leaves(source, existing, state)
         print(f"\nTranslating: {locale} ({len(pending)} strings pending)")
 
-        translated = translate_pending(pending, locale) if pending else {}
+        translated = (
+            translate_pending(pending, locale, build_module_glossary(source, existing))
+            if pending
+            else {}
+        )
 
         target = build_locale(source, existing, state, translated, counters)
         locale_targets[locale] = target

--- a/scripts/translations/translator.py
+++ b/scripts/translations/translator.py
@@ -153,8 +153,8 @@ TERMS = {
         "'to open'",
     },
     "top": {
-        "sense": "in rankings (Top N, Top Queries): highest-ranked — not the "
-        "spatial top edge",
+        "sense": "in rankings (Top N, Top Queries): highest-ranked; in layout "
+        "and position labels it is the ordinary spatial top",
     },
     "value": {
         "sense": "the data value of a field or metric — never worth/merit",

--- a/scripts/translations/translator.py
+++ b/scripts/translations/translator.py
@@ -89,7 +89,17 @@ TERMS = {
         "sense": "a named dataset of ingested telemetry (logs, metrics, or traces) "
         "— the data-stream sense, never a brook/creek and never audio/video streaming",
         "zh-CN": "数据流",
-        "zh-TW": "資料流",
+        "zh-TW": "串流",
+    },
+    "alert": {
+        "sense": "a monitoring alert: an alerting rule or the notification it "
+        "sends — the alarm sense, not a browser dialog",
+        "zh-CN": "告警",
+        "zh-TW": "警示",
+    },
+    "filter": {
+        "sense": "a condition that narrows query or list results",
+        "zh-CN": "过滤器",
     },
     "event": {
         "sense": "a recorded occurrence in the system (log event, alert event) — "
@@ -121,6 +131,8 @@ TERMS = {
     "pipeline": {
         "sense": "a data-processing pipeline that routes and transforms ingested "
         "records",
+        "zh-CN": "流水线",
+        "zh-TW": "管線",
     },
     "destination": {
         "sense": "a configured endpoint that alerts or pipeline output are "

--- a/scripts/translations/translator.py
+++ b/scripts/translations/translator.py
@@ -17,7 +17,12 @@ Decision per key (per locale):
 
 Pending leaves are translated in batches (many strings per API call) to keep the
 request count and cost low, and several batches are in flight at once so a large
-backlog finishes in minutes rather than hours. Each item is validated
+backlog finishes in minutes rather than hours. Each string travels with its i18n
+key path, and the prompt carries the TERMS glossary (English senses plus optional
+per-locale pinned renderings) and the locale's own module names (mined from its
+committed `menu.*` translations), so short ambiguous labels resolve to the right
+sense and reuse the established vocabulary instead of being translated blind.
+Each item is validated
 independently — a string whose translation drops/alters an interpolation
 placeholder (e.g. `{count}`) is rejected and left un-advanced so it retries on the
 next run, exactly like a hard API failure.
@@ -71,6 +76,93 @@ LANGUAGE_NAMES = {
     # (and auto-served to ar/fa browsers) the moment their files are generated.
     # Add them here together with RTL layout support and their web wiring.
 }
+
+# The term table injected into every prompt. Strings reach the model as isolated
+# UI fragments, so without the `sense` lines an "event" is a party, a "stream" is
+# a brook and "live" is a broadcast — exactly the mistranslations a zh-CN audit
+# found. A sense steers every target language at once; an optional per-locale key
+# pins one language's rendering, because the same audit found the same word coined
+# differently across batches (stream = 流/数据流, trace = 追踪/跟踪). Keeping both
+# in one table means a pinned rendering can never lose its sense definition.
+TERMS = {
+    "stream": {
+        "sense": "a named dataset of ingested telemetry (logs, metrics, or traces) "
+        "— the data-stream sense, never a brook/creek and never audio/video streaming",
+        "zh-CN": "数据流",
+        "zh-TW": "資料流",
+    },
+    "event": {
+        "sense": "a recorded occurrence in the system (log event, alert event) — "
+        "the record/incident sense, never a social activity or gathering",
+        "zh-CN": "事件",
+        "zh-TW": "事件",
+    },
+    "live": {
+        "sense": "updating in real time (live tail, live data) — the real-time "
+        "sense, never a live broadcast or livestream",
+        "zh-CN": "实时",
+        "zh-TW": "即時",
+    },
+    "trace": {
+        "sense": "a distributed trace: one request's recorded path through services",
+        "zh-CN": "追踪",
+        "zh-TW": "追蹤",
+    },
+    "span": {
+        "sense": "a single operation inside a distributed trace — the APM term of "
+        "art; keep 'Span' when the language has no established equivalent",
+        "zh-CN": "Span",
+        "zh-TW": "Span",
+    },
+    "function": {
+        "sense": "a user-defined data-transformation function (VRL) — the "
+        "programming sense",
+    },
+    "pipeline": {
+        "sense": "a data-processing pipeline that routes and transforms ingested "
+        "records",
+    },
+    "destination": {
+        "sense": "a configured endpoint that alerts or pipeline output are "
+        "delivered to",
+        "zh-CN": "目标",
+        "zh-TW": "目標",
+    },
+    "organization": {
+        "sense": "a tenant/workspace that groups users and data — the account sense",
+    },
+    "firing": {
+        "sense": "the state of an alert that is currently triggered",
+        "zh-CN": "触发中",
+        "zh-TW": "觸發中",
+    },
+    "open": {
+        "sense": "as an incident/issue status: still unresolved — not the verb "
+        "'to open'",
+    },
+    "top": {
+        "sense": "in rankings (Top N, Top Queries): highest-ranked — not the "
+        "spatial top edge",
+    },
+    "value": {
+        "sense": "the data value of a field or metric — never worth/merit",
+        "zh-CN": "值",
+        "zh-TW": "值",
+    },
+    "breakdown": {
+        "sense": "splitting a chart or metric by a dimension — never a failure "
+        "or collapse",
+    },
+    "report": {
+        "sense": "a scheduled or exported dashboard report document",
+        "zh-CN": "报表",
+        "zh-TW": "報表",
+    },
+}
+
+# Subtrees of en-US.json whose leaves are canonical module names; their committed
+# translations are mined per locale into the prompt's fixed-renderings table.
+MODULE_NAME_SUBTREES = ("menu",)
 
 # printf / linked-message tokens that MUST survive translation unchanged.
 # Brace tokens are handled by _scan_tokens, which a regex cannot do: `{'}'}` is a
@@ -310,14 +402,75 @@ def _model():
     return os.environ.get("DEEPSEEK_MODEL", "deepseek-v4-flash")
 
 
-def _system_prompt(locale):
+def build_module_glossary(source, existing):
+    """(English, translated) pairs for the app's module names.
+
+    The MODULE_NAME_SUBTREES trees are where every major module's user-facing
+    name lives (Alerts, Pipelines, Dashboards, Streams, …). Pulling the pairs
+    from the locale's own committed translations means new strings reuse the
+    established vocabulary (zh-CN: Alerts -> 告警, Pipelines -> 流水线) instead of
+    each batch coining its own, with no per-language table to maintain. A pair
+    kept in English (RUM -> RUM) is included on purpose: it tells the model
+    "leave this as is". Sorted so the prompt is byte-stable per locale, which
+    keeps provider-side prompt caching effective across batches.
+    """
+    terms = {}
+    for subtree in MODULE_NAME_SUBTREES:
+        src = source.get(subtree) if isinstance(source.get(subtree), dict) else {}
+        dst = existing.get(subtree) if isinstance(existing.get(subtree), dict) else {}
+        for key, en in src.items():
+            tr = dst.get(key)
+            if not isinstance(en, str) or not isinstance(tr, str):
+                continue
+            # Token-bearing entries (aria templates) are messages, not names.
+            if _placeholders(en) or not en.strip() or not tr.strip():
+                continue
+            terms.setdefault(en, tr)
+    return sorted(terms.items())
+
+
+def _system_prompt(locale, module_terms):
     lang = LANGUAGE_NAMES.get(locale, locale)
-    return (
+    pinned = {term: entry[locale] for term, entry in TERMS.items() if locale in entry}
+    # One renderings table, curated pinned terms winning over mined module names
+    # (case/plural-insensitively), so the prompt can never mandate two different
+    # renderings for the same word.
+    renderings = {
+        en: tr
+        for en, tr in module_terms
+        if en.lower() not in pinned and en.lower().removesuffix("s") not in pinned
+    }
+    renderings.update(pinned)
+    parts = [
         f"You are a professional software localization engine. Translate UI strings "
-        f"for OpenObserve, an observability platform, from English into {lang}.\n"
+        f"for OpenObserve from English into {lang}.\n"
+        "Context: OpenObserve is an observability platform. Users ingest logs, "
+        "metrics, and traces into streams, search them, chart them on dashboards, "
+        "alert on them, and transform them with functions and pipelines. Every "
+        "string is UI text from this product (buttons, labels, menu items, table "
+        "headers, messages), so always prefer a word's technical/monitoring sense "
+        "over its everyday sense.\n"
+        'Each input item has "key" and "text". The key is the i18n key path — '
+        "context that tells you where in the UI the text appears (for key "
+        "alerts.incidents.statusOpen, 'Open' is an incident status meaning "
+        "unresolved, not the verb). Use it to resolve ambiguity; translate only "
+        "the text, and never echo the key in the output.\n"
+        "Glossary — the sense these terms always carry in OpenObserve:\n"
+    ]
+    parts.extend(f"- {term}: {entry['sense']}\n" for term, entry in TERMS.items())
+    if renderings:
+        parts.append(
+            f"Fixed {lang} renderings — always render these terms and module "
+            "names exactly as shown:\n"
+        )
+        parts.extend(
+            f"- {en} -> {tr}\n"
+            for en, tr in sorted(renderings.items(), key=lambda kv: kv[0].lower())
+        )
+    parts.append(
         "Rules:\n"
         '- Reply with ONLY a JSON object of the form {\"translations\": [...]} '
-        "containing exactly one translated string per input string, in the same order.\n"
+        "containing exactly one translated string per input item, in the same order.\n"
         "- Preserve every interpolation placeholder EXACTLY as written and untranslated: "
         "curly-brace tokens like {count}, {name}, {0}; printf tokens like %s, %d; and "
         "linked-message tokens like @:common.name. Never translate, reorder, or remove them.\n"
@@ -333,13 +486,18 @@ def _system_prompt(locale):
         "- Produce natural, concise wording appropriate for buttons, labels, and short UI messages.\n"
         "- Do not add explanations, notes, or any text outside the JSON object."
     )
+    return "".join(parts)
 
 
-def translate_batch(texts, locale, max_retries=3, _depth=0):
+def translate_batch(items, locale, prompt, max_retries=3, _depth=0):
     """
-    Translate a list of strings via DeepSeek, index-aligned to `texts`.
+    Translate a list of (key, text) pairs via DeepSeek, index-aligned to `items`.
 
-    Returns a list the same length as `texts`; each element is the translated
+    `key` is the string's dotted i18n path, sent purely as disambiguating
+    context. `prompt` is the locale's system prompt, built once per locale by
+    translate_pending.
+
+    Returns a list the same length as `items`; each element is the translated
     string, or None if that specific item could not be translated. A None item is
     left un-advanced by the caller so it retries on the next run.
 
@@ -353,10 +511,13 @@ def translate_batch(texts, locale, max_retries=3, _depth=0):
         is pointless, subsequent attempts raise the temperature so the model can
         actually produce a different (valid) response.
     """
-    if not texts:
+    if not items:
         return []
 
-    payload = json.dumps({"strings": texts}, ensure_ascii=False)
+    payload = json.dumps(
+        {"strings": [{"key": key, "text": text} for key, text in items]},
+        ensure_ascii=False,
+    )
     temperature = 0.0
     last_err = None
     for attempt in range(max_retries):
@@ -364,7 +525,7 @@ def translate_batch(texts, locale, max_retries=3, _depth=0):
             resp = _get_client().chat.completions.create(
                 model=_model(),
                 messages=[
-                    {"role": "system", "content": _system_prompt(locale)},
+                    {"role": "system", "content": prompt},
                     {"role": "user", "content": payload},
                 ],
                 stream=False,
@@ -374,9 +535,9 @@ def translate_batch(texts, locale, max_retries=3, _depth=0):
             content = resp.choices[0].message.content
             data = json.loads(content) if content else {}
             out = data.get("translations") if isinstance(data, dict) else None
-            if not isinstance(out, list) or len(out) != len(texts):
+            if not isinstance(out, list) or len(out) != len(items):
                 raise TranslationError(
-                    f"expected {len(texts)} translations, got "
+                    f"expected {len(items)} translations, got "
                     f"{len(out) if isinstance(out, list) else type(out).__name__}"
                 )
             # An empty/whitespace/non-string element is a failed item, not a valid
@@ -387,7 +548,7 @@ def translate_batch(texts, locale, max_retries=3, _depth=0):
             if all(c is not None for c in cleaned):
                 return cleaned
             raise TranslationError(
-                f"{cleaned.count(None)} of {len(texts)} translations were empty/invalid"
+                f"{cleaned.count(None)} of {len(items)} translations were empty/invalid"
             )
         except (json.JSONDecodeError, TranslationError, KeyError, IndexError, TypeError) as e:
             # Malformed / wrong-length response — perturb temperature and retry.
@@ -401,14 +562,14 @@ def translate_batch(texts, locale, max_retries=3, _depth=0):
     # aren't lost with it. Recursion bottoms out naturally at a single string
     # (which returns [None]); the depth guard is only a stack backstop and must be
     # large enough to reach singletons for any batch size (log2(4096) = 12).
-    if len(texts) > 1 and _depth < 32:
-        mid = len(texts) // 2
-        left = translate_batch(texts[:mid], locale, max_retries, _depth + 1)
-        right = translate_batch(texts[mid:], locale, max_retries, _depth + 1)
+    if len(items) > 1 and _depth < 32:
+        mid = len(items) // 2
+        left = translate_batch(items[:mid], locale, prompt, max_retries, _depth + 1)
+        right = translate_batch(items[mid:], locale, prompt, max_retries, _depth + 1)
         return left + right
 
-    print(f"  ! translation failed for [{locale}] ({len(texts)} item(s)): {last_err}")
-    return [None] * len(texts)
+    print(f"  ! translation failed for [{locale}] ({len(items)} item(s)): {last_err}")
+    return [None] * len(items)
 
 
 def _src_text(value):
@@ -575,37 +736,41 @@ def _validate(src, out):
     return out
 
 
-def translate_pending(pending, locale):
+def translate_pending(pending, locale, module_terms):
     """
     Translate all pending leaves for a locale in batches.
 
     `pending` is a list of (path_tuple, value) where value is a string or a list
-    of strings. Returns {path_tuple: translated_value} for leaves that translated
-    successfully AND passed `_validate` for every string. String leaves map to a
-    string; array leaves map to a list (translated element-wise, type preserved).
-    A leaf with any failed/invalid string is omitted entirely (left to retry).
+    of strings; `module_terms` is the locale's module-name glossary from
+    build_module_glossary. Returns {path_tuple: translated_value} for leaves that
+    translated successfully AND passed `_validate` for every string. String
+    leaves map to a string; array leaves map to a list (translated element-wise,
+    type preserved). A leaf with any failed/invalid string is omitted entirely
+    (left to retry).
     """
     batch_size = int(os.environ.get("TRANSLATION_BATCH_SIZE", "50"))
+    prompt = _system_prompt(locale, module_terms)
 
     # Flatten every translatable string across all leaves into one work list so
     # array elements share batches with plain strings. `slots` holds the eventual
     # per-leaf output (translated strings, kept non-str/empty elements, or None).
     units = []  # [path, kind, slots]
-    flat = []   # [(unit_idx, elem_idx, source_string)]
+    flat = []   # [(unit_idx, elem_idx, (dotted_key, source_string))]
     for path, value in pending:
+        dotted = ".".join(path)
         if isinstance(value, list):
             slots = [None] * len(value)
             uidx = len(units)
             units.append([path, "list", slots])
             for i, el in enumerate(value):
                 if isinstance(el, str) and el.strip():
-                    flat.append((uidx, i, el))
+                    flat.append((uidx, i, (f"{dotted}.{i}", el)))
                 else:
                     slots[i] = el  # non-string / empty — keep as-is, never billed
         else:
             uidx = len(units)
             units.append([path, "str", [None]])
-            flat.append((uidx, 0, value))
+            flat.append((uidx, 0, (dotted, value)))
 
     total = len(flat)
     chunks = [flat[start : start + batch_size] for start in range(0, total, batch_size)]
@@ -620,13 +785,15 @@ def translate_pending(pending, locale):
 
     if workers == 1 or len(chunks) <= 1:
         for i, chunk in enumerate(chunks):
-            batch_results[i] = translate_batch([s for _, _, s in chunk], locale)
+            batch_results[i] = translate_batch([item for _, _, item in chunk], locale, prompt)
             done += len(chunk)
             print(f"    {locale}: {done}/{total} strings translated", flush=True)
     else:
         with ThreadPoolExecutor(max_workers=workers) as pool:
             futures = {
-                pool.submit(translate_batch, [s for _, _, s in chunk], locale): i
+                pool.submit(
+                    translate_batch, [item for _, _, item in chunk], locale, prompt
+                ): i
                 for i, chunk in enumerate(chunks)
             }
             # Results are stored by index, so out-of-order completion cannot
@@ -638,7 +805,7 @@ def translate_pending(pending, locale):
                 print(f"    {locale}: {done}/{total} strings translated", flush=True)
 
     for chunk, results in zip(chunks, batch_results):
-        for (uidx, eidx, src), out in zip(chunk, results):
+        for (uidx, eidx, (_key, src)), out in zip(chunk, results):
             units[uidx][2][eidx] = _validate(src, out)  # None on failure/mismatch
 
     translated = {}


### PR DESCRIPTION
Addresses the mechanism half of #13966 — auto-translations were context-blind because `translate_batch()` sent bare string arrays with a one-line system prompt.

## What changed

- **Key-path context**: each string is now sent as `{"key": "alerts.incidents.statusOpen", "text": "Open"}` and the prompt tells the model to use the key to disambiguate ("Open" there is an incident status, not the verb). Keys are context only and never echoed into the output; the response format is unchanged.
- **Product background + `TERMS` glossary** (`translator.py`): the prompt now introduces OpenObserve and carries one term table — an English `sense` line per ambiguous term that steers all 14 languages at once (an "event" is a record, not a party; a "stream" is a data stream, not a brook; "live" is real-time, not a broadcast), plus optional per-locale pinned renderings (zh-CN/zh-TW seeded: event → 事件, stream → 数据流, live → 实时, trace → 追踪, report → 报表, …).
- **Module vocabulary mined from the locale itself**: `build_module_glossary()` extracts the committed `menu.*` translations (Alerts → 告警, Pipelines → 流水线, Dashboards → 仪表盘) and merges them with the pinned terms into a single conflict-free renderings table — pinned terms win, so the prompt can never mandate two renderings for one word. Works for every locale with no hand-maintained tables.
- The system prompt is built once per locale and is byte-stable (sorted renderings), so DeepSeek's prefix caching keeps the added prompt tokens cheap. Change detection, validation, batching/split-retry, and the state file are untouched.

## Testing

- Stubbed the API client and verified: payload shape, batch/index alignment (string + array leaves), failed-item isolation via split retry, prompt assembly for locales with and without pinned terms, byte-stability of the prompt, and the pinned-vs-module dedup (`Streams` module entry absorbed by pinned `stream`).
- `python3 main.py --check` (the pure comparison the merge-queue gate runs) is unaffected.

## Not in this PR

Existing wrong translations are not re-sent (state hashes unchanged); the backfill pass and the bootstrap-run gap are tracked as follow-ups in #13966.
