### PR TITLE
fix: skip client-side SQL parsing past a safe nesting depth to preven…

### DIFF
--- a/web/src/components/functions/TestFunction.vue
+++ b/web/src/components/functions/TestFunction.vue
@@ -278,6 +278,7 @@ import { useQueryPlaceholder } from "@/components/logs/useQueryPlaceholder";
 import { debounce } from "lodash-es";
 import useQuery from "@/composables/useQuery";
 import { rangesFromServerError, type SqlErrorRange } from "@/utils/query/sqlDiagnostics";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 import searchService from "@/services/search";
 import { useStore } from "vuex";
 import { getConsumableRelativeTime } from "@/utils/date";
@@ -554,6 +555,10 @@ watch(inputQuery, (value) => {
 // the SQL the user typed.
 const debouncedSyncStreamFromQuery = debounce(async (sql: string) => {
   if (!sql || !parser) return;
+  // parse() is exponential in paren nesting depth — skip a pathologically
+  // nested query rather than freeze the tab. Losing this convenience sync
+  // is fine; the user can still pick the stream from the dropdown.
+  if (maxParenDepth(sql) > SQL_PARSE_MAX_DEPTH) return;
   try {
     const parsed = parser.parse(sql);
     const fromStream = parsed?.ast?.from?.[0]?.table as string | undefined;

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -1002,6 +1002,7 @@ import { debounce } from "lodash-es";
 import useSqlSuggestions from "@/composables/useSuggestions";
 import { useSqlEditorDiagnostics } from "@/composables/useSqlEditorDiagnostics";
 import { type SqlErrorRange } from "@/utils/query/sqlDiagnostics";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 import { createPipelinesContextProvider } from "@/composables/contextProviders/pipelinesContextProvider";
 import { contextRegistry } from "@/composables/contextProviders";
 import OSpinner from "@/lib/feedback/Spinner/OSpinner.vue";
@@ -1755,6 +1756,10 @@ const updateQueryValue = (value: string) => {
 // "stream changed → regenerate default query" watch.
 const debouncedSyncStreamFromQuery = debounce(async (sql: string) => {
   if (!sql || !parser) return;
+  // parse() is exponential in paren nesting depth — skip a pathologically
+  // nested query rather than freeze the tab. Losing this convenience sync
+  // is fine; the user can still pick the stream from the dropdown.
+  if (maxParenDepth(sql) > SQL_PARSE_MAX_DEPTH) return;
   try {
     const parsed = parser.parse(sql);
     const fromStream = parsed?.ast?.from?.[0]?.table as string | undefined;

--- a/web/src/composables/dashboard/useDashboardPanel.ts
+++ b/web/src/composables/dashboard/useDashboardPanel.ts
@@ -19,6 +19,7 @@ import { useStore } from "vuex";
 import useNotifications from "../useNotifications";
 import { b64EncodeUnicode, isStreamingEnabled } from "@/utils/zincutils";
 import { extractFields, getStreamNameFromQuery } from "@/utils/query/sqlUtils";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 import { validatePanel } from "@/utils/dashboard/panelValidation";
 import { CUSTOM_QUERY_CHART_TYPES } from "@/utils/dashboard/constants";
 import useStreams from "../useStreams";
@@ -1111,6 +1112,15 @@ const useDashboardPanelData = (pageKey: string = "dashboard", t: TranslateFn) =>
           /(?:\$\{\s*[a-zA-Z0-9_-]+\s*:\s*pipe\s*\})|(?:\{\{\s*[a-zA-Z0-9_-]+\s*:\s*pipe\s*\}\})/g,
           "1|2",
         );
+
+        // astify() is exponential in paren nesting depth — skip parsing a
+        // pathologically nested query rather than freeze the tab for seconds.
+        // The query still runs fine server-side; only these client-side
+        // custom-fields/errors go unpopulated.
+        if (maxParenDepth(currentQuery) > SQL_PARSE_MAX_DEPTH) {
+          dashboardPanelData.meta.parsedQuery = null;
+          return;
+        }
 
         const variables = extractVariables(currentQuery); // Extract all unique variables
         const validatedQuery = validateQuery(currentQuery, variables);

--- a/web/src/composables/useAlertForm.ts
+++ b/web/src/composables/useAlertForm.ts
@@ -58,6 +58,7 @@ import {
   type JsonValidationContext,
 } from "@/utils/alerts/alertValidation";
 import { type SqlErrorRange } from "@/utils/query/sqlDiagnostics";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 import {
   getAlertPayload as getAlertPayloadUtil,
   prepareAndSaveAlert as prepareAndSaveAlertUtil,
@@ -767,6 +768,10 @@ export function useAlertForm(props: AlertFormProps, emit: AlertFormEmit) {
 
   const debouncedSyncStreamFromSql = debounce(async (sql: string) => {
     if (!sql || !parser || isSyncingStreamFromSql.value) return;
+    // parse() is exponential in paren nesting depth — skip a pathologically
+    // nested query rather than freeze the tab. Losing this convenience sync
+    // is fine; the user can still pick the stream from the dropdown.
+    if (maxParenDepth(sql) > SQL_PARSE_MAX_DEPTH) return;
     try {
       const parsed = parser.parse(sql);
       const fromStream = parsed?.ast?.from?.[0]?.table as string | undefined;

--- a/web/src/composables/useLogs/logsUtils.ts
+++ b/web/src/composables/useLogs/logsUtils.ts
@@ -31,6 +31,7 @@ import { TimestampRange, ParsedSQLResult, TimePeriodUnit } from "@/ts/interfaces
 import { TIME_MULTIPLIERS } from "@/utils/logs/constants";
 import { toast } from "@/lib/feedback/Toast/useToast";
 import type { TranslateFn } from "@/types/i18n";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 
 interface SQLColumn {
   expr?: {
@@ -132,6 +133,10 @@ export const logsUtils = () => {
         .split("\n")
         .filter((line: string) => !line.trim().startsWith("--"))
         .join("\n");
+
+      if (maxParenDepth(filteredQuery) > SQL_PARSE_MAX_DEPTH) {
+        return DEFAULT_PARSED_RESULT;
+      }
 
       const parsedQuery: ExtendedParsedSQLResult | null = parser?.astify(
         filteredQuery,

--- a/web/src/composables/useLogs/useSearchQuery.ts
+++ b/web/src/composables/useLogs/useSearchQuery.ts
@@ -29,6 +29,7 @@ import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import { buildFieldToGroupIdMap } from "@/utils/telemetryCorrelation";
 import { Parser as SqlParser } from "@openobserve/node-sql-parser/build/datafusionsql";
 import { buildContextualSqlMessage, isParserLimitation } from "@/utils/query/sqlDiagnostics";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 import { raw, type TranslateFn } from "@/types/i18n";
 
 // Walk the WHERE clause AST and replace column references whose name matches
@@ -254,8 +255,10 @@ export const useSearchQuery = (t: TranslateFn) => {
         searchObj.data.sqlSyntaxErrorRanges = [];
       }
 
-      // Pre-flight SQL syntax check — runs only in SQL mode, before firing the query
-      if (!readOnly && searchObj.meta.sqlMode && query) {
+      // Pre-flight SQL syntax check — runs only in SQL mode, before firing the query.
+      // Skipped past SQL_PARSE_MAX_DEPTH: astify() is exponential in paren nesting
+      // depth and would freeze the tab for seconds; the server still validates.
+      if (!readOnly && searchObj.meta.sqlMode && query && maxParenDepth(query) <= SQL_PARSE_MAX_DEPTH) {
         try {
           const _sqlParser = new SqlParser();
           _sqlParser.astify(query);

--- a/web/src/composables/useLogs/useSearchQuery.ts
+++ b/web/src/composables/useLogs/useSearchQuery.ts
@@ -258,7 +258,12 @@ export const useSearchQuery = (t: TranslateFn) => {
       // Pre-flight SQL syntax check — runs only in SQL mode, before firing the query.
       // Skipped past SQL_PARSE_MAX_DEPTH: astify() is exponential in paren nesting
       // depth and would freeze the tab for seconds; the server still validates.
-      if (!readOnly && searchObj.meta.sqlMode && query && maxParenDepth(query) <= SQL_PARSE_MAX_DEPTH) {
+      if (
+        !readOnly &&
+        searchObj.meta.sqlMode &&
+        query &&
+        maxParenDepth(query) <= SQL_PARSE_MAX_DEPTH
+      ) {
         try {
           const _sqlParser = new SqlParser();
           _sqlParser.astify(query);

--- a/web/src/utils/alerts/alertSqlUtils.ts
+++ b/web/src/utils/alerts/alertSqlUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TranslateFn } from "@/types/i18n";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 
 export interface SqlUtilsContext {
   parser: any;
@@ -14,6 +15,11 @@ type ComparisonOperator = ">=" | "<=" | ">" | "<" | "=" | "!=" | "<>";
 
 export const getParser = (sqlQuery: string, context: SqlUtilsContext): boolean => {
   const { parser, sqlQueryErrorMsg, t } = context;
+  // astify() is exponential in paren nesting depth — skip a pathologically
+  // nested query rather than freeze the tab. Same "assume OK" fallback as the
+  // catch below: this only checks for a bare `SELECT *`, and the backend
+  // still validates the query regardless.
+  if (maxParenDepth(sqlQuery) > SQL_PARSE_MAX_DEPTH) return true;
   try {
     // As default is a reserved keyword in sql-parser, we are replacing it with default1
     const regex = /\bdefault\b/g;
@@ -80,6 +86,13 @@ export const addHavingClauseToQuery = (
 
   if (!parser || typeof parser.astify !== "function" || typeof parser.sqlify !== "function") {
     throw new Error("Invalid parser: must have astify and sqlify methods");
+  }
+
+  // astify() is exponential in paren nesting depth — a pathologically nested
+  // query would freeze the tab, so go straight to the regex fallback instead
+  // of attempting the AST parse at all.
+  if (maxParenDepth(sqlQuery) > SQL_PARSE_MAX_DEPTH) {
+    return fallbackHavingInsertion(sqlQuery, yAxisColumn, operator, threshold);
   }
 
   try {

--- a/web/src/utils/query/sqlComplexity.ts
+++ b/web/src/utils/query/sqlComplexity.ts
@@ -1,0 +1,37 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// @openobserve/node-sql-parser's astify()/parse() is a PEG parser whose runtime
+// grows exponentially with WHERE-clause parenthesis nesting depth (measured:
+// ~14ms at depth 5, ~1000ms at depth 15), so a deeply nested paste can freeze
+// the tab for many seconds. Callers use this to skip client-side parsing
+// (quickMode field extraction, inline diagnostics, dashboard/alert query
+// building) for queries past a safe depth — the query still runs fine
+// server-side, only these optional client-side UX features are lost.
+export const SQL_PARSE_MAX_DEPTH = 12;
+
+export const maxParenDepth = (text: string): number => {
+  let depth = 0;
+  let max = 0;
+  for (const ch of text) {
+    if (ch === "(") {
+      depth++;
+      if (depth > max) max = depth;
+    } else if (ch === ")") {
+      depth--;
+    }
+  }
+  return max;
+};

--- a/web/src/utils/query/sqlDiagnostics.ts
+++ b/web/src/utils/query/sqlDiagnostics.ts
@@ -38,6 +38,7 @@
 // ─── Public types ─────────────────────────────────────────────────────────────
 
 import { gt, raw, type I18nText } from "@/types/i18n";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 
 export interface SqlErrorRange {
   startLine: number;
@@ -844,6 +845,8 @@ export async function validateSql(
   lineOffset = 0,
   colOffset = 0,
 ): Promise<SqlErrorRange | null> {
+  if (maxParenDepth(sql) > SQL_PARSE_MAX_DEPTH) return null;
+
   const parser = await getParser();
   try {
     parser.astify(sql);
@@ -896,13 +899,18 @@ export async function rangesFromSqlParserDetail(
     //   (b) It hit a parser-limitation or unclassified fingerprint and suppressed.
     //       → Fall through and use the server-reported position with a cleaned message,
     //         because the server told us there IS a real parse error at a known location.
-    // Distinguish: re-parse and check if it throws at all.
-    const parser = await getParser();
-    let clientThrows = false;
-    try {
-      parser.astify(originalSql);
-    } catch {
-      clientThrows = true;
+    // Distinguish: re-parse and check if it throws at all. Skipped past
+    // SQL_PARSE_MAX_DEPTH for the same reason validateSql skips it above —
+    // treat as case (b) below rather than hang re-parsing a query we already
+    // know is too complex to check client-side.
+    let clientThrows = maxParenDepth(originalSql) > SQL_PARSE_MAX_DEPTH;
+    if (!clientThrows) {
+      const parser = await getParser();
+      try {
+        parser.astify(originalSql);
+      } catch {
+        clientThrows = true;
+      }
     }
     if (!clientThrows) return []; // case (a): client accepted — semantic error only
     // case (b): client rejected but suppressed — use server position + cleaned message

--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -1,4 +1,5 @@
 import { splitQuotedString, escapeSingleQuotes } from "@/utils/zincutils";
+import { maxParenDepth, SQL_PARSE_MAX_DEPTH } from "@/utils/query/sqlComplexity";
 
 let parser: any;
 let parserImportPromise: Promise<any> | null = null;
@@ -934,7 +935,7 @@ export const getStreamNameFromQuery = async (query: any) => {
   try {
     await importSqlParser();
     try {
-      if (query && query != "") {
+      if (query && query != "" && maxParenDepth(query) <= SQL_PARSE_MAX_DEPTH) {
         const parsedQuery = parser?.astify(query);
 
         // Recursively find the first base table, descending into sub-queries in


### PR DESCRIPTION
### Root cause
@openobserve/node-sql-parser's astify() (and its sibling parse()) is a PEG parser whose runtime grows exponentially with WHERE-clause parenthesis nesting depth (measured: ~14ms at depth 5, ~1000ms at depth 15). A deeply nested query — easily produced by a BI tool or a generated dashboard export — could take 10+ seconds to parse.

Several places in the frontend called this parser synchronously on the main thread, on paths that fire automatically while a user types, pastes, or blurs a SQL editor, freezing the entire browser tab for as long as the parse took:

Logs: blur-time diagnostics (validateSql), the Cmd+Enter pre-flight check, and quickMode/pagination field extraction (fnParsedSQL)
Dashboards: the panel query-text watcher (updateQueryValue) and getStreamNameFromQuery
Alerts: getParser (the SELECT * check) and addHavingClauseToQuery
Alerts / Test Function / Scheduled Pipeline: a duplicated "sync stream name from the SQL you're typing" feature, debounced 600ms, using parser.parse() directly — this is what caused the hang specifically on Scheduled alerts, since it's independent of the blur-triggered validation path

### Solution
Added a shared maxParenDepth() helper (sqlComplexity.ts) and skip client-side parsing entirely once a query's nesting exceeds 12 levels — well beyond anything a hand-written query would use, but short-circuiting before the parser's cost becomes noticeable. The query still runs fine server-side; only these optional client-side conveniences are skipped for a pathological query:

Inline SQL diagnostics squiggle
QuickMode field list / pagination sizing
HAVING-clause auto-injection into an alert's SQL (falls back to the function's existing regex-based insertion instead of skipping outright, since that path was already built for when AST parsing fails)
Stream-name auto-sync from typed SQL
No Worker, no async/signature changes — every guarded function keeps its original sync/async shape, so this is a small, mechanical, low-risk change.

### Testing
Full vue-tsc --noEmit and eslint pass with zero errors across all touched files.
1,100 existing unit tests across Logs, Dashboards, Alerts, Test Function, and Scheduled Pipeline pass unchanged — no test updates were needed, since no function's calling contract changed.
Reviewer/QA should verify a deeply nested query (17+ levels of parens) no longer freezes the tab in: the Logs query editor (paste, blur, Cmd+Enter), a Dashboard panel's custom SQL editor, and an Alert's SQL editor in both real-time and Scheduled mode.