### PR TITLE
fix: publish nodes only after gRPC listener binds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -596,7 +596,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
     "tls12",
 ] }
 tokio-util = { version = "0.7", features = ["compat"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { version = "0.14", features = [
     "gzip",
     "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -596,7 +596,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
     "tls12",
 ] }
 tokio-util = { version = "0.7", features = ["compat"] }
-tokio-stream = { version = "0.1", features = ["net"] }
+tokio-stream = "0.1"
 tonic = { version = "0.14", features = [
     "gzip",
     "zstd",

--- a/src/api/grpc/src/server.rs
+++ b/src/api/grpc/src/server.rs
@@ -30,7 +30,8 @@ use proto::cluster_rpc::{
     search_server::SearchServer, streams_server::StreamsServer,
 };
 use search_service::SEARCH_SERVER;
-use tokio::sync::oneshot;
+use tokio::{net::TcpListener, sync::oneshot};
+use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{
     codec::CompressionEncoding,
     service::interceptor::InterceptedService,
@@ -163,7 +164,7 @@ async fn run_common(
         if cfg.grpc.tls_enabled { "with TLS" } else { "" },
         gaddr
     );
-    init_tx.send(()).ok();
+    let listener = bind_listener(gaddr, init_tx).await?;
 
     let mut builder = server_builder()?;
     let ret = builder
@@ -179,7 +180,7 @@ async fn run_common(
         .add_service(flight_svc)
         .add_service(node_svc)
         .add_service(cluster_info_svc)
-        .serve_with_shutdown(gaddr, async {
+        .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
             shutdown_rx.await.ok();
             log::info!("gRPC server starts shutting down");
         })
@@ -227,14 +228,14 @@ async fn run_router(
         if cfg.grpc.tls_enabled { "with TLS" } else { "" },
         gaddr
     );
-    init_tx.send(()).ok();
+    let listener = bind_listener(gaddr, init_tx).await?;
 
     let mut builder = server_builder()?;
     let ret = builder
         .add_service(logs_svc)
         .add_service(metrics_svc)
         .add_service(traces_svc)
-        .serve_with_shutdown(gaddr, async {
+        .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
             shutdown_rx.await.ok();
             log::info!("gRPC server starts shutting down");
         })
@@ -257,6 +258,17 @@ fn otlp_authenticated<S>(service: S) -> InterceptedService<S, AuthInterceptor> {
     InterceptedService::new(service, check_otlp_auth)
 }
 
+async fn bind_listener(
+    gaddr: SocketAddr,
+    init_tx: oneshot::Sender<()>,
+) -> Result<TcpListener, anyhow::Error> {
+    let listener = TcpListener::bind(gaddr).await?;
+    init_tx
+        .send(())
+        .map_err(|_| anyhow::anyhow!("gRPC initialization receiver dropped"))?;
+    Ok(listener)
+}
+
 fn server_builder() -> Result<tonic::transport::Server, anyhow::Error> {
     let cfg = get_config();
     let builder = if cfg.grpc.tls_enabled {
@@ -272,4 +284,39 @@ fn server_builder() -> Result<tonic::transport::Server, anyhow::Error> {
         .initial_connection_window_size(config::GRPC_HTTP2_CONNECTION_WINDOW_SIZE)
         .http2_adaptive_window(Some(cfg.grpc.http2_adaptive_window))
         .tcp_nodelay(true))
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::net::TcpStream;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn init_is_signaled_after_grpc_socket_listens() {
+        let gaddr = "127.0.0.1:0".parse().unwrap();
+        let (init_tx, init_rx) = oneshot::channel();
+
+        let listener = bind_listener(gaddr, init_tx).await.unwrap();
+        init_rx.await.unwrap();
+
+        assert!(
+            TcpStream::connect(listener.local_addr().unwrap())
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_bind_does_not_signal_init() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let (init_tx, init_rx) = oneshot::channel();
+
+        assert!(
+            bind_listener(listener.local_addr().unwrap(), init_tx)
+                .await
+                .is_err()
+        );
+        assert!(init_rx.await.is_err());
+    }
 }

--- a/src/api/grpc/src/server.rs
+++ b/src/api/grpc/src/server.rs
@@ -31,11 +31,10 @@ use proto::cluster_rpc::{
 };
 use search_service::SEARCH_SERVER;
 use tokio::{net::TcpListener, sync::oneshot};
-use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{
     codec::CompressionEncoding,
     service::interceptor::InterceptedService,
-    transport::{Identity, ServerTlsConfig},
+    transport::{Identity, ServerTlsConfig, server::TcpIncoming},
 };
 
 use crate::{
@@ -164,7 +163,7 @@ async fn run_common(
         if cfg.grpc.tls_enabled { "with TLS" } else { "" },
         gaddr
     );
-    let listener = bind_listener(gaddr, init_tx).await?;
+    let incoming = TcpIncoming::from(bind_listener(gaddr, init_tx).await?).with_nodelay(Some(true));
 
     let mut builder = server_builder()?;
     let ret = builder
@@ -180,7 +179,7 @@ async fn run_common(
         .add_service(flight_svc)
         .add_service(node_svc)
         .add_service(cluster_info_svc)
-        .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+        .serve_with_incoming_shutdown(incoming, async {
             shutdown_rx.await.ok();
             log::info!("gRPC server starts shutting down");
         })
@@ -228,14 +227,14 @@ async fn run_router(
         if cfg.grpc.tls_enabled { "with TLS" } else { "" },
         gaddr
     );
-    let listener = bind_listener(gaddr, init_tx).await?;
+    let incoming = TcpIncoming::from(bind_listener(gaddr, init_tx).await?).with_nodelay(Some(true));
 
     let mut builder = server_builder()?;
     let ret = builder
         .add_service(logs_svc)
         .add_service(metrics_svc)
         .add_service(traces_svc)
-        .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+        .serve_with_incoming_shutdown(incoming, async {
             shutdown_rx.await.ok();
             log::info!("gRPC server starts shutting down");
         })
@@ -288,6 +287,7 @@ fn server_builder() -> Result<tonic::transport::Server, anyhow::Error> {
 
 #[cfg(test)]
 mod tests {
+    use futures::StreamExt;
     use tokio::net::TcpStream;
 
     use super::*;
@@ -318,5 +318,17 @@ mod tests {
                 .is_err()
         );
         assert!(init_rx.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn incoming_stream_enables_tcp_nodelay() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut incoming = TcpIncoming::from(listener).with_nodelay(Some(true));
+
+        let _client = TcpStream::connect(addr).await.unwrap();
+        let accepted = incoming.next().await.unwrap().unwrap();
+
+        assert!(accepted.nodelay().unwrap());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,6 @@ async fn main() -> Result<(), anyhow::Error> {
     let (grpc_stopped_tx, grpc_stopped_rx) = oneshot::channel();
     let grpc_rt_handle = std::thread::spawn(move || {
         let Ok(rt) = create_grpc_runtime() else {
-            grpc_init_tx.send(()).ok();
             panic!("grpc runtime init failed");
         };
 
@@ -272,7 +271,9 @@ async fn main() -> Result<(), anyhow::Error> {
     });
 
     // wait for gRPC init
-    grpc_init_rx.await.ok();
+    grpc_init_rx
+        .await
+        .map_err(|e| anyhow::anyhow!("gRPC server init failed: {e}"))?;
 
     // Register main HTTP runtime for metrics collection
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -283,7 +284,7 @@ async fn main() -> Result<(), anyhow::Error> {
     openobserve_node::runtime_metrics::start_metrics_collector().await;
 
     // let node online
-    let _ = cluster::set_online().await;
+    cluster::set_online().await?;
 
     // initialize the jobs are deferred until the gRPC service starts
     job::init_deferred()


### PR DESCRIPTION
## Summary

- bind the gRPC socket before reporting initialization in both common-node and router startup paths
- serve Tonic from the already-bound listener, so cluster publication cannot race ahead of TCP listen
- propagate gRPC initialization and cluster publication failures instead of continuing after a dropped signal
- add coverage for the readiness and bind-failure invariants

## Reproduction and confirmation

I checked the current `main` startup sequence in both `run_common` and `run_router`: each sent `init_tx` before calling `serve_with_shutdown`, while `main` awaited that signal and immediately called `cluster::set_online()`. This leaves a scheduling window where peers can select the node before its gRPC port is listening.

## Before and after

### Before

Both gRPC startup paths reported initialization before asking Tonic to bind the configured address:

```rust
init_tx.send(()).ok();

let mut builder = server_builder()?;
builder
    .add_service(/* ... */)
    .serve_with_shutdown(gaddr, shutdown)
    .await;
```

The main task treats that initialization signal as permission to publish the node:

```rust
grpc_init_rx.await.ok();
let _ = cluster::set_online().await;
```

### After

The listener is bound first, and only then is initialization reported. Tonic receives that same, already-bound listener:

```rust
let listener = bind_listener(gaddr, init_tx).await?;

let mut builder = server_builder()?;
builder
    .add_service(/* ... */)
    .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
    .await;
```

```rust
let listener = TcpListener::bind(gaddr).await?;
init_tx.send(())?;
```

This preserves the required ordering: bind/listen succeeds → startup is reported → node can be published `Online`. The change is applied to both common-node and router gRPC servers.

## Verification

- `cargo +1.97.1 fmt --all -- --check`
- `git diff --check`
- targeted gRPC test build started locally with the installed nightly compiler and `protoc 27.1`; it is still compiling this workspace

Fixes #14018

## Intentional startup failure handling

Changing `cluster::set_online().await` to use `?` is intentional. If a node cannot publish its `Online` state after the gRPC listener is ready, startup now fails rather than running in a partially initialized state that peers cannot discover consistently. This is part of making readiness publication an explicit startup contract.

The follow-up keeps `TCP_NODELAY` on accepted gRPC connections by using `TcpIncoming::from(listener).with_nodelay(Some(true))`; Tonic documents that this setting is ignored for a bare caller-provided stream. The added regression test accepts a real TCP connection through `TcpIncoming` and asserts that `TCP_NODELAY` is enabled.