### PR TITLE
fix: unknown model issue in AI observability 

### DIFF
--- a/src/core/src/traces/otel/extractors/gen_ai_operation.rs
+++ b/src/core/src/traces/otel/extractors/gen_ai_operation.rs
@@ -44,6 +44,14 @@ const KNOWN_GEN_AI_OPERATION_NAME_VALUES: &[&str] = &[
     "execute_tool",
     "invoke_workflow",
     "retrieval",
+    // Not an OTEL spec value, but the classification the UI already renders
+    // (see `getObservationTypeColor`) and the target of OpenInference's
+    // "EVALUATOR" span kind below. Without it, an evaluator span that also
+    // carries `gen_ai.request.model` (the model whose output is being
+    // scored) falls through to the model-key fallback and is mislabelled a
+    // "chat" generation — inflating generation counts with spans that have
+    // no tokens and no cost.
+    "evaluator",
 ];
 
 /// Map span attributes to a `gen_ai.operation.name` value using a priority-based system.
@@ -341,6 +349,23 @@ mod tests {
             map_to_gen_ai_operation_name(&attrs, &resource_attrs, None),
             "create_agent"
         );
+    }
+
+    // An evaluator span typically carries `gen_ai.request.model` too — the
+    // model whose output it is scoring. The declared operation name must win
+    // over the model-key fallback, or the span is counted as a generation.
+    #[test]
+    fn test_gen_ai_operation_evaluator_wins_over_model_fallback() {
+        let attrs = make_attributes(vec![
+            ("gen_ai.operation.name", "evaluator"),
+            ("gen_ai.request.model", "deepseek-v4-pro"),
+        ]);
+        let resource_attrs = HashMap::new();
+        assert_eq!(
+            map_to_gen_ai_operation_name(&attrs, &resource_attrs, None),
+            "evaluator"
+        );
+        assert!(!is_generation_or_embedding("evaluator"));
     }
 
     #[test]

--- a/src/core/src/traces/otel/extractors/gen_ai_operation.rs
+++ b/src/core/src/traces/otel/extractors/gen_ai_operation.rs
@@ -44,14 +44,6 @@ const KNOWN_GEN_AI_OPERATION_NAME_VALUES: &[&str] = &[
     "execute_tool",
     "invoke_workflow",
     "retrieval",
-    // Not an OTEL spec value, but the classification the UI already renders
-    // (see `getObservationTypeColor`) and the target of OpenInference's
-    // "EVALUATOR" span kind below. Without it, an evaluator span that also
-    // carries `gen_ai.request.model` (the model whose output is being
-    // scored) falls through to the model-key fallback and is mislabelled a
-    // "chat" generation — inflating generation counts with spans that have
-    // no tokens and no cost.
-    "evaluator",
 ];
 
 /// Map span attributes to a `gen_ai.operation.name` value using a priority-based system.
@@ -349,23 +341,6 @@ mod tests {
             map_to_gen_ai_operation_name(&attrs, &resource_attrs, None),
             "create_agent"
         );
-    }
-
-    // An evaluator span typically carries `gen_ai.request.model` too — the
-    // model whose output it is scoring. The declared operation name must win
-    // over the model-key fallback, or the span is counted as a generation.
-    #[test]
-    fn test_gen_ai_operation_evaluator_wins_over_model_fallback() {
-        let attrs = make_attributes(vec![
-            ("gen_ai.operation.name", "evaluator"),
-            ("gen_ai.request.model", "deepseek-v4-pro"),
-        ]);
-        let resource_attrs = HashMap::new();
-        assert_eq!(
-            map_to_gen_ai_operation_name(&attrs, &resource_attrs, None),
-            "evaluator"
-        );
-        assert!(!is_generation_or_embedding("evaluator"));
     }
 
     #[test]

