### PR TITLE
perf(traces): batched per-stream scan for multi-id time range lookup

### DIFF
--- a/src/api/search/src/traces/time_index/mod.rs
+++ b/src/api/search/src/traces/time_index/mod.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+mod scan;
+
 use std::{
     collections::HashSet,
     sync::atomic::{AtomicBool, Ordering},
@@ -30,7 +32,7 @@ use config::{
     meta::{
         search::{Query, Request, RequestEncoding, SearchEventType},
         stream::StreamType,
-        traces::session::{quote_identifier, quote_sql_string},
+        traces::session::{key_in_predicate, quote_identifier, quote_sql_string},
     },
     utils::{json, time::now_micros, util::get_trace_time_index_stream_name},
 };
@@ -44,8 +46,11 @@ use serde::Serialize;
 use tokio::time::Instant;
 use utoipa::ToSchema;
 
-use crate::common::{
-    meta::http::HttpResponse as MetaHttpResponse, utils::http::get_or_create_trace_id,
+use crate::{
+    common::{meta::http::HttpResponse as MetaHttpResponse, utils::http::get_or_create_trace_id},
+    traces::time_index::scan::{
+        BatchScanner, ScanBounds, ScanOutcome, margin_span, session_uuid_floor,
+    },
 };
 
 const DAY_MICROS: i64 = 24 * 60 * 60 * 1_000_000;
@@ -183,7 +188,6 @@ struct TimerStats {
     locate_rounds: u64,
     expand_rounds: u64,
     timed_out: bool,
-    coverage_missing: bool,
 }
 
 /// Locate honors the scan bounds (tightened by a caller range); expand honors
@@ -194,10 +198,7 @@ struct TimerContext<'a> {
     kind: TimeIndexKind,
     key: &'a str,
     key_uuid_ts: Option<i64>,
-    scan_start: i64,
-    scan_end: i64,
-    hard_start: i64,
-    hard_end: i64,
+    bounds: ScanBounds,
     deadline: Instant,
 }
 
@@ -219,21 +220,29 @@ struct LookupRequest {
     bounds: Option<TraceTimeRange>,
 }
 
-/// `coverage_missing` reports that the lookup could not consult an index at
-/// all (feature disabled or index stream absent), so a miss is not proof.
-struct TimeIndexLookup {
-    result: Option<SessionTimeIndexResult>,
-    timed_out: bool,
-    coverage_missing: bool,
-}
-
-/// One (key, stream) fan-out result.
+/// One (key, stream) fan-out result. For a found key `timed_out` means the
+/// scan gave up while completing its margins (a partial range).
 struct LookupOutcome {
     key_index: usize,
     stream_index: usize,
     range: Option<TraceTimeRange>,
     timed_out: bool,
-    coverage_missing: bool,
+}
+
+/// Inputs for one stream's batch scan over all keys. The key-derived fields
+/// are built once per request and shared by every stream's scan.
+struct ScanParams<'a> {
+    org_id: &'a str,
+    stream_index: usize,
+    stream_name: &'a str,
+    kind: TimeIndexKind,
+    keys: &'a [String],
+    key_indexes: &'a HashMap<&'a str, usize>,
+    key_uuid_ts: &'a [Option<i64>],
+    hint_ts: Option<i64>,
+    bounds: Option<TraceTimeRange>,
+    deadline: Instant,
+    resolved: &'a [AtomicBool],
 }
 
 /// One window's worth of index rows: the merged overall range drives the
@@ -266,27 +275,18 @@ fn probe_range(candidate: i64, expand_window: i64, scan_start: i64, scan_end: i6
     }
 }
 
