### PR TITLE
feat: org-scoped search inspector with dedicated permission [v0.80]

### DIFF
--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -1069,6 +1069,19 @@ where
                     || path.contains("/users/bulk")
                     || path.contains("/reports/bulk"));
 
+            // module-level grant: org admins pass implicitly, everyone else
+            // needs an explicit `search_inspector` custom-role grant
+            if url_len == 3 && path_columns[1].eq("search") && path_columns[2].eq("profile") {
+                return Ok(AuthExtractor {
+                    auth: auth_str.to_owned(),
+                    method: "GET".to_string(),
+                    o2_type: format!("search_inspector:_all_{org_id}"),
+                    org_id,
+                    bypass_check: false,
+                    parent_id: folder,
+                });
+            }
+
             if (method.eq("POST") && url_len > 1 && path_columns[1].starts_with("_search"))
             || (method.eq("POST")
                 && url_len > 1
@@ -1111,9 +1124,6 @@ where
                 && path_columns[0].eq(V2_API_PREFIX)
                 && path_columns[2].eq("alerts")
                 && path_columns[3].eq("history"))
-            || (url_len == 3
-                && path_columns[1].eq("search")
-                && path_columns[2].eq("profile"))
             {
                 return Ok(AuthExtractor {
                     auth: auth_str.to_owned(),

--- a/src/handler/http/request/search/search_inspector.rs
+++ b/src/handler/http/request/search/search_inspector.rs
@@ -20,7 +20,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use config::{
-    get_config,
+    META_ORG_ID, get_config,
     meta::{
         search::{Query as SearchQuery, SearchEventType},
         stream::StreamType,
@@ -40,13 +40,7 @@ use crate::{
             stream::get_settings_max_query_range,
         },
     },
-    handler::http::{
-        extractors::Headers,
-        request::search::{
-            error_utils,
-            utils::{StreamPermissionResourceType, check_stream_permissions},
-        },
-    },
+    handler::http::{extractors::Headers, request::search::error_utils},
     service::{
         search::{inspector::*, sql::visitor::cipher_key::get_cipher_key_names},
         self_reporting::http_report_metrics,
@@ -65,7 +59,8 @@ use crate::{
     description = "Retrieves detailed performance profiling information for search queries executed within a specified time \
                    range. This includes execution timing, node information, component performance metrics, and resource \
                    usage statistics. Use this to analyze and optimize search performance, troubleshoot slow queries, and \
-                   understand query execution patterns across your cluster.",
+                   understand query execution patterns across your cluster. The trace must belong to a search executed in \
+                   the requesting organization; traces of other organizations are answered as not found.",
     security(
         ("Authorization"= [])
     ),
@@ -103,7 +98,7 @@ use crate::{
     )
 )]
 pub async fn get_search_profile(
-    Path(_path): Path<String>,
+    Path(org_id): Path<String>,
     Query(query): Query<HashMap<String, String>>,
     Headers(user_email): Headers<UserEmail>,
     headers: HeaderMap,
@@ -111,10 +106,12 @@ pub async fn get_search_profile(
     let start = std::time::Instant::now();
     let cfg = get_config();
 
-    let (org_id, stream_name) = ("_meta", "default".to_string());
+    // profiling traces are stored in the _meta org; org ownership is enforced
+    // on the result set below
+    let (meta_org_id, stream_name) = (META_ORG_ID, "default".to_string());
     let mut range_error = String::new();
     let http_span = if cfg.common.should_create_span() {
-        tracing::info_span!("/api/{org_id}/{stream_name}/search/profile")
+        tracing::info_span!("/api/{org_id}/search/profile", org_id = org_id.clone())
     } else {
         Span::none()
     };
@@ -127,6 +124,9 @@ pub async fn get_search_profile(
     let Some(query_trace_id) = query.get("trace_id") else {
         return meta::http::HttpResponse::bad_request("trace_id is required");
     };
+    if !is_valid_trace_id(query_trace_id) {
+        return meta::http::HttpResponse::bad_request("trace_id is invalid");
+    }
     let start_time_from_trace_id =
         config::ider::get_start_time_from_trace_id(query_trace_id).unwrap_or(0);
 
@@ -178,9 +178,12 @@ pub async fn get_search_profile(
     req.use_cache = get_use_cache_from_request(&query);
 
     // get stream settings
-    if let Some(settings) = infra::schema::get_settings(org_id, &stream_name, stream_type).await {
+    if let Some(settings) =
+        infra::schema::get_settings(meta_org_id, &stream_name, stream_type).await
+    {
         let max_query_range =
-            get_settings_max_query_range(settings.max_query_range, org_id, Some(&user_id)).await;
+            get_settings_max_query_range(settings.max_query_range, meta_org_id, Some(&user_id))
+                .await;
         if max_query_range > 0
             && (req.query.end_time - req.query.start_time) > max_query_range * 3600 * 1_000_000
         {
@@ -189,19 +192,6 @@ pub async fn get_search_profile(
                 "Query duration is modified due to query range restriction of {max_query_range} hours"
             );
         }
-    }
-
-    // Check permissions on stream
-    if let Some(res) = check_stream_permissions(
-        &stream_name,
-        org_id,
-        &user_id,
-        &stream_type,
-        StreamPermissionResourceType::Search,
-    )
-    .await
-    {
-        return res;
     }
 
     let keys_used = match get_cipher_key_names(&req.query.sql) {
@@ -273,7 +263,7 @@ pub async fn get_search_profile(
     // run search with cache
     let res = crate::service::search::cache::search(
         &trace_id,
-        org_id,
+        meta_org_id,
         stream_type,
         Some(user_id),
         &req,
@@ -301,6 +291,7 @@ pub async fn get_search_profile(
             let mut search_summary = Vec::new();
             let mut stream_summary = Vec::new();
 
+            let mut org_verified = org_id == meta_org_id;
             for hit in res.hits {
                 if let Some(events_str) = hit.get("events")
                     && let Ok(parsed_events) = serde_json::from_str::<Vec<SearchInspectorEvent>>(
@@ -314,6 +305,9 @@ pub async fn get_search_profile(
                             if let Some(mut fields) =
                                 extract_search_inspector_fields(event.name.as_str())
                             {
+                                if fields.org_id.as_deref() == Some(org_id.as_str()) {
+                                    org_verified = true;
+                                }
                                 if fields.component == Some("summary".to_string()) {
                                     search_summary.push(fields);
                                 } else if fields.component == Some("stream_summary".to_string()) {
@@ -328,6 +322,12 @@ pub async fn get_search_profile(
 
                     events.extend(inspectors);
                 }
+            }
+
+            // a trace not owned by the caller's org gets the same empty answer
+            // as a nonexistent trace, so trace ids can't be probed across orgs
+            if !org_verified {
+                return Json(si).into_response();
             }
 
             if stream_summary.is_empty() {
@@ -373,7 +373,7 @@ pub async fn get_search_profile(
                 .unwrap_or("".to_string());
             http_report_metrics(
                 start,
-                org_id,
+                &org_id,
                 stream_type,
                 "500",
                 "search/profile",
@@ -537,6 +537,15 @@ where
         .collect()
 }
 
+// trace_id is interpolated into the profile SQL, so restrict it to the
+// alphanumeric-and-dash alphabet trace ids are built from
+fn is_valid_trace_id(trace_id: &str) -> bool {
+    !trace_id.is_empty()
+        && trace_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
 fn format_trace_id(trace_id: Option<String>) -> String {
     let Some(trace_id) = trace_id else {
         return "".to_string();
@@ -554,4 +563,20 @@ fn format_trace_id(trace_id: Option<String>) -> String {
         }
     }
     cols.join("-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_trace_id() {
+        assert!(is_valid_trace_id("684a4e5dac43429a86a0a2ef9adf62c2"));
+        assert!(is_valid_trace_id(
+            "019cae07a3f0740ab34831ba04563200-1-13jPR6A"
+        ));
+        assert!(!is_valid_trace_id(""));
+        assert!(!is_valid_trace_id("abc' OR '1'='1"));
+        assert!(!is_valid_trace_id("abc; drop table default"));
+    }
 }

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -308,6 +308,7 @@ pub async fn search(
             ),
             SearchInspectorFieldsBuilder::new()
                 .trace_id(trace_id.to_string())
+                .org_id(org_id.to_string())
                 .node_name(LOCAL_NODE.name.clone())
                 .component("summary".to_string())
                 .search_role(search_role)

--- a/src/service/search/inspector.rs
+++ b/src/service/search/inspector.rs
@@ -48,6 +48,8 @@ pub struct SearchInspectorFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_name: Option<String>,
@@ -107,6 +109,11 @@ impl SearchInspectorFieldsBuilder {
 
     pub fn trace_id(mut self, trace_id: String) -> Self {
         self.fields.trace_id = Some(trace_id);
+        self
+    }
+
+    pub fn org_id(mut self, org_id: String) -> Self {
+        self.fields.org_id = Some(org_id);
         self
     }
 

--- a/src/service/search/streaming/mod.rs
+++ b/src/service/search/streaming/mod.rs
@@ -619,6 +619,7 @@ pub async fn process_search_stream_request(
         accumulated_records += hits;
     }
     let trace_id_clone = trace_id.clone();
+    let org_id_clone = org_id.clone();
     async move {
         log::info!(
             "{}",
@@ -629,6 +630,7 @@ pub async fn process_search_stream_request(
                 ),
                 SearchInspectorFieldsBuilder::new()
                     .trace_id(trace_id_clone.to_string())
+                    .org_id(org_id_clone)
                     .node_name(LOCAL_NODE.name.clone())
                     .component("stream_summary".to_string())
                     .search_role(search_role)


### PR DESCRIPTION
Design at: #14004

Port of #14005 to `branch-v0.80.0` (pairs with openobserve/o2-enterprise#2516, port of o2-enterprise#2507).

## What

Lets org users use the search inspector without being members of the `_meta` org, gated by a new `search_inspector` permission.

- `SearchInspectorFields` gains an `org_id` field, recorded by the `summary`/`stream_summary` emission sites, so every inspectable trace carries its owning org.
- `GET /api/{org_id}/search/profile` now uses the URL org: the profile search still runs against the `_meta` store, the `trace_id` parameter is validated to the alphanumeric-and-dash alphabet, and the result set is accepted only when an event carries the requesting org's `org_id` — otherwise the response is identical to a nonexistent trace. Requests with `_meta` as the URL org keep today's full view.

## Port adaptations (differences from the main PR)

- This branch has no `ROUTE_PERMISSIONS` table in o2-enterprise; the route mapping lives in the OSS auth extractor instead. `/{org}/search/profile` moves out of the bypass list and now resolves to a GET check on `search_inspector:_all_{org}` (module-level object, admins pass implicitly, everyone else needs an explicit custom-role grant — enforced by the paired enterprise PR).
- The per-user `search_inspector_enabled` computation in `GET /config` is NOT ported: on this branch the config endpoint is global and unauthenticated (`/config`, no org in the path), so there is no user/org context to compute it from. The UI keeps gating on the instance-level flag; a user without the grant who clicks an inspector entry point gets a 403 from the API. No frontend change.

## Compatibility

- Traces recorded before this change carry no org marker: non-`_meta` users get an empty profile for those until retention ages them out. `_meta` admins are unaffected.
- Pairs with the same-named branch in o2-enterprise (new OFGA `search_inspector` resource, `o2_version` 0.0.31 → 0.0.32, migrates automatically at startup); CI checks out the paired branch by name.

## Verification

- `cargo check` (default features) and `cargo clippy -- -D warnings` — clean
- Enterprise `cargo check --all-targets` against the paired enterprise branch (swapped `Cargo.toml.openobserve`) — clean
- `cargo test --lib inspector` — pass (the handler module is enterprise-gated on this branch, so the new `is_valid_trace_id` test compiles under the enterprise check; the identical test runs green on the v0.40 port)
