### PR TITLE
fix: paginate multi-stream logs with a single UNION ALL BY NAME query [v0.40]

### DIFF
--- a/tests/ui-testing/playwright-tests/dashboards/crossLinkMultiStream.spec.js
+++ b/tests/ui-testing/playwright-tests/dashboards/crossLinkMultiStream.spec.js
@@ -247,8 +247,8 @@ test.describe("Cross-Linking Multi-Stream testcases", () => {
         testLogger.info('PASSED: Both streams cross-links visible in UNION ALL SQL query');
     });
 
-    // P1: Network verification — multiple result_schema calls for multi-stream
-    test("should fire separate result_schema calls for each stream in multi-stream mode", {
+    // P1: Network verification — one result_schema call covering every selected stream
+    test("should fire one result_schema call covering both streams in multi-stream mode", {
         tag: ['@crossLinking', '@multiStream', '@functional', '@P1', '@all']
     }, async ({ page }) => {
         testLogger.info('Testing network calls for multi-stream cross-links');
@@ -262,7 +262,7 @@ test.describe("Cross-Linking Multi-Stream testcases", () => {
         page.on('request', (request) => {
             const url = request.url();
             if (url.includes('result_schema') && url.includes('cross_linking=true')) {
-                resultSchemaRequests.push(url);
+                resultSchemaRequests.push({ url, payload: request.postData() || '' });
             }
         });
 
@@ -270,17 +270,24 @@ test.describe("Cross-Linking Multi-Stream testcases", () => {
         await pm.logsPage.runQueryAndWaitForResults();
         await page.waitForTimeout(3000);
 
-        // Step 4: Verify multiple result_schema calls were fired
+        // Step 4: Verify the cross-linking call fired for the union query
         testLogger.info('result_schema calls captured', {
             count: resultSchemaRequests.length,
-            urls: resultSchemaRequests
+            urls: resultSchemaRequests.map((r) => r.url)
         });
 
+        // Multi-stream search is one UNION ALL BY NAME query, so cross-linking needs a
+        // single result_schema call — the backend resolves every table in the query and
+        // merges their links (see resolve_stream_names in the cross_linking branch).
         expect(resultSchemaRequests.length,
-            'Should fire at least 2 result_schema calls for 2 streams'
-        ).toBeGreaterThanOrEqual(2);
+            'Should fire exactly one result_schema call for the union query'
+        ).toBe(1);
 
-        testLogger.info('PASSED: Multiple result_schema calls verified for multi-stream');
+        const payload = resultSchemaRequests[0]?.payload || '';
+        expect(payload, `result_schema payload should query ${STREAM_A}`).toContain(STREAM_A);
+        expect(payload, `result_schema payload should query ${STREAM_B}`).toContain(STREAM_B);
+
+        testLogger.info('PASSED: single result_schema call covers both streams');
     });
 
     // P1: Dashboard table panel — single stream cross-link in drilldown menu

--- a/web/src/composables/useLogs/useHistogram.spec.ts
+++ b/web/src/composables/useLogs/useHistogram.spec.ts
@@ -82,10 +82,6 @@ describe("useHistogram Composable", () => {
       expect(typeof wrapper.vm.resetHistogramWithError).toBe("function");
     });
 
-    it("should have setMultiStreamHistogramQuery function", () => {
-      expect(typeof wrapper.vm.setMultiStreamHistogramQuery).toBe("function");
-    });
-
     it("should have isHistogramEnabled function", () => {
       expect(typeof wrapper.vm.isHistogramEnabled).toBe("function");
     });

--- a/web/src/composables/useLogs/useHistogram.ts
+++ b/web/src/composables/useLogs/useHistogram.ts
@@ -268,33 +268,6 @@ export const useHistogram = () => {
     }
   };
 
-  const setMultiStreamHistogramQuery = (queryReq: any) => {
-    let histogramQuery = `select histogram(${store.state.zoConfig.timestamp_column}, '${searchObj.meta.resultGrid.chartInterval}') AS zo_sql_key, count(*) AS zo_sql_num from "[INDEX_NAME]" [WHERE_CLAUSE] GROUP BY zo_sql_key`;
-    let multiSql = [];
-
-    for (const stream of searchObj.data.stream.selectedStream) {
-      // one or more filter fields are missing in this stream so no need to include in histogram query
-      // this is to avoid the issue of missing fields in multi stream histogram query
-      if (
-        searchObj.data.stream.missingStreamMultiStreamFilter.includes(stream)
-      ) {
-        continue;
-      }
-      // Replace the index name and where clause in the histogram query for each stream
-      multiSql.push(
-        histogramQuery
-          .replace("[INDEX_NAME]", stream)
-          .replace(
-            "[WHERE_CLAUSE]",
-            searchObj.data.query ? "WHERE " + searchObj.data.query : "",
-          ),
-      );
-    }
-
-    return multiSql.join(" UNION ALL ");
-  };
-
-  // Bhargav Todo: duplicate function in index.vue
   const isHistogramEnabled = (searchObj: any) => {
     return (
       searchObj.meta.refreshHistogram &&
@@ -585,7 +558,6 @@ export const useHistogram = () => {
     generateHistogramData,
     resetHistogramWithError,
     generateHistogramSkeleton,
-    setMultiStreamHistogramQuery,
     isHistogramEnabled,
   };
 };

--- a/web/src/composables/useLogs/useSearchHistogramManager.ts
+++ b/web/src/composables/useLogs/useSearchHistogramManager.ts
@@ -36,7 +36,6 @@ export const useSearchHistogramManager = () => {
   const {
     resetHistogramWithError,
     generateHistogramSkeleton,
-    setMultiStreamHistogramQuery,
     isHistogramEnabled,
   } = useHistogram();
 
@@ -49,9 +48,7 @@ export const useSearchHistogramManager = () => {
         (!searchObj.meta.sqlMode ||
           isNonAggregatedSQLMode(searchObj, parsedSQL))) ||
         (isHistogramEnabled(searchObj) && !searchObj.meta.sqlMode)) &&
-      (searchObj.data.stream.selectedStream.length === 1 ||
-        (searchObj.data.stream.selectedStream.length > 1 &&
-          !searchObj.meta.sqlMode))
+      searchObj.data.stream.selectedStream.length === 1
     );
   };
 
@@ -71,13 +68,11 @@ export const useSearchHistogramManager = () => {
   ) => {
     const parsedSQL: any = fnParsedSQL();
 
-    if (
-      searchObj.data.stream.selectedStream.length > 1 &&
-      searchObj.meta.sqlMode == true
-    ) {
-      const errMsg =
-        "Histogram is not available for multi-stream SQL mode search.";
-      resetHistogramWithError(errMsg, 0);
+    if (searchObj.data.stream.selectedStream.length > 1) {
+      resetHistogramWithError(
+        "Histogram unavailable for CTEs, DISTINCT, UNION, JOIN and LIMIT queries.",
+        -1,
+      );
     }
 
     if (!searchObj.data.queryResults?.hits?.length) {
@@ -119,20 +114,11 @@ export const useSearchHistogramManager = () => {
           payload.onReset = callbacks.onReset;
         }
 
-        if (
-          searchObj.data.stream.selectedStream.length > 1 &&
-          searchObj.meta.sqlMode == false
-        ) {
-          payload.queryReq.query.sql = setMultiStreamHistogramQuery(
-            searchObj.data.histogramQuery.query,
-          );
-        } else {
-          payload.queryReq.query.sql =
+        payload.queryReq.query.sql =
             searchObj.data.histogramQuery.query.sql.replace(
               "[INTERVAL]",
               searchObj.meta.resultGrid.chartInterval,
             );
-        }
 
         payload.meta = {
           isHistogramOnly: searchObj.meta.histogramDirtyFlag,

--- a/web/src/composables/useLogs/useSearchQuery.ts
+++ b/web/src/composables/useLogs/useSearchQuery.ts
@@ -292,7 +292,7 @@ export const useSearchQuery = () => {
             interestingFields.join(","),
           );
         }
-      } else {
+      } else if (searchObj.data.stream.selectedStream.length <= 1) {
         req.query.sql = req.query.sql.replace("[FIELD_LIST]", "*");
       }
 
@@ -346,7 +346,7 @@ export const useSearchQuery = () => {
       if (searchObj.meta.sqlMode == true) {
         return handleSqlMode(query, req, readOnly);
       } else {
-        return handleNonSqlMode(query, req);
+        return handleNonSqlMode(query, req, ignoreQuickMode);
       }
     } catch (e: any) {
       notificationMsg.value =
@@ -443,7 +443,11 @@ export const useSearchQuery = () => {
     return buildSearch(true);
   };
 
-  const handleNonSqlMode = (query: string, req: any): SearchRequestPayload => {
+  const handleNonSqlMode = (
+    query: string,
+    req: any,
+    ignoreQuickMode: boolean = false,
+  ): SearchRequestPayload => {
     const parseQuery = [query];
     let queryFunctions = "";
     let whereClause = "";
@@ -489,7 +493,7 @@ export const useSearchQuery = () => {
     );
 
     if (searchObj.data.stream.selectedStream.length > 1) {
-      return handleMultiStream(req, whereClause);
+      return handleMultiStream(req, whereClause, ignoreQuickMode);
     } else {
       req.query.sql = req.query.sql.replace(
         "[INDEX_NAME]",
@@ -500,9 +504,36 @@ export const useSearchQuery = () => {
     return finalizeRequest(req);
   };
 
+  const armProjection = (stream: string, ignoreQuickMode: boolean): string => {
+    if (!searchObj.meta.quickMode || ignoreQuickMode) {
+      return "*";
+    }
+
+    const timestampCol = store.state.zoConfig.timestamp_column || "_timestamp";
+    const fields = searchObj.data.stream.interestingFieldList.filter(
+      (field: string) =>
+        searchObj.data.stream.selectedStreamFields.some(
+          (streamField: any) =>
+            streamField?.name === field &&
+            streamField?.streams?.includes(stream),
+        ),
+    );
+
+    if (fields.length === 0) {
+      return "*";
+    }
+
+    // A set operation is never rewritten by AddTimestampVisitor, so the arm must ask for _timestamp.
+    return [
+      timestampCol,
+      ...fields.filter((f: string) => f !== timestampCol),
+    ].join(",");
+  };
+
   const handleMultiStream = (
     req: any,
     whereClause: string,
+    ignoreQuickMode: boolean = false,
   ): SearchRequestPayload => {
     let streams: any = searchObj.data.stream.selectedStream;
 
@@ -523,41 +554,31 @@ export const useSearchQuery = () => {
     }
 
     const preSQLQuery = req.query.sql;
-    req.query.sql = [];
 
-    streams
-      .join(",")
-      .split(",")
-      .forEach((item: any) => {
-        let finalQuery: string = preSQLQuery.replace("[INDEX_NAME]", item);
+    // A stream listed twice would emit two identical arms and duplicate every row.
+    const uniqueStreams: string[] = [
+      ...new Set<string>(streams.join(",").split(",")),
+    ].filter((stream: string) => stream.trim() !== "");
 
-        const listOfFields: any = [];
-        let streamField: any = {};
+    const arms: string[] = uniqueStreams.map((item: string) => {
+      const finalQuery: string = preSQLQuery.replace("[INDEX_NAME]", item);
+      return finalQuery.replace(
+        "[FIELD_LIST]",
+        `${armProjection(item, ignoreQuickMode)}, '${item}' as _stream_name`,
+      );
+    });
 
-        for (const field of searchObj.data.stream.interestingFieldList) {
-          for (streamField of searchObj.data.stream.selectedStreamFields) {
-            if (
-              streamField?.name == field &&
-              streamField?.streams.indexOf(item) > -1 &&
-              listOfFields.indexOf(field) == -1
-            ) {
-              listOfFields.push(field);
-            }
-          }
-        }
+    if (arms.length === 0) {
+      return null;
+    }
 
-        let queryFieldList: string = "";
-        if (listOfFields.length > 0) {
-          queryFieldList = "," + listOfFields.join(",");
-        }
-
-        finalQuery = finalQuery.replace(
-          "[FIELD_LIST]",
-          `'${item}' as _stream_name` + queryFieldList,
-        );
-
-        req.query.sql.push(finalQuery);
-      });
+    // BY NAME merges differing columns, ALL keeps duplicate events, and a set operation gets no implicit ORDER BY.
+    req.query.sql =
+      arms.length > 1
+        ? `${arms.join(" UNION ALL BY NAME ")} ORDER BY ${
+            store.state.zoConfig.timestamp_column || "_timestamp"
+          } DESC`
+        : arms[0];
 
     return req;
   };

--- a/web/src/composables/useStreamingSearch.ts
+++ b/web/src/composables/useStreamingSearch.ts
@@ -217,11 +217,6 @@ const useHttpStreaming = () => {
         url += `&clear_cache=${clear_cache}`;
       if (meta?.is_ui_histogram) url += `&is_ui_histogram=${meta?.is_ui_histogram}`;
 
-      if (type === "histogram") {
-        let is_multi_stream_search = false;
-        if (queryReq.query?.sql.indexOf(' UNION ALL ') !== -1) is_multi_stream_search = true;
-        url += `&is_multi_stream_search=${is_multi_stream_search}`;
-      }
 
     } else if (type === "values") {
       const fieldsString = meta?.fields.join(",");

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -2729,7 +2729,7 @@ export default defineComponent({
 
         if (this.searchObj.meta.sqlMode && this.isLimitQuery(parsedSQL)) {
           this.resetHistogramWithError(
-            "Histogram unavailable for CTEs, DISTINCT, JOIN and LIMIT queries.",
+            "Histogram unavailable for CTEs, DISTINCT, UNION, JOIN and LIMIT queries.",
             -1,
           );
           this.searchObj.meta.histogramDirtyFlag = false;
@@ -2738,16 +2738,14 @@ export default defineComponent({
           (this.isDistinctQuery(parsedSQL) || this.isWithQuery(parsedSQL))
         ) {
           this.resetHistogramWithError(
-            "Histogram unavailable for CTEs, DISTINCT, JOIN and LIMIT queries.",
+            "Histogram unavailable for CTEs, DISTINCT, UNION, JOIN and LIMIT queries.",
             -1,
           );
           this.searchObj.meta.histogramDirtyFlag = false;
-        } else if (
-          this.searchObj.data.stream.selectedStream.length > 1 &&
-          this.searchObj.meta.sqlMode == true
-        ) {
+        } else if (this.searchObj.data.stream.selectedStream.length > 1) {
           this.resetHistogramWithError(
-            "Histogram is not available for multi stream search.",
+            "Histogram unavailable for CTEs, DISTINCT, UNION, JOIN and LIMIT queries.",
+            -1,
           );
         } else if (
           this.searchObj.data.queryResults.is_histogram_eligible == false


### PR DESCRIPTION
Backport of #14057 to `branch-v0.40.0`. Fixes openobserve/o2-enterprise#2455 on that line. Companion backport for v0.80: #14063.

## Problem

Multi-stream auto-mode logs search sent **one query per stream** to `_search_multi_stream`, and `from` was copied into every sub-query:

```
page 2 (from=50)  ->  stream A: skip 50 of 36  -> 0 rows
                      stream B: skip 50 of 35  -> 0 rows
                                                    |
                                        "No events found", counter says 71
```

The histogram on the same path was independently broken: the server discarded the client SQL and rebuilt it without the `WHERE` clause, so a query matching 71 events reported the full stream contents — offering pages that were all empty.

## Fix

One query to `_search_stream`, so the engine does the global sort and offset:

```sql
select *, 'demo_a' as _stream_name from "demo_a" WHERE match_all('...')
UNION ALL BY NAME
select *, 'demo_b' as _stream_name from "demo_b" WHERE match_all('...')
ORDER BY _timestamp DESC
```

`BY NAME` is load-bearing: plain `UNION` deletes rows genuinely duplicated across streams, and bare `UNION ALL` matches columns positionally, so two streams with different fields either mislabel data or fail to plan. `BY NAME` matches on name, and the planner substitutes `NULL` for columns an arm lacks — nulls that `arrow_json::ArrayWriter` then omits, so each row reaches the UI with exactly its own fields.

Multi-stream loses the histogram, matching what SQL mode has always done for a union. The event count stays exact — it comes from the separate `track_total_hits` request, which the histogram gate now triggers.

Full rationale, measurements and the impacted-areas breakdown are in #14057.

## Differences from the main PR

This branch is well behind main, so the port is adapted rather than cherry-picked:

- The histogram notices here are hardcoded English strings rather than i18n keys, so the locale and `translation_state` changes from #14057 do not apply. The multi-stream notice reuses this branch's existing "Histogram unavailable for …" string (with `UNION` added to its list) and renders as the compact tooltip (`errorCode -1`) instead of a chart-area banner.
- `handleMultiStream` here has no `multiStreamFieldMapping` per-arm WHERE rewrite (newer on main), so the arm builder is simpler.
- This branch has no `quoteSqlIdentifierIfNeeded`, so the quick-mode arm projection joins field names the same way the existing code did.
- The cross-linking e2e spec here uses an inline request array rather than a page-object capture helper, so the same assertion change is applied inline.

## Testing

- `useHistogram.spec.ts`, `useSearchBar.spec.ts`, `usePagination.spec.ts`: **26 passed, 0 failed** against this branch's own dependency install.
- `vue-tsc` type-check clean; prettier clean on the touched files.
- Behaviour verified on main against a live instance — 4 streams with deliberately divergent schemas, 141 matching rows, pages 50/50/41, zero duplicates, zero gaps. Numbers in #14057.

Note for maintainers: `npm ci` fails on this branch (`package.json` and `package-lock.json` are out of sync) — pre-existing, unrelated to this change; I used `npm install` locally and did not commit the lock file.
