### PR TITLE
feat: org-scoped search inspector with dedicated permission [v0.40]

### DIFF
--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -794,6 +794,18 @@ impl FromRequest for AuthExtractor {
 
             // if let Some(auth_header) = req.headers().get("Authorization") {
             if !auth_str.is_empty() {
+                // module-level grant: org admins pass implicitly, everyone else
+                // needs an explicit `search_inspector` custom-role grant
+                if url_len == 3 && path_columns[1].eq("search") && path_columns[2].eq("profile") {
+                    return Ok(AuthExtractor {
+                        auth: auth_str.to_owned(),
+                        method: "GET".to_string(),
+                        o2_type: format!("search_inspector:_all_{org_id}"),
+                        org_id,
+                        bypass_check: false,
+                        parent_id: folder,
+                    });
+                }
                 if (method.eq("POST") && url_len > 1 && path_columns[1].starts_with("_search"))
                 || (method.eq("POST")
                     && url_len > 1

--- a/src/handler/http/request/search/search_inspector.rs
+++ b/src/handler/http/request/search/search_inspector.rs
@@ -18,7 +18,7 @@ use std::io::Error;
 use actix_http::StatusCode;
 use actix_web::{HttpRequest, HttpResponse, get, web};
 use config::{
-    get_config,
+    META_ORG_ID, get_config,
     meta::{
         search::{Query, SearchEventType},
         stream::StreamType,
@@ -28,10 +28,6 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use tracing::{Instrument, Span};
 
-#[cfg(feature = "enterprise")]
-use crate::handler::http::request::search::utils::{
-    StreamPermissionResourceType, check_stream_permissions,
-};
 #[cfg(feature = "enterprise")]
 use crate::service::search::sql::visitor::cipher_key::get_cipher_key_names;
 use crate::{
@@ -60,7 +56,8 @@ use crate::{
     description = "Retrieves detailed performance profiling information for search queries executed within a specified time \
                    range. This includes execution timing, node information, component performance metrics, and resource \
                    usage statistics. Use this to analyze and optimize search performance, troubleshoot slow queries, and \
-                   understand query execution patterns across your cluster.",
+                   understand query execution patterns across your cluster. The trace must belong to a search executed in \
+                   the requesting organization; traces of other organizations are answered as not found.",
     security(
         ("Authorization"= [])
     ),
@@ -107,12 +104,12 @@ pub async fn get_search_profile(
     let cfg = get_config();
 
     let (org_id, stream_name) = (path.into_inner(), "default".to_string());
+    // profiling traces are stored in the _meta org; org ownership is enforced
+    // on the result set below
+    let meta_org_id = META_ORG_ID;
     let mut range_error = String::new();
     let http_span = if cfg.common.tracing_search_enabled || cfg.common.tracing_enabled {
-        tracing::info_span!(
-            "/api/{org_id}/{stream_name}/search/profile",
-            org_id = org_id.clone()
-        )
+        tracing::info_span!("/api/{org_id}/search/profile", org_id = org_id.clone())
     } else {
         Span::none()
     };
@@ -142,6 +139,9 @@ pub async fn get_search_profile(
                 return Ok(meta::http::HttpResponse::bad_request(
                     "trace_id/start_time/end_time cannot be empty",
                 ));
+            }
+            if !is_valid_trace_id(query_trace_id) {
+                return Ok(meta::http::HttpResponse::bad_request("trace_id is invalid"));
             }
             let start_time = start_time.parse::<i64>().unwrap_or(0);
             let end_time = end_time.parse::<i64>().unwrap_or(0);
@@ -181,9 +181,12 @@ pub async fn get_search_profile(
     req.use_cache = get_use_cache_from_request(&query);
 
     // get stream settings
-    if let Some(settings) = infra::schema::get_settings(&org_id, &stream_name, stream_type).await {
+    if let Some(settings) =
+        infra::schema::get_settings(meta_org_id, &stream_name, stream_type).await
+    {
         let max_query_range =
-            get_settings_max_query_range(settings.max_query_range, &org_id, Some(&user_id)).await;
+            get_settings_max_query_range(settings.max_query_range, meta_org_id, Some(&user_id))
+                .await;
         if max_query_range > 0
             && (req.query.end_time - req.query.start_time) > max_query_range * 3600 * 1_000_000
         {
@@ -192,20 +195,6 @@ pub async fn get_search_profile(
                 "Query duration is modified due to query range restriction of {max_query_range} hours"
             );
         }
-    }
-
-    // Check permissions on stream
-    #[cfg(feature = "enterprise")]
-    if let Some(res) = check_stream_permissions(
-        &stream_name,
-        &org_id,
-        &user_id,
-        &stream_type,
-        StreamPermissionResourceType::Search,
-    )
-    .await
-    {
-        return Ok(res);
     }
 
     #[cfg(feature = "enterprise")]
@@ -278,7 +267,7 @@ pub async fn get_search_profile(
     // run search with cache
     let res = crate::service::search::cache::search(
         &trace_id,
-        &org_id,
+        meta_org_id,
         stream_type,
         Some(user_id),
         &req,
@@ -300,6 +289,7 @@ pub async fn get_search_profile(
                 events: vec![],
             };
 
+            let mut org_verified = org_id == meta_org_id;
             for hit in res.hits {
                 if let Some(events_str) = hit.get("events")
                     && let Ok(parsed_events) = serde_json::from_str::<Vec<SearchInspectorEvent>>(
@@ -313,6 +303,9 @@ pub async fn get_search_profile(
                             if let Some(mut fields) =
                                 extract_search_inspector_fields(event.name.as_str())
                             {
+                                if fields.org_id.as_deref() == Some(org_id.as_str()) {
+                                    org_verified = true;
+                                }
                                 if fields.component == Some("summary".to_string()) {
                                     si.sql = fields.sql.unwrap();
                                     let time_range = fields.time_range.unwrap_or_default();
@@ -329,6 +322,18 @@ pub async fn get_search_profile(
 
                     events.extend(inspectors);
                 }
+            }
+
+            // a trace not owned by the caller's org gets the same empty answer
+            // as a nonexistent trace, so trace ids can't be probed across orgs
+            if !org_verified {
+                return Ok(HttpResponse::Ok().json(SearchInspector {
+                    sql: "".to_string(),
+                    start_time: "".to_string(),
+                    end_time: "".to_string(),
+                    total_duration: 0,
+                    events: vec![],
+                }));
             }
 
             si.events = events;
@@ -358,6 +363,15 @@ pub async fn get_search_profile(
     }
 }
 
+// trace_id is interpolated into the profile SQL, so restrict it to the
+// alphanumeric-and-dash alphabet trace ids are built from
+fn is_valid_trace_id(trace_id: &str) -> bool {
+    !trace_id.is_empty()
+        && trace_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SearchInspectorEvent {
     pub name: String,
@@ -378,4 +392,20 @@ pub struct SearchInspector {
     pub end_time: String,
     pub total_duration: usize,
     pub events: Vec<SearchInspectorFields>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_trace_id() {
+        assert!(is_valid_trace_id("684a4e5dac43429a86a0a2ef9adf62c2"));
+        assert!(is_valid_trace_id(
+            "019cae07a3f0740ab34831ba04563200-1-13jPR6A"
+        ));
+        assert!(!is_valid_trace_id(""));
+        assert!(!is_valid_trace_id("abc' OR '1'='1"));
+        assert!(!is_valid_trace_id("abc; drop table default"));
+    }
 }

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -299,6 +299,7 @@ pub async fn search(
                 start.elapsed().as_millis()
             ),
             SearchInspectorFieldsBuilder::new()
+                .org_id(org_id.to_string())
                 .node_name(LOCAL_NODE.name.clone())
                 .component("summary".to_string())
                 .search_role(search_role)

--- a/src/service/search/inspector.rs
+++ b/src/service/search/inspector.rs
@@ -19,6 +19,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct SearchInspectorFields {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_name: Option<String>,
@@ -65,6 +67,11 @@ impl SearchInspectorFieldsBuilder {
                 ..Default::default()
             },
         }
+    }
+
+    pub fn org_id(mut self, org_id: String) -> Self {
+        self.fields.org_id = Some(org_id);
+        self
     }
 
     pub fn node_name(mut self, value: String) -> Self {


### PR DESCRIPTION
Design at: #14004

Port of #14005 to `branch-v0.40.0` (pairs with openobserve/o2-enterprise#2515, port of o2-enterprise#2507).

## What

Lets org users use the search inspector without being members of the `_meta` org, gated by a new `search_inspector` permission.

- `SearchInspectorFields` gains an `org_id` field, recorded by the `summary` emission site, so every inspectable trace carries its owning org.
- `GET /api/{org_id}/search/profile` now searches the `_meta` store (this branch searched the URL org's own `default` traces stream, which never holds profiling data for non-`_meta` orgs), validates `trace_id` to the alphanumeric-and-dash alphabet, and accepts the result set only when an event carries the requesting org's `org_id` — otherwise the response is identical to a nonexistent trace. Requests with `_meta` as the URL org keep today's full view.
- The `_meta` stream permission check inside the handler is removed; route-level RBAC takes over via the paired enterprise PR.

## Port adaptations (differences from the main PR)

- This branch (actix-web) has no `ROUTE_PERMISSIONS` table in o2-enterprise; the route mapping lives in the OSS auth extractor. `/{org}/search/profile` now resolves to a GET check on `search_inspector:_all_{org}` (module-level object, admins pass implicitly, everyone else needs an explicit custom-role grant — enforced by the paired enterprise PR).
- This branch has no HTTP2 streaming search, so only the cache `summary` emission site records `org_id`.
- The per-user `search_inspector_enabled` computation in `GET /config` is NOT ported: on this branch the config endpoint is global and unauthenticated. This branch's web UI has no search inspector pages at all, so this is an API-level change only.

## Compatibility

- Traces recorded before this change carry no org marker: non-`_meta` users get an empty profile for those until retention ages them out. `_meta` admins are unaffected.
- Pairs with the same-named branch in o2-enterprise (new OFGA `search_inspector` resource, `o2_version` 0.0.24 → 0.0.25, migrates automatically at startup); CI checks out the paired branch by name.

## Verification

- `cargo check` (default features) and `cargo clippy -- -D warnings` — clean
- Enterprise `cargo check --all-targets` against the paired enterprise branch (swapped `Cargo.toml.openobserve`) — clean
- `cargo test --lib inspector` — 7 passed (including the new `is_valid_trace_id` cases)
