### PR TITLE
fix(search): cap result cache entries per key and stop over-invalidating the cache index

### DIFF
--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -100,6 +100,7 @@ static AGGREGATION_FILES_READER: Lazy<Vec<FileData>> = Lazy::new(|| {
     files
 });
 
+/// Metas are added under the file's bucket guard; every deletion re-verifies the other side first.
 pub static QUERY_RESULT_CACHE: Lazy<RwAHashMap<String, Vec<ResultCacheMeta>>> =
     Lazy::new(Default::default);
 
@@ -146,6 +147,12 @@ enum TrashOutcome {
     Moved(String),
     SourceMissing,
     Failed,
+}
+
+enum RemoveOutcome {
+    Removed(Option<String>), // vacated; the payload is the trash file to unlink off-lock
+    NotIndexed,
+    Failed, // the path could not be vacated; the index entry was restored
 }
 
 impl fmt::Display for FileType {
@@ -431,7 +438,7 @@ impl FileData {
     }
 
     /// Returns the trash path the file was vacated to; the caller deletes it off-lock.
-    async fn remove(&mut self, file: &str) -> Result<Option<String>, anyhow::Error> {
+    async fn remove(&mut self, file: &str) -> RemoveOutcome {
         log::debug!(
             "[CacheType:{}] File disk cache remove file {file}",
             self.file_type,
@@ -442,7 +449,7 @@ impl FileData {
                 "[CacheType:{}] File disk cache remove file {file} not in the index",
                 self.file_type,
             );
-            return Ok(None);
+            return RemoveOutcome::NotIndexed;
         };
         let file_path = self.get_file_path(key.as_str());
         let trash_file = match self.move_to_trash(key.as_str(), &file_path) {
@@ -451,7 +458,7 @@ impl FileData {
             TrashOutcome::Failed => {
                 // the file still occupies its path: keep the entry so accounting stays true
                 self.data.insert(key, data_size);
-                return Ok(None);
+                return RemoveOutcome::Failed;
             }
         };
         self.cur_size -= data_size;
@@ -479,7 +486,7 @@ impl FileData {
                 .sub(data_size as i64);
         }
 
-        Ok(trash_file)
+        RemoveOutcome::Removed(trash_file)
     }
 
     fn choose_multi_dir(&self, file: &str) -> String {
@@ -890,9 +897,9 @@ pub async fn remove(file: &str) -> Result<(), anyhow::Error> {
     } else {
         RESULT_FILES[idx].write().await
     };
-    let trash_file = files.remove(file).await?;
+    let outcome = files.remove(file).await;
     drop(files);
-    if let Some(trash_file) = trash_file
+    if let RemoveOutcome::Removed(Some(trash_file)) = outcome
         && let Err(e) = tokio::fs::remove_file(&trash_file).await
         && e.kind() != std::io::ErrorKind::NotFound
     {
@@ -979,19 +986,25 @@ async fn remove_unowned_result_file(file_key: &str) {
     if owned {
         return;
     }
-    let trash_file = match files.remove(file_key).await {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!("Remove evicted result cache file {file_key} error: {e}");
-            return;
+    match files.remove(file_key).await {
+        RemoveOutcome::Removed(trash_file) => {
+            drop(files);
+            if let Some(trash_file) = trash_file
+                && let Err(e) = tokio::fs::remove_file(&trash_file).await
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                log::error!("File disk cache remove trash file {trash_file} error: {e}");
+            }
         }
-    };
-    drop(files);
-    if let Some(trash_file) = trash_file
-        && let Err(e) = tokio::fs::remove_file(&trash_file).await
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        log::error!("File disk cache remove trash file {trash_file} error: {e}");
+        RemoveOutcome::NotIndexed => {}
+        RemoveOutcome::Failed => {
+            // the path could not be vacated: the file stays readable, so restore its meta
+            let mut w = QUERY_RESULT_CACHE.write().await;
+            let metas = w.entry(query_key).or_default();
+            if !metas.contains(&meta) {
+                metas.push(meta);
+            }
+        }
     }
 }
 
@@ -1000,14 +1013,20 @@ async fn remove_unowned_result_file(file_key: &str) {
 pub async fn remove_result_cache_metas(file_keys: &[String]) {
     let parsed = file_keys
         .iter()
-        .filter_map(|file_key| parse_result_cache_key(file_key))
-        .map(|(_, _, query_key, meta)| (query_key, meta))
+        .filter_map(|file_key| {
+            let (_, _, query_key, meta) = parse_result_cache_key(file_key)?;
+            Some((query_key, meta, get_file_path(file_key)?))
+        })
         .collect::<Vec<_>>();
     if parsed.is_empty() {
         return;
     }
     let mut r = QUERY_RESULT_CACHE.write().await;
-    for (query_key, meta) in parsed {
+    for (query_key, meta, abs_path) in parsed {
+        // checked under the lock: a rewrite lands its file before its meta push can take this lock
+        if std::path::Path::new(&abs_path).exists() {
+            continue;
+        }
         if let Some(metas) = r.get_mut(&query_key) {
             metas.retain(|m| m != &meta);
             if metas.is_empty() {
@@ -1629,14 +1648,19 @@ mod tests {
         tokio::fs::write(&file_path, b"x").await.unwrap();
         file_data.set_size(key, 1).await.unwrap();
 
-        let trash_file = file_data.remove(key).await.unwrap().unwrap();
+        let RemoveOutcome::Removed(Some(trash_file)) = file_data.remove(key).await else {
+            panic!("expected the file to be vacated to trash");
+        };
         assert!(!file_data.exist(key).await);
         assert!(!std::path::Path::new(&file_path).exists());
         assert!(std::path::Path::new(&trash_file).exists());
         tokio::fs::remove_file(&trash_file).await.unwrap();
 
         // removing an unknown key vacates nothing
-        assert!(file_data.remove(key).await.unwrap().is_none());
+        assert!(matches!(
+            file_data.remove(key).await,
+            RemoveOutcome::NotIndexed
+        ));
     }
 
     #[tokio::test]
@@ -1660,6 +1684,45 @@ mod tests {
         let on_disk = get_file_path(key).is_some_and(|path| std::path::Path::new(&path).exists());
         assert_eq!(indexed, on_disk);
         assert!(!indexed);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_remove_unowned_restores_meta_on_failed_move() {
+        use std::os::unix::fs::PermissionsExt;
+        let file_key = "results/failmove_org/logs/default/hashkey/1000_2000_0_0.json";
+        let query_key = "failmove_org_logs_default_hashkey";
+        let meta = ResultCacheMeta {
+            start_time: 1000,
+            end_time: 2000,
+            is_aggregate: false,
+            is_descending: false,
+        };
+        let file_path = get_file_path(file_key).unwrap();
+        let parent = std::path::Path::new(&file_path)
+            .parent()
+            .unwrap()
+            .to_owned();
+        tokio::fs::create_dir_all(&parent).await.unwrap();
+        tokio::fs::write(&file_path, b"x").await.unwrap();
+        set_size(file_key, 1).await.unwrap();
+
+        // a read-only parent makes the trash rename fail, so the eviction must roll back fully
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o555)).unwrap();
+        remove_unowned_result_file(file_key).await;
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(indexed_file_guard(file_key).await.is_some());
+        assert!(
+            QUERY_RESULT_CACHE
+                .read()
+                .await
+                .get(query_key)
+                .is_some_and(|metas| metas.contains(&meta))
+        );
+
+        QUERY_RESULT_CACHE.write().await.remove(query_key);
+        remove(file_key).await.unwrap();
     }
 
     #[tokio::test]
@@ -1988,8 +2051,18 @@ mod tests {
         let metas = QUERY_RESULT_CACHE.read().await.get(query_key).cloned();
         assert_eq!(metas, Some(vec![meta2]));
 
-        // removing the last file drops the query key
+        // a meta whose file was rewritten on disk survives the delayed prune
         let file2 = "results/rm_meta_org/logs/default/hashkey/3000_4000_0_1.json".to_string();
+        let abs_path = get_file_path(&file2).unwrap();
+        tokio::fs::create_dir_all(std::path::Path::new(&abs_path).parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&abs_path, b"x").await.unwrap();
+        remove_result_cache_metas(std::slice::from_ref(&file2)).await;
+        assert!(QUERY_RESULT_CACHE.read().await.contains_key(query_key));
+
+        // removing the last file drops the query key once the file is truly gone
+        tokio::fs::remove_file(&abs_path).await.unwrap();
         remove_result_cache_metas(&[file2]).await;
         assert!(!QUERY_RESULT_CACHE.read().await.contains_key(query_key));
     }

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -935,6 +935,10 @@ pub async fn add_result_cache_meta(file_key: &str) {
     let Some((dir, _)) = file_key.rsplit_once('/') else {
         return;
     };
+    // held across the insert so a concurrent eviction orders around the whole handoff
+    let Some(guard) = indexed_file_guard(file_key).await else {
+        return;
+    };
     let mut w = QUERY_RESULT_CACHE.write().await;
     let metas = w.entry(query_key).or_default();
     // an equal meta can already exist when re-caching after clear_cache
@@ -951,12 +955,43 @@ pub async fn add_result_cache_meta(file_key: &str) {
         Vec::new()
     };
     drop(w);
+    drop(guard);
 
     for meta in evicted {
         let file = format!("{dir}/{}", result_cache_file_name(&meta));
-        if let Err(e) = remove(&file).await {
-            log::warn!("Remove evicted result cache file {file} error: {e}");
+        remove_unowned_result_file(&file).await;
+    }
+}
+
+/// Removes the file unless a same-name rewrite re-registered its meta since the eviction.
+async fn remove_unowned_result_file(file_key: &str) {
+    let Some((_, _, query_key, meta)) = parse_result_cache_key(file_key) else {
+        return;
+    };
+    let idx = get_bucket_idx(file_key);
+    let mut files = RESULT_FILES[idx].write().await;
+    // bucket -> QUERY_RESULT_CACHE is the established lock order; writers push under the guard
+    let owned = QUERY_RESULT_CACHE
+        .read()
+        .await
+        .get(&query_key)
+        .is_some_and(|metas| metas.contains(&meta));
+    if owned {
+        return;
+    }
+    let trash_file = match files.remove(file_key).await {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("Remove evicted result cache file {file_key} error: {e}");
+            return;
         }
+    };
+    drop(files);
+    if let Some(trash_file) = trash_file
+        && let Err(e) = tokio::fs::remove_file(&trash_file).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        log::error!("File disk cache remove trash file {trash_file} error: {e}");
     }
 }
 
@@ -1628,6 +1663,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_remove_unowned_result_file() {
+        let file_key = "results/unowned_org/logs/default/hashkey/1000_2000_0_0.json";
+        let query_key = "unowned_org_logs_default_hashkey";
+        let meta = ResultCacheMeta {
+            start_time: 1000,
+            end_time: 2000,
+            is_aggregate: false,
+            is_descending: false,
+        };
+        set_size(file_key, 1).await.unwrap();
+
+        // a rewrite re-registered the meta after the eviction: the file must survive
+        QUERY_RESULT_CACHE
+            .write()
+            .await
+            .insert(query_key.to_string(), vec![meta]);
+        remove_unowned_result_file(file_key).await;
+        assert!(indexed_file_guard(file_key).await.is_some());
+
+        // with no owning meta the file is removed
+        QUERY_RESULT_CACHE.write().await.remove(query_key);
+        remove_unowned_result_file(file_key).await;
+        assert!(indexed_file_guard(file_key).await.is_none());
+    }
+
+    #[tokio::test]
     async fn test_indexed_file_guard() {
         let indexed_key = "metrics_results/guard_org/2024/01/01/00/aaa_1_2_3.pb";
         let evicted_key = "metrics_results/guard_org/2024/01/01/00/bbb_1_2_3.pb";
@@ -1943,6 +2004,7 @@ mod tests {
                 i * 1000,
                 i * 1000 + 500
             );
+            set_size(&file_key, 1).await.unwrap();
             add_result_cache_meta(&file_key).await;
         }
         let metas = QUERY_RESULT_CACHE

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -35,7 +35,6 @@ use config::{
         time::{HourFormat, get_ymdh_from_micros, now_micros},
     },
 };
-use hashbrown::HashMap;
 use object_store::{GetOptions, GetResult, GetResultPayload, ObjectMeta};
 use tokio::sync::RwLock;
 
@@ -105,6 +104,8 @@ pub static QUERY_RESULT_CACHE: Lazy<RwAHashMap<String, Vec<ResultCacheMeta>>> =
     Lazy::new(Default::default);
 
 pub static METRICS_RESULT_CACHE: Lazy<RwLock<Vec<String>>> = Lazy::new(|| RwLock::new(Vec::new()));
+
+const RESULT_CACHE_MAX_ENTRIES_PER_KEY: usize = 10;
 
 static METRICS_RESULT_CACHE_EVICT_HOOK: OnceLock<fn(Vec<String>)> = OnceLock::new();
 
@@ -345,7 +346,7 @@ impl FileData {
         );
         let mut release_size = 0;
         let mut move_failures = 0;
-        let mut result_query_keys = Vec::new();
+        let mut remove_result_files = Vec::new();
         let mut cleanup = EvictionCleanup::default();
         loop {
             let item = self.data.remove();
@@ -385,6 +386,7 @@ impl FileData {
             // metrics
             let columns = key.split('/').collect::<Vec<&str>>();
             let is_metrics_key = columns[0] == "metrics_results";
+            let is_results_key = columns[0] == "results";
             if columns[0] == "files" {
                 metrics::QUERY_DISK_CACHE_FILES
                     .with_label_values(&[columns[1], columns[2]])
@@ -396,10 +398,6 @@ impl FileData {
                 metrics::QUERY_DISK_RESULT_CACHE_USED_BYTES
                     .with_label_values(&[columns[1], columns[2], "results"])
                     .sub(data_size as i64);
-                result_query_keys.push(format!(
-                    "{}_{}_{}_{}",
-                    columns[1], columns[2], columns[3], columns[4]
-                ));
             } else if columns[0] == "metrics_results" {
                 metrics::QUERY_DISK_METRICS_CACHE_USED_BYTES
                     .with_label_values(&[columns[1]])
@@ -409,7 +407,9 @@ impl FileData {
                     .with_label_values(&[columns[1], columns[2], "aggregations"])
                     .sub(data_size as i64);
             }
-            if is_metrics_key {
+            if is_results_key {
+                remove_result_files.push(key);
+            } else if is_metrics_key {
                 cleanup.metrics_files.push(key);
             }
 
@@ -421,12 +421,7 @@ impl FileData {
         }
 
         // pruned inline so the prune completes before the caller can insert a new meta
-        if !result_query_keys.is_empty() {
-            let mut r = QUERY_RESULT_CACHE.write().await;
-            for query_key in result_query_keys {
-                r.remove(&query_key);
-            }
-        }
+        remove_result_cache_metas(&remove_result_files).await;
 
         log::info!(
             "[CacheType:{}] File disk cache gc done, released {release_size} bytes, took: {} ms",
@@ -931,10 +926,65 @@ pub fn set_metrics_result_cache_evict_hook(hook: fn(Vec<String>)) {
     }
 }
 
+/// Add the given `results/...` file to the QUERY_RESULT_CACHE index and enforce the per-key
+/// entry limit, removing evicted entries' files from disk.
+pub async fn add_result_cache_meta(file_key: &str) {
+    let Some((_, _, query_key, meta)) = parse_result_cache_key(file_key) else {
+        return;
+    };
+    let Some((dir, _)) = file_key.rsplit_once('/') else {
+        return;
+    };
+    let mut w = QUERY_RESULT_CACHE.write().await;
+    let metas = w.entry(query_key).or_default();
+    // an equal meta can already exist when re-caching after clear_cache
+    if !metas.contains(&meta) {
+        metas.push(meta);
+    }
+    let evicted: Vec<_> = if metas.len() > RESULT_CACHE_MAX_ENTRIES_PER_KEY {
+        // evict the entries whose cached data range ends earliest; on a tie the narrower one
+        metas.sort_unstable_by_key(|m| (m.end_time, std::cmp::Reverse(m.start_time)));
+        metas
+            .drain(..metas.len() - RESULT_CACHE_MAX_ENTRIES_PER_KEY)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    drop(w);
+
+    for meta in evicted {
+        let file = format!("{dir}/{}", result_cache_file_name(&meta));
+        if let Err(e) = remove(&file).await {
+            log::warn!("Remove evicted result cache file {file} error: {e}");
+        }
+    }
+}
+
+/// Remove only the index entries matching the given `results/...` file keys from
+/// QUERY_RESULT_CACHE, dropping a query key only when its entry list becomes empty.
+pub async fn remove_result_cache_metas(file_keys: &[String]) {
+    let parsed = file_keys
+        .iter()
+        .filter_map(|file_key| parse_result_cache_key(file_key))
+        .map(|(_, _, query_key, meta)| (query_key, meta))
+        .collect::<Vec<_>>();
+    if parsed.is_empty() {
+        return;
+    }
+    let mut r = QUERY_RESULT_CACHE.write().await;
+    for (query_key, meta) in parsed {
+        if let Some(metas) = r.get_mut(&query_key) {
+            metas.retain(|m| m != &meta);
+            if metas.is_empty() {
+                r.remove(&query_key);
+            }
+        }
+    }
+}
+
 #[async_recursion]
 async fn load(root_dir: &PathBuf, scan_dir: &PathBuf) -> Result<(), anyhow::Error> {
     let mut entries = tokio::fs::read_dir(&scan_dir).await?;
-    let mut result_cache: HashMap<String, Vec<ResultCacheMeta>> = HashMap::new();
     let mut metrics_cache: Vec<String> = Vec::new();
     loop {
         match entries.next_entry().await {
@@ -1017,8 +1067,7 @@ async fn load(root_dir: &PathBuf, scan_dir: &PathBuf) -> Result<(), anyhow::Erro
                             .with_label_values(&[columns[1], columns[2]])
                             .add(data_size as i64);
                     } else if file_key.starts_with("results") {
-                        let Some((org_id, stream_type, query_key, meta)) =
-                            parse_result_cache_key(&file_key)
+                        let Some((org_id, stream_type, ..)) = parse_result_cache_key(&file_key)
                         else {
                             log::error!("parse result cache key error: {file_key}");
                             continue;
@@ -1034,10 +1083,7 @@ async fn load(root_dir: &PathBuf, scan_dir: &PathBuf) -> Result<(), anyhow::Erro
                             .with_label_values(&[org_id.as_str(), stream_type.as_str(), "results"])
                             .add(data_size as i64);
 
-                        result_cache
-                            .entry(query_key)
-                            .or_insert_with(Vec::new)
-                            .push(meta);
+                        add_result_cache_meta(&file_key).await;
                     } else if file_key.starts_with("metrics_results") {
                         let mut w = RESULT_FILES[idx].write().await;
                         w.cur_size += data_size;
@@ -1085,8 +1131,6 @@ async fn load(root_dir: &PathBuf, scan_dir: &PathBuf) -> Result<(), anyhow::Erro
         }
     }
 
-    // write all data from result_cache to QUERY_RESULT_CACHE
-    QUERY_RESULT_CACHE.write().await.extend(result_cache);
     // write all data from metrics_cache to QUERY_METRICS_CACHE
     METRICS_RESULT_CACHE.write().await.extend(metrics_cache);
     Ok(())
@@ -1222,28 +1266,27 @@ fn get_bucket_idx(file: &str) -> usize {
 // results/default/logs/default/16042959487540176184_30_zo_sql_key/
 // 1744081170000000_1744081170000000_1_0.json
 pub fn parse_result_cache_key(file: &str) -> Option<(String, String, String, ResultCacheMeta)> {
-    let columns = file.split('/').collect::<Vec<&str>>();
-    if columns.len() < 6 {
+    let (org_id, stream_type, query_key, filename) = split_cache_key(file, "results")?;
+    let meta = filename.split('_').collect::<Vec<&str>>();
+    if meta.len() < 4 {
         return None;
     }
-    let org_id = columns[1].to_string();
-    let stream_type = columns[2].to_string();
-    let query_key = format!(
-        "{}_{}_{}_{}",
-        columns[1], columns[2], columns[3], columns[4]
-    );
-
-    let meta = columns[5].split('_').collect::<Vec<&str>>();
-    let is_aggregate = meta[2] == "1";
-    let is_descending = meta[3] == "1";
     let meta = ResultCacheMeta {
-        start_time: meta[0].parse().unwrap(),
-        end_time: meta[1].parse().unwrap(),
-        is_aggregate,
-        is_descending,
+        start_time: meta[0].parse().ok()?,
+        end_time: meta[1].parse().ok()?,
+        is_aggregate: meta[2] == "1",
+        is_descending: meta[3] == "1",
     };
 
     Some((org_id, stream_type, query_key, meta))
+}
+
+// build the result cache file name from the meta, the inverse of parse_result_cache_key
+pub fn result_cache_file_name(meta: &ResultCacheMeta) -> String {
+    format!(
+        "{}_{}_{}_{}.json",
+        meta.start_time, meta.end_time, meta.is_aggregate as u8, meta.is_descending as u8
+    )
 }
 
 // parse the aggregation cache key from the file name
@@ -1252,38 +1295,42 @@ pub fn parse_result_cache_key(file: &str) -> Option<(String, String, String, Res
 pub fn parse_aggregation_cache_key(
     file: &str,
 ) -> Option<(String, String, String, ResultCacheMeta)> {
-    let columns = file.split('/').collect::<Vec<&str>>();
-    if columns.len() < 6 {
-        return None;
-    }
-    let org_id = columns[1].to_string();
-    let stream_type = columns[2].to_string();
-    let query_key = format!(
-        "{}_{}_{}_{}",
-        columns[1], columns[2], columns[3], columns[4]
-    );
-
-    // Remove file extension before parsing
-    let filename = columns[5];
-    let filename_without_ext = if let Some(dot_pos) = filename.rfind('.') {
-        &filename[..dot_pos]
-    } else {
-        filename
-    };
-
-    let meta = filename_without_ext.split('_').collect::<Vec<&str>>();
+    let (org_id, stream_type, query_key, filename) = split_cache_key(file, "aggregations")?;
+    let meta = filename.split('_').collect::<Vec<&str>>();
     if meta.len() < 2 {
         return None;
     }
 
     let meta = ResultCacheMeta {
-        start_time: meta[0].parse().unwrap(),
-        end_time: meta[1].parse().unwrap(),
+        start_time: meta[0].parse().ok()?,
+        end_time: meta[1].parse().ok()?,
         is_aggregate: true,
         // NOTE: aggregate record batches don't honor order by
         is_descending: false,
     };
     Some((org_id, stream_type, query_key, meta))
+}
+
+// split a `{prefix}/{org}/{stream_type}/{stream}/{hash}/{file}` cache key into
+// (org_id, stream_type, query_key, file name without extension)
+fn split_cache_key<'a>(file: &'a str, prefix: &str) -> Option<(String, String, String, &'a str)> {
+    let columns = file.split('/').collect::<Vec<&str>>();
+    if columns.len() < 6 || columns[0] != prefix {
+        return None;
+    }
+    let query_key = format!(
+        "{}_{}_{}_{}",
+        columns[1], columns[2], columns[3], columns[4]
+    );
+    let filename = columns[5]
+        .rsplit_once('.')
+        .map_or(columns[5], |(name, _)| name);
+    Some((
+        columns[1].to_string(),
+        columns[2].to_string(),
+        query_key,
+        filename,
+    ))
 }
 
 fn last_modified(metadata: &std::fs::Metadata) -> chrono::DateTime<chrono::Utc> {
@@ -1837,12 +1884,92 @@ mod tests {
         assert_eq!(meta.start_time, 1744081170000000);
         assert_eq!(meta.end_time, 1744081180000000);
         assert!(!meta.is_aggregate);
+        assert!(meta.is_descending);
     }
 
     #[test]
     fn test_parse_result_cache_key_too_short_returns_none() {
         assert!(parse_result_cache_key("too/short").is_none());
         assert!(parse_result_cache_key("a/b/c/d/e").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_remove_result_cache_metas_removes_only_matching_meta() {
+        let query_key = "rm_meta_org_logs_default_hashkey";
+        let meta1 = ResultCacheMeta {
+            start_time: 1000,
+            end_time: 2000,
+            is_aggregate: false,
+            is_descending: true,
+        };
+        let meta2 = ResultCacheMeta {
+            start_time: 3000,
+            end_time: 4000,
+            is_aggregate: false,
+            is_descending: true,
+        };
+        QUERY_RESULT_CACHE
+            .write()
+            .await
+            .insert(query_key.to_string(), vec![meta1, meta2.clone()]);
+
+        // removing one file only drops its own meta
+        let file1 = "results/rm_meta_org/logs/default/hashkey/1000_2000_0_1.json".to_string();
+        remove_result_cache_metas(&[file1]).await;
+        let metas = QUERY_RESULT_CACHE.read().await.get(query_key).cloned();
+        assert_eq!(metas, Some(vec![meta2.clone()]));
+
+        // non-results keys are ignored
+        remove_result_cache_metas(&[
+            "aggregations/rm_meta_org/logs/default/hashkey/3000_4000.arrow".to_string(),
+        ])
+        .await;
+        let metas = QUERY_RESULT_CACHE.read().await.get(query_key).cloned();
+        assert_eq!(metas, Some(vec![meta2]));
+
+        // removing the last file drops the query key
+        let file2 = "results/rm_meta_org/logs/default/hashkey/3000_4000_0_1.json".to_string();
+        remove_result_cache_metas(&[file2]).await;
+        assert!(!QUERY_RESULT_CACHE.read().await.contains_key(query_key));
+    }
+
+    #[tokio::test]
+    async fn test_add_result_cache_meta_enforces_per_key_limit() {
+        let max_entries = RESULT_CACHE_MAX_ENTRIES_PER_KEY;
+        let query_key = "add_meta_org_logs_default_hashkey";
+        for i in 0..(max_entries as i64 + 2) {
+            let file_key = format!(
+                "results/add_meta_org/logs/default/hashkey/{}_{}_0_0.json",
+                i * 1000,
+                i * 1000 + 500
+            );
+            add_result_cache_meta(&file_key).await;
+        }
+        let metas = QUERY_RESULT_CACHE
+            .read()
+            .await
+            .get(query_key)
+            .cloned()
+            .unwrap();
+        assert_eq!(metas.len(), max_entries);
+        // the two entries with the oldest data ranges were evicted
+        assert!(metas.iter().all(|m| m.start_time >= 2000));
+    }
+
+    #[test]
+    fn test_result_cache_file_name_round_trips_with_parser() {
+        let meta = ResultCacheMeta {
+            start_time: 1744081170000000,
+            end_time: 1744081180000000,
+            is_aggregate: false,
+            is_descending: true,
+        };
+        let file = format!(
+            "results/org/logs/stream/hash/{}",
+            result_cache_file_name(&meta)
+        );
+        let (_, _, _, parsed) = parse_result_cache_key(&file).unwrap();
+        assert_eq!(parsed, meta);
     }
 
     #[test]

--- a/src/search_service/src/cache/cacher.rs
+++ b/src/search_service/src/cache/cacher.rs
@@ -887,8 +887,9 @@ pub async fn delete_cache(
         if !should_delete_cache_file(&file, &criteria) {
             continue;
         }
-        match disk::remove(file.strip_prefix(&prefix).unwrap()).await {
-            Ok(_) => remove_files.push(file),
+        let file_key = file.strip_prefix(&prefix).unwrap().to_string();
+        match disk::remove(&file_key).await {
+            Ok(_) => remove_files.push(file_key),
             Err(e) => {
                 log::error!("Error deleting cache: {:?}", e);
                 return Err(std::io::Error::other("Error deleting cache"));
@@ -904,29 +905,13 @@ pub async fn delete_cache(
         if !should_delete_cache_file(&file, &criteria) {
             continue;
         }
-        match disk::remove(file.strip_prefix(&prefix).unwrap()).await {
-            Ok(_) => remove_files.push(file),
-            Err(e) => {
-                log::error!("Error deleting cache: {:?}", e);
-                return Err(std::io::Error::other("Error deleting cache"));
-            }
+        if let Err(e) = disk::remove(file.strip_prefix(&prefix).unwrap()).await {
+            log::error!("Error deleting cache: {:?}", e);
+            return Err(std::io::Error::other("Error deleting cache"));
         }
     }
 
-    for file in remove_files {
-        let columns = file
-            .strip_prefix(&prefix)
-            .unwrap()
-            .split('/')
-            .collect::<Vec<&str>>();
-
-        let query_key = format!(
-            "{}_{}_{}_{}",
-            columns[1], columns[2], columns[3], columns[4]
-        );
-        let mut r = QUERY_RESULT_CACHE.write().await;
-        r.remove(&query_key);
-    }
+    disk::remove_result_cache_metas(&remove_files).await;
     Ok(true)
 }
 

--- a/src/search_service/src/cache/cacher.rs
+++ b/src/search_service/src/cache/cacher.rs
@@ -799,7 +799,7 @@ pub fn select_cache_meta(
 }
 
 /// Drops the stale meta unless a concurrent writer already recreated its file on disk.
-async fn remove_stale_cache_meta(
+pub(crate) async fn remove_stale_cache_meta(
     file_path: &str,
     file_name: &str,
     query_key: &str,

--- a/src/search_service/src/cache/mod.rs
+++ b/src/search_service/src/cache/mod.rs
@@ -981,7 +981,7 @@ pub async fn write_results(
     // 5. skip the write when an existing entry already fully covers this range;
     // checked before the deep copy and serialization below so a covered write costs nothing
     let query_key = file_path.replace('/', "_");
-    if !clear_cache && is_range_already_cached(&query_key, &meta).await {
+    if !clear_cache && is_range_already_cached(&query_key, &file_path, &meta).await {
         log::debug!(
             "[trace_id {trace_id}] Result cache already covers {accept_start_time} - {cache_end_time}, skip caching"
         );
@@ -1044,16 +1044,34 @@ pub async fn write_results(
     });
 }
 
-async fn is_range_already_cached(query_key: &str, meta: &ResultCacheMeta) -> bool {
-    let r = QUERY_RESULT_CACHE.read().await;
-    r.get(query_key).is_some_and(|metas| {
-        metas.iter().any(|m| {
-            m.is_aggregate == meta.is_aggregate
-                && m.is_descending == meta.is_descending
-                && m.start_time <= meta.start_time
-                && m.end_time >= meta.end_time
+async fn is_range_already_cached(query_key: &str, file_path: &str, meta: &ResultCacheMeta) -> bool {
+    let covering = {
+        let r = QUERY_RESULT_CACHE.read().await;
+        r.get(query_key).map_or(Vec::new(), |metas| {
+            metas
+                .iter()
+                .filter(|m| {
+                    m.is_aggregate == meta.is_aggregate
+                        && m.is_descending == meta.is_descending
+                        && m.start_time <= meta.start_time
+                        && m.end_time >= meta.end_time
+                })
+                .cloned()
+                .collect()
         })
-    })
+    };
+    for m in covering {
+        let file_name = disk::result_cache_file_name(&m);
+        // a covering meta only counts while its file is still indexed on disk
+        if disk::indexed_file_guard(&format!("results/{file_path}/{file_name}"))
+            .await
+            .is_some()
+        {
+            return true;
+        }
+        cacher::remove_stale_cache_meta(file_path, &file_name, query_key, &m).await;
+    }
+    false
 }
 
 pub fn apply_vrl_to_response(
@@ -1300,7 +1318,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_range_already_cached() {
-        let query_key = "test_org_covered_logs_test_stream_hash_covered".to_string();
+        let file_path = "test_org_covered/logs/test_stream/hash_covered";
+        let query_key = file_path.replace('/', "_");
         let cached = ResultCacheMeta {
             start_time: 1000,
             end_time: 5000,
@@ -1311,24 +1330,38 @@ mod tests {
             .write()
             .await
             .insert(query_key.clone(), vec![cached.clone()]);
+        let covering_file = format!(
+            "results/{file_path}/{}",
+            infra::cache::file_data::disk::result_cache_file_name(&cached)
+        );
+        infra::cache::file_data::disk::set_size(&covering_file, 1)
+            .await
+            .unwrap();
 
         let inner = ResultCacheMeta {
             start_time: 2000,
             end_time: 4000,
             ..cached.clone()
         };
-        assert!(is_range_already_cached(&query_key, &inner).await);
+        assert!(is_range_already_cached(&query_key, file_path, &inner).await);
 
         let wider = ResultCacheMeta {
             end_time: 6000,
             ..inner.clone()
         };
-        assert!(!is_range_already_cached(&query_key, &wider).await);
+        assert!(!is_range_already_cached(&query_key, file_path, &wider).await);
 
         let ascending = ResultCacheMeta {
             is_descending: false,
-            ..inner
+            ..inner.clone()
         };
-        assert!(!is_range_already_cached(&query_key, &ascending).await);
+        assert!(!is_range_already_cached(&query_key, file_path, &ascending).await);
+
+        // a covering meta whose file left the disk index no longer counts and is pruned
+        infra::cache::file_data::disk::remove(&covering_file)
+            .await
+            .unwrap();
+        assert!(!is_range_already_cached(&query_key, file_path, &inner).await);
+        assert!(!QUERY_RESULT_CACHE.read().await.contains_key(&query_key));
     }
 }

--- a/src/search_service/src/cache/mod.rs
+++ b/src/search_service/src/cache/mod.rs
@@ -39,7 +39,10 @@ use config::{
     },
 };
 use infra::{
-    cache::{file_data::disk::QUERY_RESULT_CACHE, meta::ResultCacheMeta},
+    cache::{
+        file_data::disk::{self, QUERY_RESULT_CACHE},
+        meta::ResultCacheMeta,
+    },
     errors::Error,
 };
 #[cfg(feature = "enterprise")]
@@ -456,7 +459,7 @@ pub async fn search(
             &c_resp.ts_column,
             req.query.start_time,
             req.query.end_time,
-            deep_copy_response(&res),
+            &res,
             file_path,
             is_complex_query,
             c_resp.is_descending,
@@ -892,28 +895,25 @@ fn sort_response(
 ///    - Check the histogram interval, if the time range is not a multiple of the histogram
 ///      interval, we need to remove the incomplete records: first & last record.
 ///
-/// 2. **Remove Records with Discard Duration**:
-///    - Removes records that are older than the configured `discard_duration`.
-///    - The `discard_duration` is the time difference between the current time and the time when
-///      the record was created.
-///    - The `discard_duration` is configured by `ZO_CACHE_DELAY_SECS`.
+/// 2. **Discard Recent Data**:
+///    - Clamps the cache end time to `now - ZO_CACHE_DELAY_SECS` so records that may still change
+///      are not cached.
 ///
-/// 3. **Skip Caching for Empty or Insufficient Hits**:
-///    - If no hits remain after removing one, caching is skipped.
-///    - Logs a message: `"No hits found for caching, skipping caching."`
+/// 3. **Discard Short Time Ranges**:
+///    - Skips caching if the cacheable time range is smaller than `ZO_CACHE_DELAY_SECS`.
 ///
-/// 4. **Discard Short Time Ranges**:
-///    - Skips caching if the difference between the first and last record timestamps is smaller
-///      than the configured `discard_duration`.
+/// 4. **Skip Covered Ranges** (unless `clear_cache`):
+///    - Skips caching when an existing cache entry already fully covers the time range.
 ///
-/// 5. **Adjust Cache Time Range**:
-///    - Adjusts the cache start and end times based on the smallest and largest timestamps:
-///      - `start_time = max(smallest_ts, req_query_start_time)`
-///      - `end_time = min(largest_ts, req_query_end_time)`
+/// 5. **Skip Caching for Empty Hits**:
+///    - If no hits remain after filtering to the cacheable time range, caching is skipped.
 ///
 /// 6. **Cache to Disk**:
 ///    - Saves the filtered response to a file named:
 ///      `"<start_time>_<end_time>_<is_aggregate>_<is_descending>.json"`.
+///
+/// 7. **Per-Key Entry Limit**:
+///    - Evicts the entries with the oldest data range beyond the per-key entry limit.
 #[tracing::instrument(name = "service:search:cache:write_results", skip_all)]
 #[allow(clippy::too_many_arguments)]
 pub async fn write_results(
@@ -921,7 +921,7 @@ pub async fn write_results(
     ts_column: &str,
     req_query_start_time: i64,
     req_query_end_time: i64,
-    mut res: config::meta::search::Response,
+    res: &config::meta::search::Response,
     file_path: String,
     is_aggregate: bool,
     is_descending: bool,
@@ -952,15 +952,49 @@ pub async fn write_results(
         }
     }
 
-    // 2. get the data time range, check if need to remove records with discard_duration
+    // 2. check if need to remove records with discard_duration
+    let delay_ts = second_micros(get_config().limit.cache_delay_secs);
+    let accept_end_time = std::cmp::min(Utc::now().timestamp_micros() - delay_ts, accept_end_time);
+
+    // 3. check if the time range is less than discard_duration
+    if (accept_end_time - accept_start_time) < delay_ts {
+        log::info!("[trace_id {trace_id}] Time range is too short for caching, skipping caching");
+        return;
+    }
+
+    // 4. the cached time range, with the end time realigned for histogram
+    let mut cache_end_time = accept_end_time;
+    if need_adjust_end_time
+        && is_aggregate
+        && let Some(interval) = res.histogram_interval
+        && interval > 0
+    {
+        cache_end_time += interval * 1000 * 1000;
+    }
+    let meta = ResultCacheMeta {
+        start_time: accept_start_time,
+        end_time: cache_end_time,
+        is_aggregate,
+        is_descending,
+    };
+
+    // 5. skip the write when an existing entry already fully covers this range;
+    // checked before the deep copy and serialization below so a covered write costs nothing
+    let query_key = file_path.replace('/', "_");
+    if !clear_cache && is_range_already_cached(&query_key, &meta).await {
+        log::debug!(
+            "[trace_id {trace_id}] Result cache already covers {accept_start_time} - {cache_end_time}, skip caching"
+        );
+        return;
+    }
+
+    // 6. filter the records to the accept time range
     // For histogram queries with non-timestamp ORDER BY, we need to scan all hits
     // to find actual min/max timestamps, since results may not be time-ordered
+    let mut res = deep_copy_response(res);
     let is_time_ordered = !is_histogram_non_ts_order;
     let (data_start_time, data_end_time) =
         extract_timestamp_range(&res.hits, ts_column, is_time_ordered);
-    let delay_ts = second_micros(get_config().limit.cache_delay_secs);
-    let mut accept_end_time =
-        std::cmp::min(Utc::now().timestamp_micros() - delay_ts, accept_end_time);
     if data_start_time < accept_start_time || data_end_time > accept_end_time {
         res.hits.retain(|hit| {
             if let Some(hit_ts) = hit.get(ts_column)
@@ -976,38 +1010,14 @@ pub async fn write_results(
         res.total = res.hits.len();
         res.size = res.hits.len() as i64;
     }
-
-    // 3. check if the hits is empty
     if res.hits.is_empty() {
         log::info!("[trace_id {trace_id}] No hits found for caching, skipping caching");
         return;
     }
 
-    // 4. check if the time range is less than discard_duration
-    if (accept_end_time - accept_start_time) < delay_ts {
-        log::info!("[trace_id {trace_id}] Time range is too short for caching, skipping caching");
-        return;
-    }
-
-    // 5. adjust the cache time range
-    if need_adjust_end_time
-        && is_aggregate
-        && let Some(interval) = res.histogram_interval
-        && interval > 0
-    {
-        accept_end_time += interval * 1000 * 1000;
-    }
-
-    // 6. cache to disk
-    let file_name = format!(
-        "{}_{}_{}_{}.json",
-        accept_start_time,
-        accept_end_time,
-        if is_aggregate { 1 } else { 0 },
-        if is_descending { 1 } else { 0 }
-    );
+    // 7. cache to disk
+    let file_name = disk::result_cache_file_name(&meta);
     let res_cache = json::to_string(&res).unwrap();
-    let query_key = file_path.replace('/', "_");
     let trace_id = trace_id.to_string();
     tokio::spawn(async move {
         match SearchService::cache::cacher::cache_results_to_disk(
@@ -1016,26 +1026,15 @@ pub async fn write_results(
             &file_name,
             res_cache,
             clear_cache,
-            Some(accept_start_time),
-            Some(accept_end_time),
+            Some(meta.start_time),
+            Some(meta.end_time),
         )
         .await
         {
             Ok(success) => {
+                // success: false means the file already exists on disk, skip indexing
                 if success {
-                    // success: true, cache to disk success
-                    // success: false, cache to disk already exists, skipping caching
-                    QUERY_RESULT_CACHE
-                        .write()
-                        .await
-                        .entry(query_key)
-                        .or_insert_with(Vec::new)
-                        .push(ResultCacheMeta {
-                            start_time: accept_start_time,
-                            end_time: accept_end_time,
-                            is_aggregate,
-                            is_descending,
-                        });
+                    disk::add_result_cache_meta(&format!("results/{file_path}/{file_name}")).await;
                 }
             }
             Err(e) => {
@@ -1043,6 +1042,18 @@ pub async fn write_results(
             }
         }
     });
+}
+
+async fn is_range_already_cached(query_key: &str, meta: &ResultCacheMeta) -> bool {
+    let r = QUERY_RESULT_CACHE.read().await;
+    r.get(query_key).is_some_and(|metas| {
+        metas.iter().any(|m| {
+            m.is_aggregate == meta.is_aggregate
+                && m.is_descending == meta.is_descending
+                && m.start_time <= meta.start_time
+                && m.end_time >= meta.end_time
+        })
+    })
 }
 
 pub fn apply_vrl_to_response(
@@ -1285,5 +1296,39 @@ mod tests {
     fn test_is_result_array_skip_vrl_no_marker() {
         let query_fn = "just a normal query";
         assert!(!is_result_array_skip_vrl(query_fn));
+    }
+
+    #[tokio::test]
+    async fn test_is_range_already_cached() {
+        let query_key = "test_org_covered_logs_test_stream_hash_covered".to_string();
+        let cached = ResultCacheMeta {
+            start_time: 1000,
+            end_time: 5000,
+            is_aggregate: false,
+            is_descending: true,
+        };
+        QUERY_RESULT_CACHE
+            .write()
+            .await
+            .insert(query_key.clone(), vec![cached.clone()]);
+
+        let inner = ResultCacheMeta {
+            start_time: 2000,
+            end_time: 4000,
+            ..cached.clone()
+        };
+        assert!(is_range_already_cached(&query_key, &inner).await);
+
+        let wider = ResultCacheMeta {
+            end_time: 6000,
+            ..inner.clone()
+        };
+        assert!(!is_range_already_cached(&query_key, &wider).await);
+
+        let ascending = ResultCacheMeta {
+            is_descending: false,
+            ..inner
+        };
+        assert!(!is_range_already_cached(&query_key, &ascending).await);
     }
 }

--- a/src/search_service/src/streaming/cache.rs
+++ b/src/search_service/src/streaming/cache.rs
@@ -101,7 +101,7 @@ pub async fn write_results_to_cache(
             &c_resp.ts_column,
             start_time,
             end_time,
-            merged_response,
+            &merged_response,
             c_resp.file_path.clone(),
             c_resp.is_aggregate,
             c_resp.is_descending,


### PR DESCRIPTION
Closes #13965

## Problem

The search result cache index (`QUERY_RESULT_CACHE`) had no per-key limit: a dashboard panel auto-refreshing a relative time window produced a new disk file plus a new index entry on nearly every refresh, growing one key without bound until the global disk-cache GC kicked in. The read path scans all metas per lookup, so lookups degraded linearly (O(n²) in the multi-cache path) and logged one candidate line per meta.

Worse, when the disk-cache GC evicted a single `results/...` file it removed the **entire** query key from the index — all other still-on-disk files for that key became unreachable orphans (resurrected into the index on restart), and one cold evicted file forced full re-computation for the whole key.

## Fix

- **Per-key entry limit**: a hardcoded `RESULT_CACHE_MAX_ENTRIES_PER_KEY` of 10, mirroring the metrics cache's hardcoded per-key cap. `disk::add_result_cache_meta` inserts the meta, evicts the entries with the oldest data range beyond the limit, and deletes their disk files so no orphans are left. It is used by both the write path and the startup disk scan (`load()`), so deployments that already accumulated thousands of entries per key are trimmed on the first restart.
- **Covered-range skip**: the write is skipped when an existing entry with the same flags already fully covers the time range. The check runs before the response deep copy and JSON serialization, so the common case (repeated dashboard refreshes) costs nothing.
- **Precise index invalidation**: disk-cache GC and `delete_cache` now remove only the meta matching each evicted file (query key dropped only when its list becomes empty). Remaining cache files for the key stay usable.
- **Parser fixes**: `parse_result_cache_key` did not strip the file extension, so `is_descending` was always `false` for metas rebuilt from disk (`"1.json" != "1"`); it also indexed without bounds checks and `unwrap()`ed parses. Both cache-key parsers now validate their prefix (an `aggregations/...` key can no longer alias a results index entry) and share one splitter. `result_cache_file_name` is the single builder for the file-name format, with a parse/build round-trip test.

## Verification

- `cargo fmt` and the CI clippy command pass; `infra` and `search_service` cache tests pass, including new tests for the per-key limit, per-file meta removal, covered-range check, and file-name round-trip.
- Enterprise compatibility verified by swapping in `Cargo.toml.openobserve` (o2-enterprise `main`) and running `cargo check --all-targets` — clean; the enterprise repo has no references to the touched APIs. No paired enterprise PR needed.