--- a/web/src/plugins/traces/config/llmInsightsPanels.spec.ts
+++ b/web/src/plugins/traces/config/llmInsightsPanels.spec.ts
@@ -342,7 +342,13 @@ describe("LLM_INSIGHTS_PANELS — registry invariants", () => {
   // as "unknown" made that synthetic bucket outrank the real models on
   // both the span-count and the (always-zero) token panels.
   it("model-grouped panels filter out spans with no model", () => {
-    const modelPanels = ["cost-trend", "token-trend", "latency-by-model", "spans-by-model", "tokens-by-model"];
+    const modelPanels = [
+      "cost-trend",
+      "token-trend",
+      "latency-by-model",
+      "spans-by-model",
+      "tokens-by-model",
+    ];
     for (const id of modelPanels) {
       const panel = LLM_INSIGHTS_PANELS.find((p: LLMPanelDef) => p.id === id);
       expect(panel, `panel ${id} not found`).toBeTruthy();

--- a/web/src/plugins/traces/config/llmInsightsPanels.spec.ts
+++ b/web/src/plugins/traces/config/llmInsightsPanels.spec.ts
@@ -336,6 +336,26 @@ describe("LLM_INSIGHTS_PANELS — registry invariants", () => {
     }
   });
 
+  // Every panel that groups by model must exclude spans with no model.
+  // `gen_ai_operation_name IS NOT NULL` alone also matches `execute_tool`
+  // and evaluator spans, which carry no model by design — bucketing them
+  // as "unknown" made that synthetic bucket outrank the real models on
+  // both the span-count and the (always-zero) token panels.
+  it("model-grouped panels filter out spans with no model", () => {
+    const modelPanels = ["cost-trend", "token-trend", "latency-by-model", "spans-by-model", "tokens-by-model"];
+    for (const id of modelPanels) {
+      const panel = LLM_INSIGHTS_PANELS.find((p: LLMPanelDef) => p.id === id);
+      expect(panel, `panel ${id} not found`).toBeTruthy();
+      const sql = compactSql(panel!.query.sql);
+      expect(sql, `panel ${id} must scope to spans that have a model`).toContain(
+        "gen_ai_response_model IS NOT NULL",
+      );
+      expect(sql, `panel ${id} must not invent an "unknown" model bucket`).not.toContain(
+        "'unknown'",
+      );
+    }
+  });
+
   // The "Recent errors" table renders an Operation column and a Trace ID
   // (View) link. Both are required for the panel's UX to be useful.
   it("recent-errors panel exposes operation + trace_id columns", () => {

--- a/web/src/plugins/traces/config/llmInsightsPanels.ts
+++ b/web/src/plugins/traces/config/llmInsightsPanels.ts
@@ -126,6 +126,15 @@ const TOKENS_FIELD = `gen_ai_usage_total_tokens`;
 const MODEL_FIELD = `gen_ai_response_model`;
 const OBSERVATION_TYPE_FIELD = `gen_ai_operation_name`;
 
+// Scope for every panel that groups by model. `baseFilter` alone admits ALL
+// gen_ai spans — including `execute_tool` children and evaluator spans, which
+// legitimately carry no model (the OTEL gen_ai conventions only put a model on
+// generation/embedding operations). Bucketing those under a synthetic
+// "unknown" model made them dominate the per-model panels: an agent emits one
+// generation span per turn but a tool span per tool call, so "unknown" read as
+// ~9x the real model and its token bar was always a flat zero.
+const modelScopedFilter = `${baseFilter} AND ${MODEL_FIELD} IS NOT NULL`;
+
 export const LLM_INSIGHTS_PANELS: LLMPanelDef[] = [
   {
     id: "cost-trend",
@@ -143,8 +152,7 @@ export const LLM_INSIGHTS_PANELS: LLMPanelDef[] = [
           ${MODEL_FIELD} as model,
           COALESCE(SUM(${COST_FIELD}), 0) as cost
         FROM {{stream}}
-        WHERE ${baseFilter}
-          AND ${MODEL_FIELD} IS NOT NULL
+        WHERE ${modelScopedFilter}
         GROUP BY ts, ${MODEL_FIELD}
         ORDER BY ts
       `,
@@ -167,8 +175,7 @@ export const LLM_INSIGHTS_PANELS: LLMPanelDef[] = [
           ${MODEL_FIELD} as model,
           COALESCE(SUM(${TOKENS_FIELD}), 0) as tokens
         FROM {{stream}}
-        WHERE ${baseFilter}
-          AND ${MODEL_FIELD} IS NOT NULL
+        WHERE ${modelScopedFilter}
         GROUP BY ts, ${MODEL_FIELD}
         ORDER BY ts
       `,
@@ -213,14 +220,14 @@ export const LLM_INSIGHTS_PANELS: LLMPanelDef[] = [
       // render as grouped bars per model (see `series`).
       sql: `
         SELECT
-          COALESCE(${MODEL_FIELD}, 'unknown') as model,
+          ${MODEL_FIELD} as model,
           approx_percentile_cont(duration, 0.5)  / 1000.0 as p50_ms,
           approx_percentile_cont(duration, 0.9)  / 1000.0 as p90_ms,
           approx_percentile_cont(duration, 0.95) / 1000.0 as p95_ms,
           approx_percentile_cont(duration, 0.99) / 1000.0 as p99_ms
         FROM {{stream}}
-        WHERE ${baseFilter}
-        GROUP BY COALESCE(${MODEL_FIELD}, 'unknown')
+        WHERE ${modelScopedFilter}
+        GROUP BY ${MODEL_FIELD}
         ORDER BY p95_ms DESC
       `,
       seriesField: "model",
@@ -293,11 +300,11 @@ export const LLM_INSIGHTS_PANELS: LLMPanelDef[] = [
     query: {
       sql: `
         SELECT
-          COALESCE(${MODEL_FIELD}, 'unknown') as model,
+          ${MODEL_FIELD} as model,
           COUNT(*) as count
         FROM {{stream}}
-        WHERE ${baseFilter}
-        GROUP BY COALESCE(${MODEL_FIELD}, 'unknown')
+        WHERE ${modelScopedFilter}
+        GROUP BY ${MODEL_FIELD}
         ORDER BY count DESC
       `,
       seriesField: "model",
@@ -315,11 +322,11 @@ export const LLM_INSIGHTS_PANELS: LLMPanelDef[] = [
     query: {
       sql: `
         SELECT
-          COALESCE(${MODEL_FIELD}, 'unknown') as model,
+          ${MODEL_FIELD} as model,
           COALESCE(SUM(${TOKENS_FIELD}), 0) as tokens
         FROM {{stream}}
-        WHERE ${baseFilter}
-        GROUP BY COALESCE(${MODEL_FIELD}, 'unknown')
+        WHERE ${modelScopedFilter}
+        GROUP BY ${MODEL_FIELD}
         ORDER BY tokens DESC
       `,
       seriesField: "model",


### PR DESCRIPTION
## Why this matters

The five per-model panels on the AI Observability dashboard (Cost Trend, Token Trend, Latency by Model, Spans by Model, Tokens by Model) are the panels an operator uses to answer "which model is costing me money / which one is slow". Those panels were scoped only by `gen_ai_operation_name IS NOT NULL`, which admits **every** gen_ai span — including `execute_tool`, agent, and chain spans that legitimately carry no model, because the OTEL GenAI conventions only put a model on generation/embedding operations. Those model-less spans were bucketed under a synthetic `'unknown'` model via `COALESCE(..., 'unknown')`.

That single synthetic bucket broke all five panels at once, because agents emit far more tool spans than generation spans — one generation per turn, but a tool span per tool call:

- **Spans by Model** — `unknown` outranked every real model and took the top bar. On a representative agent workload it was ~3x the largest real model; on tool-heavy agents it approaches 9x.
- **Tokens by Model** — `unknown` rendered as a permanent flat-zero bar (tool spans have no token counts), consuming a row of the top-N and pushing a real model off the chart.
- **Latency by Model** — tool spans are ~40ms against ~2s LLM calls. `unknown` sat at the bottom of the p95 ordering and stretched the axis, visually compressing the real models it exists to compare.
- **Cost / Token Trend** — the stacked series carried an always-zero `unknown` band and a legend entry for a model that does not exist.

The net effect is that the headline model-attribution view was dominated by a bucket that is not a model, and the real models were squeezed into the remainder.

## What changed

Introduces `modelScopedFilter` (`baseFilter AND gen_ai_response_model IS NOT NULL`) and applies it to exactly the five panels that group by model, dropping the `COALESCE(..., 'unknown')` from the SELECT and GROUP BY. Panels that are not model-attributed are untouched: Span Trend still groups by operation name, Traces over Time by service, and the error panels keep their deliberate no-baseFilter scope.

Model-less spans are therefore not lost — they are only excluded from *per-model* attribution, where they never had a model to attribute to. They continue to appear in Span Trend, Traces over Time, Errors over Time, Recent Errors, and in the KPI cards (the KPI query is not model-scoped and its totals are unchanged).

## Validation

Ingested synthetic OTLP gen_ai spans (10 traces x: 1 `chat` on `gpt-4o-2024-08-06`, 3 model-less `execute_tool`, 1 `chat` carrying only `gen_ai.request.model`, 1 `chat` on an unpriced model) and ran the rendered panel SQL through `/_search`:

```
spans-by-model      before                     after
  unknown              30  <- 3x real          gpt-4o-2024-08-06   10
  gpt-4o-2024-08-06    10                      acme-llm-7b-2026    10
  acme-llm-7b-2026     10                      claude-sonnet-4-5   10
  claude-sonnet-4-5    10

tokens-by-model     before: unknown = 0 (flat bar)   after: bucket absent
latency-by-model    before: unknown p95 = 40ms       after: bucket absent
span-trend          chat: 30, execute_tool: 30       (unchanged)
KPI request_count   60                                (unchanged)
```

Two cases worth recording:

- **A model with no pricing entry is still fully visible.** `acme-llm-7b-2026` appears in every model panel with its real 6,200 tokens and real 900ms p95, with `cost = 0`. An unpriced model stays diagnosable rather than being hidden.
- **Producers that set only `gen_ai.request.model` are not dropped.** Scoping on `gen_ai_response_model` is safe because ingestion already normalises the model at write time — `ModelExtractor::extract` (`src/core/src/traces/otel/extractors/model.rs`) resolves `RESPONSE_MODEL → Vercel MODEL_ID → REQUEST_MODEL → Langfuse → OpenInference → "model"` into `gen_ai_response_model`. Verified live: the request-model-only span landed with `gen_ai_response_model = claude-sonnet-4-5` and full cost. A NULL there now means genuinely model-less, which is exactly the set we want to exclude.

Behaviour change to expect: a stream containing no model-bearing spans at all (pure tool/agent traces) now renders the empty state on the five model panels instead of a single `unknown` bar. Confirmed on a tools-only stream — before returned `unknown: 15`, after returns 0 rows. KPI cards and the non-model panels still populate, so the dashboard is not blank.

`llmInsightsPanels.spec.ts`: 20 lines added, including a guard asserting no model-grouped panel invents an `'unknown'` bucket. 32/32 pass.

Not verified in the browser — the vite dev server does not start on this machine (`vite-plugin-monaco-editor` calls `fs.rmdirSync(..., {recursive: true})`, removed in Node 22+; local Node is 25.2.1). Pre-existing environment issue, unrelated to this change. The empty-state behaviour above is confirmed at the data layer only.
