### PR TITLE
fix(metrics): bound the metrics cache index by memory budget and sync it with disk eviction

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1739,8 +1739,6 @@ pub struct Common {
         help = "Default theme color for dark mode. If not set, uses application default."
     )]
     pub default_theme_dark_mode_color: String,
-    #[env_config(name = "ZO_METRICS_DEDUP_ENABLED", default = true)]
-    pub metrics_dedup_enabled: bool,
     #[env_config(name = "ZO_BLOOM_FILTER_ENABLED", default = true)]
     pub bloom_filter_enabled: bool,
     #[env_config(
@@ -2267,18 +2265,14 @@ pub struct Limit {
     pub traces_query_retention: String,
     #[env_config(name = "ZO_METRICS_QUERY_RETENTION", default = "daily")]
     pub metrics_query_retention: String,
-    #[env_config(name = "ZO_METRICS_LEADER_PUSH_INTERVAL", default = 15)]
-    pub metrics_leader_push_interval: u64,
-    #[env_config(name = "ZO_METRICS_LEADER_ELECTION_INTERVAL", default = 30)]
-    pub metrics_leader_election_interval: i64,
     #[env_config(name = "ZO_METRICS_MAX_POINTS_PER_SERIES", default = 30000)]
     pub metrics_max_points_per_series: usize,
     #[env_config(name = "ZO_METRICS_MAX_SERIES_RESPONSE", default = 40000)]
     pub metrics_max_series_response: usize,
     // Memory budget in MB for the PromQL result cache index. 0 (default)
     // means auto: 1% of total memory, clamped to [32, 256] MB.
-    #[env_config(name = "ZO_METRICS_CACHE_MAX_SIZE", default = 0)]
-    pub metrics_cache_max_size: usize,
+    #[env_config(name = "ZO_METRICS_RESULT_CACHE_MAX_SIZE", default = 0)]
+    pub metrics_result_cache_max_size: usize,
     // Memory budget in MB for the PromQL series label cache. 0 (default)
     // means auto: 5% of total memory, clamped to [100, 1024] MB.
     #[env_config(name = "ZO_METRICS_LABEL_CACHE_MAX_SIZE", default = 0)]
@@ -3018,6 +3012,12 @@ pub struct Sns {
 
 #[derive(Serialize, Debug, EnvConfig, Default)]
 pub struct Prometheus {
+    #[env_config(name = "ZO_METRICS_DEDUP_ENABLED", default = true)]
+    pub dedup_enabled: bool,
+    #[env_config(name = "ZO_METRICS_LEADER_PUSH_INTERVAL", default = 15)]
+    pub leader_push_interval: u64,
+    #[env_config(name = "ZO_METRICS_LEADER_ELECTION_INTERVAL", default = 30)]
+    pub leader_election_interval: i64,
     #[env_config(name = "ZO_PROMETHEUS_HA_CLUSTER", default = "cluster")]
     pub ha_cluster_label: String,
     #[env_config(name = "ZO_PROMETHEUS_HA_REPLICA", default = "__replica__")]
@@ -3992,14 +3992,14 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         cfg.limit.datafusion_file_stat_cache_max_size *= SIZE_IN_MB as usize;
     }
 
-    if cfg.limit.metrics_cache_max_size == 0 {
+    if cfg.limit.metrics_result_cache_max_size == 0 {
         // 1% of total mem, clamped to [32, 256] MB; the promql result cache
         // index holds roughly 200 B per entry at this size.
-        cfg.limit.metrics_cache_max_size =
+        cfg.limit.metrics_result_cache_max_size =
             ((cfg.limit.mem_total as f64 / SIZE_IN_MB * 0.01) as usize).clamp(32, 256)
                 * (SIZE_IN_MB as usize);
     } else {
-        cfg.limit.metrics_cache_max_size *= SIZE_IN_MB as usize;
+        cfg.limit.metrics_result_cache_max_size *= SIZE_IN_MB as usize;
     }
     Ok(())
 }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -3999,7 +3999,9 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
             ((cfg.limit.mem_total as f64 / SIZE_IN_MB * 0.01) as usize).clamp(32, 256)
                 * (SIZE_IN_MB as usize);
     } else {
-        cfg.limit.metrics_result_cache_max_size *= SIZE_IN_MB as usize;
+        // below 32 MB a bucket cannot hold one saturated key and every write evicts itself
+        cfg.limit.metrics_result_cache_max_size =
+            cfg.limit.metrics_result_cache_max_size.max(32) * (SIZE_IN_MB as usize);
     }
     Ok(())
 }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -3999,7 +3999,9 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
             ((cfg.limit.mem_total as f64 / SIZE_IN_MB * 0.01) as usize).clamp(32, 256)
                 * (SIZE_IN_MB as usize);
     } else {
-        // below 32 MB a bucket cannot hold one saturated key and every write evicts itself
+        if cfg.limit.metrics_result_cache_max_size < 32 {
+            log::warn!("ZO_METRICS_RESULT_CACHE_MAX_SIZE raised to the 32 MB minimum");
+        }
         cfg.limit.metrics_result_cache_max_size =
             cfg.limit.metrics_result_cache_max_size.max(32) * (SIZE_IN_MB as usize);
     }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2275,8 +2275,10 @@ pub struct Limit {
     pub metrics_max_points_per_series: usize,
     #[env_config(name = "ZO_METRICS_MAX_SERIES_RESPONSE", default = 40000)]
     pub metrics_max_series_response: usize,
-    #[env_config(name = "ZO_METRICS_CACHE_MAX_ENTRIES", default = 10000)]
-    pub metrics_cache_max_entries: usize,
+    // Memory budget in MB for the PromQL result cache index. 0 (default)
+    // means auto: 1% of total memory, clamped to [32, 256] MB.
+    #[env_config(name = "ZO_METRICS_CACHE_MAX_SIZE", default = 0)]
+    pub metrics_cache_max_size: usize,
     // Memory budget in MB for the PromQL series label cache. 0 (default)
     // means auto: 5% of total memory, clamped to [100, 1024] MB.
     #[env_config(name = "ZO_METRICS_LABEL_CACHE_MAX_SIZE", default = 0)]
@@ -3570,9 +3572,6 @@ fn check_common_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     if cfg.limit.metrics_max_points_per_series == 0 {
         cfg.limit.metrics_max_points_per_series = 30_000;
     }
-    if cfg.limit.metrics_cache_max_entries == 0 {
-        cfg.limit.metrics_cache_max_entries = 10_000;
-    }
 
     // check search job retention
     if cfg.limit.search_job_retention == 0 {
@@ -3991,6 +3990,16 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
                 * (SIZE_IN_MB as usize);
     } else {
         cfg.limit.datafusion_file_stat_cache_max_size *= SIZE_IN_MB as usize;
+    }
+
+    if cfg.limit.metrics_cache_max_size == 0 {
+        // 1% of total mem, clamped to [32, 256] MB; the promql result cache
+        // index holds roughly 200 B per entry at this size.
+        cfg.limit.metrics_cache_max_size =
+            ((cfg.limit.mem_total as f64 / SIZE_IN_MB * 0.01) as usize).clamp(32, 256)
+                * (SIZE_IN_MB as usize);
+    } else {
+        cfg.limit.metrics_cache_max_size *= SIZE_IN_MB as usize;
     }
     Ok(())
 }

