### PR TITLE
fix: reduce db calls for realtime alerts [v0.40]

### DIFF
--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -33,6 +33,11 @@ pub mod alert;
 pub mod deduplication;
 pub mod incidents;
 
+/// Minimum silence applied to a realtime alert after each notification, even
+/// when the alert's own silence is 0 — without a floor, every matching
+/// ingestion request sends a notification and its db writes.
+const REALTIME_MIN_SILENCE_SECS: i64 = 30;
+
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq, Default)]
 #[serde(default)]
 pub struct TriggerCondition {
@@ -311,6 +316,15 @@ impl TriggerCondition {
                 start_from,
             )
         }
+    }
+
+    /// Effective realtime-alert silence in microseconds: the alert's own
+    /// silence (minutes) floored by [`REALTIME_MIN_SILENCE_SECS`].
+    pub fn effective_silence_micros(&self) -> i64 {
+        self.silence
+            .saturating_mul(60)
+            .max(REALTIME_MIN_SILENCE_SECS)
+            .saturating_mul(1_000_000)
     }
 }
 

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -14,9 +14,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
-use config::meta::{
-    meta_store::MetaStore,
-    triggers::{Trigger, TriggerId, TriggerModule, TriggerStatus},
+use config::{
+    meta::{
+        meta_store::MetaStore,
+        triggers::{Trigger, TriggerId, TriggerModule, TriggerStatus},
+    },
+    utils::json,
 };
 use once_cell::sync::Lazy;
 
@@ -235,4 +238,20 @@ pub async fn clear() -> Result<()> {
 pub fn get_scheduler_max_retries() -> (bool, i32) {
     let max_retries = config::get_config().limit.scheduler_max_retries;
     (max_retries > 0, max_retries.unsigned_abs() as i32)
+}
+
+/// Realtime alert triggers are cached on every node; the trigger rides in the
+/// event body so watchers can update their cache without a db read.
+async fn emit_realtime_trigger_event(trigger: &Trigger) -> Result<()> {
+    if trigger.module != TriggerModule::Alert || !trigger.is_realtime {
+        return Ok(());
+    }
+    let key = format!(
+        "{TRIGGERS_KEY}{}/{}/{}",
+        trigger.module, trigger.org, trigger.module_key
+    );
+    let cluster_coordinator = crate::db::get_coordinator().await;
+    cluster_coordinator
+        .put(&key, json::to_vec(trigger).unwrap().into(), true, None)
+        .await
 }

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -14,7 +14,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use chrono::Duration;
 use config::{
     metrics::DB_QUERY_NUMS,
@@ -182,17 +181,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
             return Err(e.into());
         }
 
-        // For now, only send realtime alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, &trigger.org, &trigger.module_key
-            );
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, Bytes::from(""), true, None)
-                .await?;
-        }
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 
@@ -281,7 +270,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     SET status = ?, start_time = ?, end_time = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?, data = ?
     WHERE org = ? AND module_key = ? AND module = ?;"#,
             )
-            .bind(trigger.status)
+            .bind(&trigger.status)
             .bind(trigger.start_time)
             .bind(trigger.end_time)
             .bind(trigger.retries)
@@ -298,7 +287,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     SET status = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?, data = ?
     WHERE org = ? AND module_key = ? AND module = ?;"#,
             )
-            .bind(trigger.status)
+            .bind(&trigger.status)
             .bind(trigger.retries)
             .bind(trigger.next_run_at)
             .bind(trigger.is_realtime)
@@ -311,17 +300,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
 
         query.execute(&pool).await?;
 
