### PR TITLE
fix: eliminate compactor/service-discovery Postgres write amplification

### DIFF
--- a/src/compaction/src/dump.rs
+++ b/src/compaction/src/dump.rs
@@ -316,7 +316,7 @@ pub async fn dump(job: &DumpJob) -> Result<(), anyhow::Error> {
     }
 
     // generate the dump file
-    let dumped_ids: Vec<(i64, String)> = files.iter().map(|r| (r.id, r.date.clone())).collect();
+    let dumped_ids = dump_delete_pairs(&files);
     let dump_file = match generate_dump(
         &job.org_id,
         job.stream_type,
@@ -786,6 +786,11 @@ fn create_record_batch(files: Vec<FileRecord>) -> Result<RecordBatch, errors::Er
         ],
     )?;
     Ok(batch)
+}
+
+/// Each id must pair with that record's own stored date, or the pruned delete leaks its row.
+fn dump_delete_pairs(files: &[FileRecord]) -> Vec<(i64, String)> {
+    files.iter().map(|r| (r.id, r.date.clone())).collect()
 }
 
 #[cfg(test)]
@@ -1749,5 +1754,47 @@ mod tests {
                 type_str
             );
         }
+    }
+
+    // ---- dump_delete_pairs ----
+
+    fn delete_pairs_record(id: i64, date: &str) -> FileRecord {
+        FileRecord {
+            id,
+            account: "acct".to_string(),
+            org: "org".to_string(),
+            stream: "org/logs/stream".to_string(),
+            date: date.to_string(),
+            file: "f.parquet".to_string(),
+            deleted: false,
+            flattened: false,
+            min_ts: 1,
+            max_ts: 2,
+            records: 1,
+            original_size: 1,
+            compressed_size: 1,
+            index_size: 0,
+            bloom_ver: 0,
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn test_dump_delete_pairs_uses_each_records_own_id_and_date() {
+        let files = vec![
+            delete_pairs_record(11, "2021/01/01/00"),
+            delete_pairs_record(22, "2021/01/02/07"),
+            delete_pairs_record(33, "2021/01/01/23"),
+        ];
+        assert_eq!(
+            dump_delete_pairs(&files),
+            vec![
+                (11, "2021/01/01/00".to_string()),
+                (22, "2021/01/02/07".to_string()),
+                (33, "2021/01/01/23".to_string()),
+            ],
+            "every pair must carry that record's own stored (id, date), in input order"
+        );
+        assert!(dump_delete_pairs(&[]).is_empty());
     }
 }

--- a/src/compaction/src/dump.rs
+++ b/src/compaction/src/dump.rs
@@ -316,7 +316,7 @@ pub async fn dump(job: &DumpJob) -> Result<(), anyhow::Error> {
     }
 
     // generate the dump file
-    let ids: Vec<i64> = files.iter().map(|r| r.id).collect();
+    let dumped_ids: Vec<(i64, String)> = files.iter().map(|r| (r.id, r.date.clone())).collect();
     let dump_file = match generate_dump(
         &job.org_id,
         job.stream_type,
@@ -337,7 +337,7 @@ pub async fn dump(job: &DumpJob) -> Result<(), anyhow::Error> {
         // update the entries in db
         let records = dump_file.meta.records;
         let file_name = dump_file.key.clone();
-        infra_file_list::update_dump_records(&dump_file, &ids).await?;
+        infra_file_list::update_dump_records(&dump_file, &dumped_ids).await?;
 
         // insert dump stats
         if let Err(e) = infra_file_list::insert_dump_stats(&file_name, &stats).await {

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -74,7 +74,12 @@ pub trait FileList: Sync + Send + 'static {
     async fn batch_add(&self, files: &[FileKey]) -> Result<()>;
     async fn batch_add_with_id(&self, files: &[FileKey]) -> Result<()>;
     async fn batch_add_history(&self, files: &[FileKey]) -> Result<()>;
-    async fn update_dump_records(&self, dump_file: &FileKey, dumped_ids: &[i64]) -> Result<()>;
+    /// `dumped_ids` pairs each file_list id with its `date` so partitioned backends can prune.
+    async fn update_dump_records(
+        &self,
+        dump_file: &FileKey,
+        dumped_ids: &[(i64, String)],
+    ) -> Result<()>;
     async fn batch_process(&self, files: &[FileKey]) -> Result<()>;
     async fn batch_add_deleted(
         &self,
@@ -299,7 +304,7 @@ pub async fn batch_process(files: &[FileKey]) -> Result<()> {
 }
 
 #[inline]
-pub async fn update_dump_records(dump_file: &FileKey, dumped_ids: &[i64]) -> Result<()> {
+pub async fn update_dump_records(dump_file: &FileKey, dumped_ids: &[(i64, String)]) -> Result<()> {
     CLIENT.update_dump_records(dump_file, dumped_ids).await
 }
 

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1369,8 +1369,7 @@ DO UPDATE SET
         limit: i64,
         fast_mode: bool,
     ) -> Result<Vec<super::MergeJobRecord>> {
-        // quick check without the advisory lock, if there are no pending jobs we can skip the
-        // locked transaction.
+        // quick check on the read pool: no pending jobs means the claim transaction can be skipped.
         let pool = CLIENT_RO.clone();
         let has_pending = sqlx::query("SELECT id FROM file_list_jobs WHERE status = $1 LIMIT 1;")
             .bind(super::FileListJobStatus::Pending)
@@ -1382,31 +1381,31 @@ DO UPDATE SET
 
         let pool = CLIENT_RW.clone();
         let mut tx = pool.begin().await?;
-        let lock_id = pending_jobs_lock_key("");
-        let lock_sql = format!("SELECT pg_advisory_xact_lock({lock_id})");
-        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
-        if let Err(e) = sqlx::query(&lock_sql).execute(&mut *tx).await {
-            if let Err(e) = tx.rollback().await {
-                log::error!("[POSTGRES] rollback get_pending_jobs error: {e}");
-            }
-            return Err(e.into());
-        }
 
         DB_QUERY_NUMS
             .with_label_values(&["select", "file_list_jobs"])
             .inc();
 
-        // get pending jobs group by stream and order by num desc
+        // FOR UPDATE SKIP LOCKED makes the claim self-guarding, so no advisory lock is needed.
         let sql = if fast_mode {
-            r#"SELECT stream, id, 0::BIGINT AS num FROM file_list_jobs WHERE status = $1 ORDER BY offsets DESC LIMIT $2;"#
+            r#"SELECT stream, id, 0::BIGINT AS num FROM file_list_jobs WHERE status = $1 ORDER BY offsets DESC LIMIT $2 FOR UPDATE SKIP LOCKED;"#
         } else {
+            // a stream whose max(id) row is lock-skipped is skipped whole: a peer owns it
             r#"
-    SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
-        FROM file_list_jobs
-        WHERE status = $1
-        GROUP BY stream
-        ORDER BY num DESC
-        LIMIT $2;"#
+    WITH candidates AS (
+        SELECT stream, max(id) AS id, COUNT(*)::BIGINT AS num
+            FROM file_list_jobs
+            WHERE status = $1
+            GROUP BY stream
+            ORDER BY num DESC
+            LIMIT $2
+    )
+    SELECT c.stream, c.id, c.num
+        FROM candidates c
+        JOIN file_list_jobs j ON j.id = c.id
+        WHERE j.status = $1
+        ORDER BY c.num DESC
+        FOR UPDATE OF j SKIP LOCKED;"#
         };
         let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(sql)
             .bind(super::FileListJobStatus::Pending)
@@ -1430,8 +1429,9 @@ DO UPDATE SET
             }
             return Ok(Vec::new());
         }
+        // rows are row-locked above; the status re-check is defense-in-depth against double claims
         let sql = format!(
-            "UPDATE file_list_jobs SET status = $1, node = $2, started_at = $3, updated_at = $4 WHERE id IN ({});",
+            "UPDATE file_list_jobs SET status = $1, node = $2, started_at = $3, updated_at = $4 WHERE id IN ({}) AND status = $5;",
             ids.join(",")
         );
         let now = config::utils::time::now_micros();
@@ -1443,6 +1443,7 @@ DO UPDATE SET
             .bind(node)
             .bind(now)
             .bind(now)
+            .bind(super::FileListJobStatus::Pending)
             .execute(&mut *tx)
             .await
         {
@@ -2179,18 +2180,6 @@ fn chunked_pruned_delete_statements(
         .chunks(chunk_size.max(1))
         .flat_map(|chunk| build_pruned_delete_statements(table, chunk))
         .collect()
-}
-
-/// Advisory lock key for get_pending_jobs claims; scope is ignored until Fix 4 wires a real one.
-fn pending_jobs_lock_key(_scope: &str) -> i64 {
-    // TODO(fix-4-implementation): callers must pass a real scope once the scoping decision lands.
-    // Shared advisory-id space with scheduler_pull_lock/get_for_update_*; collisions only block.
-    let lock_id = config::utils::hash::gxhash::new().sum64("file_list_jobs:get_pending_jobs");
-    if lock_id > (i64::MAX as u64) {
-        (lock_id >> 1) as i64
-    } else {
-        lock_id as i64
-    }
 }
 
 /// Derive date range for partition pruning from microsecond timestamps.
@@ -5226,7 +5215,6 @@ mod tests {
                 }
             }
 
-            // TODO(fix-4-implementation): fast_mode shares the unguarded UPDATE; guard both paths.
             let (r1, r2) = tokio::join!(
                 postgres_list.get_pending_jobs("fix4-node-1", 100, false),
                 postgres_list.get_pending_jobs("fix4-node-2", 100, false),
@@ -5289,87 +5277,83 @@ mod tests {
                 .execute(&pool)
                 .await;
         }
-    }
 
-    // Fix 4 regression tests: get_pending_jobs serializes ALL nodes on ONE global advisory lock.
-
-    /// Advisory locks match on value, so the key derivation must be deterministic per scope.
-    #[test]
-    fn test_pending_jobs_lock_key_is_deterministic() {
-        assert_eq!(pending_jobs_lock_key("x"), pending_jobs_lock_key("x"));
-    }
-
-    /// Fix spec [RED until Fix 4 lands]: distinct scopes must map to distinct advisory lock keys.
-    #[tokio::test]
-    #[ignore = "Requires test PostgreSQL database setup"]
-    async fn test_fix_different_scopes_do_not_serialize() {
-        // TODO(fix-4-implementation): the advisory lock is the ONLY double-claim guard today.
-        // TODO(fix-4-implementation): claim UPDATE has no status re-check; SELECT no FOR UPDATE.
-        // TODO(fix-4-implementation): per-node scoping is unsafe without self-guarding SQL.
-        // TODO(fix-4-implementation): a narrowed scope needs a scoped claim query or guarded SQL.
-        let pool = connect_partitioned_test_db().await;
-        let key_a = pending_jobs_lock_key("stream-a");
-        let key_b = pending_jobs_lock_key("stream-b");
-
-        let mut tx_a = pool.begin().await.unwrap();
-        sqlx::query(&format!("SELECT pg_advisory_xact_lock({key_a})"))
-            .execute(&mut *tx_a)
+        // ---- Fix 4 [GREEN]: claims must not serialize on the legacy global advisory lock ----
+        let legacy = config::utils::hash::gxhash::new().sum64("file_list_jobs:get_pending_jobs");
+        let legacy_key = if legacy > (i64::MAX as u64) {
+            (legacy >> 1) as i64
+        } else {
+            legacy as i64
+        };
+        let lock_stream = format!("fix4_org/logs/nolock_{pid}");
+        let lock_job_id: i64 = sqlx::query_scalar(
+            "INSERT INTO file_list_jobs (org, stream, offsets, status, node, started_at, \
+             updated_at) VALUES ('fix4_org', $1, 1000, 0, '', 0, 0) RETURNING id",
+        )
+        .bind(&lock_stream)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let mut lock_tx = pool.begin().await.unwrap();
+        sqlx::query(&format!("SELECT pg_advisory_xact_lock({legacy_key})"))
+            .execute(&mut *lock_tx)
             .await
             .unwrap();
 
-        let mut tx_b = pool.begin().await.unwrap();
-        let acquired: bool =
-            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key_b})"))
-                .fetch_one(&mut *tx_b)
-                .await
-                .unwrap();
-
-        tx_b.rollback().await.unwrap();
-        tx_a.rollback().await.unwrap();
-
+        // Before Fix 4 this blocked forever: the claim waited behind the held global lock key.
+        let claimed = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            postgres_list.get_pending_jobs("fix4-node-3", 100, false),
+        )
+        .await
+        .expect("get_pending_jobs must not block behind any advisory lock")
+        .unwrap();
+        lock_tx.rollback().await.unwrap();
         assert!(
-            acquired,
-            "scope 'stream-b' (key {key_b}) must not block behind scope 'stream-a' (key {key_a}); \
-             equal keys mean the lock key is still the global constant"
-        );
-    }
-
-    /// Invariant guard [GREEN]: claimers in the SAME scope must keep serializing on one lock key.
-    #[tokio::test]
-    #[ignore = "Requires test PostgreSQL database setup"]
-    async fn test_same_scope_still_serializes() {
-        // Until Fix 4 lands every scope shares one key, so run DB tests with --test-threads=1.
-        let pool = connect_partitioned_test_db().await;
-        let key = pending_jobs_lock_key("stream-same");
-
-        let mut tx_a = pool.begin().await.unwrap();
-        sqlx::query(&format!("SELECT pg_advisory_xact_lock({key})"))
-            .execute(&mut *tx_a)
-            .await
-            .unwrap();
-
-        let mut tx_b = pool.begin().await.unwrap();
-        let acquired: bool =
-            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key})"))
-                .fetch_one(&mut *tx_b)
-                .await
-                .unwrap();
-        assert!(
-            !acquired,
-            "same scope must serialize: try-lock on key {key} must fail while tx_a holds it"
+            claimed.iter().any(|j| j.id == lock_job_id),
+            "claim running under a held legacy advisory lock must still claim the seeded job"
         );
 
-        tx_a.rollback().await.unwrap();
-
-        let acquired: bool =
-            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key})"))
-                .fetch_one(&mut *tx_b)
+        // ---- Fix 4 [GREEN]: fast_mode shares the SKIP LOCKED guard; claims stay disjoint ----
+        let mut fast_seeded: HashSet<i64> = HashSet::new();
+        for stream in [&stream_a, &stream_b] {
+            for offsets in [100_000_i64, 200_000] {
+                let id: i64 = sqlx::query_scalar(
+                    "INSERT INTO file_list_jobs (org, stream, offsets, status, node, \
+                     started_at, updated_at) VALUES ('fix4_org', $1, $2, 0, '', 0, 0) \
+                     RETURNING id",
+                )
+                .bind(stream)
+                .bind(offsets)
+                .fetch_one(&pool)
                 .await
                 .unwrap();
-        assert!(
-            acquired,
-            "xact-scoped advisory lock on key {key} must be free once tx_a ends"
+                fast_seeded.insert(id);
+            }
+        }
+        let (r1, r2) = tokio::join!(
+            postgres_list.get_pending_jobs("fix4-node-4", 100, true),
+            postgres_list.get_pending_jobs("fix4-node-5", 100, true),
         );
-        tx_b.rollback().await.unwrap();
+        let (fast1, fast2) = (r1.unwrap(), r2.unwrap());
+        let fast_ids1: HashSet<i64> = fast1
+            .iter()
+            .map(|j| j.id)
+            .filter(|id| fast_seeded.contains(id))
+            .collect();
+        let fast_ids2: HashSet<i64> = fast2
+            .iter()
+            .map(|j| j.id)
+            .filter(|id| fast_seeded.contains(id))
+            .collect();
+        assert!(
+            fast_ids1.is_disjoint(&fast_ids2),
+            "fast_mode: a job was claimed by both callers: {fast_ids1:?} vs {fast_ids2:?}"
+        );
+        assert_eq!(
+            fast_ids1.union(&fast_ids2).count(),
+            fast_seeded.len(),
+            "fast_mode: every seeded pending job must be claimed by exactly one caller"
+        );
     }
 }

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -2152,6 +2152,60 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
     }
 }
 
+/// TEST-ONLY SCAFFOLDING for the compactor write-amplification fix (not yet implemented).
+///
+/// `update_dump_records` (Site A, above) and `inner_batch_process`'s delete path (Site B, above)
+/// both currently issue `DELETE FROM file_list WHERE id IN (...)` with no `date` predicate, which
+/// defeats partition pruning on the range-partitioned `file_list` table (see
+/// `file_list_partition_ddl`). The planned fix threads `date` alongside `id` and groups deletes by
+/// date so each DELETE only touches its own partition.
+///
+/// This helper models that planned shape ahead of the real fix landing at the two call sites.
+/// Once the fix is implemented at Site A/Site B directly, this helper (and its "current buggy
+/// behavior" sibling below) should be removed in favor of calling the real code paths.
+#[cfg(test)]
+async fn delete_file_list_by_id_and_date_fixed(
+    tx: &mut sqlx::Transaction<'_, Postgres>,
+    table: &str,
+    ids_with_dates: &[(i64, String)],
+) -> Result<()> {
+    let mut by_date: stdHashMap<&str, Vec<i64>> = stdHashMap::new();
+    for (id, date) in ids_with_dates {
+        by_date.entry(date.as_str()).or_default().push(*id);
+    }
+    for (date, ids) in by_date {
+        let ids_str = ids
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<String>>()
+            .join(",");
+        let sql = format!("DELETE FROM {table} WHERE date = $1 AND id IN ({ids_str})");
+        sqlx::query(&sql).bind(date).execute(&mut **tx).await?;
+    }
+    Ok(())
+}
+
+/// TEST-ONLY: reproduces today's buggy (unpruned) delete shape used at both Site A
+/// (`postgres.rs:199`) and Site B (`postgres.rs:2128`), for bug-reproduction tests.
+#[cfg(test)]
+async fn delete_file_list_by_id_buggy(
+    tx: &mut sqlx::Transaction<'_, Postgres>,
+    table: &str,
+    ids: &[i64],
+) -> Result<()> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let ids_str = ids
+        .iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<String>>()
+        .join(",");
+    let sql = format!("DELETE FROM {table} WHERE id IN ({ids_str})");
+    sqlx::query(&sql).execute(&mut **tx).await?;
+    Ok(())
+}
+
 /// Derive date range for partition pruning from microsecond timestamps.
 /// Returns (date_from, date_to) in "YYYY/MM/DD/HH" format suitable for `WHERE date >= $from AND
 /// date < $to`.
