### PR TITLE
feat(promql): streaming fused aggregation over hash-sorted metrics files

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1531,6 +1531,12 @@ pub struct Search {
     )]
     pub feature_metrics_fused_agg_enabled: bool,
     #[env_config(
+        name = "ZO_FEATURE_METRICS_STREAMING_AGG_ENABLED",
+        default = true,
+        help = "Evaluate fused PromQL agg(range_func(...)) queries as a stream over hash-sorted metrics files, series by series, instead of materializing all samples; falls back to the fused evaluator when the file layout or query shape does not allow it"
+    )]
+    pub feature_metrics_streaming_agg_enabled: bool,
+    #[env_config(
         name = "ZO_FEATURE_DYNAMIC_PUSHDOWN_FILTER_ENABLED",
         default = true,
         help = "Enable dynamic pushdown filter"

--- a/src/config/src/meta/promql/mod.rs
+++ b/src/config/src/meta/promql/mod.rs
@@ -76,6 +76,9 @@ pub const BUCKET_LABEL: &str = "le";
 pub const QUANTILE_LABEL: &str = "quantile";
 pub const METADATA_LABEL: &str = "prom_metadata"; // for schema metadata key
 pub const EXEMPLARS_LABEL: &str = "exemplars";
+/// Table registered alongside a metrics table when every backing file is
+/// `(__hash__, _timestamp)` sorted, with that ordering declared to DataFusion.
+pub const STREAMING_AGG_TABLE_SUFFIX: &str = "__hash_sorted";
 
 /// Columns that metrics ingestion may exclude when deriving [`HASH_LABEL`].
 ///

--- a/src/promql/src/engine/aggregate.rs
+++ b/src/promql/src/engine/aggregate.rs
@@ -19,17 +19,20 @@ use std::sync::Arc;
 
 use config::meta::promql::value::*;
 use datafusion::error::{DataFusionError, Result};
-use promql_parser::parser::{Call, Expr as PromExpr, LabelModifier, token};
+use promql_parser::parser::{Call, Expr as PromExpr, LabelModifier, MatrixSelector, token};
 
 use super::Engine;
 use crate::{aggregations, functions, fused};
 
-/// A recognized `agg(range_func(...))` expression, the shape the fused
-/// evaluator accepts.
+/// A recognized `agg(range_func(...))` expression, the shape the fused and
+/// streaming evaluators accept.
 struct FusedAggShape<'a> {
     op: fused::FusedAggOp,
     func: Arc<dyn functions::RangeFunc>,
     range_arg: &'a PromExpr,
