### PR TITLE
chore: streamline external and dependabot PR automation

### DIFF
--- a/.github/workflows/auto-assign-metadata.yml
+++ b/.github/workflows/auto-assign-metadata.yml
@@ -233,14 +233,20 @@ jobs:
             && echo "Assigned simranquirky to stranger issue #$NUMBER" \
             || echo "::warning::Could not assign to stranger issue #$NUMBER"
 
-      # ── Stranger: assign PR to oasisk + hengfeiyang ──
-      - name: Assign stranger PR
+      # ── Stranger: assign PR to hengfeiyang + label as community (label skips bots) ──
+      - name: Assign and label stranger PR
         if: github.event_name == 'pull_request_target' && steps.classify.outputs.category == 'stranger'
         env:
           GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.pull_request.number }}
+          USER_TYPE: ${{ github.event.pull_request.user.type }}
         run: |
-          gh pr edit "$NUMBER" --add-assignee "oasisk" --add-assignee "hengfeiyang" \
-            && echo "Assigned oasisk and hengfeiyang to stranger PR #$NUMBER" \
+          gh pr edit "$NUMBER" --add-assignee "hengfeiyang" \
+            && echo "Assigned hengfeiyang to stranger PR #$NUMBER" \
             || echo "::warning::Could not assign to stranger PR #$NUMBER"
+          if [ "$USER_TYPE" != "Bot" ]; then
+            gh pr edit "$NUMBER" --add-label "community" \
+              && echo "Labeled stranger PR #$NUMBER as community" \
+              || echo "::warning::Could not label stranger PR #$NUMBER"
+          fi

--- a/.github/workflows/auto-assign-metadata.yml
+++ b/.github/workflows/auto-assign-metadata.yml
@@ -250,3 +250,21 @@ jobs:
               && echo "Labeled stranger PR #$NUMBER as community" \
               || echo "::warning::Could not label stranger PR #$NUMBER"
           fi
+
+      # ── Dependabot: label e2e to unlock gated CI, approve any held runs ──
+      - name: Enable CI for dependabot PR
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh pr edit "$NUMBER" --add-label "e2e" \
+            && echo "Labeled dependabot PR #$NUMBER with e2e" \
+            || echo "::warning::Could not label dependabot PR #$NUMBER"
+          for id in $(gh api "repos/$GH_REPO/actions/runs?head_sha=$HEAD_SHA&status=action_required" --jq '.workflow_runs[].id'); do
+            gh api -X POST "repos/$GH_REPO/actions/runs/$id/approve" \
+              && echo "Approved held run $id" \
+              || echo "::warning::Could not approve run $id"
+          done

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+# Merge a dependabot PR the moment a maintainer approves it; branch protection
+# (1 approval + required checks) still decides whether the merge is allowed.
+name: Dependabot Auto Merge
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  merge:
+    if: >-
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.review.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Merge approved dependabot PR
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr merge "$NUMBER" --squash \
+            && echo "Merged dependabot PR #$NUMBER" \
+            || echo "::warning::PR #$NUMBER not merged — required checks or reviews not yet satisfied"


### PR DESCRIPTION
## Summary

**External contributor PRs** — merged into a single step in the existing `auto-assign-metadata` workflow (its `stranger` classification: not on the engineering allowlist and not an org member):

- Auto-assign now adds **hengfeiyang only** (oasisk removed).
- The PR also gets the `community` label, skipped for bot authors via `user.type`.

**Dependabot PRs** (new step + new workflow):

- `auto-assign-metadata`: adds the `e2e` label so the label-gated api-testing suites run, and approves any workflow runs held as `action_required` (a safety net — held runs have not been observed for dependabot).
- `dependabot-auto-merge.yml`: on an approving review from a MEMBER/OWNER/COLLABORATOR, attempts `gh pr merge --squash`. Branch protection (1 approval + required checks) remains the authority — the merge simply fails with a warning until it is satisfied, so nothing can land without a maintainer approval and green CI.

Both reuse the existing classify step and `ORG_ADMIN_TOKEN`; no new checkout steps, so the `pull_request_target` safety note in the file still holds.

## Why

Make external contributions immediately identifiable and filterable via `label:community` with a single triage owner, and reduce dependabot PRs to a one-click approve.

## Test plan

- YAML validated; steps mirror the surrounding steps' structure and guard conditions.
- `community` label exists and has been backfilled onto the currently open external PRs.
- Auto-merge path exercises only on dependabot-authored PRs and cannot bypass branch protection.