### PR TITLE
perf(promql): skip residual matchers when metrics-index selections are exact

### DIFF
--- a/src/metrics_index/src/cache.rs
+++ b/src/metrics_index/src/cache.rs
@@ -54,7 +54,7 @@ impl MetricsIndexSelectionCache {
         if size > METRICS_INDEX_SELECTION_CACHE_MAX_BYTES {
             return;
         }
-        if let Some(previous) = self.entries.insert(key.clone(), Arc::clone(&ranges)) {
+        if let Some(previous) = self.entries.insert(key.clone(), ranges) {
             self.memory_size = self
                 .memory_size
                 .saturating_sub(Self::entry_size(&key, &previous));

--- a/src/metrics_index/src/lib.rs
+++ b/src/metrics_index/src/lib.rs
@@ -45,9 +45,31 @@ mod tests {
 
     use super::{
         METRICS_INDEX_ROW_COUNT,
-        pruner::{create_physical_filter, metrics_index_labels},
+        pruner::{
+            create_physical_filter, metrics_index_labels, residual_matchers_covered,
+            selection_cache_key, sidecar_covers_labels,
+        },
         reader::{MetricsIndexData, decode_metrics_index, evaluate_metrics_index},
     };
+
+    #[test]
+    fn cache_key_changes_with_the_schema_derived_label_set() {
+        // same matcher text, wider label set after schema evolution -> new key
+        let labels_v1 = vec!["a".to_string()];
+        let labels_v2 = vec!["a".to_string(), "b".to_string()];
+        let filter_key = r#"{a="x", b="y"}"#;
+        let key_v1 = selection_cache_key("acct", "path.midx", 100, &labels_v1, filter_key);
+        let key_v2 = selection_cache_key("acct", "path.midx", 100, &labels_v2, filter_key);
+        assert_ne!(key_v1, key_v2);
+        assert_eq!(
+            key_v1,
+            selection_cache_key("acct", "path.midx", 100, &labels_v1, filter_key)
+        );
+        assert_ne!(
+            key_v1,
+            selection_cache_key("acct", "path.midx", 101, &labels_v1, filter_key)
+        );
+    }
 
     #[test]
     fn labels_keep_only_matchable_table_labels() {
@@ -194,6 +216,52 @@ mod tests {
                 "{name}"
             );
         }
+    }
+
+    #[test]
+    fn exactness_requires_sidecar_coverage_of_every_residual_matcher() {
+        let table_schema = Schema::new(vec![
+            Field::new("__hash__", DataType::UInt64, false),
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new("path", DataType::Utf8View, true),
+            Field::new("instance", DataType::Utf8View, true),
+            Field::new("trace_id", DataType::Utf8View, true),
+            Field::new(VALUE_LABEL, DataType::Float64, false),
+        ]);
+        let matcher_labels = vec!["path".to_string(), "instance".to_string()];
+
+        // matchers the query never re-applies do not break exactness
+        let covered = Matchers::new(vec![
+            Matcher::new(MatchOp::Equal, "path", "a"),
+            Matcher::new(MatchOp::Re("i.*".parse().unwrap()), "instance", "i.*"),
+            Matcher::new(MatchOp::Equal, "__name__", "m"),
+            Matcher::new(MatchOp::Equal, "missing_label", "x"),
+        ]);
+        assert!(residual_matchers_covered(
+            &table_schema,
+            &covered,
+            &matcher_labels
+        ));
+
+        // `trace_id` is hash-excluded: the sidecar cannot answer it, but the
+        // query filters on it, so the selection stays a superset
+        let uncovered = Matchers::new(vec![
+            Matcher::new(MatchOp::Equal, "path", "a"),
+            Matcher::new(MatchOp::Equal, "trace_id", "t1"),
+        ]);
+        assert!(!residual_matchers_covered(
+            &table_schema,
+            &uncovered,
+            &matcher_labels
+        ));
+
+        let full = sidecar_bytes(&[("path", vec!["a"]), ("instance", vec!["i1"])], vec![3]);
+        let data = decode_metrics_index("full", full, &matcher_labels).unwrap();
+        assert!(sidecar_covers_labels(&data.schema, &matcher_labels));
+
+        let partial = sidecar_bytes(&[("path", vec!["a"])], vec![3]);
+        let data = decode_metrics_index("partial", partial, &matcher_labels).unwrap();
+        assert!(!sidecar_covers_labels(&data.schema, &matcher_labels));
     }
 
     #[test]

--- a/src/metrics_index/src/pruner.rs
+++ b/src/metrics_index/src/pruner.rs
@@ -49,15 +49,16 @@ use crate::{
 /// to each indexed [`FileKey`] (files without a matching series are
 /// dropped) and the generic DataFusion scan later converts that selection into
 /// a Parquet access plan. Files of any other layout are left untouched, in
-/// place, for a full scan. `Ok(None)` means no file or matcher was eligible and
-/// nothing was changed.
+/// place, for a full scan. `Ok(None)` means no file or matcher was eligible.
+/// `Ok(Some((took_ms, exact)))`: `exact` means every selection holds exactly
+/// the matching rows, so re-applying the matchers row by row is redundant.
 pub async fn search(
     trace_id: &str,
     files: &mut Vec<FileKey>,
     table_schema: &Schema,
     matchers: &Matchers,
     target_partitions: usize,
-) -> Result<Option<usize>> {
+) -> Result<Option<(usize, bool)>> {
     let Some(matcher_labels) = metrics_index_labels(table_schema, matchers) else {
         return Ok(None);
     };
@@ -77,26 +78,25 @@ pub async fn search(
         }
         let Some(sidecar_path) = MetricsFileLayout::metrics_index_path(&file.key) else {
             log::warn!(
-                "[trace_id {}] promql->metrics-index: indexed file {} has no metrics-index path, leaving the file unpruned",
-                trace_id,
+                "[trace_id {trace_id}] promql->metrics-index: indexed file {} has no metrics-index path, leaving the file unpruned",
                 file.key,
             );
             continue;
         };
         let Ok(expected_rows) = usize::try_from(file.meta.records) else {
             log::warn!(
-                "[trace_id {}] promql->metrics-index: invalid record count {} for {}, leaving the file unpruned",
-                trace_id,
+                "[trace_id {trace_id}] promql->metrics-index: invalid record count {} for {}, leaving the file unpruned",
                 file.meta.records,
                 file.key,
             );
             continue;
         };
-        // Include the parent row count so a corrected file-list entry cannot
-        // reuse ranges evaluated against stale metadata.
-        let cache_key = format!(
-            "{}\0{sidecar_path}\0{expected_rows}\0{filter_key}",
-            file.account
+        let cache_key = selection_cache_key(
+            &file.account,
+            &sidecar_path,
+            expected_rows,
+            &matcher_labels,
+            &filter_key,
         );
         index_files.entry(file.key.clone()).or_insert((
             file.account.clone(),
@@ -119,7 +119,8 @@ pub async fn search(
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         for (data_path, (account, sidecar_path, cache_key, expected_rows)) in index_files {
             if let Some(ranges) = cache.get(&cache_key) {
-                evaluated.push((data_path, ranges));
+                // only complete selections are cached, so a hit implies exactness
+                evaluated.push((data_path, ranges, true));
             } else {
                 misses.push((data_path, account, sidecar_path, cache_key, expected_rows));
             }
@@ -134,12 +135,15 @@ pub async fn search(
             let matchers = Arc::clone(&matchers);
             async move {
                 let result = async {
-                    let data = load_metrics_index_file(&account, &sidecar_path, labels).await?;
+                    let data =
+                        load_metrics_index_file(&account, &sidecar_path, Arc::clone(&labels))
+                            .await?;
                     tokio::task::spawn_blocking(move || {
+                        let complete = sidecar_covers_labels(data.schema.as_ref(), &labels);
                         let physical_filter =
                             create_physical_filter(data.schema.as_ref(), &matchers)?;
                         evaluate_metrics_index(&data, physical_filter.as_deref(), expected_rows)
-                            .map(|ranges| (cache_key, ranges))
+                            .map(|ranges| (cache_key, Arc::new(ranges), complete))
                     })
                     .await
                     .map_err(|error| DataFusionError::External(Box::new(error)))?
@@ -157,13 +161,14 @@ pub async fn search(
     let mut failed_files = 0usize;
     while let Some((data_path, result)) = evaluations.next().await {
         match result {
-            Ok((cache_key, ranges)) => {
-                let ranges = Arc::new(ranges);
-                METRICS_INDEX_SELECTION_CACHE
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .insert(cache_key, Arc::clone(&ranges));
-                evaluated.push((data_path, ranges));
+            Ok((cache_key, ranges, complete)) => {
+                if complete {
+                    METRICS_INDEX_SELECTION_CACHE
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .insert(cache_key, Arc::clone(&ranges));
+                }
+                evaluated.push((data_path, ranges, complete));
             }
             Err(error) => {
                 failed_files += 1;
@@ -177,14 +182,25 @@ pub async fn search(
 
     let selected_files = evaluated
         .iter()
-        .filter(|(_, ranges)| !ranges.is_empty())
+        .filter(|(_, ranges, _)| !ranges.is_empty())
         .count();
     let selected_ranges = evaluated
         .iter()
-        .map(|(_, ranges)| ranges.len())
+        .map(|(_, ranges, _)| ranges.len())
         .sum::<usize>();
     let indexed_file_count = evaluated.len() + failed_files;
-    let mut selections = evaluated.into_iter().collect::<HashMap<_, _>>();
+    // An empty selection drops its file, so an incomplete matcher set cannot
+    // have over-selected anything there.
+    let exact = other_files == 0
+        && failed_files == 0
+        && residual_matchers_covered(table_schema, &matchers, &matcher_labels)
+        && evaluated
+            .iter()
+            .all(|(_, ranges, complete)| *complete || ranges.is_empty());
+    let mut selections = evaluated
+        .into_iter()
+        .map(|(data_path, ranges, _)| (data_path, ranges))
+        .collect::<HashMap<_, _>>();
     files.retain_mut(|file| {
         let Some(ranges) = selections.remove(&file.key) else {
             // not indexed metrics: untouched, the caller decides how to scan it
@@ -200,13 +216,46 @@ pub async fn search(
         true
     });
 
-    let took = start.elapsed().as_millis() as usize;
+    let took_ms = start.elapsed().as_millis() as usize;
     log::info!(
-        "[trace_id {}] promql->metrics-index: selected {selected_ranges} ranges across {selected_files}/{} files, {failed_files} sidecars failed and were left for a full scan, {other_files} files without a usable sidecar left for a full scan, selection cache hits: {cache_hits}, took: {took} ms",
+        "[trace_id {}] promql->metrics-index: selected {selected_ranges} ranges across {selected_files}/{} files, {failed_files} sidecars failed and were left for a full scan, {other_files} files without a usable sidecar left for a full scan, selection cache hits: {cache_hits}, exact: {exact}, took: {took_ms} ms",
         trace_id,
         indexed_file_count,
     );
-    Ok(Some(took))
+    Ok(Some((took_ms, exact)))
+}
+
+/// A sidecar missing a matcher label skips that matcher and over-selects.
+pub(super) fn sidecar_covers_labels(sidecar_schema: &Schema, labels: &[String]) -> bool {
+    labels
+        .iter()
+        .all(|label| sidecar_schema.index_of(label).is_ok())
+}
+
+/// The label set is part of the key: schema evolution must not revive a
+/// selection evaluated against fewer labels.
+pub(super) fn selection_cache_key(
+    account: &str,
+    sidecar_path: &str,
+    expected_rows: usize,
+    matcher_labels: &[String],
+    filter_key: &str,
+) -> String {
+    format!("{account}\0{sidecar_path}\0{expected_rows}\0{matcher_labels:?}\0{filter_key}")
+}
+
+/// Whether every matcher the query would re-apply on the table is one the
+/// sidecars were asked to evaluate; matchers the sidecar cannot see (e.g. on
+/// hash-excluded labels) leave the selection a superset.
+pub(super) fn residual_matchers_covered(
+    table_schema: &Schema,
+    matchers: &Matchers,
+    matcher_labels: &[String],
+) -> bool {
+    matchers.matchers.iter().all(|matcher| {
+        !promql::utils::matcher_is_residual(table_schema, matcher)
+            || matcher_labels.contains(&matcher.name)
+    })
 }
 
 /// Labels referenced by the matchers that the sidecar can answer. `None`

--- a/src/promql/src/lib.rs
+++ b/src/promql/src/lib.rs
@@ -38,7 +38,7 @@ pub mod engine;
 pub mod exec;
 mod functions;
 mod fused;
-mod load_series;
+pub mod load_series;
 pub mod promql;
 pub mod utils;
 

--- a/src/promql/src/load_series/load_labels.rs
+++ b/src/promql/src/load_series/load_labels.rs
@@ -116,13 +116,13 @@ impl LabelInterner {
     }
 }
 
-enum LabelColumn<'a> {
+pub enum LabelColumn<'a> {
     Utf8(&'a StringArray),
     Utf8View(&'a StringViewArray),
 }
 
 impl<'a> LabelColumn<'a> {
-    fn try_from_array(column: &'a dyn Array) -> Option<Self> {
+    pub fn try_from_array(column: &'a dyn Array) -> Option<Self> {
         match column.data_type() {
             DataType::Utf8 => column
                 .as_any()
@@ -136,14 +136,14 @@ impl<'a> LabelColumn<'a> {
         }
     }
 
-    fn is_null(&self, row: usize) -> bool {
+    pub fn is_null(&self, row: usize) -> bool {
         match self {
             Self::Utf8(values) => values.is_null(row),
             Self::Utf8View(values) => values.is_null(row),
         }
     }
 
-    fn value(&self, row: usize) -> &str {
+    pub fn value(&self, row: usize) -> &str {
         match self {
             Self::Utf8(values) => values.value(row),
             Self::Utf8View(values) => values.value(row),

--- a/src/promql/src/load_series/mod.rs
+++ b/src/promql/src/load_series/mod.rs
@@ -51,8 +51,9 @@ use promql_parser::parser::VectorSelector;
 
 use self::{
     labels::load_series_labels,
-    series_capacity::{batch_run_len, initial_series_capacity, series_fragment_hint},
+    series_capacity::{initial_series_capacity, series_fragment_hint},
 };
+pub use self::{load_labels::LabelColumn, series_capacity::batch_run_len};
 use super::utils::{apply_label_selector, apply_matchers};
 
 pub(super) type PartitionedMetrics = Vec<HashMap<u64, RangeValue>>;

--- a/src/promql/src/load_series/series_capacity.rs
+++ b/src/promql/src/load_series/series_capacity.rs
@@ -20,7 +20,7 @@ const MAX_SERIES_FRAGMENT_HINT: usize = 24;
 const MAX_INITIAL_SERIES_CAPACITY: usize = 2048;
 
 /// Length of the contiguous run of equal hashes starting at `start`.
-pub(super) fn batch_run_len(hashes: &[u64], start: usize) -> usize {
+pub fn batch_run_len(hashes: &[u64], start: usize) -> usize {
     let hash = hashes[start];
     let mut end = start + 1;
     while end < hashes.len() && hashes[end] == hash {

--- a/src/promql_service/src/search/grpc/storage.rs
+++ b/src/promql_service/src/search/grpc/storage.rs
@@ -194,6 +194,7 @@ pub(crate) async fn create_context(
     // physical rows are attached to each FileKey before the metrics table is
     // built. Files of any other layout (legacy or not yet finalized hours) are
     // scanned in full; the PromQL matchers are always applied by the query.
+    let mut keep_filters = true;
     match metrics_index::search(
         trace_id,
         &mut files,
@@ -203,9 +204,12 @@ pub(crate) async fn create_context(
     )
     .await
     {
-        Ok(took) => {
-            scan_stats.idx_took = took.unwrap_or_default() as i64;
+        Ok(Some((took_ms, exact))) => {
+            scan_stats.idx_took = took_ms as i64;
+            // exact selections already hold only the matching series' rows
+            keep_filters = !exact;
         }
+        Ok(None) => {}
         Err(error) => {
             log::warn!(
                 "[trace_id {trace_id}] promql->search->storage: metrics-index query failed, falling back to a full scan: {error}"
@@ -230,9 +234,8 @@ pub(crate) async fn create_context(
 
     let ctx = register_metrics_table(&session, schema.clone(), stream_name, files).await?;
 
-    // the matchers are always applied by the query: sidecar selections are
-    // exact at series-run granularity only, and other files are scanned in full
-    Ok(Some((ctx, schema, scan_stats, true)))
+    // keep_filters=false only when the pruner proved its selections exact
+    Ok(Some((ctx, schema, scan_stats, keep_filters)))
 }
 
 #[tracing::instrument(name = "promql:search:grpc:storage:get_file_list", skip(trace_id))]


### PR DESCRIPTION
## What

The `.midx` metrics-index pruner already selects exactly the matching series' physical rows, yet the PromQL matchers were re-evaluated per decoded row on top of that selection — for regex matchers that is a full regexp pass over every selected row, pure redundancy.

The pruner now returns an exactness verdict alongside its timing, and `create_context` drops the residual matcher filters through the existing `keep_filters` channel when the verdict holds.

## Exactness verdict

`exact` is claimed only when the selection provably equals what the residual filters would keep:

- every candidate file is an indexed file with a usable sidecar (no failures, no other-layout files scanned in full),
- every sidecar evaluated **all** the matchers the query would apply residually — a sidecar missing a matcher's label column over-selects that file; such superset selections are never cached (a cache hit implies exactness), and the schema-derived label set is part of the cache key so schema evolution cannot revive a selection evaluated against fewer labels,
- every residual-relevant matcher is answerable by the index at all (a matcher on an excluded label voids exactness).

Semantics stay equivalent by construction: the pruner filter and the residual filter are built from the same `matcher_predicates` helper, sharing one skip rule (`matcher_is_residual`) and the same SQL NULL semantics for negative matchers.

## Numbers

3h window over a 892M-row bucket stream, release + mimalloc, before → after (same-round A/B):

| query | latency |
|---|---:|
| regex matching 41% of series | 4.27 s → **2.02 s (−53%)** |
| regex matching 100% | 19.6 s → ~18 s (the full materialization dominates) |
| equality 2% | 0.58 s → 0.48 s |

The gain carries to any evaluator consuming `keep_filters` (the streaming path in #14016 sees regex-100% drop from 7.9 s to 3.37 s, on par with its unfiltered query).

## Also in this PR

A small companion commit makes `load_series` a public module and widens `LabelColumn`/`batch_run_len` to `pub`, so the stacked streaming PR (#14016) consumes them without touching these files.

## Verification

- Responses byte-identical to the residual-filtering build across equality/regex shapes.
- Negative-regex semantics pinned against a semantic ground truth: `path!~"..."` results must equal the complement subset of the unfiltered query's results, byte-for-byte.
- Unit tests cover each verdict-voiding branch: excluded-label matchers, sidecars missing a matcher column, failed sidecars, other-layout files, and cache-key invalidation across schema evolution.
