### PR TITLE
fix: short url add lock order [v0.40]

### DIFF
--- a/src/infra/src/table/short_urls.rs
+++ b/src/infra/src/table/short_urls.rs
@@ -137,10 +137,13 @@ pub async fn add(short_id: &str, original_url: &str) -> Result<bool, errors::Err
         ..Default::default()
     };
 
+    // init the client before get_lock: connect_to_orm locks the same CLIENT_RW
+    // mutex on sqlite, so the reverse order self-deadlocks on first db access
+    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
     // make sure only one client is writing to the database(only for sqlite)
     let _lock = get_lock().await;
 
-    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     let inserted = Entity::insert(record)
         .on_conflict(
             sea_orm::sea_query::OnConflict::column(Column::ShortId)


### PR DESCRIPTION
Follow-up to #13976 (already merged), fixing a latent lock-order deadlock the port exposed.

On this branch `connect_to_orm` locks the same `CLIENT_RW` mutex that `get_lock()` holds. The reworked `shorten()` no longer performs a db read before writing, so `short_urls::add` can be the first orm access in a process — it takes `get_lock()` and then deadlocks initializing `ORM_CLIENT`. Fix: initialize the client before taking the lock.

This is what hung the `test_process_dest_template_*` unit tests on the v0.80 PR (#13975, fixed there the same way). v0.40 has no test that hits the path, but the deadlock is just as reachable, so the same two-line reorder applies. main is not affected — `CLIENT_RW` there is a plain pool since the orm getter refactor.
