### PR TITLE
test: fail-loud when WORKFLOWS_REQUIRED=1 instead of silent skip

### DIFF
--- a/tests/api-testing/tests/workflows/test_workflow_conditions.py
+++ b/tests/api-testing/tests/workflows/test_workflow_conditions.py
@@ -40,10 +40,15 @@ DEST_URL = "http://localhost:8080/sink"  # same fake sink as test_workflows.py
 # ── Enterprise gate (mirrors test_workflows.py:36-41) ─────────────────────────
 @pytest.fixture(scope="module", autouse=True)
 def _require_workflows(create_session, base_url):
-    """Skip the whole module on OSS / builds where Workflows isn't enabled."""
+    # WORKFLOWS_REQUIRED=1 (set in ent CI) turns the skip into a hard fail so
+    # a route-registration regression or accidentally-off feature flag can't
+    # slip through as silent skips.
     resp = create_session.get(f"{base_url}api/{ORG_ID}/workflows")
     if resp.status_code in (403, 404):
-        pytest.skip("Workflows feature not available (enterprise-only / not enabled on this build).")
+        msg = f"Workflows feature not available (/workflows returned {resp.status_code})."
+        if os.environ.get("WORKFLOWS_REQUIRED") == "1":
+            pytest.fail(f"{msg} WORKFLOWS_REQUIRED=1 — expected enabled on this build.")
+        pytest.skip(f"{msg} Enterprise-only / not enabled on this build.")
 
 
 # ── Shared per-module dry-run destination ─────────────────────────────────────

--- a/tests/api-testing/tests/workflows/test_workflows.py
+++ b/tests/api-testing/tests/workflows/test_workflows.py
@@ -35,10 +35,15 @@ ORG_ID = os.environ.get("TEST_ORG_ID", "default")
 
 @pytest.fixture(scope="module", autouse=True)
 def _require_workflows(create_session, base_url):
-    """Workflows is Enterprise-only. Skip the whole module on OSS / builds where it is not enabled."""
+    # WORKFLOWS_REQUIRED=1 (set in ent CI) turns the skip into a hard fail so
+    # a route-registration regression or accidentally-off feature flag can't
+    # slip through as silent skips.
     resp = create_session.get(f"{base_url}api/{ORG_ID}/workflows")
     if resp.status_code in (403, 404):
-        pytest.skip("Workflows feature not available (enterprise-only / not enabled on this build).")
+        msg = f"Workflows feature not available (/workflows returned {resp.status_code})."
+        if os.environ.get("WORKFLOWS_REQUIRED") == "1":
+            pytest.fail(f"{msg} WORKFLOWS_REQUIRED=1 — expected enabled on this build.")
+        pytest.skip(f"{msg} Enterprise-only / not enabled on this build.")
 
 
 def _suffix():


### PR DESCRIPTION
## Summary

Turn the workflows-suite silent-skip into a hard fail when the environment declares that the feature *must* be on.

## Problem

Both `tests/api-testing/tests/workflows/test_workflows.py` and `tests/api-testing/tests/workflows/test_workflow_conditions.py` have an autouse `_require_workflows` fixture that probes `GET /workflows` and calls `pytest.skip(...)` on 403/404. That's correct for OSS builds (feature genuinely not compiled in) but wrong for the enterprise api-testing matrix — a route-registration regression, a flipped enterprise-config default, or a removed CI env pin all show up as 17+ silently-skipped cases. CI stays green, nobody notices.

## Fix

Read `WORKFLOWS_REQUIRED` from the environment:

- `WORKFLOWS_REQUIRED=1` → `pytest.fail(...)` on 403/404 (loud, CI red).
- Unset → `pytest.skip(...)` as today (OSS builds unchanged).

Applied to both fixture copies.

## Rollout

- OSS CI: doesn't set `WORKFLOWS_REQUIRED` → identical behaviour to today (clean skip on OSS builds).
- ENT CI: paired change in `o2-enterprise` (same branch name `test/workflows-required-fail-loud`) sets `WORKFLOWS_REQUIRED: "1"` next to the existing `O2_WORKFLOWS_ENABLED: true` pin in `.github/workflows/api-testing.yml`. If the route ever stops responding on an ENT build, CI turns red instead of green-with-skips.

Guardrail is the fail-loud fixture + the required flag together — the env-var pin from #13999 / o2-enterprise#2505 alone does not detect a broken/off route.

## Test plan

- [x] Local pytest against an enterprise env (feature on) — both suites pass with `WORKFLOWS_REQUIRED=1` set (`pytest.fail` branch not hit).
- [x] Local pytest with `O2_WORKFLOWS_ENABLED=false` in the target and `WORKFLOWS_REQUIRED=1` — both suites fail loudly on module setup (verifies the fail path).
- [x] Local pytest with `O2_WORKFLOWS_ENABLED=false` and `WORKFLOWS_REQUIRED` unset — both suites skip cleanly (verifies OSS behaviour preserved).