### PR TITLE
perf(promql): preallocate hash-sorted series samples

### DIFF
--- a/src/promql/src/load_series/load_labels.rs
+++ b/src/promql/src/load_series/load_labels.rs
@@ -503,7 +503,7 @@ mod tests {
         .unwrap();
         let sample_df = ctx.read_batch(sample_batch).unwrap();
         let (metrics, _) =
-            load_samples_from_datafusion("test", &DataType::UInt64, sample_df, false)
+            load_samples_from_datafusion("test", &DataType::UInt64, sample_df, false, 1, 0)
                 .await
                 .unwrap();
         let label_df = ctx.read_batch(label_batch).unwrap();

--- a/src/promql/src/load_series/mod.rs
+++ b/src/promql/src/load_series/mod.rs
@@ -18,6 +18,7 @@
 mod label_cache;
 mod labels;
 mod load_labels;
+mod series_capacity;
 
 use std::sync::Arc;
 
@@ -45,10 +46,13 @@ use datafusion::{
     prelude::{DataFrame, Expr, SessionContext, col, lit},
 };
 use futures::TryStreamExt;
-use hashbrown::{HashMap, HashSet};
+use hashbrown::{HashMap, HashSet, hash_map::Entry};
 use promql_parser::parser::VectorSelector;
 
-use self::labels::load_series_labels;
+use self::{
+    labels::load_series_labels,
+    series_capacity::{batch_run_len, initial_series_capacity, series_fragment_hint},
+};
 use super::utils::{apply_label_selector, apply_matchers};
 
 pub(super) type PartitionedMetrics = Vec<HashMap<u64, RangeValue>>;
@@ -65,51 +69,6 @@ pub(super) enum LoadedMetrics {
 }
 
 type TokioResult = tokio::task::JoinHandle<Result<(HashMap<u64, RangeValue>, HashSet<i64>)>>;
-
-const STORAGE_HOUR_MICROS: i64 = 60 * 60 * 1_000_000;
-const MAX_SERIES_FRAGMENT_HINT: usize = 24;
-const MAX_INITIAL_SERIES_CAPACITY: usize = 2048;
-
-fn series_fragment_hint(start: i64, end: i64, lookback: i64) -> usize {
-    let query_start = start.saturating_sub(lookback);
-    let duration = end.saturating_sub(query_start).max(0);
-    let hourly_fragments = duration
-        .saturating_add(STORAGE_HOUR_MICROS - 1)
-        .div_euclid(STORAGE_HOUR_MICROS)
-        .max(1);
-    usize::try_from(hourly_fragments)
-        .unwrap_or(1)
-        .clamp(1, MAX_SERIES_FRAGMENT_HINT)
-}
-
-fn initial_series_capacity(
-    first_run_len: usize,
-    fragment_hint: usize,
-    first_timestamp: i64,
-    last_timestamp: i64,
-    query_duration: i64,
-) -> usize {
-    let run_based = first_run_len.saturating_mul(fragment_hint.max(1));
-    let interval_based = if first_run_len > 1 && last_timestamp > first_timestamp {
-        let intervals = i64::try_from(first_run_len - 1).unwrap_or(i64::MAX);
-        let sample_interval = (last_timestamp - first_timestamp)
-            .div_euclid(intervals)
-            .max(1);
-        usize::try_from(
-            query_duration
-                .max(0)
-                .saturating_add(sample_interval - 1)
-                .div_euclid(sample_interval)
-                .saturating_add(1),
-        )
-        .unwrap_or(MAX_INITIAL_SERIES_CAPACITY)
-    } else {
-        0
-    };
-    run_based
-        .max(interval_based)
-        .min(MAX_INITIAL_SERIES_CAPACITY.max(first_run_len))
-}
 
 /// Materialize the labels exposed to the query. The process-wide cache stores
 /// only source labels, so raw-data queries add their synthetic hash label at
@@ -234,13 +193,14 @@ pub(super) async fn selector_load_data_from_datafusion(
         )
         .await?
     } else {
+        let query_duration = end.saturating_sub(start.saturating_sub(lookback));
         load_samples_from_datafusion(
             &query_ctx.trace_id,
             hash_field_type,
             df_group.clone(),
             !skip_labels,
-            series_fragment_hint(start, end, lookback),
-            end.saturating_sub(start.saturating_sub(lookback)),
+            series_fragment_hint(query_duration),
+            query_duration,
         )
         .await?
     };