-        // For now, only send realtime alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, &trigger.org, &trigger.module_key
-            );
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, Bytes::from(""), true, None)
-                .await?;
-        }
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 
@@ -382,22 +361,12 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
 
         // Handle cluster coordinator for realtime alerts
         for trigger in &triggers {
-            if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-                let key = format!(
-                    "{TRIGGERS_KEY}{}/{}/{}",
-                    trigger.module, &trigger.org, &trigger.module_key
+            if let Err(e) = super::emit_realtime_trigger_event(trigger).await {
+                log::error!(
+                    "Error updating cluster coordinator for trigger {}/{}: {e}",
+                    trigger.org,
+                    trigger.module_key
                 );
-                let cluster_coordinator = db::get_coordinator().await;
-                if let Err(e) = cluster_coordinator
-                    .put(&key, Bytes::from(""), true, None)
-                    .await
-                {
-                    log::error!(
-                        "Error updating cluster coordinator for trigger {}: {}",
-                        key,
-                        e
-                    );
-                }
             }
         }
 

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -14,7 +14,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use chrono::Duration;
 use config::{
     metrics::DB_QUERY_NUMS,
@@ -215,17 +214,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
             return Err(e.into());
         }
 
-        // For now, only send realtime alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, &trigger.org, &trigger.module_key
-            );
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, Bytes::from(""), true, None)
-                .await?;
-        }
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 
@@ -313,7 +302,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     SET status = $1, start_time = $2, end_time = $3, retries = $4, next_run_at = $5, is_realtime = $6, is_silenced = $7, data = $8
     WHERE org = $9 AND module_key = $10 AND module = $11;"#,
             )
-            .bind(trigger.status)
+            .bind(&trigger.status)
             .bind(trigger.start_time)
             .bind(trigger.end_time)
             .bind(trigger.retries)
@@ -330,7 +319,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
     WHERE org = $7 AND module_key = $8 AND module = $9;"#,
             )
-            .bind(trigger.status)
+            .bind(&trigger.status)
             .bind(trigger.retries)
             .bind(trigger.next_run_at)
             .bind(trigger.is_realtime)
@@ -343,17 +332,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
 
         query.execute(&pool).await?;
 
-        // For now, only send realtime alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, &trigger.org, &trigger.module_key
-            );
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, Bytes::from(""), true, None)
-                .await?;
-        }
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 
@@ -421,22 +400,12 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
                     .inc();
                 // Handle cluster coordinator for realtime alerts
                 for trigger in &triggers {
-                    if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-                        let key = format!(
-                            "{TRIGGERS_KEY}{}/{}/{}",
-                            trigger.module, &trigger.org, &trigger.module_key
+                    if let Err(e) = super::emit_realtime_trigger_event(trigger).await {
+                        log::error!(
+                            "Error updating cluster coordinator for trigger {}/{}: {e}",
+                            trigger.org,
+                            trigger.module_key
                         );
-                        let cluster_coordinator = db::get_coordinator().await;
-                        if let Err(e) = cluster_coordinator
-                            .put(&key, Bytes::from(""), true, None)
-                            .await
-                        {
-                            log::error!(
-                                "Error updating cluster coordinator for trigger {}: {}",
-                                key,
-                                e
-                            );
-                        }
                     }
                 }
                 Ok(())

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -15,7 +15,7 @@
 
 use async_trait::async_trait;
 use chrono::Duration;
-use config::utils::{json, time::now_micros};
+use config::utils::time::now_micros;
 use sqlx::{Pool, Row, Sqlite};
 
 use super::{TRIGGERS_KEY, Trigger, TriggerModule, TriggerStatus, get_scheduler_max_retries};
@@ -165,22 +165,11 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         // release lock
         drop(client);
 
-        // For now, only send realtime alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, &trigger.org, &trigger.module_key
-            );
-
-            // TODO: For sqlite cluster coordinator, the alert triggers are put
-            // into the sqlite meta database to send watch events. Hence, there is a
-            // redundancy of alert triggers stored both in scheduled_jobs and meta
-            // tables. How to remove this redundancy?
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, json::to_vec(&trigger).unwrap().into(), true, None)
-                .await?;
-        }
+        // TODO: For sqlite cluster coordinator, the alert triggers are put
+        // into the sqlite meta database to send watch events. Hence, there is a
+        // redundancy of alert triggers stored both in scheduled_jobs and meta
+        // tables. How to remove this redundancy?
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 
@@ -298,17 +287,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         // release lock
         drop(client);
 
