### PR TITLE
chore(ci): save unit-tests rust cache from merge_group runs too

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -127,7 +127,8 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: unit-tests
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # merge_group so an evicted cache self-heals from the next queue run, not only main pushes
+          save-if: ${{ github.event_name == 'merge_group' || github.ref == 'refs/heads/main' }}
 
       - name: Install Protoc
         run: bash ./.github/protoc.sh


### PR DESCRIPTION
## Problem

The `unit-tests` shared rust-cache is saved only on `main` push runs (`save-if: github.ref == 'refs/heads/main'`). This morning (2026-08-27) showed the failure mode:

- The cache entry (`v0-rust-unit-tests-Linux-x64-…`) was evicted from the repo's 10GB Actions cache quota (crowded out by mobile-e2e 2×2GB, CodeQL ~0.9GB×3, gradle ~1.3GB entries).
- The next two `main` push runs of Unit tests were both cancelled by newer pushes, so nothing re-saved the cache.
- Result: every PR and merge-queue run cold-compiled the entire workspace with llvm-cov instrumentation — e.g. [this merge-queue sqlite job](https://github.com/openobserve/openobserve/actions/runs/33050490347/job/98444670899) spent ~23 min compiling (07:39 `No cache found` → 08:02 tests start) out of a 29-min job.

## Fix

Let the postgres job (the only saver of the `unit-tests` shared key) also save on `merge_group` runs, the same pattern [playwright.yml](https://github.com/openobserve/openobserve/blob/main/.github/workflows/playwright.yml) already uses for its `playwright-release-ci` key. After an eviction, the first merge-queue run cold-compiles once and repairs the cache immediately, instead of waiting for an uncancelled `main` push.

Swatinem/rust-cache only saves on a primary-key miss (key = toolchain + Cargo.lock hash), so this does not add churn while the key is unchanged — it only widens who is allowed to write after an eviction or a lockfile/toolchain change. The sqlite and static-check jobs keep `save-if: false`.