### PR TITLE
fix(logs): persist the builder chart in saved views [v0.80]

### DIFF
--- a/web/src/composables/dashboard/useDashboardPanel.ts
+++ b/web/src/composables/dashboard/useDashboardPanel.ts
@@ -40,6 +40,11 @@ let parser: any;
 
 const dashboardPanelDataObj: any = {};
 
+// Read-only handle on a page's shared panel state for callers that must not
+// register this composable's watchers (SearchBar reading the build page).
+export const getPanelDataForPageKey = (pageKey: string) =>
+  dashboardPanelDataObj[pageKey] ?? null;
+
 const useDashboardPanelData = (pageKey: string = "dashboard") => {
   const store = useStore();
   const { showErrorNotification } = useNotifications();

--- a/web/src/plugins/logs/BuildQueryPage.vue
+++ b/web/src/plugins/logs/BuildQueryPage.vue
@@ -63,6 +63,7 @@ import {
 import { decodeBuildConfig } from "@/composables/useLogs/logsVisualization";
 import { parseWhereClauseToFilter } from "@/utils/query/sqlUtils";
 import useNotifications from "@/composables/useNotifications";
+import { searchState } from "@/composables/useLogs/searchState";
 
 // ============================================================================
 // Component Imports
@@ -174,6 +175,7 @@ const {
 } = useDashboardPanelData("build");
 
 const { showErrorNotification } = useNotifications();
+const { searchObj } = searchState();
 
 // Provide page key for child components
 provide("dashboardPanelDataPageKey", "build");
@@ -235,11 +237,17 @@ const initializeFromQuery = async () => {
     dashboardPanelData.meta.dateTime = { ...props.selectedDateTime };
   }
 
-  // Restore config/chart type from URL params (similar to visualization's preservedConfig)
-  // NOTE: This only restores config, NOT fields. Fields are always parsed from props.searchQuery.
-  // Chart type is only restored on FIRST toggle (for shared links). On subsequent tab switches,
-  // chart type is always auto-selected based on the query.
-  const urlConfig = restoreConfigFromUrl();
+  // Restore config/chart type from the saved view being applied, else from URL
+  // params (similar to visualization's preservedConfig). Fields and chart type are
+  // only restored on the FIRST toggle (shared links); on later tab switches they
+  // are re-derived from props.searchQuery. A saved view is the exception: it wins
+  // over the URL — which still holds the build_data of whatever was open before —
+  // and restores in full even when the build tab was already visited. Consumed
+  // once, so later toggles go back to re-deriving from the logs query.
+  const savedViewConfig = searchObj.meta.savedBuildConfig;
+  searchObj.meta.savedBuildConfig = null;
+  const urlConfig = savedViewConfig ?? restoreConfigFromUrl();
+  const restoreFields = props.isFirstToggle || !!savedViewConfig;
   let shouldAutoSelectChartType = true;
 
   // Always restore config from URL (for settings like table_dynamic_columns, etc.)
@@ -249,17 +257,15 @@ const initializeFromQuery = async () => {
       ...urlConfig.config,
     };
   }
-  // Only restore chart type from URL on FIRST toggle (shared link scenario)
-  // On subsequent toggles, always re-parse and auto-select chart type
-  if (urlConfig.type && props.isFirstToggle) {
+  if (urlConfig.type && restoreFields) {
     dashboardPanelData.data.type = urlConfig.type;
     shouldAutoSelectChartType = false;
   }
 
-  // On FIRST toggle (shared link): if URL has saved fields, restore them directly
-  // instead of parsing searchQuery. This preserves the exact builder/custom state.
+  // Restore saved fields directly instead of parsing searchQuery, preserving the
+  // exact builder/custom state.
   if (
-    props.isFirstToggle &&
+    restoreFields &&
     urlConfig.fields &&
     (urlConfig.fields.x?.length ||
       urlConfig.fields.y?.length ||

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -2318,7 +2318,9 @@ import {
 import savedviewsService from "@/services/saved_views";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import { cloneDeep } from "lodash-es";
-import useDashboardPanelData from "@/composables/dashboard/useDashboardPanel";
+import useDashboardPanelData, {
+  getPanelDataForPageKey,
+} from "@/composables/dashboard/useDashboardPanel";
 import { inject } from "vue";
 import useCancelQuery from "@/composables/dashboard/useCancelQuery";
 import { computed } from "vue";
@@ -2336,6 +2338,8 @@ import {
   getVisualizationConfig,
   encodeVisualizationConfig,
   decodeVisualizationConfig,
+  getBuildConfig,
+  encodeBuildConfig,
 } from "@/composables/useLogs/logsVisualization";
 
 import useSearchBar from "@/composables/useLogs/useSearchBar";
@@ -3647,6 +3651,24 @@ export default defineComponent({
       }
     };
 
+    // Point build_data at the view being applied. Without this the URL keeps the
+    // build_data of whatever was open before, which a later toggle back to the
+    // build tab would restore instead of the view the user opened.
+    const restoreBuildData = async (buildData) => {
+      const currentQuery = { ...router.currentRoute.value.query };
+      const encoded = buildData ? encodeBuildConfig(buildData) : null;
+      if (encoded) {
+        currentQuery.build_data = encoded;
+      } else {
+        delete currentQuery.build_data;
+      }
+
+      await router.replace({
+        name: router.currentRoute.value.name,
+        query: currentQuery,
+      });
+    };
+
     const applySavedView = async (item) => {
       await cancelQuery();
       searchObj.shouldIgnoreWatcher = true;
@@ -3756,12 +3778,20 @@ export default defineComponent({
               mergeDeep(searchObj, extractedObj);
               searchObj.shouldIgnoreWatcher = true;
 
+              // Hand the saved builder chart to BuildQueryPage. Must be set
+              // synchronously after the merge: the merge flips
+              // logsVisualizeToggle to "build", and the first await below lets
+              // Vue mount BuildQueryPage, which reads this on mount.
+              searchObj.meta.savedBuildConfig =
+                extractedObj.data.buildData ?? null;
+
               // Restore visualization data if available
               if (extractedObj.data.visualizationData) {
                 await restoreVisualizationData(
                   extractedObj.data.visualizationData,
                 );
               }
+              await restoreBuildData(extractedObj.data.buildData ?? null);
               // await nextTick();
               if (extractedObj.data.tempFunctionContent != "") {
                 populateFunctionImplementation(
@@ -3965,12 +3995,20 @@ export default defineComponent({
               mergeDeep(searchObj, extractedObj);
               searchObj.data.streamResults = {};
 
+              // Hand the saved builder chart to BuildQueryPage. Must be set
+              // synchronously after the merge: the merge flips
+              // logsVisualizeToggle to "build", and the first await below lets
+              // Vue mount BuildQueryPage, which reads this on mount.
+              searchObj.meta.savedBuildConfig =
+                extractedObj.data.buildData ?? null;
+
               // Restore visualization data if available
               if (extractedObj.data.visualizationData) {
                 await restoreVisualizationData(
                   extractedObj.data.visualizationData,
                 );
               }
+              await restoreBuildData(extractedObj.data.buildData ?? null);
 
               const streamData = await getStreams(
                 searchObj.data.stream.streamType,
@@ -4264,6 +4302,19 @@ export default defineComponent({
             savedSearchObj.data.visualizationData = visualizationData;
           }
         }
+
+        // Include the builder chart (stream, fields, joins, chart type, config) when
+        // in build mode — without it the builder is re-derived from the logs query on
+        // restore and loses everything the user configured.
+        if (searchObj.meta.logsVisualizeToggle === "build") {
+          const buildData = getBuildConfig(getPanelDataForPageKey("build"));
+          if (buildData) {
+            savedSearchObj.data.buildData = buildData;
+          }
+        }
+
+        // Transient hand-off to BuildQueryPage, never part of a saved view.
+        delete savedSearchObj.meta.savedBuildConfig;
 
         return savedSearchObj;
         // return b64EncodeUnicode(JSON.stringify(savedSearchObj));

--- a/web/src/utils/logs/constants.ts
+++ b/web/src/utils/logs/constants.ts
@@ -103,6 +103,8 @@ export const DEFAULT_LOGS_CONFIG = {
   meta: {
     logsVisualizeToggle: "logs" as const,
     buildModeQueryEditorDisabled: false, // true when in build mode and customQuery is false
+    // One-shot hand-off of a saved view's builder chart to BuildQueryPage; not persisted.
+    savedBuildConfig: null as any,
     refreshInterval: 0 as number,
     refreshIntervalLabel: "Off",
     refreshHistogram: false,


### PR DESCRIPTION
Fixes #13990

Backport of the `main` fix (`fix/builder-view-saved-view-13990`) to `branch-v0.80.0`. The issue was reported against v0.80.12.

## Problem

A saved view captured `logsVisualizeToggle: "build"` but none of the builder's state. Verified against the live API on wmsingle — the saved payload came back with `hasBuildData: false`. Only `visualize` mode had a persisted config (`visualizationData`); `build` mode had nothing.

On restore, `BuildQueryPage` therefore re-derived the chart from the logs query plus whatever `build_data` the URL still carried from the previous session. Two symptoms:

- **Wrong stream** (the reported one) — intermittent, a race. `applySavedView` flips the toggle to `"build"` at `mergeDeep`, which mounts `BuildQueryPage` several `await`s before `selectedStream` is repopulated, so the builder initialises with an empty stream and the selector falls back to its first entry.
- **Chart config silently lost** — deterministic. Baseline on wmsingle: saved the builder on `default` with an **Area** chart, applied it from `k8s_events`, and it came back as **Bar**.

## Fix

- `SearchBar.vue` — `getSearchObj()` stores `data.buildData` (stream, fields, joins, chart type, config, custom query) in build mode, mirroring the existing `visualizationData`. `applySavedView` hands that config to `BuildQueryPage` synchronously after the merge (before the first `await`, so it lands before Vue mounts the page — this is what closes the race) and points the URL's `build_data` at the view being applied, clearing it when the view has none.
- `BuildQueryPage.vue` — consumes the hand-off on mount. It wins over the URL and restores in full even when the build tab was already visited. Consumed once, so later tab toggles keep re-deriving from the query as before.
- `useDashboardPanel.ts` — `getPanelDataForPageKey` accessor so `SearchBar` can read the build page's shared state without registering the composable's watchers a third time.
- `constants.ts` — the one-shot hand-off field.

Saved views created before this change still load; they simply have no `buildData` and fall back to the previous behaviour.

## Verification (wmsingle, `default` stream — the issue's own repro)

| | Before | After |
|---|---|---|
| Saved payload | `hasBuildData: false` | `{type: "area", stream: "default", x: 1, y: 1}` |
| Apply from `k8s_events` | Bar chart (Area lost) | stream `default`, Area chart |
| URL `build_data` | stale / absent | decodes to the applied view |

Both halves were measured on the same build: the baseline was captured with the patch stashed, then re-applied and re-measured. `savedBuildConfig` is confirmed not to leak into the persisted payload.

Tests: 412 pass (logs/build/saved-view specs). eslint reports 157 problems both with and without the patch, i.e. no new issues — the pre-existing count on this branch.

## Note for review

Chart type still auto-selects if you toggle Search → Build *after* restoring a view. That is pre-existing intentional behaviour (`shouldAutoSelectChartType`, restored only on first toggle) and is left alone here.
