### PR TITLE
test(workflows): un-skip the UI specs and fix the builder page object

### DIFF
--- a/tests/ui-testing/pages/workflowsPages/workflowsPage.js
+++ b/tests/ui-testing/pages/workflowsPages/workflowsPage.js
@@ -6,9 +6,8 @@
 // data-test on a NON-interactive wrapper (the <OInput data-test="x"> value lands on a <div>).
 // The fillable <input>/<textarea> is exposed as `x-field`; OTable's container is `o2-table-root`.
 // Always target the inner element for fill()/type(), never the wrapper.
-// NOTE: the canvas node-interaction selectors (trigger add-out/delete, palette-*) are NOT yet
-// present in merged markup — the nodes render on a vue-flow canvas. They feed only the parked
-// test.fixme cases and must be discovered live on an ENT build before those tests are enabled.
+// The canvas node-interaction selectors (palette-*, workflow-node-*) ARE present in merged
+// markup and sit on the live path of the build-and-configure specs — not parked fixmes.
 //
 // Known quirks baked in here:
 //   K9 — the editor Save button has a tooltip overlay that intercepts pointer events; we click it
@@ -18,9 +17,13 @@
 const { expect } = require('@playwright/test');
 const testLogger = require('../../playwright-tests/utils/test-logger.js');
 const { getOrgIdentifier } = require('../../playwright-tests/utils/cloud-auth.js');
+const MonacoEditorHelper = require('../../playwright-tests/utils/MonacoEditorHelper.js');
 
 const LIST_TIMEOUT_MS = 45000;   // K10: list load is slow
 const DRAWER_TIMEOUT_MS = 15000;