--- a/src/core/src/metrics/prom.rs
+++ b/src/core/src/metrics/prom.rs
@@ -79,8 +79,8 @@ pub async fn remote_write(
     let started_at = Utc::now().timestamp_micros();
 
     let cfg = get_config();
-    let dedup_enabled = cfg.common.metrics_dedup_enabled;
-    let election_interval = cfg.limit.metrics_leader_election_interval * 1000000;
+    let dedup_enabled = cfg.prom.dedup_enabled;
+    let election_interval = cfg.prom.leader_election_interval * 1000000;
     let mut cluster_name = String::new();
     let mut metric_data_map: HashMap<String, HashMap<String, SchemaRecords>> = HashMap::new();
     let mut metric_schema_map: HashMap<String, SchemaCache> = HashMap::new();

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -108,6 +108,8 @@ pub static METRICS_RESULT_CACHE: Lazy<RwLock<Vec<String>>> = Lazy::new(|| RwLock
 
 static METRICS_RESULT_CACHE_EVICT_HOOK: OnceLock<fn(Vec<String>)> = OnceLock::new();
 
+static TRASH_ID: AtomicUsize = AtomicUsize::new(0);
+
 pub static LOADING_FROM_DISK_NUM: Lazy<AtomicUsize> = Lazy::new(|| AtomicUsize::new(0));
 pub static LOADING_FROM_DISK_DONE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 
@@ -130,9 +132,8 @@ pub enum FileType {
 /// Eviction cleanup whose Drop spawns a task, so it also runs when the gc future is cancelled.
 #[derive(Default)]
 struct EvictionCleanup {
-    result_query_keys: Vec<String>,
     metrics_files: Vec<String>,
-    evicted_files: Vec<(String, String)>, // (cache key, absolute file path)
+    trash_files: Vec<String>,
 }
 
 impl fmt::Display for FileType {
@@ -153,15 +154,11 @@ impl Default for FileData {
 
 impl Drop for EvictionCleanup {
     fn drop(&mut self) {
-        if self.result_query_keys.is_empty()
-            && self.metrics_files.is_empty()
-            && self.evicted_files.is_empty()
-        {
+        if self.metrics_files.is_empty() && self.trash_files.is_empty() {
             return;
         }
-        let result_query_keys = std::mem::take(&mut self.result_query_keys);
         let metrics_files = std::mem::take(&mut self.metrics_files);
-        let evicted_files = std::mem::take(&mut self.evicted_files);
+        let trash_files = std::mem::take(&mut self.trash_files);
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             log::error!(
                 "File disk cache eviction cleanup dropped outside a runtime, index entries may be stale"
@@ -169,20 +166,17 @@ impl Drop for EvictionCleanup {
             return;
         };
         handle.spawn(async move {
-            // normally drained inline by gc; only a cancelled gc leaves keys here
-            if !result_query_keys.is_empty() {
-                let mut r = QUERY_RESULT_CACHE.write().await;
-                for query_key in result_query_keys {
-                    r.remove(&query_key);
-                }
-            }
             if !metrics_files.is_empty()
                 && let Some(hook) = METRICS_RESULT_CACHE_EVICT_HOOK.get()
             {
                 hook(metrics_files);
             }
-            for (key, file_path) in evicted_files {
-                remove_evicted_file(&key, &file_path).await;
+            for trash_file in trash_files {
+                if let Err(e) = tokio::fs::remove_file(&trash_file).await
+                    && e.kind() != std::io::ErrorKind::NotFound
+                {
+                    log::error!("File disk cache remove trash file {trash_file} error: {e}");
+                }
             }
         });
     }
@@ -266,18 +260,12 @@ impl FileData {
             );
             // cache is full, need release some space
             let cfg = get_config();
-            // scale the release size by cache type, the same way the periodic gc job does
-            let type_max_size = match self.file_type {
-                FileType::Data => cfg.disk_cache.max_size,
-                FileType::Result => cfg.disk_cache.result_max_size,
-                FileType::Aggregation => cfg.disk_cache.aggregation_max_size,
-            };
-            let scale_factor = max(1, cfg.disk_cache.max_size / max(1, type_max_size));
-            let release_size = max(
-                10 * config::SIZE_IN_MB as usize,
-                cfg.disk_cache.release_size / scale_factor,
+            // scaled so one full-cache write cannot flush a whole result/aggregation bucket
+            let scale_factor = max(1, cfg.disk_cache.max_size / max(1, self.max_size));
+            let need_release_size = min(
+                self.max_size,
+                max(cfg.disk_cache.release_size / scale_factor, data_size * 100),
             );
-            let need_release_size = min(self.max_size, max(release_size, data_size * 100));
             self.gc(need_release_size).await;
         }
 
@@ -285,9 +273,6 @@ impl FileData {
         let file_ops_start = std::time::Instant::now();
         let file_path = self.get_file_path(file);
         tokio::fs::create_dir_all(Path::new(&file_path).parent().unwrap()).await?;
-        // a stale same-name file can await the eviction cleanup; clear it so the rename works on
-        // windows
-        let _ = tokio::fs::remove_file(&file_path).await;
         tokio::fs::rename(tmp_file, &file_path).await.map_err(|e| {
             anyhow::anyhow!(
                 "[CacheType:{}] File disk cache rename tmp file {tmp_file} to real file {file_path} error: {e}",
@@ -346,6 +331,7 @@ impl FileData {
             need_release_size
         );
         let mut release_size = 0;
+        let mut result_query_keys = Vec::new();
         let mut cleanup = EvictionCleanup::default();
         loop {
             let item = self.data.remove();
@@ -379,7 +365,7 @@ impl FileData {
                 metrics::QUERY_DISK_RESULT_CACHE_USED_BYTES
                     .with_label_values(&[columns[1], columns[2], "results"])
                     .sub(data_size as i64);
-                cleanup.result_query_keys.push(format!(
+                result_query_keys.push(format!(
                     "{}_{}_{}_{}",
                     columns[1], columns[2], columns[3], columns[4]
                 ));
@@ -392,8 +378,9 @@ impl FileData {
                     .with_label_values(&[columns[1], columns[2], "aggregations"])
                     .sub(data_size as i64);
             }
-            // the guard's task unlinks best effort; survivors are re-adopted by the startup scan
-            cleanup.evicted_files.push((key.clone(), file_path));
+            if let Some(trash_path) = self.move_to_trash(&key, &file_path) {
+                cleanup.trash_files.push(trash_path);
+            }
             if is_metrics_key {
                 cleanup.metrics_files.push(key);
             }
@@ -404,12 +391,11 @@ impl FileData {
         }
 
         // pruned inline so the prune completes before the caller can insert a new meta
-        if !cleanup.result_query_keys.is_empty() {
+        if !result_query_keys.is_empty() {
             let mut r = QUERY_RESULT_CACHE.write().await;
-            for query_key in cleanup.result_query_keys.drain(..) {
+            for query_key in result_query_keys {
                 r.remove(&query_key);
             }
-            drop(r);
         }
 
         log::info!(
@@ -479,6 +465,43 @@ impl FileData {
         format!("{}/", self.multi_dir.get(index as usize).unwrap())
     }
 
+    /// Vacates the deterministic path under the bucket lock, so same-key writers never collide.
+    fn move_to_trash(&self, key: &str, file_path: &str) -> Option<String> {
+        let trash_path = format!(
+            "{}{}trash/{}",
+            self.root_dir,
+            self.choose_multi_dir(key),
+            TRASH_ID.fetch_add(1, Ordering::Relaxed)
+        );
+        match std::fs::rename(file_path, &trash_path) {
+            Ok(()) => Some(trash_path),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if !Path::new(file_path).exists() {
+                    return None;
+                }
+                // first eviction of a run creates the trash dir, then the rename is retried
+                let parent = Path::new(&trash_path).parent()?;
+                if std::fs::create_dir_all(parent).is_ok()
+                    && std::fs::rename(file_path, &trash_path).is_ok()
+                {
+                    return Some(trash_path);
+                }
+                log::error!(
+                    "[CacheType:{}] File disk cache move file {file_path} to trash error",
+                    self.file_type,
+                );
+                None
+            }
+            Err(e) => {
+                log::error!(
+                    "[CacheType:{}] File disk cache move file {file_path} to trash error: {e}",
+                    self.file_type,
+                );
+                None
+            }
+        }
+    }
+
     fn size(&self) -> (usize, usize) {
         (self.max_size, self.cur_size)
     }
@@ -516,6 +539,19 @@ pub async fn init() -> Result<(), anyhow::Error> {
     tokio::task::spawn(async move {
         log::info!("Loading disk cache start");
         let root_dir = FILES[0].read().await.root_dir.clone();
+        // clear the trash of a previous run so the scan cannot adopt half-deleted files
+        let cfg = get_config();
+        let mut trash_dirs = vec![format!("{root_dir}trash/")];
+        for dir in cfg.disk_cache.multi_dir.split(',') {
+            if !dir.trim().is_empty() {
+                trash_dirs.push(format!("{root_dir}{}/trash/", dir.trim()));
+            }
+        }
+        for dir in trash_dirs {
+            if let Err(e) = std::fs::remove_dir_all(&dir) {
+                log::debug!("clean trash dir {dir} error: {e}");
+            }
+        }
         let root_dir = tokio::fs::canonicalize(&root_dir).await.unwrap();
         if let Err(e) = load(&root_dir, &root_dir).await {
             log::error!("load disk cache error: {e}");
@@ -525,6 +561,20 @@ pub async fn init() -> Result<(), anyhow::Error> {
             LOADING_FROM_DISK_NUM.load(Ordering::Relaxed)
         );
         LOADING_FROM_DISK_DONE.store(true, Ordering::SeqCst);
+        // the scan can bring a bucket back far over its budget; trim once instead of thrashing
+        for files in [&*FILES, &*RESULT_FILES, &*AGGREGATION_FILES] {
+            for file in files.iter() {
+                let r = file.read().await;
+                let over_size = r.cur_size.saturating_sub(r.max_size);
+                drop(r);
+                if over_size == 0 {
+                    continue;
+                }
+                let mut w = file.write().await;
+                w.gc(over_size).await;
+                drop(w);
+            }
+        }
     });
 
     spawn_pausable_job!("disk_cache_gc", get_config().disk_cache.gc_interval, {
@@ -1000,7 +1050,10 @@ async fn gc() -> Result<(), anyhow::Error> {
         w.gc(cfg.disk_cache.gc_size).await;
         drop(w);
     }
-    let scale_factor = std::cmp::max(1, cfg.disk_cache.max_size / cfg.disk_cache.result_max_size);
+    let scale_factor = std::cmp::max(
+        1,
+        cfg.disk_cache.max_size / std::cmp::max(1, cfg.disk_cache.result_max_size),
+    );
     let release_size = std::cmp::max(
         10 * config::SIZE_IN_MB as usize,
         cfg.disk_cache.release_size / scale_factor,
@@ -1018,7 +1071,7 @@ async fn gc() -> Result<(), anyhow::Error> {
     }
     let scale_factor = std::cmp::max(
         1,
-        cfg.disk_cache.max_size / cfg.disk_cache.aggregation_max_size,
+        cfg.disk_cache.max_size / std::cmp::max(1, cfg.disk_cache.aggregation_max_size),
     );
     let release_size = std::cmp::max(
         10 * config::SIZE_IN_MB as usize,
@@ -1104,28 +1157,6 @@ fn get_bucket_idx(file: &str) -> usize {
         let h = gxhash::new().sum64(file);
         (h as usize) % cfg.disk_cache.bucket_num
     }
-}
-
-/// Unlink an evicted file unless a same-key writer re-indexed the path since the eviction.
-async fn remove_evicted_file(key: &str, file_path: &str) {
-    let idx = get_bucket_idx(key);
-    let files = if key.starts_with("files") {
-        FILES[idx].read().await
-    } else if key.starts_with("results") {
-        RESULT_FILES[idx].read().await
-    } else if key.starts_with("aggregations") {
-        AGGREGATION_FILES[idx].read().await
-    } else {
-        RESULT_FILES[idx].read().await
-    };
-    if files.exist(key).await {
-        return;
-    }
-    // the read guard is held across the unlink so no writer can recreate the path meanwhile
-    if let Err(e) = tokio::fs::remove_file(file_path).await {
-        log::error!("File disk cache gc remove file: {file_path}, error: {e}");
-    }
-    drop(files);
 }
 
 // parse the result cache key from the file name
@@ -1420,6 +1451,25 @@ mod tests {
         assert!(file_data.size().0 > 0);
 
         assert_eq!(file_data.get(&file_key, None).await, Some(content))
+    }
+
+    #[tokio::test]
+    async fn test_disk_move_to_trash() {
+        let file_data = FileData::with_capacity_and_cache_strategy(FileType::Result, 1024, "lru");
+        let key = "results/trash_org/logs/default/hash/1000_2000_0_0.json";
+        let file_path = file_data.get_file_path(key);
+        tokio::fs::create_dir_all(std::path::Path::new(&file_path).parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&file_path, b"x").await.unwrap();
+
+        let trash_path = file_data.move_to_trash(key, &file_path).unwrap();
+        assert!(!std::path::Path::new(&file_path).exists());
+        assert!(std::path::Path::new(&trash_path).exists());
+
+        // a missing source is not an error, just nothing to move
+        assert!(file_data.move_to_trash(key, &file_path).is_none());
+        tokio::fs::remove_file(&trash_path).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -143,6 +143,37 @@ impl Default for FileData {
     }
 }
 
+/// Index cleanup for evicted cache entries that must run even when the evicting future is
+/// cancelled: on drop it spawns a task that prunes QUERY_RESULT_CACHE and notifies the
+/// metrics evict hook, with no disk cache lock held.
+#[derive(Default)]
+struct EvictionCleanup {
+    result_query_keys: Vec<String>,
+    metrics_files: Vec<String>,
+}
+
+impl Drop for EvictionCleanup {
+    fn drop(&mut self) {
+        if self.result_query_keys.is_empty() && self.metrics_files.is_empty() {
+            return;
+        }
+        let result_query_keys = std::mem::take(&mut self.result_query_keys);
+        let metrics_files = std::mem::take(&mut self.metrics_files);
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        handle.spawn(async move {
+            if !result_query_keys.is_empty() {
+                let mut r = QUERY_RESULT_CACHE.write().await;
+                for query_key in result_query_keys {
+                    r.remove(&query_key);
+                }
+            }
+            notify_metrics_evicted(metrics_files);
+        });
+    }
+}
+
 impl FileData {
     fn new(file_type: FileType) -> FileData {
         let cfg = get_config();
@@ -208,14 +239,11 @@ impl FileData {
         }
     }
 
-    /// Files evicted by a triggered gc are appended to `evicted_metrics_files` even when the
-    /// write itself fails, so the caller can still notify the metrics evict hook.
     async fn set(
         &mut self,
         file: &str,
         tmp_file: &str,
         data_size: usize,
-        evicted_metrics_files: &mut Vec<String>,
     ) -> Result<(), anyhow::Error> {
         if self.cur_size + data_size >= self.max_size {
             log::info!(
@@ -227,7 +255,7 @@ impl FileData {
                 self.max_size,
                 max(get_config().disk_cache.release_size, data_size * 100),
             );
-            *evicted_metrics_files = self.gc(need_release_size).await;
+            self.gc(need_release_size).await;
         }
 
         // rename tmp file to real file
@@ -281,9 +309,10 @@ impl FileData {
         Ok(())
     }
 
-    /// Returns the evicted `metrics_results/...` keys; the caller invokes the metrics evict
-    /// hook after releasing the bucket lock.
-    async fn gc(&mut self, need_release_size: usize) -> Vec<String> {
+    /// Cancellation-safe: size accounting and the cleanup lists are updated before each
+    /// await, and the index cleanup (QUERY_RESULT_CACHE + metrics evict hook) is owned by a
+    /// drop guard, so it still runs when this future is dropped mid-eviction.
+    async fn gc(&mut self, need_release_size: usize) {
         let start = std::time::Instant::now();
         log::info!(
             "[CacheType:{}] File disk cache start gc {}/{}, need to release {} bytes",
@@ -293,8 +322,7 @@ impl FileData {
             need_release_size
         );
         let mut release_size = 0;
-        let mut remove_result_files = vec![];
-        let mut remove_metrics_files = vec![];
+        let mut cleanup = EvictionCleanup::default();
         loop {
             let item = self.data.remove();
             if item.is_none() {
@@ -305,27 +333,14 @@ impl FileData {
                 break;
             }
             let (key, data_size) = item.unwrap();
-            // delete file from local disk
+            self.cur_size -= data_size;
+            release_size += data_size;
             let file_path = self.get_file_path(key.as_str());
             log::debug!(
                 "[CacheType:{}] File disk cache gc remove file: {key}",
                 self.file_type,
             );
-            if let Err(e) = tokio::fs::remove_file(&file_path).await {
-                log::error!(
-                    "[CacheType:{}] File disk cache gc remove file: {file_path}, error: {e}",
-                    self.file_type,
-                );
-            }
 
-            if key.starts_with("results/") {
-                let columns = key.split('/').collect::<Vec<&str>>();
-                let query_key = format!(
-                    "{}_{}_{}_{}",
-                    columns[1], columns[2], columns[3], columns[4]
-                );
-                remove_result_files.push(query_key);
-            }
             // metrics
             let columns = key.split('/').collect::<Vec<&str>>();
             let is_metrics_key = columns[0] == "metrics_results";
@@ -340,6 +355,10 @@ impl FileData {
                 metrics::QUERY_DISK_RESULT_CACHE_USED_BYTES
                     .with_label_values(&[columns[1], columns[2], "results"])
                     .sub(data_size as i64);
+                cleanup.result_query_keys.push(format!(
+                    "{}_{}_{}_{}",
+                    columns[1], columns[2], columns[3], columns[4]
+                ));
             } else if columns[0] == "metrics_results" {
                 metrics::QUERY_DISK_METRICS_CACHE_USED_BYTES
                     .with_label_values(&[columns[1]])
@@ -350,30 +369,28 @@ impl FileData {
                     .sub(data_size as i64);
             }
             if is_metrics_key {
-                remove_metrics_files.push(key);
+                cleanup.metrics_files.push(key);
             }
 
-            release_size += data_size;
+            // delete file from local disk, best effort: an entry is fully evicted above,
+            // a file surviving a cancelled unlink is re-indexed by the next startup scan
+            if let Err(e) = tokio::fs::remove_file(&file_path).await {
+                log::error!(
+                    "[CacheType:{}] File disk cache gc remove file: {file_path}, error: {e}",
+                    self.file_type,
+                );
+            }
+
             if release_size >= need_release_size {
                 break;
             }
         }
-        self.cur_size -= release_size;
 
-        if !remove_result_files.is_empty() {
-            let mut r = QUERY_RESULT_CACHE.write().await;
-            for query_key in remove_result_files {
-                r.remove(&query_key);
-            }
-            drop(r);
-        }
         log::info!(
             "[CacheType:{}] File disk cache gc done, released {release_size} bytes, took: {} ms",
             self.file_type,
             start.elapsed().as_millis()
         );
-
-        remove_metrics_files
     }
 
     async fn remove(&mut self, file: &str) -> Result<(), anyhow::Error> {
@@ -715,10 +732,7 @@ pub async fn set(file: &str, data: Bytes) -> Result<(), anyhow::Error> {
         }
         return Ok(());
     }
-    let mut evicted_metrics_files = Vec::new();
-    let ret = files
-        .set(&file, &tmp_file, data_size, &mut evicted_metrics_files)
-        .await;
+    let ret = files.set(&file, &tmp_file, data_size).await;
     drop(files);
 
     let set_took = start.elapsed().as_millis() as usize;
@@ -726,8 +740,6 @@ pub async fn set(file: &str, data: Bytes) -> Result<(), anyhow::Error> {
         log::info!("disk->cache: set file {file} took: {set_took} ms");
     }
 
-    // notify even when the write failed: a triggered gc already deleted these files
-    notify_metrics_evicted(evicted_metrics_files);
     ret
 }
 
@@ -977,9 +989,8 @@ async fn gc() -> Result<(), anyhow::Error> {
         }
         drop(r);
         let mut w = file.write().await;
-        let evicted_metrics_files = w.gc(cfg.disk_cache.gc_size).await;
+        w.gc(cfg.disk_cache.gc_size).await;
         drop(w);
-        notify_metrics_evicted(evicted_metrics_files);
     }
     let scale_factor = std::cmp::max(
         1,
@@ -1200,9 +1211,7 @@ mod tests {
                 i
             );
             let (_file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
-            let resp = file_data
-                .set(&file_key, &tmp_file, data_size, &mut Vec::new())
-                .await;
+            let resp = file_data.set(&file_key, &tmp_file, data_size).await;
             assert!(resp.is_ok());
         }
     }
@@ -1220,14 +1229,14 @@ mod tests {
         let (file_key, tmp_file) = write_tmp_file(file_key, content.clone()).await.unwrap();
 
         file_data
-            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
 
         let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
         file_data
-            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
@@ -1244,14 +1253,14 @@ mod tests {
         let (file_key1, tmp_file) = write_tmp_file(file_key1, content.clone()).await.unwrap();
         // set one key
         file_data
-            .set(&file_key1, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key1, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key1).await);
         // set another key, will release first key
         let (file_key2, tmp_file) = write_tmp_file(file_key2, content.clone()).await.unwrap();
         file_data
-            .set(&file_key2, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key2, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key2).await);
@@ -1271,9 +1280,7 @@ mod tests {
                 i
             );
             let (_file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
-            let resp = file_data
-                .set(&file_key, &tmp_file, data_size, &mut Vec::new())
-                .await;
+            let resp = file_data.set(&file_key, &tmp_file, data_size).await;
             if let Some(e) = resp.as_ref().err() {
                 println!("set file_key: {} error: {:?}", file_key, e);
             }
@@ -1294,14 +1301,14 @@ mod tests {
         let (file_key, tmp_file) = write_tmp_file(file_key, content.clone()).await.unwrap();
 
         file_data
-            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
 
         let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
         file_data
-            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
@@ -1318,14 +1325,14 @@ mod tests {
         let (file_key1, tmp_file) = write_tmp_file(file_key1, content.clone()).await.unwrap();
         // set one key
         file_data
-            .set(&file_key1, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key1, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key1).await);
         // set another key, will release first key
         let (file_key2, tmp_file) = write_tmp_file(file_key2, content.clone()).await.unwrap();
         file_data
-            .set(&file_key2, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key2, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key2).await);
@@ -1353,14 +1360,14 @@ mod tests {
         let (file_key, tmp_file) = write_tmp_file(file_key, content.clone()).await.unwrap();
 
         file_data
-            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
 
         let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
         file_data
-            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+            .set(&file_key, &tmp_file, data_size)
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
@@ -1518,9 +1525,7 @@ mod tests {
         let bucket_id = gxhash::new().sum64(&file_key);
         let bucket_id = (bucket_id as usize) % FILES.len();
         let mut file_data = FILES[bucket_id].write().await;
-        let _ = file_data
-            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
-            .await;
+        let _ = file_data.set(&file_key, &tmp_file, data_size).await;
         drop(file_data);
 
         // Get stats after adding data
@@ -1555,9 +1560,7 @@ mod tests {
             let bucket_id = gxhash::new().sum64(&file_key);
             let bucket_id = (bucket_id as usize) % RESULT_FILES.len();
             let mut file_data = RESULT_FILES[bucket_id].write().await;
-            let _ = file_data
-                .set(&file_key, &tmp_file, data_size, &mut Vec::new())
-                .await;
+            let _ = file_data.set(&file_key, &tmp_file, data_size).await;
             drop(file_data);
         }
 

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -320,7 +320,8 @@ impl FileData {
         Ok(())
     }
 
-    /// Cancellation-safe: all bookkeeping precedes the only await; the drop guard finishes cleanup.
+    /// Cancellation-safe: per-item bookkeeping completes before every await; the guard finishes
+    /// cleanup.
     async fn gc(&mut self, need_release_size: usize) {
         let start = std::time::Instant::now();
         log::info!(
@@ -388,6 +389,8 @@ impl FileData {
             if release_size >= need_release_size {
                 break;
             }
+            // the sync renames must not monopolize the worker for a whole batch
+            tokio::task::consume_budget().await;
         }
 
         // pruned inline so the prune completes before the caller can insert a new meta

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -283,8 +283,9 @@ impl FileData {
         // rename tmp file to real file
         let file_ops_start = std::time::Instant::now();
         let file_path = self.get_file_path(file);
-        tokio::fs::create_dir_all(Path::new(&file_path).parent().unwrap()).await?;
-        tokio::fs::rename(tmp_file, &file_path).await.map_err(|e| {
+        std::fs::create_dir_all(Path::new(&file_path).parent().unwrap())?;
+        // sync on purpose: the rename and the set_size index insert must be one uncancellable poll
+        std::fs::rename(tmp_file, &file_path).map_err(|e| {
             anyhow::anyhow!(
                 "[CacheType:{}] File disk cache rename tmp file {tmp_file} to real file {file_path} error: {e}",
                 self.file_type,
@@ -1554,6 +1555,29 @@ mod tests {
 
         // removing an unknown key vacates nothing
         assert!(file_data.remove(key).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_set_leaves_no_destination() {
+        let key = "metrics_results/cancelset_org/2024/01/01/00/fff_1_2_3.pb";
+        let idx = get_bucket_idx(key);
+
+        // park the write on the bucket lock, then abort it before the rename can happen
+        let w = RESULT_FILES[idx].write().await;
+        let task_key = key.to_string();
+        let handle = tokio::spawn(async move {
+            let _ = set(&task_key, Bytes::from("x")).await;
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        handle.abort();
+        let _ = handle.await;
+        drop(w);
+
+        // the destination file and the index entry either both exist or neither does
+        let indexed = RESULT_FILES[idx].read().await.exist(key).await;
+        let on_disk = get_file_path(key).is_some_and(|path| std::path::Path::new(&path).exists());
+        assert_eq!(indexed, on_disk);
+        assert!(!indexed);
     }
 
     #[tokio::test]

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -127,6 +127,14 @@ pub enum FileType {
     Aggregation,
 }
 
+/// Eviction cleanup whose Drop spawns a task, so it also runs when the gc future is cancelled.
+#[derive(Default)]
+struct EvictionCleanup {
+    result_query_keys: Vec<String>,
+    metrics_files: Vec<String>,
+    file_paths: Vec<String>,
+}
+
 impl fmt::Display for FileType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -143,33 +151,41 @@ impl Default for FileData {
     }
 }
 
-/// Index cleanup for evicted cache entries that must run even when the evicting future is
-/// cancelled: on drop it spawns a task that prunes QUERY_RESULT_CACHE and notifies the
-/// metrics evict hook, with no disk cache lock held.
-#[derive(Default)]
-struct EvictionCleanup {
-    result_query_keys: Vec<String>,
-    metrics_files: Vec<String>,
-}
-
 impl Drop for EvictionCleanup {
     fn drop(&mut self) {
-        if self.result_query_keys.is_empty() && self.metrics_files.is_empty() {
+        if self.result_query_keys.is_empty()
+            && self.metrics_files.is_empty()
+            && self.file_paths.is_empty()
+        {
             return;
         }
         let result_query_keys = std::mem::take(&mut self.result_query_keys);
         let metrics_files = std::mem::take(&mut self.metrics_files);
+        let file_paths = std::mem::take(&mut self.file_paths);
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            log::error!(
+                "File disk cache eviction cleanup dropped outside a runtime, index entries may be stale"
+            );
             return;
         };
         handle.spawn(async move {
+            // normally drained inline by gc; only a cancelled gc leaves keys here
             if !result_query_keys.is_empty() {
                 let mut r = QUERY_RESULT_CACHE.write().await;
                 for query_key in result_query_keys {
                     r.remove(&query_key);
                 }
             }
-            notify_metrics_evicted(metrics_files);
+            if !metrics_files.is_empty()
+                && let Some(hook) = METRICS_RESULT_CACHE_EVICT_HOOK.get()
+            {
+                hook(metrics_files);
+            }
+            for file_path in file_paths {
+                if let Err(e) = tokio::fs::remove_file(&file_path).await {
+                    log::error!("File disk cache gc remove file: {file_path}, error: {e}");
+                }
+            }
         });
     }
 }
@@ -251,10 +267,19 @@ impl FileData {
                 self.file_type,
             );
             // cache is full, need release some space
-            let need_release_size = min(
-                self.max_size,
-                max(get_config().disk_cache.release_size, data_size * 100),
+            let cfg = get_config();
+            // scale the release size by cache type, the same way the periodic gc job does
+            let type_max_size = match self.file_type {
+                FileType::Data => cfg.disk_cache.max_size,
+                FileType::Result => cfg.disk_cache.result_max_size,
+                FileType::Aggregation => cfg.disk_cache.aggregation_max_size,
+            };
+            let scale_factor = max(1, cfg.disk_cache.max_size / max(1, type_max_size));
+            let release_size = max(
+                10 * config::SIZE_IN_MB as usize,
+                cfg.disk_cache.release_size / scale_factor,
             );
+            let need_release_size = min(self.max_size, max(release_size, data_size * 100));
             self.gc(need_release_size).await;
         }
 
@@ -309,9 +334,7 @@ impl FileData {
         Ok(())
     }
 
-    /// Cancellation-safe: size accounting and the cleanup lists are updated before each
-    /// await, and the index cleanup (QUERY_RESULT_CACHE + metrics evict hook) is owned by a
-    /// drop guard, so it still runs when this future is dropped mid-eviction.
+    /// Cancellation-safe: all bookkeeping precedes the only await; the drop guard finishes cleanup.
     async fn gc(&mut self, need_release_size: usize) {
         let start = std::time::Instant::now();
         log::info!(
@@ -371,19 +394,21 @@ impl FileData {
             if is_metrics_key {
                 cleanup.metrics_files.push(key);
             }
-
-            // delete file from local disk, best effort: an entry is fully evicted above,
-            // a file surviving a cancelled unlink is re-indexed by the next startup scan
-            if let Err(e) = tokio::fs::remove_file(&file_path).await {
-                log::error!(
-                    "[CacheType:{}] File disk cache gc remove file: {file_path}, error: {e}",
-                    self.file_type,
-                );
-            }
+            // the guard's task unlinks best effort; survivors are re-adopted by the startup scan
+            cleanup.file_paths.push(file_path);
 
             if release_size >= need_release_size {
                 break;
             }
+        }
+
+        // pruned inline so the prune completes before the caller can insert a new meta
+        if !cleanup.result_query_keys.is_empty() {
+            let mut r = QUERY_RESULT_CACHE.write().await;
+            for query_key in cleanup.result_query_keys.drain(..) {
+                r.remove(&query_key);
+            }
+            drop(r);
         }
 
         log::info!(
@@ -400,6 +425,10 @@ impl FileData {
         );
 
         let Some((key, data_size)) = self.data.remove_key(file) else {
+            log::debug!(
+                "[CacheType:{}] File disk cache remove file {file} not in the index",
+                self.file_type,
+            );
             return Ok(());
         };
         self.cur_size -= data_size;
@@ -786,21 +815,10 @@ pub async fn remove(file: &str) -> Result<(), anyhow::Error> {
     files.remove(file).await
 }
 
-/// Register the callback invoked with the `metrics_results/...` keys evicted by the disk
-/// cache gc, so the metrics result cache index can drop the matching entries. The hook is
-/// invoked after all disk cache locks are released.
+/// The hook runs on a detached task and may run concurrently with held disk cache locks.
 pub fn set_metrics_result_cache_evict_hook(hook: fn(Vec<String>)) {
     if METRICS_RESULT_CACHE_EVICT_HOOK.set(hook).is_err() {
         log::warn!("metrics result cache evict hook is already registered");
-    }
-}
-
-fn notify_metrics_evicted(files: Vec<String>) {
-    if files.is_empty() {
-        return;
-    }
-    if let Some(hook) = METRICS_RESULT_CACHE_EVICT_HOOK.get() {
-        hook(files);
     }
 }
 
@@ -912,6 +930,11 @@ async fn load(root_dir: &PathBuf, scan_dir: &PathBuf) -> Result<(), anyhow::Erro
                             .or_insert_with(Vec::new)
                             .push(meta);
                     } else if file_key.starts_with("metrics_results") {
+                        let mut w = RESULT_FILES[idx].write().await;
+                        w.cur_size += data_size;
+                        w.data.insert(file_key.clone(), data_size);
+                        drop(w);
+
                         // metrics
                         let columns = file_key.split('/').collect::<Vec<&str>>();
                         metrics::QUERY_DISK_METRICS_CACHE_USED_BYTES

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -136,6 +136,17 @@ struct EvictionCleanup {
     trash_files: Vec<String>,
 }
 
+/// While held, the file's disk cache bucket cannot evict, so the file stays on disk.
+pub struct IndexedFileGuard {
+    _guard: tokio::sync::RwLockReadGuard<'static, FileData>,
+}
+
+enum TrashOutcome {
+    Moved(String),
+    SourceMissing,
+    Failed,
+}
+
 impl fmt::Display for FileType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -332,6 +343,7 @@ impl FileData {
             need_release_size
         );
         let mut release_size = 0;
+        let mut move_failures = 0;
         let mut result_query_keys = Vec::new();
         let mut cleanup = EvictionCleanup::default();
         loop {
@@ -344,13 +356,30 @@ impl FileData {
                 break;
             }
             let (key, data_size) = item.unwrap();
-            self.cur_size -= data_size;
-            release_size += data_size;
             let file_path = self.get_file_path(key.as_str());
             log::debug!(
                 "[CacheType:{}] File disk cache gc remove file: {key}",
                 self.file_type,
             );
+            match self.move_to_trash(&key, &file_path) {
+                TrashOutcome::Moved(trash_path) => cleanup.trash_files.push(trash_path),
+                TrashOutcome::SourceMissing => {}
+                TrashOutcome::Failed => {
+                    // the file still occupies its path: keep the entry so accounting stays true
+                    self.data.insert(key, data_size);
+                    move_failures += 1;
+                    if move_failures >= 3 {
+                        log::error!(
+                            "[CacheType:{}] File disk cache gc stopped after repeated trash failures",
+                            self.file_type,
+                        );
+                        break;
+                    }
+                    continue;
+                }
+            }
+            self.cur_size -= data_size;
+            release_size += data_size;
 
             // metrics
             let columns = key.split('/').collect::<Vec<&str>>();
@@ -378,9 +407,6 @@ impl FileData {
                 metrics::QUERY_DISK_RESULT_CACHE_USED_BYTES
                     .with_label_values(&[columns[1], columns[2], "aggregations"])
                     .sub(data_size as i64);
-            }
-            if let Some(trash_path) = self.move_to_trash(&key, &file_path) {
-                cleanup.trash_files.push(trash_path);
             }
             if is_metrics_key {
                 cleanup.metrics_files.push(key);
@@ -422,10 +448,17 @@ impl FileData {
             );
             return Ok(None);
         };
-        self.cur_size -= data_size;
-
         let file_path = self.get_file_path(key.as_str());
-        let trash_file = self.move_to_trash(key.as_str(), &file_path);
+        let trash_file = match self.move_to_trash(key.as_str(), &file_path) {
+            TrashOutcome::Moved(trash_path) => Some(trash_path),
+            TrashOutcome::SourceMissing => None,
+            TrashOutcome::Failed => {
+                // the file still occupies its path: keep the entry so accounting stays true
+                self.data.insert(key, data_size);
+                return Ok(None);
+            }
+        };
+        self.cur_size -= data_size;
 
         // metrics
         let columns = key.split('/').collect::<Vec<&str>>();
@@ -464,7 +497,7 @@ impl FileData {
     }
 
     /// Vacates the deterministic path under the bucket lock, so same-key writers never collide.
-    fn move_to_trash(&self, key: &str, file_path: &str) -> Option<String> {
+    fn move_to_trash(&self, key: &str, file_path: &str) -> TrashOutcome {
         let trash_path = format!(
             "{}{}trash/{}",
             self.root_dir,
@@ -472,30 +505,30 @@ impl FileData {
             TRASH_ID.fetch_add(1, Ordering::Relaxed)
         );
         match std::fs::rename(file_path, &trash_path) {
-            Ok(()) => Some(trash_path),
+            Ok(()) => TrashOutcome::Moved(trash_path),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 if !Path::new(file_path).exists() {
-                    return None;
+                    return TrashOutcome::SourceMissing;
                 }
                 // first eviction of a run creates the trash dir, then the rename is retried
-                let parent = Path::new(&trash_path).parent()?;
-                if std::fs::create_dir_all(parent).is_ok()
-                    && std::fs::rename(file_path, &trash_path).is_ok()
-                {
-                    return Some(trash_path);
+                let created = Path::new(&trash_path)
+                    .parent()
+                    .is_some_and(|parent| std::fs::create_dir_all(parent).is_ok());
+                if created && std::fs::rename(file_path, &trash_path).is_ok() {
+                    return TrashOutcome::Moved(trash_path);
                 }
                 log::error!(
                     "[CacheType:{}] File disk cache move file {file_path} to trash error",
                     self.file_type,
                 );
-                None
+                TrashOutcome::Failed
             }
             Err(e) => {
                 log::error!(
                     "[CacheType:{}] File disk cache move file {file_path} to trash error: {e}",
                     self.file_type,
                 );
-                None
+                TrashOutcome::Failed
             }
         }
     }
@@ -572,8 +605,6 @@ pub async fn init() -> Result<(), anyhow::Error> {
                 drop(w);
             }
         }
-        // the metrics replay must not adopt keys the trim just evicted, so prune before publishing
-        prune_pending_metrics_replay().await;
         LOADING_FROM_DISK_DONE.store(true, Ordering::SeqCst);
     });
 
@@ -874,6 +905,24 @@ pub async fn remove(file: &str) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Returns a guard proving the file is indexed; while held, the bucket cannot evict it.
+pub async fn indexed_file_guard(file: &str) -> Option<IndexedFileGuard> {
+    let idx = get_bucket_idx(file);
+    let files = if file.starts_with("files") {
+        FILES[idx].read().await
+    } else if file.starts_with("results") {
+        RESULT_FILES[idx].read().await
+    } else if file.starts_with("aggregations") {
+        AGGREGATION_FILES[idx].read().await
+    } else {
+        RESULT_FILES[idx].read().await
+    };
+    if !files.exist(file).await {
+        return None;
+    }
+    Some(IndexedFileGuard { _guard: files })
+}
+
 /// The hook runs on a detached task and may run concurrently with held disk cache locks.
 pub fn set_metrics_result_cache_evict_hook(hook: fn(Vec<String>)) {
     if METRICS_RESULT_CACHE_EVICT_HOOK.set(hook).is_err() {
@@ -1155,18 +1204,6 @@ pub async fn download(
         ));
     };
     Ok(data_len)
-}
-
-/// Drops pending metrics replay keys whose files are no longer in the disk cache index.
-async fn prune_pending_metrics_replay() {
-    let mut pending = METRICS_RESULT_CACHE.write().await;
-    let keys = std::mem::take(&mut *pending);
-    for key in keys {
-        let idx = get_bucket_idx(&key);
-        if RESULT_FILES[idx].read().await.exist(&key).await {
-            pending.push(key);
-        }
-    }
 }
 
 fn get_bucket_idx(file: &str) -> usize {
@@ -1483,12 +1520,17 @@ mod tests {
             .unwrap();
         tokio::fs::write(&file_path, b"x").await.unwrap();
 
-        let trash_path = file_data.move_to_trash(key, &file_path).unwrap();
+        let TrashOutcome::Moved(trash_path) = file_data.move_to_trash(key, &file_path) else {
+            panic!("expected the file to move to trash");
+        };
         assert!(!std::path::Path::new(&file_path).exists());
         assert!(std::path::Path::new(&trash_path).exists());
 
         // a missing source is not an error, just nothing to move
-        assert!(file_data.move_to_trash(key, &file_path).is_none());
+        assert!(matches!(
+            file_data.move_to_trash(key, &file_path),
+            TrashOutcome::SourceMissing
+        ));
         tokio::fs::remove_file(&trash_path).await.unwrap();
     }
 
@@ -1515,26 +1557,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_prune_pending_metrics_replay() {
-        let kept_key = "metrics_results/replay_org/2024/01/01/00/aaa_1_2_3.pb";
-        let evicted_key = "metrics_results/replay_org/2024/01/01/00/bbb_1_2_3.pb";
-        let idx = get_bucket_idx(kept_key);
+    async fn test_indexed_file_guard() {
+        let indexed_key = "metrics_results/guard_org/2024/01/01/00/aaa_1_2_3.pb";
+        let evicted_key = "metrics_results/guard_org/2024/01/01/00/bbb_1_2_3.pb";
+        let idx = get_bucket_idx(indexed_key);
         RESULT_FILES[idx]
             .write()
             .await
-            .set_size(kept_key, 1)
+            .set_size(indexed_key, 1)
             .await
             .unwrap();
-        METRICS_RESULT_CACHE
-            .write()
-            .await
-            .extend([kept_key.to_string(), evicted_key.to_string()]);
 
-        prune_pending_metrics_replay().await;
-
-        let pending = METRICS_RESULT_CACHE.read().await;
-        assert!(pending.contains(&kept_key.to_string()));
-        assert!(!pending.contains(&evicted_key.to_string()));
+        assert!(indexed_file_guard(indexed_key).await.is_some());
+        assert!(indexed_file_guard(evicted_key).await.is_none());
     }
 
     #[tokio::test]

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -19,7 +19,7 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     sync::{
-        LazyLock as Lazy,
+        LazyLock as Lazy, OnceLock,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::SystemTime,
@@ -105,6 +105,8 @@ pub static QUERY_RESULT_CACHE: Lazy<RwAHashMap<String, Vec<ResultCacheMeta>>> =
     Lazy::new(Default::default);
 
 pub static METRICS_RESULT_CACHE: Lazy<RwLock<Vec<String>>> = Lazy::new(|| RwLock::new(Vec::new()));
+
+static METRICS_RESULT_CACHE_EVICT_HOOK: OnceLock<fn(Vec<String>)> = OnceLock::new();
 
 pub static LOADING_FROM_DISK_NUM: Lazy<AtomicUsize> = Lazy::new(|| AtomicUsize::new(0));
 pub static LOADING_FROM_DISK_DONE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
@@ -206,12 +208,14 @@ impl FileData {
         }
     }
 
+    /// Returns the evicted `metrics_results/...` keys when the write triggered a gc.
     async fn set(
         &mut self,
         file: &str,
         tmp_file: &str,
         data_size: usize,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<Vec<String>, anyhow::Error> {
+        let mut evicted_metrics_files = Vec::new();
         if self.cur_size + data_size >= self.max_size {
             log::info!(
                 "[CacheType:{}] File disk cache is full, can't cache extra {data_size} bytes",
@@ -222,7 +226,7 @@ impl FileData {
                 self.max_size,
                 max(get_config().disk_cache.release_size, data_size * 100),
             );
-            self.gc(need_release_size).await?;
+            evicted_metrics_files = self.gc(need_release_size).await?;
         }
 
         // rename tmp file to real file
@@ -244,7 +248,8 @@ impl FileData {
         }
 
         // set size
-        self.set_size(file, data_size).await
+        self.set_size(file, data_size).await?;
+        Ok(evicted_metrics_files)
     }
 
     async fn set_size(&mut self, file: &str, data_size: usize) -> Result<(), anyhow::Error> {
@@ -276,7 +281,9 @@ impl FileData {
         Ok(())
     }
 
-    async fn gc(&mut self, need_release_size: usize) -> Result<(), anyhow::Error> {
+    /// Returns the evicted `metrics_results/...` keys; the caller invokes the metrics evict
+    /// hook after releasing the bucket lock.
+    async fn gc(&mut self, need_release_size: usize) -> Result<Vec<String>, anyhow::Error> {
         let start = std::time::Instant::now();
         log::info!(
             "[CacheType:{}] File disk cache start gc {}/{}, need to release {} bytes",
@@ -287,6 +294,7 @@ impl FileData {
         );
         let mut release_size = 0;
         let mut remove_result_files = vec![];
+        let mut remove_metrics_files = vec![];
         loop {
             let item = self.data.remove();
             if item.is_none() {
@@ -320,6 +328,7 @@ impl FileData {
             }
             // metrics
             let columns = key.split('/').collect::<Vec<&str>>();
+            let is_metrics_key = columns[0] == "metrics_results";
             if columns[0] == "files" {
                 metrics::QUERY_DISK_CACHE_FILES
                     .with_label_values(&[columns[1], columns[2]])
@@ -339,6 +348,9 @@ impl FileData {
                 metrics::QUERY_DISK_RESULT_CACHE_USED_BYTES
                     .with_label_values(&[columns[1], columns[2], "aggregations"])
                     .sub(data_size as i64);
+            }
+            if is_metrics_key {
+                remove_metrics_files.push(key);
             }
 
             release_size += data_size;
@@ -361,7 +373,7 @@ impl FileData {
             start.elapsed().as_millis()
         );
 
-        Ok(())
+        Ok(remove_metrics_files)
     }
 
     async fn remove(&mut self, file: &str) -> Result<(), anyhow::Error> {
@@ -704,13 +716,15 @@ pub async fn set(file: &str, data: Bytes) -> Result<(), anyhow::Error> {
         return Ok(());
     }
     let ret = files.set(&file, &tmp_file, data_size).await;
+    drop(files);
 
     let set_took = start.elapsed().as_millis() as usize;
     if set_took > 100 {
         log::info!("disk->cache: set file {file} took: {set_took} ms");
     }
 
-    ret
+    notify_metrics_evicted(ret?);
+    Ok(())
 }
 
 #[inline]
@@ -754,6 +768,24 @@ pub async fn remove(file: &str) -> Result<(), anyhow::Error> {
         RESULT_FILES[idx].write().await
     };
     files.remove(file).await
+}
+
+/// Register the callback invoked with the `metrics_results/...` keys evicted by the disk
+/// cache gc, so the metrics result cache index can drop the matching entries. The hook is
+/// invoked after all disk cache locks are released.
+pub fn set_metrics_result_cache_evict_hook(hook: fn(Vec<String>)) {
+    if METRICS_RESULT_CACHE_EVICT_HOOK.set(hook).is_err() {
+        log::warn!("metrics result cache evict hook is already registered");
+    }
+}
+
+fn notify_metrics_evicted(files: Vec<String>) {
+    if files.is_empty() {
+        return;
+    }
+    if let Some(hook) = METRICS_RESULT_CACHE_EVICT_HOOK.get() {
+        hook(files);
+    }
 }
 
 #[async_recursion]
@@ -941,8 +973,9 @@ async fn gc() -> Result<(), anyhow::Error> {
         }
         drop(r);
         let mut w = file.write().await;
-        w.gc(cfg.disk_cache.gc_size).await?;
+        let evicted_metrics_files = w.gc(cfg.disk_cache.gc_size).await?;
         drop(w);
+        notify_metrics_evicted(evicted_metrics_files);
     }
     let scale_factor = std::cmp::max(
         1,

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -208,14 +208,15 @@ impl FileData {
         }
     }
 
-    /// Returns the evicted `metrics_results/...` keys when the write triggered a gc.
+    /// Files evicted by a triggered gc are appended to `evicted_metrics_files` even when the
+    /// write itself fails, so the caller can still notify the metrics evict hook.
     async fn set(
         &mut self,
         file: &str,
         tmp_file: &str,
         data_size: usize,
-    ) -> Result<Vec<String>, anyhow::Error> {
-        let mut evicted_metrics_files = Vec::new();
+        evicted_metrics_files: &mut Vec<String>,
+    ) -> Result<(), anyhow::Error> {
         if self.cur_size + data_size >= self.max_size {
             log::info!(
                 "[CacheType:{}] File disk cache is full, can't cache extra {data_size} bytes",
@@ -226,7 +227,7 @@ impl FileData {
                 self.max_size,
                 max(get_config().disk_cache.release_size, data_size * 100),
             );
-            evicted_metrics_files = self.gc(need_release_size).await?;
+            *evicted_metrics_files = self.gc(need_release_size).await;
         }
 
         // rename tmp file to real file
@@ -248,8 +249,7 @@ impl FileData {
         }
 
         // set size
-        self.set_size(file, data_size).await?;
-        Ok(evicted_metrics_files)
+        self.set_size(file, data_size).await
     }
 
     async fn set_size(&mut self, file: &str, data_size: usize) -> Result<(), anyhow::Error> {
@@ -283,7 +283,7 @@ impl FileData {
 
     /// Returns the evicted `metrics_results/...` keys; the caller invokes the metrics evict
     /// hook after releasing the bucket lock.
-    async fn gc(&mut self, need_release_size: usize) -> Result<Vec<String>, anyhow::Error> {
+    async fn gc(&mut self, need_release_size: usize) -> Vec<String> {
         let start = std::time::Instant::now();
         log::info!(
             "[CacheType:{}] File disk cache start gc {}/{}, need to release {} bytes",
@@ -373,7 +373,7 @@ impl FileData {
             start.elapsed().as_millis()
         );
 
-        Ok(remove_metrics_files)
+        remove_metrics_files
     }
 
     async fn remove(&mut self, file: &str) -> Result<(), anyhow::Error> {
@@ -715,7 +715,10 @@ pub async fn set(file: &str, data: Bytes) -> Result<(), anyhow::Error> {
         }
         return Ok(());
     }
-    let ret = files.set(&file, &tmp_file, data_size).await;
+    let mut evicted_metrics_files = Vec::new();
+    let ret = files
+        .set(&file, &tmp_file, data_size, &mut evicted_metrics_files)
+        .await;
     drop(files);
 
     let set_took = start.elapsed().as_millis() as usize;
@@ -723,8 +726,9 @@ pub async fn set(file: &str, data: Bytes) -> Result<(), anyhow::Error> {
         log::info!("disk->cache: set file {file} took: {set_took} ms");
     }
 
-    notify_metrics_evicted(ret?);
-    Ok(())
+    // notify even when the write failed: a triggered gc already deleted these files
+    notify_metrics_evicted(evicted_metrics_files);
+    ret
 }
 
 #[inline]
@@ -957,7 +961,7 @@ async fn gc() -> Result<(), anyhow::Error> {
         }
         drop(r);
         let mut w = file.write().await;
-        w.gc(cfg.disk_cache.gc_size).await?;
+        w.gc(cfg.disk_cache.gc_size).await;
         drop(w);
     }
     let scale_factor = std::cmp::max(1, cfg.disk_cache.max_size / cfg.disk_cache.result_max_size);
@@ -973,7 +977,7 @@ async fn gc() -> Result<(), anyhow::Error> {
         }
         drop(r);
         let mut w = file.write().await;
-        let evicted_metrics_files = w.gc(cfg.disk_cache.gc_size).await?;
+        let evicted_metrics_files = w.gc(cfg.disk_cache.gc_size).await;
         drop(w);
         notify_metrics_evicted(evicted_metrics_files);
     }
@@ -993,7 +997,7 @@ async fn gc() -> Result<(), anyhow::Error> {
         }
         drop(r);
         let mut w = file.write().await;
-        w.gc(cfg.disk_cache.gc_size).await?;
+        w.gc(cfg.disk_cache.gc_size).await;
         drop(w);
     }
     Ok(())
@@ -1196,7 +1200,9 @@ mod tests {
                 i
             );
             let (_file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
-            let resp = file_data.set(&file_key, &tmp_file, data_size).await;
+            let resp = file_data
+                .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+                .await;
             assert!(resp.is_ok());
         }
     }
@@ -1214,14 +1220,14 @@ mod tests {
         let (file_key, tmp_file) = write_tmp_file(file_key, content.clone()).await.unwrap();
 
         file_data
-            .set(&file_key, &tmp_file, data_size)
+            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
 
         let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
         file_data
-            .set(&file_key, &tmp_file, data_size)
+            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
@@ -1238,14 +1244,14 @@ mod tests {
         let (file_key1, tmp_file) = write_tmp_file(file_key1, content.clone()).await.unwrap();
         // set one key
         file_data
-            .set(&file_key1, &tmp_file, data_size)
+            .set(&file_key1, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key1).await);
         // set another key, will release first key
         let (file_key2, tmp_file) = write_tmp_file(file_key2, content.clone()).await.unwrap();
         file_data
-            .set(&file_key2, &tmp_file, data_size)
+            .set(&file_key2, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key2).await);
@@ -1265,7 +1271,9 @@ mod tests {
                 i
             );
             let (_file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
-            let resp = file_data.set(&file_key, &tmp_file, data_size).await;
+            let resp = file_data
+                .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+                .await;
             if let Some(e) = resp.as_ref().err() {
                 println!("set file_key: {} error: {:?}", file_key, e);
             }
@@ -1286,14 +1294,14 @@ mod tests {
         let (file_key, tmp_file) = write_tmp_file(file_key, content.clone()).await.unwrap();
 
         file_data
-            .set(&file_key, &tmp_file, data_size)
+            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
 
         let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
         file_data
-            .set(&file_key, &tmp_file, data_size)
+            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
@@ -1310,14 +1318,14 @@ mod tests {
         let (file_key1, tmp_file) = write_tmp_file(file_key1, content.clone()).await.unwrap();
         // set one key
         file_data
-            .set(&file_key1, &tmp_file, data_size)
+            .set(&file_key1, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key1).await);
         // set another key, will release first key
         let (file_key2, tmp_file) = write_tmp_file(file_key2, content.clone()).await.unwrap();
         file_data
-            .set(&file_key2, &tmp_file, data_size)
+            .set(&file_key2, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key2).await);
@@ -1345,14 +1353,14 @@ mod tests {
         let (file_key, tmp_file) = write_tmp_file(file_key, content.clone()).await.unwrap();
 
         file_data
-            .set(&file_key, &tmp_file, data_size)
+            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
 
         let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
         file_data
-            .set(&file_key, &tmp_file, data_size)
+            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
             .await
             .unwrap();
         assert!(file_data.exist(&file_key).await);
@@ -1510,7 +1518,9 @@ mod tests {
         let bucket_id = gxhash::new().sum64(&file_key);
         let bucket_id = (bucket_id as usize) % FILES.len();
         let mut file_data = FILES[bucket_id].write().await;
-        let _ = file_data.set(&file_key, &tmp_file, data_size).await;
+        let _ = file_data
+            .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+            .await;
         drop(file_data);
 
         // Get stats after adding data
@@ -1545,7 +1555,9 @@ mod tests {
             let bucket_id = gxhash::new().sum64(&file_key);
             let bucket_id = (bucket_id as usize) % RESULT_FILES.len();
             let mut file_data = RESULT_FILES[bucket_id].write().await;
-            let _ = file_data.set(&file_key, &tmp_file, data_size).await;
+            let _ = file_data
+                .set(&file_key, &tmp_file, data_size, &mut Vec::new())
+                .await;
             drop(file_data);
         }
 

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -405,7 +405,8 @@ impl FileData {
         );
     }
 
-    async fn remove(&mut self, file: &str) -> Result<(), anyhow::Error> {
+    /// Returns the trash path the file was vacated to; the caller deletes it off-lock.
+    async fn remove(&mut self, file: &str) -> Result<Option<String>, anyhow::Error> {
         log::debug!(
             "[CacheType:{}] File disk cache remove file {file}",
             self.file_type,
@@ -416,18 +417,12 @@ impl FileData {
                 "[CacheType:{}] File disk cache remove file {file} not in the index",
                 self.file_type,
             );
-            return Ok(());
+            return Ok(None);
         };
         self.cur_size -= data_size;
 
-        // delete file from local disk
         let file_path = self.get_file_path(key.as_str());
-        if let Err(e) = tokio::fs::remove_file(&file_path).await {
-            log::error!(
-                "[CacheType:{}] File disk cache remove file: {file_path}, error: {e}",
-                self.file_type,
-            );
-        }
+        let trash_file = self.move_to_trash(key.as_str(), &file_path);
 
         // metrics
         let columns = key.split('/').collect::<Vec<&str>>();
@@ -452,7 +447,7 @@ impl FileData {
                 .sub(data_size as i64);
         }
 
-        Ok(())
+        Ok(trash_file)
     }
 
     fn choose_multi_dir(&self, file: &str) -> String {
@@ -560,7 +555,6 @@ pub async fn init() -> Result<(), anyhow::Error> {
             "Loading disk cache done, total files: {}",
             LOADING_FROM_DISK_NUM.load(Ordering::Relaxed)
         );
-        LOADING_FROM_DISK_DONE.store(true, Ordering::SeqCst);
         // the scan can bring a bucket back far over its budget; trim once instead of thrashing
         for files in [&*FILES, &*RESULT_FILES, &*AGGREGATION_FILES] {
             for file in files.iter() {
@@ -575,6 +569,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
                 drop(w);
             }
         }
+        // the metrics replay must not adopt keys the trim just evicted, so prune before publishing
+        prune_pending_metrics_replay().await;
+        LOADING_FROM_DISK_DONE.store(true, Ordering::SeqCst);
     });
 
     spawn_pausable_job!("disk_cache_gc", get_config().disk_cache.gc_interval, {
@@ -863,7 +860,15 @@ pub async fn remove(file: &str) -> Result<(), anyhow::Error> {
     } else {
         RESULT_FILES[idx].write().await
     };
-    files.remove(file).await
+    let trash_file = files.remove(file).await?;
+    drop(files);
+    if let Some(trash_file) = trash_file
+        && let Err(e) = tokio::fs::remove_file(&trash_file).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        log::error!("File disk cache remove trash file {trash_file} error: {e}");
+    }
+    Ok(())
 }
 
 /// The hook runs on a detached task and may run concurrently with held disk cache locks.
@@ -1147,6 +1152,18 @@ pub async fn download(
         ));
     };
     Ok(data_len)
+}
+
+/// Drops pending metrics replay keys whose files are no longer in the disk cache index.
+async fn prune_pending_metrics_replay() {
+    let mut pending = METRICS_RESULT_CACHE.write().await;
+    let keys = std::mem::take(&mut *pending);
+    for key in keys {
+        let idx = get_bucket_idx(&key);
+        if RESULT_FILES[idx].read().await.exist(&key).await {
+            pending.push(key);
+        }
+    }
 }
 
 fn get_bucket_idx(file: &str) -> usize {
@@ -1470,6 +1487,51 @@ mod tests {
         // a missing source is not an error, just nothing to move
         assert!(file_data.move_to_trash(key, &file_path).is_none());
         tokio::fs::remove_file(&trash_path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_disk_remove_vacates_path_via_trash() {
+        let mut file_data =
+            FileData::with_capacity_and_cache_strategy(FileType::Result, 1024, "lru");
+        let key = "results/trash_rm_org/logs/default/hash/1000_2000_0_0.json";
+        let file_path = file_data.get_file_path(key);
+        tokio::fs::create_dir_all(std::path::Path::new(&file_path).parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&file_path, b"x").await.unwrap();
+        file_data.set_size(key, 1).await.unwrap();
+
+        let trash_file = file_data.remove(key).await.unwrap().unwrap();
+        assert!(!file_data.exist(key).await);
+        assert!(!std::path::Path::new(&file_path).exists());
+        assert!(std::path::Path::new(&trash_file).exists());
+        tokio::fs::remove_file(&trash_file).await.unwrap();
+
+        // removing an unknown key vacates nothing
+        assert!(file_data.remove(key).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_prune_pending_metrics_replay() {
+        let kept_key = "metrics_results/replay_org/2024/01/01/00/aaa_1_2_3.pb";
+        let evicted_key = "metrics_results/replay_org/2024/01/01/00/bbb_1_2_3.pb";
+        let idx = get_bucket_idx(kept_key);
+        RESULT_FILES[idx]
+            .write()
+            .await
+            .set_size(kept_key, 1)
+            .await
+            .unwrap();
+        METRICS_RESULT_CACHE
+            .write()
+            .await
+            .extend([kept_key.to_string(), evicted_key.to_string()]);
+
+        prune_pending_metrics_replay().await;
+
+        let pending = METRICS_RESULT_CACHE.read().await;
+        assert!(pending.contains(&kept_key.to_string()));
+        assert!(!pending.contains(&evicted_key.to_string()));
     }
 
     #[tokio::test]

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -132,7 +132,7 @@ pub enum FileType {
 struct EvictionCleanup {
     result_query_keys: Vec<String>,
     metrics_files: Vec<String>,
-    file_paths: Vec<String>,
+    evicted_files: Vec<(String, String)>, // (cache key, absolute file path)
 }
 
 impl fmt::Display for FileType {
@@ -155,13 +155,13 @@ impl Drop for EvictionCleanup {
     fn drop(&mut self) {
         if self.result_query_keys.is_empty()
             && self.metrics_files.is_empty()
-            && self.file_paths.is_empty()
+            && self.evicted_files.is_empty()
         {
             return;
         }
         let result_query_keys = std::mem::take(&mut self.result_query_keys);
         let metrics_files = std::mem::take(&mut self.metrics_files);
-        let file_paths = std::mem::take(&mut self.file_paths);
+        let evicted_files = std::mem::take(&mut self.evicted_files);
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             log::error!(
                 "File disk cache eviction cleanup dropped outside a runtime, index entries may be stale"
@@ -181,10 +181,8 @@ impl Drop for EvictionCleanup {
             {
                 hook(metrics_files);
             }
-            for file_path in file_paths {
-                if let Err(e) = tokio::fs::remove_file(&file_path).await {
-                    log::error!("File disk cache gc remove file: {file_path}, error: {e}");
-                }
+            for (key, file_path) in evicted_files {
+                remove_evicted_file(&key, &file_path).await;
             }
         });
     }
@@ -287,6 +285,9 @@ impl FileData {
         let file_ops_start = std::time::Instant::now();
         let file_path = self.get_file_path(file);
         tokio::fs::create_dir_all(Path::new(&file_path).parent().unwrap()).await?;
+        // a stale same-name file can await the eviction cleanup; clear it so the rename works on
+        // windows
+        let _ = tokio::fs::remove_file(&file_path).await;
         tokio::fs::rename(tmp_file, &file_path).await.map_err(|e| {
             anyhow::anyhow!(
                 "[CacheType:{}] File disk cache rename tmp file {tmp_file} to real file {file_path} error: {e}",
@@ -391,11 +392,11 @@ impl FileData {
                     .with_label_values(&[columns[1], columns[2], "aggregations"])
                     .sub(data_size as i64);
             }
+            // the guard's task unlinks best effort; survivors are re-adopted by the startup scan
+            cleanup.evicted_files.push((key.clone(), file_path));
             if is_metrics_key {
                 cleanup.metrics_files.push(key);
             }
-            // the guard's task unlinks best effort; survivors are re-adopted by the startup scan
-            cleanup.file_paths.push(file_path);
 
             if release_size >= need_release_size {
                 break;
@@ -1103,6 +1104,28 @@ fn get_bucket_idx(file: &str) -> usize {
         let h = gxhash::new().sum64(file);
         (h as usize) % cfg.disk_cache.bucket_num
     }
+}
+
+/// Unlink an evicted file unless a same-key writer re-indexed the path since the eviction.
+async fn remove_evicted_file(key: &str, file_path: &str) {
+    let idx = get_bucket_idx(key);
+    let files = if key.starts_with("files") {
+        FILES[idx].read().await
+    } else if key.starts_with("results") {
+        RESULT_FILES[idx].read().await
+    } else if key.starts_with("aggregations") {
+        AGGREGATION_FILES[idx].read().await
+    } else {
+        RESULT_FILES[idx].read().await
+    };
+    if files.exist(key).await {
+        return;
+    }
+    // the read guard is held across the unlink so no writer can recreate the path meanwhile
+    if let Err(e) = tokio::fs::remove_file(file_path).await {
+        log::error!("File disk cache gc remove file: {file_path}, error: {e}");
+    }
+    drop(files);
 }
 
 // parse the result cache key from the file name

--- a/src/jobs/src/job/promql.rs
+++ b/src/jobs/src/job/promql.rs
@@ -27,7 +27,7 @@ pub fn run() -> Option<tokio::task::JoinHandle<()>> {
 
     Some(spawn_pausable_job!(
         "promql_metrics_leader",
-        config::get_config().limit.metrics_leader_push_interval,
+        config::get_config().prom.leader_push_interval,
         {
             // only update if there's a change
             let map = METRIC_CLUSTER_LEADER.read().await.clone();
@@ -48,6 +48,6 @@ pub fn run() -> Option<tokio::task::JoinHandle<()>> {
                 }
             }
         },
-        pause_if: config::get_config().limit.metrics_leader_push_interval == 0 || !config::get_config().common.metrics_dedup_enabled
+        pause_if: config::get_config().prom.leader_push_interval == 0 || !config::get_config().prom.dedup_enabled
     ))
 }

--- a/src/promql_service/src/search/cache/mod.rs
+++ b/src/promql_service/src/search/cache/mod.rs
@@ -130,9 +130,9 @@ pub async fn get(
     index.touch();
 
     // get the best key
-    let mut best_key = String::new();
+    let mut best_idx = None;
     let mut best_diff = 0;
-    for entry in index.entries.iter() {
+    for (i, entry) in index.entries.iter().enumerate() {
         if start < entry.start {
             continue;
         }
@@ -141,31 +141,31 @@ pub async fn get(
             d = end - start;
         }
         if d >= best_diff {
-            best_key = entry.key.clone();
+            best_idx = Some(i);
             best_diff = d;
         }
     }
+    let best_key = best_idx.map(|i| index.entries[i].key.clone());
     drop(r);
-    if best_key.is_empty() {
+    let Some(best_key) = best_key else {
         return Ok(None);
-    }
+    };
 
     // get the data from disk cache
     let Some(data) = infra::cache::file_data::disk::get(&best_key, None).await else {
-        // need to drop the key from index
-        let mut w = GLOBAL_CACHE[bucket_id].write().await;
-        w.remove_files(&key, &HashSet::from_iter([best_key]));
-        drop(w);
+        remove_index_entry(bucket_id, &key, best_key).await;
         return Ok(None);
     };
     let mut resp = match proto::cluster_rpc::MetricsQueryResponse::decode(data) {
         Ok(resp) => resp,
         Err(e) => {
             log::error!("decode metrics query response error: {e}");
+            remove_index_entry(bucket_id, &key, best_key).await;
             return Ok(None);
         }
     };
     if resp.series.is_empty() {
+        remove_index_entry(bucket_id, &key, best_key).await;
         return Ok(None);
     }
 
@@ -334,6 +334,10 @@ pub async fn set(
             }
         }
     };
+    // the retention filter can drain everything; caching an empty payload would poison the range
+    if range_values.is_empty() {
+        return Ok(());
+    }
 
     // convert RangeValue to proto::cluster_rpc::MetricsQueryResponse then encode to vec
     let mut resp = proto::cluster_rpc::MetricsQueryResponse::default();
@@ -372,8 +376,7 @@ pub async fn load(cache_key: &str) -> Result<()> {
     Ok(())
 }
 
-/// Insert into the bucket index and delete the disk files of any evicted entries,
-/// so budget enforcement and file cleanup cannot be separated. Returns the evicted count.
+/// Insert into the bucket index and queue evicted entries' disk files for deletion.
 async fn insert_index(
     bucket_id: usize,
     key: String,
@@ -383,12 +386,10 @@ async fn insert_index(
     let mut w = GLOBAL_CACHE[bucket_id].write().await;
     let evicted = w.insert(key, query, item);
     drop(w);
-    let evicted_len = evicted.len();
     if !evicted.is_empty() {
-        // detached: the cleanup has no ordering dependency on the caller
-        tokio::spawn(remove_disk_files(evicted));
+        infra::cache::file_data::delete::add(evicted.iter().map(|v| v.key.clone()).collect());
     }
-    evicted_len
+    evicted.len()
 }
 
 /// drop the index entries whose disk files were evicted by the disk cache gc
@@ -415,13 +416,10 @@ async fn remove_evicted_files(files: Vec<String>) {
     }
 }
 
-/// delete the disk files of entries evicted from the index
-async fn remove_disk_files(evicted: Vec<Arc<MetricsIndexCacheItem>>) {
-    for item in evicted {
-        if let Err(e) = infra::cache::file_data::disk::remove(&item.key).await {
-            log::warn!("Remove evicted metrics cache file {} error: {e}", item.key);
-        }
-    }
+async fn remove_index_entry(bucket_id: usize, key: &str, file_key: String) {
+    let mut w = GLOBAL_CACHE[bucket_id].write().await;
+    w.remove_files(key, &HashSet::from_iter([file_key]));
+    drop(w);
 }
 
 fn get_hash_key(query: &str, step: i64) -> String {
@@ -483,8 +481,7 @@ impl MetricsIndex {
         }
     }
 
-    /// Insert the item under the key, enforcing the per-key item cap and the memory budget.
-    /// Returns the evicted items so the caller can delete their disk files.
+    /// Insert the item, enforcing the per-key item cap and the memory budget.
     fn insert(
         &mut self,
         key: String,
@@ -498,6 +495,11 @@ impl MetricsIndex {
             MetricsIndexCache::new(query)
         });
         index.touch();
+        // load() restores keys with an empty query; upgrade it so the hash-conflict guard works
+        if index.query.is_empty() && !query.is_empty() {
+            self.cur_size += query.len();
+            index.query = query.to_string();
+        }
         let mut evicted = Vec::new();
         if index.entries.len() >= METRICS_INDEX_CACHE_MAX_ITEMS {
             // remove the first half items
@@ -525,16 +527,14 @@ impl MetricsIndex {
             }
         });
         self.cur_size -= freed;
-        if !index.entries.is_empty() {
-            return;
-        }
-        if let Some(index) = self.data.remove(key) {
-            self.cur_size -= index_base_size(key, &index.query);
+        if index.entries.is_empty() {
+            let base_size = index_base_size(key, &index.query);
+            self.data.remove(key);
+            self.cur_size -= base_size;
         }
     }
 
-    /// When over budget, evict the least recently used keys until
-    /// METRICS_INDEX_CACHE_GC_PERCENT of the budget is free.
+    /// Evict the least recently used keys until a tenth of the memory budget is free.
     fn gc(&mut self) -> Vec<Arc<MetricsIndexCacheItem>> {
         if self.cur_size <= self.max_size {
             return Vec::new();
@@ -867,32 +867,15 @@ mod tests {
         assert_eq!(len, 0);
         assert_eq!(mem, 0);
 
-        metrics.insert(
-            "acct_key".to_string(),
-            "acct_query",
-            MetricsIndexCacheItem::new("metrics_results/org/acct1.pb", 100, 200),
-        );
-        metrics.insert(
-            "acct_key".to_string(),
-            "acct_query",
-            MetricsIndexCacheItem::new("metrics_results/org/acct2.pb", 200, 300),
-        );
+        let item1 = MetricsIndexCacheItem::new("metrics_results/org/acct1.pb", 100, 200);
+        let item2 = MetricsIndexCacheItem::new("metrics_results/org/acct2.pb", 200, 300);
+        let expected_mem =
+            index_base_size("acct_key", "acct_query") + item_size(&item1) + item_size(&item2);
+        metrics.insert("acct_key".to_string(), "acct_query", item1);
+        metrics.insert("acct_key".to_string(), "acct_query", item2);
         let (len, _cap, mem) = metrics.stats();
         assert_eq!(len, 2);
-        assert_eq!(
-            mem,
-            index_base_size("acct_key", "acct_query")
-                + item_size(&MetricsIndexCacheItem::new(
-                    "metrics_results/org/acct1.pb",
-                    100,
-                    200
-                ))
-                + item_size(&MetricsIndexCacheItem::new(
-                    "metrics_results/org/acct2.pb",
-                    200,
-                    300
-                ))
-        );
+        assert_eq!(mem, expected_mem);
 
         // removing one file frees its bytes; removing the last one drops the key
         metrics.remove_files(
@@ -905,6 +888,34 @@ mod tests {
         metrics.remove_files(
             "acct_key",
             &HashSet::from_iter(["metrics_results/org/acct2.pb".to_string()]),
+        );
+        assert!(metrics.data.is_empty());
+        assert_eq!(metrics.cur_size, 0);
+    }
+
+    #[test]
+    fn test_metrics_index_insert_upgrades_empty_query() {
+        let mut metrics = MetricsIndex::new(1024 * 1024);
+        metrics.insert(
+            "upgrade_key".to_string(),
+            "",
+            MetricsIndexCacheItem::new("metrics_results/org/upg1.pb", 100, 200),
+        );
+        metrics.insert(
+            "upgrade_key".to_string(),
+            "real_query",
+            MetricsIndexCacheItem::new("metrics_results/org/upg2.pb", 200, 300),
+        );
+        assert_eq!(metrics.data.get("upgrade_key").unwrap().query, "real_query");
+
+        // accounting stays symmetric after the upgrade
+        metrics.remove_files(
+            "upgrade_key",
+            &HashSet::from_iter(["metrics_results/org/upg1.pb".to_string()]),
+        );
+        metrics.remove_files(
+            "upgrade_key",
+            &HashSet::from_iter(["metrics_results/org/upg2.pb".to_string()]),
         );
         assert!(metrics.data.is_empty());
         assert_eq!(metrics.cur_size, 0);

--- a/src/promql_service/src/search/cache/mod.rs
+++ b/src/promql_service/src/search/cache/mod.rs
@@ -42,8 +42,8 @@ const METRICS_INDEX_ITEM_OVERHEAD: usize = 16
 static CACHE_KEY_SUFFIX: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(now_micros()));
 
 static GLOBAL_CACHE: Lazy<Vec<RwLock<MetricsIndex>>> = Lazy::new(|| {
-    // metrics_cache_max_size is resolved to bytes in check_config
-    let max_bytes = get_config().limit.metrics_cache_max_size;
+    // metrics_result_cache_max_size is resolved to bytes in check_config
+    let max_bytes = get_config().limit.metrics_result_cache_max_size;
     let mut metrics = Vec::with_capacity(METRICS_INDEX_CACHE_BUCKETS);
     for _ in 0..METRICS_INDEX_CACHE_BUCKETS {
         metrics.push(RwLock::new(MetricsIndex::new(

--- a/src/promql_service/src/search/cache/mod.rs
+++ b/src/promql_service/src/search/cache/mod.rs
@@ -160,11 +160,14 @@ pub async fn get(
         Ok(resp) => resp,
         Err(e) => {
             log::error!("decode metrics query response error: {e}");
+            // the corrupt file would be re-adopted at every restart if left on disk
+            infra::cache::file_data::delete::add(vec![best_key.clone()]);
             remove_index_entry(bucket_id, &key, best_key).await;
             return Ok(None);
         }
     };
     if resp.series.is_empty() {
+        infra::cache::file_data::delete::add(vec![best_key.clone()]);
         remove_index_entry(bucket_id, &key, best_key).await;
         return Ok(None);
     }
@@ -370,6 +373,13 @@ pub async fn load(cache_key: &str) -> Result<()> {
         return Ok(());
     };
     let bucket_id = get_bucket_id(&key);
+    // an over-budget bucket rejects startup adoption; the disk gc reclaims the unindexed files
+    {
+        let r = GLOBAL_CACHE[bucket_id].read().await;
+        if r.cur_size >= r.max_size {
+            return Ok(());
+        }
+    }
     let cache_item = MetricsIndexCacheItem::new(cache_key, start, end);
     insert_index(bucket_id, key, "", cache_item).await;
 
@@ -387,6 +397,7 @@ async fn insert_index(
     let evicted = w.insert(key, query, item);
     drop(w);
     if !evicted.is_empty() {
+        // cache keys are never reused (monotonic suffix), so a queued delete cannot race a rewrite
         infra::cache::file_data::delete::add(evicted.iter().map(|v| v.key.clone()).collect());
     }
     evicted.len()
@@ -419,7 +430,6 @@ async fn remove_evicted_files(files: Vec<String>) {
 async fn remove_index_entry(bucket_id: usize, key: &str, file_key: String) {
     let mut w = GLOBAL_CACHE[bucket_id].write().await;
     w.remove_files(key, &HashSet::from_iter([file_key]));
-    drop(w);
 }
 
 fn get_hash_key(query: &str, step: i64) -> String {

--- a/src/promql_service/src/search/cache/mod.rs
+++ b/src/promql_service/src/search/cache/mod.rs
@@ -13,12 +13,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-    collections::VecDeque,
-    sync::{
-        Arc, LazyLock as Lazy,
-        atomic::{AtomicI64, Ordering},
-    },
+use std::sync::{
+    Arc, LazyLock as Lazy,
+    atomic::{AtomicI64, Ordering},
 };
 
 use config::{
@@ -29,24 +26,28 @@ use config::{
         time::{HourFormat, get_ymdh_from_micros, now_micros, second_micros},
     },
 };
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use infra::errors::{Error, Result};
 use prost::Message;
 use tokio::sync::RwLock;
 
-const METRICS_INDEX_CACHE_GC_TRIGGER_NUM: usize = 10;
-const METRICS_INDEX_CACHE_GC_PERCENT: usize = 10; // 10% of the items will be removed
+const METRICS_INDEX_CACHE_GC_PERCENT: usize = 10; // gc releases 10% of the memory budget
 const METRICS_INDEX_CACHE_MAX_ITEMS: usize = 100;
 const METRICS_INDEX_CACHE_BUCKETS: usize = 100;
+// Arc control block (strong + weak counts) + the Vec's pointer slot + the item itself
+const METRICS_INDEX_ITEM_OVERHEAD: usize = 16
+    + std::mem::size_of::<Arc<MetricsIndexCacheItem>>()
+    + std::mem::size_of::<MetricsIndexCacheItem>();
 
 static CACHE_KEY_SUFFIX: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(now_micros()));
 
 static GLOBAL_CACHE: Lazy<Vec<RwLock<MetricsIndex>>> = Lazy::new(|| {
-    let cfg = get_config();
+    // metrics_cache_max_size is resolved to bytes in check_config
+    let max_bytes = get_config().limit.metrics_cache_max_size;
     let mut metrics = Vec::with_capacity(METRICS_INDEX_CACHE_BUCKETS);
     for _ in 0..METRICS_INDEX_CACHE_BUCKETS {
         metrics.push(RwLock::new(MetricsIndex::new(
-            cfg.limit.metrics_cache_max_entries / METRICS_INDEX_CACHE_BUCKETS,
+            max_bytes / METRICS_INDEX_CACHE_BUCKETS,
         )));
     }
     metrics
@@ -66,6 +67,11 @@ pub async fn get_cache_stats() -> (usize, usize, usize) {
 }
 
 pub async fn init() -> Result<()> {
+    // drop index entries whose disk files get evicted by the disk cache gc
+    infra::cache::file_data::disk::set_metrics_result_cache_evict_hook(|files| {
+        tokio::spawn(remove_evicted_files(files));
+    });
+
     let cfg = get_config();
     if !cfg.common.result_cache_enabled {
         return Ok(());
@@ -121,6 +127,7 @@ pub async fn get(
         );
         return Ok(None);
     }
+    index.touch();
 
     // get the best key
     let mut best_key = String::new();
@@ -147,9 +154,7 @@ pub async fn get(
     let Some(data) = infra::cache::file_data::disk::get(&best_key, None).await else {
         // need to drop the key from index
         let mut w = GLOBAL_CACHE[bucket_id].write().await;
-        if let Some(index) = w.data.get_mut(&key) {
-            index.entries.retain(|entry| entry.key != best_key);
-        }
+        w.remove_files(&key, &HashSet::from_iter([best_key]));
         drop(w);
         return Ok(None);
     };
@@ -268,12 +273,7 @@ pub async fn set(
             return Ok(());
         }
     }
-    let need_gc = r.cacher.len() >= r.max_entries - METRICS_INDEX_CACHE_GC_TRIGGER_NUM;
     drop(r);
-
-    if need_gc && let Err(e) = gc(bucket_id).await {
-        log::error!("[trace_id {trace_id}] promql->search->cache: gc err: {e}");
-    }
 
     // filter the samples
     if end >= max_ts {
@@ -348,15 +348,10 @@ pub async fn set(
 
     // store the cache item
     let cache_item = MetricsIndexCacheItem::new(&cache_key, start, new_end);
-    let mut w = GLOBAL_CACHE[bucket_id].write().await;
-    w.cacher.push_back(key.to_string());
-    let index = w.data.entry(key).or_insert(MetricsIndexCache::new(query));
-    if index.entries.len() >= METRICS_INDEX_CACHE_MAX_ITEMS {
-        // remove the first half items
-        index.entries.drain(0..METRICS_INDEX_CACHE_MAX_ITEMS / 2);
+    let evicted = insert_index(bucket_id, key, query, cache_item).await;
+    if evicted > 0 {
+        log::debug!("[trace_id {trace_id}] promql->search->cache: evicted {evicted} index entries");
     }
-    index.entries.push(Arc::new(cache_item));
-    drop(w);
 
     Ok(())
 }
@@ -372,28 +367,61 @@ pub async fn load(cache_key: &str) -> Result<()> {
     };
     let bucket_id = get_bucket_id(&key);
     let cache_item = MetricsIndexCacheItem::new(cache_key, start, end);
-    let mut w = GLOBAL_CACHE[bucket_id].write().await;
-    w.cacher.push_back(key.to_string());
-    let index = w.data.entry(key).or_insert(MetricsIndexCache::new(""));
-    index.entries.push(Arc::new(cache_item));
-    drop(w);
+    insert_index(bucket_id, key, "", cache_item).await;
 
     Ok(())
 }
 
-async fn gc(bucket_id: usize) -> Result<()> {
-    log::warn!("MetricsIndexCache is full, releasing 10% of the cache");
+/// Insert into the bucket index and delete the disk files of any evicted entries,
+/// so budget enforcement and file cleanup cannot be separated. Returns the evicted count.
+async fn insert_index(
+    bucket_id: usize,
+    key: String,
+    query: &str,
+    item: MetricsIndexCacheItem,
+) -> usize {
     let mut w = GLOBAL_CACHE[bucket_id].write().await;
-    for _ in 0..(w.max_entries / METRICS_INDEX_CACHE_GC_PERCENT) {
-        if let Some(key) = w.cacher.pop_front() {
-            w.data.remove(&key);
-        } else {
-            break;
+    let evicted = w.insert(key, query, item);
+    drop(w);
+    let evicted_len = evicted.len();
+    if !evicted.is_empty() {
+        // detached: the cleanup has no ordering dependency on the caller
+        tokio::spawn(remove_disk_files(evicted));
+    }
+    evicted_len
+}
+
+/// drop the index entries whose disk files were evicted by the disk cache gc
+async fn remove_evicted_files(files: Vec<String>) {
+    // group by bucket and key so each bucket lock is taken once
+    let mut buckets: HashMap<usize, HashMap<String, HashSet<String>>> = HashMap::new();
+    for file in files {
+        let Some((key, ..)) = parse_cache_item_key(&file) else {
+            continue;
+        };
+        buckets
+            .entry(get_bucket_id(&key))
+            .or_default()
+            .entry(key)
+            .or_default()
+            .insert(file);
+    }
+    for (bucket_id, keys) in buckets {
+        let mut w = GLOBAL_CACHE[bucket_id].write().await;
+        for (key, file_keys) in keys {
+            w.remove_files(&key, &file_keys);
+        }
+        drop(w);
+    }
+}
+
+/// delete the disk files of entries evicted from the index
+async fn remove_disk_files(evicted: Vec<Arc<MetricsIndexCacheItem>>) {
+    for item in evicted {
+        if let Err(e) = infra::cache::file_data::disk::remove(&item.key).await {
+            log::warn!("Remove evicted metrics cache file {} error: {e}", item.key);
         }
     }
-    drop(w);
-
-    Ok(())
 }
 
 fn get_hash_key(query: &str, step: i64) -> String {
@@ -442,36 +470,112 @@ fn get_bucket_id(key: &str) -> usize {
 
 struct MetricsIndex {
     data: HashMap<String, MetricsIndexCache>,
-    cacher: VecDeque<String>,
-    max_entries: usize,
+    max_size: usize, // memory budget in bytes for this bucket
+    cur_size: usize, // accounted bytes of keys, queries and entries
 }
 
 impl MetricsIndex {
-    fn new(max_entries: usize) -> Self {
+    fn new(max_size: usize) -> Self {
         Self {
             data: HashMap::new(),
-            cacher: VecDeque::new(),
-            max_entries,
+            max_size,
+            cur_size: 0,
         }
+    }
+
+    /// Insert the item under the key, enforcing the per-key item cap and the memory budget.
+    /// Returns the evicted items so the caller can delete their disk files.
+    fn insert(
+        &mut self,
+        key: String,
+        query: &str,
+        item: MetricsIndexCacheItem,
+    ) -> Vec<Arc<MetricsIndexCacheItem>> {
+        let base_size = index_base_size(&key, query);
+        let cur_size = &mut self.cur_size;
+        let index = self.data.entry(key).or_insert_with(|| {
+            *cur_size += base_size;
+            MetricsIndexCache::new(query)
+        });
+        index.touch();
+        let mut evicted = Vec::new();
+        if index.entries.len() >= METRICS_INDEX_CACHE_MAX_ITEMS {
+            // remove the first half items
+            evicted.extend(index.entries.drain(0..METRICS_INDEX_CACHE_MAX_ITEMS / 2));
+            self.cur_size -= evicted.iter().map(|v| item_size(v)).sum::<usize>();
+        }
+        self.cur_size += item_size(&item);
+        index.entries.push(Arc::new(item));
+        evicted.extend(self.gc());
+        evicted
+    }
+
+    /// Remove entries by their disk file keys; drops the key when its entry list becomes empty.
+    fn remove_files(&mut self, key: &str, file_keys: &HashSet<String>) {
+        let Some(index) = self.data.get_mut(key) else {
+            return;
+        };
+        let mut freed = 0;
+        index.entries.retain(|entry| {
+            if file_keys.contains(entry.key.as_str()) {
+                freed += item_size(entry);
+                false
+            } else {
+                true
+            }
+        });
+        self.cur_size -= freed;
+        if !index.entries.is_empty() {
+            return;
+        }
+        if let Some(index) = self.data.remove(key) {
+            self.cur_size -= index_base_size(key, &index.query);
+        }
+    }
+
+    /// When over budget, evict the least recently used keys until
+    /// METRICS_INDEX_CACHE_GC_PERCENT of the budget is free.
+    fn gc(&mut self) -> Vec<Arc<MetricsIndexCacheItem>> {
+        if self.cur_size <= self.max_size {
+            return Vec::new();
+        }
+        log::warn!("MetricsIndex is over its memory budget, releasing the coldest keys");
+        let target = self.max_size - self.max_size * METRICS_INDEX_CACHE_GC_PERCENT / 100;
+        let mut keys = self
+            .data
+            .iter()
+            .map(|(k, v)| (k.clone(), v.last_used.load(Ordering::Relaxed)))
+            .collect::<Vec<_>>();
+        keys.sort_unstable_by_key(|(_, last_used)| *last_used);
+        let mut evicted = Vec::new();
+        for (key, _) in keys {
+            if self.cur_size <= target {
+                break;
+            }
+            let Some(index) = self.data.remove(&key) else {
+                continue;
+            };
+            self.cur_size -= key_size(&key, &index);
+            evicted.extend(index.entries);
+        }
+        evicted
     }
 
     fn stats(&self) -> (usize, usize, usize) {
         let mut total_len = 0;
         let mut total_cap = 0;
-        let mut total_mem = 0;
-        for (k, v) in self.data.iter() {
-            let (len, cap, mem_size) = v.stats();
-            total_len += len;
-            total_cap += cap;
-            total_mem += mem_size + k.len();
+        for v in self.data.values() {
+            total_len += v.entries.len();
+            total_cap += v.entries.capacity();
         }
-        (total_len, total_cap, total_mem)
+        (total_len, total_cap, self.cur_size)
     }
 }
 
 struct MetricsIndexCache {
     query: String,
     entries: Vec<Arc<MetricsIndexCacheItem>>,
+    last_used: AtomicI64,
 }
 
 impl MetricsIndexCache {
@@ -479,14 +583,12 @@ impl MetricsIndexCache {
         Self {
             query: query.to_string(),
             entries: Vec::new(),
+            last_used: AtomicI64::new(now_micros()),
         }
     }
 
-    fn stats(&self) -> (usize, usize, usize) {
-        let len = self.entries.len();
-        let cap = self.entries.capacity();
-        let mem_size = std::mem::size_of::<MetricsIndexCacheItem>() * len + self.query.len();
-        (len, cap, mem_size)
+    fn touch(&self) {
+        self.last_used.store(now_micros(), Ordering::Relaxed);
     }
 }
 
@@ -504,6 +606,18 @@ impl MetricsIndexCacheItem {
             end,
         }
     }
+}
+
+fn index_base_size(key: &str, query: &str) -> usize {
+    key.len() + query.len() + std::mem::size_of::<MetricsIndexCache>()
+}
+
+fn item_size(item: &MetricsIndexCacheItem) -> usize {
+    METRICS_INDEX_ITEM_OVERHEAD + item.key.len()
+}
+
+fn key_size(key: &str, index: &MetricsIndexCache) -> usize {
+    index_base_size(key, &index.query) + index.entries.iter().map(|v| item_size(v)).sum::<usize>()
 }
 
 #[cfg(test)]
@@ -746,47 +860,84 @@ mod tests {
         assert_eq!(total_mem, manual_mem);
     }
 
-    #[tokio::test]
-    async fn test_metrics_index_stats() {
-        // Test the MetricsIndex::stats() method directly
-        let mut metrics = MetricsIndex::new(100);
-
-        // Initial stats should be zero
+    #[test]
+    fn test_metrics_index_size_accounting() {
+        let mut metrics = MetricsIndex::new(1024 * 1024);
         let (len, _cap, mem) = metrics.stats();
         assert_eq!(len, 0);
         assert_eq!(mem, 0);
 
-        // Add an entry
-        let cache = MetricsIndexCache::new("test_query");
-        metrics.data.insert("test_key".to_string(), cache);
+        metrics.insert(
+            "acct_key".to_string(),
+            "acct_query",
+            MetricsIndexCacheItem::new("metrics_results/org/acct1.pb", 100, 200),
+        );
+        metrics.insert(
+            "acct_key".to_string(),
+            "acct_query",
+            MetricsIndexCacheItem::new("metrics_results/org/acct2.pb", 200, 300),
+        );
+        let (len, _cap, mem) = metrics.stats();
+        assert_eq!(len, 2);
+        assert_eq!(
+            mem,
+            index_base_size("acct_key", "acct_query")
+                + item_size(&MetricsIndexCacheItem::new(
+                    "metrics_results/org/acct1.pb",
+                    100,
+                    200
+                ))
+                + item_size(&MetricsIndexCacheItem::new(
+                    "metrics_results/org/acct2.pb",
+                    200,
+                    300
+                ))
+        );
 
-        // Stats should reflect the added entry
-        let (len, cap, mem) = metrics.stats();
-        assert_eq!(len, 0); // No entries in the cache itself yet
-        assert_eq!(cap, 0);
-        assert!(mem > 0); // Should have memory for the key and query
+        // removing one file frees its bytes; removing the last one drops the key
+        metrics.remove_files(
+            "acct_key",
+            &HashSet::from_iter(["metrics_results/org/acct1.pb".to_string()]),
+        );
+        let (len, _cap, mem_after) = metrics.stats();
+        assert_eq!(len, 1);
+        assert!(mem_after < mem);
+        metrics.remove_files(
+            "acct_key",
+            &HashSet::from_iter(["metrics_results/org/acct2.pb".to_string()]),
+        );
+        assert!(metrics.data.is_empty());
+        assert_eq!(metrics.cur_size, 0);
     }
 
-    #[tokio::test]
-    async fn test_metrics_index_cache_stats() {
-        // Test the MetricsIndexCache::stats() method directly
-        let mut cache = MetricsIndexCache::new("test_query");
+    #[test]
+    fn test_metrics_index_gc_evicts_coldest_keys() {
+        let mut metrics = MetricsIndex::new(1024 * 1024);
+        for i in 0..3 {
+            metrics.insert(
+                format!("gc_key_{i}"),
+                "q",
+                MetricsIndexCacheItem::new(&format!("metrics_results/org/gc{i}.pb"), 0, 1),
+            );
+        }
+        for i in 0..3i64 {
+            metrics
+                .data
+                .get(&format!("gc_key_{i}"))
+                .unwrap()
+                .last_used
+                .store(i, Ordering::Relaxed);
+        }
 
-        // Initial stats
-        let (len, cap, mem) = cache.stats();
-        assert_eq!(len, 0);
-        assert_eq!(cap, 0);
-        assert!(mem > 0); // Should have memory for the query string
-
-        // Add an entry
-        let item = Arc::new(MetricsIndexCacheItem::new("test_key", 100, 200));
-        cache.entries.push(item);
-
-        // Stats should reflect the added entry
-        let (len, cap, mem) = cache.stats();
-        assert_eq!(len, 1);
-        assert!(cap >= 1);
-        assert!(mem > "test_query".len()); // Should include query + entry size
+        // shrink the budget below the current size and gc: only the coldest key goes
+        metrics.max_size = metrics.cur_size - 1;
+        let evicted = metrics.gc();
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].key, "metrics_results/org/gc0.pb");
+        assert!(!metrics.data.contains_key("gc_key_0"));
+        assert!(metrics.data.contains_key("gc_key_1"));
+        assert!(metrics.data.contains_key("gc_key_2"));
+        assert!(metrics.cur_size <= metrics.max_size);
     }
 
     #[tokio::test]

--- a/src/promql_service/src/search/cache/mod.rs
+++ b/src/promql_service/src/search/cache/mod.rs
@@ -372,6 +372,10 @@ pub async fn load(cache_key: &str) -> Result<()> {
     let Some((key, start, end)) = parse_cache_item_key(cache_key) else {
         return Ok(());
     };
+    // held across the insert so a concurrent disk eviction orders after it and prunes the entry
+    let Some(_indexed) = infra::cache::file_data::disk::indexed_file_guard(cache_key).await else {
+        return Ok(());
+    };
     let bucket_id = get_bucket_id(&key);
     // an over-budget bucket rejects startup adoption; the disk gc reclaims the unindexed files
     {

--- a/src/promql_service/src/search/cache/mod.rs
+++ b/src/promql_service/src/search/cache/mod.rs
@@ -354,12 +354,16 @@ pub async fn set(
         .map_err(|e| Error::Message(e.to_string()))?;
 
     // store the cache item
+    // a cancelled future must not leave the file on disk without a GLOBAL_CACHE entry
+    let mut cleanup = DiskFileCleanup(Some(cache_key.clone()));
     // held across the insert so a concurrent disk eviction orders after it and prunes the entry
     let Some(_indexed) = infra::cache::file_data::disk::indexed_file_guard(&cache_key).await else {
+        cleanup.0 = None;
         return Ok(());
     };
     let cache_item = MetricsIndexCacheItem::new(&cache_key, start, new_end);
     let evicted = insert_index(bucket_id, key, query, cache_item).await;
+    cleanup.0 = None;
     if evicted > 0 {
         log::debug!("[trace_id {trace_id}] promql->search->cache: evicted {evicted} index entries");
     }
@@ -622,6 +626,17 @@ impl MetricsIndexCacheItem {
             key: key.to_string(),
             start,
             end,
+        }
+    }
+}
+
+/// Queues the disk file for deletion on drop unless disarmed after the index insert commits.
+struct DiskFileCleanup(Option<String>);
+
+impl Drop for DiskFileCleanup {
+    fn drop(&mut self) {
+        if let Some(file_key) = self.0.take() {
+            infra::cache::file_data::delete::add(vec![file_key]);
         }
     }
 }
@@ -909,6 +924,57 @@ mod tests {
         );
         assert!(metrics.data.is_empty());
         assert_eq!(metrics.cur_size, 0);
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_insert_is_cleaned_up() {
+        let key = get_hash_key("cancel_probe_query", 15_000_000);
+        let bucket_id = get_bucket_id(&key);
+        let file_key = "metrics_results/cancel_org/2024/01/01/00/eee_1_2_3.pb".to_string();
+        infra::cache::file_data::disk::set_size(&file_key, 1)
+            .await
+            .unwrap();
+        assert!(
+            infra::cache::file_data::disk::indexed_file_guard(&file_key)
+                .await
+                .is_some()
+        );
+
+        // park the handoff on the bucket write lock, then abort it mid-insert
+        let w = GLOBAL_CACHE[bucket_id].write().await;
+        let task_key = key.clone();
+        let task_file = file_key.clone();
+        let handle = tokio::spawn(async move {
+            let mut cleanup = DiskFileCleanup(Some(task_file.clone()));
+            let _indexed = infra::cache::file_data::disk::indexed_file_guard(&task_file).await;
+            let item = MetricsIndexCacheItem::new(&task_file, 1, 2);
+            insert_index(bucket_id, task_key, "q", item).await;
+            cleanup.0 = None;
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        handle.abort();
+        let _ = handle.await;
+        drop(w);
+
+        // nothing was inserted, and the armed guard queued the disk file for deletion
+        assert!(
+            GLOBAL_CACHE[bucket_id]
+                .read()
+                .await
+                .data
+                .get(&key)
+                .is_none()
+        );
+        for _ in 0..100 {
+            if infra::cache::file_data::disk::indexed_file_guard(&file_key)
+                .await
+                .is_none()
+            {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("cleanup guard did not queue the file for deletion");
     }
 
     #[test]

--- a/src/promql_service/src/search/cache/mod.rs
+++ b/src/promql_service/src/search/cache/mod.rs
@@ -354,6 +354,10 @@ pub async fn set(
         .map_err(|e| Error::Message(e.to_string()))?;
 
     // store the cache item
+    // held across the insert so a concurrent disk eviction orders after it and prunes the entry
+    let Some(_indexed) = infra::cache::file_data::disk::indexed_file_guard(&cache_key).await else {
+        return Ok(());
+    };
     let cache_item = MetricsIndexCacheItem::new(&cache_key, start, new_end);
     let evicted = insert_index(bucket_id, key, query, cache_item).await;
     if evicted > 0 {

--- a/src/search_service/src/cache/cacher.rs
+++ b/src/search_service/src/cache/cacher.rs
@@ -459,6 +459,18 @@ pub async fn get_cached_results(
             log::error!(
                 "[trace_id {trace_id}] Get results from disk failed: file: {file_path}/{file_name}, error: {e}"
             );
+            // file gone: drop the stale meta; matching flags prove the missed name is its own file
+            if matching_meta.is_aggregate == cache_req.is_aggregate
+                && matching_meta.is_descending == cache_req.is_descending
+            {
+                let mut w = QUERY_RESULT_CACHE.write().await;
+                if let Some(metas) = w.get_mut(&query_key) {
+                    metas.retain(|m| !m.eq(&matching_meta));
+                    if metas.is_empty() {
+                        w.remove(&query_key);
+                    }
+                }
+            }
             return None;
         }
     };
@@ -1265,6 +1277,36 @@ mod tests {
         assert!(result.is_ok());
         let filtered_responses = result.unwrap();
         assert_eq!(filtered_responses.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_cached_results_heals_stale_meta_on_disk_miss() {
+        let file_path = "heal_org/logs/heal_stream/heal_hash";
+        let query_key = file_path.replace('/', "_");
+        let meta = ResultCacheMeta {
+            start_time: 1000,
+            end_time: 2000,
+            is_aggregate: false,
+            is_descending: false,
+        };
+        QUERY_RESULT_CACHE
+            .write()
+            .await
+            .insert(query_key.clone(), vec![meta]);
+
+        let cache_req = CacheQueryRequest {
+            q_start_time: 1000,
+            q_end_time: 2000,
+            is_aggregate: false,
+            ts_column: "_timestamp".to_string(),
+            histogram_interval: 0,
+            is_descending: false,
+            is_histogram_non_ts_order: false,
+        };
+        let res = get_cached_results("heal_trace", file_path, cache_req, None).await;
+        assert!(res.is_none());
+        // the meta pointing at the missing file was removed on the miss
+        assert!(!QUERY_RESULT_CACHE.read().await.contains_key(&query_key));
     }
 
     #[tokio::test]

--- a/src/search_service/src/cache/cacher.rs
+++ b/src/search_service/src/cache/cacher.rs
@@ -463,13 +463,7 @@ pub async fn get_cached_results(
             if matching_meta.is_aggregate == cache_req.is_aggregate
                 && matching_meta.is_descending == cache_req.is_descending
             {
-                let mut w = QUERY_RESULT_CACHE.write().await;
-                if let Some(metas) = w.get_mut(&query_key) {
-                    metas.retain(|m| !m.eq(&matching_meta));
-                    if metas.is_empty() {
-                        w.remove(&query_key);
-                    }
-                }
+                remove_stale_cache_meta(file_path, &file_name, &query_key, &matching_meta).await;
             }
             return None;
         }
@@ -800,6 +794,29 @@ pub fn select_cache_meta(
             } else {
                 0
             }
+        }
+    }
+}
+
+/// Drops the stale meta unless a concurrent writer already recreated its file on disk.
+async fn remove_stale_cache_meta(
+    file_path: &str,
+    file_name: &str,
+    query_key: &str,
+    meta: &ResultCacheMeta,
+) {
+    let Some(abs_path) = disk::get_file_path(&format!("results/{file_path}/{file_name}")) else {
+        return;
+    };
+    let mut w = QUERY_RESULT_CACHE.write().await;
+    // checked under the lock: a rewrite lands its file before its meta push can take this lock
+    if std::path::Path::new(&abs_path).exists() {
+        return;
+    }
+    if let Some(metas) = w.get_mut(query_key) {
+        metas.retain(|m| !m.eq(meta));
+        if metas.is_empty() {
+            w.remove(query_key);
         }
     }
 }
@@ -1277,6 +1294,37 @@ mod tests {
         assert!(result.is_ok());
         let filtered_responses = result.unwrap();
         assert_eq!(filtered_responses.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_remove_stale_cache_meta_keeps_recreated_file() {
+        let file_path = "heal2_org/logs/heal2_stream/heal2_hash";
+        let query_key = file_path.replace('/', "_");
+        let file_name = "1000_2000_0_0.json";
+        let meta = ResultCacheMeta {
+            start_time: 1000,
+            end_time: 2000,
+            is_aggregate: false,
+            is_descending: false,
+        };
+        QUERY_RESULT_CACHE
+            .write()
+            .await
+            .insert(query_key.clone(), vec![meta.clone()]);
+
+        // a concurrent writer recreated the file between the read miss and the prune: keep the meta
+        let abs_path = disk::get_file_path(&format!("results/{file_path}/{file_name}")).unwrap();
+        tokio::fs::create_dir_all(std::path::Path::new(&abs_path).parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&abs_path, b"x").await.unwrap();
+        remove_stale_cache_meta(file_path, file_name, &query_key, &meta).await;
+        assert!(QUERY_RESULT_CACHE.read().await.contains_key(&query_key));
+
+        // with the file truly gone the stale meta is removed
+        tokio::fs::remove_file(&abs_path).await.unwrap();
+        remove_stale_cache_meta(file_path, file_name, &query_key, &meta).await;
+        assert!(!QUERY_RESULT_CACHE.read().await.contains_key(&query_key));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #13980

## Problem

The PromQL result cache index was bounded by `ZO_METRICS_CACHE_MAX_ENTRIES`, which is a poor control in several ways:

- The unit ("entries") maps to memory with ~100x variance: measured per-entry cost is ~200 B plus the per-key query text, so the default 10000 means ~25 MB typically but up to ~200 MB worst case, invisible to the operator.
- The counter tracked FIFO pushes, not entries: `set()` queued one slot per call, so a hot key refreshed N times held N slots, and GC popping any stale slot evicted the whole hot key.
- The index and the disk cache were not synchronized: disk gc evicting a `metrics_results/...` file left a stale index entry (cleaned only lazily when a later lookup happened to select it), and index GC dropping a key left its files orphaned on disk.
- `get_cache_stats()` omitted each entry's key-string heap and under-reported memory by roughly 4x.

## Fix

- **Memory budget**: `ZO_METRICS_CACHE_MAX_SIZE` (MB; 0 = auto, 1% of total memory clamped to [32, 256] MB) replaces `ZO_METRICS_CACHE_MAX_ENTRIES`. Resolution to bytes happens in `check_config`, next to the other cache size limits that use the same formula. The index accounts bytes for keys, query text and entries as they are inserted and removed.
- **LRU eviction**: each key tracks `last_used`; when a bucket exceeds its budget the least-recently-used keys are evicted until 10% of the budget is free. Reads refresh recency under the read lock (atomic store), so the hot lookup path keeps its read lock.
- **Bidirectional disk sync**:
  - Index evictions delete their disk files, detached from the query path (spawned), so a `set()` that evicts entries does not stall the response on file unlinks.
  - Disk cache gc returns the evicted `metrics_results/...` keys out of the locked region, and the module-level callers invoke a registered evict hook after all disk cache locks are released; the promql layer registers the hook at init and drops the matching index entries, grouped by bucket so each bucket lock is taken once.
- **Accurate stats**: `get_cache_stats()` now reports the maintained byte counter (and got cheaper, since it no longer recomputes sizes per key).

## Verification

- `cargo fmt` and the CI clippy command pass; `promql-service` and `infra` cache tests pass, including new tests for byte accounting symmetry (back to zero after removals) and LRU eviction order.
- Enterprise compatibility verified by swapping in `Cargo.toml.openobserve` (o2-enterprise `main`) and running `cargo check --all-targets` — clean; the enterprise repo has no references to the removed or added APIs.


## Operational notes

- `ZO_METRICS_CACHE_MAX_ENTRIES` is removed and now a no-op if still set; the replacement is `ZO_METRICS_RESULT_CACHE_MAX_SIZE` (MB, 0 = auto, explicit values floored at 32 MB).
- The status endpoint's `PROMQL_QUERY_CACHE.mem_size` now reports the fully accounted bytes; expect a one-time ~4-5x step up at upgrade with no change in actual entries (the old estimate omitted each entry's key-string heap).
- Effective key capacity is now memory-driven instead of the old flat 10000-entry count; on small nodes the auto budget (1% of memory, min 32 MB) can index fewer fully saturated keys than before, by design.