@@ -4522,5 +4576,548 @@ mod tests {
         // Empty / invalid falls back to midnight UTC.
         assert_eq!(maintenance_hour(""), 0);
         assert_eq!(maintenance_hour("foo,bar"), 0);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Partition-pruning regression tests for the compactor write-amplification bug.
+    //
+    // `update_dump_records` (Site A, postgres.rs:199) and `inner_batch_process`'s delete path
+    // (Site B, postgres.rs:2128) issue `DELETE FROM file_list WHERE id IN (...)` with no `date`
+    // predicate. Because `file_list` is RANGE partitioned on `date` (`file_list_partition_ddl`)
+    // and the `id` index (`file_list_partition_index_ddl`) becomes one local index PER
+    // PARTITION rather than a global index, a bare `id IN (...)` delete cannot be pruned and
+    // Postgres must probe every partition's local `id` index.
+    //
+    // Unlike `setup_test_tables` above (a single non-partitioned table, which cannot
+    // distinguish a pruned plan from an unpruned one), these tests build a REAL partitioned
+    // table with 3 distinct date partitions, matching production DDL, so a pruning-vs-full-scan
+    // difference is actually observable via `EXPLAIN`.
+    // ------------------------------------------------------------------------------------------
+
+    /// Process-wide counter used to build a table name unique to each call. A bare counter
+    /// (rather than e.g. a timestamp) keeps the generated name short: Postgres silently
+    /// truncates identifiers over 63 bytes, and the longest derived index name
+    /// (`{table}_stream_file_idx`) leaves little budget after the `file_list_partitioned_test_`
+    /// prefix -- a longer unique suffix would truncate two different table names down to the
+    /// same 63-byte identifier and reintroduce the very collision this exists to prevent. Plain
+    /// `Ordering::Relaxed` is enough: uniqueness only requires each call see a distinct value,
+    /// not any cross-thread ordering guarantee.
+    static PARTITIONED_TEST_TABLE_COUNTER: std::sync::atomic::AtomicU64 =
+        std::sync::atomic::AtomicU64::new(0);
+
+    /// Builds a table name unique to this call, so concurrent tests (the default under
+    /// `cargo test`, which runs `#[tokio::test]` functions in parallel) never `CREATE TABLE` the
+    /// same physical table/sequence and collide on `pg_class_relname_nsp_index`.
+    fn unique_partitioned_test_table_name() -> String {
+        let n = PARTITIONED_TEST_TABLE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        format!("file_list_partitioned_test_{n}")
+    }
+
+    /// Opens a dedicated `PgPool` for a single test, instead of reusing the process-wide
+    /// `DB_POOL` (`setup_test_db`). `#[tokio::test]` gives each test its own Tokio runtime by
+    /// default, but `sqlx::Pool`'s background maintenance/reaper task is bound to whichever
+    /// runtime created it; once that first test's runtime shuts down, a `PgPool` cached in a
+    /// `static OnceCell` and reused by a later test (a different runtime) starts failing every
+    /// `acquire()` with `PoolTimedOut`, because Sqlx does not reason about connections it can't
+    /// account for anymore. A fresh pool per test sidesteps this instead of fighting it.
+    async fn connect_partitioned_test_db() -> PgPool {
+        let database_url = std::env::var("TEST_POSTGRES_URL").unwrap_or_else(|_| {
+            "postgresql://postgres:password@localhost:5432/openobserve_test".to_string()
+        });
+        PgPool::connect(&database_url)
+            .await
+            .expect("Failed to connect to test PostgreSQL database")
+    }
+
+    /// Builds a fresh, REAL partitioned `file_list`-shaped table (same column set and index set
+    /// as `file_list_partition_ddl` / `file_list_partition_index_ddl`) with 3 distinct date
+    /// partitions, so partition pruning is actually observable in `EXPLAIN` output. `table` must
+    /// be unique per call (see `unique_partitioned_test_table_name`) -- concurrent tests sharing
+    /// one hardcoded name race to `CREATE TABLE`/`CREATE SEQUENCE` and collide.
+    async fn setup_partitioned_test_table(pool: &PgPool, table: &str) -> Result<()> {
+        sqlx::query(&format!("DROP TABLE IF EXISTS {table}"))
+            .execute(pool)
+            .await?;
+        sqlx::query(&file_list_partition_ddl(table))
+            .execute(pool)
+            .await?;
+        for ddl in file_list_partition_index_ddl(table) {
+            sqlx::query(&ddl).execute(pool).await?;
+        }
+        for day in ["01", "02", "03"] {
+            let part_name = format!("{table}_p_202101{day}");
+            let range_from = format!("2021/01/{day}/00");
+            let next_day = format!("{:02}", day.parse::<u32>().unwrap() + 1);
+            let range_to = format!("2021/01/{next_day}/00");
+            sqlx::query(&format!(
+                "CREATE TABLE {part_name} PARTITION OF {table} FOR VALUES FROM ('{range_from}') TO ('{range_to}')"
+            ))
+            .execute(pool)
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Drops a table created by `setup_partitioned_test_table`, including its partitions
+    /// (Postgres cascades a parent `DROP TABLE` onto its declarative partitions automatically).
+    /// Called explicitly at the end of every partitioned test so the shared test database
+    /// doesn't accumulate garbage tables run after run. A test that panics via `unwrap()` skips
+    /// this call and leaves its table behind, but each table's unique name (see
+    /// `unique_partitioned_test_table_name`) means an orphan is only ever cosmetic clutter --
+    /// never a name collision with a later test, which is the actual correctness property this
+    /// suite depends on.
+    async fn drop_partitioned_test_table(pool: &PgPool, table: &str) {
+        let _ = sqlx::query(&format!("DROP TABLE IF EXISTS {table}"))
+            .execute(pool)
+            .await;
+    }
+
+    async fn insert_partitioned_test_row(
+        pool: &PgPool,
+        table: &str,
+        date: &str,
+        stream: &str,
+        file: &str,
+    ) -> Result<i64> {
+        let now_ts = now_micros();
+        let id: i64 = sqlx::query_scalar(&format!(
+            r#"INSERT INTO {table}
+              (account, org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, bloom_ver, flattened, updated_at)
+            VALUES
+              ('acct', 'org1', $1, $2, $3, false, 1, 2, 1, 1, 1, 1, 0, false, $4)
+            RETURNING id"#
+        ))
+        .bind(stream)
+        .bind(date)
+        .bind(file)
+        .bind(now_ts)
+        .fetch_one(pool)
+        .await?;
+        Ok(id)
+    }
+
+    /// Runs `EXPLAIN (FORMAT TEXT) <delete_sql>` and returns the raw plan lines (one row per
+    /// line of plan text, matching `psql`'s own rendering of `EXPLAIN`). Wrapped in a
+    /// transaction that is always rolled back so EXPLAIN's actual execution of the DELETE
+    /// (needed for accurate row-count estimates) never persists.
+    async fn explain_delete_lines(
+        pool: &PgPool,
+        delete_sql: &str,
+        bind_date: Option<&str>,
+    ) -> Result<Vec<String>> {
+        let mut tx = pool.begin().await?;
+        let explain_sql = format!("EXPLAIN (FORMAT TEXT) {delete_sql}");
+        let query = if let Some(date) = bind_date {
+            sqlx::query(&explain_sql).bind(date)
+        } else {
+            sqlx::query(&explain_sql)
+        };
+        let rows = query.fetch_all(&mut *tx).await?;
+        tx.rollback().await?;
+        Ok(rows.iter().map(|r| r.get::<String, usize>(0)).collect())
+    }
+
+    /// Counts `Delete on <partition>` lines in an EXPLAIN TEXT plan for a partitioned table --
+    /// i.e. how many partitions the planner actually touches. The first line is always
+    /// `Delete on <parent_table> ...` (the ModifyTable node itself, not a partition), so it is
+    /// excluded.
+    fn count_touched_partitions(plan_lines: &[String]) -> usize {
+        plan_lines
+            .iter()
+            .skip(1)
+            .filter(|line| line.trim_start().starts_with("Delete on "))
+            .count()
+    }
+
+    /// CATEGORY: bug reproduction (expected to PASS today; documents the bug).
+    ///
+    /// A bare `DELETE FROM file_list WHERE id IN (...)` against a 3-partition table touches ALL
+    /// 3 partitions in the query plan, even though the target id only exists in 1 partition.
+    /// This is the root cause of the multi-second/23s DELETE latency seen in production.
+    ///
+    /// This test is intentionally kept as a permanent regression guard: if a future change
+    /// removes the `date` predicate from the fixed delete path again, this test's assertion
+    /// (`touched == 3`, i.e. no pruning) still holds and continues to document/prove the
+    /// unpruned shape is what "no date predicate" produces on this schema. It is not meant to
+    /// start failing once the fix lands elsewhere -- it tests the OLD query shape directly, not
+    /// the code at Site A/B.
+    #[tokio::test]
+    async fn test_bug_repro_unpruned_delete_touches_all_partitions() {
+        let pool = connect_partitioned_test_db().await;
+        let table = unique_partitioned_test_table_name();
+        setup_partitioned_test_table(&pool, &table).await.unwrap();
+
+        let id1 = insert_partitioned_test_row(&pool, &table, "2021/01/01/00", "s1", "f1.parquet")
+            .await
+            .unwrap();
+
+        let plan = explain_delete_lines(
+            &pool,
+            &format!("DELETE FROM {table} WHERE id IN ({id1})"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_touched_partitions(&plan),
+            3,
+            "bug repro: bare `id IN (...)` with no date predicate must touch all 3 partitions, plan:\n{}",
+            plan.join("\n")
+        );
+
+        drop_partitioned_test_table(&pool, &table).await;
+    }
+
+    /// CATEGORY: bug reproduction. `delete_file_list_by_id_buggy` (the exact query shape
+    /// currently used at Site A/B) is functionally correct today -- it deletes the right row --
+    /// which is precisely why the bug has been latent: nothing about correctness signals the
+    /// missing partition pruning. Only EXPLAIN (see the test above) reveals it.
+    #[tokio::test]
+    async fn test_bug_repro_buggy_delete_is_functionally_correct_but_unpruned() {
+        let pool = connect_partitioned_test_db().await;
+        let table = unique_partitioned_test_table_name();
+        setup_partitioned_test_table(&pool, &table).await.unwrap();
+
+        let keep =
+            insert_partitioned_test_row(&pool, &table, "2021/01/01/00", "s1", "keep.parquet")
+                .await
+                .unwrap();
+        let del = insert_partitioned_test_row(&pool, &table, "2021/01/02/00", "s1", "del.parquet")
+            .await
+            .unwrap();
+
+        let mut tx = pool.begin().await.unwrap();
+        delete_file_list_by_id_buggy(&mut tx, &table, &[del])
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let remaining: Vec<i64> = sqlx::query_scalar(&format!("SELECT id FROM {table}"))
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining,
+            vec![keep],
+            "the buggy shape deletes the correct row -- its problem is unpruned latency, not correctness"
+        );
+
+        drop_partitioned_test_table(&pool, &table).await;
+    }
+
+    /// CATEGORY: fix behavior (expected to FAIL until the fix threads `date` through the delete
+    /// path, or in this test's case, until it is confirmed the `date = $1 AND id IN (...)` shape
+    /// prunes correctly -- this proves the SQL shape the fix will use is correct).
+    ///
+    /// With a `date = $1 AND id IN (...)` predicate, only the ONE partition holding that date is
+    /// touched, even though the same ids table has 3 partitions total.
+    #[tokio::test]
+    async fn test_fix_pruned_delete_touches_single_partition() {
+        let pool = connect_partitioned_test_db().await;
+        let table = unique_partitioned_test_table_name();
+        setup_partitioned_test_table(&pool, &table).await.unwrap();
+
+        let id1 = insert_partitioned_test_row(&pool, &table, "2021/01/01/00", "s1", "f1.parquet")
+            .await
+            .unwrap();
+
+        let plan = explain_delete_lines(
+            &pool,
+            &format!("DELETE FROM {table} WHERE date = $1 AND id IN ({id1})"),
+            Some("2021/01/01/00"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_touched_partitions(&plan),
+            1,
+            "fix: `date = $1 AND id IN (...)` must touch exactly 1 partition, plan:\n{}",
+            plan.join("\n")
+        );
+        assert!(
+            plan.iter()
+                .any(|l| l.contains(&format!("{table}_p_20210101"))),
+            "the single touched partition must be the one actually holding the target id, plan:\n{}",
+            plan.join("\n")
+        );
+
+        drop_partitioned_test_table(&pool, &table).await;
+    }
+
+    /// CATEGORY: fix behavior. Ids spanning 2 different date partitions must be handled as 2
+    /// separate pruned single-partition deletes (per `delete_file_list_by_id_and_date_fixed`,
+    /// which groups by date), never a single unpruned multi-partition delete. Also verifies
+    /// actual row deletion correctness: right rows gone, nothing else touched.
+    #[tokio::test]
+    async fn test_fix_multiple_dates_grouped_into_pruned_deletes() {
+        let pool = connect_partitioned_test_db().await;
+        let table = unique_partitioned_test_table_name();
+        setup_partitioned_test_table(&pool, &table).await.unwrap();
+
+        let id_day1 =
+            insert_partitioned_test_row(&pool, &table, "2021/01/01/00", "s1", "f1.parquet")
+                .await
+                .unwrap();
+        let id_day2 =
+            insert_partitioned_test_row(&pool, &table, "2021/01/02/00", "s1", "f2.parquet")
+                .await
+                .unwrap();
+        let id_day3_untouched =
+            insert_partitioned_test_row(&pool, &table, "2021/01/03/00", "s1", "f3.parquet")
+                .await
+                .unwrap();
+
+        // Each date group's delete plan, taken individually, must be pruned to 1 partition.
+        for (id, date, expected_partition) in [
+            (id_day1, "2021/01/01/00", "20210101"),
+            (id_day2, "2021/01/02/00", "20210102"),
+        ] {
+            let plan = explain_delete_lines(
+                &pool,
+                &format!("DELETE FROM {table} WHERE date = $1 AND id IN ({id})"),
+                Some(date),
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                count_touched_partitions(&plan),
+                1,
+                "date group {date} must touch exactly 1 partition, plan:\n{}",
+                plan.join("\n")
+            );
+            assert!(
+                plan.iter()
+                    .any(|l| l.contains(&format!("{table}_p_{expected_partition}"))),
+                "date group {date} must touch partition {expected_partition}, plan:\n{}",
+                plan.join("\n")
+            );
+        }
+
+        // Now actually run the grouped delete and verify exact row-level correctness.
+        let mut tx = pool.begin().await.unwrap();
+        delete_file_list_by_id_and_date_fixed(
+            &mut tx,
+            &table,
+            &[
+                (id_day1, "2021/01/01/00".to_string()),
+                (id_day2, "2021/01/02/00".to_string()),
+            ],
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        let remaining_ids: Vec<i64> =
+            sqlx::query_scalar(&format!("SELECT id FROM {table} ORDER BY id"))
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            remaining_ids,
+            vec![id_day3_untouched],
+            "only the day-3 row should remain after deleting the day-1 and day-2 ids"
+        );
+
+        drop_partitioned_test_table(&pool, &table).await;
+    }
+
+    /// CATEGORY: correctness regression guard, independent of EXPLAIN. After a grouped
+    /// `(id, date)` delete, exactly the targeted rows are gone and no others, verified via row
+    /// counts and explicit id membership before/after.
+    #[tokio::test]
+    async fn test_correctness_delete_removes_exactly_targeted_rows() {
+        let pool = connect_partitioned_test_db().await;
+        let table = unique_partitioned_test_table_name();
+        setup_partitioned_test_table(&pool, &table).await.unwrap();
+
+        let keep1 =
+            insert_partitioned_test_row(&pool, &table, "2021/01/01/00", "s1", "keep1.parquet")
+                .await
+                .unwrap();
+        let del1 =
+            insert_partitioned_test_row(&pool, &table, "2021/01/01/00", "s1", "del1.parquet")
+                .await
+                .unwrap();
+        let keep2 =
+            insert_partitioned_test_row(&pool, &table, "2021/01/02/00", "s1", "keep2.parquet")
+                .await
+                .unwrap();
+        let del2 =
+            insert_partitioned_test_row(&pool, &table, "2021/01/03/00", "s1", "del2.parquet")
+                .await
+                .unwrap();
+
+        let before_count: i64 = sqlx::query_scalar(&format!("SELECT count(*) FROM {table}"))
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(before_count, 4);
+
+        let mut tx = pool.begin().await.unwrap();
+        delete_file_list_by_id_and_date_fixed(
+            &mut tx,
+            &table,
+            &[
+                (del1, "2021/01/01/00".to_string()),
+                (del2, "2021/01/03/00".to_string()),
+            ],
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        let mut remaining_ids: Vec<i64> = sqlx::query_scalar(&format!("SELECT id FROM {table}"))
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        remaining_ids.sort();
+        let mut expected = vec![keep1, keep2];
+        expected.sort();
+        assert_eq!(
+            remaining_ids, expected,
+            "exactly the deleted ids should be gone; unrelated rows must remain untouched"
+        );
+
+        drop_partitioned_test_table(&pool, &table).await;
+    }
+
+    /// Site A (`update_dump_records`, postgres.rs:140) AND Site B (`inner_batch_process`'s
+    /// delete path, postgres.rs:2128), exercised end-to-end via the `FileList` trait against
+    /// the test DB, in a single test function.
+    ///
+    /// Both halves are kept in ONE `#[tokio::test]` rather than two, deliberately: both go
+    /// through `PostgresFileList`, which uses the process-wide `static Lazy<Pool<Postgres>>`
+    /// `CLIENT_RW`/`CLIENT_RO` (`db/postgres.rs`), not the per-test pool the partition tests
+    /// above use. `#[tokio::test]` gives every test its own Tokio runtime, but `CLIENT_RW`'s
+    /// pool is created lazily on first use and then bound to whichever test's runtime touched
+    /// it first; once that runtime shuts down, a second `#[tokio::test]` (a new runtime) reusing
+    /// the same `CLIENT_RW` fails every acquire with `PoolTimedOut`. Splitting Site A and Site B
+    /// into separate test functions reproduced exactly that failure. A single test function
+    /// keeps `CLIENT_RW` alive under one runtime for both checks.
+    ///
+    /// Confirms the current (unfixed) code deletes the right ROWS at both sites -- functional
+    /// correctness holds today; what's missing is partition pruning, covered by the
+    /// EXPLAIN-based tests above. Also confirms `FileRecord.date` (`file_list/mod.rs:774`, no
+    /// `#[sqlx(default)]`, i.e. required on every row) flows through `query_for_dump` correctly
+    /// -- that's the data the real Site A fix threads through instead of bare ids.
+    #[tokio::test]
+    async fn test_site_a_and_site_b_delete_paths_remove_correct_rows() {
+        let pool = setup_test_db().await;
+        cleanup_test_data(&pool).await;
+
+        let postgres_list = PostgresFileList::new();
+        let meta = create_test_file_meta();
+
+        // ---- Site A: update_dump_records ----
+        let dump_stream_key = "org1/logs/dump_test_stream";
+        let keep_key = format!("files/{dump_stream_key}/2021/01/01/00/keep.parquet");
+        let dump_key = format!("files/{dump_stream_key}/2021/01/01/00/dumped.parquet");
+        let keep_id = postgres_list.add("acct", &keep_key, &meta).await.unwrap();
+        let dump_id = postgres_list.add("acct", &dump_key, &meta).await.unwrap();
+
+        // `query_for_dump` returns FileRecord, whose `date` field is required (non-default) --
+        // this is the data the real Site A fix threads through instead of bare ids.
+        let records = postgres_list
+            .query_for_dump(
+                "org1",
+                StreamType::Logs,
+                "dump_test_stream",
+                (meta.min_ts - 1000, meta.max_ts + 1000),
+            )
+            .await
+            .unwrap();
+        let dumped_record = records
+            .iter()
+            .find(|r| r.id == dump_id)
+            .expect("dumped file must be present in query_for_dump results");
+        assert_eq!(
+            dumped_record.date, "2021/01/01/00",
+            "FileRecord.date must flow through query_for_dump correctly"
+        );
+
+        let dump_file_key = create_test_file_key(
+            "acct",
+            &format!("files/{dump_stream_key}/2021/01/02/00/dump_summary.parquet"),
+            false,
+        );
+        postgres_list
+            .update_dump_records(&dump_file_key, &[dump_id])
+            .await
+            .unwrap();
+
+        let remaining: Vec<i64> = sqlx::query_scalar("SELECT id FROM file_list WHERE stream = $1")
+            .bind(dump_stream_key)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert!(
+            !remaining.contains(&dump_id),
+            "update_dump_records must delete the dumped id"
+        );
+        assert!(
+            remaining.contains(&keep_id),
+            "update_dump_records must not delete unrelated ids"
+        );
+
+        // ---- Site B: inner_batch_process's delete path (via batch_process) ----
+        // del_items with `id > 0` (the common case once ids are already known, e.g. from a
+        // prior `batch_add`) currently skip date-key extraction entirely in
+        // `inner_batch_process` -- the `parse_file_key_columns` call in that loop only runs on
+        // the `id <= 0` branch. The real fix must extract `date_key` unconditionally for every
+        // del_item, not just the zero-id ones.
+        let batch_stream = "org1/logs/batch_del_stream";
+        let batch_keep_key = format!("files/{batch_stream}/2021/01/01/00/keep.parquet");
+        let batch_del_key = format!("files/{batch_stream}/2021/01/02/00/del.parquet");
+
+        let add_files = vec![
+            create_test_file_key("acct", &batch_keep_key, false),
+            create_test_file_key("acct", &batch_del_key, false),
+        ];
+        postgres_list.batch_add(&add_files).await.unwrap();
+
+        let ids: Vec<(String, i64)> =
+            sqlx::query("SELECT file, id FROM file_list WHERE stream = $1")
+                .bind(batch_stream)
+                .fetch_all(&pool)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|r| (r.get::<String, _>(0), r.get::<i64, _>(1)))
+                .collect();
+        let del_id = ids
+            .iter()
+            .find(|(f, _)| f == "del.parquet")
+            .map(|(_, id)| *id)
+            .expect("del.parquet must have been inserted with an id");
+        let batch_keep_id = ids
+            .iter()
+            .find(|(f, _)| f == "keep.parquet")
+            .map(|(_, id)| *id)
+            .expect("keep.parquet must have been inserted with an id");
+
+        // del_items carrying a real (>0) id, as inner_batch_process sorts/dedupes on before
+        // deleting -- this is the branch that currently skips date-key extraction entirely.
+        let mut del_file_key = create_test_file_key("acct", &batch_del_key, true);
+        del_file_key.id = del_id;
+        postgres_list
+            .batch_process(std::slice::from_ref(&del_file_key))
+            .await
+            .unwrap();
+
+        let remaining: Vec<i64> = sqlx::query_scalar("SELECT id FROM file_list WHERE stream = $1")
+            .bind(batch_stream)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert!(
+            !remaining.contains(&del_id),
+            "inner_batch_process must delete the targeted (deleted=true) id"
+        );
+        assert!(
+            remaining.contains(&batch_keep_id),
+            "inner_batch_process must not delete unrelated ids"
+        );
     }
 }

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1390,7 +1390,7 @@ DO UPDATE SET
         let sql = if fast_mode {
             r#"SELECT stream, id, 0::BIGINT AS num FROM file_list_jobs WHERE status = $1 ORDER BY offsets DESC LIMIT $2 FOR UPDATE SKIP LOCKED;"#
         } else {
-            // a stream whose max(id) row is lock-skipped is skipped whole: a peer owns it
+            // a stream whose max(id) row is lock-skipped is skipped whole until the peer commits
             r#"
     WITH candidates AS (
         SELECT stream, max(id) AS id, COUNT(*)::BIGINT AS num
@@ -1456,11 +1456,13 @@ DO UPDATE SET
         DB_QUERY_NUMS
             .with_label_values(&["select", "file_list_jobs"])
             .inc();
+        // status filter stands alone: a row the guarded UPDATE skipped must not be returned
         let sql = format!(
-            "SELECT * FROM file_list_jobs WHERE id IN ({});",
+            "SELECT * FROM file_list_jobs WHERE id IN ({}) AND status = $1;",
             ids.join(",")
         );
         let ret = match sqlx::query_as::<_, super::MergeJobRecord>(&sql)
+            .bind(super::FileListJobStatus::Running)
             .fetch_all(&mut *tx)
             .await
         {
@@ -5355,6 +5357,56 @@ mod tests {
             fast_ids1.union(&fast_ids2).count(),
             fast_seeded.len(),
             "fast_mode: every seeded pending job must be claimed by exactly one caller"
+        );
+
+        // ---- Fix 4 [GREEN]: a row-locked max-id row is SKIPPED, never waited on ----
+        let locked_stream = format!("fix4_org/logs/rowlock_{pid}_locked");
+        let free_stream = format!("fix4_org/logs/rowlock_{pid}_free");
+        let mut rowlock_max: stdHashMap<String, i64> = stdHashMap::new();
+        for stream in [&locked_stream, &free_stream] {
+            for offsets in [1_000_i64, 2_000] {
+                let id: i64 = sqlx::query_scalar(
+                    "INSERT INTO file_list_jobs (org, stream, offsets, status, node, \
+                     started_at, updated_at) VALUES ('fix4_org', $1, $2, 0, '', 0, 0) \
+                     RETURNING id",
+                )
+                .bind(stream)
+                .bind(offsets)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+                rowlock_max.insert((*stream).clone(), id);
+            }
+        }
+
+        // A genuine row lock from a separate session, held across the whole claim call.
+        let mut row_tx = pool.begin().await.unwrap();
+        let locked_id: i64 =
+            sqlx::query_scalar("SELECT id FROM file_list_jobs WHERE id = $1 FOR UPDATE")
+                .bind(rowlock_max[&locked_stream])
+                .fetch_one(&mut *row_tx)
+                .await
+                .unwrap();
+
+        // A plain-FOR-UPDATE mutant blocks here until row_tx ends and fails this timeout.
+        let claims = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            postgres_list.get_pending_jobs("fix4-node-6", 100, false),
+        )
+        .await
+        .expect("get_pending_jobs must skip a row-locked max-id row, not block on it")
+        .unwrap();
+        row_tx.rollback().await.unwrap();
+
+        assert!(
+            !claims.iter().any(|j| j.stream == locked_stream),
+            "the stream whose max-id row {locked_id} is row-locked must be skipped whole"
+        );
+        assert!(
+            claims
+                .iter()
+                .any(|j| j.stream == free_stream && j.id == rowlock_max[&free_stream]),
+            "the unlocked stream's max-id job must still be claimed in the same call"
         );
     }
 }

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -5141,11 +5141,20 @@ mod tests {
 
     // Fix 4 regression tests: get_pending_jobs serializes ALL nodes on ONE global advisory lock.
 
+    /// Advisory locks match on value, so the key derivation must be deterministic per scope.
+    #[test]
+    fn test_pending_jobs_lock_key_is_deterministic() {
+        assert_eq!(pending_jobs_lock_key("x"), pending_jobs_lock_key("x"));
+    }
+
     /// Fix spec [RED until Fix 4 lands]: distinct scopes must map to distinct advisory lock keys.
     #[tokio::test]
     #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_fix_different_scopes_do_not_serialize() {
-        // TODO(fix-4-implementation): decide + pin per-node vs per-stream scoping with a test.
+        // TODO(fix-4-implementation): the advisory lock is the ONLY double-claim guard today.
+        // TODO(fix-4-implementation): claim UPDATE has no status re-check; SELECT no FOR UPDATE.
+        // TODO(fix-4-implementation): per-node scoping is unsafe without self-guarding SQL.
+        // TODO(fix-4-implementation): a narrowed scope needs a scoped claim query or guarded SQL.
         let pool = connect_partitioned_test_db().await;
         let key_a = pending_jobs_lock_key("stream-a");
         let key_b = pending_jobs_lock_key("stream-b");
@@ -5220,81 +5229,105 @@ mod tests {
         let pool = setup_test_db().await;
         cleanup_test_data(&pool).await;
 
+        let test_db: String = sqlx::query_scalar("SELECT current_database()")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let client_rw_db: String = sqlx::query_scalar("SELECT current_database()")
+            .fetch_one(&CLIENT_RW.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            client_rw_db, test_db,
+            "ZO_META_POSTGRES_DSN (CLIENT_RW) must target the same DB as TEST_POSTGRES_URL"
+        );
+
         let pid = std::process::id();
         let stream_a = format!("fix4_org/logs/claim_{pid}_a");
         let stream_b = format!("fix4_org/logs/claim_{pid}_b");
-        let mut seeded: Vec<i64> = Vec::new();
-        for stream in [&stream_a, &stream_b] {
-            for offsets in [1_000_i64, 2_000] {
-                let id: i64 = sqlx::query_scalar(
-                    "INSERT INTO file_list_jobs (org, stream, offsets, status, node, started_at, \
-                     updated_at) VALUES ('fix4_org', $1, $2, 0, '', 0, 0) RETURNING id",
-                )
-                .bind(stream)
-                .bind(offsets)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
-                seeded.push(id);
-            }
-        }
-
         let postgres_list = PostgresFileList::new();
-        let (r1, r2) = tokio::join!(
-            postgres_list.get_pending_jobs("fix4-node-1", 100, false),
-            postgres_list.get_pending_jobs("fix4-node-2", 100, false),
-        );
-        let (jobs1, jobs2) = (r1.unwrap(), r2.unwrap());
 
-        // Sibling ignored tests share file_list_jobs; assert only on this test's seeded streams.
-        let ids1: HashSet<i64> = jobs1
-            .iter()
-            .filter(|j| j.stream == stream_a || j.stream == stream_b)
-            .map(|j| j.id)
-            .collect();
-        let ids2: HashSet<i64> = jobs2
-            .iter()
-            .filter(|j| j.stream == stream_a || j.stream == stream_b)
-            .map(|j| j.id)
-            .collect();
-        assert!(
-            ids1.is_disjoint(&ids2),
-            "concurrent get_pending_jobs must never claim the same job twice: {ids1:?} vs {ids2:?}"
-        );
+        // 20 seeded races amplify scheduling variance so a broken lock scope cannot pass by luck.
+        for cycle in 0_i64..20 {
+            let mut seeded: Vec<i64> = Vec::new();
+            for stream in [&stream_a, &stream_b] {
+                for offsets in [cycle * 10_000 + 1_000, cycle * 10_000 + 2_000] {
+                    let id: i64 = sqlx::query_scalar(
+                        "INSERT INTO file_list_jobs (org, stream, offsets, status, node, \
+                         started_at, updated_at) VALUES ('fix4_org', $1, $2, 0, '', 0, 0) \
+                         RETURNING id",
+                    )
+                    .bind(stream)
+                    .bind(offsets)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+                    seeded.push(id);
+                }
+            }
 
-        // A single call claims max(id) per stream; the concurrent pair must cover at least that.
-        let union: Vec<i64> = ids1.union(&ids2).copied().collect();
-        for single_call_claim in [seeded[1], seeded[3]] {
-            assert!(
-                union.contains(&single_call_claim),
-                "the union {union:?} must cover what one call alone would claim ({single_call_claim})"
+            // TODO(fix-4-implementation): fast_mode shares the unguarded UPDATE; guard both paths.
+            let (r1, r2) = tokio::join!(
+                postgres_list.get_pending_jobs("fix4-node-1", 100, false),
+                postgres_list.get_pending_jobs("fix4-node-2", 100, false),
             );
-        }
+            let (jobs1, jobs2) = (r1.unwrap(), r2.unwrap());
 
-        let rows = sqlx::query("SELECT id, status, node FROM file_list_jobs WHERE id = ANY($1)")
-            .bind(&union)
-            .fetch_all(&pool)
-            .await
-            .unwrap();
-        assert_eq!(rows.len(), union.len(), "every claimed id must still exist");
-        for row in &rows {
-            let id: i64 = row.get(0);
-            let status: i32 = row.get(1);
-            let node: String = row.get(2);
+            // Sibling ignored tests share file_list_jobs; assert only on this test's streams.
+            let ids1: HashSet<i64> = jobs1
+                .iter()
+                .filter(|j| j.stream == stream_a || j.stream == stream_b)
+                .map(|j| j.id)
+                .collect();
+            let ids2: HashSet<i64> = jobs2
+                .iter()
+                .filter(|j| j.stream == stream_a || j.stream == stream_b)
+                .map(|j| j.id)
+                .collect();
+            assert!(
+                ids1.is_disjoint(&ids2),
+                "cycle {cycle}: a job was claimed by both callers: {ids1:?} vs {ids2:?}"
+            );
+
+            // A single call claims max(id) per stream; the pair's union must cover at least that.
+            let union: Vec<i64> = ids1.union(&ids2).copied().collect();
+            for single_call_claim in [seeded[1], seeded[3]] {
+                assert!(
+                    union.contains(&single_call_claim),
+                    "cycle {cycle}: union {union:?} must cover single-call claim {single_call_claim}"
+                );
+            }
+
+            let rows =
+                sqlx::query("SELECT id, status, node FROM file_list_jobs WHERE id = ANY($1)")
+                    .bind(&union)
+                    .fetch_all(&pool)
+                    .await
+                    .unwrap();
             assert_eq!(
-                status, 1,
-                "claimed job {id} must have transitioned to running"
+                rows.len(),
+                union.len(),
+                "cycle {cycle}: claimed ids must exist"
             );
-            assert!(
-                node.starts_with("fix4-node-"),
-                "claimed job {id} must record the claiming node, got {node:?}"
-            );
-        }
+            for row in &rows {
+                let id: i64 = row.get(0);
+                let status: i32 = row.get(1);
+                let node: String = row.get(2);
+                assert_eq!(
+                    status, 1,
+                    "cycle {cycle}: claimed job {id} must have transitioned to running"
+                );
+                assert!(
+                    node.starts_with("fix4-node-"),
+                    "cycle {cycle}: claimed job {id} must record the claiming node, got {node:?}"
+                );
+            }
 
-        let _ = sqlx::query("DELETE FROM file_list_jobs WHERE stream = $1 OR stream = $2")
-            .bind(&stream_a)
-            .bind(&stream_b)
-            .execute(&pool)
-            .await;
+            let _ = sqlx::query("DELETE FROM file_list_jobs WHERE stream = $1 OR stream = $2")
+                .bind(&stream_a)
+                .bind(&stream_b)
+                .execute(&pool)
+                .await;
+        }
     }
 }

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1383,13 +1383,7 @@ DO UPDATE SET
 
         let pool = CLIENT_RW.clone();
         let mut tx = pool.begin().await?;
-        let lock_key = "file_list_jobs:get_pending_jobs";
-        let lock_id = config::utils::hash::gxhash::new().sum64(lock_key);
-        let lock_id = if lock_id > (i64::MAX as u64) {
-            (lock_id >> 1) as i64
-        } else {
-            lock_id as i64
-        };
+        let lock_id = pending_jobs_lock_key("");
         let lock_sql = format!("SELECT pg_advisory_xact_lock({lock_id})");
         DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         if let Err(e) = sqlx::query(&lock_sql).execute(&mut *tx).await {
@@ -2214,10 +2208,10 @@ async fn delete_file_list_by_id_buggy(
     Ok(())
 }
 
-/// TEST-ONLY: Fix 4 will make production get_pending_jobs derive its lock id from a real scope.
-#[cfg(test)]
+/// Advisory lock key for get_pending_jobs claims; scope is ignored until Fix 4 wires a real one.
 fn pending_jobs_lock_key(_scope: &str) -> i64 {
-    // TODO(fix-4-implementation): production get_pending_jobs must consume this with a real scope.
+    // TODO(fix-4-implementation): callers must pass a real scope once the scoping decision lands.
+    // Shared advisory-id space with scheduler_pull_lock/get_for_update_*; collisions only block.
     let lock_id = config::utils::hash::gxhash::new().sum64("file_list_jobs:get_pending_jobs");
     if lock_id > (i64::MAX as u64) {
         (lock_id >> 1) as i64
@@ -5020,13 +5014,13 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// Sites A+B in ONE test: CLIENT_RW's pool binds to its first runtime; a 2nd test times out.
+    /// Sites A+B + Fix-4 disjointness in ONE test: CLIENT_RW's pool binds to its first runtime.
     // TODO(fix-3-implementation): assert pruning at real Site A/B via the shared builder.
     // TODO(fix-3-implementation): compose date-grouping WITH file_list_deleted_batch_size chunking.
     // TODO(fix-3-implementation): chunk within each date group (or vice versa); pin with a test.
     #[tokio::test]
     #[ignore = "Requires test PostgreSQL database setup"]
-    async fn test_site_a_and_site_b_delete_paths_remove_correct_rows() {
+    async fn test_client_rw_paths_site_ab_deletes_and_pending_jobs_disjointness() {
         // CLIENT_RW (ZO_META_POSTGRES_DSN) and the TEST_POSTGRES_URL pool must be the same DB.
         let pool = setup_test_db().await;
         cleanup_test_data(&pool).await;
@@ -5137,98 +5131,9 @@ mod tests {
             remaining.contains(&batch_keep_id),
             "inner_batch_process must not delete unrelated ids"
         );
-    }
 
-    // Fix 4 regression tests: get_pending_jobs serializes ALL nodes on ONE global advisory lock.
-
-    /// Advisory locks match on value, so the key derivation must be deterministic per scope.
-    #[test]
-    fn test_pending_jobs_lock_key_is_deterministic() {
-        assert_eq!(pending_jobs_lock_key("x"), pending_jobs_lock_key("x"));
-    }
-
-    /// Fix spec [RED until Fix 4 lands]: distinct scopes must map to distinct advisory lock keys.
-    #[tokio::test]
-    #[ignore = "Requires test PostgreSQL database setup"]
-    async fn test_fix_different_scopes_do_not_serialize() {
-        // TODO(fix-4-implementation): the advisory lock is the ONLY double-claim guard today.
-        // TODO(fix-4-implementation): claim UPDATE has no status re-check; SELECT no FOR UPDATE.
-        // TODO(fix-4-implementation): per-node scoping is unsafe without self-guarding SQL.
-        // TODO(fix-4-implementation): a narrowed scope needs a scoped claim query or guarded SQL.
-        let pool = connect_partitioned_test_db().await;
-        let key_a = pending_jobs_lock_key("stream-a");
-        let key_b = pending_jobs_lock_key("stream-b");
-
-        let mut tx_a = pool.begin().await.unwrap();
-        sqlx::query(&format!("SELECT pg_advisory_xact_lock({key_a})"))
-            .execute(&mut *tx_a)
-            .await
-            .unwrap();
-
-        let mut tx_b = pool.begin().await.unwrap();
-        let acquired: bool =
-            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key_b})"))
-                .fetch_one(&mut *tx_b)
-                .await
-                .unwrap();
-
-        tx_b.rollback().await.unwrap();
-        tx_a.rollback().await.unwrap();
-
-        assert!(
-            acquired,
-            "scope 'stream-b' (key {key_b}) must not block behind scope 'stream-a' (key {key_a}); \
-             equal keys mean the lock key is still the global constant"
-        );
-    }
-
-    /// Invariant guard [GREEN]: claimers in the SAME scope must keep serializing on one lock key.
-    #[tokio::test]
-    #[ignore = "Requires test PostgreSQL database setup"]
-    async fn test_same_scope_still_serializes() {
-        // Until Fix 4 lands every scope shares one key, so run DB tests with --test-threads=1.
-        let pool = connect_partitioned_test_db().await;
-        let key = pending_jobs_lock_key("stream-same");
-
-        let mut tx_a = pool.begin().await.unwrap();
-        sqlx::query(&format!("SELECT pg_advisory_xact_lock({key})"))
-            .execute(&mut *tx_a)
-            .await
-            .unwrap();
-
-        let mut tx_b = pool.begin().await.unwrap();
-        let acquired: bool =
-            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key})"))
-                .fetch_one(&mut *tx_b)
-                .await
-                .unwrap();
-        assert!(
-            !acquired,
-            "same scope must serialize: try-lock on key {key} must fail while tx_a holds it"
-        );
-
-        tx_a.rollback().await.unwrap();
-
-        let acquired: bool =
-            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key})"))
-                .fetch_one(&mut *tx_b)
-                .await
-                .unwrap();
-        assert!(
-            acquired,
-            "xact-scoped advisory lock on key {key} must be free once tx_a ends"
-        );
-        tx_b.rollback().await.unwrap();
-    }
-
-    /// Fix-4 invariant [GREEN, must survive the fix]: no job is ever claimed by two callers.
-    #[tokio::test]
-    #[ignore = "Requires test PostgreSQL database setup"]
-    async fn test_concurrent_get_pending_jobs_claims_are_disjoint() {
-        // CLIENT_RW (ZO_META_POSTGRES_DSN) and the TEST_POSTGRES_URL pool must be the same DB.
-        let pool = setup_test_db().await;
-        cleanup_test_data(&pool).await;
-
+        // ---- Fix 4: concurrent get_pending_jobs claims must stay disjoint ----
+        // Fix-4 invariant [GREEN, must survive the fix]: no job is ever claimed by two callers.
         let test_db: String = sqlx::query_scalar("SELECT current_database()")
             .fetch_one(&pool)
             .await
@@ -5245,7 +5150,6 @@ mod tests {
         let pid = std::process::id();
         let stream_a = format!("fix4_org/logs/claim_{pid}_a");
         let stream_b = format!("fix4_org/logs/claim_{pid}_b");
-        let postgres_list = PostgresFileList::new();
 
         // 20 seeded races amplify scheduling variance so a broken lock scope cannot pass by luck.
         for cycle in 0_i64..20 {
@@ -5329,5 +5233,87 @@ mod tests {
                 .execute(&pool)
                 .await;
         }
+    }
+
+    // Fix 4 regression tests: get_pending_jobs serializes ALL nodes on ONE global advisory lock.
+
+    /// Advisory locks match on value, so the key derivation must be deterministic per scope.
+    #[test]
+    fn test_pending_jobs_lock_key_is_deterministic() {
+        assert_eq!(pending_jobs_lock_key("x"), pending_jobs_lock_key("x"));
+    }
+
+    /// Fix spec [RED until Fix 4 lands]: distinct scopes must map to distinct advisory lock keys.
+    #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
+    async fn test_fix_different_scopes_do_not_serialize() {
+        // TODO(fix-4-implementation): the advisory lock is the ONLY double-claim guard today.
+        // TODO(fix-4-implementation): claim UPDATE has no status re-check; SELECT no FOR UPDATE.
+        // TODO(fix-4-implementation): per-node scoping is unsafe without self-guarding SQL.
+        // TODO(fix-4-implementation): a narrowed scope needs a scoped claim query or guarded SQL.
+        let pool = connect_partitioned_test_db().await;
+        let key_a = pending_jobs_lock_key("stream-a");
+        let key_b = pending_jobs_lock_key("stream-b");
+
+        let mut tx_a = pool.begin().await.unwrap();
+        sqlx::query(&format!("SELECT pg_advisory_xact_lock({key_a})"))
+            .execute(&mut *tx_a)
+            .await
+            .unwrap();
+
+        let mut tx_b = pool.begin().await.unwrap();
+        let acquired: bool =
+            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key_b})"))
+                .fetch_one(&mut *tx_b)
+                .await
+                .unwrap();
+
+        tx_b.rollback().await.unwrap();
+        tx_a.rollback().await.unwrap();
+
+        assert!(
+            acquired,
+            "scope 'stream-b' (key {key_b}) must not block behind scope 'stream-a' (key {key_a}); \
+             equal keys mean the lock key is still the global constant"
+        );
+    }
+
+    /// Invariant guard [GREEN]: claimers in the SAME scope must keep serializing on one lock key.
+    #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
+    async fn test_same_scope_still_serializes() {
+        // Until Fix 4 lands every scope shares one key, so run DB tests with --test-threads=1.
+        let pool = connect_partitioned_test_db().await;
+        let key = pending_jobs_lock_key("stream-same");
+
+        let mut tx_a = pool.begin().await.unwrap();
+        sqlx::query(&format!("SELECT pg_advisory_xact_lock({key})"))
+            .execute(&mut *tx_a)
+            .await
+            .unwrap();
+
+        let mut tx_b = pool.begin().await.unwrap();
+        let acquired: bool =
+            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key})"))
+                .fetch_one(&mut *tx_b)
+                .await
+                .unwrap();
+        assert!(
+            !acquired,
+            "same scope must serialize: try-lock on key {key} must fail while tx_a holds it"
+        );
+
+        tx_a.rollback().await.unwrap();
+
+        let acquired: bool =
+            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key})"))
+                .fetch_one(&mut *tx_b)
+                .await
+                .unwrap();
+        assert!(
+            acquired,
+            "xact-scoped advisory lock on key {key} must be free once tx_a ends"
+        );
+        tx_b.rollback().await.unwrap();
     }
 }

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -2152,17 +2152,7 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
     }
 }
 