@@ -351,19 +311,14 @@ pub(super) async fn load_samples_from_datafusion(
                                 let timestamp = time_values.value(i);
                                 let hash: u64 = hash_values.value(i);
                                 let entry = match metrics.entry(hash) {
-                                    hashbrown::hash_map::Entry::Occupied(entry) => entry.into_mut(),
-                                    hashbrown::hash_map::Entry::Vacant(entry) => {
-                                        let mut run_end = i + 1;
-                                        while run_end < batch.num_rows()
-                                            && hash_values.value(run_end) == hash
-                                        {
-                                            run_end += 1;
-                                        }
+                                    Entry::Occupied(entry) => entry.into_mut(),
+                                    Entry::Vacant(entry) => {
+                                        let run_len = batch_run_len(hash_values, i);
                                         let capacity = initial_series_capacity(
-                                            run_end - i,
+                                            run_len,
                                             fragment_hint,
                                             time_values.value(i),
-                                            time_values.value(run_end - 1),
+                                            time_values.value(i + run_len - 1),
                                             query_duration,
                                         );
                                         entry.insert(RangeValue {
@@ -600,28 +555,6 @@ mod tests {
     };
 
     use super::*;
-
-    #[test]
-    fn test_series_fragment_and_capacity_hints_are_bounded() {
-        let hour = STORAGE_HOUR_MICROS;
-        assert_eq!(
-            series_fragment_hint(8 * hour, 11 * hour, 5 * 60 * 1_000_000),
-            4
-        );
-        assert_eq!(series_fragment_hint(8 * hour, 8 * hour, 0), 1);
-        assert_eq!(
-            series_fragment_hint(0, 100 * hour, 0),
-            MAX_SERIES_FRAGMENT_HINT,
-        );
-
-        assert_eq!(initial_series_capacity(160, 4, 0, 0, 0), 640);
-        assert_eq!(
-            initial_series_capacity(100, 4, 0, 99 * 15 * 1_000_000, 11_100 * 1_000_000,),
-            741,
-        );
-        assert_eq!(initial_series_capacity(1024, 4, 0, 0, 0), 2048);
-        assert_eq!(initial_series_capacity(4096, 4, 0, 0, 0), 4096);
-    }
 
     #[test]
     fn test_into_loaded_metrics_only_keeps_uint64_hashes_partitioned() {

--- a/src/promql/src/load_series/mod.rs
+++ b/src/promql/src/load_series/mod.rs
@@ -35,7 +35,7 @@ use config::{
 };
 use datafusion::{
     arrow::{
-        array::{Array, AsArray, Float64Array, Int64Array, RecordBatch},
+        array::{Array, AsArray, RecordBatch},
         datatypes::{DataType, Float64Type, Int64Type, Schema, UInt64Type},
     },
     error::{DataFusionError, Result},
@@ -294,8 +294,8 @@ pub(super) async fn load_samples_from_datafusion(
                         append_batch_samples(
                             &mut metrics,
                             &hashes,
-                            time_values,
-                            value_values,
+                            time_values.values(),
+                            value_values.values(),
                             fragment_hint,
                             query_duration,
                         );
@@ -338,21 +338,22 @@ pub(super) async fn load_samples_from_datafusion(
 fn append_batch_samples(
     metrics: &mut HashMap<u64, RangeValue>,
     hashes: &[u64],
-    time_values: &Int64Array,
-    value_values: &Float64Array,
+    timestamps: &[i64],
+    values: &[f64],
     fragment_hint: usize,
     query_duration: i64,
 ) {
-    for (i, &hash) in hashes.iter().enumerate() {
-        let entry = match metrics.entry(hash) {
+    let mut i = 0;
+    while i < hashes.len() {
+        let run_len = batch_run_len(hashes, i);
+        let entry = match metrics.entry(hashes[i]) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let run_len = batch_run_len(hashes, i);
                 let capacity = initial_series_capacity(
                     run_len,
                     fragment_hint,
-                    time_values.value(i),
-                    time_values.value(i + run_len - 1),
+                    timestamps[i],
+                    timestamps[i + run_len - 1],
                     query_duration,
                 );
                 entry.insert(RangeValue {
@@ -363,9 +364,13 @@ fn append_batch_samples(
                 })
             }
         };
-        entry
-            .samples
-            .push(Sample::new(time_values.value(i), value_values.value(i)));
+        entry.samples.extend(
+            timestamps[i..i + run_len]
+                .iter()
+                .zip(&values[i..i + run_len])
+                .map(|(&timestamp, &value)| Sample::new(timestamp, value)),
+        );
+        i += run_len;
     }
 }
 

--- a/src/promql/src/load_series/mod.rs
+++ b/src/promql/src/load_series/mod.rs
@@ -20,7 +20,7 @@ mod labels;
 mod load_labels;
 mod series_capacity;
 
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use config::{
     TIMESTAMP_COL_NAME,
@@ -35,8 +35,8 @@ use config::{
 };
 use datafusion::{
     arrow::{
-        array::{Float64Array, Int64Array, StringArray, UInt64Array},
-        datatypes::{DataType, Schema},
+        array::{Array, AsArray, Float64Array, Int64Array, RecordBatch},
+        datatypes::{DataType, Float64Type, Int64Type, Schema, UInt64Type},
     },
     error::{DataFusionError, Result},
     logical_expr::utils::disjunction,
@@ -287,73 +287,18 @@ pub(super) async fn load_samples_from_datafusion(
             loop {
                 match stream.try_next().await {
                     Ok(Some(batch)) => {
-                        let time_values = batch
-                            .column_by_name(TIMESTAMP_COL_NAME)
-                            .unwrap()
-                            .as_any()
-                            .downcast_ref::<Int64Array>()
-                            .unwrap();
-                        let value_values = batch
-                            .column_by_name(VALUE_LABEL)
-                            .unwrap()
-                            .as_any()
-                            .downcast_ref::<Float64Array>()
-                            .unwrap();
+                        let time_values = batch[TIMESTAMP_COL_NAME].as_primitive::<Int64Type>();
+                        let value_values = batch[VALUE_LABEL].as_primitive::<Float64Type>();
 
-                        if hash_field_type == DataType::UInt64 {
-                            let hash_values = batch
-                                .column_by_name(HASH_LABEL)
-                                .unwrap()
-                                .as_any()
-                                .downcast_ref::<UInt64Array>()
-                                .unwrap();
-                            for i in 0..batch.num_rows() {
-                                let timestamp = time_values.value(i);
-                                let hash: u64 = hash_values.value(i);
-                                let entry = match metrics.entry(hash) {
-                                    Entry::Occupied(entry) => entry.into_mut(),
-                                    Entry::Vacant(entry) => {
-                                        let run_len = batch_run_len(hash_values, i);
-                                        let capacity = initial_series_capacity(
-                                            run_len,
-                                            fragment_hint,
-                                            time_values.value(i),
-                                            time_values.value(i + run_len - 1),
-                                            query_duration,
-                                        );
-                                        entry.insert(RangeValue {
-                                            labels: vec![],
-                                            samples: Vec::with_capacity(capacity),
-                                            exemplars: None,
-                                            time_window: None,
-                                        })
-                                    }
-                                };
-                                entry
-                                    .samples
-                                    .push(Sample::new(timestamp, value_values.value(i)));
-                            }
-                        } else {
-                            let hash_values = batch
-                                .column_by_name(HASH_LABEL)
-                                .unwrap()
-                                .as_any()
-                                .downcast_ref::<StringArray>()
-                                .unwrap();
-                            for i in 0..batch.num_rows() {
-                                let timestamp = time_values.value(i);
-                                let hash: u64 = gxhash::new().sum64(hash_values.value(i));
-                                let entry = metrics.entry(hash).or_insert_with(|| RangeValue {
-                                    labels: vec![],
-                                    samples: vec![],
-                                    exemplars: None,
-                                    time_window: None,
-                                });
-                                entry
-                                    .samples
-                                    .push(Sample::new(timestamp, value_values.value(i)));
-                            }
-                        }
+                        let hashes = batch_hash_values(&batch, &hash_field_type);
+                        append_batch_samples(
+                            &mut metrics,
+                            &hashes,
+                            time_values,
+                            value_values,
+                            fragment_hint,
+                            query_duration,
+                        );
                     }
                     Ok(None) => break,
                     Err(e) => {
@@ -388,6 +333,57 @@ pub(super) async fn load_samples_from_datafusion(
     }
 
     Ok((metrics, all_unique_timestamps))
+}
+
+fn append_batch_samples(
+    metrics: &mut HashMap<u64, RangeValue>,
+    hashes: &[u64],
+    time_values: &Int64Array,
+    value_values: &Float64Array,
+    fragment_hint: usize,
+    query_duration: i64,
+) {
+    for (i, &hash) in hashes.iter().enumerate() {
+        let entry = match metrics.entry(hash) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let run_len = batch_run_len(hashes, i);
+                let capacity = initial_series_capacity(
+                    run_len,
+                    fragment_hint,
+                    time_values.value(i),
+                    time_values.value(i + run_len - 1),
+                    query_duration,
+                );
+                entry.insert(RangeValue {
+                    labels: vec![],
+                    samples: Vec::with_capacity(capacity),
+                    exemplars: None,
+                    time_window: None,
+                })
+            }
+        };
+        entry
+            .samples
+            .push(Sample::new(time_values.value(i), value_values.value(i)));
+    }
+}
+
+/// The hash column as u64 values: zero-copy for UInt64, hashed per row for
+/// Utf8.
+fn batch_hash_values<'a>(batch: &'a RecordBatch, hash_field_type: &DataType) -> Cow<'a, [u64]> {
+    if *hash_field_type == DataType::UInt64 {
+        let hash_values = batch[HASH_LABEL].as_primitive::<UInt64Type>();
+        Cow::Borrowed(hash_values.values().as_ref())
+    } else {
+        let hash_values = batch[HASH_LABEL].as_string::<i32>();
+        let mut hasher = gxhash::new();
+        Cow::Owned(
+            (0..hash_values.len())
+                .map(|i| hasher.sum64(hash_values.value(i)))
+                .collect(),
+        )
+    }
 }
 
 async fn load_exemplars_from_datafusion(
@@ -428,61 +424,21 @@ async fn load_exemplars_from_datafusion(
             loop {
                 match stream.try_next().await {
                     Ok(Some(batch)) => {
-                        let exemplars_values = batch
-                            .column_by_name(EXEMPLARS_LABEL)
-                            .unwrap()
-                            .as_any()
-                            .downcast_ref::<StringArray>()
-                            .unwrap();
-                        if hash_field_type == DataType::UInt64 {
-                            let hash_values = batch
-                                .column_by_name(HASH_LABEL)
-                                .unwrap()
-                                .as_any()
-                                .downcast_ref::<UInt64Array>()
-                                .unwrap();
-                            for i in 0..batch.num_rows() {
-                                let hash: u64 = hash_values.value(i);
-                                let exemplar = exemplars_values.value(i);
-                                if let Ok(exemplars) = json::from_str::<Vec<json::Value>>(exemplar)
-                                {
-                                    let entry = metrics.entry(hash).or_insert_with(|| RangeValue {
-                                        labels: vec![],
-                                        samples: vec![],
-                                        exemplars: Some(vec![]),
-                                        time_window: None,
-                                    });
-                                    let entry = entry.exemplars.as_mut().unwrap();
-                                    for exemplar in exemplars {
-                                        if let Some(exemplar) = exemplar.as_object() {
-                                            entry.push(Arc::new(Exemplar::from(exemplar)));
-                                        }
-                                    }
-                                }
-                            }
-                        } else {
-                            let hash_values = batch
-                                .column_by_name(HASH_LABEL)
-                                .unwrap()
-                                .as_any()
-                                .downcast_ref::<StringArray>()
-                                .unwrap();
-                            for i in 0..batch.num_rows() {
-                                let hash: u64 = gxhash::new().sum64(hash_values.value(i));
-                                let exemplar = exemplars_values.value(i);
-                                if let Ok(exemplars) = json::from_str::<Vec<json::Value>>(exemplar)
-                                {
-                                    let entry = metrics.entry(hash).or_insert_with(|| RangeValue {
-                                        labels: vec![],
-                                        samples: vec![],
-                                        exemplars: Some(vec![]),
-                                        time_window: None,
-                                    });
-                                    let entry = entry.exemplars.as_mut().unwrap();
-                                    for exemplar in exemplars {
-                                        if let Some(exemplar) = exemplar.as_object() {
-                                            entry.push(Arc::new(Exemplar::from(exemplar)));
-                                        }
+                        let exemplars_values = batch[EXEMPLARS_LABEL].as_string::<i32>();
+                        let hashes = batch_hash_values(&batch, &hash_field_type);
+                        for (i, &hash) in hashes.iter().enumerate() {
+                            let exemplar = exemplars_values.value(i);
+                            if let Ok(exemplars) = json::from_str::<Vec<json::Value>>(exemplar) {
+                                let entry = metrics.entry(hash).or_insert_with(|| RangeValue {
+                                    labels: vec![],
+                                    samples: vec![],
+                                    exemplars: Some(vec![]),
+                                    time_window: None,
+                                });
+                                let entry = entry.exemplars.as_mut().unwrap();
+                                for exemplar in exemplars {
+                                    if let Some(exemplar) = exemplar.as_object() {
+                                        entry.push(Arc::new(Exemplar::from(exemplar)));
                                     }
                                 }
                             }

--- a/src/promql/src/load_series/mod.rs
+++ b/src/promql/src/load_series/mod.rs
@@ -66,6 +66,51 @@ pub(super) enum LoadedMetrics {
 
 type TokioResult = tokio::task::JoinHandle<Result<(HashMap<u64, RangeValue>, HashSet<i64>)>>;
 
+const STORAGE_HOUR_MICROS: i64 = 60 * 60 * 1_000_000;
+const MAX_SERIES_FRAGMENT_HINT: usize = 24;
+const MAX_INITIAL_SERIES_CAPACITY: usize = 2048;
+
+fn series_fragment_hint(start: i64, end: i64, lookback: i64) -> usize {
+    let query_start = start.saturating_sub(lookback);
+    let duration = end.saturating_sub(query_start).max(0);
+    let hourly_fragments = duration
+        .saturating_add(STORAGE_HOUR_MICROS - 1)
+        .div_euclid(STORAGE_HOUR_MICROS)
+        .max(1);
+    usize::try_from(hourly_fragments)
+        .unwrap_or(1)
+        .clamp(1, MAX_SERIES_FRAGMENT_HINT)
+}
+
+fn initial_series_capacity(
+    first_run_len: usize,
+    fragment_hint: usize,
+    first_timestamp: i64,
+    last_timestamp: i64,
+    query_duration: i64,
+) -> usize {
+    let run_based = first_run_len.saturating_mul(fragment_hint.max(1));
+    let interval_based = if first_run_len > 1 && last_timestamp > first_timestamp {
+        let intervals = i64::try_from(first_run_len - 1).unwrap_or(i64::MAX);
+        let sample_interval = (last_timestamp - first_timestamp)
+            .div_euclid(intervals)
+            .max(1);
+        usize::try_from(
+            query_duration
+                .max(0)
+                .saturating_add(sample_interval - 1)
+                .div_euclid(sample_interval)
+                .saturating_add(1),
+        )
+        .unwrap_or(MAX_INITIAL_SERIES_CAPACITY)
+    } else {
+        0
+    };
+    run_based
+        .max(interval_based)
+        .min(MAX_INITIAL_SERIES_CAPACITY.max(first_run_len))
+}
+
 /// Materialize the labels exposed to the query. The process-wide cache stores
 /// only source labels, so raw-data queries add their synthetic hash label at
 /// this boundary for both cache hits and freshly loaded labels.
@@ -194,6 +239,8 @@ pub(super) async fn selector_load_data_from_datafusion(
             hash_field_type,
             df_group.clone(),
             !skip_labels,
+            series_fragment_hint(start, end, lookback),
+            end.saturating_sub(start.saturating_sub(lookback)),
         )
         .await?
     };
@@ -246,6 +293,8 @@ pub(super) async fn load_samples_from_datafusion(
     hash_field_type: &DataType,
     df: DataFrame,
     collect_timestamps: bool,
+    fragment_hint: usize,
+    query_duration: i64,
 ) -> Result<(PartitionedMetrics, HashSet<i64>)> {
     let ctx = Arc::new(df.task_ctx());
     let target_partitions = ctx.session_config().target_partitions();
@@ -301,12 +350,30 @@ pub(super) async fn load_samples_from_datafusion(
                             for i in 0..batch.num_rows() {
                                 let timestamp = time_values.value(i);
                                 let hash: u64 = hash_values.value(i);
-                                let entry = metrics.entry(hash).or_insert_with(|| RangeValue {
-                                    labels: vec![],
-                                    samples: vec![],
-                                    exemplars: None,
-                                    time_window: None,
-                                });
+                                let entry = match metrics.entry(hash) {
+                                    hashbrown::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                                    hashbrown::hash_map::Entry::Vacant(entry) => {
+                                        let mut run_end = i + 1;
+                                        while run_end < batch.num_rows()
+                                            && hash_values.value(run_end) == hash
+                                        {
+                                            run_end += 1;
+                                        }
+                                        let capacity = initial_series_capacity(
+                                            run_end - i,
+                                            fragment_hint,
+                                            time_values.value(i),
+                                            time_values.value(run_end - 1),
+                                            query_duration,
+                                        );
+                                        entry.insert(RangeValue {
+                                            labels: vec![],
+                                            samples: Vec::with_capacity(capacity),
+                                            exemplars: None,
+                                            time_window: None,
+                                        })
+                                    }
+                                };
                                 entry
                                     .samples
                                     .push(Sample::new(timestamp, value_values.value(i)));
@@ -535,6 +602,28 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_series_fragment_and_capacity_hints_are_bounded() {
+        let hour = STORAGE_HOUR_MICROS;
+        assert_eq!(
+            series_fragment_hint(8 * hour, 11 * hour, 5 * 60 * 1_000_000),
+            4
+        );
+        assert_eq!(series_fragment_hint(8 * hour, 8 * hour, 0), 1);
+        assert_eq!(
+            series_fragment_hint(0, 100 * hour, 0),
+            MAX_SERIES_FRAGMENT_HINT,
+        );
+
+        assert_eq!(initial_series_capacity(160, 4, 0, 0, 0), 640);
+        assert_eq!(
+            initial_series_capacity(100, 4, 0, 99 * 15 * 1_000_000, 11_100 * 1_000_000,),
+            741,
+        );
+        assert_eq!(initial_series_capacity(1024, 4, 0, 0, 0), 2048);
+        assert_eq!(initial_series_capacity(4096, 4, 0, 0, 0), 4096);
+    }
+
+    #[test]
     fn test_into_loaded_metrics_only_keeps_uint64_hashes_partitioned() {
         let partitions = vec![HashMap::from([(11, RangeValue::default())])];
         assert!(matches!(
@@ -569,7 +658,7 @@ mod tests {
         let df = ctx.read_batch(batch).unwrap();
 
         let (metrics_without_timestamps, skipped_timestamps) =
-            load_samples_from_datafusion("test", &DataType::UInt64, df.clone(), false)
+            load_samples_from_datafusion("test", &DataType::UInt64, df.clone(), false, 1, 0)
                 .await
                 .unwrap();
         assert!(skipped_timestamps.is_empty());
@@ -578,7 +667,7 @@ mod tests {
         assert_eq!(metrics_without_timestamps[&11].samples.len(), 2);
 
         let (metrics, timestamps) =
-            load_samples_from_datafusion("test", &DataType::UInt64, df, true)
+            load_samples_from_datafusion("test", &DataType::UInt64, df, true, 1, 0)
                 .await
                 .unwrap();
         let metrics = merge_partitioned_metrics(metrics);

--- a/src/promql/src/load_series/series_capacity.rs
+++ b/src/promql/src/load_series/series_capacity.rs
@@ -45,7 +45,9 @@ pub(super) fn initial_series_capacity(
     query_duration: i64,
 ) -> usize {
     let run_based = first_run_len.saturating_mul(fragment_hint);
-    let interval_based = if first_run_len > 1 && run_last_ts > run_first_ts {
+    // At least two intervals, so a single anomalous gap (adjacent
+    // near-duplicate rows in time-sorted input) cannot dictate the estimate.
+    let interval_based = if first_run_len >= 3 && run_last_ts > run_first_ts {
         let sample_interval =
             ((run_last_ts - run_first_ts) / (first_run_len - 1) as i64).max(1) as u64;
         let samples = (query_duration.max(0) as u64)
@@ -89,6 +91,11 @@ mod tests {
         );
         assert_eq!(initial_series_capacity(1024, 4, 0, 0, 0), 2048);
         assert_eq!(initial_series_capacity(4096, 4, 0, 0, 0), 4096);
+        // A 2-row run must not infer an interval from its single gap.
+        assert_eq!(
+            initial_series_capacity(2, 4, 0, 1_000, 11_100 * 1_000_000),
+            8
+        );
     }
 
     #[test]

--- a/src/promql/src/load_series/series_capacity.rs
+++ b/src/promql/src/load_series/series_capacity.rs
@@ -15,17 +15,15 @@
 
 //! Sample-capacity estimation for hash-sorted series materialization.
 
-use datafusion::arrow::array::UInt64Array;
-
 const STORAGE_HOUR_MICROS: i64 = 60 * 60 * 1_000_000;
 const MAX_SERIES_FRAGMENT_HINT: usize = 24;
 const MAX_INITIAL_SERIES_CAPACITY: usize = 2048;
 
 /// Length of the contiguous run of equal hashes starting at `start`.
-pub(super) fn batch_run_len(hash_values: &UInt64Array, start: usize) -> usize {
-    let hash = hash_values.value(start);
+pub(super) fn batch_run_len(hashes: &[u64], start: usize) -> usize {
+    let hash = hashes[start];
     let mut end = start + 1;
-    while end < hash_values.len() && hash_values.value(end) == hash {
+    while end < hashes.len() && hashes[end] == hash {
         end += 1;
     }
     end - start
@@ -76,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_batch_run_len() {
-        let hashes = UInt64Array::from(vec![7u64, 7, 7, 9, 9, 1]);
+        let hashes = [7u64, 7, 7, 9, 9, 1];
         assert_eq!(batch_run_len(&hashes, 0), 3);
         assert_eq!(batch_run_len(&hashes, 3), 2);
         assert_eq!(batch_run_len(&hashes, 5), 1);

--- a/src/promql/src/load_series/series_capacity.rs
+++ b/src/promql/src/load_series/series_capacity.rs
@@ -1,0 +1,103 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Sample-capacity estimation for hash-sorted series materialization.
+
+use datafusion::arrow::array::UInt64Array;
+
+const STORAGE_HOUR_MICROS: i64 = 60 * 60 * 1_000_000;
+const MAX_SERIES_FRAGMENT_HINT: usize = 24;
+const MAX_INITIAL_SERIES_CAPACITY: usize = 2048;
+
+/// Length of the contiguous run of equal hashes starting at `start`.
+pub(super) fn batch_run_len(hash_values: &UInt64Array, start: usize) -> usize {
+    let hash = hash_values.value(start);
+    let mut end = start + 1;
+    while end < hash_values.len() && hash_values.value(end) == hash {
+        end += 1;
+    }
+    end - start
+}
+
+/// Estimate the total sample count of a series from its first contiguous run
+/// of `first_run_len` rows spanning `[run_first_ts, run_last_ts]`.
+///
+/// Two estimates cover the common shapes: `run × fragments` fits a series
+/// whose runs arrive whole, `duration / interval` recovers a first run
+/// truncated by a batch boundary. Overestimating (short-lived series, the
+/// sparse-window optimization path) only wastes capacity, bounded by
+/// `MAX_INITIAL_SERIES_CAPACITY`.
+pub(super) fn initial_series_capacity(
+    first_run_len: usize,
+    fragment_hint: usize,
+    run_first_ts: i64,
+    run_last_ts: i64,
+    query_duration: i64,
+) -> usize {
+    let run_based = first_run_len.saturating_mul(fragment_hint);
+    let interval_based = if first_run_len > 1 && run_last_ts > run_first_ts {
+        let sample_interval =
+            ((run_last_ts - run_first_ts) / (first_run_len - 1) as i64).max(1) as u64;
+        let samples = (query_duration.max(0) as u64)
+            .div_ceil(sample_interval)
+            .saturating_add(1);
+        usize::try_from(samples).unwrap_or(MAX_INITIAL_SERIES_CAPACITY)
+    } else {
+        0
+    };
+    // The current batch already proves first_run_len samples exist, so the
+    // cap never allocates below that.
+    let cap = MAX_INITIAL_SERIES_CAPACITY.max(first_run_len);
+    run_based.max(interval_based).min(cap)
+}
+
+/// Hash-sorted parquet is written per storage hour, so a series arrives as
+/// roughly one contiguous run per hour fragment of the query span.
+pub(super) fn series_fragment_hint(query_duration: i64) -> usize {
+    let hourly_fragments = (query_duration.max(0) as u64).div_ceil(STORAGE_HOUR_MICROS as u64);
+    hourly_fragments.clamp(1, MAX_SERIES_FRAGMENT_HINT as u64) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_batch_run_len() {
+        let hashes = UInt64Array::from(vec![7u64, 7, 7, 9, 9, 1]);
+        assert_eq!(batch_run_len(&hashes, 0), 3);
+        assert_eq!(batch_run_len(&hashes, 3), 2);
+        assert_eq!(batch_run_len(&hashes, 5), 1);
+    }
+
+    #[test]
+    fn test_initial_series_capacity_is_bounded() {
+        assert_eq!(initial_series_capacity(160, 4, 0, 0, 0), 640);
+        assert_eq!(
+            initial_series_capacity(100, 4, 0, 99 * 15 * 1_000_000, 11_100 * 1_000_000),
+            741,
+        );
+        assert_eq!(initial_series_capacity(1024, 4, 0, 0, 0), 2048);
+        assert_eq!(initial_series_capacity(4096, 4, 0, 0, 0), 4096);
+    }
+
+    #[test]
+    fn test_series_fragment_hint_is_bounded() {
+        let hour = STORAGE_HOUR_MICROS;
+        assert_eq!(series_fragment_hint(3 * hour + 5 * 60 * 1_000_000), 4);
+        assert_eq!(series_fragment_hint(0), 1);
+        assert_eq!(series_fragment_hint(100 * hour), MAX_SERIES_FRAGMENT_HINT);
+    }
+}


### PR DESCRIPTION
## Summary

- estimate a series sample-capacity hint from the query span, storage-hour fragments, and the first contiguous hash run
- preallocate the sample vector when a hash-sorted UInt64 series is first materialized
- bound the fragment hint to 24 and the normal initial capacity to 2048 samples
- add unit coverage for fragment estimation, interval-based capacity, and capacity bounds

This extracts only the series-capacity preallocation from #13964. It keeps the existing DataFusion `RepartitionExec` and does not include the hash-run router, fused `sum(rate(...))`, or histogram changes.

## Why

On high-cardinality range queries, each series currently starts with an empty sample vector. Growing a roughly 630-sample series through the normal doubling sequence causes repeated allocations and copies. With approximately 898,560 series in the benchmark, allocator contention and sample copying dominate series construction.

The first hash run already provides enough information to estimate a useful bounded capacity:

- `first_run_len * hourly_fragment_count`
- or `query_duration / observed_sample_interval + 1`

The larger bounded estimate is used for the initial allocation. Irregular or fragmented input remains correct; a less accurate estimate only changes allocation efficiency.

## Parquet benchmark

Configuration:

- hash-sorted indexed Parquet only
- 3-hour query range, 15-second step, 5-minute rate window
- 12 target partitions
- cache and compaction disabled
- one warm-up followed by 10 recorded requests
- baseline measured before and after the variant and pooled

Query:

```promql
histogram_quantile(0.9, sum by(le, path) (rate(codelab_api_request_duration_seconds_bucket[5m])))
```

| Case | Endpoint mean | `load hashing and sample` mean |
|---|---:|---:|
| main | 18.007185 s | 10.146067 s |
| this PR | 8.380245 s | 3.227432 s |
| reduction | 53.46% | 68.19% |

The filtered query improves from 0.439404 seconds to 0.429662 seconds (2.22%). It has only 16,640 series versus 898,560 in the no-filter query, so allocation overhead is much less significant.

All recorded responses match main after removing the random `trace_id` field:

- filter SHA-256: `20bfe5f29d6936f0fc6d2f7c9726d7f843a14b6d408e81d4688a750b8022982f`
- no-filter SHA-256: `23f2fefc0a432d6ba8b94b0b916a46aaca6b92ec1e542d7871ff613fbcc15fd6`

## Testing

```text
cargo test -p promql --lib
381 passed; 0 failed
```
