### PR TITLE
fix: MCP auth on SSO deployments — first-use provisioning + browser CORS

### DIFF
--- a/src/api/common/src/auth/token.rs
+++ b/src/api/common/src/auth/token.rs
@@ -54,6 +54,26 @@ fn may_skip_permission_check(
     is_list_invite_call || is_reject_invite_call || is_member_subscription || is_org_list_call
 }
 
+/// The identity to hand `process_token` when provisioning a first-time SSO user
+/// who arrived over MCP.
+///
+/// `verify_decode_token` stamps `user_role: Some(ServiceAccount)` on every
+/// response whose audience check was relaxed — which is precisely the MCP case,
+/// since MCP clients register dynamically with Dex and so never carry our static
+/// `client_id` as `aud`. `process_token` treats that field as the role to create
+/// the user with, so passing it through would provision a human SSO login as a
+/// service account and skip the OpenFGA user-creation tuple. Clear it so the
+/// user lands on `O2_DEX_DEFAULT_ROLE`, exactly as a web SSO login would.
+#[cfg(any(feature = "enterprise", test))]
+fn sso_identity_for_provisioning(
+    token_res: &common::meta::user::TokenValidationResponse,
+) -> common::meta::user::TokenValidationResponse {
+    common::meta::user::TokenValidationResponse {
+        user_role: None,
+        ..token_res.clone()
+    }
+}
+
 #[cfg(feature = "enterprise")]
 pub async fn token_validator(
     req_data: &RequestData,
@@ -61,7 +81,7 @@ pub async fn token_validator(
 ) -> Result<AuthValidationResult, AuthError> {
     use openobserve_core::{auth::V2_API_PREFIX, authz::check_permissions};
 
-    let user;
+    let mut user;
     let keys = get_dex_jwks().await;
     let path = match req_data
         .uri
@@ -87,16 +107,18 @@ pub async fn token_validator(
     // For MCP requests with dynamic clients, skip audience validation
     let login_flow = !is_mcp_request;
 
+    // The decoded claims are only needed to provision a first-time SSO identity
+    // arriving on the MCP endpoint (see below); every other path discards them.
     match jwt::verify_decode_token(
         auth_info.auth.strip_prefix("Bearer").unwrap().trim(),
         &keys,
         &get_dex_config().client_id,
-        false,
+        is_mcp_endpoint,
         login_flow,
     ) {
-        Ok(res) => {
-            let user_id = &res.0.user_email;
-            if res.0.is_valid {
+        Ok((token_res, token_data)) => {
+            let user_id = token_res.user_email.as_str();
+            if token_res.is_valid {
                 // System-wide blocklist. This path validates Dex-issued session tokens (the UI
                 // `access_token: "session …"` cookie flow), which are EXTERNAL SSO identities by
                 // construction — so a blocked email must be denied on EVERY request, not only at
@@ -203,6 +225,28 @@ pub async fn token_validator(
                         }
                     }
                 };
+
+                // An MCP client registers dynamically with Dex and receives the code at
+                // its OWN callback, so `/config/redirect` — the only place external
+                // identities are provisioned — never runs for it. Without provisioning
+                // here an SSO user who has never opened the web UI authenticates fine but
+                // has no membership, and the resulting 401 sends the client back through
+                // authorization forever. Gated on the real `/{org}/mcp` path, never the
+                // caller-settable `x-o2-mcp` header, and only for an identity with no user
+                // record at all — so this cannot be driven repeatedly on other routes.
+                if user.is_none()
+                    && is_mcp_endpoint
+                    && let Some(token_data) = token_data
+                    && let Some(org_id) = path_columns.first()
+                    && db::user::get_user_by_email(user_id).await.is_none()
+                {
+                    let sso_identity = sso_identity_for_provisioning(&token_res);
+                    match super::jwt::process_token((sso_identity, Some(token_data))).await {
+                        Ok(_) => user = users::get_user(Some(org_id), user_id).await,
+                        Err(e) => log::warn!("MCP SSO provisioning failed for {user_id}: {e}"),
+                    }
+                }
+
                 match user {
                     // specifically for list invite call, even if the user is not present
                     // in db, which can be the case when a new user is joining o2 cloud for first
@@ -221,7 +265,7 @@ pub async fn token_validator(
                     {
                         // Allow these special cases without requiring user in DB
                         Ok(AuthValidationResult {
-                            user_email: res.0.user_email.clone(),
+                            user_email: token_res.user_email.clone(),
                             user_role: None,
                             is_internal_user: false,
                         })
@@ -326,5 +370,37 @@ mod tests {
              (allow_nonexistent_user) was a cross-org authorization bypass and \
              must not return."
         );
+    }
+
+    /// SECURITY REGRESSION GUARD: MCP tokens reach `verify_decode_token` with the
+    /// audience check relaxed, which stamps `user_role: Some(ServiceAccount)`.
+    /// Provisioning must not inherit it — a human SSO login created as a service
+    /// account gets the wrong role and is skipped by the OpenFGA user-creation
+    /// tuple, and service accounts are barred from interactive login elsewhere.
+    #[test]
+    fn mcp_provisioning_never_inherits_the_service_account_stamp() {
+        let stamped = common::meta::user::TokenValidationResponse {
+            is_valid: true,
+            user_email: "sso.user@example.com".to_string(),
+            user_name: "SSO User".to_string(),
+            family_name: "User".to_string(),
+            given_name: "SSO".to_string(),
+            is_internal_user: false,
+            user_role: Some(config::meta::user::UserRole::ServiceAccount),
+        };
+
+        let provisioned = sso_identity_for_provisioning(&stamped);
+
+        assert_eq!(
+            provisioned.user_role, None,
+            "SECURITY: the ServiceAccount role stamped by the relaxed-audience \
+             decode must be cleared before provisioning, so the identity falls \
+             back to O2_DEX_DEFAULT_ROLE like a web SSO login."
+        );
+        assert_eq!(
+            provisioned.user_email, stamped.user_email,
+            "the identity itself must be carried through unchanged"
+        );
+        assert_eq!(provisioned.user_name, stamped.user_name);
     }
 }

--- a/src/api/http/src/handler/http/router/mod.rs
+++ b/src/api/http/src/handler/http/router/mod.rs
@@ -107,7 +107,14 @@ pub fn cors_layer() -> CorsLayer {
             header::HeaderName::from_static("x-openobserve-trace-id"),
             header::HeaderName::from_static("x-openobserve-sampled"),
             X_O2_ASSISTANT_SESSION_ID,
+            header::HeaderName::from_static("mcp-protocol-version"),
+            header::HeaderName::from_static("mcp-method"),
+            header::HeaderName::from_static("mcp-name"),
         ])
+        // A browser MCP client starts discovery by reading `WWW-Authenticate` off
+        // the 401; without this the fetch response hides the header and the flow
+        // never begins. Desktop clients are unaffected — they see it regardless.
+        .expose_headers([header::WWW_AUTHENTICATE])
         // Restrict CORS to the configured web_url origin, plus any extra origins in
         // ZO_CORS_ALLOWED_ORIGINS (comma-separated).  mirror_request() + allow_credentials(true)
         // allows any origin to make credentialed requests — effectively disabling same-origin
@@ -2353,5 +2360,71 @@ mod tests {
 
         let response = app.oneshot(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+    /// A browser MCP client cannot begin OAuth discovery unless the preflight
+    /// admits the MCP request headers and `WWW-Authenticate` is readable off the
+    /// 401. Both halves are invisible to desktop clients, so nothing else fails
+    /// if they regress.
+    #[tokio::test]
+    async fn preflight_admits_mcp_headers_and_exposes_the_auth_challenge() {
+        let app = Router::new()
+            .route("/{org_id}/mcp", post(|| async { StatusCode::OK }))
+            .layer(cors_layer());
+
+        let preflight = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/default/mcp")
+                    // web_url is empty under test, so any origin is reflected.
+                    .header(header::ORIGIN, "https://claude.ai")
+                    .header(header::ACCESS_CONTROL_REQUEST_METHOD, "POST")
+                    .header(
+                        header::ACCESS_CONTROL_REQUEST_HEADERS,
+                        "authorization,content-type,mcp-protocol-version,mcp-method,mcp-name",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let allowed = preflight
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        for h in ["mcp-protocol-version", "mcp-method", "mcp-name"] {
+            assert!(
+                allowed.contains(h),
+                "preflight must admit {h}; got {allowed:?}"
+            );
+        }
+
+        // Expose-Headers rides the actual response, never the preflight.
+        let actual = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/default/mcp")
+                    .header(header::ORIGIN, "https://claude.ai")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let exposed = actual
+            .headers()
+            .get(header::ACCESS_CONTROL_EXPOSE_HEADERS)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        assert!(
+            exposed.contains("www-authenticate"),
+            "WWW-Authenticate must be exposed or discovery cannot start; got {exposed:?}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Registering the MCP server against an SSO-enabled deployment never completes. The browser opens the login page, and completing SSO there doesn't authorise the MCP client — it just loops back to the login page.

OAuth discovery is not the problem. Traced end to end against a Dex-backed deployment, every discovery step already works:

1. `POST /api/{org}/mcp` → `401` + `WWW-Authenticate: Bearer resource_metadata="…"`
2. that metadata → `authorization_servers: ["<dex>"]`
3. Dex discovery + dynamic client registration → a real `client_id` with the MCP client's own callback registered
4. `/dex/auth` → `302` → `/dex/auth/google` → `302` → the IdP sign-in page

The break is after the token comes back.

This PR carries two independent fixes for it: **first-use provisioning** (all clients) and **CORS** (browser clients only). Either one alone leaves a class of client broken.

---

## Fix 1 — provision the SSO identity on first MCP use

### Root cause

`process_token` (`src/api/common/src/auth/jwt.rs`) is the only place external SSO identities are created, and it is called from exactly two places — the `/config/redirect` **web** SSO callback and the `/config/token` exchange.

`token_validator`, which every MCP request goes through, never calls it. It only *looks up* the user, and on `None` returns 401 (MCP is deliberately excluded from `may_skip_permission_check`).

The MCP OAuth flow structurally cannot reach the provisioning path: the client registers dynamically with Dex and receives the code at **its own** callback, not at `O2_DEX_REDIRECT_URL`, so OpenObserve never sees a redirect.

Net effect: an SSO user who has never opened the web UI authenticates fine but has no user record, every MCP call 401s, and because that 401 carries `WWW-Authenticate` the client restarts authorisation — forever. It only works today for people who happen to have logged into the web UI at least once.

### Change

Provision on first MCP use, mirroring what web login does.

When a request on the real `/{org}/mcp` path carries a valid Dex token for an identity with no user record at all, `token_validator` now runs `process_token` once and re-resolves the user. The identity then takes the normal `Some(user)` arm and is **still fully permission-checked** by OpenFGA — no authorisation exemption is added, and `may_skip_permission_check` is untouched.

Three deliberate constraints on that block:

- **Gated on `is_mcp_endpoint`, not `is_mcp_request`.** The latter includes the caller-settable `x-o2-mcp: true` header, which would let any Dex-token holder trigger provisioning from arbitrary routes. The path-based check cannot be spoofed.
- **Only when the user has no record at all** (`get_user_by_email` → `None`), so this is genuine first-use. Someone probing `/api/{other-org}/mcp` with a valid token cannot drive repeated DB + OpenFGA writes.
- **The `ServiceAccount` stamp is cleared** before provisioning. `verify_decode_token` sets `user_role: Some(ServiceAccount)` on *every* response whose audience check was relaxed (`src/common/src/utils/jwt.rs:143`) — which is exactly the MCP case, since dynamic clients never carry our static `client_id` as `aud`. `process_token` uses that field as the role to create the user with, so passing it through would provision a human SSO login as a service account *and* skip the OpenFGA user-creation tuple. Extracted into `sso_identity_for_provisioning` with a regression test.

The domain-management blocklist is unaffected: it is checked before this point in `token_validator` and re-checked inside `process_token`, so a blocked identity is never provisioned.

---

## Fix 2 — let browser MCP clients start discovery at all

### Root cause

A browser-based MCP client (e.g. the claude.ai web connector) cannot even reach step 1 above. `cors_layer()` (`src/api/http/src/handler/http/router/mod.rs`) declares no `expose_headers`, so `WWW-Authenticate` is stripped from what JS can read off the 401 — the RFC 9728 pointer that *starts* discovery is invisible. Separately, `allow_headers` omits the MCP request headers, so the preflight rejects the follow-up call.

Desktop/CLI clients (Claude Code, Cursor) are unaffected by both — they aren't subject to CORS.

### Change

- `expose_headers([WWW_AUTHENTICATE])` — so the challenge is readable and discovery can begin.
- `allow_headers` gains `mcp-protocol-version`, `mcp-method`, `mcp-name` — exactly the three headers `validate_mcp_headers` reads (`src/api/http/src/handler/http/request/mcp/mod.rs:34-38`).

Nothing else is exposed or admitted. Responses never set `MCP-Protocol-Version`, and O2 MCP is stateless (`handle_mcp_delete` is a no-op), so there is no `Mcp-Session-Id` to expose. The origin predicate, `allow_credentials`, and the `is_origin_allowed` anti-prefix-bypass logic are untouched — this widens headers only, not origins.

---

## Testing

- OSS `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` — clean (the exact CI gate).
- OSS tests for both touched crates — 90/90 pass.
- Enterprise build (o2-enterprise `Cargo.toml.openobserve` swapped in): `cargo check --all-targets` clean.
- `mcp_provisioning_never_inherits_the_service_account_stamp` fails if the role clearing is removed.
- `preflight_admits_mcp_headers_and_exposes_the_auth_challenge` verified non-vacuous — it fails on both assertions when the CORS change is reverted.
- Confirmed `mcp` is a registered OpenFGA resource with route permissions for `/{org}/mcp`, so a provisioned user actually clears `check_permissions`.

**Not covered:** no end-to-end run against a live server. Both changes are enterprise-gated / need Dex + OpenFGA running, so the behavioural claims rest on the code paths rather than an observed green run. Worth a manual check on a Dex deployment with a user who has never opened the web UI, and a browser-connector registration against the same host.

## Notes for reviewers / operators

- Rebased onto current `main`.
- Users are provisioned into `O2_DEX_DEFAULT_ORG` with `O2_DEX_DEFAULT_ROLE`, exactly as web SSO login does. If the IdP token carries no `groups` claim, everyone lands in the default org — so `/api/{other-org}/mcp` will still (correctly) 401. Point MCP clients at the org users are actually provisioned into.
- Neither fix touches the **native/basic-auth** MCP path, which has no MCP-specific gate: `oo_validator_internal` → `validator` → `validate_credentials` → `check_permissions`, and `UserRole::Root` short-circuits before OpenFGA. A basic-auth MCP failure is a credentials/deployment issue, not this bug.
- Two pre-existing `cognitive_complexity` failures show up when building with `--features enterprise` (`src/core/src/alerts/scheduler/handlers.rs:1409`, `src/core/src/ofga/mod.rs:46`). Both are untouched by this PR and are invisible to CI because the OSS default build doesn't compile them.