-/// TEST-ONLY SCAFFOLDING for the compactor write-amplification fix (not yet implemented).
-///
-/// `update_dump_records` (Site A, above) and `inner_batch_process`'s delete path (Site B, above)
-/// both currently issue `DELETE FROM file_list WHERE id IN (...)` with no `date` predicate, which
-/// defeats partition pruning on the range-partitioned `file_list` table (see
-/// `file_list_partition_ddl`). The planned fix threads `date` alongside `id` and groups deletes by
-/// date so each DELETE only touches its own partition.
-///
-/// This helper models that planned shape ahead of the real fix landing at the two call sites.
-/// Once the fix is implemented at Site A/Site B directly, this helper (and its "current buggy
-/// behavior" sibling below) should be removed in favor of calling the real code paths.
+/// TEST-ONLY: models the planned Site A/B fix; remove once the real fix lands there.
 #[cfg(test)]
 async fn delete_file_list_by_id_and_date_fixed(
     tx: &mut sqlx::Transaction<'_, Postgres>,
@@ -2178,11 +2168,7 @@ async fn delete_file_list_by_id_and_date_fixed(
     Ok(())
 }
 
-/// TEST-ONLY today (intended to graduate to Site A/Site B when the production fix lands): the
-/// single source of the pruned-delete SQL shape -- both the executing helper above and the
-/// EXPLAIN-based pruning tests consume this, so the string the tests EXPLAIN is the string the
-/// helper executes, by construction. Groups `(id, date)` pairs by date and returns one
-/// `(bind_date, sql)` pair per date group, sorted by date for determinism.
+/// TEST-ONLY: single SQL source, so tests EXPLAIN the exact string the fixed helper executes.
 #[cfg(test)]
 fn build_pruned_delete_statements(
     table: &str,
@@ -2208,8 +2194,7 @@ fn build_pruned_delete_statements(
     stmts
 }
 
-/// TEST-ONLY: reproduces today's buggy (unpruned) delete shape used at both Site A
-/// (`postgres.rs:199`) and Site B (`postgres.rs:2128`), for bug-reproduction tests.
+/// TEST-ONLY: same unpruned shape (modulo whitespace/semicolon) as today's Site A/B deletes.
 #[cfg(test)]
 async fn delete_file_list_by_id_buggy(
     tx: &mut sqlx::Transaction<'_, Postgres>,
@@ -4601,48 +4586,19 @@ mod tests {
         assert_eq!(maintenance_hour("foo,bar"), 0);
     }
 
-    // ------------------------------------------------------------------------------------------
-    // Partition-pruning regression tests for the compactor write-amplification bug.
-    //
-    // `update_dump_records` (Site A, postgres.rs:199) and `inner_batch_process`'s delete path
-    // (Site B, postgres.rs:2128) issue `DELETE FROM file_list WHERE id IN (...)` with no `date`
-    // predicate. Because `file_list` is RANGE partitioned on `date` (`file_list_partition_ddl`)
-    // and the `id` index (`file_list_partition_index_ddl`) becomes one local index PER
-    // PARTITION rather than a global index, a bare `id IN (...)` delete cannot be pruned and
-    // Postgres must probe every partition's local `id` index.
-    //
-    // Unlike `setup_test_tables` above (a single non-partitioned table, which cannot
-    // distinguish a pruned plan from an unpruned one), these tests build a REAL partitioned
-    // table with 3 distinct date partitions, matching production DDL, so a pruning-vs-full-scan
-    // difference is actually observable via `EXPLAIN`.
-    // ------------------------------------------------------------------------------------------
+    // Partition-pruning regression tests: Sites A/B delete by bare id, defeating pruning.
 
-    /// Process-wide counter used to build a table name unique to each call. A bare counter
-    /// (rather than e.g. a timestamp) keeps the generated name short: Postgres silently
-    /// truncates identifiers over 63 bytes, and the longest derived index name
-    /// (`{table}_stream_file_idx`) leaves little budget after the `file_list_partitioned_test_`
-    /// prefix -- a longer unique suffix would truncate two different table names down to the
-    /// same 63-byte identifier and reintroduce the very collision this exists to prevent. Plain
-    /// `Ordering::Relaxed` is enough: uniqueness only requires each call see a distinct value,
-    /// not any cross-thread ordering guarantee.
+    /// Pid + counter: unique across processes and calls, within Postgres's 63-byte cap.
     static PARTITIONED_TEST_TABLE_COUNTER: std::sync::atomic::AtomicU64 =
         std::sync::atomic::AtomicU64::new(0);
 
-    /// Builds a table name unique to this call, so concurrent tests (the default under
-    /// `cargo test`, which runs `#[tokio::test]` functions in parallel) never `CREATE TABLE` the
-    /// same physical table/sequence and collide on `pg_class_relname_nsp_index`.
+    /// Unique per process AND call, so parallel tests and concurrent runs never share a table.
     fn unique_partitioned_test_table_name() -> String {
         let n = PARTITIONED_TEST_TABLE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        format!("file_list_partitioned_test_{n}")
+        format!("file_list_partitioned_test_{}_{n}", std::process::id())
     }
 
-    /// Opens a dedicated `PgPool` for a single test, instead of reusing the process-wide
-    /// `DB_POOL` (`setup_test_db`). `#[tokio::test]` gives each test its own Tokio runtime by
-    /// default, but `sqlx::Pool`'s background maintenance/reaper task is bound to whichever
-    /// runtime created it; once that first test's runtime shuts down, a `PgPool` cached in a
-    /// `static OnceCell` and reused by a later test (a different runtime) starts failing every
-    /// `acquire()` with `PoolTimedOut`, because Sqlx does not reason about connections it can't
-    /// account for anymore. A fresh pool per test sidesteps this instead of fighting it.
+    /// Per-test pool: a pool outliving its creating runtime fails every acquire (PoolTimedOut).
     async fn connect_partitioned_test_db() -> PgPool {
         let database_url = std::env::var("TEST_POSTGRES_URL").unwrap_or_else(|_| {
             "postgresql://postgres:password@localhost:5432/openobserve_test".to_string()
@@ -4652,11 +4608,7 @@ mod tests {
             .expect("Failed to connect to test PostgreSQL database")
     }
 
-    /// Builds a fresh, REAL partitioned `file_list`-shaped table (same column set and index set
-    /// as `file_list_partition_ddl` / `file_list_partition_index_ddl`) with 3 distinct date
-    /// partitions, so partition pruning is actually observable in `EXPLAIN` output. `table` must
-    /// be unique per call (see `unique_partitioned_test_table_name`) -- concurrent tests sharing
-    /// one hardcoded name race to `CREATE TABLE`/`CREATE SEQUENCE` and collide.
+    /// Production-DDL table, 3 date partitions, so EXPLAIN shows pruning; name unique per call.
     async fn setup_partitioned_test_table(pool: &PgPool, table: &str) -> Result<()> {
         sqlx::query(&format!("DROP TABLE IF EXISTS {table}"))
             .execute(pool)
@@ -4681,14 +4633,7 @@ mod tests {
         Ok(())
     }
 
-    /// Drops a table created by `setup_partitioned_test_table`, including its partitions
-    /// (Postgres cascades a parent `DROP TABLE` onto its declarative partitions automatically).
-    /// Called explicitly at the end of every partitioned test so the shared test database
-    /// doesn't accumulate garbage tables run after run. A test that panics via `unwrap()` skips
-    /// this call and leaves its table behind, but each table's unique name (see
-    /// `unique_partitioned_test_table_name`) means an orphan is only ever cosmetic clutter --
-    /// never a name collision with a later test, which is the actual correctness property this
-    /// suite depends on.
+    /// A panicking test skips this and orphans its table; unique names make that cosmetic only.
     async fn drop_partitioned_test_table(pool: &PgPool, table: &str) {
         let _ = sqlx::query(&format!("DROP TABLE IF EXISTS {table}"))
             .execute(pool)
@@ -4719,10 +4664,7 @@ mod tests {
         Ok(id)
     }
 
-    /// Runs `EXPLAIN (FORMAT TEXT) <delete_sql>` and returns the raw plan lines (one row per
-    /// line of plan text, matching `psql`'s own rendering of `EXPLAIN`). Wrapped in a
-    /// transaction that is always rolled back so EXPLAIN's actual execution of the DELETE
-    /// (needed for accurate row-count estimates) never persists.
+    /// Plain EXPLAIN never executes the DELETE; the rollback wrapper is just defensive redundancy.
     async fn explain_delete_lines(
         pool: &PgPool,
         delete_sql: &str,
@@ -4740,10 +4682,7 @@ mod tests {
         Ok(rows.iter().map(|r| r.get::<String, usize>(0)).collect())
     }
 
-    /// Counts `Delete on <partition>` lines in an EXPLAIN TEXT plan for a partitioned table --
-    /// i.e. how many partitions the planner actually touches. The first line is always
-    /// `Delete on <parent_table> ...` (the ModifyTable node itself, not a partition), so it is
-    /// excluded.
+    /// Counts partition `Delete on` lines; the first line is the parent node, not a partition.
     fn count_touched_partitions(plan_lines: &[String]) -> usize {
         plan_lines
             .iter()
@@ -4752,19 +4691,9 @@ mod tests {
             .count()
     }
 
-    /// CATEGORY: bug reproduction (expected to PASS today; documents the bug).
-    ///
-    /// A bare `DELETE FROM file_list WHERE id IN (...)` against a 3-partition table touches ALL
-    /// 3 partitions in the query plan, even though the target id only exists in 1 partition.
-    /// This is the root cause of the multi-second/23s DELETE latency seen in production.
-    ///
-    /// This test is intentionally kept as a permanent regression guard: if a future change
-    /// removes the `date` predicate from the fixed delete path again, this test's assertion
-    /// (`touched == 3`, i.e. no pruning) still holds and continues to document/prove the
-    /// unpruned shape is what "no date predicate" produces on this schema. It is not meant to
-    /// start failing once the fix lands elsewhere -- it tests the OLD query shape directly, not
-    /// the code at Site A/B.
+    /// Bug repro, permanent guard: a bare `id IN (...)` delete must touch all 3 partitions.
     #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_bug_repro_unpruned_delete_touches_all_partitions() {
         let pool = connect_partitioned_test_db().await;
         let table = unique_partitioned_test_table_name();
@@ -4792,11 +4721,9 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// CATEGORY: bug reproduction. `delete_file_list_by_id_buggy` (the exact query shape
-    /// currently used at Site A/B) is functionally correct today -- it deletes the right row --
-    /// which is precisely why the bug has been latent: nothing about correctness signals the
-    /// missing partition pruning. Only EXPLAIN (see the test above) reveals it.
+    /// Bug repro: Site A/B's shape (modulo whitespace/semicolon) is correct but unpruned.
     #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_bug_repro_buggy_delete_is_functionally_correct_but_unpruned() {
         let pool = connect_partitioned_test_db().await;
         let table = unique_partitioned_test_table_name();
@@ -4829,15 +4756,9 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// CATEGORY: fix specification -- pins the target query shape. This test is green by
-    /// construction (it asserts what a pruned delete plan looks like, not that Site A/B use
-    /// it yet); its value is that it EXPLAINs the very SQL `build_pruned_delete_statements`
-    /// builds -- the same string `delete_file_list_by_id_and_date_fixed` executes -- so
-    /// dropping the `date` predicate from the shared builder makes this test fail.
-    ///
-    /// With a `date = $1 AND id IN (...)` predicate, only the ONE partition holding that date is
-    /// touched, even though the same ids table has 3 partitions total.
+    /// Fix spec: the builder's SQL must prune to exactly 1 partition; dropping date fails this.
     #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_fix_pruned_delete_touches_single_partition() {
         let pool = connect_partitioned_test_db().await;
         let table = unique_partitioned_test_table_name();
@@ -4870,12 +4791,9 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// CATEGORY: fix specification. Ids spanning 2 different date partitions must be handled as
-    /// 2 separate pruned single-partition deletes (per `build_pruned_delete_statements`, which
-    /// groups by date and is the same SQL `delete_file_list_by_id_and_date_fixed` executes),
-    /// never a single unpruned multi-partition delete. Also verifies actual row deletion
-    /// correctness: right rows gone, nothing else touched.
+    /// Fix spec: ids spanning 2 dates become 2 pruned deletes, never one unpruned delete.
     #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_fix_multiple_dates_grouped_into_pruned_deletes() {
         let pool = connect_partitioned_test_db().await;
         let table = unique_partitioned_test_table_name();
@@ -4945,10 +4863,9 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// CATEGORY: correctness regression guard, independent of EXPLAIN. After a grouped
-    /// `(id, date)` delete, exactly the targeted rows are gone and no others, verified via row
-    /// counts and explicit id membership before/after.
+    /// Correctness guard independent of EXPLAIN: exactly the targeted rows are gone, no others.
     #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_correctness_delete_removes_exactly_targeted_rows() {
         let pool = connect_partitioned_test_db().await;
         let table = unique_partitioned_test_table_name();
@@ -5005,12 +4922,9 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// CATEGORY: edge case. A date matching NO live partition must be handled gracefully: the
-    /// planner short-circuits the pruned delete to `Result` with `One-Time Filter: false`
-    /// (verified against real Postgres 17), so the plan has ZERO partition-level `Delete on`
-    /// lines (only the parent ModifyTable line remains) and executing the helper neither errors
-    /// nor deletes anything.
+    /// Edge case: a no-partition date prunes to `One-Time Filter: false` -- no error, no delete.
     #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_fix_date_matching_no_partition_is_graceful_noop() {
         let pool = connect_partitioned_test_db().await;
         let table = unique_partitioned_test_table_name();
@@ -5061,9 +4975,9 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// CATEGORY: edge case. An empty `(id, date)` list must be a complete no-op: no SQL is
-    /// built (an empty `IN ()` would be a syntax error), no statement executes, no rows change.
+    /// Edge case: empty input builds no SQL (empty `IN ()` is a syntax error) and deletes nothing.
     #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_fix_empty_id_list_is_noop() {
         let pool = connect_partitioned_test_db().await;
         let table = unique_partitioned_test_table_name();
@@ -5094,31 +5008,14 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// Site A (`update_dump_records`, postgres.rs:140) AND Site B (`inner_batch_process`'s
-    /// delete path, postgres.rs:2128), exercised end-to-end via the `FileList` trait against
-    /// the test DB, in a single test function.
-    ///
-    /// Both halves are kept in ONE `#[tokio::test]` rather than two, deliberately: both go
-    /// through `PostgresFileList`, which uses the process-wide `static Lazy<Pool<Postgres>>`
-    /// `CLIENT_RW`/`CLIENT_RO` (`db/postgres.rs`), not the per-test pool the partition tests
-    /// above use. `#[tokio::test]` gives every test its own Tokio runtime, but `CLIENT_RW`'s
-    /// pool is created lazily on first use and then bound to whichever test's runtime touched
-    /// it first; once that runtime shuts down, a second `#[tokio::test]` (a new runtime) reusing
-    /// the same `CLIENT_RW` fails every acquire with `PoolTimedOut`. Splitting Site A and Site B
-    /// into separate test functions reproduced exactly that failure. A single test function
-    /// keeps `CLIENT_RW` alive under one runtime for both checks.
-    ///
-    /// Confirms the current (unfixed) code deletes the right ROWS at both sites -- functional
-    /// correctness holds today; what's missing is partition pruning, covered by the
-    /// EXPLAIN-based tests above. Also confirms `FileRecord.date` (`file_list/mod.rs:774`, no
-    /// `#[sqlx(default)]`, i.e. required on every row) flows through `query_for_dump` correctly
-    /// -- that's the data the real Site A fix threads through instead of bare ids.
-    // TODO(fix-3-implementation): when the production fix lands at Site A/Site B, this test
-    // MUST grow pruning assertions against the REAL call sites (not just row correctness) --
-    // the intended mechanism is having those sites build their delete SQL via the shared
-    // `build_pruned_delete_statements` so their EXPLAINed and executed SQL stay one string.
+    /// Sites A+B in ONE test: CLIENT_RW's pool binds to its first runtime; a 2nd test times out.
+    // TODO(fix-3-implementation): assert pruning at real Site A/B via the shared builder.
+    // TODO(fix-3-implementation): compose date-grouping WITH file_list_deleted_batch_size chunking.
+    // TODO(fix-3-implementation): chunk within each date group (or vice versa); pin with a test.
     #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_site_a_and_site_b_delete_paths_remove_correct_rows() {
+        // CLIENT_RW (ZO_META_POSTGRES_DSN) and the TEST_POSTGRES_URL pool must be the same DB.
         let pool = setup_test_db().await;
         cleanup_test_data(&pool).await;
 
@@ -5132,8 +5029,7 @@ mod tests {
         let keep_id = postgres_list.add("acct", &keep_key, &meta).await.unwrap();
         let dump_id = postgres_list.add("acct", &dump_key, &meta).await.unwrap();
 
-        // `query_for_dump` returns FileRecord, whose `date` field is required (non-default) --
-        // this is the data the real Site A fix threads through instead of bare ids.
+        // FileRecord.date is required -- what the real Site A fix threads instead of bare ids.
         let records = postgres_list
             .query_for_dump(
                 "org1",
@@ -5177,11 +5073,7 @@ mod tests {
         );
 
         // ---- Site B: inner_batch_process's delete path (via batch_process) ----
-        // del_items with `id > 0` (the common case once ids are already known, e.g. from a
-        // prior `batch_add`) currently skip date-key extraction entirely in
-        // `inner_batch_process` -- the `parse_file_key_columns` call in that loop only runs on
-        // the `id <= 0` branch. The real fix must extract `date_key` unconditionally for every
-        // del_item, not just the zero-id ones.
+        // del_items with id > 0 skip date-key extraction; the fix must always extract it.
         let batch_stream = "org1/logs/batch_del_stream";
         let batch_keep_key = format!("files/{batch_stream}/2021/01/01/00/keep.parquet");
         let batch_del_key = format!("files/{batch_stream}/2021/01/02/00/del.parquet");
@@ -5212,8 +5104,7 @@ mod tests {
             .map(|(_, id)| *id)
             .expect("keep.parquet must have been inserted with an id");
 
-        // del_items carrying a real (>0) id, as inner_batch_process sorts/dedupes on before
-        // deleting -- this is the branch that currently skips date-key extraction entirely.
+        // del_items carry a real (>0) id -- the branch that currently skips date-key extraction.
         let mut del_file_key = create_test_file_key("acct", &batch_del_key, true);
         del_file_key.id = del_id;
         postgres_list

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -2214,6 +2214,18 @@ async fn delete_file_list_by_id_buggy(
     Ok(())
 }
 
+/// TEST-ONLY: Fix 4 will make production get_pending_jobs derive its lock id from a real scope.
+#[cfg(test)]
+fn pending_jobs_lock_key(_scope: &str) -> i64 {
+    // TODO(fix-4-implementation): production get_pending_jobs must consume this with a real scope.
+    let lock_id = config::utils::hash::gxhash::new().sum64("file_list_jobs:get_pending_jobs");
+    if lock_id > (i64::MAX as u64) {
+        (lock_id >> 1) as i64
+    } else {
+        lock_id as i64
+    }
+}
+
 /// Derive date range for partition pruning from microsecond timestamps.
 /// Returns (date_from, date_to) in "YYYY/MM/DD/HH" format suitable for `WHERE date >= $from AND
 /// date < $to`.
@@ -5125,5 +5137,164 @@ mod tests {
             remaining.contains(&batch_keep_id),
             "inner_batch_process must not delete unrelated ids"
         );
+    }
+
+    // Fix 4 regression tests: get_pending_jobs serializes ALL nodes on ONE global advisory lock.
+
+    /// Fix spec [RED until Fix 4 lands]: distinct scopes must map to distinct advisory lock keys.
+    #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
+    async fn test_fix_different_scopes_do_not_serialize() {
+        // TODO(fix-4-implementation): decide + pin per-node vs per-stream scoping with a test.
+        let pool = connect_partitioned_test_db().await;
+        let key_a = pending_jobs_lock_key("stream-a");
+        let key_b = pending_jobs_lock_key("stream-b");
+
+        let mut tx_a = pool.begin().await.unwrap();
+        sqlx::query(&format!("SELECT pg_advisory_xact_lock({key_a})"))
+            .execute(&mut *tx_a)
+            .await
+            .unwrap();
+
+        let mut tx_b = pool.begin().await.unwrap();
+        let acquired: bool =
+            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key_b})"))
+                .fetch_one(&mut *tx_b)
+                .await
+                .unwrap();
+
+        tx_b.rollback().await.unwrap();
+        tx_a.rollback().await.unwrap();
+
+        assert!(
+            acquired,
+            "scope 'stream-b' (key {key_b}) must not block behind scope 'stream-a' (key {key_a}); \
+             equal keys mean the lock key is still the global constant"
+        );
+    }
+
+    /// Invariant guard [GREEN]: claimers in the SAME scope must keep serializing on one lock key.
+    #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
+    async fn test_same_scope_still_serializes() {
+        // Until Fix 4 lands every scope shares one key, so run DB tests with --test-threads=1.
+        let pool = connect_partitioned_test_db().await;
+        let key = pending_jobs_lock_key("stream-same");
+
+        let mut tx_a = pool.begin().await.unwrap();
+        sqlx::query(&format!("SELECT pg_advisory_xact_lock({key})"))
+            .execute(&mut *tx_a)
+            .await
+            .unwrap();
+
+        let mut tx_b = pool.begin().await.unwrap();
+        let acquired: bool =
+            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key})"))
+                .fetch_one(&mut *tx_b)
+                .await
+                .unwrap();
+        assert!(
+            !acquired,
+            "same scope must serialize: try-lock on key {key} must fail while tx_a holds it"
+        );
+
+        tx_a.rollback().await.unwrap();
+
+        let acquired: bool =
+            sqlx::query_scalar(&format!("SELECT pg_try_advisory_xact_lock({key})"))
+                .fetch_one(&mut *tx_b)
+                .await
+                .unwrap();
+        assert!(
+            acquired,
+            "xact-scoped advisory lock on key {key} must be free once tx_a ends"
+        );
+        tx_b.rollback().await.unwrap();
+    }
+
+    /// Fix-4 invariant [GREEN, must survive the fix]: no job is ever claimed by two callers.
+    #[tokio::test]
+    #[ignore = "Requires test PostgreSQL database setup"]
+    async fn test_concurrent_get_pending_jobs_claims_are_disjoint() {
+        // CLIENT_RW (ZO_META_POSTGRES_DSN) and the TEST_POSTGRES_URL pool must be the same DB.
+        let pool = setup_test_db().await;
+        cleanup_test_data(&pool).await;
+
+        let pid = std::process::id();
+        let stream_a = format!("fix4_org/logs/claim_{pid}_a");
+        let stream_b = format!("fix4_org/logs/claim_{pid}_b");
+        let mut seeded: Vec<i64> = Vec::new();
+        for stream in [&stream_a, &stream_b] {
+            for offsets in [1_000_i64, 2_000] {
+                let id: i64 = sqlx::query_scalar(
+                    "INSERT INTO file_list_jobs (org, stream, offsets, status, node, started_at, \
+                     updated_at) VALUES ('fix4_org', $1, $2, 0, '', 0, 0) RETURNING id",
+                )
+                .bind(stream)
+                .bind(offsets)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+                seeded.push(id);
+            }
+        }
+
+        let postgres_list = PostgresFileList::new();
+        let (r1, r2) = tokio::join!(
+            postgres_list.get_pending_jobs("fix4-node-1", 100, false),
+            postgres_list.get_pending_jobs("fix4-node-2", 100, false),
+        );
+        let (jobs1, jobs2) = (r1.unwrap(), r2.unwrap());
+
+        // Sibling ignored tests share file_list_jobs; assert only on this test's seeded streams.
+        let ids1: HashSet<i64> = jobs1
+            .iter()
+            .filter(|j| j.stream == stream_a || j.stream == stream_b)
+            .map(|j| j.id)
+            .collect();
+        let ids2: HashSet<i64> = jobs2
+            .iter()
+            .filter(|j| j.stream == stream_a || j.stream == stream_b)
+            .map(|j| j.id)
+            .collect();
+        assert!(
+            ids1.is_disjoint(&ids2),
+            "concurrent get_pending_jobs must never claim the same job twice: {ids1:?} vs {ids2:?}"
+        );
+
+        // A single call claims max(id) per stream; the concurrent pair must cover at least that.
+        let union: Vec<i64> = ids1.union(&ids2).copied().collect();
+        for single_call_claim in [seeded[1], seeded[3]] {
+            assert!(
+                union.contains(&single_call_claim),
+                "the union {union:?} must cover what one call alone would claim ({single_call_claim})"
+            );
+        }
+
+        let rows = sqlx::query("SELECT id, status, node FROM file_list_jobs WHERE id = ANY($1)")
+            .bind(&union)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), union.len(), "every claimed id must still exist");
+        for row in &rows {
+            let id: i64 = row.get(0);
+            let status: i32 = row.get(1);
+            let node: String = row.get(2);
+            assert_eq!(
+                status, 1,
+                "claimed job {id} must have transitioned to running"
+            );
+            assert!(
+                node.starts_with("fix4-node-"),
+                "claimed job {id} must record the claiming node, got {node:?}"
+            );
+        }
+
+        let _ = sqlx::query("DELETE FROM file_list_jobs WHERE stream = $1 OR stream = $2")
+            .bind(&stream_a)
+            .bind(&stream_b)
+            .execute(&pool)
+            .await;
     }
 }

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -137,7 +137,11 @@ impl super::FileList for PostgresFileList {
         self.inner_batch_process("file_list", files).await
     }
 
-    async fn update_dump_records(&self, dump_file: &FileKey, dumped_ids: &[i64]) -> Result<()> {
+    async fn update_dump_records(
+        &self,
+        dump_file: &FileKey,
+        dumped_ids: &[(i64, String)],
+    ) -> Result<()> {
         let pool = CLIENT_RW.clone();
 
         // insert the dump file into file_list table
@@ -186,22 +190,17 @@ impl super::FileList for PostgresFileList {
             return Err(e.into());
         }
 
-        // delete the dumped ids from file_list table
-        for chunk in dumped_ids.chunks(get_config().compact.file_list_deleted_batch_size) {
-            if chunk.is_empty() {
-                continue;
-            }
-            let ids = chunk
-                .iter()
-                .map(|id| id.to_string())
-                .collect::<Vec<String>>()
-                .join(",");
-            let query_str = format!("DELETE FROM file_list WHERE id IN ({ids})");
+        // delete the dumped ids from file_list table; date predicate enables partition pruning
+        for (date, query_str) in chunked_pruned_delete_statements(
+            "file_list",
+            dumped_ids,
+            get_config().compact.file_list_deleted_batch_size,
+        ) {
             DB_QUERY_NUMS
                 .with_label_values(&["delete_by_ids", "file_list"])
                 .inc();
             let start = std::time::Instant::now();
-            let res = sqlx::query(&query_str).execute(&mut *tx).await;
+            let res = sqlx::query(&query_str).bind(&date).execute(&mut *tx).await;
             let time = start.elapsed().as_secs_f64();
             DB_QUERY_TIME
                 .with_label_values(&["delete_by_ids", "file_list"])
@@ -2075,15 +2074,15 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
         if !del_items.is_empty() {
             let chunks = del_items.chunks(deleted_batch_size);
             for files in chunks {
-                // get ids of the files
-                let mut ids = Vec::with_capacity(files.len());
+                // get (id, date) of the files; date predicate enables partition pruning
+                let mut ids: Vec<(i64, String)> = Vec::with_capacity(files.len());
                 for file in files {
-                    if file.id > 0 {
-                        ids.push(file.id.to_string());
-                        continue;
-                    }
                     let (stream_key, date_key, file_name) = parse_file_key_columns(&file.key)
                         .map_err(|e| Error::Message(e.to_string()))?;
+                    if file.id > 0 {
+                        ids.push((file.id, date_key));
+                        continue;
+                    }
                     DB_QUERY_NUMS
                         .with_label_values(&["select_id", "file_list"])
                         .inc();
@@ -2092,7 +2091,7 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
                     r#"SELECT id FROM file_list WHERE stream = $1 AND date = $2 AND file = $3;"#,
                     )
                     .bind(stream_key)
-                    .bind(date_key)
+                    .bind(&date_key)
                     .bind(file_name)
                     .fetch_one(&mut *tx)
                     .await;
@@ -2101,7 +2100,7 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
                         .with_label_values(&["select_id", "file_list"])
                         .observe(time);
                     match query_res {
-                        Ok(Some(v)) => ids.push(v.to_string()),
+                        Ok(Some(v)) => ids.push((v, date_key)),
                         Ok(None) => continue,
                         Err(sqlx::Error::RowNotFound) => continue,
                         Err(e) => {
@@ -2114,14 +2113,13 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
                         }
                     };
                 }
-                // delete files by ids
-                if !ids.is_empty() {
+                // delete files by ids, one pruned statement per date group
+                for (date, sql) in build_pruned_delete_statements("file_list", &ids) {
                     DB_QUERY_NUMS
                         .with_label_values(&["delete_id", "file_list"])
                         .inc();
-                    let sql = format!("DELETE FROM file_list WHERE id IN({});", ids.join(","));
                     let start = std::time::Instant::now();
-                    if let Err(e) = sqlx::query(sql.as_str()).execute(&mut *tx).await {
+                    if let Err(e) = sqlx::query(&sql).bind(&date).execute(&mut *tx).await {
                         if let Err(e) = tx.rollback().await {
                             log::error!(
                                 "[POSTGRES] rollback {table} batch process for delete error: {e}"
@@ -2146,24 +2144,7 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
     }
 }
 
-/// TEST-ONLY: models the planned Site A/B fix; remove once the real fix lands there.
-#[cfg(test)]
-async fn delete_file_list_by_id_and_date_fixed(
-    tx: &mut sqlx::Transaction<'_, Postgres>,
-    table: &str,
-    ids_with_dates: &[(i64, String)],
-) -> Result<()> {
-    if ids_with_dates.is_empty() {
-        return Ok(());
-    }
-    for (date, sql) in build_pruned_delete_statements(table, ids_with_dates) {
-        sqlx::query(&sql).bind(&date).execute(&mut **tx).await?;
-    }
-    Ok(())
-}
-
-/// TEST-ONLY: single SQL source, so tests EXPLAIN the exact string the fixed helper executes.
-#[cfg(test)]
+/// Groups (id, date) pairs into one `date = $1 AND id IN (...)` delete per date so each prunes.
 fn build_pruned_delete_statements(
     table: &str,
     ids_with_dates: &[(i64, String)],
@@ -2188,24 +2169,16 @@ fn build_pruned_delete_statements(
     stmts
 }
 
-/// TEST-ONLY: same unpruned shape (modulo whitespace/semicolon) as today's Site A/B deletes.
-#[cfg(test)]
-async fn delete_file_list_by_id_buggy(
-    tx: &mut sqlx::Transaction<'_, Postgres>,
+/// Chunks first (bounding per-statement id counts), then prune-groups by date within each chunk.
+fn chunked_pruned_delete_statements(
     table: &str,
-    ids: &[i64],
-) -> Result<()> {
-    if ids.is_empty() {
-        return Ok(());
-    }
-    let ids_str = ids
-        .iter()
-        .map(|id| id.to_string())
-        .collect::<Vec<String>>()
-        .join(",");
-    let sql = format!("DELETE FROM {table} WHERE id IN ({ids_str})");
-    sqlx::query(&sql).execute(&mut **tx).await?;
-    Ok(())
+    ids_with_dates: &[(i64, String)],
+    chunk_size: usize,
+) -> Vec<(String, String)> {
+    ids_with_dates
+        .chunks(chunk_size.max(1))
+        .flat_map(|chunk| build_pruned_delete_statements(table, chunk))
+        .collect()
 }
 
 /// Advisory lock key for get_pending_jobs claims; scope is ignored until Fix 4 wires a real one.
@@ -4727,7 +4700,7 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// Bug repro: Site A/B's shape (modulo whitespace/semicolon) is correct but unpruned.
+    /// Bug repro: the pre-fix Site A/B shape was correct but unpruned; kept as documentation.
     #[tokio::test]
     #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_bug_repro_buggy_delete_is_functionally_correct_but_unpruned() {
@@ -4743,11 +4716,10 @@ mod tests {
             .await
             .unwrap();
 
-        let mut tx = pool.begin().await.unwrap();
-        delete_file_list_by_id_buggy(&mut tx, &table, &[del])
+        sqlx::query(&format!("DELETE FROM {table} WHERE id IN ({del})"))
+            .execute(&pool)
             .await
             .unwrap();
-        tx.commit().await.unwrap();
 
         let remaining: Vec<i64> = sqlx::query_scalar(&format!("SELECT id FROM {table}"))
             .fetch_all(&pool)
@@ -4850,9 +4822,17 @@ mod tests {
 
         // Now actually run the grouped delete and verify exact row-level correctness.
         let mut tx = pool.begin().await.unwrap();
-        delete_file_list_by_id_and_date_fixed(&mut tx, &table, &targets)
-            .await
-            .unwrap();
+        for (date, sql) in chunked_pruned_delete_statements(
+            &table,
+            &targets,
+            get_config().compact.file_list_deleted_batch_size,
+        ) {
+            sqlx::query(&sql)
+                .bind(&date)
+                .execute(&mut *tx)
+                .await
+                .unwrap();
+        }
         tx.commit().await.unwrap();
 
         let remaining_ids: Vec<i64> =
@@ -4900,17 +4880,22 @@ mod tests {
             .unwrap();
         assert_eq!(before_count, 4);
 
+        let targets = [
+            (del1, "2021/01/01/00".to_string()),
+            (del2, "2021/01/03/00".to_string()),
+        ];
         let mut tx = pool.begin().await.unwrap();
-        delete_file_list_by_id_and_date_fixed(
-            &mut tx,
+        for (date, sql) in chunked_pruned_delete_statements(
             &table,
-            &[
-                (del1, "2021/01/01/00".to_string()),
-                (del2, "2021/01/03/00".to_string()),
-            ],
-        )
-        .await
-        .unwrap();
+            &targets,
+            get_config().compact.file_list_deleted_batch_size,
+        ) {
+            sqlx::query(&sql)
+                .bind(&date)
+                .execute(&mut *tx)
+                .await
+                .unwrap();
+        }
         tx.commit().await.unwrap();
 
         let mut remaining_ids: Vec<i64> = sqlx::query_scalar(&format!("SELECT id FROM {table}"))
@@ -4963,9 +4948,13 @@ mod tests {
         );
 
         let mut tx = pool.begin().await.unwrap();
-        delete_file_list_by_id_and_date_fixed(&mut tx, &table, &[(keep, no_partition_date)])
-            .await
-            .expect("a no-partition date must not be an execution error");
+        for (date, sql) in build_pruned_delete_statements(&table, &[(keep, no_partition_date)]) {
+            sqlx::query(&sql)
+                .bind(&date)
+                .execute(&mut *tx)
+                .await
+                .expect("a no-partition date must not be an execution error");
+        }
         tx.commit().await.unwrap();
 
         let remaining: Vec<i64> = sqlx::query_scalar(&format!("SELECT id FROM {table}"))
@@ -4998,12 +4987,10 @@ mod tests {
             build_pruned_delete_statements(&table, &[]).is_empty(),
             "empty input must build zero statements"
         );
-
-        let mut tx = pool.begin().await.unwrap();
-        delete_file_list_by_id_and_date_fixed(&mut tx, &table, &[])
-            .await
-            .expect("empty input must not be an error");
-        tx.commit().await.unwrap();
+        assert!(
+            chunked_pruned_delete_statements(&table, &[], 1000).is_empty(),
+            "empty input must build zero statements through the chunked composition too"
+        );
 
         let remaining: Vec<i64> = sqlx::query_scalar(&format!("SELECT id FROM {table}"))
             .fetch_all(&pool)
@@ -5014,10 +5001,52 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
+    /// Pins Site A's chunk+prune composition: chunk boundaries first, date grouping within each.
+    #[test]
+    fn test_fix_chunked_pruned_delete_statements_composition() {
+        let d1 = "2021/01/01/00".to_string();
+        let d2 = "2021/01/02/00".to_string();
+        let pairs = vec![
+            (1_i64, d1.clone()),
+            (2, d1.clone()),
+            (3, d2.clone()),
+            (4, d1.clone()),
+            (5, d2.clone()),
+        ];
+
+        // chunks of 2 are [1,2] [3,4] [5]; the mixed-date chunk splits into two sorted groups
+        let stmt = |ids: &str| format!("DELETE FROM file_list WHERE date = $1 AND id IN ({ids})");
+        assert_eq!(
+            chunked_pruned_delete_statements("file_list", &pairs, 2),
+            vec![
+                (d1.clone(), stmt("1,2")),
+                (d1.clone(), stmt("4")),
+                (d2.clone(), stmt("3")),
+                (d2.clone(), stmt("5")),
+            ],
+            "every IN-list must stay within the chunk size, grouped by date within each chunk"
+        );
+
+        // a chunk size covering all pairs degenerates to pure date grouping
+        assert_eq!(
+            chunked_pruned_delete_statements("file_list", &pairs, 1000),
+            vec![(d1.clone(), stmt("1,2,4")), (d2.clone(), stmt("3,5"))],
+        );
+        assert_eq!(
+            chunked_pruned_delete_statements("file_list", &pairs, 1000),
+            build_pruned_delete_statements("file_list", &pairs),
+            "one chunk must be exactly the plain builder output"
+        );
+
+        // chunk size 0 must not panic; it is clamped to 1
+        assert_eq!(
+            chunked_pruned_delete_statements("file_list", &pairs, 0).len(),
+            pairs.len()
+        );
+        assert!(chunked_pruned_delete_statements("file_list", &[], 2).is_empty());
+    }
+
     /// Sites A+B + Fix-4 disjointness in ONE test: CLIENT_RW's pool binds to its first runtime.
-    // TODO(fix-3-implementation): assert pruning at real Site A/B via the shared builder.
-    // TODO(fix-3-implementation): compose date-grouping WITH file_list_deleted_batch_size chunking.
-    // TODO(fix-3-implementation): chunk within each date group (or vice versa); pin with a test.
     #[tokio::test]
     #[ignore = "Requires test PostgreSQL database setup"]
     async fn test_client_rw_paths_site_ab_deletes_and_pending_jobs_disjointness() {
@@ -5035,7 +5064,7 @@ mod tests {
         let keep_id = postgres_list.add("acct", &keep_key, &meta).await.unwrap();
         let dump_id = postgres_list.add("acct", &dump_key, &meta).await.unwrap();
 
-        // FileRecord.date is required -- what the real Site A fix threads instead of bare ids.
+        // FileRecord.date is required -- what dump.rs threads to update_dump_records as pairs.
         let records = postgres_list
             .query_for_dump(
                 "org1",
@@ -5059,11 +5088,13 @@ mod tests {
             &format!("files/{dump_stream_key}/2021/01/02/00/dump_summary.parquet"),
             false,
         );
+        let site_a_pairs = [(dump_id, dumped_record.date.clone())];
         postgres_list
-            .update_dump_records(&dump_file_key, &[dump_id])
+            .update_dump_records(&dump_file_key, &site_a_pairs)
             .await
             .unwrap();
 
+        // The date is a real DELETE predicate: a wrong pair would leave the dumped row behind.
         let remaining: Vec<i64> = sqlx::query_scalar("SELECT id FROM file_list WHERE stream = $1")
             .bind(dump_stream_key)
             .fetch_all(&pool)
@@ -5078,8 +5109,22 @@ mod tests {
             "update_dump_records must not delete unrelated ids"
         );
 
+        // Trust chain: Site A executes exactly these statements; EXPLAIN tests pin them as pruned.
+        assert_eq!(
+            chunked_pruned_delete_statements(
+                "file_list",
+                &site_a_pairs,
+                get_config().compact.file_list_deleted_batch_size,
+            ),
+            vec![(
+                "2021/01/01/00".to_string(),
+                format!("DELETE FROM file_list WHERE date = $1 AND id IN ({dump_id})"),
+            )],
+            "Site A inputs must yield a single per-date pruned delete"
+        );
+
         // ---- Site B: inner_batch_process's delete path (via batch_process) ----
-        // del_items with id > 0 skip date-key extraction; the fix must always extract it.
+        // del_items carrying a real (>0) id must still get a date key parsed from the file key.
         let batch_stream = "org1/logs/batch_del_stream";
         let batch_keep_key = format!("files/{batch_stream}/2021/01/01/00/keep.parquet");
         let batch_del_key = format!("files/{batch_stream}/2021/01/02/00/del.parquet");
@@ -5123,6 +5168,7 @@ mod tests {
             .fetch_all(&pool)
             .await
             .unwrap();
+        // The delete succeeding proves the date derived from the key matched the stored row.
         assert!(
             !remaining.contains(&del_id),
             "inner_batch_process must delete the targeted (deleted=true) id"
@@ -5130,6 +5176,16 @@ mod tests {
         assert!(
             remaining.contains(&batch_keep_id),
             "inner_batch_process must not delete unrelated ids"
+        );
+
+        // Trust chain: Site B groups each chunk through the same EXPLAIN-pinned builder.
+        assert_eq!(
+            build_pruned_delete_statements("file_list", &[(del_id, "2021/01/02/00".to_string())]),
+            vec![(
+                "2021/01/02/00".to_string(),
+                format!("DELETE FROM file_list WHERE date = $1 AND id IN ({del_id})"),
+            )],
+            "Site B inputs must yield a single per-date pruned delete"
         );
 
         // ---- Fix 4: concurrent get_pending_jobs claims must stay disjoint ----

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -2115,7 +2115,7 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
                     };
                 }
                 // delete files by ids, one pruned statement per date group
-                for (date, sql) in build_pruned_delete_statements("file_list", &ids) {
+                for (date, sql) in build_pruned_delete_statements(table, &ids) {
                     DB_QUERY_NUMS
                         .with_label_values(&["delete_id", "file_list"])
                         .inc();
@@ -2150,6 +2150,7 @@ fn build_pruned_delete_statements(
     table: &str,
     ids_with_dates: &[(i64, String)],
 ) -> Vec<(String, String)> {
+    // each date MUST be the stored column value byte-for-byte, else the delete silently no-ops
     let mut by_date: stdHashMap<&str, Vec<i64>> = stdHashMap::new();
     for (id, date) in ids_with_dates {
         by_date.entry(date.as_str()).or_default().push(*id);

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -2169,20 +2169,43 @@ async fn delete_file_list_by_id_and_date_fixed(
     table: &str,
     ids_with_dates: &[(i64, String)],
 ) -> Result<()> {
+    if ids_with_dates.is_empty() {
+        return Ok(());
+    }
+    for (date, sql) in build_pruned_delete_statements(table, ids_with_dates) {
+        sqlx::query(&sql).bind(&date).execute(&mut **tx).await?;
+    }
+    Ok(())
+}
+
+/// TEST-ONLY today (intended to graduate to Site A/Site B when the production fix lands): the
+/// single source of the pruned-delete SQL shape -- both the executing helper above and the
+/// EXPLAIN-based pruning tests consume this, so the string the tests EXPLAIN is the string the
+/// helper executes, by construction. Groups `(id, date)` pairs by date and returns one
+/// `(bind_date, sql)` pair per date group, sorted by date for determinism.
+#[cfg(test)]
+fn build_pruned_delete_statements(
+    table: &str,
+    ids_with_dates: &[(i64, String)],
+) -> Vec<(String, String)> {
     let mut by_date: stdHashMap<&str, Vec<i64>> = stdHashMap::new();
     for (id, date) in ids_with_dates {
         by_date.entry(date.as_str()).or_default().push(*id);
     }
-    for (date, ids) in by_date {
-        let ids_str = ids
-            .iter()
-            .map(|id| id.to_string())
-            .collect::<Vec<String>>()
-            .join(",");
-        let sql = format!("DELETE FROM {table} WHERE date = $1 AND id IN ({ids_str})");
-        sqlx::query(&sql).bind(date).execute(&mut **tx).await?;
-    }
-    Ok(())
+    let mut stmts: Vec<(String, String)> = by_date
+        .into_iter()
+        .map(|(date, ids)| {
+            let ids_str = ids
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<String>>()
+                .join(",");
+            let sql = format!("DELETE FROM {table} WHERE date = $1 AND id IN ({ids_str})");
+            (date.to_string(), sql)
+        })
+        .collect();
+    stmts.sort();
+    stmts
 }
 
 /// TEST-ONLY: reproduces today's buggy (unpruned) delete shape used at both Site A
@@ -4806,9 +4829,11 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// CATEGORY: fix behavior (expected to FAIL until the fix threads `date` through the delete
-    /// path, or in this test's case, until it is confirmed the `date = $1 AND id IN (...)` shape
-    /// prunes correctly -- this proves the SQL shape the fix will use is correct).
+    /// CATEGORY: fix specification -- pins the target query shape. This test is green by
+    /// construction (it asserts what a pruned delete plan looks like, not that Site A/B use
+    /// it yet); its value is that it EXPLAINs the very SQL `build_pruned_delete_statements`
+    /// builds -- the same string `delete_file_list_by_id_and_date_fixed` executes -- so
+    /// dropping the `date` predicate from the shared builder makes this test fail.
     ///
     /// With a `date = $1 AND id IN (...)` predicate, only the ONE partition holding that date is
     /// touched, even though the same ids table has 3 partitions total.
@@ -4822,13 +4847,12 @@ mod tests {
             .await
             .unwrap();
 
-        let plan = explain_delete_lines(
-            &pool,
-            &format!("DELETE FROM {table} WHERE date = $1 AND id IN ({id1})"),
-            Some("2021/01/01/00"),
-        )
-        .await
-        .unwrap();
+        let stmts = build_pruned_delete_statements(&table, &[(id1, "2021/01/01/00".to_string())]);
+        assert_eq!(stmts.len(), 1, "one date group must yield one statement");
+        let (bind_date, sql) = &stmts[0];
+        let plan = explain_delete_lines(&pool, sql, Some(bind_date))
+            .await
+            .unwrap();
 
         assert_eq!(
             count_touched_partitions(&plan),
@@ -4846,10 +4870,11 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
-    /// CATEGORY: fix behavior. Ids spanning 2 different date partitions must be handled as 2
-    /// separate pruned single-partition deletes (per `delete_file_list_by_id_and_date_fixed`,
-    /// which groups by date), never a single unpruned multi-partition delete. Also verifies
-    /// actual row deletion correctness: right rows gone, nothing else touched.
+    /// CATEGORY: fix specification. Ids spanning 2 different date partitions must be handled as
+    /// 2 separate pruned single-partition deletes (per `build_pruned_delete_statements`, which
+    /// groups by date and is the same SQL `delete_file_list_by_id_and_date_fixed` executes),
+    /// never a single unpruned multi-partition delete. Also verifies actual row deletion
+    /// correctness: right rows gone, nothing else touched.
     #[tokio::test]
     async fn test_fix_multiple_dates_grouped_into_pruned_deletes() {
         let pool = connect_partitioned_test_db().await;
@@ -4869,44 +4894,41 @@ mod tests {
                 .await
                 .unwrap();
 
-        // Each date group's delete plan, taken individually, must be pruned to 1 partition.
-        for (id, date, expected_partition) in [
-            (id_day1, "2021/01/01/00", "20210101"),
-            (id_day2, "2021/01/02/00", "20210102"),
-        ] {
-            let plan = explain_delete_lines(
-                &pool,
-                &format!("DELETE FROM {table} WHERE date = $1 AND id IN ({id})"),
-                Some(date),
-            )
-            .await
-            .unwrap();
+        let targets = [
+            (id_day1, "2021/01/01/00".to_string()),
+            (id_day2, "2021/01/02/00".to_string()),
+        ];
+
+        // EXPLAIN the exact statements the helper will execute: 1 pruned statement per date.
+        let stmts = build_pruned_delete_statements(&table, &targets);
+        assert_eq!(
+            stmts.len(),
+            2,
+            "two date groups must yield two separate delete statements"
+        );
+        for ((bind_date, sql), expected_partition) in stmts.iter().zip(["20210101", "20210102"]) {
+            let plan = explain_delete_lines(&pool, sql, Some(bind_date))
+                .await
+                .unwrap();
             assert_eq!(
                 count_touched_partitions(&plan),
                 1,
-                "date group {date} must touch exactly 1 partition, plan:\n{}",
+                "date group {bind_date} must touch exactly 1 partition, plan:\n{}",
                 plan.join("\n")
             );
             assert!(
                 plan.iter()
                     .any(|l| l.contains(&format!("{table}_p_{expected_partition}"))),
-                "date group {date} must touch partition {expected_partition}, plan:\n{}",
+                "date group {bind_date} must touch partition {expected_partition}, plan:\n{}",
                 plan.join("\n")
             );
         }
 
         // Now actually run the grouped delete and verify exact row-level correctness.
         let mut tx = pool.begin().await.unwrap();
-        delete_file_list_by_id_and_date_fixed(
-            &mut tx,
-            &table,
-            &[
-                (id_day1, "2021/01/01/00".to_string()),
-                (id_day2, "2021/01/02/00".to_string()),
-            ],
-        )
-        .await
-        .unwrap();
+        delete_file_list_by_id_and_date_fixed(&mut tx, &table, &targets)
+            .await
+            .unwrap();
         tx.commit().await.unwrap();
 
         let remaining_ids: Vec<i64> =
@@ -4983,6 +5005,95 @@ mod tests {
         drop_partitioned_test_table(&pool, &table).await;
     }
 
+    /// CATEGORY: edge case. A date matching NO live partition must be handled gracefully: the
+    /// planner short-circuits the pruned delete to `Result` with `One-Time Filter: false`
+    /// (verified against real Postgres 17), so the plan has ZERO partition-level `Delete on`
+    /// lines (only the parent ModifyTable line remains) and executing the helper neither errors
+    /// nor deletes anything.
+    #[tokio::test]
+    async fn test_fix_date_matching_no_partition_is_graceful_noop() {
+        let pool = connect_partitioned_test_db().await;
+        let table = unique_partitioned_test_table_name();
+        setup_partitioned_test_table(&pool, &table).await.unwrap();
+
+        let keep =
+            insert_partitioned_test_row(&pool, &table, "2021/01/01/00", "s1", "keep.parquet")
+                .await
+                .unwrap();
+
+        // A date outside every partition's range; the id value is irrelevant to pruning.
+        let no_partition_date = "2099/12/31/00".to_string();
+        let stmts = build_pruned_delete_statements(&table, &[(keep, no_partition_date.clone())]);
+        assert_eq!(stmts.len(), 1, "one date group must yield one statement");
+        let (bind_date, sql) = &stmts[0];
+
+        let plan = explain_delete_lines(&pool, sql, Some(bind_date))
+            .await
+            .unwrap();
+        assert_eq!(
+            count_touched_partitions(&plan),
+            0,
+            "a date with no live partition must prune away every partition, plan:\n{}",
+            plan.join("\n")
+        );
+        assert!(
+            plan.iter().any(|l| l.contains("One-Time Filter: false")),
+            "the plan must short-circuit via `Result / One-Time Filter: false`, plan:\n{}",
+            plan.join("\n")
+        );
+
+        let mut tx = pool.begin().await.unwrap();
+        delete_file_list_by_id_and_date_fixed(&mut tx, &table, &[(keep, no_partition_date)])
+            .await
+            .expect("a no-partition date must not be an execution error");
+        tx.commit().await.unwrap();
+
+        let remaining: Vec<i64> = sqlx::query_scalar(&format!("SELECT id FROM {table}"))
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining,
+            vec![keep],
+            "a delete whose date matches no partition must delete nothing"
+        );
+
+        drop_partitioned_test_table(&pool, &table).await;
+    }
+
+    /// CATEGORY: edge case. An empty `(id, date)` list must be a complete no-op: no SQL is
+    /// built (an empty `IN ()` would be a syntax error), no statement executes, no rows change.
+    #[tokio::test]
+    async fn test_fix_empty_id_list_is_noop() {
+        let pool = connect_partitioned_test_db().await;
+        let table = unique_partitioned_test_table_name();
+        setup_partitioned_test_table(&pool, &table).await.unwrap();
+
+        let keep =
+            insert_partitioned_test_row(&pool, &table, "2021/01/01/00", "s1", "keep.parquet")
+                .await
+                .unwrap();
+
+        assert!(
+            build_pruned_delete_statements(&table, &[]).is_empty(),
+            "empty input must build zero statements"
+        );
+
+        let mut tx = pool.begin().await.unwrap();
+        delete_file_list_by_id_and_date_fixed(&mut tx, &table, &[])
+            .await
+            .expect("empty input must not be an error");
+        tx.commit().await.unwrap();
+
+        let remaining: Vec<i64> = sqlx::query_scalar(&format!("SELECT id FROM {table}"))
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining, vec![keep], "empty input must delete nothing");
+
+        drop_partitioned_test_table(&pool, &table).await;
+    }
+
     /// Site A (`update_dump_records`, postgres.rs:140) AND Site B (`inner_batch_process`'s
     /// delete path, postgres.rs:2128), exercised end-to-end via the `FileList` trait against
     /// the test DB, in a single test function.
@@ -5002,6 +5113,10 @@ mod tests {
     /// EXPLAIN-based tests above. Also confirms `FileRecord.date` (`file_list/mod.rs:774`, no
     /// `#[sqlx(default)]`, i.e. required on every row) flows through `query_for_dump` correctly
     /// -- that's the data the real Site A fix threads through instead of bare ids.
+    // TODO(fix-3-implementation): when the production fix lands at Site A/Site B, this test
+    // MUST grow pruning assertions against the REAL call sites (not just row correctness) --
+    // the intended mechanism is having those sites build their delete SQL via the shared
+    // `build_pruned_delete_statements` so their EXPLAINed and executed SQL stay one string.
     #[tokio::test]
     async fn test_site_a_and_site_b_delete_paths_remove_correct_rows() {
         let pool = setup_test_db().await;

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -106,7 +106,11 @@ impl super::FileList for SqliteFileList {
         self.inner_batch_process("file_list", files).await
     }
 
-    async fn update_dump_records(&self, file: &FileKey, dumped_ids: &[i64]) -> Result<()> {
+    async fn update_dump_records(
+        &self,
+        file: &FileKey,
+        dumped_ids: &[(i64, String)],
+    ) -> Result<()> {
         let client = CLIENT_RW.clone();
         let mut tx = client.begin().await?;
 
@@ -142,14 +146,14 @@ impl super::FileList for SqliteFileList {
             return Err(e.into());
         }
 
-        // delete the dumped ids from file_list table
+        // delete the dumped ids from file_list table; sqlite is unpartitioned, so no date needed
         for chunk in dumped_ids.chunks(get_config().compact.file_list_deleted_batch_size) {
             if chunk.is_empty() {
                 continue;
             }
             let ids = chunk
                 .iter()
-                .map(|id| id.to_string())
+                .map(|(id, _)| id.to_string())
                 .collect::<Vec<String>>()
                 .join(",");
             let query_str = format!("DELETE FROM file_list WHERE id IN ({ids})");

--- a/src/infra/src/table/service_streams.rs
+++ b/src/infra/src/table/service_streams.rs
@@ -127,8 +127,7 @@ pub struct ServiceRecord {
 pub struct PutOutcome {
     /// `disambiguation` JSON of each orphaned lower-specificity row this put deleted (F19).
     pub orphans: Vec<serde_json::Value>,
-    /// True iff a data column changed, a row was inserted, or an orphan was deleted;
-    /// last_seen-only writes do not count.
+    /// True iff a data column changed, a row inserted, or an orphan deleted; not last_seen alone.
     pub changed: bool,
 }
 
@@ -1517,6 +1516,33 @@ mod tests {
         );
     }
 
+    // Metrics varies alone, so a typo'd comparand triplicating logs/traces cannot survive.
+    #[tokio::test]
+    async fn metrics_streams_only_change_reports_changed_true() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let _ = put_with(
+            &db,
+            "org1",
+            service_record(disambiguation.clone(), 1_000),
+            DEFAULT_MAX_STREAMS_PER_TYPE,
+        )
+        .await
+        .unwrap();
+
+        let mut second = service_record(disambiguation, 1_000);
+        second.metrics_streams =
+            serde_json::json!(["checkout-service-metrics", "checkout-service-metrics-v2"]);
+        let outcome = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(
+            outcome.changed,
+            "metrics_streams is the only field that grew and it must count as changed"
+        );
+    }
+
     #[tokio::test]
     async fn plain_insert_reports_changed_true() {
         let db = db().await;
@@ -1538,6 +1564,7 @@ mod tests {
             serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
             1_000,
         );
+        let richer_id = richer.id.clone();
         let _ = put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
@@ -1551,6 +1578,15 @@ mod tests {
         assert!(
             outcome.orphans.is_empty(),
             "the only row is the kept one, so nothing is orphaned"
+        );
+        let row = Entity::find_by_id(richer_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.last_seen, 2_000,
+            "changed=false must not mean the UPDATE was skipped — last_seen still persists"
         );
         assert!(
             !outcome.changed,
@@ -1603,6 +1639,114 @@ mod tests {
         assert!(
             outcome.changed,
             "the stream union gained an entry, so the upgrade branch must report changed"
+        );
+    }
+
+    // Upgrade twin of the fnm-only case: a copy-paste derivation dropping fnm there must die.
+    #[tokio::test]
+    async fn upgrade_branch_fnm_only_change_reports_changed_true() {
+        let db = db().await;
+        let richer = service_record(
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
+            1_000,
+        );
+        let _ = put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        // Case-B upgrade: streams, dims, and disambiguation all resolve to stored.
+        let mut subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+        subset.field_name_mapping = Some(serde_json::json!({"service": "different_raw_field"}));
+        let outcome = put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(
+            outcome.changed,
+            "field_name_mapping is the only field that differs and the upgrade branch must count it"
+        );
+    }
+
+    // Upgrade twin of the dims-only case; a NEW key survives the base-wins union.
+    #[tokio::test]
+    async fn upgrade_branch_all_dimensions_only_change_reports_changed_true() {
+        let db = db().await;
+        let richer = service_record(
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
+            1_000,
+        );
+        let _ = put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        let mut subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+        subset.all_dimensions = serde_json::json!({
+            "k8s-cluster": "prod",
+            "k8s-namespace": "ecommerce",
+            "k8s-region": "us-east-1"
+        });
+        let outcome = put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(
+            outcome.changed,
+            "the merged all_dimensions gained a key and the upgrade branch must count it"
+        );
+    }
+
+    // Pins orphan→changed in the upgrade branch too, not just the exact-match branch.
+    #[tokio::test]
+    async fn upgrade_branch_orphan_deletion_on_noop_reports_changed_true() {
+        let db = db().await;
+        let richer = service_record(
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
+            1_000,
+        );
+        let richer_id = richer.id.clone();
+        let _ = put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        // Disjoint from the incoming subset so the put cannot exact-match or upgrade this row.
+        let orphan = ActiveModel {
+            id: Set(svix_ksuid::Ksuid::new(None, None).to_string()),
+            org_id: Set("org1".to_owned()),
+            service_name: Set("checkout-service".to_owned()),
+            set_id: Set("k8s".to_owned()),
+            disambiguation: Set(serde_json::json!({"k8s-namespace": "ecommerce"})),
+            all_dimensions: Set(serde_json::json!({})),
+            logs_streams: Set(serde_json::json!([])),
+            traces_streams: Set(serde_json::json!([])),
+            metrics_streams: Set(serde_json::json!([])),
+            field_name_mapping: Set(None),
+            last_seen: Set(500),
+        };
+        Entity::insert(orphan).exec(&db).await.unwrap();
+
+        // Case-B upgrade whose kept-row fields all resolve to stored; only the orphan dies.
+        let subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 2_000);
+        let outcome = put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome.orphans,
+            vec![serde_json::json!({"k8s-namespace": "ecommerce"})],
+            "the seeded strict-subset row must be deleted as an orphan"
+        );
+        let row = Entity::find_by_id(richer_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.last_seen, 2_000,
+            "the upgrade-branch no-op must still persist last_seen"
+        );
+        assert!(
+            outcome.changed,
+            "the upgrade branch deleted a row, so caches must evict its key"
         );
     }
 

--- a/src/infra/src/table/service_streams.rs
+++ b/src/infra/src/table/service_streams.rs
@@ -144,6 +144,15 @@ impl ServiceRecord {
     }
 }
 
+/// Outcome of a [`put`]; a named struct so call sites cannot positionally confuse the two facts.
+#[derive(Debug, Clone)]
+pub struct PutOutcome {
+    /// `disambiguation` JSON of each orphaned lower-specificity row this put deleted (F19).
+    pub orphans: Vec<serde_json::Value>,
+    /// True iff the call mutated a row (insert, data-column change, or orphan deletion).
+    pub changed: bool,
+}
+
 pub async fn create_table() -> Result<(), errors::Error> {
     let client = get_orm_client_ddl().await;
     let builder = client.get_database_backend();
@@ -177,16 +186,12 @@ fn normalize_json_object(v: serde_json::Value) -> serde_json::Value {
     }
 }
 
-/// Upsert a service record.
-///
-/// Returns the `disambiguation` JSON of every orphaned (lower-specificity) row that was
-/// deleted as part of this put, so callers can evict the matching cache keys (F19).
-/// Empty on a plain insert.
+/// Upsert a service record; callers gate cache-invalidation events on `PutOutcome::changed`.
 pub async fn put(
     org_id: &str,
     record: ServiceRecord,
     max_streams_per_type: usize,
-) -> Result<Vec<serde_json::Value>, errors::Error> {
+) -> Result<PutOutcome, errors::Error> {
     let client = get_orm_client_rw().await;
     put_with(client, org_id, record, max_streams_per_type).await
 }
@@ -197,7 +202,7 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
     org_id: &str,
     mut record: ServiceRecord,
     max_streams_per_type: usize,
-) -> Result<Vec<serde_json::Value>, errors::Error> {
+) -> Result<PutOutcome, errors::Error> {
     // Normalize disambiguation to sorted-key JSON so that text comparisons in SQLite
     // are stable regardless of insertion order of the original object.
     record.disambiguation = normalize_json_object(record.disambiguation);
@@ -266,7 +271,7 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
         // Delete any orphaned rows that are strict subsets of the row we just updated.
         // These accumulate when a record with fewer disambiguation fields was written before
         // the richer variant existed.
-        delete_subset_orphans(
+        let orphans = delete_subset_orphans(
             client,
             org_id,
             &record.service_name,
@@ -274,7 +279,12 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
             &incoming_map,
             &kept_id,
         )
-        .await
+        .await?;
+        // Stub derivation: every call above still issues an UPDATE, so always-true is honest.
+        Ok(PutOutcome {
+            orphans,
+            changed: true,
+        })
     } else {
         // No exact match. Check if an existing row can be upgraded:
         // A row is upgradeable if its disambiguation is a subset of the incoming one
@@ -372,7 +382,7 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
                 .map_err(|e| Error::DbError(DbError::SeaORMError(e.to_string())))?;
 
             // Clean up any other orphaned subset rows for this service (same set_id)
-            delete_subset_orphans(
+            let orphans = delete_subset_orphans(
                 client,
                 org_id,
                 &record.service_name,
@@ -380,7 +390,11 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
                 richer_map,
                 &kept_id,
             )
-            .await
+            .await?;
+            Ok(PutOutcome {
+                orphans,
+                changed: true,
+            })
         } else {
             let active_model = ActiveModel {
                 id: Set(record.id),
@@ -401,8 +415,11 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
                 .await
                 .map_err(|e| Error::DbError(DbError::SeaORMError(e.to_string())))?;
 
-            // Plain insert: nothing was orphaned.
-            Ok(Vec::new())
+            // Plain insert: nothing was orphaned, and a new row is always a mutation.
+            Ok(PutOutcome {
+                orphans: Vec::new(),
+                changed: true,
+            })
         }
     }
 }
@@ -1195,11 +1212,11 @@ mod tests {
         let record = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
         let id = record.id.clone();
 
-        let orphans = put_with(&db, "org1", record, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let outcome = put_with(&db, "org1", record, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
-        assert!(orphans.is_empty(), "a plain insert orphans nothing");
+        assert!(outcome.orphans.is_empty(), "a plain insert orphans nothing");
         assert_eq!(
             total_set_clause_hits(&db, &id).await,
             0,
@@ -1350,6 +1367,208 @@ mod tests {
             row.all_dimensions,
             serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
             "stored values win over conflicting incoming values"
+        );
+    }
+
+    // If a pure no-op reported changed, every flush would still invalidate cluster caches.
+    #[tokio::test]
+    async fn exact_repeat_noop_reports_changed_false() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        put_with(
+            &db,
+            "org1",
+            service_record(disambiguation.clone(), 1_000),
+            DEFAULT_MAX_STREAMS_PER_TYPE,
+        )
+        .await
+        .unwrap();
+
+        let outcome = put_with(
+            &db,
+            "org1",
+            service_record(disambiguation, 1_000),
+            DEFAULT_MAX_STREAMS_PER_TYPE,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            outcome.orphans.is_empty(),
+            "an exact repeat orphans nothing"
+        );
+        assert!(
+            !outcome.changed,
+            "no data column changed, so the call must not report changed"
+        );
+    }
+
+    // last_seen-only writes must NOT count as changed, else every call still invalidates.
+    #[tokio::test]
+    async fn subset_incoming_noop_reports_changed_false() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let mut first = service_record(disambiguation.clone(), 1_000);
+        first.logs_streams =
+            serde_json::json!(["checkout-service-logs", "checkout-service-logs-v2"]);
+        first.traces_streams =
+            serde_json::json!(["checkout-service-traces", "checkout-service-traces-v2"]);
+        first.metrics_streams =
+            serde_json::json!(["checkout-service-metrics", "checkout-service-metrics-v2"]);
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        // Every incoming field merges back to the stored value; only last_seen differs.
+        let mut second = service_record(disambiguation, 2_000);
+        second.all_dimensions = serde_json::json!({"k8s-cluster": "prod"});
+        let outcome = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(outcome.orphans.is_empty(), "a subset put orphans nothing");
+        assert!(
+            !outcome.changed,
+            "only last_seen was written, which must not count as changed"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_change_reports_changed_true() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        put_with(
+            &db,
+            "org1",
+            service_record(disambiguation.clone(), 1_000),
+            DEFAULT_MAX_STREAMS_PER_TYPE,
+        )
+        .await
+        .unwrap();
+
+        let mut second = service_record(disambiguation, 1_000);
+        second.traces_streams =
+            serde_json::json!(["checkout-service-traces", "checkout-service-traces-v2"]);
+        let outcome = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(
+            outcome.changed,
+            "traces_streams genuinely grew, so the call must report changed"
+        );
+    }
+
+    #[tokio::test]
+    async fn plain_insert_reports_changed_true() {
+        let db = db().await;
+        let record = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+
+        let outcome = put_with(&db, "org1", record, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(outcome.orphans.is_empty(), "a plain insert orphans nothing");
+        assert!(outcome.changed, "a new row is always a mutation");
+    }
+
+    // Subset incoming resolves every field to the stored value in the upgrade branch too.
+    #[tokio::test]
+    async fn upgrade_branch_identical_resolution_reports_changed_false() {
+        let db = db().await;
+        let richer = service_record(
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
+            1_000,
+        );
+        put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        let subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+        let outcome = put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(
+            outcome.orphans.is_empty(),
+            "the only row is the kept one, so nothing is orphaned"
+        );
+        assert!(
+            !outcome.changed,
+            "every field resolved to the stored value, so the upgrade branch must not report changed"
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_branch_richer_incoming_reports_changed_true() {
+        let db = db().await;
+        let sparse = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+        put_with(&db, "org1", sparse, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        let richer = service_record(
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
+            2_000,
+        );
+        let outcome = put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(
+            outcome.changed,
+            "disambiguation was upgraded to the richer incoming value, so the call must report changed"
+        );
+    }
+
+    // Orphan deletion is a mutation: only the caller's put event makes nodes drop the dead key.
+    #[tokio::test]
+    async fn orphan_deletion_on_noop_update_reports_changed_true() {
+        let db = db().await;
+        let richer_disambiguation =
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"});
+        put_with(
+            &db,
+            "org1",
+            service_record(richer_disambiguation.clone(), 1_000),
+            DEFAULT_MAX_STREAMS_PER_TYPE,
+        )
+        .await
+        .unwrap();
+
+        // Seeded directly: put() upgrade-merges subsets, so legacy orphans can only pre-exist.
+        let orphan = ActiveModel {
+            id: Set(svix_ksuid::Ksuid::new(None, None).to_string()),
+            org_id: Set("org1".to_owned()),
+            service_name: Set("checkout-service".to_owned()),
+            set_id: Set("k8s".to_owned()),
+            disambiguation: Set(serde_json::json!({"k8s-cluster": "prod"})),
+            all_dimensions: Set(serde_json::json!({})),
+            logs_streams: Set(serde_json::json!([])),
+            traces_streams: Set(serde_json::json!([])),
+            metrics_streams: Set(serde_json::json!([])),
+            field_name_mapping: Set(None),
+            last_seen: Set(500),
+        };
+        Entity::insert(orphan).exec(&db).await.unwrap();
+
+        let outcome = put_with(
+            &db,
+            "org1",
+            service_record(richer_disambiguation, 1_000),
+            DEFAULT_MAX_STREAMS_PER_TYPE,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome.orphans,
+            vec![serde_json::json!({"k8s-cluster": "prod"})],
+            "the seeded subset row must be deleted as an orphan"
+        );
+        assert!(
+            outcome.changed,
+            "a row was deleted, so caches must evict its key even though the kept row was a no-op"
         );
     }
 }

--- a/src/infra/src/table/service_streams.rs
+++ b/src/infra/src/table/service_streams.rs
@@ -184,14 +184,28 @@ fn normalize_json_object(v: serde_json::Value) -> serde_json::Value {
 /// Empty on a plain insert.
 pub async fn put(
     org_id: &str,
+    record: ServiceRecord,
+    max_streams_per_type: usize,
+) -> Result<Vec<serde_json::Value>, errors::Error> {
+    let client = get_orm_client_rw().await;
+    put_with(client, org_id, record, max_streams_per_type).await
+}
+
+/// [`put`] against a caller-supplied connection.
+///
+/// The `_with` variant exists so the no-op/write-amplification behavior can be
+/// exercised against a real schema in tests — the same shape
+/// `alert_states::get`/`get_with` already use. `put` delegates here so a test
+/// cannot accidentally verify a different code path from the one production runs.
+pub async fn put_with<C: sea_orm::ConnectionTrait>(
+    client: &C,
+    org_id: &str,
     mut record: ServiceRecord,
     max_streams_per_type: usize,
 ) -> Result<Vec<serde_json::Value>, errors::Error> {
     // Normalize disambiguation to sorted-key JSON so that text comparisons in SQLite
     // are stable regardless of insertion order of the original object.
     record.disambiguation = normalize_json_object(record.disambiguation);
-
-    let client = get_orm_client_rw().await;
 
     // Look up the exact row via (org_id, service_name, set_id, disambiguation).
     // Scoping by set_id ensures records from different identity sets never merge.
@@ -403,8 +417,8 @@ pub async fn put(
 ///
 /// Returns the `disambiguation` JSON of each deleted row so callers can evict the
 /// corresponding cache entries (F19).
-async fn delete_subset_orphans(
-    client: &sea_orm::DatabaseConnection,
+async fn delete_subset_orphans<C: sea_orm::ConnectionTrait>(
+    client: &C,
     org_id: &str,
     service_name: &str,
     set_id: &str,
@@ -732,5 +746,600 @@ mod tests {
         assert_eq!(record.set_id, "setid1");
         assert_eq!(record.last_seen, 0);
         assert!(!record.id.is_empty());
+    }
+
+    // ── put_with no-op / write-amplification tests ─────────────────────────
+    //
+    // The bug: `put()` always builds every mutable column as `Set(..)`, so
+    // `.update()` issues a full-column UPDATE even when nothing changed
+    // (measured: 251,333 UPDATEs / 12h in production, ~58% of DB time). The
+    // fix marks a column `Unchanged(existing_value)` instead of `Set(value)`
+    // when the computed new value equals what's already stored, so SeaORM's
+    // own `Updater::is_noop()` (sea-orm 1.1.20, `executor/update.rs`) skips
+    // issuing SQL entirely once every column ends up Unchanged/NotSet.
+    //
+    // Proving "no UPDATE was issued" against sqlite in-memory: row content
+    // alone can't distinguish the fix from the bug (both leave the same
+    // final values — one gets there via a wasted UPDATE). Directly
+    // inspecting SeaORM's `Updater::is_noop()` isn't reachable from outside
+    // the crate. So the fixture (`db()` below) attaches a real SQLite
+    // `AFTER UPDATE OF <column>` trigger per mutable column to
+    // `service_streams`, each incrementing its own counter in a sidecar
+    // `update_audit` table every time that column is named in an UPDATE's
+    // SET clause — regardless of whether the assigned value actually
+    // changed. This is driver-level ground truth: `UpdateOne::prepare_values`
+    // (sea-orm `query/update.rs`) only adds a column to the SQL SET clause
+    // when the ActiveModel field is `ActiveValue::Set(_)`; `Unchanged`/
+    // `NotSet` fields never reach the statement. So `set_clause_count(..)`
+    // for one column proves that column was never `Set(_)` on the
+    // ActiveModel for that call — not just that its final value happens to
+    // match. `last_seen` is `Set(_)` unconditionally in both branches (out
+    // of scope for this fix — see test 7), so `total_set_clause_hits(..)`
+    // is only ever 0 for a call that issues no UPDATE at all (an insert);
+    // an update call that is a no-op for every OTHER column still shows
+    // exactly 1 via `last_seen`, which the per-column tests check for
+    // explicitly rather than relying on the whole-row total.
+
+    /// Every mutable column `put`/`put_with` can write, in the exact spelling
+    /// SQLite uses for the column name (snake_case). Drives the per-column
+    /// audit triggers below, so adding a mutable column to the entity is a
+    /// visible one-line change here rather than a silent gap in coverage.
+    const MUTABLE_COLUMNS: [&str; 7] = [
+        "disambiguation",
+        "all_dimensions",
+        "logs_streams",
+        "traces_streams",
+        "metrics_streams",
+        "field_name_mapping",
+        "last_seen",
+    ];
+
+    /// Sidecar table + trigger fixture, matching `alert_states.rs`'s `db()`
+    /// precedent (`Schema::new(backend).create_table_from_entity`) for the
+    /// base schema.
+    ///
+    /// Per-column `AFTER UPDATE OF <col>` triggers are the no-op proof: SQLite
+    /// fires `UPDATE OF <col>` iff `<col>` is named in the UPDATE statement's
+    /// SET clause — independent of whether the assigned value actually
+    /// differs from what was stored (verified directly against sqlite3: a
+    /// same-value `SET a = 10` still fires `AFTER UPDATE OF a`, while an
+    /// UPDATE that never names `a` does not). SeaORM's `UpdateOne::prepare_values`
+    /// (sea-orm `query/update.rs`) only adds a column to the SET clause when
+    /// the ActiveModel field is `ActiveValue::Set(_)` — `Unchanged`/`NotSet`
+    /// fields never reach the statement. So a zero count on a column's audit
+    /// row after a `put_with` call proves that column was never `Set` on the
+    /// ActiveModel for that call — not merely that its final value matches.
+    async fn db() -> sea_orm::DatabaseConnection {
+        use sea_orm::{ConnectionTrait, Database, Schema};
+
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        let backend = db.get_database_backend();
+        let schema = Schema::new(backend);
+        let create_table_stmt = schema.create_table_from_entity(Entity);
+        db.execute(backend.build(&create_table_stmt)).await.unwrap();
+
+        db.execute_unprepared(
+            "CREATE TABLE update_audit (id TEXT NOT NULL, col TEXT NOT NULL, hit_count INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (id, col))",
+        )
+        .await
+        .unwrap();
+        for col in MUTABLE_COLUMNS {
+            let sql = format!(
+                "CREATE TRIGGER service_streams_audit_{col} \
+                 AFTER UPDATE OF {col} ON service_streams \
+                 BEGIN \
+                     INSERT INTO update_audit (id, col, hit_count) VALUES (NEW.id, '{col}', 1) \
+                     ON CONFLICT(id, col) DO UPDATE SET hit_count = hit_count + 1; \
+                 END"
+            );
+            db.execute_unprepared(&sql).await.unwrap();
+        }
+
+        db
+    }
+
+    /// Number of times `col` has appeared in an UPDATE statement's SET
+    /// clause against `id` since the fixture was created — SQL-level ground
+    /// truth for "was this column `Set(_)` on the ActiveModel," independent
+    /// of the row's final stored value. See [`db`] for why this is a real
+    /// proof and not a value-equality check in disguise.
+    async fn set_clause_count(db: &sea_orm::DatabaseConnection, id: &str, col: &str) -> i64 {
+        use sea_orm::{ConnectionTrait, FromQueryResult, Statement};
+
+        #[derive(FromQueryResult)]
+        struct Row {
+            hit_count: i64,
+        }
+
+        let stmt = Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "SELECT hit_count FROM update_audit WHERE id = ? AND col = ?",
+            [id.into(), col.into()],
+        );
+        Row::find_by_statement(stmt)
+            .one(db)
+            .await
+            .unwrap()
+            .map(|r| r.hit_count)
+            .unwrap_or(0)
+    }
+
+    /// Total UPDATE-statement touches across every mutable column — zero iff
+    /// `Updater::is_noop()` (sea-orm `executor/update.rs`) skipped issuing
+    /// SQL for this row entirely, since a no-op SET clause is empty and no
+    /// column-scoped trigger can fire.
+    async fn total_set_clause_hits(db: &sea_orm::DatabaseConnection, id: &str) -> i64 {
+        let mut total = 0;
+        for col in MUTABLE_COLUMNS {
+            total += set_clause_count(db, id, col).await;
+        }
+        total
+    }
+
+    /// A record shaped like real service-registry telemetry: a k8s identity
+    /// set with a cluster/namespace disambiguation, non-trivial stream
+    /// arrays and dimensions — not an empty/degenerate fixture.
+    fn service_record(disambiguation: serde_json::Value, last_seen: i64) -> ServiceRecord {
+        let mut r = ServiceRecord::new("org1", "checkout-service", "k8s", disambiguation);
+        r.all_dimensions = serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"});
+        r.logs_streams = serde_json::json!(["checkout-service-logs"]);
+        r.traces_streams = serde_json::json!(["checkout-service-traces"]);
+        r.metrics_streams = serde_json::json!(["checkout-service-metrics"]);
+        r.field_name_mapping = Some(serde_json::json!({"service": "kubernetes_labels_app"}));
+        r.last_seen = last_seen;
+        r
+    }
+
+    /// 1. Exact-match branch, byte-identical repeat: the second `put_with`
+    /// call must not touch logs/traces/metrics/all_dimensions/field_name_mapping.
+    /// `last_seen` is explicitly OUT of scope for this fix (see [`db`]'s
+    /// sibling test 7): `active.last_seen = Set(record.last_seen)` stays
+    /// unconditional, so it is `Set(_)` on every call regardless of whether
+    /// its value changed, and its own trigger firing once here is expected,
+    /// not a bug — only the other 5 columns' triggers must stay silent.
+    #[tokio::test]
+    async fn exact_repeat_call_issues_no_update() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let first = service_record(disambiguation.clone(), 1_000);
+        let first_id = first.id.clone();
+
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+        assert_eq!(
+            total_set_clause_hits(&db, &first_id).await,
+            0,
+            "insert is not an UPDATE"
+        );
+
+        let repeat = service_record(disambiguation, 1_000);
+        put_with(&db, "org1", repeat, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        for col in [
+            "disambiguation",
+            "all_dimensions",
+            "logs_streams",
+            "traces_streams",
+            "metrics_streams",
+            "field_name_mapping",
+        ] {
+            assert_eq!(
+                set_clause_count(&db, &first_id, col).await,
+                0,
+                "{col} is byte-identical between calls and must never have been Set(_)"
+            );
+        }
+    }
+
+    /// 2. Partial change: only `traces_streams` grows between calls. Proves,
+    /// at the SQL SET-clause level (not just final row values, which the old
+    /// buggy code would also get right via a wasted full-column UPDATE):
+    /// `traces_streams` was actually `Set(_)` on the ActiveModel, while
+    /// `disambiguation`/`all_dimensions`/`logs_streams`/`metrics_streams`/
+    /// `field_name_mapping` were not — only `last_seen` (always written,
+    /// out of scope for this fix) and `traces_streams` may appear.
+    #[tokio::test]
+    async fn partial_change_updates_only_when_a_field_actually_differs() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let first = service_record(disambiguation.clone(), 1_000);
+        let first_id = first.id.clone();
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        let mut second = service_record(disambiguation, 1_000);
+        second.traces_streams =
+            serde_json::json!(["checkout-service-traces", "checkout-service-traces-v2"]);
+        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            set_clause_count(&db, &first_id, "traces_streams").await,
+            1,
+            "traces_streams grew, so it must have been Set(_) on the ActiveModel"
+        );
+        // last_seen is unconditionally Set every call regardless of scope (out of
+        // scope for this fix), so it is expected to appear here even though its
+        // value (1_000) did not change between the two calls.
+        assert_eq!(
+            set_clause_count(&db, &first_id, "last_seen").await,
+            1,
+            "last_seen is always written, in or out of the no-op set"
+        );
+        for col in [
+            "disambiguation",
+            "all_dimensions",
+            "logs_streams",
+            "metrics_streams",
+            "field_name_mapping",
+        ] {
+            assert_eq!(
+                set_clause_count(&db, &first_id, col).await,
+                0,
+                "{col} did not change and must have been Unchanged(_), not Set(_), on the ActiveModel"
+            );
+        }
+
+        let row = Entity::find_by_id(first_id.clone())
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        let traces: Vec<&str> = row
+            .traces_streams
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(
+            traces,
+            vec!["checkout-service-traces", "checkout-service-traces-v2"]
+        );
+        assert_eq!(
+            row.logs_streams,
+            serde_json::json!(["checkout-service-logs"]),
+            "logs_streams did not change and must retain its original value"
+        );
+    }
+
+    /// 3. Full change: every field the exact-match branch can touch differs
+    /// between calls. Proves a real UPDATE happens and every new value is
+    /// actually persisted. `disambiguation` is excluded here on purpose: the
+    /// exact-match branch is reached only when disambiguation is identical
+    /// between calls (that is what makes it an exact match), and the branch
+    /// never assigns `active.disambiguation` at all — only the upgrade
+    /// branch (tests 5a/5b) can rewrite it.
+    #[tokio::test]
+    async fn full_change_updates_and_persists_every_new_value() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let first = service_record(disambiguation.clone(), 1_000);
+        let first_id = first.id.clone();
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        let mut second = service_record(disambiguation, 2_000);
+        second.all_dimensions =
+            serde_json::json!({"k8s-cluster": "prod", "k8s-region": "us-east-1"});
+        second.logs_streams = serde_json::json!(["checkout-service-logs-v2"]);
+        second.traces_streams = serde_json::json!(["checkout-service-traces-v2"]);
+        second.metrics_streams = serde_json::json!(["checkout-service-metrics-v2"]);
+        second.field_name_mapping =
+            Some(serde_json::json!({"service": "kubernetes_labels_app_v2"}));
+        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        for col in [
+            "all_dimensions",
+            "logs_streams",
+            "traces_streams",
+            "metrics_streams",
+            "field_name_mapping",
+        ] {
+            assert_eq!(
+                set_clause_count(&db, &first_id, col).await,
+                1,
+                "{col} changed and must have been Set(_)"
+            );
+        }
+        assert_eq!(
+            set_clause_count(&db, &first_id, "disambiguation").await,
+            0,
+            "the exact-match branch never assigns disambiguation, no matter what else changed"
+        );
+        let row = Entity::find_by_id(first_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.logs_streams,
+            serde_json::json!(["checkout-service-logs", "checkout-service-logs-v2"]),
+            "logs_streams unions rather than replaces — existing entries are kept"
+        );
+        assert_eq!(row.last_seen, 2_000);
+        assert_eq!(
+            row.field_name_mapping,
+            Some(serde_json::json!({"service": "kubernetes_labels_app_v2"}))
+        );
+    }
+
+    /// 4a. `field_name_mapping: None` on the second call must leave the
+    /// stored mapping untouched — existing behavior, must not regress —
+    /// and must not itself force a rewrite (only `last_seen`, out of scope
+    /// for this fix, is expected to have been `Set(_)`).
+    #[tokio::test]
+    async fn field_name_mapping_none_preserves_existing_value_and_is_a_noop_field() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let first = service_record(disambiguation.clone(), 1_000);
+        let first_id = first.id.clone();
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        let mut second = service_record(disambiguation, 1_000);
+        second.field_name_mapping = None;
+        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        for col in [
+            "disambiguation",
+            "all_dimensions",
+            "logs_streams",
+            "traces_streams",
+            "metrics_streams",
+            "field_name_mapping",
+        ] {
+            assert_eq!(
+                set_clause_count(&db, &first_id, col).await,
+                0,
+                "{col}: field_name_mapping=None plus otherwise-identical fields must stay Unchanged(_)"
+            );
+        }
+        let row = Entity::find_by_id(first_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.field_name_mapping,
+            Some(serde_json::json!({"service": "kubernetes_labels_app"})),
+            "existing field_name_mapping must be preserved when the incoming record has None"
+        );
+    }
+
+    /// 4b. `field_name_mapping: Some(x)` where `x` is byte-identical to what's
+    /// stored counts as a no-op for this field specifically.
+    #[tokio::test]
+    async fn field_name_mapping_identical_some_is_a_noop_field() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let first = service_record(disambiguation.clone(), 1_000);
+        let first_id = first.id.clone();
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        // Identical to service_record()'s default field_name_mapping.
+        let second = service_record(disambiguation, 1_000);
+        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            set_clause_count(&db, &first_id, "field_name_mapping").await,
+            0,
+            "identical Some(..) field_name_mapping must not force a rewrite"
+        );
+    }
+
+    /// 4c. `field_name_mapping: Some(x)` where `x` differs from what's stored
+    /// must produce a real update.
+    #[tokio::test]
+    async fn field_name_mapping_changed_some_updates() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let first = service_record(disambiguation.clone(), 1_000);
+        let first_id = first.id.clone();
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        let mut second = service_record(disambiguation, 1_000);
+        second.field_name_mapping = Some(serde_json::json!({"service": "different_raw_field"}));
+        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            set_clause_count(&db, &first_id, "field_name_mapping").await,
+            1,
+            "field_name_mapping changed and must have been Set(_)"
+        );
+        let row = Entity::find_by_id(first_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.field_name_mapping,
+            Some(serde_json::json!({"service": "different_raw_field"}))
+        );
+    }
+
+    /// 5a. Upgrade branch: incoming disambiguation is a subset of the
+    /// existing (richer) row's, and the richer_disambiguation therefore
+    /// resolves to byte-identical to what's already stored. `disambiguation`
+    /// (upgrade-branch-only field) must be marked Unchanged, not rewritten —
+    /// combined with identical logs/traces/metrics/all_dimensions/
+    /// field_name_mapping, the whole call must be a no-op.
+    #[tokio::test]
+    async fn upgrade_branch_subset_incoming_leaves_richer_disambiguation_untouched() {
+        let db = db().await;
+        // Existing row already has the richer disambiguation.
+        let richer = service_record(
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
+            1_000,
+        );
+        let richer_id = richer.id.clone();
+        put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        // Incoming disambiguation ({"k8s-cluster": "prod"}) is a strict subset
+        // of the stored one, and every other mutable field is identical, so
+        // richer_disambiguation resolves to the existing value verbatim.
+        let subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+        put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        for col in [
+            "disambiguation",
+            "all_dimensions",
+            "logs_streams",
+            "traces_streams",
+            "metrics_streams",
+            "field_name_mapping",
+        ] {
+            assert_eq!(
+                set_clause_count(&db, &richer_id, col).await,
+                0,
+                "{col}: the upgrade branch must not rewrite a field whose resolved value is unchanged"
+            );
+        }
+        let row = Entity::find_by_id(richer_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.disambiguation,
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"})
+        );
+    }
+
+    /// 5b. Upgrade branch: incoming disambiguation is richer than the
+    /// existing (subset) row's, so richer_disambiguation genuinely changes —
+    /// this must be a real update, including the disambiguation column.
+    #[tokio::test]
+    async fn upgrade_branch_richer_incoming_updates_disambiguation() {
+        let db = db().await;
+        let sparse = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+        let sparse_id = sparse.id.clone();
+        put_with(&db, "org1", sparse, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        let richer = service_record(
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
+            1_000,
+        );
+        put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            set_clause_count(&db, &sparse_id, "disambiguation").await,
+            1,
+            "the incoming row is richer, so disambiguation must actually have been Set(_)"
+        );
+        let row = Entity::find_by_id(sparse_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.disambiguation,
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"})
+        );
+    }
+
+    /// 6. Insert path (no existing row, no upgrade candidate) must keep
+    /// working exactly as today — a regression-safety check, not new
+    /// behavior. An insert is not an UPDATE at all, so it must not touch
+    /// any of the update-counting triggers.
+    #[tokio::test]
+    async fn plain_insert_is_unaffected_and_is_not_an_update() {
+        let db = db().await;
+        let record = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+        let id = record.id.clone();
+
+        let orphans = put_with(&db, "org1", record, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(orphans.is_empty(), "a plain insert orphans nothing");
+        assert_eq!(
+            total_set_clause_hits(&db, &id).await,
+            0,
+            "an insert must never register as an UPDATE"
+        );
+        let row = Entity::find_by_id(id).one(&db).await.unwrap().unwrap();
+        assert_eq!(row.org_id, "org1");
+        assert_eq!(row.service_name, "checkout-service");
+        assert_eq!(
+            row.logs_streams,
+            serde_json::json!(["checkout-service-logs"])
+        );
+    }
+
+    /// 7. `last_seen` is explicitly out of scope for this fix: it must be
+    /// written on every call, even when every other field is identical.
+    /// Guards against the fix accidentally scope-creeping into also
+    /// skipping `last_seen` (that coarsening is a separate, deferred
+    /// change) — this call SHOULD still issue a real UPDATE of `last_seen`,
+    /// while every other (identical) field stays Unchanged(_).
+    #[tokio::test]
+    async fn last_seen_always_updates_even_when_nothing_else_changed() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let first = service_record(disambiguation.clone(), 1_000);
+        let first_id = first.id.clone();
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        // Only last_seen differs from the first call.
+        let second = service_record(disambiguation, 2_000);
+        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            set_clause_count(&db, &first_id, "last_seen").await,
+            1,
+            "last_seen changed, so it must actually have been Set(_)"
+        );
+        for col in [
+            "disambiguation",
+            "all_dimensions",
+            "logs_streams",
+            "traces_streams",
+            "metrics_streams",
+            "field_name_mapping",
+        ] {
+            assert_eq!(
+                set_clause_count(&db, &first_id, col).await,
+                0,
+                "{col} did not change and must stay Unchanged(_) even though last_seen updated"
+            );
+        }
+        let row = Entity::find_by_id(first_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.last_seen, 2_000);
     }
 }

--- a/src/infra/src/table/service_streams.rs
+++ b/src/infra/src/table/service_streams.rs
@@ -1126,6 +1126,43 @@ mod tests {
         );
     }
 
+    // Stored NULL is a real comparand: a fix that skips the fnm compare when None must die.
+    #[tokio::test]
+    async fn field_name_mapping_null_to_some_updates_and_reports_changed_true() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let mut first = service_record(disambiguation.clone(), 1_000);
+        first.field_name_mapping = None;
+        let first_id = first.id.clone();
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        let second = service_record(disambiguation, 1_000);
+        let outcome = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            set_clause_count(&db, &first_id, "field_name_mapping").await,
+            1,
+            "stored NULL differs from incoming Some, so field_name_mapping must have been Set(_)"
+        );
+        assert!(
+            outcome.changed,
+            "field_name_mapping went NULL to Some and must count as changed"
+        );
+        let row = Entity::find_by_id(first_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.field_name_mapping,
+            Some(serde_json::json!({"service": "kubernetes_labels_app"}))
+        );
+    }
+
     // Subset incoming resolves richer_disambiguation to the stored value: rewrite nothing.
     #[tokio::test]
     async fn upgrade_branch_subset_incoming_leaves_richer_disambiguation_untouched() {

--- a/src/infra/src/table/service_streams.rs
+++ b/src/infra/src/table/service_streams.rs
@@ -255,14 +255,15 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
         );
 
         let mut active: ActiveModel = existing_model.into();
-        active.logs_streams = Set(logs);
-        active.traces_streams = Set(traces);
-        active.metrics_streams = Set(metrics);
-        active.all_dimensions = Set(merged_dims);
-        active.last_seen = Set(record.last_seen);
+        let mut dirty = false;
+        set_if_dirty(&mut active.logs_streams, logs, &mut dirty);
+        set_if_dirty(&mut active.traces_streams, traces, &mut dirty);
+        set_if_dirty(&mut active.metrics_streams, metrics, &mut dirty);
+        set_if_dirty(&mut active.all_dimensions, merged_dims, &mut dirty);
         if let Some(fnm) = record.field_name_mapping {
-            active.field_name_mapping = Set(Some(fnm));
+            set_if_dirty(&mut active.field_name_mapping, Some(fnm), &mut dirty);
         }
+        active.last_seen = Set(record.last_seen);
 
         active
             .update(client)
@@ -281,11 +282,8 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
             &kept_id,
         )
         .await?;
-        // Stub derivation: every call above still issues an UPDATE, so always-true is honest.
-        Ok(PutOutcome {
-            orphans,
-            changed: true,
-        })
+        let changed = dirty || !orphans.is_empty();
+        Ok(PutOutcome { orphans, changed })
     } else {
         // No exact match. Check if an existing row can be upgraded:
         // A row is upgradeable if its disambiguation is a subset of the incoming one
@@ -367,15 +365,20 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
             let merged_dims =
                 union_dimension_objects(&existing_model.all_dimensions, &record.all_dimensions);
             let mut active: ActiveModel = existing_model.into();
-            active.disambiguation = Set(richer_disambiguation);
-            active.logs_streams = Set(logs);
-            active.traces_streams = Set(traces);
-            active.metrics_streams = Set(metrics);
-            active.all_dimensions = Set(merged_dims);
-            active.last_seen = Set(record.last_seen);
+            let mut dirty = false;
+            set_if_dirty(
+                &mut active.disambiguation,
+                richer_disambiguation,
+                &mut dirty,
+            );
+            set_if_dirty(&mut active.logs_streams, logs, &mut dirty);
+            set_if_dirty(&mut active.traces_streams, traces, &mut dirty);
+            set_if_dirty(&mut active.metrics_streams, metrics, &mut dirty);
+            set_if_dirty(&mut active.all_dimensions, merged_dims, &mut dirty);
             if let Some(fnm) = record.field_name_mapping {
-                active.field_name_mapping = Set(Some(fnm));
+                set_if_dirty(&mut active.field_name_mapping, Some(fnm), &mut dirty);
             }
+            active.last_seen = Set(record.last_seen);
 
             active
                 .update(client)
@@ -392,10 +395,8 @@ pub async fn put_with<C: sea_orm::ConnectionTrait>(
                 &kept_id,
             )
             .await?;
-            Ok(PutOutcome {
-                orphans,
-                changed: true,
-            })
+            let changed = dirty || !orphans.is_empty();
+            Ok(PutOutcome { orphans, changed })
         } else {
             let active_model = ActiveModel {
                 id: Set(record.id),
@@ -479,6 +480,19 @@ async fn delete_subset_orphans<C: sea_orm::ConnectionTrait>(
 /// Default cap on streams tracked per telemetry type, matching the enterprise
 /// `StreamMergePolicy` default. Used by callers that have no config access.
 pub const DEFAULT_MAX_STREAMS_PER_TYPE: usize = 50;
+
+/// Compares typed values, never serialized text: preserve_order builds would spuriously differ.
+fn set_if_dirty<T: Into<sea_orm::Value> + PartialEq>(
+    slot: &mut sea_orm::ActiveValue<T>,
+    computed: T,
+    dirty: &mut bool,
+) {
+    if matches!(slot, sea_orm::ActiveValue::Unchanged(stored) if *stored == computed) {
+        return;
+    }
+    *slot = Set(computed);
+    *dirty = true;
+}
 
 /// Union two JSON objects of dimension values; keys already present in `base`
 /// win (same semantics as `ServiceMetadata::merge`), so later ingests can add

--- a/src/infra/src/table/service_streams.rs
+++ b/src/infra/src/table/service_streams.rs
@@ -121,6 +121,17 @@ pub struct ServiceRecord {
     pub last_seen: i64,
 }
 
+/// Outcome of a [`put`]; a named struct so call sites cannot positionally confuse the two facts.
+#[must_use]
+#[derive(Debug, Clone)]
+pub struct PutOutcome {
+    /// `disambiguation` JSON of each orphaned lower-specificity row this put deleted (F19).
+    pub orphans: Vec<serde_json::Value>,
+    /// True iff a data column changed, a row was inserted, or an orphan was deleted;
+    /// last_seen-only writes do not count.
+    pub changed: bool,
+}
+
 impl ServiceRecord {
     pub fn new(
         org_id: &str,
@@ -142,15 +153,6 @@ impl ServiceRecord {
             last_seen: 0,
         }
     }
-}
-
-/// Outcome of a [`put`]; a named struct so call sites cannot positionally confuse the two facts.
-#[derive(Debug, Clone)]
-pub struct PutOutcome {
-    /// `disambiguation` JSON of each orphaned lower-specificity row this put deleted (F19).
-    pub orphans: Vec<serde_json::Value>,
-    /// True iff the call mutated a row (insert, data-column change, or orphan deletion).
-    pub changed: bool,
 }
 
 pub async fn create_table() -> Result<(), errors::Error> {
@@ -854,7 +856,7 @@ mod tests {
         let first = service_record(disambiguation.clone(), 1_000);
         let first_id = first.id.clone();
 
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
         assert_eq!(
@@ -864,7 +866,7 @@ mod tests {
         );
 
         let repeat = service_record(disambiguation, 1_000);
-        put_with(&db, "org1", repeat, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", repeat, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -891,14 +893,14 @@ mod tests {
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
         let first = service_record(disambiguation.clone(), 1_000);
         let first_id = first.id.clone();
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
         let mut second = service_record(disambiguation, 1_000);
         second.traces_streams =
             serde_json::json!(["checkout-service-traces", "checkout-service-traces-v2"]);
-        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -957,7 +959,7 @@ mod tests {
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
         let first = service_record(disambiguation.clone(), 1_000);
         let first_id = first.id.clone();
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -969,7 +971,7 @@ mod tests {
         second.metrics_streams = serde_json::json!(["checkout-service-metrics-v2"]);
         second.field_name_mapping =
             Some(serde_json::json!({"service": "kubernetes_labels_app_v2"}));
-        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1020,13 +1022,13 @@ mod tests {
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
         let first = service_record(disambiguation.clone(), 1_000);
         let first_id = first.id.clone();
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
         let mut second = service_record(disambiguation, 1_000);
         second.field_name_mapping = None;
-        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1062,13 +1064,13 @@ mod tests {
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
         let first = service_record(disambiguation.clone(), 1_000);
         let first_id = first.id.clone();
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
         // Identical to service_record()'s default field_name_mapping.
         let second = service_record(disambiguation, 1_000);
-        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1085,13 +1087,13 @@ mod tests {
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
         let first = service_record(disambiguation.clone(), 1_000);
         let first_id = first.id.clone();
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
         let mut second = service_record(disambiguation, 1_000);
         second.field_name_mapping = Some(serde_json::json!({"service": "different_raw_field"}));
-        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1120,12 +1122,12 @@ mod tests {
             1_000,
         );
         let richer_id = richer.id.clone();
-        put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
         let subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
-        put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1159,7 +1161,7 @@ mod tests {
         let db = db().await;
         let sparse = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
         let sparse_id = sparse.id.clone();
-        put_with(&db, "org1", sparse, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", sparse, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1170,7 +1172,7 @@ mod tests {
         );
         richer.traces_streams =
             serde_json::json!(["checkout-service-traces", "checkout-service-traces-v2"]);
-        put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1238,12 +1240,12 @@ mod tests {
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
         let first = service_record(disambiguation.clone(), 1_000);
         let first_id = first.id.clone();
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
         let second = service_record(disambiguation, 2_000);
-        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1287,14 +1289,14 @@ mod tests {
         first.metrics_streams =
             serde_json::json!(["checkout-service-metrics", "checkout-service-metrics-v2"]);
         let first_id = first.id.clone();
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
         // service_record()'s 1-element stream arrays are strict subsets of what is now stored.
         let mut second = service_record(disambiguation, 2_000);
         second.all_dimensions = serde_json::json!({"k8s-cluster": "prod"});
-        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1336,7 +1338,7 @@ mod tests {
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
         let first = service_record(disambiguation.clone(), 1_000);
         let first_id = first.id.clone();
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1344,7 +1346,7 @@ mod tests {
         let mut second = service_record(disambiguation, 1_000);
         second.all_dimensions =
             serde_json::json!({"k8s-cluster": "staging", "k8s-namespace": "legacy"});
-        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1375,7 +1377,7 @@ mod tests {
     async fn exact_repeat_noop_reports_changed_false() {
         let db = db().await;
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
-        put_with(
+        let _ = put_with(
             &db,
             "org1",
             service_record(disambiguation.clone(), 1_000),
@@ -1415,7 +1417,7 @@ mod tests {
             serde_json::json!(["checkout-service-traces", "checkout-service-traces-v2"]);
         first.metrics_streams =
             serde_json::json!(["checkout-service-metrics", "checkout-service-metrics-v2"]);
-        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1437,7 +1439,7 @@ mod tests {
     async fn partial_change_reports_changed_true() {
         let db = db().await;
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
-        put_with(
+        let _ = put_with(
             &db,
             "org1",
             service_record(disambiguation.clone(), 1_000),
@@ -1456,6 +1458,62 @@ mod tests {
         assert!(
             outcome.changed,
             "traces_streams genuinely grew, so the call must report changed"
+        );
+    }
+
+    // Kills the mutant whose changed derivation omits field_name_mapping.
+    #[tokio::test]
+    async fn field_name_mapping_only_change_reports_changed_true() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let _ = put_with(
+            &db,
+            "org1",
+            service_record(disambiguation.clone(), 1_000),
+            DEFAULT_MAX_STREAMS_PER_TYPE,
+        )
+        .await
+        .unwrap();
+
+        let mut second = service_record(disambiguation, 1_000);
+        second.field_name_mapping = Some(serde_json::json!({"service": "different_raw_field"}));
+        let outcome = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(
+            outcome.changed,
+            "field_name_mapping is the only field that differs and it must count as changed"
+        );
+    }
+
+    // A NEW key survives the base-wins union, so this is a genuine all_dimensions change.
+    #[tokio::test]
+    async fn all_dimensions_only_change_reports_changed_true() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let _ = put_with(
+            &db,
+            "org1",
+            service_record(disambiguation.clone(), 1_000),
+            DEFAULT_MAX_STREAMS_PER_TYPE,
+        )
+        .await
+        .unwrap();
+
+        let mut second = service_record(disambiguation, 1_000);
+        second.all_dimensions = serde_json::json!({
+            "k8s-cluster": "prod",
+            "k8s-namespace": "ecommerce",
+            "k8s-region": "us-east-1"
+        });
+        let outcome = put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(
+            outcome.changed,
+            "the merged all_dimensions gained a key, so the call must report changed"
         );
     }
 
@@ -1480,11 +1538,12 @@ mod tests {
             serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
             1_000,
         );
-        put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
-        let subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+        // last_seen differs so a mutant deriving changed from its delta cannot survive here.
+        let subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 2_000);
         let outcome = put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
@@ -1495,7 +1554,7 @@ mod tests {
         );
         assert!(
             !outcome.changed,
-            "every field resolved to the stored value, so the upgrade branch must not report changed"
+            "every data field resolved to the stored value; last_seen alone must not count as changed"
         );
     }
 
@@ -1503,7 +1562,7 @@ mod tests {
     async fn upgrade_branch_richer_incoming_reports_changed_true() {
         let db = db().await;
         let sparse = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
-        put_with(&db, "org1", sparse, DEFAULT_MAX_STREAMS_PER_TYPE)
+        let _ = put_with(&db, "org1", sparse, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
 
@@ -1521,13 +1580,39 @@ mod tests {
         );
     }
 
+    // Kills the mutant whose upgrade branch derives changed from disambiguation alone.
+    #[tokio::test]
+    async fn upgrade_branch_new_stream_reports_changed_true() {
+        let db = db().await;
+        let richer = service_record(
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
+            1_000,
+        );
+        let _ = put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        // Case-B upgrade: disambiguation resolves to stored, but logs_streams gains an entry.
+        let mut subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
+        subset.logs_streams =
+            serde_json::json!(["checkout-service-logs", "checkout-service-logs-v2"]);
+        let outcome = put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert!(
+            outcome.changed,
+            "the stream union gained an entry, so the upgrade branch must report changed"
+        );
+    }
+
     // Orphan deletion is a mutation: only the caller's put event makes nodes drop the dead key.
     #[tokio::test]
     async fn orphan_deletion_on_noop_update_reports_changed_true() {
         let db = db().await;
         let richer_disambiguation =
             serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"});
-        put_with(
+        let _ = put_with(
             &db,
             "org1",
             service_record(richer_disambiguation.clone(), 1_000),

--- a/src/infra/src/table/service_streams.rs
+++ b/src/infra/src/table/service_streams.rs
@@ -191,12 +191,7 @@ pub async fn put(
     put_with(client, org_id, record, max_streams_per_type).await
 }
 
-/// [`put`] against a caller-supplied connection.
-///
-/// The `_with` variant exists so the no-op/write-amplification behavior can be
-/// exercised against a real schema in tests — the same shape
-/// `alert_states::get`/`get_with` already use. `put` delegates here so a test
-/// cannot accidentally verify a different code path from the one production runs.
+/// [`put`] against a caller-supplied connection, so tests exercise the exact production code path.
 pub async fn put_with<C: sea_orm::ConnectionTrait>(
     client: &C,
     org_id: &str,
@@ -748,42 +743,7 @@ mod tests {
         assert!(!record.id.is_empty());
     }
 
-    // ── put_with no-op / write-amplification tests ─────────────────────────
-    //
-    // The bug: `put()` always builds every mutable column as `Set(..)`, so
-    // `.update()` issues a full-column UPDATE even when nothing changed
-    // (measured: 251,333 UPDATEs / 12h in production, ~58% of DB time). The
-    // fix marks a column `Unchanged(existing_value)` instead of `Set(value)`
-    // when the computed new value equals what's already stored, so SeaORM's
-    // own `Updater::is_noop()` (sea-orm 1.1.20, `executor/update.rs`) skips
-    // issuing SQL entirely once every column ends up Unchanged/NotSet.
-    //
-    // Proving "no UPDATE was issued" against sqlite in-memory: row content
-    // alone can't distinguish the fix from the bug (both leave the same
-    // final values — one gets there via a wasted UPDATE). Directly
-    // inspecting SeaORM's `Updater::is_noop()` isn't reachable from outside
-    // the crate. So the fixture (`db()` below) attaches a real SQLite
-    // `AFTER UPDATE OF <column>` trigger per mutable column to
-    // `service_streams`, each incrementing its own counter in a sidecar
-    // `update_audit` table every time that column is named in an UPDATE's
-    // SET clause — regardless of whether the assigned value actually
-    // changed. This is driver-level ground truth: `UpdateOne::prepare_values`
-    // (sea-orm `query/update.rs`) only adds a column to the SQL SET clause
-    // when the ActiveModel field is `ActiveValue::Set(_)`; `Unchanged`/
-    // `NotSet` fields never reach the statement. So `set_clause_count(..)`
-    // for one column proves that column was never `Set(_)` on the
-    // ActiveModel for that call — not just that its final value happens to
-    // match. `last_seen` is `Set(_)` unconditionally in both branches (out
-    // of scope for this fix — see test 7), so `total_set_clause_hits(..)`
-    // is only ever 0 for a call that issues no UPDATE at all (an insert);
-    // an update call that is a no-op for every OTHER column still shows
-    // exactly 1 via `last_seen`, which the per-column tests check for
-    // explicitly rather than relying on the whole-row total.
-
-    /// Every mutable column `put`/`put_with` can write, in the exact spelling
-    /// SQLite uses for the column name (snake_case). Drives the per-column
-    /// audit triggers below, so adding a mutable column to the entity is a
-    /// visible one-line change here rather than a silent gap in coverage.
+    // Nothing enforces this list — keep it in sync manually when adding a mutable column.
     const MUTABLE_COLUMNS: [&str; 7] = [
         "disambiguation",
         "all_dimensions",
@@ -794,21 +754,7 @@ mod tests {
         "last_seen",
     ];
 
-    /// Sidecar table + trigger fixture, matching `alert_states.rs`'s `db()`
-    /// precedent (`Schema::new(backend).create_table_from_entity`) for the
-    /// base schema.
-    ///
-    /// Per-column `AFTER UPDATE OF <col>` triggers are the no-op proof: SQLite
-    /// fires `UPDATE OF <col>` iff `<col>` is named in the UPDATE statement's
-    /// SET clause — independent of whether the assigned value actually
-    /// differs from what was stored (verified directly against sqlite3: a
-    /// same-value `SET a = 10` still fires `AFTER UPDATE OF a`, while an
-    /// UPDATE that never names `a` does not). SeaORM's `UpdateOne::prepare_values`
-    /// (sea-orm `query/update.rs`) only adds a column to the SET clause when
-    /// the ActiveModel field is `ActiveValue::Set(_)` — `Unchanged`/`NotSet`
-    /// fields never reach the statement. So a zero count on a column's audit
-    /// row after a `put_with` call proves that column was never `Set` on the
-    /// ActiveModel for that call — not merely that its final value matches.
+    /// AFTER UPDATE OF a col fires iff it is in the SET clause, which holds only Set(_) fields.
     async fn db() -> sea_orm::DatabaseConnection {
         use sea_orm::{ConnectionTrait, Database, Schema};
 
@@ -838,11 +784,7 @@ mod tests {
         db
     }
 
-    /// Number of times `col` has appeared in an UPDATE statement's SET
-    /// clause against `id` since the fixture was created — SQL-level ground
-    /// truth for "was this column `Set(_)` on the ActiveModel," independent
-    /// of the row's final stored value. See [`db`] for why this is a real
-    /// proof and not a value-equality check in disguise.
+    /// SET-clause appearances of `col` against `id`, regardless of the assigned value.
     async fn set_clause_count(db: &sea_orm::DatabaseConnection, id: &str, col: &str) -> i64 {
         use sea_orm::{ConnectionTrait, FromQueryResult, Statement};
 
@@ -864,10 +806,7 @@ mod tests {
             .unwrap_or(0)
     }
 
-    /// Total UPDATE-statement touches across every mutable column — zero iff
-    /// `Updater::is_noop()` (sea-orm `executor/update.rs`) skipped issuing
-    /// SQL for this row entirely, since a no-op SET clause is empty and no
-    /// column-scoped trigger can fire.
+    /// Zero iff no UPDATE named an audited column (an empty SET clause fires no trigger).
     async fn total_set_clause_hits(db: &sea_orm::DatabaseConnection, id: &str) -> i64 {
         let mut total = 0;
         for col in MUTABLE_COLUMNS {
@@ -876,9 +815,7 @@ mod tests {
         total
     }
 
-    /// A record shaped like real service-registry telemetry: a k8s identity
-    /// set with a cluster/namespace disambiguation, non-trivial stream
-    /// arrays and dimensions — not an empty/degenerate fixture.
+    /// Deliberately non-degenerate: every mergeable field is populated so no-op checks bite.
     fn service_record(disambiguation: serde_json::Value, last_seen: i64) -> ServiceRecord {
         let mut r = ServiceRecord::new("org1", "checkout-service", "k8s", disambiguation);
         r.all_dimensions = serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"});
@@ -890,15 +827,11 @@ mod tests {
         r
     }
 
-    /// 1. Exact-match branch, byte-identical repeat: the second `put_with`
-    /// call must not touch logs/traces/metrics/all_dimensions/field_name_mapping.
-    /// `last_seen` is explicitly OUT of scope for this fix (see [`db`]'s
-    /// sibling test 7): `active.last_seen = Set(record.last_seen)` stays
-    /// unconditional, so it is `Set(_)` on every call regardless of whether
-    /// its value changed, and its own trigger firing once here is expected,
-    /// not a bug — only the other 5 columns' triggers must stay silent.
+    // The fix must compare serde_json::Value equality, not JSON text: prod enables preserve_order.
+
+    // last_seen is always Set (out of scope), so an UPDATE still occurs; data columns must not.
     #[tokio::test]
-    async fn exact_repeat_call_issues_no_update() {
+    async fn exact_repeat_call_sets_no_data_columns() {
         let db = db().await;
         let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
         let first = service_record(disambiguation.clone(), 1_000);
@@ -934,13 +867,7 @@ mod tests {
         }
     }
 
-    /// 2. Partial change: only `traces_streams` grows between calls. Proves,
-    /// at the SQL SET-clause level (not just final row values, which the old
-    /// buggy code would also get right via a wasted full-column UPDATE):
-    /// `traces_streams` was actually `Set(_)` on the ActiveModel, while
-    /// `disambiguation`/`all_dimensions`/`logs_streams`/`metrics_streams`/
-    /// `field_name_mapping` were not — only `last_seen` (always written,
-    /// out of scope for this fix) and `traces_streams` may appear.
+    // Only traces_streams grows, so only it and always-written last_seen may reach the SET clause.
     #[tokio::test]
     async fn partial_change_updates_only_when_a_field_actually_differs() {
         let db = db().await;
@@ -963,9 +890,7 @@ mod tests {
             1,
             "traces_streams grew, so it must have been Set(_) on the ActiveModel"
         );
-        // last_seen is unconditionally Set every call regardless of scope (out of
-        // scope for this fix), so it is expected to appear here even though its
-        // value (1_000) did not change between the two calls.
+        // Same-value guard: last_seen stays Set(_) every call, catching a fix that skips it.
         assert_eq!(
             set_clause_count(&db, &first_id, "last_seen").await,
             1,
@@ -1008,13 +933,7 @@ mod tests {
         );
     }
 
-    /// 3. Full change: every field the exact-match branch can touch differs
-    /// between calls. Proves a real UPDATE happens and every new value is
-    /// actually persisted. `disambiguation` is excluded here on purpose: the
-    /// exact-match branch is reached only when disambiguation is identical
-    /// between calls (that is what makes it an exact match), and the branch
-    /// never assigns `active.disambiguation` at all — only the upgrade
-    /// branch (tests 5a/5b) can rewrite it.
+    // disambiguation must stay 0: the exact-match branch never assigns it, only upgrade does.
     #[tokio::test]
     async fn full_change_updates_and_persists_every_new_value() {
         let db = db().await;
@@ -1065,6 +984,11 @@ mod tests {
             serde_json::json!(["checkout-service-logs", "checkout-service-logs-v2"]),
             "logs_streams unions rather than replaces — existing entries are kept"
         );
+        assert_eq!(
+            row.metrics_streams,
+            serde_json::json!(["checkout-service-metrics", "checkout-service-metrics-v2"]),
+            "metrics_streams unions rather than replaces — existing entries are kept"
+        );
         assert_eq!(row.last_seen, 2_000);
         assert_eq!(
             row.field_name_mapping,
@@ -1072,10 +996,7 @@ mod tests {
         );
     }
 
-    /// 4a. `field_name_mapping: None` on the second call must leave the
-    /// stored mapping untouched — existing behavior, must not regress —
-    /// and must not itself force a rewrite (only `last_seen`, out of scope
-    /// for this fix, is expected to have been `Set(_)`).
+    // Incoming None must preserve the stored mapping and not itself force a rewrite.
     #[tokio::test]
     async fn field_name_mapping_none_preserves_existing_value_and_is_a_noop_field() {
         let db = db().await;
@@ -1118,8 +1039,6 @@ mod tests {
         );
     }
 
-    /// 4b. `field_name_mapping: Some(x)` where `x` is byte-identical to what's
-    /// stored counts as a no-op for this field specifically.
     #[tokio::test]
     async fn field_name_mapping_identical_some_is_a_noop_field() {
         let db = db().await;
@@ -1143,8 +1062,6 @@ mod tests {
         );
     }
 
-    /// 4c. `field_name_mapping: Some(x)` where `x` differs from what's stored
-    /// must produce a real update.
     #[tokio::test]
     async fn field_name_mapping_changed_some_updates() {
         let db = db().await;
@@ -1177,16 +1094,10 @@ mod tests {
         );
     }
 
-    /// 5a. Upgrade branch: incoming disambiguation is a subset of the
-    /// existing (richer) row's, and the richer_disambiguation therefore
-    /// resolves to byte-identical to what's already stored. `disambiguation`
-    /// (upgrade-branch-only field) must be marked Unchanged, not rewritten —
-    /// combined with identical logs/traces/metrics/all_dimensions/
-    /// field_name_mapping, the whole call must be a no-op.
+    // Subset incoming resolves richer_disambiguation to the stored value: rewrite nothing.
     #[tokio::test]
     async fn upgrade_branch_subset_incoming_leaves_richer_disambiguation_untouched() {
         let db = db().await;
-        // Existing row already has the richer disambiguation.
         let richer = service_record(
             serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
             1_000,
@@ -1196,9 +1107,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Incoming disambiguation ({"k8s-cluster": "prod"}) is a strict subset
-        // of the stored one, and every other mutable field is identical, so
-        // richer_disambiguation resolves to the existing value verbatim.
         let subset = service_record(serde_json::json!({"k8s-cluster": "prod"}), 1_000);
         put_with(&db, "org1", subset, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
@@ -1229,9 +1137,6 @@ mod tests {
         );
     }
 
-    /// 5b. Upgrade branch: incoming disambiguation is richer than the
-    /// existing (subset) row's, so richer_disambiguation genuinely changes —
-    /// this must be a real update, including the disambiguation column.
     #[tokio::test]
     async fn upgrade_branch_richer_incoming_updates_disambiguation() {
         let db = db().await;
@@ -1241,10 +1146,13 @@ mod tests {
             .await
             .unwrap();
 
-        let richer = service_record(
+        // The extra stream and newer last_seen catch an upgrade branch that stops writing them.
+        let mut richer = service_record(
             serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
-            1_000,
+            2_000,
         );
+        richer.traces_streams =
+            serde_json::json!(["checkout-service-traces", "checkout-service-traces-v2"]);
         put_with(&db, "org1", richer, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
             .unwrap();
@@ -1253,6 +1161,16 @@ mod tests {
             set_clause_count(&db, &sparse_id, "disambiguation").await,
             1,
             "the incoming row is richer, so disambiguation must actually have been Set(_)"
+        );
+        assert_eq!(
+            set_clause_count(&db, &sparse_id, "traces_streams").await,
+            1,
+            "the union gained a stream, so the upgrade branch must have Set(_) traces_streams"
+        );
+        assert_eq!(
+            set_clause_count(&db, &sparse_id, "last_seen").await,
+            1,
+            "the upgrade branch must keep writing last_seen"
         );
         let row = Entity::find_by_id(sparse_id)
             .one(&db)
@@ -1263,12 +1181,14 @@ mod tests {
             row.disambiguation,
             serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"})
         );
+        assert_eq!(
+            row.traces_streams,
+            serde_json::json!(["checkout-service-traces", "checkout-service-traces-v2"]),
+            "the upgrade must persist the stream union, not discard it"
+        );
+        assert_eq!(row.last_seen, 2_000);
     }
 
-    /// 6. Insert path (no existing row, no upgrade candidate) must keep
-    /// working exactly as today — a regression-safety check, not new
-    /// behavior. An insert is not an UPDATE at all, so it must not touch
-    /// any of the update-counting triggers.
     #[tokio::test]
     async fn plain_insert_is_unaffected_and_is_not_an_update() {
         let db = db().await;
@@ -1294,12 +1214,7 @@ mod tests {
         );
     }
 
-    /// 7. `last_seen` is explicitly out of scope for this fix: it must be
-    /// written on every call, even when every other field is identical.
-    /// Guards against the fix accidentally scope-creeping into also
-    /// skipping `last_seen` (that coarsening is a separate, deferred
-    /// change) — this call SHOULD still issue a real UPDATE of `last_seen`,
-    /// while every other (identical) field stays Unchanged(_).
+    // Guards "never writes last_seen" only; the same-value guard is in the partial-change test.
     #[tokio::test]
     async fn last_seen_always_updates_even_when_nothing_else_changed() {
         let db = db().await;
@@ -1310,7 +1225,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Only last_seen differs from the first call.
         let second = service_record(disambiguation, 2_000);
         put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
             .await
@@ -1341,5 +1255,101 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(row.last_seen, 2_000);
+    }
+
+    // Raw incoming differs but union(stored, subset) == stored: the fix must compare the merge.
+    #[tokio::test]
+    async fn subset_incoming_streams_are_a_noop() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let mut first = service_record(disambiguation.clone(), 1_000);
+        first.logs_streams =
+            serde_json::json!(["checkout-service-logs", "checkout-service-logs-v2"]);
+        first.traces_streams =
+            serde_json::json!(["checkout-service-traces", "checkout-service-traces-v2"]);
+        first.metrics_streams =
+            serde_json::json!(["checkout-service-metrics", "checkout-service-metrics-v2"]);
+        let first_id = first.id.clone();
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        // service_record()'s 1-element stream arrays are strict subsets of what is now stored.
+        let mut second = service_record(disambiguation, 2_000);
+        second.all_dimensions = serde_json::json!({"k8s-cluster": "prod"});
+        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        for col in [
+            "disambiguation",
+            "all_dimensions",
+            "logs_streams",
+            "traces_streams",
+            "metrics_streams",
+            "field_name_mapping",
+        ] {
+            assert_eq!(
+                set_clause_count(&db, &first_id, col).await,
+                0,
+                "{col}: its merged value equals what is stored, so it must never have been Set(_)"
+            );
+        }
+        assert_eq!(
+            set_clause_count(&db, &first_id, "last_seen").await,
+            1,
+            "last_seen is always written, in or out of the no-op set"
+        );
+        let row = Entity::find_by_id(first_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.logs_streams,
+            serde_json::json!(["checkout-service-logs", "checkout-service-logs-v2"]),
+            "the stored superset must survive a subset put untouched"
+        );
+    }
+
+    // union_dimension_objects is base-wins, so same-keys/new-values merges back to stored.
+    #[tokio::test]
+    async fn same_keys_different_values_all_dimensions_is_a_noop() {
+        let db = db().await;
+        let disambiguation = serde_json::json!({"k8s-cluster": "prod"});
+        let first = service_record(disambiguation.clone(), 1_000);
+        let first_id = first.id.clone();
+        put_with(&db, "org1", first, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        // Same keys as stored ({"k8s-cluster", "k8s-namespace"}), every value different.
+        let mut second = service_record(disambiguation, 1_000);
+        second.all_dimensions =
+            serde_json::json!({"k8s-cluster": "staging", "k8s-namespace": "legacy"});
+        put_with(&db, "org1", second, DEFAULT_MAX_STREAMS_PER_TYPE)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            set_clause_count(&db, &first_id, "all_dimensions").await,
+            0,
+            "base-wins merge resolves to the stored value, so all_dimensions must never have been Set(_)"
+        );
+        assert_eq!(
+            set_clause_count(&db, &first_id, "last_seen").await,
+            1,
+            "last_seen is always written, in or out of the no-op set"
+        );
+        let row = Entity::find_by_id(first_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.all_dimensions,
+            serde_json::json!({"k8s-cluster": "prod", "k8s-namespace": "ecommerce"}),
+            "stored values win over conflicting incoming values"
+        );
     }
 }

--- a/src/jobs/src/job/mod.rs
+++ b/src/jobs/src/job/mod.rs
@@ -1193,6 +1193,14 @@ pub async fn init() -> Result<(), anyhow::Error> {
                                 "[service_streams_cleanup] org={} evicted={} duration={:.3}s",
                                 org_id, evicted, duration
                             );
+                            // Nothing else announces deletions: flush emits are gated on changed.
+                            if let Err(e) =
+                                infra::coordinator::service_streams::emit_reload_event(org_id).await
+                            {
+                                log::error!(
+                                    "[service_streams_cleanup] org={org_id} failed to emit reload event: {e}"
+                                );
+                            }
                         }
                     }
                     Err(e) => {

--- a/src/super_cluster_queue/src/service_streams.rs
+++ b/src/super_cluster_queue/src/service_streams.rs
@@ -50,7 +50,16 @@ pub(crate) async fn process_msg(msg: ServiceStreamsMessage) -> Result<()> {
             .await?;
             // A no-op put must not make every node re-read the org's whole table.
             if outcome.changed {
-                infra::coordinator::service_streams::emit_put_event(&org_id).await?;
+                // Never propagate: a redelivered apply re-derives changed=false, losing the emit.
+                for attempt in 1..=3u8 {
+                    match infra::coordinator::service_streams::emit_put_event(&org_id).await {
+                        Ok(()) => break,
+                        Err(e) if attempt == 3 => log::error!(
+                            "[SUPER_CLUSTER:service_streams] emit_put_event failed after {attempt} attempts: org={org_id} error={e}"
+                        ),
+                        Err(_) => tokio::time::sleep(std::time::Duration::from_millis(500)).await,
+                    }
+                }
             }
         }
         ServiceStreamsMessage::Delete {

--- a/src/super_cluster_queue/src/service_streams.rs
+++ b/src/super_cluster_queue/src/service_streams.rs
@@ -42,13 +42,16 @@ pub(crate) async fn process_msg(msg: ServiceStreamsMessage) -> Result<()> {
             let org_id = record.org_id.clone();
             // Orphan disambiguations are irrelevant here: the put event below makes this
             // cluster's nodes reload the org's services wholesale (F19).
-            let _orphans = service_streams::put(
+            let outcome = service_streams::put(
                 &org_id,
                 *record,
                 service_streams::DEFAULT_MAX_STREAMS_PER_TYPE,
             )
             .await?;
-            infra::coordinator::service_streams::emit_put_event(&org_id).await?;
+            // A no-op put must not make every node re-read the org's whole table.
+            if outcome.changed {
+                infra::coordinator::service_streams::emit_put_event(&org_id).await?;
+            }
         }
         ServiceStreamsMessage::Delete {
             org_id,


### PR DESCRIPTION
## Summary

Fixes four Postgres performance defects diagnosed from production introspect telemetry on the poc cluster, all in the compactor / service-discovery pipeline. Paired PR in o2-enterprise on the same branch name.

| # | Defect (production telemetry) | Fix |
|---|---|---|
| 1 | `service_streams::put()` issued a full 6-column UPDATE (4 JSONB) on every re-observed service — **251,333 UPDATEs/12h, 58% of DB time** | Per-field `Unchanged`/`Set` dirty-checking (serde_json::Value equality); unchanged columns leave the SET clause; a pure no-op writes only `last_seen` |
| 2 | Every non-empty flush emitted a cache-invalidation event; every querier re-read the org's whole table — **1,887 unbounded full-org SELECTs/12h, max 31.3s** | `PutOutcome.changed` (data column Set ∥ insert ∥ orphan deleted; never last_seen alone) gates `emit_put_event`; cleanup job now announces deletions; consumer retries emits under queue redelivery |
| 3 | `DELETE FROM file_list WHERE id IN(…)` on a date-partitioned table probed **every partition's** local index — p95 3.7s, max 23.3s, 2× disk-over-cache reads | Both delete sites thread `(id, date)` pairs and route through one pruned-statement builder (`WHERE date = $1 AND id IN (…)`), chunked by `file_list_deleted_batch_size` |
| 4 | `get_pending_jobs` serialized every compactor node on one global advisory lock (claim p50 1.14s, mostly lock-wait); the SQL had zero double-claim protection | Advisory lock removed; claims are self-guarding via CTE + `FOR UPDATE OF j SKIP LOCKED` with an EvalPlanQual status re-check; status-guarded UPDATE and filtered re-select as defense-in-depth |

## Measured evidence

- **Live capture on the fixed build** (real OTLP load, 75 services, 4,434 puts): dominant UPDATE shape is `SET "last_seen" = $1` (single column); partial changes emit exactly the changed field. Zero sightings of the legacy advisory-lock key across 24,665 `pg_locks` samples; 11/11 merge jobs claimed and completed lock-free; 508 rows deleted through the pruned path (each sub-ms).
- **Controlled EXPLAIN ANALYZE** (30-partition, 3M-row table): old delete shape scans 30 partitions / holds 187 relation locks; new shape scans 1 / holds 13 — ~20× cold.
- **EPQ semantics verified empirically**: with a peer committing mid-claim, the `j.status = $1` re-check excludes the just-claimed row; without it, a stale double-claim reproduces.

## Test coverage

All change-bearing code is TDD'd: suites were written first, hardened through two independent cold-review rounds each (including live mutation testing — e.g. the pruning suite fails 3 tests if the date predicate is dropped; the SKIP LOCKED suite fails on a plain-FOR-UPDATE regression via a timeout pin), then the implementation was reviewed the same way. `service_streams` suite: 35 passed / 0 failed. New DB-backed tests follow the existing `#[ignore]` convention (CI provisions no `TEST_POSTGRES_URL`); run them with `TEST_POSTGRES_URL=… cargo test -p infra --lib -- --include-ignored --test-threads=1 <filters>`.

## Notes for reviewers / dashboards

- `DB_QUERY_NUMS{operation="get_lock"}` steps down at deploy (get_pending_jobs' contribution removed; two other advisory sites remain).
- Delete QPS for `file_list` rises (one statement per date group instead of per chunk); each statement is single-partition and sub-ms.
- Super-cluster replication is deliberately **ungated**: remote `last_seen` advances only via those sends and remote stale-reapers key off it (a gated version was implemented, then reverted after review proved it would reap live services remotely).
- `sqlite` backend keeps a flat delete (unpartitioned) with an adapted signature.
- Follow-ups deliberately out of scope: `last_seen` write throttling (needs a stale-threshold margin design), startup jitter for compactor polling, running the ignored Postgres tests in CI.

## Enterprise pairing

Requires the paired o2-enterprise PR (same branch): `PutOutcome` adaptation, flush emit gated on aggregated `changed`, replication kept unconditional, per-service error over-emit hardening. Enterprise compile verified via the `Cargo.toml.openobserve` swap-check (`cargo check --all-targets` clean).