-        // For now, only send alert triggers
-        if trigger.module == TriggerModule::Alert && trigger.is_realtime {
-            let key = format!(
-                "{TRIGGERS_KEY}{}/{}/{}",
-                trigger.module, &trigger.org, &trigger.module_key
-            );
-            let cluster_coordinator = db::get_coordinator().await;
-            cluster_coordinator
-                .put(&key, json::to_vec(&trigger).unwrap().into(), true, None)
-                .await?;
-        }
+        super::emit_realtime_trigger_event(&trigger).await?;
         Ok(())
     }
 

--- a/src/infra/src/table/short_urls.rs
+++ b/src/infra/src/table/short_urls.rs
@@ -128,7 +128,8 @@ pub async fn create_table_index() -> Result<(), errors::Error> {
     Ok(())
 }
 
-pub async fn add(short_id: &str, original_url: &str) -> Result<(), errors::Error> {
+/// Returns `false` when a row with the same `short_id` already exists.
+pub async fn add(short_id: &str, original_url: &str) -> Result<bool, errors::Error> {
     let record = ActiveModel {
         short_id: Set(short_id.to_string()),
         original_url: Set(original_url.to_string()),
@@ -140,9 +141,16 @@ pub async fn add(short_id: &str, original_url: &str) -> Result<(), errors::Error
     let _lock = get_lock().await;
 
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
-    Entity::insert(record).exec(client).await?;
+    let inserted = Entity::insert(record)
+        .on_conflict(
+            sea_orm::sea_query::OnConflict::column(Column::ShortId)
+                .do_nothing()
+                .to_owned(),
+        )
+        .exec_without_returning(client)
+        .await?;
 
-    Ok(())
+    Ok(inserted > 0)
 }
 
 pub async fn remove(short_id: &str) -> Result<(), errors::Error> {
@@ -186,17 +194,6 @@ pub async fn list(limit: Option<i64>) -> Result<Vec<ShortUrlRecord>, errors::Err
     let records = res.into_model::<ShortUrlRecord>().all(client).await?;
 
     Ok(records)
-}
-
-pub async fn contains(short_id: &str) -> Result<bool, errors::Error> {
-    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
-    let record = Entity::find()
-        .filter(Column::ShortId.eq(short_id))
-        .into_model::<ShortUrlRecord>()
-        .one(client)
-        .await?;
-
-    Ok(record.is_some())
 }
 
 pub async fn len() -> usize {

--- a/src/service/db/short_url.rs
+++ b/src/service/db/short_url.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
 use chrono::Utc;
-use config::get_config;
+use config::{get_config, utils::json};
 use infra::{db::Event, table::short_urls};
 
 use crate::{common::infra::config::SHORT_URLS, service::db};
@@ -29,8 +29,8 @@ const SHORT_URL_GC_INTERVAL: i64 = 1; // days
 const SHORT_URL_CACHE_LIMIT: i64 = 10_000; // records
 
 pub async fn get(short_id: &str) -> Result<String, anyhow::Error> {
-    if let Some(v) = SHORT_URLS.get(short_id) {
-        return Ok(v.original_url.to_string());
+    if let Some(original_url) = get_cached(short_id) {
+        return Ok(original_url);
     }
 
     let val = short_urls::get(short_id)
@@ -41,19 +41,29 @@ pub async fn get(short_id: &str) -> Result<String, anyhow::Error> {
     Ok(original_url)
 }
 
-pub async fn set(short_id: &str, entry: short_urls::ShortUrlRecord) -> Result<(), anyhow::Error> {
-    if let Err(e) = short_urls::add(short_id, &entry.original_url).await {
-        log::error!("Failed to add short URL to DB : {e}");
-        return Err(e).context("Failed to add short URL to DB");
+/// Cache-only lookup.
+pub fn get_cached(short_id: &str) -> Option<String> {
+    SHORT_URLS.get(short_id).map(|v| v.original_url.to_string())
+}
+
+/// Returns `false` when a row with the same `short_id` already exists (nothing
+/// written, no events emitted).
+pub async fn set(short_id: &str, entry: short_urls::ShortUrlRecord) -> Result<bool, anyhow::Error> {
+    let inserted = short_urls::add(short_id, &entry.original_url)
+        .await
+        .inspect_err(|e| log::error!("Failed to add short URL to DB : {e}"))
+        .context("Failed to add short URL to DB")?;
+    if !inserted {
+        return Ok(false);
     }
 
     // trigger watch event cluster coordinator
-    cluster::emit_put_event(short_id).await?;
+    cluster::emit_put_event(short_id, &entry).await?;
     // trigger watch event super cluster
     #[cfg(feature = "enterprise")]
     super_cluster::emit_put_event(short_id, entry).await?;
 
-    Ok(())
+    Ok(true)
 }
 
 pub async fn watch() -> Result<(), anyhow::Error> {
@@ -82,11 +92,25 @@ pub async fn watch() -> Result<(), anyhow::Error> {
         match ev {
             Event::Put(ev) => {
                 let item_key = ev.key.strip_prefix(key).unwrap();
-                let item_value = match short_urls::get(item_key).await {
-                    Ok(val) => val,
-                    Err(e) => {
-                        log::error!("Error getting value: {e}");
-                        continue;
+                // Prefer the record carried in the event body; fall back to a
+                // db read for events from nodes that send an empty body.
+                let item_value = if let Some(val) = &ev.value
+                    && !val.is_empty()
+                {
+                    match json::from_slice::<short_urls::ShortUrlRecord>(val) {
+                        Ok(val) => val,
+                        Err(e) => {
+                            log::error!("Error parsing short URL event value: {e}");
+                            continue;
+                        }
+                    }
+                } else {
+                    match short_urls::get(item_key).await {
+                        Ok(val) => val,
+                        Err(e) => {
+                            log::error!("Error getting value: {e}");
+                            continue;
+                        }
                     }
                 };
                 SHORT_URLS.insert(item_key.to_string(), item_value);
@@ -168,13 +192,18 @@ fn days_to_minutes(days: i64) -> i64 {
 
 /// Helper functions for sending events to cache watchers in the cluster.
 mod cluster {
-    use super::SHORT_URL_KEY;
+    use config::utils::json;
+
+    use super::{SHORT_URL_KEY, short_urls};
 
     /// Sends event to the cluster cache watchers indicating that a new short URL entry has been
-    /// added.
-    pub async fn emit_put_event(short_id: &str) -> Result<(), infra::errors::Error> {
+    /// added. The record rides in the event body so watchers can cache it without a db read.
+    pub async fn emit_put_event(
+        short_id: &str,
+        entry: &short_urls::ShortUrlRecord,
+    ) -> Result<(), infra::errors::Error> {
         let key = short_url_key(short_id);
-        let value = bytes::Bytes::new();
+        let value = bytes::Bytes::from(json::to_vec(entry).unwrap());
         let cluster_coordinator = infra::db::get_coordinator().await;
         cluster_coordinator
             .put(&key, value, infra::db::NEED_WATCH, None)

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -19,7 +19,7 @@ use std::{
     sync::{Arc, atomic::Ordering},
 };
 
-use chrono::{Duration, TimeZone, Utc};
+use chrono::{TimeZone, Utc};
 use config::{
     SIZE_IN_MB, TIMESTAMP_COL_NAME,
     cluster::{LOCAL_NODE, LOCAL_NODE_ID},
@@ -220,7 +220,7 @@ pub async fn get_stream_alerts(
             })
             .collect::<Vec<_>>();
         if alerts.is_empty() {
-            return;
+            continue;
         }
         stream_alerts_map.insert(key, alerts);
     }
@@ -278,7 +278,10 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
                 if !success_msg.is_empty() {
                     trigger_data_stream.success_response = Some(success_msg);
                 }
-                if alert.trigger_condition.silence > 0 {
+                // enforce a minimum silence floor so a high-volume stream cannot
+                // fire (and write to the db) once per matching request
+                let silence_micros = alert.trigger_condition.effective_silence_micros();
+                if silence_micros > 0 {
                     log::debug!(
                         "Realtime alert {}/{}/{}/{} triggered successfully, hence applying silence period",
                         &alert.org_id,
@@ -287,11 +290,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
                         &alert.name
                     );
 
-                    let next_run_at = Utc::now().timestamp_micros()
-                        + Duration::try_minutes(alert.trigger_condition.silence)
-                            .unwrap()
-                            .num_microseconds()
-                            .unwrap();
+                    let next_run_at = Utc::now().timestamp_micros() + silence_micros;
                     // After the notification is sent successfully, we need to update
                     // the silence period of the trigger
                     if let Err(e) = db::scheduler::update_trigger(

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -584,7 +584,7 @@ async fn write_logs(
 
     // only one trigger per request
     if !triggers.is_empty() {
-        tokio::spawn(async move { evaluate_trigger(triggers).await });
+        tokio::spawn(evaluate_trigger(triggers));
     }
 
     Ok(req_stats)

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -549,10 +549,10 @@ pub async fn ingest(
         ])
         .inc();
 
-    // only one trigger per request
+    // only one trigger per request; notification/db work must not block ingestion
     for (_, entry) in stream_trigger_map {
         if let Some(entry) = entry {
-            evaluate_trigger(entry).await;
+            tokio::spawn(evaluate_trigger(entry));
         }
     }
 

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -646,10 +646,10 @@ pub async fn handle_otlp_request(
         .with_label_values(&[ep, "200", org_id, StreamType::Metrics.as_str(), "", ""])
         .inc();
 
-    // only one trigger per request
+    // only one trigger per request; notification/db work must not block ingestion
     for (_, entry) in stream_trigger_map {
         if let Some(entry) = entry {
-            evaluate_trigger(entry).await;
+            tokio::spawn(evaluate_trigger(entry));
         }
     }
 

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -735,10 +735,10 @@ async fn remote_write_inner(
         ])
         .inc();
 
-    // only one trigger per request
+    // only one trigger per request; notification/db work must not block ingestion
     for (_, entry) in stream_trigger_map {
         if let Some(entry) = entry {
-            evaluate_trigger(entry).await;
+            tokio::spawn(evaluate_trigger(entry));
         }
     }
 

--- a/src/service/short_url.rs
+++ b/src/service/short_url.rs
@@ -13,12 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use anyhow::anyhow;
 use chrono::Utc;
 use config::{get_config, utils::md5};
-use infra::{
-    errors::{DbError, Error},
-    table::short_urls::ShortUrlRecord,
-};
+use infra::table::short_urls::ShortUrlRecord;
 
 use crate::service::db;
 
@@ -40,14 +38,10 @@ pub fn construct_short_url(org_id: &str, short_id: &str) -> String {
     )
 }
 
-async fn store_short_url(
-    org_id: &str,
-    short_id: &str,
-    original_url: &str,
-) -> Result<String, anyhow::Error> {
+/// Returns `false` when a row with the same short id already exists.
+async fn store_short_url(short_id: &str, original_url: &str) -> Result<bool, anyhow::Error> {
     let entry = ShortUrlRecord::new(short_id, original_url);
-    db::short_url::set(short_id, entry).await?;
-    Ok(construct_short_url(org_id, short_id))
+    db::short_url::set(short_id, entry).await
 }
 
 fn generate_short_id(original_url: &str, timestamp: Option<i64>) -> String {
@@ -62,31 +56,32 @@ fn generate_short_id(original_url: &str, timestamp: Option<i64>) -> String {
 
 /// Shortens the given original URL and stores it in the database
 pub async fn shorten(org_id: &str, original_url: &str) -> Result<String, anyhow::Error> {
-    let mut short_id = generate_short_id(original_url, None);
+    let short_id = generate_short_id(original_url, None);
 
+    // fast path for already-shortened urls: cache only, no db read
+    if db::short_url::get_cached(&short_id).is_some_and(|url| url == original_url) {
+        return Ok(construct_short_url(org_id, &short_id));
+    }
+
+    // insert first (ON CONFLICT DO NOTHING): most urls are previously unseen,
+    // so a lookup before insert would be a wasted db call
+    if store_short_url(&short_id, original_url).await? {
+        return Ok(construct_short_url(org_id, &short_id));
+    }
+
+    // conflict: either the same url was already stored, or the short id
+    // belongs to a different url (hash collision)
     if let Ok(existing_url) = db::short_url::get(&short_id).await
         && existing_url == original_url
     {
         return Ok(construct_short_url(org_id, &short_id));
     }
-
-    let result = store_short_url(org_id, &short_id, original_url).await;
-    match result {
-        Ok(url) => Ok(url),
-        Err(e) => {
-            if let Some(infra_error) = e.downcast_ref::<Error>() {
-                match infra_error {
-                    Error::DbError(DbError::UniqueViolation) => {
-                        let timestamp = Utc::now().timestamp_micros();
-                        short_id = generate_short_id(original_url, Some(timestamp));
-                        store_short_url(org_id, &short_id, original_url).await
-                    }
-                    _ => Err(e),
-                }
-            } else {
-                Err(e)
-            }
-        }
+    let timestamp = Utc::now().timestamp_micros();
+    let short_id = generate_short_id(original_url, Some(timestamp));
+    if store_short_url(&short_id, original_url).await? {
+        Ok(construct_short_url(org_id, &short_id))
+    } else {
+        Err(anyhow!("Short URL id collision for {short_id}"))
     }
 }
 

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -1027,8 +1027,10 @@ async fn write_traces(
         log::error!("Error while writing trace_index values: {e}");
     }
 
-    // only one trigger per request
-    evaluate_trigger(triggers).await;
+    // only one trigger per request; notification/db work must not block ingestion
+    if !triggers.is_empty() {
+        tokio::spawn(evaluate_trigger(triggers));
+    }
 
     Ok(req_stats)
 }

--- a/src/super_cluster_queue/short_urls.rs
+++ b/src/super_cluster_queue/short_urls.rs
@@ -27,9 +27,7 @@ pub(crate) async fn process(msg: Message) -> Result<()> {
             if original_url.is_empty() {
                 return Err(Error::Message("Invalid message value".to_string()));
             }
-            if infra::table::short_urls::contains(&short_id).await? {
-                return Ok(());
-            }
+            // `add` is a no-op if the short id already exists.
             infra::table::short_urls::add(&short_id, &original_url).await?;
         }
         MessageType::ShortUrlDelete => {


### PR DESCRIPTION
Backport of #13920 to `branch-v0.40.0`.

Realtime alerts made a burst of metadata db calls on every firing — and with `silence = 0`, on every matching ingestion request. This cuts a firing down to 1 INSERT + 1 UPDATE with zero watcher fan-out, and bounds the firing rate:

1. Coordinator events carry the body (trigger / `ShortUrlRecord`), with the five copy-pasted emit blocks collapsed into one `emit_realtime_trigger_event` helper in `infra::scheduler`. Watchers use the body when non-empty and keep the db-read fallback for empty-body events from old nodes, so rolling upgrades are safe.
2. Short URL uses `INSERT … ON CONFLICT DO NOTHING` instead of select-then-insert; no-op writes emit no events; the dead `contains()` pre-check in the super-cluster queue is gone; md5 collisions are now genuinely handled.
3. Fixed 30s minimum silence for realtime alerts via `TriggerCondition::effective_silence_micros`, so an alert with silence 0 can no longer fire once per matching request.
4. Bug fix in `get_stream_alerts`: early `return` → `continue`, so one stream with fully filtered-out alerts no longer drops alerts for the remaining streams of a multi-stream request.
5. Traces and metrics ingestion spawn `evaluate_trigger` like the logs path, instead of awaiting notification + db work inline on the ingest request path.

Adaptations for this branch:

- Paths follow the pre-refactor layout (`src/service/*`, in-crate `src/super_cluster_queue/`).
- Short URLs are not org-scoped here, so `db::short_url::get_cached(short_id)` has no org check and `store_short_url` drops the org parameter; the logic is otherwise identical to main.
- This branch has a third scheduler backend (MySQL) that main no longer has — its three emit blocks are collapsed into the same `emit_realtime_trigger_event` helper.
- The realtime-trigger watcher already handles event bodies with db fallback — unchanged, same as main.

Verified: `cargo check --workspace --all-targets`, `cargo fmt`, branch CI clippy (`-D warnings`) all clean; config alerts unit tests pass. Enterprise verified against o2-enterprise `branch-v0.40.0` via the `Cargo.toml.openobserve` swap (`cargo check --all-targets` green); no enterprise-side changes needed.