+
+// Availability is a property of the build, not of a test — probe it once per worker.
+let workflowsEnabled;
 
 class WorkflowsPage {
   constructor(page) {
@@ -44,11 +47,13 @@ class WorkflowsPage {
     this.nameValue = '[data-test="workflow-editor-name-value"]';
     this.descTrigger = '[data-test="workflow-editor-description-trigger"]';
     this.descInput = '[data-test="workflow-editor-description-input"]';
-    // Inline "create function" form inside a Function node drawer — the name is
-    // an inline-edited title (OFormInlineEdit), same as the Functions page.
-    this.nodeFunctionCreateToggle = '[data-test="create-function-toggle-btn"]';
-    this.nodeFunctionNameTrigger = '[data-test="add-function-name-input-trigger"]';
-    this.nodeFunctionNameInput = '[data-test="add-function-name-input-input"]';
+    // Workflow single-screen function editor: the AddFunction body is ALWAYS
+    // visible below the associate-function select (FunctionPicker's `createButton`
+    // mode), so there is no "Create New" toggle. Save routes through the icon
+    // button next to the select, then a saved-function dialog collects a name and
+    // creates the function via the backend (which is where invalid JS surfaces).
+    this.nodeFunctionSaveBtn = '[data-test="wf-function-save-btn"]';
+    this.nodeFunctionNameInput = '[data-test="wf-saved-function-name-input-field"]';
     this.saveBtn = '[data-test="workflow-editor-save"]';
     this.publishBtn = '[data-test="workflow-editor-publish"]';
     this.testBtn = '[data-test="workflow-editor-test"]';
@@ -66,9 +71,12 @@ class WorkflowsPage {
     // picker instead.
     this.triggerNode = '[data-test="workflow-node-workflow_trigger"]';
     this.triggerDelete = '[data-test="workflow-node-workflow_trigger-delete-btn"]';
-    // Empty-canvas start node -> trigger picker. The editor no longer pre-places
-    // an Alert Trigger on create, so a workflow now BEGINS by choosing one here.
-    this.startNode = '[data-test="workflow-flow-start-node"]';
+    // Empty-canvas scaffold's trigger card -> trigger picker. The editor no
+    // longer pre-places an Alert Trigger on create; on a fresh /add the canvas
+    // renders a two-slot scaffold (workflow-flow-start-scaffold) and the trigger
+    // card is `workflow-flow-start-trigger`. `workflow-flow-start-node` is only
+    // the fallback when a step exists but the trigger was deleted.
+    this.startNode = '[data-test="workflow-flow-start-trigger"]';
     // Trigger-picker items are keyed by TRIGGER KIND (alert_fired, incident_event) —
     // the picker offers one row per enabled kind (all of node_type workflow_trigger).
     this.stepTriggerFor = (kind = 'alert_fired') => `[data-test="workflow-step-${kind}"]`;
@@ -76,12 +84,14 @@ class WorkflowsPage {
     this.stepCondition = '[data-test="workflow-step-condition"]';
     this.stepFunction = '[data-test="workflow-step-function"]';
     this.stepDestination = '[data-test="workflow-step-destination"]';
-    // Node config drawer (generic O2 drawer). An overlay (o-drawer-overlay) intercepts canvas
-    // clicks while a drawer is open, and the trigger drawer auto-opens on /add — close it first.
+    // Node config drawer is an ODialog (not the legacy O2 drawer) — buttons/close
+    // are `o-dialog-*`, and the panel commits config on close (there is no primary
+    // "Save" button in the footer; drawer close === save). An overlay
+    // (o-dialog-overlay) intercepts canvas clicks while the dialog is open.
     this.nodeDrawer = '[data-test="workflow-node-drawer"]';
-    this.drawerClose = '[data-test="o-drawer-close-btn"]';
-    this.drawerPrimary = '[data-test="o-drawer-primary-btn"]';
-    this.drawerSecondary = '[data-test="o-drawer-secondary-btn"]';
+    this.drawerClose = '[data-test="o-dialog-close-btn"]';
+    this.drawerPrimary = '[data-test="o-dialog-primary-btn"]';
+    this.drawerSecondary = '[data-test="o-dialog-secondary-btn"]';
     // Destination picker (inside node drawer). OSelect/OToggle put the consumer data-test on a
     // wrapper div; the interactive element is the `-trigger`/`-btn` child — use those to click.
     this.destPicker = '[data-test="destination-picker"]';
@@ -99,8 +109,7 @@ class WorkflowsPage {
     this.dialogSecondary = '[data-test="o-dialog-secondary-btn"]';
   }
 
-  // Workflows is an Enterprise-only feature. On OSS builds the API returns 404/403 and the menu is
-  // hidden, so specs must skip rather than fail. Probe the list endpoint to decide.
+  // Workflows is an Enterprise-only feature: on a build without it the API answers 404/403.
   async isAvailable() {
     const url = `${process.env.ZO_BASE_URL}/api/${getOrgIdentifier()}/workflows`;
     try {
@@ -108,6 +117,25 @@ class WorkflowsPage {
       return resp.status() !== 404 && resp.status() !== 403;
     } catch (_e) {
       return false;
+    }
+  }
+
+  /**
+   * Fail loudly, up front, when the feature is not enabled on the build under test.
+   *
+   * These specs run ONLY in the ENT playwright matrix (ci_matrix.ent.json `Workflows`
+   * shard), where playwright.yml pins O2_WORKFLOWS_ENABLED=true. A flipped default, a
+   * dropped env line or a broken route would otherwise surface as an opaque selector
+   * timeout deep inside a test — or, if anyone reintroduces a skip, as a silent green.
+   * Probed once per worker; every test then fails with the same actionable message.
+   */
+  async assertEnabled() {
+    if (workflowsEnabled === undefined) workflowsEnabled = await this.isAvailable();
+    if (!workflowsEnabled) {
+      throw new Error(
+        `Workflows is NOT enabled on ${process.env.ZO_BASE_URL} (GET /api/${getOrgIdentifier()}/workflows returned 403/404). ` +
+          'These specs are enterprise-only and must never be skipped: set O2_WORKFLOWS_ENABLED=true on the build under test.'
+      );
     }
   }
 
@@ -234,12 +262,15 @@ class WorkflowsPage {
     }, this.testBtn);
   }
 
-  /** The trigger's config drawer auto-opens on /add; its overlay blocks canvas/palette clicks. */
+  /** Close any open node dialog. Left in place as a defensive no-op — the new
+   *  editor no longer auto-opens the trigger's config panel, but a stray dialog
+   *  from a previous step would still block canvas/palette clicks via the
+   *  o-dialog-overlay. */
   async closeOpenDrawer() {
     const close = this.page.locator(this.drawerClose);
     if (await close.count()) {
       await close.first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
-      await this.page.locator('[data-test="o-drawer-overlay"]')
+      await this.page.locator('[data-test="o-dialog-overlay"]')
         .waitFor({ state: 'detached', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
     }
   }
@@ -260,6 +291,14 @@ class WorkflowsPage {
     await this.ensureNodePaletteOpen();
     const paletteSel = { condition: this.paletteCondition, function: this.paletteFunction, destination: this.paletteDestination }[type];
     await this.page.locator(paletteSel).click({ timeout: DRAWER_TIMEOUT_MS });
+    // "Insert-immediately" — the palette adds the node in Set-up-later mode and
+    // does NOT auto-open the config panel. Click the freshly-added node to open
+    // its drawer. Multiple nodes of the same type can coexist; last() picks the
+    // newest for the caller's follow-up config.
+    const nodeSel = `[data-test="workflow-node-${type}"]`;
+    const node = this.page.locator(nodeSel).last();
+    await node.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await node.click({ timeout: DRAWER_TIMEOUT_MS });
     await this.page.locator(this.nodeDrawer).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
   }
 
@@ -282,6 +321,14 @@ class WorkflowsPage {
     await nameField.fill(name);
     await this.page.locator(this.destUrlField).fill(url);
     await this.page.locator(this.destSubmitBtn).click({ timeout: DRAWER_TIMEOUT_MS });
+    // onDestinationCreated only STAGES the name (pendingSelection); the select is
+    // bound after the refetch resolves. The trigger renders before that value lands,
+    // so waiting for it to be visible races — the drawer closes first, the node
+    // commits with an empty destination_id, and Publish rejects it with "1 step needs
+    // setup before publishing". Wait for the bound value itself (OSelect stamps the
+    // option's value, which DestinationPicker.toOption sets to the destination name).
+    await expect(this.page.locator(this.destPickerSelectTrigger))
+      .toHaveAttribute('data-test-selected-value', name, { timeout: DRAWER_TIMEOUT_MS });
   }
 
   /**
@@ -291,6 +338,8 @@ class WorkflowsPage {
   async testRunFromEditor() {
     await this.page.locator(this.testBtn).click({ timeout: DRAWER_TIMEOUT_MS });
     await this.page.locator('[data-test="workflow-test-drawer"]').waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    // The Test panel is still a real ODrawer (WorkflowTestDialog.vue) — only the NODE
+    // config panel became an ODialog. Its buttons stay `o-drawer-*`.
     await this.page.locator('[data-test="workflow-test-drawer"] [data-test="o-drawer-primary-btn"]')
       .click({ timeout: DRAWER_TIMEOUT_MS });
   }
@@ -308,39 +357,57 @@ class WorkflowsPage {
       .toBeVisible({ timeout });
   }
 
-  /** Commit the node config drawer (binds the node) and wait for it to close. */
+  /** Commit the node config: the new ODialog-based drawer has no "Save" button —
+   *  closing the dialog IS the save (applyNodeConfig runs on close). Use the
+   *  built-in close X (`o-dialog-close-btn`) and wait for the drawer to detach. */
   async saveNodeDrawer() {
-    await this.page.locator(this.drawerPrimary).click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.drawerClose).first().click({ timeout: DRAWER_TIMEOUT_MS });
     await this.page.locator(this.nodeDrawer).waitFor({ state: 'detached', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
   }
 
-  /** If a node drawer is still open, commit it; otherwise no-op (some inline saves auto-close). */
+  /** If a node drawer is still open, close it (commits config); otherwise no-op. */
   async bindNodeDrawerIfOpen() {
     const drawer = this.page.locator(this.nodeDrawer);
     if (await drawer.isVisible().catch(() => false)) {
-      await this.page.locator(this.drawerPrimary).click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
+      await this.page.locator(this.drawerClose).first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
       await drawer.waitFor({ state: 'detached', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
     }
   }
 
   /**
-   * In an open Function node drawer, open the inline "create function" form, type code into the
-   * (QuickJS/JavaScript) editor, attempt to save, and return the resulting toast text. Used to
-   * assert that INVALID function code is rejected gracefully (a compile-error message, no crash).
+   * With the Function node drawer open, type code into the JS editor and route it
+   * through the save flow (icon save -> saved-function dialog: name + primary).
+   * The backend's create endpoint is what rejects invalid JS — the returned
+   * message surfaces as a toast, which we return so callers can assert on it.
    */
   async attemptCreateFunction({ name, code }) {
-    await this.page.locator(this.nodeFunctionCreateToggle).click({ timeout: DRAWER_TIMEOUT_MS });
-    // Open the inline name editor, then fill the revealed input.
-    await this.page.locator(this.nodeFunctionNameTrigger).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
-    await this.page.locator(this.nodeFunctionNameTrigger).click({ timeout: DRAWER_TIMEOUT_MS });
-    await this.page.locator(this.nodeFunctionNameInput).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
-    await this.page.locator(this.nodeFunctionNameInput).fill(name);
-    // Function code editor (workflow functions run on QuickJS — JavaScript, not VRL).
+    // The workflow single-screen has the AddFunction body always visible below the
+    // select; no create toggle. Clicking the editor WRAPPER does not focus Monaco —
+    // the keystrokes go nowhere and the untouched seed template is what gets saved,
+    // so an invalid-code test silently asserts nothing. Drive the real textarea.
     const editor = this.page.locator('[data-test="logs-vrl-function-editor"]');
-    await editor.click();
+    const monaco = new MonacoEditorHelper(this.page);
+    await monaco.focus(editor);
     await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
     await this.page.keyboard.type(code);
-    await this.page.locator('[data-test="add-function-save-btn"]').click({ timeout: DRAWER_TIMEOUT_MS });
+    // Fail here, not on the toast, if the code never landed. Compared whitespace-free:
+    // Monaco re-renders indentation and auto-closes brackets.
+    const norm = (s) => (s || '').replace(/\s+/g, '');
+    await expect
+      .poll(async () => norm(await monaco.getContent(editor)), { timeout: DRAWER_TIMEOUT_MS })
+      .toContain(norm(code));
+    // Save reads AddFunction's MODEL (getCode -> formData.function), which QueryEditor
+    // only updates after its 500ms `update:query` debounce. Clicking sooner submits the
+    // previous value — the seed template — and the backend then rightly reports success.
+    await this.page.waitForTimeout(800);
+    // Route through the workflow save button (opens the Update|Create dialog).
+    await this.page.locator(this.nodeFunctionSaveBtn).click({ timeout: DRAWER_TIMEOUT_MS });
+    // With no function currently selected the dialog defaults to Create mode
+    // and exposes the name input. Fill it and submit via the ODialog primary.
+    const nameInput = this.page.locator(this.nodeFunctionNameInput);
+    await nameInput.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await nameInput.fill(name);
+    await this.page.locator(this.drawerPrimary).click({ timeout: DRAWER_TIMEOUT_MS });
     const toast = this.page.locator('[role="alert"], .q-notification__message').first();
     await toast.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
     return (await toast.textContent().catch(() => '') || '').trim();
@@ -358,13 +425,43 @@ class WorkflowsPage {
    * Full happy path: build a Trigger -> Destination workflow with a freshly-created destination
    * and save it. Returns nothing; caller verifies via the list.
    */
+  /**
+   * Publish, and fail at the point of rejection. A blocked Publish never reaches the
+   * network — validate() bails with a warning toast — so a caller that only waits for
+   * the link-alerts dialog turns a real rejection into a silent timeout and surfaces
+   * it much later as a bare "expected true".
+   */
+  async publishAndExpectAccepted() {
+    await this.clickPublish();
+    const warning = this.page.locator('[data-test^="o-toast-"][data-test-variant="warning"]').first();
+    const linkDialog = this.page.locator(this.linkAlertsDialog);
+    const editor = this.page.locator(this.editorPage);
+    await expect
+      .poll(
+        async () => {
+          if (await warning.isVisible().catch(() => false)) return 'rejected';
+          if (await linkDialog.isVisible().catch(() => false)) return 'accepted';
+          // Trigger kinds that don't associate with alerts get no link prompt — a
+          // successful publish just navigates back to the list.
+          if (!(await editor.isVisible().catch(() => false))) return 'accepted';
+          return 'pending';
+        },
+        { timeout: DRAWER_TIMEOUT_MS, message: 'Publish produced neither a result nor a message' }
+      )
+      .not.toBe('pending');
+    if (await warning.isVisible().catch(() => false)) {
+      const msg = await warning.getAttribute('data-test-message');
+      throw new Error(`Publish was rejected: ${(msg || '').trim()}`);
+    }
+  }
+
   async buildTriggerToDestinationAndSave({ name, destName, url }) {
     await this.goToAdd();
     await this.setName(name);
     await this.addNodeFromPalette('destination');
     await this.createDestinationInline({ name: destName, url });
     await this.saveNodeDrawer();
-    await this.clickPublish();
+    await this.publishAndExpectAccepted();
     await this.skipLinkAlerts();
   }
 
@@ -393,7 +490,11 @@ class WorkflowsPage {
   }
 
   async openEdit(name) {
-    await this.page.locator(`[data-test="workflow-list-${name}-edit"]`).first().click({ timeout: DRAWER_TIMEOUT_MS });
+    // The list is slow (K10) and virtualized, so a row for an arbitrary name is not
+    // necessarily rendered — filter to it first, exactly as isPresent() does.
+    await this.waitForListReady();
+    await this.search(name);
+    await this.page.locator(`[data-test="workflow-list-${name}-edit"]`).first().click({ timeout: LIST_TIMEOUT_MS });
     await this.page.locator(this.editorPage).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
   }
 

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-crud.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-crud.spec.js
@@ -22,14 +22,13 @@ test.describe('Workflows CRUD & builder', { tag: ['@workflows', '@enterprise', '
   let pm;
 
   test.beforeEach(async ({ page }, testInfo) => {
-    // Workflows feature is under rework — skipped until it stabilizes.
-    test.skip(true, 'Workflows feature under rework');
     testLogger.testStart(testInfo.title, testInfo.file);
     await navigateToBase(page);
     pm = new PageManager(page);
     // Enterprise-only feature: these specs run ONLY in the ENT playwright matrix (never wired into
     // OSS), where Workflows is enabled by default. No runtime availability skip — if the feature is
     // missing where this runs, the test must fail loudly rather than silently pass as skipped.
+    await pm.workflowsPage.assertEnabled();
   });
 
   // CT-01 / WF-NEG-02 — a workflow requires at least one step after the trigger.

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-negative.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-negative.spec.js
@@ -31,14 +31,13 @@ test.describe(
     let pm;
 
     test.beforeEach(async ({ page }, testInfo) => {
-      // Workflows feature is under rework — skipped until it stabilizes.
-      test.skip(true, 'Workflows feature under rework');
       testLogger.testStart(testInfo.title, testInfo.file);
       await navigateToBase(page);
       pm = new PageManager(page);
       // Enterprise-only feature: these specs run ONLY in the ENT playwright matrix (never wired into
       // OSS), where Workflows is enabled by default. No runtime availability skip — if the feature is
       // missing where this runs, the test must fail loudly rather than silently pass as skipped.
+      await pm.workflowsPage.assertEnabled();
     });
 
     // =====================================================================
@@ -227,7 +226,14 @@ test.describe(
         const serverErrors = [];
 
         page.on('console', (msg) => {
-          if (msg.type() === 'error') consoleErrors.push(msg.text());
+          if (msg.type() !== 'error') return;
+          const text = msg.text();
+          // Chrome logs a "Failed to load resource: … status of 4xx" for every
+          // 4xx asset fetch. The test's contract (see header) is that 4xx from
+          // expected validation is tolerated; only real JS errors and 5xx
+          // matter. Drop resource-load 4xx noise; keep everything else.
+          if (/Failed to load resource: the server responded with a status of 4\d\d/.test(text)) return;
+          consoleErrors.push(text);
         });
         page.on('pageerror', (err) => {
           consoleErrors.push(`pageerror: ${err.message}`);


### PR DESCRIPTION
Both Workflows UI specs were blanket-skipped (`test.skip(true, 'Workflows feature under rework')`),
so 15 cases reported green without ever running. Un-skipping them exposed five page-object defects
on the add-a-node-and-configure-it path — the exact path the skip had been hiding.

### Fixes (all in `workflowsPage.js`)

| Symptom | Cause |
|---|---|
| Workflow never appeared in the list after Publish | `createDestinationInline` waited for the picker select to be *visible*, not for its value to bind. `onDestinationCreated` only stages the name; the drawer closed first, the node committed with an empty `destination_id`, and Publish refused with *"1 step needs setup before publishing"* — never issuing a request. Now waits on `data-test-selected-value`. |
| A rejected Publish failed 60s later as a bare `expect(false)` | Two silent `.catch(() => {})` swallowed it. New `publishAndExpectAccepted()` throws with the app's own toast text. |
| `openEdit` couldn't find its row | Clicked the row action without filtering the virtualized, slow-loading list (K10). Now search-then-act, matching `isPresent()`. |
| Test-run button not found | The `o-drawer-*` → `o-dialog-*` rename was over-applied. Only the *node config* panel became an `ODialog`; `WorkflowTestDialog` is still a real `ODrawer`. |
| NEG-05 asserted against code it never typed | Clicking the editor wrapper doesn't focus Monaco, so the seed template was submitted and the backend rightly reported success. Now drives Monaco via the shared `MonacoEditorHelper`, asserts the code landed, and lets `QueryEditor`'s 500ms `update:query` debounce flush before Save (which reads `AddFunction`'s model, not the editor DOM). |

### Fail-loud availability guard

`isAvailable()` existed but was **dead code**, so a flipped `O2_WORKFLOWS_ENABLED` would have
surfaced as an opaque 15s selector timeout. `assertEnabled()` now probes `/api/{org}/workflows`
once per worker and **throws** (never skips) with an actionable message. This is the UI counterpart
to the `WORKFLOWS_REQUIRED` fail-loud already on main for the pytest suite.

### Verification

Run against an enterprise build (`main.common-dev`), headless:

- **15/15 pass** serially (3.7m). Before this PR: 2 hard failures, 1 passing for the wrong reason.
- Disabled path exercised by forcing `isAvailable()` false → **1 failed**, not skipped, with the named error.
- NEG-05 now genuinely exercises invalid JS; the app returns
  `JS compilation failed: Exception generated by QuickJS`. **No product bugs were found.**

### Notes for reviewers

- **No paired ENT PR.** ENT main already has the `Workflows` shard in `ci_matrix.ent.json`,
  `O2_WORKFLOWS_ENABLED: true` in `playwright.yml`, and `WORKFLOWS_REQUIRED: "1"` in `api-testing.yml`.
  The `e2e` label lets `ent-e2e-gate.yml` build these specs against an enterprise binary.
- **Known, not fixed here:** the two `CT-19 K9` tests are still vacuous. `workflow-editor-save` only
  renders under `v-if="isExistingPublished"`, so it doesn't exist on `/add` where both run — the
  canary's `intercepted: true` means "button absent", and neither test calls `clickSave()`. Fixing
  them means deciding what K9 should test now; left for a follow-up rather than guessed at.
- **Flakiness under parallelism:** at the config default of 5 workers, `CT-19 K9` and `CT-19 NFR-03`
  failed on dev-env load (15s `/add` render, 60s navigation), not logic. Worth watching on the first CI run.