+    /// Set when the range argument is a plain matrix selector, the only
+    /// argument shape the streaming evaluator can plan.
+    matrix_selector: Option<&'a MatrixSelector>,
 }
 
 impl Engine {
@@ -42,6 +45,18 @@ impl Engine {
     ) -> Result<Value> {
         // fused shapes fold the range function into the aggregation; others stay generic
         if let Some(shape) = fused_agg_shape(op, expr) {
+            if let Some(matrix_selector) = shape.matrix_selector
+                && let Some(value) = self
+                    .try_streaming_fused_agg(
+                        matrix_selector,
+                        modifier,
+                        shape.func.clone(),
+                        shape.op,
+                    )
+                    .await?
+            {
+                return Ok(value);
+            }
             let range_input = self.exec_expr(shape.range_arg).await?;
             return fused::fused_range_agg(
                 modifier,
@@ -145,9 +160,14 @@ fn fused_agg_shape<'a>(op: &token::TokenType, expr: &'a PromExpr) -> Option<Fuse
         .args
         .last()
         .expect("promql-parser validated the function argument");
+    let matrix_selector = match range_arg {
+        PromExpr::MatrixSelector(matrix_selector) => Some(matrix_selector),
+        _ => None,
+    };
     Some(FusedAggShape {
         op: agg_op,
         func: Arc::from(range_func),
         range_arg,
+        matrix_selector,
     })
 }

--- a/src/promql/src/engine/selector.rs
+++ b/src/promql/src/engine/selector.rs
@@ -16,7 +16,7 @@
 //! Vector/matrix selector evaluation and data loading. Reads `ctx`,
 //! `label_selector`, and `skip_labels`; writes `result_type`.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use config::meta::promql::{NAME_LABEL, value::*};
 use datafusion::error::{DataFusionError, Result};
@@ -25,14 +25,16 @@ use hashbrown::HashMap;
 use infra::errors::{Error, ErrorCodes};
 use promql_parser::{
     label::{MatchOp, Matchers},
-    parser::{Offset, VectorSelector},
+    parser::{LabelModifier, MatrixSelector, Offset, VectorSelector},
 };
 use rayon::iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 
 use super::Engine;
 use crate::{
+    functions, fused,
     load_series::{LoadedMetrics, PartitionedMetrics, selector_load_data_from_datafusion},
     micros,
+    promql::rewrite::remove_filter_all,
 };
 
 impl Engine {
@@ -503,6 +505,105 @@ impl Engine {
         );
 
         Ok(metrics)
+    }
+
+    /// Attempts the streaming fused path: series arrive whole from
+    /// `(__hash__, _timestamp)` ordered scans and fold straight into the
+    /// aggregation, so the sample matrix is never materialized. `None` means
+    /// the query shape or the storage layout requires the materializing path.
+    pub(super) async fn try_streaming_fused_agg(
+        &mut self,
+        matrix_selector: &MatrixSelector,
+        modifier: &Option<LabelModifier>,
+        func: Arc<dyn functions::RangeFunc>,
+        op: fused::FusedAggOp,
+    ) -> Result<Option<Value>> {
+        let query_ctx = &self.ctx.query_ctx;
+        // need_wal bails early: WAL would split series and double the context-creation cost
+        if !config::get_config()
+            .search
+            .feature_metrics_streaming_agg_enabled
+            || query_ctx.query_exemplars
+            || query_ctx.query_data
+            || query_ctx.is_super_cluster
+            || query_ctx.need_wal
+        {
+            return Ok(None);
+        }
+        let MatrixSelector { vs, range } = matrix_selector;
+        let range = *range;
+        let mut selector = vs.clone();
+        remove_filter_all(&mut selector);
+        if !selector.matchers.or_matchers.is_empty() || selector.at.is_some() {
+            return Ok(None);
+        }
+        if selector.name.is_none() {
+            let names = selector.matchers.find_matchers(NAME_LABEL);
+            let Some(matcher) = names.first() else {
+                return Ok(None);
+            };
+            selector.name = Some(matcher.value.clone());
+            selector
+                .matchers
+                .matchers
+                .retain(|mat| mat.name != NAME_LABEL);
+        }
+        let table_name = selector.name.clone().unwrap();
+
+        let offset = get_offset_modifier(selector.offset.clone());
+        let start = self.ctx.start - micros(range) - offset;
+        let end = self.ctx.end - offset;
+        let mut filters = equal_matcher_filters(&selector.matchers);
+        let mut label_selector = self.label_selector.clone();
+        label_selector.extend(self.ctx.label_selector.iter().cloned());
+
+        let ctxs = self
+            .ctx
+            .table_provider
+            .create_context(
+                &query_ctx.org_id,
+                &table_name,
+                (start, end),
+                selector.matchers.clone(),
+                label_selector,
+                &mut filters,
+            )
+            .await?;
+        // a second context would split series and evaluate rate windows on partial data
+        if ctxs.len() != 1 {
+            return Ok(None);
+        }
+        let (ctx, schema, scan_stats, keep_filters) = ctxs.into_iter().next().unwrap();
+        if !keep_filters {
+            selector.matchers = Matchers::empty();
+        }
+
+        let value = fused::streaming_fused_agg(
+            &ctx,
+            &schema,
+            fused::StreamingSelector {
+                table_name: &table_name,
+                matchers: &selector.matchers,
+                start: self.eval_ctx.start - offset,
+                end: self.eval_ctx.end - offset,
+                step: self.eval_ctx.step,
+                lookback: micros(range),
+                offset,
+            },
+            fused::FusedShape { op, func, range },
+            modifier,
+            &self.eval_ctx,
+            query_ctx.timeout,
+        )
+        .await?;
+        if value.is_some() {
+            let mut ctx_scan_stats = self.ctx.scan_stats.write().await;
+            ctx_scan_stats.add(&scan_stats);
+            if self.result_type.is_none() {
+                self.result_type = Some("matrix".to_string());
+            }
+        }
+        Ok(value)
     }
 }
 

--- a/src/promql/src/fused/mod.rs
+++ b/src/promql/src/fused/mod.rs
@@ -20,6 +20,8 @@
 mod accumulator;
 mod eval;
 mod op;
+mod streaming;
 
 pub(crate) use eval::fused_range_agg;
 pub(crate) use op::FusedAggOp;
+pub(crate) use streaming::{FusedShape, StreamingSelector, streaming_fused_agg};

--- a/src/promql/src/fused/streaming/fold.rs
+++ b/src/promql/src/fused/streaming/fold.rs
@@ -1,0 +1,301 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Band execution: per-chain cursors, the series-run merge, and the fold of
+//! finished series into per-group accumulators merged across bands.
+
+use std::{hash::Hasher, sync::Arc, time::Duration};
+
+use config::{
+    TIMESTAMP_COL_NAME,
+    meta::promql::{
+        HASH_LABEL, VALUE_LABEL,
+        value::{EvalContext, ExtrapolationKind, Label, Labels, RangeValue, Sample, Value},
+    },
+    utils::hash::gxhash,
+};
+use datafusion::{
+    arrow::{
+        array::{AsArray, RecordBatch},
+        datatypes::{Float64Type, Int64Type, UInt64Type},
+    },
+    error::{DataFusionError, Result},
+    execution::SendableRecordBatchStream,
+};
+use futures::TryStreamExt;
+use hashbrown::{HashMap, hash_map::Entry};
+use infra::errors::{Error, ErrorCodes};
+
+use super::super::{accumulator::FusedAccumulator, eval::fold_series, op::FusedAggOp};
+use crate::{
+    functions::RangeFunc,
+    load_series::{LabelColumn, batch_run_len},
+};
+
+pub(super) type GroupAccs = HashMap<u64, GroupEntry>;
+
+pub(super) struct FoldParams {
+    pub(super) op: FusedAggOp,
+    pub(super) func: Arc<dyn RangeFunc>,
+    pub(super) counter_kind: Option<ExtrapolationKind>,
+    pub(super) range: Duration,
+    pub(super) offset: i64,
+    pub(super) eval_ctx: EvalContext,
+    pub(super) timestamps: Vec<i64>,
+    pub(super) group_cols: Vec<String>,
+}
+
+pub(super) struct GroupEntry {
+    labels: Labels,
+    acc: FusedAccumulator,
+}
+
+/// One hash-ordered input of a band's merge (a chain of non-overlapping
+/// files). All samples of one series sit in a single run per chain.
+struct ChainCursor {
+    stream: SendableRecordBatchStream,
+    batch: Option<RecordBatch>,
+    row: usize,
+}
+
+impl ChainCursor {
+    async fn start(stream: SendableRecordBatchStream) -> Result<Self> {
+        let mut cursor = Self {
+            stream,
+            batch: None,
+            row: 0,
+        };
+        cursor.next_batch().await?;
+        Ok(cursor)
+    }
+
+    fn head_hash(&self) -> Option<u64> {
+        let batch = self.batch.as_ref()?;
+        Some(batch[HASH_LABEL].as_primitive::<UInt64Type>().values()[self.row])
+    }
+
+    async fn next_batch(&mut self) -> Result<()> {
+        self.row = 0;
+        loop {
+            match self.stream.try_next().await? {
+                Some(batch) if batch.num_rows() == 0 => continue,
+                batch => {
+                    self.batch = batch;
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    /// Appends this chain's samples of series `hash`, following the run across
+    /// batch boundaries until the hash changes or the chain ends.
+    async fn consume_run(
+        &mut self,
+        hash: u64,
+        offset: i64,
+        samples: &mut Vec<Sample>,
+    ) -> Result<()> {
+        while let Some(batch) = &self.batch {
+            let hashes = batch[HASH_LABEL].as_primitive::<UInt64Type>().values();
+            if hashes[self.row] != hash {
+                return Ok(());
+            }
+            let run_len = batch_run_len(hashes, self.row);
+            let times = batch[TIMESTAMP_COL_NAME]
+                .as_primitive::<Int64Type>()
+                .values();
+            let values = batch[VALUE_LABEL].as_primitive::<Float64Type>().values();
+            samples.extend(
+                times[self.row..self.row + run_len]
+                    .iter()
+                    .zip(&values[self.row..self.row + run_len])
+                    .map(|(&timestamp, &value)| Sample::new(timestamp + offset, value)),
+            );
+            self.row += run_len;
+            if self.row < hashes.len() {
+                return Ok(());
+            }
+            self.next_batch().await?;
+        }
+        Ok(())
+    }
+}
+
+/// Aborts the band tasks when `timeout` elapses before they all finish.
+pub(super) async fn run_bands(
+    band_inputs: Vec<Vec<SendableRecordBatchStream>>,
+    params: Arc<FoldParams>,
+    timeout: u64,
+) -> Result<Vec<(GroupAccs, usize)>> {
+    let mut tasks = Vec::with_capacity(band_inputs.len());
+    let mut abort_handles = Vec::with_capacity(band_inputs.len());
+    for streams in band_inputs {
+        let task = tokio::task::spawn(fold_band(streams, params.clone()));
+        abort_handles.push(task.abort_handle());
+        tasks.push(task);
+    }
+    tokio::select! {
+        joined = futures::future::try_join_all(tasks) => {
+            joined
+                .map_err(|e| DataFusionError::Execution(e.to_string()))?
+                .into_iter()
+                .collect()
+        }
+        _ = tokio::time::sleep(Duration::from_secs(timeout)) => {
+            for handle in abort_handles {
+                handle.abort();
+            }
+            Err(DataFusionError::Plan(
+                Error::ErrorCode(ErrorCodes::SearchTimeout(
+                    "[PromQL] streaming fused agg timeout".to_string(),
+                ))
+                .to_string(),
+            ))
+        }
+    }
+}
+
+/// Merges the band's chains one series at a time: a series is one run per
+/// chain, so the merge costs one round of cursor checks per series instead of
+/// one heap operation per row.
+async fn fold_band(
+    streams: Vec<SendableRecordBatchStream>,
+    params: Arc<FoldParams>,
+) -> Result<(GroupAccs, usize)> {
+    let mut groups = GroupAccs::new();
+    let mut cursors = Vec::with_capacity(streams.len());
+    for stream in streams {
+        cursors.push(ChainCursor::start(stream).await?);
+    }
+    let mut samples: Vec<Sample> = Vec::new();
+    let mut series_count = 0;
+    while let Some(hash) = cursors.iter().filter_map(ChainCursor::head_hash).min() {
+        samples.clear();
+        let mut key = None;
+        for cursor in &mut cursors {
+            if cursor.head_hash() != Some(hash) {
+                continue;
+            }
+            if key.is_none() {
+                let batch = cursor.batch.as_ref().expect("head_hash implies a batch");
+                key = Some(group_key_at(batch, cursor.row, &params, &groups)?);
+            }
+            cursor
+                .consume_run(hash, params.offset, &mut samples)
+                .await?;
+        }
+        let (sig, labels) = key.expect("the minimum head hash has a contributing chain");
+        // classic parity: chains interleave in time, so restore per-series order
+        samples.sort_unstable_by_key(|sample| sample.timestamp);
+        let entry = match groups.entry(sig) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(GroupEntry {
+                labels: labels.unwrap_or_default(),
+                acc: FusedAccumulator::new(params.op, params.timestamps.len()),
+            }),
+        };
+        fold_series(
+            &mut entry.acc,
+            &samples,
+            params.range,
+            params.func.as_ref(),
+            params.counter_kind,
+            &params.eval_ctx,
+            &params.timestamps,
+        );
+        series_count += 1;
+    }
+    Ok((groups, series_count))
+}
+
+fn group_key_at(
+    batch: &RecordBatch,
+    row: usize,
+    params: &FoldParams,
+    groups: &GroupAccs,
+) -> Result<(u64, Option<Labels>)> {
+    let label_cols = params
+        .group_cols
+        .iter()
+        .map(|name| {
+            LabelColumn::try_from_array(batch[name.as_str()].as_ref()).ok_or_else(|| {
+                DataFusionError::Execution(format!("label column {name} is not Utf8 or Utf8View"))
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let sig = group_signature(&label_cols, &params.group_cols, row);
+    let labels = (!groups.contains_key(&sig))
+        .then(|| materialize_labels(&label_cols, &params.group_cols, row));
+    Ok((sig, labels))
+}
+
+fn group_signature(cols: &[LabelColumn<'_>], names: &[String], row: usize) -> u64 {
+    let mut hasher = gxhash::new_hasher();
+    for (values, name) in cols.iter().zip(names) {
+        if !values.is_null(row) {
+            hasher.write(name.as_bytes());
+            hasher.write(values.value(row).as_bytes());
+        }
+    }
+    hasher.finish()
+}
+
+fn materialize_labels(cols: &[LabelColumn<'_>], names: &[String], row: usize) -> Labels {
+    cols.iter()
+        .zip(names)
+        .filter(|(values, _)| !values.is_null(row))
+        .map(|(values, name)| Arc::new(Label::new(name.as_str(), values.value(row))))
+        .collect()
+}
+
+/// Merges the band-local groups in band order and materializes the result;
+/// groups whose accumulator produced no samples are dropped like the
+/// materializing path drops no-output series.
+pub(super) fn merge_folds(folds: Vec<GroupAccs>, timestamps: &[i64]) -> Value {
+    let mut folds = folds.into_iter();
+    let Some(mut merged) = folds.next() else {
+        return Value::None;
+    };
+    for fold in folds {
+        for (sig, entry) in fold {
+            match merged.entry(sig) {
+                Entry::Occupied(mut occupied) => occupied.get_mut().acc.merge(entry.acc),
+                Entry::Vacant(vacant) => {
+                    vacant.insert(entry);
+                }
+            }
+        }
+    }
+    let results: Vec<RangeValue> = merged
+        .into_values()
+        .filter_map(|entry| {
+            let samples = entry.acc.into_samples(timestamps);
+            if samples.is_empty() {
+                return None;
+            }
+            Some(RangeValue {
+                labels: entry.labels,
+                samples,
+                exemplars: None,
+                time_window: None,
+            })
+        })
+        .collect();
+    if results.is_empty() {
+        Value::None
+    } else {
+        Value::Matrix(results)
+    }
+}

--- a/src/promql/src/fused/streaming/mod.rs
+++ b/src/promql/src/fused/streaming/mod.rs
@@ -1,0 +1,568 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Streaming evaluation of `agg(range_func(selector))` over hash-sorted
+//! metrics files: each hash band merges its hash-ordered file chains one
+//! series at a time; a series is folded into its group accumulator and
+//! dropped, so the sample matrix is never materialized.
+
+mod fold;
+mod plan;
+
+use std::{sync::Arc, time::Duration};
+
+use config::{
+    TIMESTAMP_COL_NAME,
+    meta::promql::{
+        EXEMPLARS_LABEL, HASH_LABEL, NAME_LABEL, STREAMING_AGG_TABLE_SUFFIX, VALUE_LABEL,
+        value::{EvalContext, Value},
+    },
+};
+use datafusion::{
+    arrow::datatypes::{DataType, Schema},
+    error::Result,
+    prelude::SessionContext,
+};
+use promql_parser::{label::Matchers, parser::LabelModifier};
+
+use self::{
+    fold::{FoldParams, merge_folds, run_bands},
+    plan::build_band_inputs,
+};
+use crate::{
+    functions::{KEEP_METRIC_NAME_FUNC, RangeFunc},
+    fused::FusedAggOp,
+    load_series::apply_time_window,
+    utils::apply_matchers,
+};
+
+/// Load-window and matcher parameters of one selector scan, with the window
+/// already shifted for any `offset` modifier.
+pub(crate) struct StreamingSelector<'a> {
+    pub table_name: &'a str,
+    pub matchers: &'a Matchers,
+    pub start: i64,
+    pub end: i64,
+    pub step: i64,
+    pub lookback: i64,
+    pub offset: i64,
+}
+
+/// The `agg(range_func(...))` pair being evaluated.
+pub(crate) struct FusedShape {
+    pub op: FusedAggOp,
+    pub func: Arc<dyn RangeFunc>,
+    pub range: Duration,
+}
+
+/// Runs the fused aggregation as parallel per-hash-band ordered streams.
+/// Returns `None` when the layout or query shape rules the streaming plan out
+/// (no ordered table, non-UInt64 hashes, `without` grouping, a plan that would
+/// need an actual sort); the caller then falls back to the materializing path.
+pub(crate) async fn streaming_fused_agg(
+    ctx: &SessionContext,
+    schema: &Schema,
+    selector: StreamingSelector<'_>,
+    shape: FusedShape,
+    modifier: &Option<LabelModifier>,
+    eval_ctx: &EvalContext,
+    timeout: u64,
+) -> Result<Option<Value>> {
+    let start_time = std::time::Instant::now();
+    let trace_id = eval_ctx.trace_id.clone();
+
+    if schema
+        .field_with_name(HASH_LABEL)
+        .is_ok_and(|field| field.data_type() != &DataType::UInt64)
+    {
+        return Ok(None);
+    }
+    let Some(group_cols) = group_label_columns(modifier, schema, shape.func.name()) else {
+        return Ok(None);
+    };
+    let sorted_table = format!("{}{STREAMING_AGG_TABLE_SUFFIX}", selector.table_name);
+    let Ok(df) = ctx.table(sorted_table.as_str()).await else {
+        return Ok(None);
+    };
+
+    let df = apply_time_window(
+        df,
+        selector.start,
+        selector.end,
+        selector.step,
+        selector.lookback,
+    )?;
+    let df = apply_matchers(df, selector.matchers)?;
+
+    let mut columns = vec![TIMESTAMP_COL_NAME, HASH_LABEL, VALUE_LABEL];
+    columns.extend(group_cols.iter().map(String::as_str));
+
+    let bands = ctx.state().config().target_partitions();
+    let Some((band_inputs, band0_plan)) =
+        build_band_inputs(&df, &columns, bands, &trace_id).await?
+    else {
+        return Ok(None);
+    };
+
+    log::info!(
+        "[trace_id: {trace_id}] [PromQL Timing] streaming fused {}({}) started with {bands} bands",
+        shape.op.name(),
+        shape.func.name(),
+    );
+    let params = Arc::new(FoldParams {
+        op: shape.op,
+        func: shape.func.clone(),
+        counter_kind: shape.func.counter_extrapolation(),
+        range: shape.range,
+        offset: selector.offset,
+        eval_ctx: eval_ctx.clone(),
+        timestamps: eval_ctx.timestamps(),
+        group_cols,
+    });
+    let folds = run_bands(band_inputs, params.clone(), timeout).await?;
+
+    if config::get_config().common.print_key_sql {
+        log::info!(
+            "[trace_id: {trace_id}] [PromQL] streaming band 0 metrics:\n{}",
+            datafusion::physical_plan::display::DisplayableExecutionPlan::with_metrics(
+                band0_plan.as_ref()
+            )
+            .indent(true)
+        );
+    }
+    let series_count: usize = folds.iter().map(|(_, series)| series).sum();
+    let value = merge_folds(
+        folds.into_iter().map(|(groups, _)| groups).collect(),
+        &params.timestamps,
+    );
+    log::info!(
+        "[trace_id: {trace_id}] [PromQL Timing] streaming fused {}({}) completed in {:?}, folded {series_count} series into {} series",
+        shape.op.name(),
+        shape.func.name(),
+        start_time.elapsed(),
+        match &value {
+            Value::Matrix(matrix) => matrix.len(),
+            _ => 0,
+        },
+    );
+    Ok(Some(value))
+}
+
+/// Columns the aggregation groups by, sorted for a stable label order.
+/// `None` when the grouping cannot be resolved to a column set (`without`).
+fn group_label_columns(
+    modifier: &Option<LabelModifier>,
+    schema: &Schema,
+    func_name: &str,
+) -> Option<Vec<String>> {
+    let include = match modifier {
+        None => return Some(vec![]),
+        Some(LabelModifier::Include(labels)) => &labels.labels,
+        Some(LabelModifier::Exclude(_)) => return None,
+    };
+    let mut cols: Vec<String> = include
+        .iter()
+        .filter(|name| {
+            let name = name.as_str();
+            name != TIMESTAMP_COL_NAME
+                && name != HASH_LABEL
+                && name != VALUE_LABEL
+                && name != EXEMPLARS_LABEL
+                // range functions strip the metric name before aggregation
+                && (name != NAME_LABEL || KEEP_METRIC_NAME_FUNC.contains(func_name))
+                && schema.field_with_name(name).is_ok()
+        })
+        .cloned()
+        .collect();
+    cols.sort();
+    cols.dedup();
+    Some(cols)
+}
+
+#[cfg(test)]
+mod tests {
+    use config::meta::promql::value::{Label, RangeValue, Sample, TimeWindow};
+    use datafusion::{
+        arrow::array::{Float64Array, Int64Array, RecordBatch, StringArray, UInt64Array},
+        datasource::MemTable,
+        logical_expr::SortExpr,
+        prelude::{SessionConfig, col},
+    };
+    use hashbrown::HashMap;
+    use itertools::Itertools;
+    use promql_parser::label::Labels as ModifierLabels;
+
+    use super::*;
+    use crate::{functions, fused::eval::fused_range_agg};
+
+    type CanonicalSeries = (Vec<(String, String)>, Vec<(i64, u64)>);
+
+    const SECOND: i64 = 1_000_000;
+    const BASE: i64 = 1_000 * SECOND;
+
+    fn eval_ctx() -> EvalContext {
+        EvalContext::new(
+            BASE + 60 * SECOND,
+            BASE + 180 * SECOND,
+            60 * SECOND,
+            "test".into(),
+        )
+    }
+
+    fn arrow_schema() -> Arc<Schema> {
+        use datafusion::arrow::datatypes::Field;
+        Arc::new(Schema::new(vec![
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new(HASH_LABEL, DataType::UInt64, false),
+            Field::new(VALUE_LABEL, DataType::Float64, false),
+            Field::new("instance", DataType::Utf8, true),
+            Field::new("path", DataType::Utf8, true),
+        ]))
+    }
+
+    /// (hash, seconds offset, value, instance, path)
+    type Row = (u64, i64, f64, Option<&'static str>, Option<&'static str>);
+
+    /// The test series: counters, a counter reset, a late-only series, and a
+    /// series with a null label, spread over the full hash space.
+    fn test_rows() -> Vec<Row> {
+        let dense = [10, 50, 70, 110, 130, 170];
+        let series = |hash, values: [f64; 6], instance, path| {
+            dense
+                .into_iter()
+                .zip(values)
+                .map(move |(ts, value)| (hash, ts, value, instance, path))
+        };
+        let mut rows: Vec<Row> = series(
+            100,
+            [0.1, 40.7, 45.2, 85.9, 90.4, 130.8],
+            Some("a"),
+            Some("/one"),
+        )
+        .chain(series(
+            200,
+            [0.3, 80.1, 90.6, 170.2, 180.9, 260.5],
+            Some("b"),
+            Some("/one"),
+        ))
+        // counter reset (25.1 -> 3.4) crossing the partition split below
+        .chain(series(
+            5,
+            [0.2, 20.4, 25.1, 3.4, 50.3, 70.9],
+            Some("c"),
+            Some("/two"),
+        ))
+        .collect();
+        // samples only in the last window
+        rows.push((u64::MAX - 3, 130, 7.5, Some("z"), Some("/two")));
+        rows.push((u64::MAX - 3, 170, 11.25, Some("z"), Some("/two")));
+        // null instance label
+        rows.push((42, 50, 1.0, None, Some("/two")));
+        rows.push((42, 110, 3.0, None, Some("/two")));
+        rows
+    }
+
+    fn rows_to_batch(mut rows: Vec<Row>) -> RecordBatch {
+        rows.sort_by_key(|row| (row.0, row.1));
+        RecordBatch::try_new(
+            arrow_schema(),
+            vec![
+                Arc::new(Int64Array::from_iter_values(
+                    rows.iter().map(|row| BASE + row.1 * SECOND),
+                )),
+                Arc::new(UInt64Array::from_iter_values(rows.iter().map(|row| row.0))),
+                Arc::new(Float64Array::from_iter_values(rows.iter().map(|row| row.2))),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|row| row.3).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|row| row.4).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Two overlapping sorted "files": every series with more than one sample
+    /// is split across both, so only the ordered merge sees it whole.
+    fn sorted_partitions() -> Vec<Vec<RecordBatch>> {
+        let (even, odd): (Vec<Row>, Vec<Row>) =
+            test_rows()
+                .into_iter()
+                .enumerate()
+                .partition_map(|(index, row)| {
+                    if index.is_multiple_of(2) {
+                        itertools::Either::Left(row)
+                    } else {
+                        itertools::Either::Right(row)
+                    }
+                });
+        vec![vec![rows_to_batch(even)], vec![rows_to_batch(odd)]]
+    }
+
+    fn session_ctx() -> SessionContext {
+        let mut config = SessionConfig::new().with_target_partitions(3);
+        config.options_mut().optimizer.prefer_existing_sort = true;
+        SessionContext::new_with_config(config)
+    }
+
+    fn register_sorted_table(ctx: &SessionContext) {
+        let sort_order: Vec<SortExpr> = vec![
+            col(HASH_LABEL).sort(true, false),
+            col(TIMESTAMP_COL_NAME).sort(true, false),
+        ];
+        let table = MemTable::try_new(arrow_schema(), sorted_partitions())
+            .unwrap()
+            .with_sort_order(vec![sort_order]);
+        ctx.register_table(format!("m{STREAMING_AGG_TABLE_SUFFIX}"), Arc::new(table))
+            .unwrap();
+    }
+
+    /// The same data as a materialized matrix for the reference evaluator.
+    fn reference_matrix(range: Duration) -> Vec<RangeValue> {
+        let mut by_hash: HashMap<u64, RangeValue> = HashMap::new();
+        for (hash, ts, value, instance, path) in test_rows() {
+            let entry = by_hash.entry(hash).or_insert_with(|| RangeValue {
+                labels: [("instance", instance), ("path", path)]
+                    .into_iter()
+                    .filter_map(|(name, value)| Some(Arc::new(Label::new(name, value?))))
+                    .collect(),
+                samples: vec![],
+                exemplars: None,
+                time_window: Some(TimeWindow::new(range)),
+            });
+            entry.samples.push(Sample::new(BASE + ts * SECOND, value));
+        }
+        let mut matrix: Vec<RangeValue> = by_hash.into_values().collect();
+        for series in &mut matrix {
+            series
+                .samples
+                .sort_unstable_by_key(|sample| sample.timestamp);
+        }
+        matrix
+    }
+
+    fn canonical_matrix(value: Value) -> Vec<CanonicalSeries> {
+        let matrix = match value {
+            Value::Matrix(matrix) => matrix,
+            Value::None => return vec![],
+            value => panic!("expected matrix or none, got {}", value.get_type()),
+        };
+        let mut canonical = matrix
+            .into_iter()
+            .map(|series| {
+                let mut labels = series
+                    .labels
+                    .iter()
+                    .map(|label| (label.name.clone(), label.value.clone()))
+                    .collect::<Vec<_>>();
+                labels.sort();
+                let samples = series
+                    .samples
+                    .iter()
+                    .map(|sample| (sample.timestamp, sample.value.to_bits()))
+                    .collect::<Vec<_>>();
+                (labels, samples)
+            })
+            .collect::<Vec<_>>();
+        canonical.sort_by(|a, b| a.0.cmp(&b.0));
+        canonical
+    }
+
+    /// Labels and timestamps must match exactly; values may drift in the last
+    /// bits because streaming folds series in hash order, not matrix order.
+    fn assert_matrix_close(
+        expected: Vec<CanonicalSeries>,
+        actual: Vec<CanonicalSeries>,
+        context: &str,
+    ) {
+        assert_eq!(expected.len(), actual.len(), "{context}: series count");
+        for (expected, actual) in expected.iter().zip(&actual) {
+            assert_eq!(expected.0, actual.0, "{context}: labels");
+            assert_eq!(expected.1.len(), actual.1.len(), "{context}: sample count");
+            for (&(expected_ts, expected_bits), &(actual_ts, actual_bits)) in
+                expected.1.iter().zip(&actual.1)
+            {
+                assert_eq!(expected_ts, actual_ts, "{context}: timestamps");
+                if expected_bits == actual_bits {
+                    continue;
+                }
+                let expected_value = f64::from_bits(expected_bits);
+                let actual_value = f64::from_bits(actual_bits);
+                assert!(
+                    expected_value.is_finite() && actual_value.is_finite(),
+                    "{context}: non-finite values must match exactly"
+                );
+                let tolerance = expected_value.abs().max(actual_value.abs()) * 1e-12;
+                assert!(
+                    (expected_value - actual_value).abs() <= tolerance,
+                    "{context}: {expected_value} vs {actual_value}"
+                );
+            }
+        }
+    }
+
+    fn by(labels: &[&str]) -> Option<LabelModifier> {
+        Some(LabelModifier::Include(ModifierLabels {
+            labels: labels.iter().map(|label| label.to_string()).collect(),
+        }))
+    }
+
+    async fn run_streaming(
+        ctx: &SessionContext,
+        modifier: &Option<LabelModifier>,
+        func_name: &str,
+        op: FusedAggOp,
+        range: Duration,
+    ) -> Option<Value> {
+        let func: Arc<dyn RangeFunc> = Arc::from(functions::fusable_range_func(func_name).unwrap());
+        let eval_ctx = eval_ctx();
+        streaming_fused_agg(
+            ctx,
+            &arrow_schema(),
+            StreamingSelector {
+                table_name: "m",
+                matchers: &Matchers::empty(),
+                start: eval_ctx.start,
+                end: eval_ctx.end,
+                step: eval_ctx.step,
+                lookback: crate::micros(range),
+                offset: 0,
+            },
+            FusedShape { op, func, range },
+            modifier,
+            &eval_ctx,
+            10,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[test]
+    fn test_group_label_columns_resolution() {
+        let schema = arrow_schema();
+        assert_eq!(group_label_columns(&None, &schema, "rate"), Some(vec![]));
+        assert_eq!(
+            group_label_columns(&by(&["path", "instance", "path"]), &schema, "rate"),
+            Some(vec!["instance".to_string(), "path".to_string()])
+        );
+        // absent columns group like an absent label: no column to read
+        assert_eq!(
+            group_label_columns(&by(&["nope", HASH_LABEL, VALUE_LABEL]), &schema, "rate"),
+            Some(vec![])
+        );
+        // rate strips the metric name; last_over_time keeps it (not in schema here)
+        assert_eq!(
+            group_label_columns(&by(&[NAME_LABEL]), &schema, "rate"),
+            Some(vec![])
+        );
+        let without = Some(LabelModifier::Exclude(ModifierLabels {
+            labels: vec!["instance".to_string()],
+        }));
+        assert_eq!(group_label_columns(&without, &schema, "rate"), None);
+    }
+
+    #[tokio::test]
+    async fn test_streaming_matches_fused_for_all_pairs() {
+        let ctx = session_ctx();
+        register_sorted_table(&ctx);
+        let range = Duration::from_secs(60);
+        let eval_ctx = eval_ctx();
+
+        let agg_cases = [
+            FusedAggOp::Avg,
+            FusedAggOp::Count,
+            FusedAggOp::Group,
+            FusedAggOp::Max,
+            FusedAggOp::Min,
+            FusedAggOp::Stddev,
+            FusedAggOp::Stdvar,
+            FusedAggOp::Sum,
+        ];
+        let func_cases = ["rate", "increase", "sum_over_time", "last_over_time"];
+        let modifiers = [
+            None,
+            by(&["path"]),
+            by(&["instance", "path"]),
+            by(&["nope"]),
+        ];
+
+        for op in agg_cases {
+            for func_name in func_cases {
+                for modifier in &modifiers {
+                    let func = functions::fusable_range_func(func_name).unwrap();
+                    let expected = fused_range_agg(
+                        modifier,
+                        Value::Matrix(reference_matrix(range)),
+                        func.as_ref(),
+                        op,
+                        &eval_ctx,
+                    )
+                    .unwrap();
+
+                    let actual = run_streaming(&ctx, modifier, func_name, op, range)
+                        .await
+                        .expect("streaming path must not fall back on the sorted table");
+
+                    assert_matrix_close(
+                        canonical_matrix(expected),
+                        canonical_matrix(actual),
+                        &format!(
+                            "streaming {}({func_name}) (modifier: {modifier:?})",
+                            op.name()
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_streaming_falls_back_without_sorted_table() {
+        let ctx = session_ctx();
+        let table = MemTable::try_new(arrow_schema(), sorted_partitions()).unwrap();
+        ctx.register_table("m", Arc::new(table)).unwrap();
+
+        let result = run_streaming(
+            &ctx,
+            &None,
+            "rate",
+            FusedAggOp::Sum,
+            Duration::from_secs(60),
+        )
+        .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_streaming_falls_back_when_ordering_is_not_declared() {
+        let ctx = session_ctx();
+        // same data registered under the sorted name but without the ordering
+        // declaration: the plan needs a real sort, so the gate must reject it
+        let table = MemTable::try_new(arrow_schema(), sorted_partitions()).unwrap();
+        ctx.register_table(format!("m{STREAMING_AGG_TABLE_SUFFIX}"), Arc::new(table))
+            .unwrap();
+
+        let result = run_streaming(
+            &ctx,
+            &None,
+            "rate",
+            FusedAggOp::Sum,
+            Duration::from_secs(60),
+        )
+        .await;
+        assert!(result.is_none());
+    }
+}

--- a/src/promql/src/fused/streaming/plan.rs
+++ b/src/promql/src/fused/streaming/plan.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Band plan construction: hash-space partitioning, ordered chain streams,
+//! and the plan-shape gates that guard the streaming path.
+
+use std::sync::Arc;
+
+use config::meta::promql::HASH_LABEL;
+use datafusion::{
+    error::Result,
+    execution::{SendableRecordBatchStream, TaskContext},
+    physical_plan::{
+        ExecutionPlan, execute_stream, execute_stream_partitioned,
+        expressions::Column,
+        sorts::{sort::SortExec, sort_preserving_merge::SortPreservingMergeExec},
+    },
+    prelude::{DataFrame, col, lit},
+};
+
+/// Uniform partition of the u64 hash space into `count` inclusive ranges.
+pub(super) fn hash_bands(count: usize) -> Vec<(u64, u64)> {
+    let count = count.max(1) as u128;
+    let span = (u64::MAX as u128) + 1;
+    (0..count)
+        .map(|band| {
+            let lo = (span * band / count) as u64;
+            let hi = (span * (band + 1) / count - 1) as u64;
+            (lo, hi)
+        })
+        .collect()
+}
+
+/// Builds every band's ordered input streams; `None` (with the offending band
+/// logged) means some band's plan cannot stream in order.
+pub(super) async fn build_band_inputs(
+    df: &DataFrame,
+    columns: &[&str],
+    bands: usize,
+    trace_id: &str,
+) -> Result<Option<(Vec<Vec<SendableRecordBatchStream>>, Arc<dyn ExecutionPlan>)>> {
+    let mut band_inputs = Vec::with_capacity(bands);
+    let mut band0_plan = None;
+    for (band, (lo, hi)) in hash_bands(bands).into_iter().enumerate() {
+        let band_df = df
+            .clone()
+            .filter(
+                col(HASH_LABEL)
+                    .gt_eq(lit(lo))
+                    .and(col(HASH_LABEL).lt_eq(lit(hi))),
+            )?
+            .select_columns(columns)?
+            // planning-only: proves the scan partitions hash-ordered; fold_band merges, not the SPM
+            .sort(vec![col(HASH_LABEL).sort(true, false)])?;
+        let task_ctx = Arc::new(band_df.task_ctx());
+        let plan = band_df.create_physical_plan().await?;
+        let Some(streams) = band_streams(plan.clone(), task_ctx)? else {
+            log::info!(
+                "[trace_id: {trace_id}] [PromQL] streaming fused agg fallback: band {band} plan cannot stream in order"
+            );
+            return Ok(None);
+        };
+        band0_plan.get_or_insert(plan);
+        band_inputs.push(streams);
+    }
+    let band0_plan = band0_plan.expect("target_partitions is at least one band");
+    Ok(Some((band_inputs, band0_plan)))
+}
+
+/// The hash-ordered inputs a band folds from: the merge's own child
+/// partitions, so the row-level merge node itself is never executed.
+fn band_streams(
+    plan: Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
+) -> Result<Option<Vec<SendableRecordBatchStream>>> {
+    if plan_contains_sort(&plan) {
+        return Ok(None);
+    }
+    if let Some(merge) = plan.downcast_ref::<SortPreservingMergeExec>() {
+        return Ok(Some(execute_stream_partitioned(
+            merge.input().clone(),
+            task_ctx,
+        )?));
+    }
+    if plan.properties().output_partitioning().partition_count() == 1 && hash_ordered(&plan) {
+        return Ok(Some(vec![execute_stream(plan, task_ctx)?]));
+    }
+    Ok(None)
+}
+
+fn plan_contains_sort(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    plan.downcast_ref::<SortExec>().is_some()
+        || plan
+            .children()
+            .iter()
+            .any(|child| plan_contains_sort(child))
+}
+
+fn hash_ordered(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    plan.properties().output_ordering().is_some_and(|ordering| {
+        let sort = ordering.first();
+        !sort.options.descending
+            && sort
+                .expr
+                .downcast_ref::<Column>()
+                .is_some_and(|column| column.name() == HASH_LABEL)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_bands_cover_the_full_space_contiguously() {
+        for count in [1, 3, 7, 16] {
+            let bands = hash_bands(count);
+            assert_eq!(bands.len(), count);
+            assert_eq!(bands[0].0, 0);
+            assert_eq!(bands[count - 1].1, u64::MAX);
+            for pair in bands.windows(2) {
+                assert_eq!(pair[0].1.wrapping_add(1), pair[1].0);
+            }
+        }
+    }
+}

--- a/src/promql_service/src/search/grpc/storage.rs
+++ b/src/promql_service/src/search/grpc/storage.rs
@@ -30,9 +30,10 @@ use infra::{
     schema::{get_partition_time_level, unwrap_stream_settings},
 };
 use itertools::Itertools;
+use metrics_index::MetricsFileLayout;
 use promql_parser::label::Matchers;
 use search::{
-    datafusion::exec::register_metrics_table,
+    datafusion::{exec::register_metrics_table, sort_order::FileSortOrder},
     file_cache::{cache_files, calc_target_partitions},
 };
 use search_service::match_source;
@@ -232,7 +233,20 @@ pub(crate) async fn create_context(
         target_partitions,
     };
 
-    let ctx = register_metrics_table(&session, schema.clone(), stream_name, files).await?;
+    // Streaming aggregation needs every file's rows ordered by
+    // (__hash__, _timestamp); one legacy file voids the guarantee.
+    let sort_order = if cfg.search.feature_metrics_streaming_agg_enabled
+        && files
+            .iter()
+            .all(|file| MetricsFileLayout::of(&file.key).is_some())
+    {
+        FileSortOrder::HashTimestampAsc
+    } else {
+        FileSortOrder::None
+    };
+
+    let ctx =
+        register_metrics_table(&session, schema.clone(), stream_name, files, sort_order).await?;
 
     // keep_filters=false only when the pruner proved its selections exact
     Ok(Some((ctx, schema, scan_stats, keep_filters)))

--- a/src/search/src/datafusion/exec.rs
+++ b/src/search/src/datafusion/exec.rs
@@ -19,7 +19,7 @@ use arrow_schema::Field;
 use config::{
     FileFormat, TIMESTAMP_COL_NAME, get_batch_size, get_config,
     meta::{
-        promql::{EXEMPLARS_LABEL, HASH_LABEL},
+        promql::{EXEMPLARS_LABEL, HASH_LABEL, STREAMING_AGG_TABLE_SUFFIX},
         search::{Session as SearchSession, StorageType},
         stream::{FileKey, StreamType},
     },
@@ -51,7 +51,7 @@ use datafusion::{
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::search::WorkGroup;
 use vortex::{VortexSessionDefault, io::session::RuntimeSessionExt, session::VortexSession};
-use vortex_datafusion::VortexFormat;
+use vortex_datafusion::{VortexFormat, VortexTableOptions};
 
 use super::{
     peak_memory_pool::PeakMemoryPool, planner::extension_planner::OpenobserveQueryPlanner,
@@ -107,6 +107,11 @@ fn create_session_config(
             .options_mut()
             .execution
             .split_file_groups_by_statistics = true;
+        // a round-robin exchange would trade the chains' ordering for a re-sort
+        config
+            .options_mut()
+            .optimizer
+            .enable_round_robin_repartition = false;
     }
 
     // When set to true, skips verifying that the schema produced by planning the input of
@@ -514,17 +519,36 @@ pub async fn register_metrics_table(
     schema: Arc<Schema>,
     table_name: &str,
     files: Vec<FileKey>,
+    sort_order: FileSortOrder,
 ) -> Result<SessionContext> {
     let schema = metrics_query_schema(schema);
     let ctx = DataFusionContextBuilder::new()
         .trace_id(&session.id)
         .work_group(session.work_group.clone())
         .stream_type(StreamType::Metrics)
+        .sort_order(sort_order)
         .build(session.target_partitions)
         .await?;
 
+    let file_stat_cache = ctx.runtime_env().cache_manager.get_file_statistic_cache();
+    // The ordered table is registered separately: declaring the ordering on the
+    // main table would split its scan into one file group per overlapping file,
+    // changing the unsorted path's partitioning.
+    if sort_order.is_sorted() {
+        let tables = TableBuilder::new()
+            .sort_order(sort_order)
+            .file_stat_cache(file_stat_cache.clone())
+            .build(session.clone(), files.clone(), schema.clone())
+            .await?;
+        let union_table = Arc::new(NewUnionTable::new(schema.clone(), tables));
+        ctx.register_table(
+            format!("{table_name}{STREAMING_AGG_TABLE_SUFFIX}"),
+            union_table,
+        )?;
+    }
+
     let tables = TableBuilder::new()
-        .file_stat_cache(ctx.runtime_env().cache_manager.get_file_statistic_cache())
+        .file_stat_cache(file_stat_cache)
         .build(session.clone(), files, schema.clone())
         .await?;
     let union_table = Arc::new(NewUnionTable::new(schema, tables));
@@ -708,7 +732,14 @@ impl TableBuilder {
             FileFormat::Parquet => Arc::new(ParquetFormat::default()),
             FileFormat::Vortex => {
                 let vortex_session = VortexSession::default().with_tokio();
-                Arc::new(VortexFormat::new(vortex_session))
+                if self.sort_order.is_sorted() {
+                    // bands already parallelize; per-file spawned read-ahead only buys memory
+                    let mut options = VortexTableOptions::default();
+                    options.scan_concurrency = Some(1);
+                    Arc::new(VortexFormat::new_with_options(vortex_session, options))
+                } else {
+                    Arc::new(VortexFormat::new(vortex_session))
+                }
             }
         };
 
@@ -1481,7 +1512,9 @@ mod tests {
                 row_group_size: None,
             }];
 
-            let result = register_metrics_table(&session, schema, "test_table", files).await;
+            let result =
+                register_metrics_table(&session, schema, "test_table", files, FileSortOrder::None)
+                    .await;
 
             // Should create context successfully
             assert!(result.is_ok());

--- a/src/search/src/datafusion/table_provider/listing_adapter.rs
+++ b/src/search/src/datafusion/table_provider/listing_adapter.rs
@@ -16,17 +16,17 @@
 use std::sync::Arc;
 
 use arrow_schema::SchemaRef;
-use config::{TIMESTAMP_COL_NAME, get_config};
+use config::{TIMESTAMP_COL_NAME, get_config, meta::promql::HASH_LABEL};
 use datafusion::{
     catalog::{Session, TableProvider, memory::DataSourceExec},
-    common::Result,
+    common::{Result, ScalarValue},
     datasource::{
         TableType,
-        listing::{ListingTable, ListingTableConfig},
+        listing::{ListingTable, ListingTableConfig, PartitionedFile},
         physical_plan::{FileGroup, FileScanConfig},
     },
     execution::cache::cache_manager::FileStatisticsCache,
-    logical_expr::TableProviderFilterPushDown,
+    logical_expr::{Operator, TableProviderFilterPushDown},
     physical_plan::ExecutionPlan,
     prelude::Expr,
 };
@@ -141,16 +141,16 @@ impl TableProvider for ListingTableAdapter {
 
         // The files are sorted but DataFusion dropped the ordering (overlapping
         // files in one group): regroup them by statistics ourselves.
-        let regroup_order = (self.sort_order.is_sorted()
-            && parquet_exec.properties().output_ordering().is_none())
-        .then_some(self.sort_order);
+        let ordering_missing = parquet_exec.properties().output_ordering().is_none();
         let target_partitions = self.listing_table.options().target_partitions;
         let parquet_exec = handler_tantivy_index(
             &self.trace_id,
             state,
             parquet_exec,
-            regroup_order,
+            self.sort_order,
+            ordering_missing,
             target_partitions,
+            hash_interval(filters),
         );
 
         // if the index condition can remove filter, we can skip the config
@@ -190,8 +190,10 @@ fn handler_tantivy_index(
     trace_id: &str,
     state: &dyn Session,
     plan: Arc<dyn ExecutionPlan>,
-    regroup_order: Option<FileSortOrder>,
+    sort_order: FileSortOrder,
+    ordering_missing: bool,
     target_partitions: usize,
+    hash_range: Option<(u64, u64)>,
 ) -> Arc<dyn ExecutionPlan> {
     if let Some(data_source_exec) = plan.downcast_ref::<DataSourceExec>()
         && let Some(config) = data_source_exec
@@ -200,20 +202,34 @@ fn handler_tantivy_index(
     {
         let mut file_groups = config.file_groups.clone();
 
-        if let Some(sort_order) = regroup_order {
+        // prune before regrouping so ordered chains form from survivors only
+        if let Some(range) = hash_range {
+            let schema = config.file_source().table_schema().table_schema();
+            file_groups = prune_groups_by_hash_range(file_groups, schema, range);
+        }
+
+        // banded scans re-chain to the fewest chains: one task merges them all
+        let band_chains = hash_range.is_some() && sort_order.is_sorted();
+        let regroup = sort_order.is_sorted() && ordering_missing;
+        if band_chains || regroup {
             let schema = config.file_source().table_schema().table_schema();
             match sort_order.physical_ordering(schema) {
                 Some(ordering) => {
-                    match FileScanConfig::split_groups_by_statistics_with_target_partitions(
-                        schema,
-                        &file_groups,
-                        &ordering,
-                        target_partitions,
-                    ) {
+                    let split = if band_chains {
+                        FileScanConfig::split_groups_by_statistics(schema, &file_groups, &ordering)
+                    } else {
+                        FileScanConfig::split_groups_by_statistics_with_target_partitions(
+                            schema,
+                            &file_groups,
+                            &ordering,
+                            target_partitions,
+                        )
+                    };
+                    match split {
                         Ok(new_file_groups) => {
                             file_groups = new_file_groups;
                         }
-                        Err(e) if sort_order.is_timestamp_desc() => {
+                        Err(e) if regroup && sort_order.is_timestamp_desc() => {
                             // files are listed oldest first; reversing each group
                             // is the best effort approximation of `_timestamp DESC`
                             log::warn!(
@@ -275,7 +291,8 @@ fn handler_tantivy_index(
         let mut plan = Arc::new(DataSourceExec::new(Arc::new(config))) as Arc<dyn ExecutionPlan>;
         // skip repartitioning when the files were regrouped by statistics: the
         // groups already carry the ordering and there are plenty of them
-        if regroup_order.is_none()
+        if !regroup
+            && !band_chains
             && let Ok(Some(repartition_plan)) =
                 plan.repartitioned(target_partitions, state.config_options())
         {
@@ -284,6 +301,86 @@ fn handler_tantivy_index(
         return plan;
     }
     plan
+}
+
+/// The closed `__hash__` interval implied by the pushed-down scan filters.
+/// `None` when no hash bound is present (non-band scans).
+fn hash_interval(filters: &[Expr]) -> Option<(u64, u64)> {
+    let mut lo = 0u64;
+    let mut hi = u64::MAX;
+    let mut found = false;
+    for filter in filters {
+        let Expr::BinaryExpr(binary) = filter else {
+            continue;
+        };
+        let Expr::Column(column) = binary.left.as_ref() else {
+            continue;
+        };
+        if column.name != HASH_LABEL {
+            continue;
+        }
+        let Expr::Literal(ScalarValue::UInt64(Some(value)), _) = binary.right.as_ref() else {
+            continue;
+        };
+        match binary.op {
+            Operator::GtEq => lo = lo.max(*value),
+            Operator::Gt => lo = lo.max(value.saturating_add(1)),
+            Operator::LtEq => hi = hi.min(*value),
+            Operator::Lt => hi = hi.min(value.saturating_sub(1)),
+            Operator::Eq => {
+                lo = lo.max(*value);
+                hi = hi.min(*value);
+            }
+            _ => continue,
+        }
+        found = true;
+    }
+    found.then_some((lo, hi))
+}
+
+/// Keeps only files whose `__hash__` statistics may intersect `[lo, hi]`;
+/// files without usable statistics always survive.
+fn prune_groups_by_hash_range(
+    file_groups: Vec<FileGroup>,
+    schema: &arrow_schema::Schema,
+    (lo, hi): (u64, u64),
+) -> Vec<FileGroup> {
+    let Ok(hash_index) = schema.index_of(HASH_LABEL) else {
+        return file_groups;
+    };
+    let mut pruned: Vec<FileGroup> = file_groups
+        .into_iter()
+        .map(|group| {
+            FileGroup::new(
+                group
+                    .into_inner()
+                    .into_iter()
+                    .filter(|file| file_may_intersect(file, hash_index, lo, hi))
+                    .collect(),
+            )
+        })
+        .filter(|group| !group.is_empty())
+        .collect();
+    // a scan needs at least one (empty) partition
+    if pruned.is_empty() {
+        pruned.push(FileGroup::new(vec![]));
+    }
+    pruned
+}
+
+fn file_may_intersect(file: &PartitionedFile, hash_index: usize, lo: u64, hi: u64) -> bool {
+    let Some(statistics) = file.statistics.as_ref() else {
+        return true;
+    };
+    let Some(column) = statistics.column_statistics.get(hash_index) else {
+        return true;
+    };
+    match (column.min_value.get_value(), column.max_value.get_value()) {
+        (Some(ScalarValue::UInt64(Some(min))), Some(ScalarValue::UInt64(Some(max)))) => {
+            *max >= lo && *min <= hi
+        }
+        _ => true,
+    }
 }
 
 #[cfg(test)]
@@ -324,6 +421,111 @@ mod tests {
     }
 
     /// Write one file whose rows are ordered by (__hash__, _timestamp).
+    #[test]
+    fn test_hash_interval_extraction() {
+        use datafusion::prelude::{col, lit};
+        let ge = col(HASH_LABEL).gt_eq(lit(5u64));
+        let le = col(HASH_LABEL).lt_eq(lit(9u64));
+        assert_eq!(hash_interval(&[ge.clone(), le.clone()]), Some((5, 9)));
+        assert_eq!(hash_interval(&[ge]), Some((5, u64::MAX)));
+        assert_eq!(hash_interval(&[le]), Some((0, 9)));
+        assert_eq!(
+            hash_interval(&[col(HASH_LABEL).gt(lit(5u64)), col(HASH_LABEL).lt(lit(9u64))]),
+            Some((6, 8))
+        );
+        assert_eq!(
+            hash_interval(&[col(HASH_LABEL).eq(lit(7u64))]),
+            Some((7, 7))
+        );
+        // other columns, non-u64 literals, and unrelated ops leave no interval
+        assert_eq!(hash_interval(&[col("other").gt_eq(lit(5u64))]), None);
+        assert_eq!(hash_interval(&[col(HASH_LABEL).gt_eq(lit("5"))]), None);
+        assert_eq!(hash_interval(&[]), None);
+    }
+
+    #[tokio::test]
+    async fn test_scan_prunes_files_outside_hash_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        write_hash_sorted_file(
+            dir.path(),
+            "a.parquet",
+            &[(1, 10), (3, 20)],
+            FileFormat::Parquet,
+        )
+        .await;
+        write_hash_sorted_file(
+            dir.path(),
+            "b.parquet",
+            &[(5, 10), (7, 20)],
+            FileFormat::Parquet,
+        )
+        .await;
+        write_hash_sorted_file(
+            dir.path(),
+            "c.parquet",
+            &[(9, 10), (11, 20)],
+            FileFormat::Parquet,
+        )
+        .await;
+
+        let sort_order = FileSortOrder::HashTimestampAsc;
+        let ctx = DataFusionContextBuilder::new()
+            .trace_id("test_hash_prune")
+            .sort_order(sort_order)
+            .build(2)
+            .await
+            .unwrap();
+        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+            .with_target_partitions(2)
+            .with_collect_stat(true)
+            .with_file_sort_order(vec![sort_order.logical_sort_exprs()]);
+        let url = ListingTableUrl::parse(format!("file://{}/", dir.path().display())).unwrap();
+        let config = ListingTableConfig::new(url)
+            .with_listing_options(listing_options)
+            .with_schema(hash_sorted_schema());
+        let table = ListingTableAdapter::try_new(
+            config,
+            "test_hash_prune".to_string(),
+            sort_order,
+            None,
+            vec![],
+            None,
+        )
+        .unwrap();
+        ctx.register_table("t", Arc::new(table)).unwrap();
+
+        let plan = ctx
+            .state()
+            .create_logical_plan(&format!(
+                "SELECT * FROM t WHERE {HASH_LABEL} >= 5 AND {HASH_LABEL} <= 7 ORDER BY {}",
+                sort_order.order_by_clause().unwrap()
+            ))
+            .await
+            .unwrap();
+        let physical_plan = ctx.state().create_physical_plan(&plan).await.unwrap();
+        let display = displayable(physical_plan.as_ref()).indent(true).to_string();
+        assert!(
+            display.contains("b.parquet") && !display.contains("a.parquet"),
+            "expected only the intersecting file in the scan, got:\n{display}"
+        );
+        assert!(!display.contains("c.parquet"), "got:\n{display}");
+
+        let batches = collect(physical_plan, ctx.task_ctx()).await.unwrap();
+        let hashes: Vec<u64> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(hashes, vec![5, 7]);
+    }
+
     async fn write_hash_sorted_file(
         dir: &std::path::Path,
         name: &str,


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/metrics/metrics-streaming-fused-aggregation.md

## What

Make fused PromQL `agg(range_func(selector))` queries stream over hash-sorted metrics files instead of materializing the sample matrix. One commit, three pieces:

1. **Streaming fused aggregation** — evaluate per hash band as ordered streams, fold each series into its group accumulator, drop it. Gated by `ZO_FEATURE_METRICS_STREAMING_AGG_ENABLED` (default **on**); every unsupported shape or layout falls back to the materializing path unchanged.
2. **Band scans pruned to their intersecting files** — the listing adapter reads the band's hash interval from the pushed-down filters, drops files whose statistics cannot intersect it (120 → ~15 per band), and re-chains survivors into the fewest ordered chains (12 → ~5). Ordered sessions disable round-robin repartitioning: with fewer partitions than target the optimizer would trade the chains' ordering for an exchange plus sort, silently pushing every streaming query back to the fallback path.
3. **Vortex streams with bounded scan concurrency** — the vortex scan spawns `concurrency × cores` read-ahead decode tasks per file, detached from consumer backpressure; under the banded topology that parked ~10 GiB of decoded chunks. Sorted-table vortex scans are capped at `scan_concurrency = 1`; the bands already provide the decode parallelism.

## How the streaming core works

- `register_metrics_table` additionally registers a `{table}__hash_sorted` table declaring `(__hash__, _timestamp)` file sort order when every listed file is a hash-sorted/indexed file (separate registration so the main table's partitioning is untouched).
- The engine splits the u64 hash space into `target_partitions` bands. Each band plans `filter(hash range) → project(ts, hash, value, group-by labels) → sort(hash)`; the sort is planning-only — it makes the optimizer prove the scan partitions are hash-ordered (same-hour indexed files are non-overlapping hash-space slices, so DataFusion chains them into ordered chains).
- The `SortPreservingMergeExec` node is **never executed**: each band takes the merge's child partition streams and run-merges them one series at a time (one cursor round per series instead of one heap operation per row). A finished series is folded into its group accumulator (`FusedAccumulator`, merged across bands at the end) and dropped.
- Group-by label columns ride in the scan projection (long runs under this layout, near-free to decode), which also removes the label second scan.
- Fallbacks (to the materializing path): non-UInt64 hash streams, `without()` grouping, super cluster, exemplars/raw-data queries, `need_wal`, any legacy-layout file, or a plan that would need an actual `SortExec`.

## Numbers

Release + mimalloc, single node, 12 cores, local disk. Responses byte-identical to the materializing path in every benchmarked case.

3h no-filter histogram over 1.3B rows (206 indexed parquet files, 898,560 series → 1,404 groups), streaming core alone:

| | materializing | streaming |
|---|---:|---:|
| no-filter latency | 3.27 s | **2.22 s (−32%)** |
| peak RSS | 9.66 GiB | **1.25 GiB (−87%)** |

892M-row bucket stream, 3h window, same-round A/B (parquet):

| query | materializing | streaming |
|---|---:|---:|
| no-filter | 20–24 s | **3.45 s** |
| regex matching 100% of series | 18–21 s | **3.47 s** |
| regex matching 41% | 1.97 s | 1.88 s |
| equality 2% / negative-regex 7% | 0.48 / 1.02 s | 0.55 / 1.06 s |
| peak RSS (no-filter) | ~16 GiB | **0.85 GiB** |

The materializing side's heavy queries swing widely (its ~16 GiB matrix runs under memory pressure); the streaming side stays flat across runs.

## Verification

- 128-combination differential test (8 aggregations × 4 range functions × 4 modifiers) of streaming vs the fused evaluator, plus fixtures for cross-file series, counter resets across chain boundaries, null labels, and the fallback gates.
- e2e responses diffed byte-for-byte against the materializing path on both datasets and five filter shapes.
- Plan-shape guards under test: declared sort order must produce a merge (parquet and vortex listings), band pruning keeps only intersecting files, non-hash filters leave scans untouched.
- Negative-matcher semantics pinned against a semantic ground truth (complement subset of the unfiltered result).

## Notes

- **Vortex numbers** (3h no-filter over 892M rows, same-round A/B): 14-15 s / 14.7 GiB materializing → **2.95 s / 5.8 GiB** streaming, responses byte-identical. The remaining resident memory is vortex reader-side state (layout/segment caches, tracked separately); the same query over parquet stays at 0.9 GiB.
- Files without hash statistics (including hash-sorted files that predate the metrics index) survive band pruning and are handled unchanged.
- Enterprise: only config-crate types are touched, no API breakage expected; the enterprise workspace combination was not compile-verified.
- Float caveat: streaming folds in hash order while the materializing path folds in matrix order, so Kahan-summed results may differ in the last 1–2 ULP for stddev/stdvar; all benchmarked outputs were byte-identical at serialization precision.