-async fn query_window(
-    context: &TimerContext<'_>,
+/// Runs one index-window search; None means the deadline expired first.
+async fn search_index_window(
+    org_id: &str,
+    sql: String,
     start_time: i64,
     end_time: i64,
-) -> Result<WindowResult> {
-    if start_time >= end_time {
-        return Ok(WindowResult::Miss);
-    }
-    let remaining = context.deadline.saturating_duration_since(Instant::now());
+    deadline: Instant,
+) -> Result<Option<Vec<json::Value>>> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
     if remaining.is_zero() {
-        return Ok(WindowResult::TimedOut);
+        return Ok(None);
     }
-
-    // Grouping by trace_id serves both kinds: a trace lookup returns its
-    // single row, a session lookup returns one row per member trace.
-    let sql = format!(
-        "SELECT trace_id, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts FROM {} WHERE {} = {} GROUP BY trace_id",
-        quote_identifier(context.index_stream),
-        quote_identifier(context.kind.column()),
-        quote_sql_string(context.key),
-    );
     let request = Request {
         query: Query {
             sql,
@@ -323,7 +323,7 @@ async fn query_window(
     let internal_trace_id = config::ider::generate_trace_id();
     let search = SearchService::cache::search(
         &internal_trace_id,
-        context.org_id,
+        org_id,
         StreamType::Metadata,
         None,
         &request,
@@ -332,35 +332,102 @@ async fn query_window(
         None,
         false,
     );
-    let response = match tokio::time::timeout(remaining, search).await {
-        Ok(response) => {
-            response.map_err(|e| Error::Message(format!("query trace time index: {e}")))?
-        }
-        Err(_) => return Ok(WindowResult::TimedOut),
-    };
-    let mut range: Option<TraceTimeRange> = None;
-    let mut traces = Vec::with_capacity(response.hits.len());
-    for hit in &response.hits {
-        let Some(trace_id) = hit.get("trace_id").and_then(serde_json::Value::as_str) else {
-            continue;
-        };
-        let Some(min_ts) = hit.get("min_ts").map(json::get_int_value) else {
-            continue;
-        };
-        let Some(max_ts) = hit.get("max_ts").map(json::get_int_value) else {
-            continue;
-        };
-        let trace_range = TraceTimeRange {
+    match tokio::time::timeout(remaining, search).await {
+        Ok(response) => response
+            .map(|response| Some(response.hits))
+            .map_err(|e| Error::Message(format!("query trace time index: {e}"))),
+        Err(_) => Ok(None),
+    }
+}
+
+fn parse_hit_range(hit: &json::Value, key_column: &str) -> Option<(String, TraceTimeRange)> {
+    let key = hit.get(key_column).and_then(json::Value::as_str)?;
+    let min_ts = hit.get("min_ts").map(json::get_int_value)?;
+    let max_ts = hit.get("max_ts").map(json::get_int_value)?;
+    Some((
+        key.to_string(),
+        TraceTimeRange {
             start_time: min_ts,
             end_time: max_ts,
+        },
+    ))
+}
+
+async fn query_window(
+    context: &TimerContext<'_>,
+    start_time: i64,
+    end_time: i64,
+) -> Result<WindowResult> {
+    if start_time >= end_time {
+        return Ok(WindowResult::Miss);
+    }
+    // Grouping by trace_id serves both kinds: a trace lookup returns its
+    // single row, a session lookup returns one row per member trace.
+    let sql = format!(
+        "SELECT trace_id, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts FROM {} WHERE {} = {} GROUP BY trace_id",
+        quote_identifier(context.index_stream),
+        quote_identifier(context.kind.column()),
+        quote_sql_string(context.key),
+    );
+    let Some(hits) =
+        search_index_window(context.org_id, sql, start_time, end_time, context.deadline).await?
+    else {
+        return Ok(WindowResult::TimedOut);
+    };
+    let mut range: Option<TraceTimeRange> = None;
+    let mut traces = Vec::with_capacity(hits.len());
+    for hit in &hits {
+        let Some((trace_id, trace_range)) = parse_hit_range(hit, "trace_id") else {
+            continue;
         };
         range = Some(range.map_or(trace_range, |r| r.merge(trace_range)));
-        traces.push((trace_id.to_string(), trace_range));
+        traces.push((trace_id, trace_range));
     }
     match range {
         Some(range) => Ok(WindowResult::Hit(WindowHit { range, traces })),
         None => Ok(WindowResult::Miss),
     }
+}
+
+/// One batch-scan window: all active keys in a single `IN` query, one row per
+/// key (sessions group by session_id — the batch path needs no per-trace map).
+/// None means the deadline expired first.
+async fn query_batch_window(
+    params: &ScanParams<'_>,
+    index_stream: &str,
+    active: &[usize],
+    start_time: i64,
+    end_time: i64,
+) -> Result<Option<Vec<(usize, TraceTimeRange)>>> {
+    if start_time >= end_time || active.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let column = params.kind.column();
+    let predicate = key_in_predicate(
+        column,
+        active.iter().map(|&index| params.keys[index].as_str()),
+    );
+    let sql = format!(
+        "SELECT {}, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts FROM {} WHERE {predicate} GROUP BY {}",
+        quote_identifier(column),
+        quote_identifier(index_stream),
+        quote_identifier(column),
+    );
+    let Some(hits) =
+        search_index_window(params.org_id, sql, start_time, end_time, params.deadline).await?
+    else {
+        return Ok(None);
+    };
+    let mut rows = Vec::with_capacity(hits.len());
+    for hit in &hits {
+        let Some((key, range)) = parse_hit_range(hit, column) else {
+            continue;
+        };
+        if let Some(&index) = params.key_indexes.get(key.as_str()) {
+            rows.push((index, range));
+        }
+    }
+    Ok(Some(rows))
 }
 
 fn collect_traces(
@@ -397,8 +464,8 @@ async fn locate(
         let CoveredRange { start, end } = probe_range(
             candidate,
             expand_window,
-            context.scan_start,
-            context.scan_end,
+            context.bounds.scan_start,
+            context.bounds.scan_end,
         );
         stats.locate_rounds += 1;
         match query_window(context, start, end).await? {
@@ -414,12 +481,14 @@ async fn locate(
         }
     }
 
-    let mut cursor = context.scan_end;
+    let mut cursor = context.bounds.scan_end;
     for batch_size in locate_batch_sizes() {
-        if cursor <= context.scan_start {
+        if cursor <= context.bounds.scan_start {
             break;
         }
-        let start = cursor.saturating_sub(batch_size).max(context.scan_start);
+        let start = cursor
+            .saturating_sub(batch_size)
+            .max(context.bounds.scan_start);
         stats.locate_rounds += 1;
         match query_window(context, start, cursor).await? {
             WindowResult::Hit(hit) => {
@@ -446,10 +515,7 @@ async fn expand(
     let expand_window = context.kind.expand_window();
     // expand left
     loop {
-        let target = range
-            .start_time
-            .saturating_sub(expand_window)
-            .max(context.hard_start);
+        let (target, _) = margin_span(range, expand_window, context.bounds);
         if target >= covered.start {
             break;
         }
@@ -470,10 +536,7 @@ async fn expand(
 
     // expand right
     loop {
-        let target = range
-            .end_time
-            .saturating_add(expand_window)
-            .min(context.hard_end);
+        let (_, target) = margin_span(range, expand_window, context.bounds);
         if target <= covered.end {
             break;
         }
@@ -510,7 +573,7 @@ pub async fn query(
         deadline: default_deadline(),
     })
     .await
-    .map(|lookup| lookup.result.map(|result| result.range))
+    .map(|result| result.map(|result| result.range))
 }
 
 pub async fn query_session(
@@ -529,14 +592,13 @@ pub async fn query_session(
         deadline: default_deadline(),
     })
     .await
-    .map(|lookup| lookup.result)
 }
 
 fn default_deadline() -> Instant {
     Instant::now() + Duration::from_secs(get_config().limit.query_timeout)
 }
 
-async fn query_instrumented(params: &LookupParams<'_>) -> Result<TimeIndexLookup> {
+async fn query_instrumented(params: &LookupParams<'_>) -> Result<Option<SessionTimeIndexResult>> {
     let started = std::time::Instant::now();
     let mut stats = TimerStats::default();
     let result = query_inner(params, &mut stats).await;
@@ -576,53 +638,27 @@ async fn query_instrumented(params: &LookupParams<'_>) -> Result<TimeIndexLookup
         stats.expand_rounds,
         elapsed.as_millis(),
     );
-    result.map(|result| TimeIndexLookup {
-        result,
-        timed_out: stats.timed_out,
-        coverage_missing: stats.coverage_missing,
-    })
+    result
 }
 
 async fn query_inner(
     params: &LookupParams<'_>,
     stats: &mut TimerStats,
 ) -> Result<Option<SessionTimeIndexResult>> {
-    let cfg = get_config();
-    if !cfg.common.trace_time_index_enabled {
-        stats.coverage_missing = true;
-        return Ok(None);
-    }
-
     let kind = params.kind;
     let key_uuid_ts = config::ider::get_start_time_from_trace_id(params.key);
-    let mut hard_start = infra::db::trace_time_index::get_or_create_coverage_start()
-        .await
-        .map_err(|e| Error::Message(format!("read trace time index coverage marker: {e}")))?;
-    // A session's spans cannot causally precede its creation, so a UUID v7
-    // session id tightens the scan's left bound to the session's lifetime
-    // neighborhood; the expand-window margin absorbs clock skew.
-    if kind == TimeIndexKind::Session
-        && let Some(uuid_time) = key_uuid_ts
-    {
-        hard_start = hard_start.max(uuid_time.saturating_sub(kind.expand_window()));
-    }
-    let hard_end = now_micros().saturating_add(cfg.limit.ingest_allowed_in_future_micro);
-    let mut scan_start = hard_start;
-    let mut scan_end = hard_end;
-    if let Some(padded) = padded_bounds(kind, params.bounds) {
-        scan_start = scan_start.max(padded.start_time);
-        scan_end = scan_end.min(padded.end_time);
-    }
-    if scan_start >= scan_end {
-        // The caller bounds don't intersect index coverage: nothing was
-        // scanned, so this miss is not proof of absence.
-        stats.coverage_missing = true;
+    let floor = session_uuid_floor(kind, &[key_uuid_ts]);
+    let Some(bounds) = resolve_scan_bounds(
+        params.org_id,
+        params.stream_name,
+        kind,
+        params.bounds,
+        floor,
+    )
+    .await?
+    else {
         return Ok(None);
-    }
-    if !index_stream_exists(params.org_id, params.stream_name).await {
-        stats.coverage_missing = true;
-        return Ok(None);
-    }
+    };
     let index_stream = get_trace_time_index_stream_name(params.stream_name);
     let context = TimerContext {
         org_id: params.org_id,
@@ -630,10 +666,7 @@ async fn query_inner(
         kind,
         key: params.key,
         key_uuid_ts,
-        scan_start,
-        scan_end,
-        hard_start,
-        hard_end,
+        bounds,
         deadline: params.deadline,
     };
     let mut traces = HashMap::new();
@@ -644,10 +677,10 @@ async fn query_inner(
     Ok(Some(SessionTimeIndexResult { range, traces }))
 }
 
-/// Runs every (key, stream) lookup under one shared deadline, walking
-/// stream-major so a key resolved in an earlier stream is skipped in later
-/// ones (a trace or session id lives in exactly one stream). The bool reports
-/// whether any lookup ran without index coverage.
+/// Runs one batch scan per stream under one shared deadline. A trace or
+/// session id lives in exactly one stream, so a key seen by one stream's scan
+/// is skipped by the others. The bool reports whether any stream lacked index
+/// coverage.
 async fn run_lookups(
     org_id: &str,
     streams: &[String],
@@ -659,52 +692,224 @@ async fn run_lookups(
     let deadline = default_deadline();
     let resolved: Vec<AtomicBool> = (0..keys.len()).map(|_| AtomicBool::new(false)).collect();
     let resolved = &resolved;
-    let pairs = (0..streams.len())
-        .flat_map(|stream_index| (0..keys.len()).map(move |key_index| (key_index, stream_index)));
-    let outcomes = futures::stream::iter(pairs.map(|(key_index, stream_index)| async move {
-        if resolved[key_index].load(Ordering::Relaxed) {
-            return Ok::<_, Error>(None);
-        }
-        // Queued pairs must not keep draining work past the shared deadline.
-        if deadline.saturating_duration_since(Instant::now()).is_zero() {
-            return Ok(Some(LookupOutcome {
-                key_index,
-                stream_index,
-                range: None,
-                timed_out: true,
-                coverage_missing: false,
-            }));
-        }
-        let lookup = query_instrumented(&LookupParams {
+    let key_indexes: HashMap<&str, usize> = keys
+        .iter()
+        .enumerate()
+        .map(|(index, key)| (key.as_str(), index))
+        .collect();
+    let key_indexes = &key_indexes;
+    let key_uuid_ts: Vec<Option<i64>> = keys
+        .iter()
+        .map(|key| config::ider::get_start_time_from_trace_id(key))
+        .collect();
+    let key_uuid_ts = &key_uuid_ts;
+    let scans = futures::stream::iter((0..streams.len()).map(|stream_index| async move {
+        scan_stream(&ScanParams {
             org_id,
+            stream_index,
             stream_name: &streams[stream_index],
             kind,
-            key: &keys[key_index],
+            keys,
+            key_indexes,
+            key_uuid_ts,
             hint_ts,
             bounds,
             deadline,
+            resolved,
         })
-        .await?;
-        if lookup.result.is_some() {
-            resolved[key_index].store(true, Ordering::Relaxed);
-        }
-        Ok(Some(LookupOutcome {
-            key_index,
-            stream_index,
-            range: lookup.result.map(|result| result.range),
-            timed_out: lookup.timed_out,
-            coverage_missing: lookup.coverage_missing,
-        }))
+        .await
     }))
     .buffer_unordered(LOOKUP_CONCURRENCY)
-    .try_collect::<Vec<Option<LookupOutcome>>>()
+    .try_collect::<Vec<Option<Vec<LookupOutcome>>>>()
     .await?;
-    Ok(aggregate_outcomes(
-        streams,
-        kind,
-        keys,
-        outcomes.into_iter().flatten(),
+    let mut coverage_missing = false;
+    let mut outcomes = Vec::new();
+    for scan in scans {
+        match scan {
+            Some(scan) => outcomes.extend(scan),
+            None => coverage_missing = true,
+        }
+    }
+    Ok((
+        aggregate_outcomes(streams, kind, keys, outcomes),
+        coverage_missing,
     ))
+}
+
+/// Drives one stream's [`BatchScanner`]: asks it for windows, runs them, and
+/// feeds the rows back until the scan finishes or the deadline expires.
+/// None means the stream has no consultable coverage, so its misses are not
+/// proof.
+async fn scan_stream(params: &ScanParams<'_>) -> Result<Option<Vec<LookupOutcome>>> {
+    let result = scan_stream_inner(params).await;
+    if result.is_err() {
+        config::metrics::TRACE_TIME_INDEX_OPERATIONS
+            .with_label_values(&[params.org_id, params.kind.operation(), "error"])
+            .inc();
+    }
+    result
+}
+
+async fn scan_stream_inner(params: &ScanParams<'_>) -> Result<Option<Vec<LookupOutcome>>> {
+    let started = std::time::Instant::now();
+    let kind = params.kind;
+    let floor = session_uuid_floor(kind, params.key_uuid_ts);
+    let Some(bounds) = resolve_scan_bounds(
+        params.org_id,
+        params.stream_name,
+        kind,
+        params.bounds,
+        floor,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let index_stream = get_trace_time_index_stream_name(params.stream_name);
+    let mut scanner = BatchScanner::new(
+        kind,
+        params.keys.len(),
+        bounds,
+        params.hint_ts,
+        params.key_uuid_ts,
+    );
+    let mut windows = 0u64;
+    loop {
+        if params
+            .deadline
+            .saturating_duration_since(Instant::now())
+            .is_zero()
+        {
+            break;
+        }
+        for (key, flag) in params.resolved.iter().enumerate() {
+            if flag.load(Ordering::Relaxed) {
+                scanner.skip_key(key);
+            }
+        }
+        let Some((start, end)) = scanner.next_window() else {
+            break;
+        };
+        windows += 1;
+        let active = scanner.active_keys();
+        let Some(rows) = query_batch_window(params, &index_stream, &active, start, end).await?
+        else {
+            break;
+        };
+        for key in scanner.ingest(rows) {
+            params.resolved[key].store(true, Ordering::Relaxed);
+        }
+    }
+    let outcomes = collect_scan_outcomes(params.stream_index, scanner.finish());
+    record_scan_metrics(params, windows, &outcomes, started.elapsed());
+    Ok(Some(outcomes))
+}
+
+/// The stream's scan bounds, shared by the per-key and batch paths, or None
+/// when there is no consultable coverage (feature disabled, caller bounds
+/// outside coverage, or no index stream). `hard_start_floor` carries the
+/// session-UUID causality bound.
+async fn resolve_scan_bounds(
+    org_id: &str,
+    stream_name: &str,
+    kind: TimeIndexKind,
+    bounds: Option<TraceTimeRange>,
+    hard_start_floor: Option<i64>,
+) -> Result<Option<ScanBounds>> {
+    let cfg = get_config();
+    if !cfg.common.trace_time_index_enabled {
+        return Ok(None);
+    }
+    let mut hard_start = infra::db::trace_time_index::get_or_create_coverage_start()
+        .await
+        .map_err(|e| Error::Message(format!("read trace time index coverage marker: {e}")))?;
+    if let Some(floor) = hard_start_floor {
+        hard_start = hard_start.max(floor);
+    }
+    let hard_end = now_micros().saturating_add(cfg.limit.ingest_allowed_in_future_micro);
+    let mut scan_start = hard_start;
+    let mut scan_end = hard_end;
+    if let Some(padded) = padded_bounds(kind, bounds) {
+        scan_start = scan_start.max(padded.start_time);
+        scan_end = scan_end.min(padded.end_time);
+    }
+    if scan_start >= scan_end {
+        return Ok(None);
+    }
+    if !index_stream_exists(org_id, stream_name).await {
+        return Ok(None);
+    }
+    Ok(Some(ScanBounds {
+        scan_start,
+        scan_end,
+        hard_start,
+        hard_end,
+    }))
+}
+
+fn collect_scan_outcomes(
+    stream_index: usize,
+    verdicts: Vec<Option<ScanOutcome>>,
+) -> Vec<LookupOutcome> {
+    verdicts
+        .into_iter()
+        .enumerate()
+        .filter_map(|(key_index, verdict)| {
+            let (range, timed_out) = match verdict? {
+                ScanOutcome::Found { range, partial } => (Some(range), partial),
+                ScanOutcome::NotFound => (None, false),
+                ScanOutcome::Timeout => (None, true),
+            };
+            Some(LookupOutcome {
+                key_index,
+                stream_index,
+                range,
+                timed_out,
+            })
+        })
+        .collect()
+}
+
+fn record_scan_metrics(
+    params: &ScanParams<'_>,
+    windows: u64,
+    outcomes: &[LookupOutcome],
+    elapsed: std::time::Duration,
+) {
+    let org_id = params.org_id;
+    let kind = params.kind;
+    // Same per-key accounting the per-key path emits: hit/miss verdicts, plus
+    // a timeout marker whenever the scan gave up on that key. Scan duration
+    // has no per-lookup status, so only the log line carries it.
+    let (mut hits, mut timeouts) = (0u64, 0u64);
+    for outcome in outcomes {
+        let status = if outcome.range.is_some() {
+            hits += 1;
+            "hit"
+        } else {
+            "miss"
+        };
+        config::metrics::TRACE_TIME_INDEX_OPERATIONS
+            .with_label_values(&[org_id, kind.operation(), status])
+            .inc();
+        if outcome.timed_out {
+            config::metrics::TRACE_TIME_INDEX_OPERATIONS
+                .with_label_values(&[org_id, kind.operation(), "timeout"])
+                .inc();
+            timeouts += 1;
+        }
+    }
+    config::metrics::TRACE_TIME_INDEX_QUERY_ROUNDS
+        .with_label_values(&[org_id, kind.label(), "batch_scan"])
+        .observe(windows as f64);
+    log::info!(
+        "[trace_time_index] batch scan org_id={org_id:?} stream={:?} kind={} keys={} windows={windows} hits={hits} misses={} timeouts={timeouts} took={} ms",
+        params.stream_name,
+        kind.label(),
+        params.keys.len(),
+        outcomes.len() as u64 - hits,
+        elapsed.as_millis(),
+    );
 }
 
 fn aggregate_outcomes(
@@ -712,12 +917,10 @@ fn aggregate_outcomes(
     kind: TimeIndexKind,
     keys: &[String],
     outcomes: impl IntoIterator<Item = LookupOutcome>,
-) -> (Vec<TimeRangeResult>, bool) {
+) -> Vec<TimeRangeResult> {
     let mut found: Vec<Vec<(usize, TraceTimeRange, bool)>> = vec![Vec::new(); keys.len()];
     let mut timed_out = vec![false; keys.len()];
-    let mut coverage_missing = false;
     for outcome in outcomes {
-        coverage_missing |= outcome.coverage_missing;
         match outcome.range {
             Some(range) => {
                 found[outcome.key_index].push((outcome.stream_index, range, outcome.timed_out))
@@ -748,7 +951,7 @@ fn aggregate_outcomes(
             }
         }
     }
-    (results, coverage_missing)
+    results
 }
 
 fn make_result(
@@ -1249,10 +1452,12 @@ mod tests {
             kind: TimeIndexKind::Trace,
             key: "trace",
             key_uuid_ts: None,
-            scan_start: 0,
-            scan_end: EXPAND_WINDOW * 20,
-            hard_start: 0,
-            hard_end: EXPAND_WINDOW * 20,
+            bounds: ScanBounds {
+                scan_start: 0,
+                scan_end: EXPAND_WINDOW * 20,
+                hard_start: 0,
+                hard_end: EXPAND_WINDOW * 20,
+            },
             deadline: Instant::now(),
         };
         let mut stats = TimerStats::default();
@@ -1363,26 +1568,24 @@ mod tests {
             start_time: 1,
             end_time: 2,
         };
-        let outcome = |key_index, stream_index, range, timed_out, coverage_missing| LookupOutcome {
+        let outcome = |key_index, stream_index, range, timed_out| LookupOutcome {
             key_index,
             stream_index,
             range,
             timed_out,
-            coverage_missing,
         };
         let outcomes = vec![
-            // k1 found in stream b (its stream-a pair was skipped)
-            outcome(0, 1, Some(range), false, false),
-            // k2 missed everywhere, one stream timed out and lacked coverage
-            outcome(1, 0, None, true, true),
-            outcome(1, 1, None, false, false),
+            // k1 found in stream b (skipped in stream a, so no outcome there)
+            outcome(0, 1, Some(range), false),
+            // k2 missed everywhere, one stream timed out
+            outcome(1, 0, None, true),
+            outcome(1, 1, None, false),
             // k3 missed everywhere without timeouts
-            outcome(2, 0, None, false, false),
-            // k4 found but expansion timed out: the range may be partial
-            outcome(3, 0, Some(range), true, false),
+            outcome(2, 0, None, false),
+            // k4 found but the scan gave up on its margins: partial
+            outcome(3, 0, Some(range), true),
         ];
-        let (results, coverage_missing) =
-            aggregate_outcomes(&streams, TimeIndexKind::Trace, &keys, outcomes);
+        let results = aggregate_outcomes(&streams, TimeIndexKind::Trace, &keys, outcomes);
         assert_eq!(results.len(), 4);
         assert_eq!(results[0].status, TimeRangeStatus::Found);
         assert_eq!(results[0].stream.as_deref(), Some("b"));
@@ -1394,7 +1597,6 @@ mod tests {
         assert_eq!(results[3].status, TimeRangeStatus::Found);
         assert!(results[3].partial);
         assert_eq!(results[3].range, Some(range));
-        assert!(coverage_missing);
     }
 
     #[test]

--- a/src/api/search/src/traces/time_index/scan.rs
+++ b/src/api/search/src/traces/time_index/scan.rs
@@ -255,7 +255,8 @@ impl BatchScanner {
     /// interrupted scan leaves keys Seen (partial find) or Unseen
     /// (indeterminate). Skipped keys yield None — another stream already
     /// answered for them.
-    pub(super) fn finish(self) -> Vec<Option<ScanOutcome>> {
+    pub(super) fn finish(mut self) -> Vec<Option<ScanOutcome>> {
+        self.settle();
         self.keys
             .into_iter()
             .map(|state| match state {
@@ -277,20 +278,66 @@ impl BatchScanner {
             .collect()
     }
 
-    /// The first island whose attached keys still need margin coverage gets a
-    /// growth window; islands whose needs are met complete their keys.
-    fn next_island_window(&mut self) -> Option<Pending> {
+    /// Advance every query-free transition — island completions, covered-span
+    /// jumps, end-of-scan verdicts — so the outcome reflects what the covered
+    /// region already proves. Without this, a deadline landing right after the
+    /// last ingest would report a fully-covered miss as timeout and a
+    /// margin-complete hit as partial.
+    fn settle(&mut self) {
+        self.complete_satisfied_islands();
+        if self.main_done {
+            return;
+        }
+        self.jump_covered_islands();
+        self.complete_main_keys();
+        if self.cursor <= self.bounds.scan_start {
+            self.finish_main();
+            self.complete_satisfied_islands();
+        }
+    }
+
+    /// The span an island must cover to complete its attached keys.
+    fn island_needs(&self, island: &Island) -> (i64, i64) {
+        let mut needed_left = island.left;
+        let mut needed_right = island.right;
+        for &key in &island.keys {
+            if let KeyState::Seen(range) = self.keys[key] {
+                let (left, right) = margin_span(range, self.margin, self.bounds);
+                needed_left = needed_left.min(left);
+                needed_right = needed_right.max(right);
+            }
+        }
+        (needed_left, needed_right)
+    }
+
+    /// Complete the keys of every island whose needs are already covered —
+    /// a pure state transition, no queries involved.
+    fn complete_satisfied_islands(&mut self) {
         for index in 0..self.islands.len() {
+            let (needed_left, needed_right) = self.island_needs(&self.islands[index]);
             let island = &self.islands[index];
-            let mut needed_left = island.left;
-            let mut needed_right = island.right;
-            for &key in &island.keys {
+            if needed_left < island.left || needed_right > island.right {
+                continue;
+            }
+            let keys = std::mem::take(&mut self.islands[index].keys);
+            for key in keys {
                 if let KeyState::Seen(range) = self.keys[key] {
-                    let (left, right) = margin_span(range, self.margin, self.bounds);
-                    needed_left = needed_left.min(left);
-                    needed_right = needed_right.max(right);
+                    self.keys[key] = KeyState::Complete {
+                        range,
+                        partial: false,
+                    };
                 }
             }
+        }
+    }
+
+    /// The first island whose attached keys still need margin coverage gets a
+    /// growth window.
+    fn next_island_window(&mut self) -> Option<Pending> {
+        self.complete_satisfied_islands();
+        for index in 0..self.islands.len() {
+            let (needed_left, needed_right) = self.island_needs(&self.islands[index]);
+            let island = &self.islands[index];
             if needed_left < island.left {
                 return Some(Pending::IslandGrow {
                     island: index,
@@ -305,21 +352,13 @@ impl BatchScanner {
                     right: needed_right,
                 });
             }
-            let keys = std::mem::take(&mut self.islands[index].keys);
-            for key in keys {
-                if let KeyState::Seen(range) = self.keys[key] {
-                    self.keys[key] = KeyState::Complete {
-                        range,
-                        partial: false,
-                    };
-                }
-            }
         }
         None
     }
 
-    fn next_main_window(&mut self) -> Option<Pending> {
-        // Jump over spans probes or island growth already covered.
+    /// Jump the cursor over spans probes or island growth already covered —
+    /// a pure state transition, no queries involved.
+    fn jump_covered_islands(&mut self) {
         loop {
             let mut jumped = false;
             for island in &self.islands {
@@ -332,6 +371,10 @@ impl BatchScanner {
                 break;
             }
         }
+    }
+
+    fn next_main_window(&mut self) -> Option<Pending> {
+        self.jump_covered_islands();
         if self.cursor <= self.bounds.scan_start {
             return None;
         }
@@ -655,6 +698,69 @@ mod tests {
     fn probe_spans_merge_and_clamp() {
         let merged = merge_and_clamp(vec![(5, 10), (8, 20), (30, 40), (-5, 2)], 0, 35);
         assert_eq!(merged, vec![(0, 2), (5, 20), (30, 35)]);
+    }
+
+    #[test]
+    fn deadline_after_full_coverage_still_proves_absence() {
+        let mut scanner = BatchScanner::new(
+            TimeIndexKind::Trace,
+            2,
+            bounds(0, W * 4),
+            None,
+            &[None, None],
+        );
+        let data = [(0usize, range(W * 2, W * 2 + 10))];
+        // Stop right after ingesting the window that reaches scan_start,
+        // without another next_window call — as the driver does on deadline.
+        while let Some((start, end)) = scanner.next_window() {
+            let rows = data
+                .iter()
+                .filter(|(_, r)| r.start_time <= end && r.end_time >= start)
+                .map(|&(k, r)| (k, r))
+                .collect();
+            scanner.ingest(rows);
+            if start <= 0 {
+                break;
+            }
+        }
+        let outcomes = scanner.finish();
+        assert_eq!(
+            outcomes[0],
+            Some(ScanOutcome::Found {
+                range: data[0].1,
+                partial: false,
+            })
+        );
+        assert_eq!(outcomes[1], Some(ScanOutcome::NotFound));
+    }
+
+    #[test]
+    fn deadline_after_island_completion_is_not_partial() {
+        let hint = W * 20;
+        let mut scanner = BatchScanner::new(
+            TimeIndexKind::Trace,
+            1,
+            bounds(0, W * 40),
+            Some(hint),
+            &[None],
+        );
+        let data = [(0usize, range(hint, hint))];
+        // Probe window only; the deadline lands before any further window.
+        let (start, end) = scanner.next_window().unwrap();
+        let rows = data
+            .iter()
+            .filter(|(_, r)| r.start_time <= end && r.end_time >= start)
+            .map(|&(k, r)| (k, r))
+            .collect();
+        scanner.ingest(rows);
+        let outcomes = scanner.finish();
+        assert_eq!(
+            outcomes[0],
+            Some(ScanOutcome::Found {
+                range: data[0].1,
+                partial: false,
+            })
+        );
     }
 
     #[test]

--- a/src/api/search/src/traces/time_index/scan.rs
+++ b/src/api/search/src/traces/time_index/scan.rs
@@ -1,0 +1,685 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! One shared backward scan per stream over a batch of unresolved keys,
+//! replacing per-key locate/expand fan-out. The scanner is a pure state
+//! machine: the async driver asks it which window to query next and feeds
+//! the rows back, so the completion logic is unit-testable without a store.
+//!
+//! Correctness shape (see the design doc): a naive "locate then expand the
+//! merged range" is wrong for unrelated keys — a miss window between two
+//! distant keys would end expansion before the older key is found. Instead
+//! the scan stays contiguous and each key completes individually once the
+//! covered region extends one expand window past its leftmost hit (the right
+//! side is covered by construction, since the scan starts at the top).
+
+use super::{TimeIndexKind, TraceTimeRange};
+
+/// A wildly-scattered UUID cluster degenerates into re-scanning everything,
+/// so wider clusters fall through to the main scan.
+const UUID_ISLAND_MAX_WIDTH_WINDOWS: i64 = 8;
+/// Defensive backstop against a window-emission logic bug; the deadline is
+/// the real bound.
+const MAX_WINDOWS: u32 = 1000;
+
+/// Per-key verdict for one stream, mirroring the API's three states plus the
+/// partial rider.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ScanOutcome {
+    Found {
+        range: TraceTimeRange,
+        partial: bool,
+    },
+    NotFound,
+    Timeout,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum KeyState {
+    Unseen,
+    Seen(TraceTimeRange),
+    Complete {
+        range: TraceTimeRange,
+        partial: bool,
+    },
+    Skipped,
+    Absent,
+}
+
+impl KeyState {
+    fn is_active(&self) -> bool {
+        matches!(self, KeyState::Unseen | KeyState::Seen(_))
+    }
+}
+
+/// A covered span detached from the main scan: a probe window, its growth
+/// toward the attached keys' completion margins, or the whole scan span when
+/// boundary keys must grow past the caller bounds.
+#[derive(Debug)]
+struct Island {
+    left: i64,
+    right: i64,
+    keys: Vec<usize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Pending {
+    Probe {
+        left: i64,
+        right: i64,
+    },
+    IslandGrow {
+        island: usize,
+        left: i64,
+        right: i64,
+    },
+    Main {
+        left: i64,
+    },
+}
+
+/// Scan bounds: locate walks `[scan_start, scan_end]`; completion margins and
+/// island growth clamp to the hard bounds, so found ranges are never
+/// truncated by a caller range.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ScanBounds {
+    pub scan_start: i64,
+    pub scan_end: i64,
+    pub hard_start: i64,
+    pub hard_end: i64,
+}
+
+pub(super) struct BatchScanner {
+    margin: i64,
+    bounds: ScanBounds,
+    keys: Vec<KeyState>,
+    islands: Vec<Island>,
+    probes: Vec<(i64, i64)>,
+    cursor: i64,
+    batch_index: usize,
+    main_done: bool,
+    pending: Option<Pending>,
+    windows_emitted: u32,
+}
+
+impl BatchScanner {
+    pub(super) fn new(
+        kind: TimeIndexKind,
+        key_count: usize,
+        bounds: ScanBounds,
+        hint_ts: Option<i64>,
+        key_uuid_ts: &[Option<i64>],
+    ) -> Self {
+        let margin = kind.expand_window();
+        let mut probes = Vec::new();
+        if let Some(hint) = hint_ts {
+            probes.push((hint.saturating_sub(margin), hint.saturating_add(margin)));
+        }
+        let uuid_ts: Vec<i64> = key_uuid_ts.iter().copied().flatten().collect();
+        if let (Some(&min), Some(&max)) = (uuid_ts.iter().min(), uuid_ts.iter().max())
+            && max.saturating_sub(min) <= UUID_ISLAND_MAX_WIDTH_WINDOWS * margin
+        {
+            probes.push((min.saturating_sub(margin), max.saturating_add(margin)));
+        }
+        let probes = merge_and_clamp(probes, bounds.scan_start, bounds.scan_end);
+        Self {
+            margin,
+            bounds,
+            keys: vec![KeyState::Unseen; key_count],
+            islands: Vec::new(),
+            probes,
+            cursor: bounds.scan_end,
+            batch_index: 0,
+            main_done: false,
+            pending: None,
+            windows_emitted: 0,
+        }
+    }
+
+    /// Keys worth putting in the next window's `IN` list: every key that is
+    /// neither terminal nor skipped. A completed key's rows are already
+    /// merged, so re-listing it buys nothing.
+    pub(super) fn active_keys(&self) -> Vec<usize> {
+        self.keys
+            .iter()
+            .enumerate()
+            .filter(|(_, state)| state.is_active())
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    /// Drop an unseen key because another stream resolved it. A key already
+    /// seen here keeps completing — the response reports what the index holds.
+    pub(super) fn skip_key(&mut self, key: usize) {
+        if matches!(self.keys[key], KeyState::Unseen) {
+            self.keys[key] = KeyState::Skipped;
+        }
+    }
+
+    fn has_active_keys(&self) -> bool {
+        self.keys.iter().any(KeyState::is_active)
+    }
+
+    /// The next window to query, closed interval `[start, end]`, or None when
+    /// the scan is finished. Must alternate with `ingest`.
+    pub(super) fn next_window(&mut self) -> Option<(i64, i64)> {
+        debug_assert!(self.pending.is_none(), "ingest the previous window first");
+        if self.windows_emitted >= MAX_WINDOWS {
+            return None;
+        }
+        let pending = loop {
+            if !self.has_active_keys() {
+                return None;
+            }
+            if let Some((left, right)) = self.probes.pop() {
+                break Pending::Probe { left, right };
+            }
+            if let Some(pending) = self.next_island_window() {
+                break pending;
+            }
+            if self.main_done {
+                return None;
+            }
+            if let Some(pending) = self.next_main_window() {
+                break pending;
+            }
+            self.finish_main();
+        };
+        self.windows_emitted += 1;
+        self.pending = Some(pending);
+        match pending {
+            Pending::Probe { left, right } | Pending::IslandGrow { left, right, .. } => {
+                Some((left, right))
+            }
+            Pending::Main { left } => Some((left, self.cursor)),
+        }
+    }
+
+    /// Feed back the rows of the window handed out by `next_window`, merged
+    /// per key. Returns the keys first seen in this window (for cross-stream
+    /// pruning).
+    pub(super) fn ingest(&mut self, rows: Vec<(usize, TraceTimeRange)>) -> Vec<usize> {
+        let pending = self.pending.take().expect("no window pending");
+        let mut newly_seen = Vec::new();
+        for (key, range) in rows {
+            match self.keys[key] {
+                KeyState::Unseen => {
+                    self.keys[key] = KeyState::Seen(range);
+                    newly_seen.push(key);
+                }
+                KeyState::Seen(existing) => self.keys[key] = KeyState::Seen(existing.merge(range)),
+                // Skipped keys are not in the IN list, so no rows arrive.
+                KeyState::Skipped | KeyState::Complete { .. } | KeyState::Absent => {}
+            }
+        }
+        match pending {
+            Pending::Probe { left, right } => {
+                // Keep the span even with no hits: the main scan jumps over it.
+                self.islands.push(Island {
+                    left,
+                    right,
+                    keys: newly_seen.clone(),
+                });
+            }
+            Pending::IslandGrow {
+                island,
+                left,
+                right,
+            } => {
+                let island = &mut self.islands[island];
+                island.left = island.left.min(left);
+                island.right = island.right.max(right);
+                island.keys.extend(newly_seen.iter().copied());
+            }
+            Pending::Main { left } => {
+                self.cursor = left;
+                self.complete_main_keys();
+            }
+        }
+        newly_seen
+    }
+
+    /// Terminal per-key outcomes, derived purely from key state: an
+    /// interrupted scan leaves keys Seen (partial find) or Unseen
+    /// (indeterminate). Skipped keys yield None — another stream already
+    /// answered for them.
+    pub(super) fn finish(self) -> Vec<Option<ScanOutcome>> {
+        self.keys
+            .into_iter()
+            .map(|state| match state {
+                KeyState::Complete { range, partial } => {
+                    Some(ScanOutcome::Found { range, partial })
+                }
+                // An interrupted scan can only have covered part of the
+                // margins, so a seen key is a partial find.
+                KeyState::Seen(range) => Some(ScanOutcome::Found {
+                    range,
+                    partial: true,
+                }),
+                // Reachable via the deadline or the window backstop; either
+                // way the scan bounds were not covered — indeterminate.
+                KeyState::Unseen => Some(ScanOutcome::Timeout),
+                KeyState::Absent => Some(ScanOutcome::NotFound),
+                KeyState::Skipped => None,
+            })
+            .collect()
+    }
+
+    /// The first island whose attached keys still need margin coverage gets a
+    /// growth window; islands whose needs are met complete their keys.
+    fn next_island_window(&mut self) -> Option<Pending> {
+        for index in 0..self.islands.len() {
+            let island = &self.islands[index];
+            let mut needed_left = island.left;
+            let mut needed_right = island.right;
+            for &key in &island.keys {
+                if let KeyState::Seen(range) = self.keys[key] {
+                    let (left, right) = margin_span(range, self.margin, self.bounds);
+                    needed_left = needed_left.min(left);
+                    needed_right = needed_right.max(right);
+                }
+            }
+            if needed_left < island.left {
+                return Some(Pending::IslandGrow {
+                    island: index,
+                    left: needed_left,
+                    right: island.left,
+                });
+            }
+            if needed_right > island.right {
+                return Some(Pending::IslandGrow {
+                    island: index,
+                    left: island.right,
+                    right: needed_right,
+                });
+            }
+            let keys = std::mem::take(&mut self.islands[index].keys);
+            for key in keys {
+                if let KeyState::Seen(range) = self.keys[key] {
+                    self.keys[key] = KeyState::Complete {
+                        range,
+                        partial: false,
+                    };
+                }
+            }
+        }
+        None
+    }
+
+    fn next_main_window(&mut self) -> Option<Pending> {
+        // Jump over spans probes or island growth already covered.
+        loop {
+            let mut jumped = false;
+            for island in &self.islands {
+                if island.left <= self.cursor && self.cursor <= island.right {
+                    self.cursor = island.left;
+                    jumped = true;
+                }
+            }
+            if !jumped {
+                break;
+            }
+        }
+        if self.cursor <= self.bounds.scan_start {
+            return None;
+        }
+        let batch = locate_batch_size(self.batch_index);
+        self.batch_index += 1;
+        let left = self
+            .cursor
+            .saturating_sub(batch)
+            .max(self.bounds.scan_start);
+        Some(Pending::Main { left })
+    }
+
+    /// After a main window: a seen key completes once the contiguous covered
+    /// region `[cursor, scan_end]` extends one margin past both of its ends
+    /// (clamps count as covered).
+    fn complete_main_keys(&mut self) {
+        for state in &mut self.keys {
+            if let KeyState::Seen(range) = *state {
+                let (needed_left, needed_right) = margin_span(range, self.margin, self.bounds);
+                if self.cursor <= needed_left && self.bounds.scan_end >= needed_right {
+                    *state = KeyState::Complete {
+                        range,
+                        partial: false,
+                    };
+                }
+            }
+        }
+    }
+
+    /// The main scan covered the whole `[scan_start, scan_end]`: unseen keys
+    /// are proven absent; seen keys whose margins fall outside the caller
+    /// bounds grow past them through a boundary island.
+    fn finish_main(&mut self) {
+        self.main_done = true;
+        let mut boundary_keys = Vec::new();
+        for (index, state) in self.keys.iter_mut().enumerate() {
+            match *state {
+                KeyState::Unseen => *state = KeyState::Absent,
+                KeyState::Seen(_) => boundary_keys.push(index),
+                _ => {}
+            }
+        }
+        if !boundary_keys.is_empty() {
+            self.islands.push(Island {
+                left: self.bounds.scan_start,
+                right: self.bounds.scan_end,
+                keys: boundary_keys,
+            });
+        }
+    }
+}
+
+/// A range's completion margins: one expand window past each end, clamped to
+/// the hard bounds (a clamp counts as covered).
+pub(super) fn margin_span(range: TraceTimeRange, margin: i64, bounds: ScanBounds) -> (i64, i64) {
+    (
+        range
+            .start_time
+            .saturating_sub(margin)
+            .max(bounds.hard_start),
+        range.end_time.saturating_add(margin).min(bounds.hard_end),
+    )
+}
+
+/// The session-causality floor: spans cannot precede their session's UUID v7
+/// creation time, so the hard bound can rise to one expand window below the
+/// earliest key. Only sound when every key carries a timestamp.
+pub(super) fn session_uuid_floor(kind: TimeIndexKind, key_uuid_ts: &[Option<i64>]) -> Option<i64> {
+    if kind != TimeIndexKind::Session || key_uuid_ts.is_empty() {
+        return None;
+    }
+    let mut earliest = i64::MAX;
+    for ts in key_uuid_ts {
+        earliest = earliest.min((*ts)?);
+    }
+    Some(earliest.saturating_sub(kind.expand_window()))
+}
+
+fn locate_batch_size(index: usize) -> i64 {
+    super::locate_batch_sizes().nth(index).unwrap_or(i64::MAX)
+}
+
+fn merge_and_clamp(mut spans: Vec<(i64, i64)>, min: i64, max: i64) -> Vec<(i64, i64)> {
+    spans.sort_unstable();
+    let mut merged: Vec<(i64, i64)> = Vec::with_capacity(spans.len());
+    for (left, right) in spans {
+        let (left, right) = (left.max(min), right.min(max));
+        if left >= right {
+            continue;
+        }
+        match merged.last_mut() {
+            Some(last) if left <= last.1 => last.1 = last.1.max(right),
+            _ => merged.push((left, right)),
+        }
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::{EXPAND_WINDOW, SESSION_EXPAND_WINDOW},
+        *,
+    };
+
+    const W: i64 = EXPAND_WINDOW;
+
+    fn bounds(scan_start: i64, scan_end: i64) -> ScanBounds {
+        ScanBounds {
+            scan_start,
+            scan_end,
+            hard_start: scan_start,
+            hard_end: scan_end,
+        }
+    }
+
+    fn range(start: i64, end: i64) -> TraceTimeRange {
+        TraceTimeRange {
+            start_time: start,
+            end_time: end,
+        }
+    }
+
+    /// Drives the scanner against a synthetic dataset of per-key spans and
+    /// records the windows it queried.
+    fn drive(scanner: &mut BatchScanner, data: &[(usize, TraceTimeRange)]) -> Vec<(i64, i64)> {
+        let mut windows = Vec::new();
+        while let Some((start, end)) = scanner.next_window() {
+            windows.push((start, end));
+            let rows = data
+                .iter()
+                .filter(|(_, r)| r.start_time <= end && r.end_time >= start)
+                .map(|&(k, r)| (k, r))
+                .collect();
+            scanner.ingest(rows);
+        }
+        windows
+    }
+
+    #[test]
+    fn single_key_completes_after_margin_is_covered() {
+        let mut scanner =
+            BatchScanner::new(TimeIndexKind::Trace, 1, bounds(0, W * 40), None, &[None]);
+        let data = [(0usize, range(W * 30, W * 30 + 100))];
+        drive(&mut scanner, &data);
+        let outcomes = scanner.finish();
+        assert_eq!(
+            outcomes[0],
+            Some(ScanOutcome::Found {
+                range: data[0].1,
+                partial: false,
+            })
+        );
+    }
+
+    #[test]
+    fn scan_continues_past_the_first_find_until_every_key_is_answered() {
+        // k0 recent, k1 much older: the merged-range mistake would stop at
+        // the miss gap after k0 and never reach k1.
+        let mut scanner = BatchScanner::new(
+            TimeIndexKind::Trace,
+            2,
+            bounds(0, W * 40),
+            None,
+            &[None, None],
+        );
+        let data = [
+            (0usize, range(W * 38, W * 38 + 10)),
+            (1usize, range(W * 5, W * 5 + 10)),
+        ];
+        drive(&mut scanner, &data);
+        let outcomes = scanner.finish();
+        assert_eq!(
+            outcomes[0],
+            Some(ScanOutcome::Found {
+                range: data[0].1,
+                partial: false,
+            })
+        );
+        assert_eq!(
+            outcomes[1],
+            Some(ScanOutcome::Found {
+                range: data[1].1,
+                partial: false,
+            })
+        );
+    }
+
+    #[test]
+    fn unseen_keys_are_proven_absent_only_after_full_coverage() {
+        let mut scanner = BatchScanner::new(
+            TimeIndexKind::Trace,
+            2,
+            bounds(0, W * 40),
+            None,
+            &[None, None],
+        );
+        let data = [(0usize, range(W * 20, W * 20 + 10))];
+        drive(&mut scanner, &data);
+        let outcomes = scanner.finish();
+        assert!(matches!(outcomes[0], Some(ScanOutcome::Found { .. })));
+        assert_eq!(outcomes[1], Some(ScanOutcome::NotFound));
+    }
+
+    #[test]
+    fn timeout_reports_seen_keys_partial_and_unseen_indeterminate() {
+        let mut scanner = BatchScanner::new(
+            TimeIndexKind::Trace,
+            2,
+            bounds(0, W * 400),
+            None,
+            &[None, None],
+        );
+        let data = [(0usize, range(W * 399, W * 399 + 10))];
+        // One window, then the driver hits the deadline.
+        let (start, end) = scanner.next_window().unwrap();
+        let rows = data
+            .iter()
+            .filter(|(_, r)| r.start_time <= end && r.end_time >= start)
+            .map(|&(k, r)| (k, r))
+            .collect();
+        scanner.ingest(rows);
+        let outcomes = scanner.finish();
+        assert_eq!(
+            outcomes[0],
+            Some(ScanOutcome::Found {
+                range: data[0].1,
+                partial: true,
+            })
+        );
+        assert_eq!(outcomes[1], Some(ScanOutcome::Timeout));
+    }
+
+    #[test]
+    fn hint_probe_resolves_clustered_keys_in_few_windows() {
+        let hint = W * 20;
+        let mut scanner = BatchScanner::new(
+            TimeIndexKind::Trace,
+            2,
+            bounds(0, W * 40),
+            Some(hint),
+            &[None, None],
+        );
+        let data = [
+            (0usize, range(hint - 50, hint + 50)),
+            (1usize, range(hint + 100, hint + 200)),
+        ];
+        let windows = drive(&mut scanner, &data);
+        let outcomes = scanner.finish();
+        assert!(matches!(
+            outcomes[0],
+            Some(ScanOutcome::Found { partial: false, .. })
+        ));
+        assert!(matches!(
+            outcomes[1],
+            Some(ScanOutcome::Found { partial: false, .. })
+        ));
+        // probe + margin growth, then the main scan skips the covered island:
+        // far fewer windows than two full backward scans.
+        assert!(
+            windows.len() <= 8,
+            "expected a handful of windows, got {windows:?}"
+        );
+    }
+
+    #[test]
+    fn uuid_cluster_probe_is_dropped_when_too_wide() {
+        let uuid_ts = [Some(W), Some(W * 30)];
+        let scanner = BatchScanner::new(TimeIndexKind::Trace, 2, bounds(0, W * 40), None, &uuid_ts);
+        assert!(scanner.probes.is_empty());
+
+        let clustered = [Some(W * 20), Some(W * 21)];
+        let scanner =
+            BatchScanner::new(TimeIndexKind::Trace, 2, bounds(0, W * 40), None, &clustered);
+        assert_eq!(scanner.probes.len(), 1);
+    }
+
+    #[test]
+    fn boundary_key_grows_past_the_caller_bounds() {
+        // Caller bound clips the scan to [10W, 12W] inside hard [0, 40W];
+        // the key's data continues below the bound.
+        let scan_bounds = ScanBounds {
+            scan_start: W * 10,
+            scan_end: W * 12,
+            hard_start: 0,
+            hard_end: W * 40,
+        };
+        let mut scanner = BatchScanner::new(TimeIndexKind::Trace, 1, scan_bounds, None, &[None]);
+        let data = [(0usize, range(W * 9, W * 11))];
+        drive(&mut scanner, &data);
+        let outcomes = scanner.finish();
+        // The full range, including the part outside the caller bound.
+        assert_eq!(
+            outcomes[0],
+            Some(ScanOutcome::Found {
+                range: data[0].1,
+                partial: false,
+            })
+        );
+    }
+
+    #[test]
+    fn skipped_keys_leave_the_in_list_and_yield_no_outcome() {
+        let mut scanner = BatchScanner::new(
+            TimeIndexKind::Trace,
+            2,
+            bounds(0, W * 4),
+            None,
+            &[None, None],
+        );
+        scanner.skip_key(1);
+        assert_eq!(scanner.active_keys(), vec![0]);
+        let data = [(0usize, range(W * 2, W * 2 + 10))];
+        drive(&mut scanner, &data);
+        let outcomes = scanner.finish();
+        assert!(matches!(outcomes[0], Some(ScanOutcome::Found { .. })));
+        assert_eq!(outcomes[1], None);
+    }
+
+    #[test]
+    fn probe_spans_merge_and_clamp() {
+        let merged = merge_and_clamp(vec![(5, 10), (8, 20), (30, 40), (-5, 2)], 0, 35);
+        assert_eq!(merged, vec![(0, 2), (5, 20), (30, 35)]);
+    }
+
+    #[test]
+    fn session_floor_requires_every_key_to_carry_a_timestamp() {
+        let full = [
+            Some(SESSION_EXPAND_WINDOW * 10),
+            Some(SESSION_EXPAND_WINDOW * 12),
+        ];
+        assert_eq!(
+            session_uuid_floor(TimeIndexKind::Session, &full),
+            Some(SESSION_EXPAND_WINDOW * 9)
+        );
+        let partial = [Some(SESSION_EXPAND_WINDOW * 10), None];
+        assert_eq!(session_uuid_floor(TimeIndexKind::Session, &partial), None);
+        assert_eq!(session_uuid_floor(TimeIndexKind::Trace, &full), None);
+        assert_eq!(session_uuid_floor(TimeIndexKind::Session, &[]), None);
+    }
+
+    #[test]
+    fn window_backstop_ends_as_indeterminate_not_proof() {
+        let mut scanner =
+            BatchScanner::new(TimeIndexKind::Trace, 1, bounds(0, W * 40), None, &[None]);
+        scanner.windows_emitted = MAX_WINDOWS;
+        assert!(scanner.next_window().is_none());
+        let outcomes = scanner.finish();
+        assert_eq!(outcomes[0], Some(ScanOutcome::Timeout));
+    }
+}

--- a/src/api/search/src/traces/time_index/scan.rs
+++ b/src/api/search/src/traces/time_index/scan.rs
@@ -189,6 +189,11 @@ impl BatchScanner {
             if let Some(pending) = self.next_island_window() {
                 break pending;
             }
+            // Island completions may have just retired the last active key;
+            // don't emit a phantom main window for nobody.
+            if !self.has_active_keys() {
+                return None;
+            }
             if self.main_done {
                 return None;
             }
@@ -700,6 +705,31 @@ mod tests {
     fn probe_spans_merge_and_clamp() {
         let merged = merge_and_clamp(vec![(5, 10), (8, 20), (30, 40), (-5, 2)], 0, 35);
         assert_eq!(merged, vec![(0, 2), (5, 20), (30, 35)]);
+    }
+
+    #[test]
+    fn exact_hint_hit_costs_exactly_one_window() {
+        let hint = W * 20;
+        let mut scanner = BatchScanner::new(
+            TimeIndexKind::Trace,
+            2,
+            bounds(0, W * 40),
+            Some(hint),
+            &[None, None],
+        );
+        let data = [(0usize, range(hint, hint)), (1usize, range(hint, hint))];
+        let windows = drive(&mut scanner, &data);
+        assert_eq!(
+            windows.len(),
+            1,
+            "a full hint hit must not emit a phantom main window: {windows:?}"
+        );
+        let outcomes = scanner.finish();
+        assert!(
+            outcomes
+                .iter()
+                .all(|o| matches!(o, Some(ScanOutcome::Found { partial: false, .. })))
+        );
     }
 
     #[test]

--- a/src/api/search/src/traces/time_index/scan.rs
+++ b/src/api/search/src/traces/time_index/scan.rs
@@ -357,12 +357,14 @@ impl BatchScanner {
     }
 
     /// Jump the cursor over spans probes or island growth already covered —
-    /// a pure state transition, no queries involved.
+    /// a pure state transition, no queries involved. The strict left-edge
+    /// comparison makes every jump lower the cursor, so the loop terminates;
+    /// a cursor already at an island's left edge has nothing to gain.
     fn jump_covered_islands(&mut self) {
         loop {
             let mut jumped = false;
             for island in &self.islands {
-                if island.left <= self.cursor && self.cursor <= island.right {
+                if island.left < self.cursor && self.cursor <= island.right {
                     self.cursor = island.left;
                     jumped = true;
                 }
@@ -698,6 +700,29 @@ mod tests {
     fn probe_spans_merge_and_clamp() {
         let merged = merge_and_clamp(vec![(5, 10), (8, 20), (30, 40), (-5, 2)], 0, 35);
         assert_eq!(merged, vec![(0, 2), (5, 20), (30, 35)]);
+    }
+
+    #[test]
+    fn missed_hint_island_does_not_trap_the_main_scan() {
+        // A wrong hint leaves a keyless covered island; the main scan must
+        // jump over it (and not spin at its left edge) and still answer both
+        // keys from the region below.
+        let hint = W * 30;
+        let mut scanner = BatchScanner::new(
+            TimeIndexKind::Trace,
+            2,
+            bounds(0, W * 40),
+            Some(hint),
+            &[None, None],
+        );
+        let data = [(0usize, range(W * 5, W * 5 + 10))];
+        drive(&mut scanner, &data);
+        let outcomes = scanner.finish();
+        assert!(matches!(
+            outcomes[0],
+            Some(ScanOutcome::Found { partial: false, .. })
+        ));
+        assert_eq!(outcomes[1], Some(ScanOutcome::NotFound));
     }
 
     #[test]

--- a/src/config/src/meta/traces.rs
+++ b/src/config/src/meta/traces.rs
@@ -125,13 +125,17 @@ pub mod session {
         trace_ids
     }
 
-    pub fn trace_id_predicate(trace_ids: &[String]) -> String {
-        let values = trace_ids
-            .iter()
-            .map(|trace_id| quote_sql_string(trace_id))
+    pub fn key_in_predicate<'a>(column: &str, values: impl IntoIterator<Item = &'a str>) -> String {
+        let values = values
+            .into_iter()
+            .map(quote_sql_string)
             .collect::<Vec<_>>()
             .join(", ");
-        format!("{} IN ({values})", quote_identifier("trace_id"))
+        format!("{} IN ({values})", quote_identifier(column))
+    }
+
+    pub fn trace_id_predicate(trace_ids: &[String]) -> String {
+        key_in_predicate("trace_id", trace_ids.iter().map(String::as_str))
     }
 
     pub fn span_rows_sql(


### PR DESCRIPTION
Design: https://github.com/openobserve/designs/blob/main/infrastructure/file-list/trace-time-range-multi-lookup.md (the "Batched scan (phase 2)" section)

Follow-up to #13992. No API changes — same routes, parameters, and response contract; this changes how the fan-out resolves a batch.

## Summary

- replace the per-(key × stream) locate/expand fan-out with **one shared backward scan per stream** over all unresolved keys: every window queries the active keys in a single `IN` list (sessions group by `session_id`), rows merge into per-key ranges, and keys leave the list when complete, proven absent, or seen by another stream's scan (the one-id-one-stream contract)
- `hint_ts` and the UUIDv7 cluster are probed first as **islands** that grow until they cover each caught key's completion margins — a batched expand shared by all keys the probe caught; the main exponential backward scan jumps over covered island spans
- each key **completes individually** once the contiguous covered region extends one expand window past its ends; expanding a merged range instead would stop at the miss gap between two distant keys and never find the older one (the design doc covers why)
- verdicts derive from scanner state: complete → `found`; seen but interrupted → `found` + `partial`; unseen after full coverage → `not_found`; unseen otherwise → `timeout` — the same contract #13992 shipped
- the scanner is a **pure state machine** (`time_index/scan.rs`) driven by an async executor, so probe/island/boundary/timeout/completion logic is unit-tested without a store
- the session-UUID causality floor now flows through a shared `resolve_scan_bounds` used by both the batch path and the single-key wrappers, so absence proofs for UUIDv7 session ids stay bounded to the session's lifetime neighborhood
- `key_in_predicate` generalizes the existing `trace_id_predicate` IN-builder (inheriting its SQL-escaping test) for the batch window SQL

The single-key `query()`/`query_session()` wrappers used by the details/session APIs keep the original per-key timer — they also need the per-trace map the batch path deliberately drops.

## Cost

Proving absence over a year of coverage now costs ~8–10 window queries **per stream, independent of id count**, instead of per (id × stream); a good hint or caller bound resolves a whole batch in ~1–2 windows per stream. Batch-scan window counts are observable via `trace_time_index_query_rounds{phase="batch_scan"}`.

Deferred follow-ups (noted in the design doc): speculative prefetch of main-scan windows (the sequence is result-independent, so 2–4 could run concurrently), and wider rounds-histogram buckets for the batch phase.

## Validation

- `cargo test -p openobserve-api-search --lib` — 169 passed, including 15 scanner state-machine tests (multi-key staggered depths, hint islands, caller-bound boundary growth, cross-stream skip, timeout/backstop verdicts, session floor, deadline-boundary settling, island-jump progress, exact hint-hit window count)
- `cargo test -p config --lib meta::traces` — 5 passed
- `cargo test -p openobserve-api-http --lib` — 55 passed
- `cargo fmt --all` and the CI clippy command over the workspace — clean
- enterprise compile verified by swapping in the enterprise `Cargo.toml.openobserve` — clean; no route or permission changes, so no paired PR
