### PR TITLE
fix: Fix/logs editor sql parse hang

### DIFF
--- a/web/src/components/alerts/QueryEditorDialog.vue
+++ b/web/src/components/alerts/QueryEditorDialog.vue
@@ -657,13 +657,13 @@ onMounted(async () => {
 });
 
 // Get parser function to validate SQL queries (checks for SELECT * and reserved words)
-const getParser = (sqlQuery: string) => {
+const getParser = async (sqlQuery: string) => {
   const sqlUtilsContext: SqlUtilsContext = {
     parser: parser.value,
     sqlQueryErrorMsg: localSqlQueryErrorMsg,
     t,
   };
-  return getParserUtil(sqlQuery, sqlUtilsContext);
+  return await getParserUtil(sqlQuery, sqlUtilsContext);
 };
 
 // Dialog state
@@ -988,7 +988,7 @@ const runSqlQuery = async () => {
   queryHitCount.value = 0;
 
   // Validate SQL query before running (checks for SELECT * and reserved words)
-  const parserResult = getParser(localSqlQuery.value);
+  const parserResult = await getParser(localSqlQuery.value);
 
   if (!parserResult) {
     // Parser validation failed - don't run the query

--- a/web/src/components/functions/TestFunction.vue
+++ b/web/src/components/functions/TestFunction.vue
@@ -278,6 +278,7 @@ import { useQueryPlaceholder } from "@/components/logs/useQueryPlaceholder";
 import { debounce } from "lodash-es";
 import useQuery from "@/composables/useQuery";
 import { rangesFromServerError, type SqlErrorRange } from "@/utils/query/sqlDiagnostics";
+import { astifyOffThread } from "@/utils/query/sqlAstifyWorkerClient";
 import searchService from "@/services/search";
 import { useStore } from "vuex";
 import { getConsumableRelativeTime } from "@/utils/date";
@@ -555,8 +556,8 @@ watch(inputQuery, (value) => {
 const debouncedSyncStreamFromQuery = debounce(async (sql: string) => {
   if (!sql || !parser) return;
   try {
-    const parsed = parser.parse(sql);
-    const fromStream = parsed?.ast?.from?.[0]?.table as string | undefined;
+    const parsed: any = await astifyOffThread(sql);
+    const fromStream = parsed?.from?.[0]?.table as string | undefined;
     if (fromStream && fromStream !== selectedStream.value.name) {
       selectedStream.value.name = fromStream;
     }

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -1002,6 +1002,7 @@ import { debounce } from "lodash-es";
 import useSqlSuggestions from "@/composables/useSuggestions";
 import { useSqlEditorDiagnostics } from "@/composables/useSqlEditorDiagnostics";
 import { type SqlErrorRange } from "@/utils/query/sqlDiagnostics";
+import { astifyOffThread } from "@/utils/query/sqlAstifyWorkerClient";
 import { createPipelinesContextProvider } from "@/composables/contextProviders/pipelinesContextProvider";
 import { contextRegistry } from "@/composables/contextProviders";
 import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
@@ -1756,8 +1757,8 @@ const updateQueryValue = (value: string) => {
 const debouncedSyncStreamFromQuery = debounce(async (sql: string) => {
   if (!sql || !parser) return;
   try {
-    const parsed = parser.parse(sql);
-    const fromStream = parsed?.ast?.from?.[0]?.table as string | undefined;
+    const parsed: any = await astifyOffThread(sql);
+    const fromStream = parsed?.from?.[0]?.table as string | undefined;
     if (fromStream && fromStream !== selectedStreamName.value) {
       isSyncingStreamFromQuery.value = true;
       form.setFieldValue("stream_name", fromStream, { dontUpdateMeta: true });

--- a/web/src/composables/dashboard/useDashboardPanel.ts
+++ b/web/src/composables/dashboard/useDashboardPanel.ts
@@ -19,6 +19,7 @@ import { useStore } from "vuex";
 import useNotifications from "../useNotifications";
 import { b64EncodeUnicode, isStreamingEnabled } from "@/utils/zincutils";
 import { extractFields, getStreamNameFromQuery } from "@/utils/query/sqlUtils";
+import { astifyOffThread } from "@/utils/query/sqlAstifyWorkerClient";
 import { validatePanel } from "@/utils/dashboard/panelValidation";
 import { CUSTOM_QUERY_CHART_TYPES } from "@/utils/dashboard/constants";
 import useStreams from "../useStreams";
@@ -955,7 +956,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard", t: TranslateFn) =>
     await ensureParser();
 
     // do not allow to modify custom query fields for logs page
-    updateQueryValue(pageKey == "logs" ? true : false);
+    await updateQueryValue(pageKey == "logs" ? true : false);
   };
 
   // based on chart type it will create auto sql query
@@ -1013,7 +1014,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard", t: TranslateFn) =>
     );
   };
 
-  const validateQuery = (query: any, variables: any) => {
+  const validateQuery = async (query: any, variables: any) => {
     // Helper to test one replacement (string or number)
     const testReplacement = (q: any, varName: any, replacement: any) => {
       const regex = new RegExp(`\\$(?:{${varName}}|${varName})(?!\\w)`, "g");
@@ -1021,11 +1022,11 @@ const useDashboardPanelData = (pageKey: string = "dashboard", t: TranslateFn) =>
     };
 
     // Recursive validation function
-    const validateRecursive: any = (currentQuery: any, remainingVars: any) => {
+    const validateRecursive: any = async (currentQuery: any, remainingVars: any) => {
       if (!remainingVars.length) {
         try {
           // Try parsing the current query
-          parser.astify(currentQuery);
+          await astifyOffThread(currentQuery);
           return currentQuery; // Return valid query
         } catch (error) {
           return null; // Invalid query
@@ -1037,19 +1038,19 @@ const useDashboardPanelData = (pageKey: string = "dashboard", t: TranslateFn) =>
 
       // Try as string
       const stringQuery = testReplacement(currentQuery, varName, "VARIABLE_PLACEHOLDER");
-      const resultAsString: any = validateRecursive(stringQuery, restVars);
+      const resultAsString: any = await validateRecursive(stringQuery, restVars);
       if (resultAsString) return resultAsString; // Found valid query
 
       // Try as number
       const numericQuery = testReplacement(currentQuery, varName, "10");
-      const resultAsNumber = validateRecursive(numericQuery, restVars);
+      const resultAsNumber = await validateRecursive(numericQuery, restVars);
       if (resultAsNumber) return resultAsNumber; // Found valid query
 
       // If neither works, return null
       throw new Error("Invalid query");
     };
 
-    return validateRecursive(query, variables);
+    return await validateRecursive(query, variables);
   };
 
   // Extract variables from the query (supports $var, ${var}, and {{var}} syntax, with optional spaces)
@@ -1113,10 +1114,10 @@ const useDashboardPanelData = (pageKey: string = "dashboard", t: TranslateFn) =>
         );
 
         const variables = extractVariables(currentQuery); // Extract all unique variables
-        const validatedQuery = validateQuery(currentQuery, variables);
+        const validatedQuery = await validateQuery(currentQuery, variables);
 
         if (validatedQuery) {
-          dashboardPanelData.meta.parsedQuery = parser.astify(validatedQuery);
+          dashboardPanelData.meta.parsedQuery = await astifyOffThread(validatedQuery);
         } else {
           dashboardPanelData.meta.parsedQuery = null;
         }

--- a/web/src/composables/useAlertForm.ts
+++ b/web/src/composables/useAlertForm.ts
@@ -58,6 +58,7 @@ import {
   type JsonValidationContext,
 } from "@/utils/alerts/alertValidation";
 import { type SqlErrorRange } from "@/utils/query/sqlDiagnostics";
+import { astifyOffThread } from "@/utils/query/sqlAstifyWorkerClient";
 import {
   getAlertPayload as getAlertPayloadUtil,
   prepareAndSaveAlert as prepareAndSaveAlertUtil,
@@ -681,13 +682,13 @@ export function useAlertForm(props: AlertFormProps, emit: AlertFormEmit) {
     parser = await sqlParser();
   };
 
-  const getParser = (sqlQuery: string) => {
+  const getParser = async (sqlQuery: string) => {
     const sqlUtilsContext: SqlUtilsContext = {
       parser,
       sqlQueryErrorMsg,
       t,
     };
-    return getParserUtil(sqlQuery, sqlUtilsContext);
+    return await getParserUtil(sqlQuery, sqlUtilsContext);
   };
 
   // ── Stream Methods ──────────────────────────────────────────────────────
@@ -768,8 +769,8 @@ export function useAlertForm(props: AlertFormProps, emit: AlertFormEmit) {
   const debouncedSyncStreamFromSql = debounce(async (sql: string) => {
     if (!sql || !parser || isSyncingStreamFromSql.value) return;
     try {
-      const parsed = parser.parse(sql);
-      const fromStream = parsed?.ast?.from?.[0]?.table as string | undefined;
+      const parsed: any = await astifyOffThread(sql);
+      const fromStream = parsed?.from?.[0]?.table as string | undefined;
       if (fromStream && fromStream !== formData.value.stream_name) {
         isSyncingStreamFromSql.value = true;
         setF("stream_name", fromStream);
@@ -1617,7 +1618,7 @@ export function useAlertForm(props: AlertFormProps, emit: AlertFormEmit) {
           { column: string; operator: string; value: number } | undefined;
         if (sql && sqlHaving?.column) {
           if (!parser) await importSqlParser();
-          sql = addHavingClauseToQuery(
+          sql = await addHavingClauseToQuery(
             sql,
             sqlHaving.column,
             sqlHaving.operator,
@@ -2035,7 +2036,7 @@ export function useAlertForm(props: AlertFormProps, emit: AlertFormEmit) {
     if (
       formData.value.is_real_time == "false" &&
       formData.value.query_condition.type == "sql" &&
-      !getParser(formData.value.query_condition.sql)
+      !(await getParser(formData.value.query_condition.sql))
     ) {
       activeTab.value = "condition";
       toast({

--- a/web/src/composables/useLogs/logsUtils.ts
+++ b/web/src/composables/useLogs/logsUtils.ts
@@ -31,6 +31,7 @@ import { TimestampRange, ParsedSQLResult, TimePeriodUnit } from "@/ts/interfaces
 import { TIME_MULTIPLIERS } from "@/utils/logs/constants";
 import { toast } from "@/lib/feedback/Toast/useToast";
 import type { TranslateFn } from "@/types/i18n";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 
 interface SQLColumn {
   expr?: {
@@ -132,6 +133,10 @@ export const logsUtils = () => {
         .split("\n")
         .filter((line: string) => !line.trim().startsWith("--"))
         .join("\n");
+
+      if (maxParenDepth(filteredQuery) > SQL_PARSE_MAX_DEPTH) {
+        return DEFAULT_PARSED_RESULT;
+      }
 
       const parsedQuery: ExtendedParsedSQLResult | null = parser?.astify(
         filteredQuery,

--- a/web/src/composables/useLogs/useSearchQuery.ts
+++ b/web/src/composables/useLogs/useSearchQuery.ts
@@ -27,8 +27,8 @@ import { quoteSqlIdentifierIfNeeded } from "@/utils/query/sqlIdentifiers";
 import { hasLimitClause } from "@/utils/query/nonSqlLimit";
 import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import { buildFieldToGroupIdMap } from "@/utils/telemetryCorrelation";
-import { Parser as SqlParser } from "@openobserve/node-sql-parser/build/datafusionsql";
 import { buildContextualSqlMessage, isParserLimitation } from "@/utils/query/sqlDiagnostics";
+import { astifyOffThread } from "@/utils/query/sqlAstifyWorkerClient";
 import { raw, type TranslateFn } from "@/types/i18n";
 
 // Walk the WHERE clause AST and replace column references whose name matches
@@ -254,33 +254,35 @@ export const useSearchQuery = (t: TranslateFn) => {
         searchObj.data.sqlSyntaxErrorRanges = [];
       }
 
-      // Pre-flight SQL syntax check — runs only in SQL mode, before firing the query
+      // Pre-flight SQL syntax check — runs only in SQL mode, before firing the query.
+      // Off the main thread and fire-and-forget: astify() is exponential in paren
+      // nesting depth (10+ seconds on a pathological query) and must not block
+      // building/firing the actual search request while it runs. The query is
+      // re-checked against searchObj.data.query when the result lands, since the
+      // user may already have moved on to a different query by then.
       if (!readOnly && searchObj.meta.sqlMode && query) {
-        try {
-          const _sqlParser = new SqlParser();
-          _sqlParser.astify(query);
-        } catch (syntaxErr: any) {
+        astifyOffThread(query).catch((syntaxErr: any) => {
+          if (searchObj.data.query.trim() !== query) return;
+
           // Suppress parser-limitation false positives — these are valid SQL
           // constructs the PEG parser can't handle (e.g. SUM(COUNT(*)) OVER,
           // COALESCE in PARTITION BY) but the DataFusion backend accepts.
-          if (isParserLimitation(syntaxErr)) {
-            // continue past the error — don't block the query
-          } else {
-            const loc = syntaxErr?.location?.start;
-            const line = loc?.line ?? 1;
-            const col = loc?.column ?? 1;
-            const msg = buildContextualSqlMessage(query, syntaxErr);
-            searchObj.data.errorMsg = t("search.sqlSyntaxErrorDetail", {
-              line,
-              column: col,
-              message: msg,
-            });
-            searchObj.data.sqlSyntaxErrorRanges = [
-              // msg is string|null; `!` is compile-time only (null passes through unchanged).
-              { startLine: line, endLine: line, column: col, error: msg! },
-            ];
-          }
-        }
+          if (isParserLimitation(syntaxErr)) return; // continue past the error — don't block the query
+
+          const loc = syntaxErr?.location?.start;
+          const line = loc?.line ?? 1;
+          const col = loc?.column ?? 1;
+          const msg = buildContextualSqlMessage(query, syntaxErr);
+          searchObj.data.errorMsg = t("search.sqlSyntaxErrorDetail", {
+            line,
+            column: col,
+            message: msg,
+          });
+          searchObj.data.sqlSyntaxErrorRanges = [
+            // msg is string|null; `!` is compile-time only (null passes through unchanged).
+            { startLine: line, endLine: line, column: col, error: msg! },
+          ];
+        });
       }
 
       const req: any = {

--- a/web/src/utils/alerts/alertSqlUtils.spec.ts
+++ b/web/src/utils/alerts/alertSqlUtils.spec.ts
@@ -1,5 +1,30 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { addHavingClauseToQuery } from "./alertSqlUtils";
+import { Parser as RealSqlParser } from "@openobserve/node-sql-parser/build/datafusionsql";
+
+// addHavingClauseToQuery() runs astify() through a Web Worker
+// (sqlAstifyWorkerClient), which doesn't exist in this test environment. Uses
+// the real parser so parsing behaviour is unchanged.
+class MockWorker {
+  onmessage: ((event: { data: any }) => void) | null = null;
+  private parser = new RealSqlParser();
+
+  postMessage(msg: { id: number; sql: string }) {
+    queueMicrotask(() => {
+      try {
+        const ast = this.parser.astify(msg.sql);
+        this.onmessage?.({ data: { id: msg.id, ok: true, ast } });
+      } catch (err: any) {
+        this.onmessage?.({
+          data: { id: msg.id, ok: false, error: { message: err?.message } },
+        });
+      }
+    });
+  }
+
+  terminate() {}
+}
+vi.stubGlobal("Worker", MockWorker);
 
 describe("alertSqlUtils", () => {
   let parser: any;
@@ -12,9 +37,9 @@ describe("alertSqlUtils", () => {
   });
 
   describe("addHavingClauseToQuery", () => {
-    it("should add HAVING clause before LIMIT", () => {
+    it("should add HAVING clause before LIMIT", async () => {
       const query = "SELECT count(*) as cnt FROM table1 GROUP BY field1 ORDER BY cnt DESC LIMIT 10";
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       // Check that HAVING comes before LIMIT
       const havingIndex = result.toLowerCase().indexOf("having");
@@ -27,9 +52,9 @@ describe("alertSqlUtils", () => {
       expect(result.toLowerCase()).toMatch(/having\s+(cnt|"cnt")\s+>=\s+5/);
     });
 
-    it("should add HAVING clause before ORDER BY", () => {
+    it("should add HAVING clause before ORDER BY", async () => {
       const query = "SELECT avg(value) as avg_val FROM table1 GROUP BY region ORDER BY region";
-      const result = addHavingClauseToQuery(query, "avg_val", ">", 10, parser);
+      const result = await addHavingClauseToQuery(query, "avg_val", ">", 10, parser);
 
       const havingIndex = result.toLowerCase().indexOf("having");
       const orderByIndex = result.toLowerCase().indexOf("order by");
@@ -40,10 +65,10 @@ describe("alertSqlUtils", () => {
       expect(result.toLowerCase()).toMatch(/having\s+(avg_val|"avg_val")\s+>\s+10/);
     });
 
-    it("should add HAVING clause before LIMIT and OFFSET", () => {
+    it("should add HAVING clause before LIMIT and OFFSET", async () => {
       const query =
         "SELECT sum(amount) as total FROM sales GROUP BY category ORDER BY total DESC LIMIT 100 OFFSET 50";
-      const result = addHavingClauseToQuery(query, "total", "<=", 1000, parser);
+      const result = await addHavingClauseToQuery(query, "total", "<=", 1000, parser);
 
       const havingIndex = result.toLowerCase().indexOf("having");
       const limitIndex = result.toLowerCase().indexOf("limit");
@@ -55,10 +80,10 @@ describe("alertSqlUtils", () => {
       expect(result.toLowerCase()).toMatch(/having\s+(total|"total")\s+<=\s+1000/);
     });
 
-    it("should combine with existing HAVING clause using AND", () => {
+    it("should combine with existing HAVING clause using AND", async () => {
       const query =
         "SELECT count(*) as cnt FROM table GROUP BY field HAVING cnt > 0 ORDER BY cnt DESC";
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       expect(result.toLowerCase()).toContain("having");
       expect(result).toContain("cnt >= 5");
@@ -66,12 +91,12 @@ describe("alertSqlUtils", () => {
       expect(result).toContain("cnt > 0");
     });
 
-    it("should add HAVING to query without GROUP BY with warning", () => {
+    it("should add HAVING to query without GROUP BY with warning", async () => {
       // Note: HAVING without GROUP BY is semantically incorrect in SQL,
       // but the function adds it anyway because backend validation will catch it.
       // This allows for more flexible alert creation from various chart types.
       const query = "SELECT count(*) as cnt FROM users ORDER BY cnt LIMIT 10";
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       // Should add HAVING clause despite missing GROUP BY
       // Column name might be quoted
@@ -82,42 +107,42 @@ describe("alertSqlUtils", () => {
       // Backend SQL validation will reject this query if it's invalid
     });
 
-    it("should handle simple GROUP BY without ORDER BY or LIMIT", () => {
+    it("should handle simple GROUP BY without ORDER BY or LIMIT", async () => {
       const query = "SELECT count(*) as cnt FROM table GROUP BY field";
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       expect(result).toContain("HAVING");
       expect(result).toContain("cnt >= 5");
     });
 
-    it("should handle different operators", () => {
+    it("should handle different operators", async () => {
       const query = "SELECT avg(score) as avg_score FROM tests GROUP BY student";
 
       const operators = [">=", "<=", ">", "<", "="];
-      operators.forEach((op) => {
-        const result = addHavingClauseToQuery(query, "avg_score", op, 75, parser);
+      for (const op of operators) {
+        const result = await addHavingClauseToQuery(query, "avg_score", op, 75, parser);
         // Use regex to handle quoted column names
         // Properly escape special regex characters
         const escapedOp = op.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         expect(result.toLowerCase()).toMatch(
           new RegExp(`having\\s+(avg_score|"avg_score")\\s+${escapedOp}\\s+75`),
         );
-      });
+      }
     });
 
-    it("should preserve double quotes in table names", () => {
+    it("should preserve double quotes in table names", async () => {
       const query = 'SELECT count(*) as cnt FROM "my-table" GROUP BY field1 ORDER BY cnt LIMIT 10';
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       // Parser converts backticks to double quotes
       expect(result).toContain('"my-table"');
       expect(result.toLowerCase()).toMatch(/having\s+(cnt|"cnt")\s+>=\s+5/);
     });
 
-    it("should handle complex aggregation functions", () => {
+    it("should handle complex aggregation functions", async () => {
       const query =
         "SELECT histogram(_timestamp) AS zo_sql_key, COUNT(*) as zo_sql_val FROM stream GROUP BY zo_sql_key ORDER BY zo_sql_key ASC";
-      const result = addHavingClauseToQuery(query, "zo_sql_val", ">=", 10, parser);
+      const result = await addHavingClauseToQuery(query, "zo_sql_val", ">=", 10, parser);
 
       const havingIndex = result.toLowerCase().indexOf("having");
       const orderByIndex = result.toLowerCase().indexOf("order by");
@@ -129,59 +154,63 @@ describe("alertSqlUtils", () => {
   });
 
   describe("Input Validation", () => {
-    it("should throw error for empty SQL query", () => {
-      expect(() => addHavingClauseToQuery("", "cnt", ">=", 5, parser)).toThrow(
+    it("should throw error for empty SQL query", async () => {
+      await expect(addHavingClauseToQuery("", "cnt", ">=", 5, parser)).rejects.toThrow(
         "Invalid SQL query: must be a non-empty string",
       );
     });
 
-    it("should throw error for null column name", () => {
+    it("should throw error for null column name", async () => {
       const query = "SELECT count(*) as cnt FROM table1 GROUP BY field1";
-      expect(() => addHavingClauseToQuery(query, null as any, ">=", 5, parser)).toThrow(
-        "Column name must be a non-empty string",
-      );
+      await expect(
+        addHavingClauseToQuery(query, null as any, ">=", 5, parser),
+      ).rejects.toThrow("Column name must be a non-empty string");
     });
 
-    it("should throw error for invalid operator", () => {
+    it("should throw error for invalid operator", async () => {
       const query = "SELECT count(*) as cnt FROM table1 GROUP BY field1";
-      expect(() => addHavingClauseToQuery(query, "cnt", "INVALID" as any, 5, parser)).toThrow(
-        "Invalid operator: INVALID",
-      );
+      await expect(
+        addHavingClauseToQuery(query, "cnt", "INVALID" as any, 5, parser),
+      ).rejects.toThrow("Invalid operator: INVALID");
     });
 
-    it("should throw error for non-numeric threshold", () => {
+    it("should throw error for non-numeric threshold", async () => {
       const query = "SELECT count(*) as cnt FROM table1 GROUP BY field1";
-      expect(() => addHavingClauseToQuery(query, "cnt", ">=", NaN, parser)).toThrow(
+      await expect(addHavingClauseToQuery(query, "cnt", ">=", NaN, parser)).rejects.toThrow(
         "Invalid threshold: NaN",
       );
     });
 
-    it("should throw error for infinite threshold", () => {
+    it("should throw error for infinite threshold", async () => {
       const query = "SELECT count(*) as cnt FROM table1 GROUP BY field1";
-      expect(() => addHavingClauseToQuery(query, "cnt", ">=", Infinity, parser)).toThrow(
+      await expect(addHavingClauseToQuery(query, "cnt", ">=", Infinity, parser)).rejects.toThrow(
         "Invalid threshold: Infinity",
       );
     });
 
-    it("should accept column names with underscores", () => {
+    it("should accept column names with underscores", async () => {
       const query = "SELECT count(*) as my_count FROM table1 GROUP BY field1";
-      expect(() => addHavingClauseToQuery(query, "my_count", ">=", 5, parser)).not.toThrow();
+      await expect(
+        addHavingClauseToQuery(query, "my_count", ">=", 5, parser),
+      ).resolves.toEqual(expect.any(String));
     });
 
-    it("should accept qualified column names", () => {
+    it("should accept qualified column names", async () => {
       const query = "SELECT count(*) as cnt FROM table1 GROUP BY field1";
       // Qualified names like table.column should work
-      expect(() => addHavingClauseToQuery(query, "table1.cnt", ">=", 5, parser)).not.toThrow();
+      await expect(
+        addHavingClauseToQuery(query, "table1.cnt", ">=", 5, parser),
+      ).resolves.toEqual(expect.any(String));
     });
   });
 
   describe("Edge Cases", () => {
-    it("should handle UNION queries", () => {
+    it("should handle UNION queries", async () => {
       const query =
         "SELECT count(*) as cnt FROM table1 GROUP BY field1 UNION SELECT count(*) as cnt FROM table2 GROUP BY field2";
       // UNION queries may either throw an error or handle gracefully depending on parser
       try {
-        const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+        const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
         // If it doesn't throw, verify the query contains HAVING
         expect(result.toLowerCase()).toContain("having");
       } catch (error: any) {
@@ -190,10 +219,10 @@ describe("alertSqlUtils", () => {
       }
     });
 
-    it("should handle queries with parentheses in functions", () => {
+    it("should handle queries with parentheses in functions", async () => {
       const query =
         "SELECT func(col1, col2) as result FROM table1 GROUP BY func(col1, col2) ORDER BY result";
-      const result = addHavingClauseToQuery(query, "result", ">", 10, parser);
+      const result = await addHavingClauseToQuery(query, "result", ">", 10, parser);
 
       expect(result.toLowerCase()).toContain("having");
       const havingIndex = result.toLowerCase().indexOf("having");
@@ -201,11 +230,11 @@ describe("alertSqlUtils", () => {
       expect(havingIndex).toBeLessThan(orderByIndex);
     });
 
-    it("should not create double quotes when column name is already without quotes", () => {
+    it("should not create double quotes when column name is already without quotes", async () => {
       // Test case from the bug report: column name passed without quotes should get single quotes in output
       const query =
         'SELECT histogram(_timestamp) AS "x_axis_1", COUNT(_timestamp) AS "y_axis_1" FROM "default" GROUP BY x_axis_1 ORDER BY x_axis_1 ASC LIMIT 100';
-      const result = addHavingClauseToQuery(query, "y_axis_1", "<=", 18258, parser);
+      const result = await addHavingClauseToQuery(query, "y_axis_1", "<=", 18258, parser);
 
       // Should have HAVING with single-quoted column name, not double-quoted
       expect(result).not.toContain('""y_axis_1""');
@@ -221,10 +250,10 @@ describe("alertSqlUtils", () => {
       expect(havingIndex).toBeLessThan(limitIndex);
     });
 
-    it("should skip adding HAVING if exact condition already exists", () => {
+    it("should skip adding HAVING if exact condition already exists", async () => {
       const query =
         "SELECT count(*) as cnt FROM table1 GROUP BY field1 HAVING cnt >= 5 ORDER BY cnt";
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       // Should return unchanged query since the exact condition already exists
       expect(result.toLowerCase()).toMatch(/having\s+(cnt|"cnt")\s+>=\s+5/);
@@ -233,17 +262,17 @@ describe("alertSqlUtils", () => {
       expect(havingMatches?.length).toBe(1);
     });
 
-    it("should append to existing HAVING if condition is different", () => {
+    it("should append to existing HAVING if condition is different", async () => {
       const query =
         "SELECT count(*) as cnt FROM table1 GROUP BY field1 HAVING cnt > 0 ORDER BY cnt";
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       // Should append with AND
       expect(result.toLowerCase()).toContain("and");
       expect(result.toLowerCase()).toMatch(/having.*cnt.*>.*0.*and.*cnt.*>=.*5/);
     });
 
-    it("should handle CTE (WITH) queries with fallback", () => {
+    it("should handle CTE (WITH) queries with fallback", async () => {
       // This is the actual production issue that occurred
       const query = `WITH aggregated_data AS (
         SELECT
@@ -257,7 +286,7 @@ describe("alertSqlUtils", () => {
       ORDER BY x_axis_1 ASC
       LIMIT 100`;
 
-      const result = addHavingClauseToQuery(query, "y_axis_1", "<=", 18258, parser);
+      const result = await addHavingClauseToQuery(query, "y_axis_1", "<=", 18258, parser);
 
       // CTE queries will use fallback method
       // Should contain HAVING somewhere in the result
@@ -265,13 +294,13 @@ describe("alertSqlUtils", () => {
       expect(result.toLowerCase()).toMatch(/y_axis_1.*<=.*18258/);
     });
 
-    it("should handle CTE with existing HAVING clause", () => {
+    it("should handle CTE with existing HAVING clause", async () => {
       const query = `WITH cte AS (
         SELECT count(*) as cnt FROM users GROUP BY region HAVING cnt > 0
       )
       SELECT * FROM cte ORDER BY cnt LIMIT 100`;
 
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       // Should handle gracefully, likely using fallback
       expect(result.toLowerCase()).toContain("having");
@@ -279,12 +308,12 @@ describe("alertSqlUtils", () => {
   });
 
   describe("Fallback Regex Method", () => {
-    it("should use regex fallback when AST parsing fails", () => {
+    it("should use regex fallback when AST parsing fails", async () => {
       // Query with vendor-specific syntax that parser might not understand
       const query = "SELECT count(*) as cnt FROM users GROUP BY user_id ORDER BY cnt LIMIT 10";
 
       // Even if parser fails, fallback should work
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       expect(result.toLowerCase()).toContain("having");
       const havingIndex = result.toLowerCase().indexOf("having");
@@ -296,24 +325,24 @@ describe("alertSqlUtils", () => {
       expect(havingIndex).toBeLessThan(limitIndex);
     });
 
-    it("should handle complex nested queries in fallback", () => {
+    it("should handle complex nested queries in fallback", async () => {
       // Nested query that might force fallback
       const query =
         "SELECT region, count(*) as cnt FROM (SELECT * FROM users WHERE active = true) as active_users GROUP BY region ORDER BY cnt DESC LIMIT 50";
 
-      const result = addHavingClauseToQuery(query, "cnt", ">", 10, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">", 10, parser);
 
       // Should contain HAVING
       expect(result.toLowerCase()).toContain("having");
       expect(result.toLowerCase()).toMatch(/cnt.*>.*10/);
     });
 
-    it("should warn but not fail for queries without GROUP BY", () => {
+    it("should warn but not fail for queries without GROUP BY", async () => {
       // This tests the fallback warning behavior
       const query = "SELECT count(*) as cnt FROM users ORDER BY cnt LIMIT 10";
 
       // Should not throw, but will add HAVING anyway (backend will validate)
-      const result = addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
+      const result = await addHavingClauseToQuery(query, "cnt", ">=", 5, parser);
 
       // Column name might be quoted
       expect(result.toLowerCase()).toMatch(/(cnt|"cnt")\s+>=\s+5/);

--- a/web/src/utils/alerts/alertSqlUtils.ts
+++ b/web/src/utils/alerts/alertSqlUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TranslateFn } from "@/types/i18n";
+import { astifyOffThread } from "@/utils/query/sqlAstifyWorkerClient";
 
 export interface SqlUtilsContext {
   parser: any;
@@ -12,12 +13,12 @@ export interface SqlUtilsContext {
 }
 type ComparisonOperator = ">=" | "<=" | ">" | "<" | "=" | "!=" | "<>";
 
-export const getParser = (sqlQuery: string, context: SqlUtilsContext): boolean => {
-  const { parser, sqlQueryErrorMsg, t } = context;
+export const getParser = async (sqlQuery: string, context: SqlUtilsContext): Promise<boolean> => {
+  const { sqlQueryErrorMsg, t } = context;
   try {
     // As default is a reserved keyword in sql-parser, we are replacing it with default1
     const regex = /\bdefault\b/g;
-    const columns = parser.astify(sqlQuery.replace(regex, "default1")).columns;
+    const columns = ((await astifyOffThread(sqlQuery.replace(regex, "default1"))) as any).columns;
     for (const column of columns) {
       if (column.expr.column === "*") {
         sqlQueryErrorMsg.value = t("alerts.selectAllColumnsNotAllowed");
@@ -50,13 +51,13 @@ export const getParser = (sqlQuery: string, context: SqlUtilsContext): boolean =
  * @param parser - The node-sql-parser instance
  * @returns The modified SQL query with the HAVING clause properly inserted
  */
-export const addHavingClauseToQuery = (
+export const addHavingClauseToQuery = async (
   sqlQuery: string,
   yAxisColumn: string,
   operator: string,
   threshold: number,
   parser: any,
-): string => {
+): Promise<string> => {
   // === Input Validation ===
   if (!sqlQuery || typeof sqlQuery !== "string" || sqlQuery.trim().length === 0) {
     throw new Error("Invalid SQL query: must be a non-empty string");
@@ -84,7 +85,7 @@ export const addHavingClauseToQuery = (
 
   try {
     // Parse the SQL query into an AST
-    const ast = parser.astify(sqlQuery);
+    const ast: any = await astifyOffThread(sqlQuery);
 
     // Handle array of statements (e.g., UNION queries)
     if (Array.isArray(ast)) {

--- a/web/src/utils/alerts/alertValidation.ts
+++ b/web/src/utils/alerts/alertValidation.ts
@@ -419,7 +419,7 @@ export interface ValidationContext {
   sqlErrorRanges?: any;
   vrlFunctionError: any;
   buildQueryPayload: any;
-  getParser: (sqlQuery: string) => boolean;
+  getParser: (sqlQuery: string) => Promise<boolean>;
 }
 
 export interface AlertFormData {
@@ -456,7 +456,7 @@ export interface JsonValidationContext {
   t: Translator;
   streams: any;
   getStreams: (streamType: string, schema: boolean) => Promise<any>;
-  getParser: (sql: string) => boolean;
+  getParser: (sql: string) => Promise<boolean>;
   buildQueryPayload: (options: any) => any;
   prepareAndSaveAlert: (data: any) => Promise<void>;
 }
@@ -597,7 +597,7 @@ export const validateSqlQuery = async (
     return;
   }
 
-  if (!getParser(formData.query_condition.sql)) {
+  if (!(await getParser(formData.query_condition.sql))) {
     return;
   }
 
@@ -720,7 +720,7 @@ export const saveAlertJson = async (
   if (jsonPayload.is_real_time === false && jsonPayload.query_condition.type === "sql") {
     try {
       // First check if query has SELECT *
-      if (!getParser(jsonPayload.query_condition.sql)) {
+      if (!(await getParser(jsonPayload.query_condition.sql))) {
         validationErrors.value = [t("alerts.validation.selectAllNotAllowed")];
         return;
       }

--- a/web/src/utils/query/sqlAstifyWorkerClient.ts
+++ b/web/src/utils/query/sqlAstifyWorkerClient.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// One persistent worker for every astifyOffThread caller in the app — spinning
+// one up per call would add startup overhead on the hot editor-diagnostics path.
+// Requests resolve in the order the worker receives them: a fast query queued
+// behind a pathologically nested one still waits for that one to finish before
+// its own result comes back. That only delays a diagnostic squiggle; it never
+// blocks the main thread, which is the actual bug this exists to avoid.
+
+export interface AstifyError {
+  message?: string;
+  location?: { start?: { line?: number; column?: number; offset?: number } };
+  expected?: unknown[];
+  found?: string | null;
+  name?: string;
+}
+
+let worker: Worker | null = null;
+let nextId = 0;
+const pending = new Map<
+  number,
+  { resolve: (ast: unknown) => void; reject: (err: AstifyError) => void }
+>();
+
+const getWorker = (): Worker => {
+  if (worker) return worker;
+  worker = new Worker(new URL("../../workers/sqlParserWorker.js", import.meta.url), {
+    type: "module",
+  });
+  worker.onmessage = (
+    event: MessageEvent<{ id: number; ok: boolean; ast?: unknown; error?: AstifyError }>,
+  ) => {
+    const { id, ok, ast, error } = event.data;
+    const settled = pending.get(id);
+    if (!settled) return;
+    pending.delete(id);
+    if (ok) settled.resolve(ast);
+    else settled.reject(error as AstifyError);
+  };
+  return worker;
+};
+
+export const astifyOffThread = (sql: string): Promise<unknown> => {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    getWorker().postMessage({ id, sql });
+  });
+};

--- a/web/src/utils/query/sqlAstifyWorkerClient.ts
+++ b/web/src/utils/query/sqlAstifyWorkerClient.ts
@@ -20,13 +20,34 @@
 // its own result comes back. That only delays a diagnostic squiggle; it never
 // blocks the main thread, which is the actual bug this exists to avoid.
 
-export interface AstifyError {
-  message?: string;
+export interface AstifyError extends Error {
   location?: { start?: { line?: number; column?: number; offset?: number } };
+  expected?: unknown[];
+  found?: string | null;
+}
+
+interface SerializedAstifyError {
+  message?: string;
+  location?: AstifyError["location"];
   expected?: unknown[];
   found?: string | null;
   name?: string;
 }
+
+// The worker can only postMessage plain, structured-clonable data — not an
+// Error instance — so rebuild one here. Callers (sqlDiagnostics.ts and
+// friends) read .location/.expected/.found off the caught value exactly as
+// they did off whatever parser.astify() used to throw synchronously, and
+// anything that checks `instanceof Error` (logging, error reporting) still
+// works, unlike a bare rejected plain object.
+const toAstifyError = (serialized: SerializedAstifyError): AstifyError => {
+  const err = new Error(serialized.message ?? "SQL parse error") as AstifyError;
+  if (serialized.name) err.name = serialized.name;
+  err.location = serialized.location;
+  err.expected = serialized.expected;
+  err.found = serialized.found;
+  return err;
+};
 
 let worker: Worker | null = null;
 let nextId = 0;
@@ -41,14 +62,14 @@ const getWorker = (): Worker => {
     type: "module",
   });
   worker.onmessage = (
-    event: MessageEvent<{ id: number; ok: boolean; ast?: unknown; error?: AstifyError }>,
+    event: MessageEvent<{ id: number; ok: boolean; ast?: unknown; error?: SerializedAstifyError }>,
   ) => {
     const { id, ok, ast, error } = event.data;
     const settled = pending.get(id);
     if (!settled) return;
     pending.delete(id);
     if (ok) settled.resolve(ast);
-    else settled.reject(error as AstifyError);
+    else settled.reject(toAstifyError(error ?? {}));
   };
   return worker;
 };

--- a/web/src/utils/query/sqlComplexity.ts
+++ b/web/src/utils/query/sqlComplexity.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// @openobserve/node-sql-parser's astify() is a PEG parser whose runtime grows
+// exponentially with WHERE-clause parenthesis nesting depth (measured: ~14ms
+// at depth 5, ~1000ms at depth 15), so a deeply nested paste can freeze the
+// tab for many seconds. Callers use this to skip client-side parsing (quickMode
+// field extraction, inline diagnostics) for queries past a safe depth — the
+// query still runs fine server-side, only these optional UX features are lost.
+export const SQL_PARSE_MAX_DEPTH = 12;
+
+export const maxParenDepth = (text: string): number => {
+  let depth = 0;
+  let max = 0;
+  for (const ch of text) {
+    if (ch === "(") {
+      depth++;
+      if (depth > max) max = depth;
+    } else if (ch === ")") {
+      depth--;
+    }
+  }
+  return max;
+};

--- a/web/src/utils/query/sqlDiagnostics.spec.ts
+++ b/web/src/utils/query/sqlDiagnostics.spec.ts
@@ -25,7 +25,7 @@
  *     test data (10 mutation types) produce a specific error message at ≥ 94%.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   buildContextualSqlMessage,
   isParserLimitation,
@@ -35,6 +35,48 @@ import {
   type SqlErrorRange,
 } from "./sqlDiagnostics";
 import { Parser } from "@openobserve/node-sql-parser/build/datafusionsql";
+
+// validateSql() runs astify() through a Web Worker (sqlAstifyWorkerClient) that
+// doesn't exist in this test environment. Mirrors the real worker's message
+// contract using the same parser, so every assertion below still exercises the
+// genuine astify() output — only the thread it runs on differs. Safe to stub
+// after the imports above: the client only constructs a Worker lazily, on the
+// first validateSql() call inside a test, not at module load time.
+class MockWorker {
+  onmessage: ((event: { data: any }) => void) | null = null;
+  private parser = new Parser();
+
+  postMessage(msg: { id: number; sql: string }) {
+    queueMicrotask(() => {
+      try {
+        const ast = this.parser.astify(msg.sql);
+        this.onmessage?.({ data: { id: msg.id, ok: true, ast } });
+      } catch (err: any) {
+        this.onmessage?.({
+          data: {
+            id: msg.id,
+            ok: false,
+            error: {
+              message: err?.message,
+              location: err?.location,
+              expected: err?.expected,
+              found: err?.found,
+              name: err?.name,
+            },
+          },
+        });
+      }
+    });
+  }
+
+  terminate() {}
+}
+Object.defineProperty(window, "Worker", {
+  writable: true,
+  configurable: true,
+  value: MockWorker,
+});
+vi.stubGlobal("Worker", MockWorker);
 import basicSelect from "../../../../tests/test-data/query-agent/queries/basic_select.json";
 import aggregation from "../../../../tests/test-data/query-agent/queries/aggregation.json";
 import combined from "../../../../tests/test-data/query-agent/queries/combined.json";

--- a/web/src/utils/query/sqlDiagnostics.ts
+++ b/web/src/utils/query/sqlDiagnostics.ts
@@ -38,6 +38,7 @@
 // ─── Public types ─────────────────────────────────────────────────────────────
 
 import { gt, raw, type I18nText } from "@/types/i18n";
+import { astifyOffThread } from "@/utils/query/sqlAstifyWorkerClient";
 
 export interface SqlErrorRange {
   startLine: number;
@@ -817,15 +818,6 @@ export function isParserLimitation(err: any, sql?: string): boolean {
 
 // ─── Async validator ──────────────────────────────────────────────────────────
 
-let _parserInstance: any = null;
-
-async function getParser(): Promise<any> {
-  if (_parserInstance) return _parserInstance;
-  const mod = await import("@openobserve/node-sql-parser/build/datafusionsql");
-  _parserInstance = new ((mod as any).default?.Parser ?? (mod as any).Parser)();
-  return _parserInstance;
-}
-
 /**
  * Run a client-side syntax check on a SQL string.
  * Returns `null` if valid (or the error is unclassified / a parser-grammar gap),
@@ -844,9 +836,8 @@ export async function validateSql(
   lineOffset = 0,
   colOffset = 0,
 ): Promise<SqlErrorRange | null> {
-  const parser = await getParser();
   try {
-    parser.astify(sql);
+    await astifyOffThread(sql);
     return null;
   } catch (err: any) {
     // Suppress known parser-grammar gaps — DataFusion accepts these even though
@@ -897,10 +888,9 @@ export async function rangesFromSqlParserDetail(
     //       → Fall through and use the server-reported position with a cleaned message,
     //         because the server told us there IS a real parse error at a known location.
     // Distinguish: re-parse and check if it throws at all.
-    const parser = await getParser();
     let clientThrows = false;
     try {
-      parser.astify(originalSql);
+      await astifyOffThread(originalSql);
     } catch {
       clientThrows = true;
     }

--- a/web/src/utils/query/sqlUtils.spec.ts
+++ b/web/src/utils/query/sqlUtils.spec.ts
@@ -56,6 +56,30 @@ vi.mock("@/composables/useParser", () => ({
   }),
 }));
 
+// getStreamNameFromQuery() runs astify() through a Web Worker
+// (sqlAstifyWorkerClient), which doesn't exist in this test environment.
+// Routes through the same mockAstify used above so existing assertions on it
+// still work.
+class MockWorker {
+  onmessage: ((event: { data: any }) => void) | null = null;
+
+  postMessage(msg: { id: number; sql: string }) {
+    queueMicrotask(() => {
+      try {
+        const ast = mockAstify(msg.sql);
+        this.onmessage?.({ data: { id: msg.id, ok: true, ast } });
+      } catch (err: any) {
+        this.onmessage?.({
+          data: { id: msg.id, ok: false, error: { message: err?.message } },
+        });
+      }
+    });
+  }
+
+  terminate() {}
+}
+vi.stubGlobal("Worker", MockWorker);
+
 describe("isSqlQuery", () => {
   describe("returns true for full SQL statements", () => {
     it("detects SELECT * FROM", () => {

--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -1,4 +1,5 @@
 import { splitQuotedString, escapeSingleQuotes } from "@/utils/zincutils";
+import { astifyOffThread } from "@/utils/query/sqlAstifyWorkerClient";
 
 let parser: any;
 let parserImportPromise: Promise<any> | null = null;
@@ -935,7 +936,7 @@ export const getStreamNameFromQuery = async (query: any) => {
     await importSqlParser();
     try {
       if (query && query != "") {
-        const parsedQuery = parser?.astify(query);
+        const parsedQuery: any = await astifyOffThread(query);
 
         // Recursively find the first base table, descending into sub-queries in
         // FROM / WHERE / SELECT. This resolves `FROM (SELECT ... FROM stream)` to

--- a/web/src/workers/sqlParserWorker.js
+++ b/web/src/workers/sqlParserWorker.js
@@ -1,0 +1,27 @@
+// Runs @openobserve/node-sql-parser's astify() off the main thread — it's a PEG
+// parser whose runtime grows exponentially with WHERE-clause parenthesis nesting
+// depth, so a pathologically nested query can take 10+ seconds. Off the main
+// thread, that time no longer freezes the tab.
+import { Parser } from "@openobserve/node-sql-parser/build/datafusionsql";
+
+const parser = new Parser();
+
+self.onmessage = (event) => {
+  const { id, sql } = event.data;
+  try {
+    const ast = parser.astify(sql);
+    postMessage({ id, ok: true, ast });
+  } catch (err) {
+    postMessage({
+      id,
+      ok: false,
+      error: {
+        message: err?.message,
+        location: err?.location,
+        expected: err?.expected,
+        found: err?.found,
+        name: err?.name,
+      },
+    });
+  }
+};


### PR DESCRIPTION
### Root cause
@openobserve/node-sql-parser's astify() (and parse(), its sibling) is a PEG parser whose runtime grows exponentially with WHERE-clause parenthesis nesting depth. A deeply nested query — the kind a BI tool or generated dashboard export can easily produce — could take 10+ seconds to parse. Several places in the frontend called this parser synchronously on the main thread, on paths that fire automatically while a user types, pastes, or blurs a SQL editor:

Logs: SearchBar.vue's Monaco blur handler and quickMode field extraction (fnParsedSQL)
Dashboards: useDashboardPanel.ts's reactive query-text watcher (updateQueryValue) and sqlUtils.ts's getStreamNameFromQuery
Alerts: alertSqlUtils.ts's getParser (SELECT * check) and addHavingClauseToQuery
Alerts / Test Function / Scheduled Pipeline: a duplicated "sync stream name from the SQL you're typing" feature, debounced 600ms, using parser.parse() directly
Any of these could freeze the entire browser tab — not just the editor — for as long as the parse took.

### Solution
Added a shared Web Worker (sqlParserWorker.js) and a thin client (sqlAstifyWorkerClient.ts — astifyOffThread(sql)) that runs astify() off the main thread. Requests are queued and resolved in order on one persistent worker, so the tab never blocks regardless of query complexity.
Routed every synchronous astify()/parse() call site above through astifyOffThread() instead. Most of the converted functions were already async (blur handlers, save/run handlers, reactive watchers), so this was a low-risk, mostly mechanical swap; each was checked individually for its caller graph before conversion.
fnParsedSQL (Logs' quickMode/pagination path) was the one exception: its ~40 call sites reach into the core search-execution pipeline, and fully converting it to async was judged too large/risky for this fix. It keeps a depth-guard (maxParenDepth > 12 levels → skip, matching the shape of a real generated query but rejecting pathological nesting) instead of the worker.
astifyOffThread's rejection now reconstructs a real Error (with .location/.expected/.found attached) rather than a bare plain object, since a Worker can't postMessage an actual Error instance — this keeps instanceof Error checks and existing error-classification code working unchanged for every caller.

### Testing
Full vue-tsc --noEmit and eslint pass with zero errors across all touched files.
1000+ existing unit tests across Logs, Dashboards, Alerts, and Pipelines pass, including new/updated Worker mocks (matching the existing useStreamingSearch.spec.ts convention) so tests still exercise genuine parser output rather than skipping it.
The specific hangs reported during development (Logs paste/blur, Dashboard panel editing, Alert Scheduled blur) were reproduced and fixed iteratively; reviewer/QA should re-verify a deeply nested query no longer freezes the tab in each editor before merging.