### PR TITLE
chore: give the AI review matrix job an explicit short check name

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   review:
+    # Explicit name: without it GitHub serializes the whole matrix object (api_key_env, marker) into the public check name.
+    name: review (${{ matrix.provider.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 25
     # Concurrency is per-job (not workflow-level) so it can see `matrix`: keyed per-PR AND


### PR DESCRIPTION
The `review` job in `.github/workflows/ai-code-review.yml` has no explicit `name`, and its matrix value is an object — so GitHub builds the check name by concatenating every field of that object. The result is a long, truncated check name on every PR (`AI Code Review / review (deepseek, DeepSeek-V4-Pro, deepseek-review, deepseek-v4-pro, , DEEPSEEK_API_KEY, <!-- ai-co…`) that drags internal wiring details (the `api_key_env` field and the comment-marker literal) into the public checks list.

This adds an explicit job-level `name` keyed on the provider's short name, so the check reads `AI Code Review / review (deepseek)`. Future providers added to the matrix automatically get the same clean naming.

No behavior change — matrix values, concurrency grouping, and steps are untouched. Nothing (branch protection / merge queue / scripts) references the old serialized check name. Verified the YAML parses cleanly.