### PR TITLE
fix(search): scan the exact requested range for histogram queries

### DIFF
--- a/src/search/src/datafusion/distributed_plan/node.rs
+++ b/src/search/src/datafusion/distributed_plan/node.rs
@@ -23,8 +23,6 @@ use datafusion::common::TableReference;
 use hashbrown::HashMap;
 use proto::cluster_rpc::{IndexInfo, KvItem, QueryIdentifier, SearchInfo, SuperClusterInfo};
 
-use crate::sql::histogram::histogram_bucket_start;
-
 #[derive(Debug, Clone)]
 pub struct RemoteScanNodes {
     pub req: Request,
@@ -75,14 +73,9 @@ impl RemoteScanNodes {
                 .get(table_name)
                 .unwrap_or(&vec![])
                 .clone(),
-            start_time: {
-                let t = self.req.time_range.as_ref().map(|x| x.0).unwrap_or(0);
-                if self.req.histogram_interval > 0 {
-                    histogram_bucket_start(t, self.req.histogram_interval * 1_000_000)
-                } else {
-                    t
-                }
-            },
+            // never widen this to a histogram bucket boundary: the scan window must
+            // equal the requested range or bucket sums exceed count(*) (#13946)
+            start_time: self.req.time_range.as_ref().map(|x| x.0).unwrap_or(0),
             end_time: self.req.time_range.as_ref().map(|x| x.1).unwrap_or(0),
             timeout: self.req.timeout as u64,
             use_cache: self.req.use_cache,
@@ -236,6 +229,29 @@ mod tests {
         node.search_infos.file_id_list = vec![vec![1, 2], vec![]];
         assert!(!node.is_file_list_empty(0));
         assert!(node.is_file_list_empty(1));
+    }
+
+    #[test]
+    fn test_get_remote_node_keeps_raw_start_time_for_histogram() {
+        // the scan window must match the requested range exactly; widening it
+        // to a bucket boundary makes bucket sums exceed count(*) (#13946)
+        let req = Request {
+            time_range: Some((1_700_000_017_000_000, 1_700_000_900_000_000)),
+            histogram_interval: 30,
+            ..Default::default()
+        };
+        let nodes = RemoteScanNodes::new(
+            req,
+            vec![],
+            HashMap::new(),
+            HashMap::new(),
+            false,
+            opentelemetry::Context::new(),
+            None,
+        );
+        let info = nodes.get_remote_node(&TableReference::from("logs"));
+        assert_eq!(info.search_infos.start_time, 1_700_000_017_000_000);
+        assert_eq!(info.search_infos.end_time, 1_700_000_900_000_000);
     }
 
     #[test]

--- a/src/search/src/sql/histogram.rs
+++ b/src/search/src/sql/histogram.rs
@@ -229,13 +229,6 @@ fn extract_where_clause(statement: &Statement) -> Result<String, Error> {
     }
 }
 
-/// Snaps `timestamp_us` down to the nearest histogram bucket boundary.
-/// Both arguments are in microseconds. Used to ensure the first bucket
-/// returned by date_bin() is fully populated rather than partial.
-pub fn histogram_bucket_start(timestamp_us: i64, interval_us: i64) -> i64 {
-    timestamp_us - timestamp_us % interval_us
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/search/src/sql/visitor/histogram_interval.rs
+++ b/src/search/src/sql/visitor/histogram_interval.rs
@@ -115,11 +115,8 @@ pub fn generate_histogram_interval(time_range: (i64, i64)) -> &'static str {
             return interval;
         }
     }
-    // Ranges narrower than one 10s bucket drop to 1s buckets: a bucket wider
-    // than the whole range makes the scan-start snap (histogram_bucket_start)
-    // pull in up to 10s of data from before the range, so bucket counts dwarf
-    // the range total (#13896). With 1s buckets the snap widens the scan by
-    // less than a second (zero for whole-second range starts).
+    // Ranges narrower than one 10s bucket drop to 1s buckets so the chart
+    // still gets multiple points instead of one bar wider than the range (#13896)
     "1 second"
 }
 
@@ -541,8 +538,7 @@ mod tests {
     #[test]
     fn test_generate_histogram_interval_narrow_range() {
         let second = 1_000_000_i64;
-        // a range narrower than the 10s floor drops to 1s buckets so the
-        // scan-start snap cannot widen the query past the range (#13896)
+        // a range narrower than the 10s floor drops to 1s buckets (#13896)
         assert_eq!(generate_histogram_interval((0, second)), "1 second");
         assert_eq!(
             generate_histogram_interval((0, 10 * second - 1)),


### PR DESCRIPTION
## Problem

Fixes #13946. The sum of histogram bucket counts exceeded `count(*)` over the same time range (e.g. 2744 vs 2704).

#12313 made the leader snap the follower scan `start_time` **down** to the histogram bucket boundary in `RemoteScanNodes::get_remote_node()`, to keep the first chart bucket fully populated. But that widens the actual scan window: records in `[bucket_start, requested_start)` — data the user explicitly excluded — get counted into the first bucket, while `count(*)` (a separate query without `histogram_interval`) scans the exact requested range. The reporter confirmed the diagnosis: aligning `count(*)`'s start to the bucket grid makes the two numbers match.

#13896 was the same root cause surfacing on sub-10s ranges (worked around in #13916 by dropping to 1s buckets there, without touching the snap).

## Fix

Revert the snap: the scan window sent to followers now equals the requested range exactly.

- `distributed_plan/node.rs`: `start_time` passes through unchanged; a comment pins the invariant and a regression test (`test_get_remote_node_keeps_raw_start_time_for_histogram`) asserts the window is not widened when `histogram_interval > 0`.
- `sql/histogram.rs`: delete the now-unused `histogram_bucket_start()` (zero remaining references, including in the enterprise repo).
- `sql/visitor/histogram_interval.rs`: reword two comments that were written in terms of the snap. The 1s interval floor for sub-10s ranges from #13916 is kept — a bucket wider than the whole range is bad charting regardless of the snap.

Histogram semantics are now the same as Elasticsearch/Kibana `date_histogram`: buckets only count in-range records, so `sum(buckets) == count(*)` always holds, and the first bucket may be partial.

Safety notes:

- The tantivy `SimpleHistogram` fast path is unaffected: it aligns bucket *labels* itself (`start_time - start_time % rounding_by`) and only counts docs matched by the query's own time filter, consistent with the `date_bin` path.
- The results cache is unaffected: `write_results` already aligns the cache-accepted window *inward* and drops edge buckets, so partial (and previously over-counted) first buckets never entered the cache.

## Trade-off / follow-up for the UI

The left-edge display artifact that motivated #12313 (first bar looks lower because its bucket is cut by the range start) returns by design. Suggested frontend handling, either:

- align the picker's `start_time` down to the returned `histogram_interval` and issue **all** page queries (histogram + logs + count) over that aligned range — Grafana's approach; totals stay consistent and no partial bucket exists, or
- detect `buckets[0].key < start_time` and dim/annotate the first bar as partial.

## Test plan

- `search` crate: 88 histogram tests + 9 node tests pass (includes the new regression test); workspace clippy with CI flags passes.
- Single-node E2E: ingested 240 events at 500ms spacing over 120s; queried with mid-bucket start/end (+17s/+107s), interval 30s. `count(*)` = 180; buckets 26+60+60+34 = 180 (match). First bucket correctly holds 26 in-range records instead of the full 60 (old behavior summed to 214).
