### PR TITLE
fix(dashboards): table PDF reports cut off the last rows in print mode [v0.80]

### DIFF
--- a/web/src/components/dashboards/panels/TableRenderer.vue
+++ b/web/src/components/dashboards/panels/TableRenderer.vue
@@ -335,18 +335,21 @@ export default defineComponent({
 }
 
 @media print {
-  // .table-wrapper is the containing block (position:relative).
-  // It clips the expanded table at the panel height; the footer is
-  // pinned to its bottom edge via absolute positioning (see below).
+  // Grow with the table's natural content height instead of clipping at the
+  // panel height. The old height:100% + overflow:hidden pair sliced whichever
+  // row straddled the panel edge and hid every row after it, and the
+  // absolutely-pinned opaque footer then painted over the last visible row —
+  // so a 4-row table printed 3 rows under a footer still reading "1-4 of 4".
+  // Rows that don't fit the page now continue on the next page.
   .table-wrapper {
     position: relative !important;
-    height: 100% !important;
+    height: auto !important;
+    min-height: 100% !important;
     max-height: none !important;
-    overflow: hidden !important;
+    overflow: visible !important;
   }
 
   .my-sticky-virtscroll-table {
-    // Expand to natural content height so all rows are rendered from the top.
     height: auto !important;
     overflow: visible !important;
 
@@ -356,28 +359,26 @@ export default defineComponent({
       top: auto !important;
     }
 
+    // Repeat the column headers at the top of every printed page.
+    :deep(thead) {
+      display: table-header-group !important;
+    }
+
     // Let the scroll container expand to show all rows.
     :deep(.table-container) {
       overflow: visible !important;
       height: auto !important;
     }
 
-    // Pin the footer to the bottom of .table-wrapper (the nearest
-    // position:relative ancestor) so it is always visible at the
-    // bottom of the panel, regardless of how many rows the table has.
-    :deep([data-test="dashboard-table-pagination"]) {
-      position: absolute !important;
-      bottom: 0 !important;
-      left: 0 !important;
-      right: 0 !important;
-      background-color: #fff !important;
-      z-index: 1 !important;
+    // Never slice a row across a page boundary — move it whole to the next page.
+    :deep(tbody tr) {
+      break-inside: avoid;
+      page-break-inside: avoid;
     }
-  }
 
-  .body--dark .my-sticky-virtscroll-table {
+    // Footer flows below the last row instead of being pinned over it.
     :deep([data-test="dashboard-table-pagination"]) {
-      background-color: #1a1a2e !important;
+      position: static !important;
     }
   }
 }


### PR DESCRIPTION
## Problem

Table panels in emailed PDF reports print with the last row(s) missing or sliced in half, while the same dashboard looks correct in browser print mode.

- A 4-row table prints 3 rows, with the pagination footer still reading `1-4 of 4`
- On shorter panels a row is cut in half at the panel edge

## Root cause

The `@media print` CSS in `TableRenderer.vue` clips the panel at its on-screen height (`.table-wrapper { height: 100%; overflow: hidden }`) while expanding the inner table to natural height — whichever row straddles the panel edge is sliced and everything below it is hidden. The pagination footer is then absolutely pinned to the wrapper's bottom edge with an opaque background and `z-index: 1`, painting over the last visible row.

Browser print mode looks fine on screen because there the footer sits below a scrollable table instead of overlaying it; only the actual print layout (report server's `Page.printToPDF`, or Cmd+P) hits these rules.

## Fix

In print only:
- `.table-wrapper` grows with its content (`height: auto; min-height: 100%; overflow: visible`) instead of clipping
- `tbody tr { break-inside: avoid }` — a row that doesn't fit the page moves to the next page whole
- `thead { display: table-header-group }` — headers repeat on every printed page
- the pagination footer flows after the last row instead of being pinned over it

## Verification

Printed through Chrome's PDF pipeline at the report server's exact settings (1370x730 viewport, `landscape: true`, all other `printToPDF` params default):

| case | before | after |
|---|---|---|
| single table panel, 4 rows | 3 rows, footer overlaying, `1-4 of 4` | all 4 rows, footer below |
| single table panel, 120 rows | rows lost | all 120 rows across 6 pages, header repeated, footer on last page |

Frontend-only change; reaches emailed reports once deployed (the report server renders the deployed web UI).