### PR TITLE
fix: vortex Utf8-typed string statistics broke Utf8View interval analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -371,7 +371,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1754,7 +1754,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2514,7 +2514,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -4248,7 +4248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4596,7 +4596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5975,7 +5975,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5989,15 +5989,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -7105,7 +7096,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9275,7 +9266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -9296,7 +9287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9309,7 +9300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9710,7 +9701,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10667,7 +10658,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10726,7 +10717,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11670,7 +11661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11992,7 +11983,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12497,7 +12488,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12517,7 +12508,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13523,7 +13514,7 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -13559,7 +13550,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -13577,7 +13568,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "arc-swap",
  "arcref",
@@ -13624,7 +13615,7 @@ dependencies = [
 [[package]]
 name = "vortex-array-macros"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13634,7 +13625,7 @@ dependencies = [
 [[package]]
 name = "vortex-arrow"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -13656,7 +13647,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "itertools 0.14.0",
  "pco",
@@ -13682,7 +13673,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "arrow-buffer",
  "bitvec",
@@ -13695,7 +13686,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "num-traits",
  "vortex-array",
@@ -13707,7 +13698,7 @@ dependencies = [
 [[package]]
 name = "vortex-compressor"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -13725,7 +13716,7 @@ dependencies = [
 [[package]]
 name = "vortex-compute"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "vortex-buffer",
 ]
@@ -13733,7 +13724,7 @@ dependencies = [
 [[package]]
 name = "vortex-datafusion"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -13765,7 +13756,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "num-traits",
  "prost 0.14.4",
@@ -13779,7 +13770,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "num-traits",
  "prost 0.14.4",
@@ -13793,7 +13784,7 @@ dependencies = [
 [[package]]
 name = "vortex-edition"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "parking_lot 0.12.5",
  "vortex-session",
@@ -13802,7 +13793,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -13815,7 +13806,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "fastlanes",
  "itertools 0.14.0",
@@ -13832,7 +13823,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -13878,7 +13869,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -13888,7 +13879,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "fsst-rs",
  "num-traits",
@@ -13903,7 +13894,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "async-fs",
  "async-stream",
@@ -13932,7 +13923,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -13949,7 +13940,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "arcref",
  "arrow-array",
@@ -13992,7 +13983,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -14002,7 +13993,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "parking_lot 0.12.5",
  "sketches-ddsketch",
@@ -14011,7 +14002,7 @@ dependencies = [
 [[package]]
 name = "vortex-onpair"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "num-traits",
  "onpair",
@@ -14026,7 +14017,7 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "pco",
  "prost 0.14.4",
@@ -14040,7 +14031,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "prost 0.14.4",
  "prost-types 0.14.4",
@@ -14049,7 +14040,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -14064,7 +14055,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "async-trait",
  "futures",
@@ -14080,7 +14071,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "num-traits",
  "prost 0.14.4",
@@ -14096,7 +14087,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "arc-swap",
  "lasso",
@@ -14108,7 +14099,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -14123,7 +14114,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "dashmap",
  "hashbrown 0.17.1",
@@ -14132,7 +14123,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "vortex-array",
  "vortex-buffer",
@@ -14145,7 +14136,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vortex?rev=1cb48912c14d9c7bd29832d9aff5666d730e1f0e#1cb48912c14d9c7bd29832d9aff5666d730e1f0e"
+source = "git+https://github.com/openobserve/vortex?rev=3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c#3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.4",
@@ -14566,7 +14557,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -359,11 +359,11 @@ o2_dex = { path = "src/enterprise/o2_dex" }
 o2_enterprise = { path = "src/enterprise/o2_enterprise", default-features = false }
 o2_openfga = { path = "src/enterprise/o2_openfga" }
 o2_ratelimit = { path = "src/enterprise/o2_ratelimit" }
-vortex = { git = "https://github.com/openobserve/vortex", rev = "1cb48912c14d9c7bd29832d9aff5666d730e1f0e", features = [
+vortex = { git = "https://github.com/openobserve/vortex", rev = "3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c", features = [
     "tokio",
 ] }
-vortex-btrblocks = { git = "https://github.com/openobserve/vortex", rev = "1cb48912c14d9c7bd29832d9aff5666d730e1f0e" }
-vortex-datafusion = { git = "https://github.com/openobserve/vortex", rev = "1cb48912c14d9c7bd29832d9aff5666d730e1f0e" }
+vortex-btrblocks = { git = "https://github.com/openobserve/vortex", rev = "3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c" }
+vortex-datafusion = { git = "https://github.com/openobserve/vortex", rev = "3c77193fa8fb90d055f95d8a3e1f6748a4d15f8c" }
 aes-siv = "0.7.0"
 ahash = { version = "0.8", features = ["serde"] }
 axum = { version = "0.8", features = ["macros", "multipart", "tracing"] }

--- a/src/search/src/datafusion/table_provider/listing_adapter.rs
+++ b/src/search/src/datafusion/table_provider/listing_adapter.rs
@@ -480,4 +480,98 @@ mod tests {
         expected.sort();
         assert_eq!(rows, expected);
     }
+
+    // Utf8-typed vortex min with max dropped used to panic FilterExec interval analysis on a
+    // Utf8View schema
+    #[tokio::test]
+    async fn test_vortex_utf8view_stats_plan_and_scan() {
+        use arrow::array::StringArray;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let batch1 = RecordBatch::try_new(
+            file_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1i64, 2, 3])),
+                Arc::new(StringArray::from(vec![Some("a"), Some("b"), Some("c")])),
+            ],
+        )
+        .unwrap();
+        // chunk with the string column entirely null: file-level Max is skipped
+        let batch2 = RecordBatch::try_new(
+            file_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![4i64, 5, 6])),
+                Arc::new(StringArray::from(vec![None::<&str>, None, None])),
+            ],
+        )
+        .unwrap();
+
+        let session = VortexSession::default().with_tokio();
+        let mut buf = Vec::new();
+        let mut writer = VortexWriteOptions::new(session.clone())
+            .writer(&mut buf, DType::from_arrow(file_schema.as_ref()));
+        writer
+            .push(ArrayRef::from_arrow(batch1, false).unwrap())
+            .await
+            .unwrap();
+        writer
+            .push(ArrayRef::from_arrow(batch2, false).unwrap())
+            .await
+            .unwrap();
+        writer.finish().await.unwrap();
+        std::fs::write(dir.path().join("a.vortex"), buf).unwrap();
+
+        // table schema the way finalize_schemas produces it: Utf8 -> Utf8View
+        let table_schema = Arc::new(Schema::new(vec![
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new("name", DataType::Utf8View, true),
+        ]));
+
+        let ctx = DataFusionContextBuilder::new()
+            .trace_id("test_vortex_utf8view_stats")
+            .build(2)
+            .await
+            .unwrap();
+        let format: Arc<dyn DataFusionFileFormat> =
+            Arc::new(VortexFormat::new(VortexSession::default().with_tokio()));
+        let listing_options = ListingOptions::new(format)
+            .with_target_partitions(2)
+            .with_collect_stat(true);
+        let url = ListingTableUrl::parse(format!("file://{}/", dir.path().display())).unwrap();
+        let config = ListingTableConfig::new(url)
+            .with_listing_options(listing_options)
+            .with_schema(table_schema);
+        let table = ListingTableAdapter::try_new(
+            config,
+            "test_vortex_utf8view_stats".to_string(),
+            FileSortOrder::None,
+            None,
+            vec![],
+            None,
+        )
+        .unwrap();
+        ctx.register_table("t", Arc::new(table)).unwrap();
+
+        let plan = ctx
+            .state()
+            .create_logical_plan(
+                "SELECT count(name) FROM t WHERE _timestamp >= 1 AND _timestamp < 100",
+            )
+            .await
+            .unwrap();
+        let physical_plan = ctx.state().create_physical_plan(&plan).await.unwrap();
+        let batches = collect(physical_plan, ctx.task_ctx()).await.unwrap();
+        let counts = batches
+            .iter()
+            .flat_map(|b| {
+                let col = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+                (0..b.num_rows()).map(|i| col.value(i)).collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(counts, vec![3]);
+    }
 }


### PR DESCRIPTION
## Problem

Queries over vortex files failed at physical-plan time with:

```
Internal error: Assertion failed: lower.data_type() == upper.data_type() (left: Utf8, right: Utf8View): Endpoints of an Interval should have the same type.
```

Root cause chain (all upstream vortex behavior, verified via blame):

1. vortex-datafusion maps string fields to `Utf8View` in the table schema, but its statistics conversion produces `ScalarValue::Utf8` min/max — vortex `DType` has no view types, so the arrow view-ness is lost on the round trip.
2. When any chunk of a file has an all-null string column, vortex drops the file-level `max` statistic entirely (skipping nulls when aggregating an upper bound is unsound) while `min` survives.
3. DataFusion's `FilterExec` computes statistics eagerly at construction; `ExprBoundaries::try_from_column` fills the missing endpoint with a schema-typed (`Utf8View`) null next to the `Utf8`-typed min, and `Interval::try_new` asserts.

Any filtered query over such a vortex file fails, regardless of whether the string column is referenced — an all-null chunk in fields like `k8s_container_name` is enough.

## Fix

Bump the vortex fork to openobserve/vortex@3c77193 (branch `fix/utf8view-file-stats`), which casts statistics scalars to the arrow schema field type in `scalar_stat_to_df` / `stats_set_to_df`.

## Test

New regression test `test_vortex_utf8view_stats_plan_and_scan`: writes a vortex file with an all-null string chunk, registers it behind a `Utf8View` schema, and verifies both physical planning and execution. Reproduces the assertion verbatim on the old rev; passes on the new one.

Pairs with the same-named branch in o2-enterprise (vortex rev bump in `Cargo.toml.openobserve`).