### PR TITLE
test(workflows): cover conditions, the incident trigger, and destination delivery

### DIFF
--- a/tests/ui-testing/pages/workflowsPages/workflowsPage.js
+++ b/tests/ui-testing/pages/workflowsPages/workflowsPage.js
@@ -141,12 +141,8 @@ class WorkflowsPage {
     this.destHeaderKeyField = (key = '') => `[data-test="add-destination-header-${key}-key-input-field"]`;
     this.destHeaderValueField = (key = '') => `[data-test="add-destination-header-${key}-value-input-field"]`;
     this.triggerBody = '[data-test="workflow-trigger-body"]';
-    this.triggerStructure = '[data-test="workflow-trigger-structure"]';
     this.triggerVariantTrigger = '[data-test="workflow-trigger-sample-variant-trigger"]';
     this.triggerVariantOption = '[data-test="workflow-trigger-sample-variant-option"]';
-    this.triggerCommonStructure = '[data-test="workflow-trigger-common-structure"]';
-    this.triggerSpecificStructure = '[data-test="workflow-trigger-specific-structure"]';
-    this.triggerNoExtras = '[data-test="workflow-trigger-no-extras"]';
     // Condition node body + the shared ConditionBuilder. OFormSelect/OFormInput
     // bind {...$attrs} onto OSelect/OInput, so the consumer data-test lands on the
     // wrapper and the interactive child is `-trigger` (select) / `-field` (input).
@@ -408,11 +404,6 @@ class WorkflowsPage {
     await this.pickSelectOption(this.triggerVariantTrigger, this.triggerVariantOption, eventType);
   }
 
-  /** Incident kinds split the payload into common + event-specific blocks. */
-  async expectSplitPayloadView() {
-    await expect(this.page.locator(this.triggerCommonStructure)).toBeVisible();
-  }
-
   /**
    * The trigger's payload as TEXT, independent of how it is laid out: main renders
    * a common + event-specific pair, while an in-flight UX branch merges them into a
@@ -437,15 +428,6 @@ class WorkflowsPage {
         .map((ed) => ed.getValue())
         .join('\n');
     });
-  }
-
-  /** An event_type whose `extras` are {} shows the no-extras note instead. */
-  async expectNoExtrasNote() {
-    await expect(this.page.locator(this.triggerNoExtras)).toBeVisible();
-  }
-
-  async expectSpecificStructure() {
-    await expect(this.page.locator(this.triggerSpecificStructure)).toBeVisible();
   }
 
   // ---------- condition node ----------

--- a/tests/ui-testing/pages/workflowsPages/workflowsPage.js
+++ b/tests/ui-testing/pages/workflowsPages/workflowsPage.js
@@ -107,6 +107,64 @@ class WorkflowsPage {
     // Post-save "link to alerts" dialog (ODialog): Skip = secondary button.
     this.linkAlertsDialog = '[data-test="workflow-link-alerts-dialog"]';
     this.dialogSecondary = '[data-test="o-dialog-secondary-btn"]';
+    // Trigger config panel — a READ-ONLY payload reference, no config to save.
+    // Kinds with `commonMetaKeys` (incidents) render a SPLIT view: a variant
+    // OSelect plus common/event-specific blocks. Kinds without (alerts) render a
+    // single combined block. `no-extras` replaces the specific block when an
+    // event_type adds nothing (e.g. `created`, whose extras are {}).
+    // Canvas chrome + per-node selectors. Node-scoped ones are factories (same
+    // pattern as stepTriggerFor/destTypeCard) because they key on node_type / name.
+    this.dialogOverlay = '[data-test="o-dialog-overlay"]';
+    this.palette = '[data-test="workflow-palette"]';
+    this.paletteCollapseBtn = '[data-test="workflow-palette-collapse-btn"]';
+    this.nodeFor = (t) => `[data-test="workflow-node-${t}"]`;
+    this.nodeTestOkFor = (t) => `[data-test="workflow-node-${t}-test-ok"]`;
+    this.nodeTestErrorFor = (t) => `[data-test="workflow-node-${t}-test-error"]`;
+    this.listRowPrefixFor = (n) => `[data-test^="workflow-list-${n}-"]`;
+    this.listRowActionFor = (n, a) => `[data-test="workflow-list-${n}-${a}"]`;
+    // NDV output pane — on a successful destination send this holds the sink's
+    // response body, which is what makes delivery assertable.
+    this.ndvOutput = '[data-test="workflow-ndv-output"]';
+    // Test-run drawer. Still a real ODrawer (WorkflowTestDialog.vue) — only the NODE
+    // config panel became an ODialog — so its buttons stay `o-drawer-*`.
+    this.testDrawer = '[data-test="workflow-test-drawer"]';
+    this.testDrawerPrimary = '[data-test="workflow-test-drawer"] [data-test="o-drawer-primary-btn"]';
+    // Workflow function code editor (QuickJS/JavaScript), shared with the Functions page.
+    this.functionEditor = '[data-test="logs-vrl-function-editor"]';
+    // Warning toast — how a blocked Publish reports itself, since it never reaches the network.
+    this.warningToast = '[data-test^="o-toast-"][data-test-variant="warning"]';
+    this.anyToast = '[role="alert"], .q-notification__message';
+    this.confirmButton =
+      '[data-test$="-confirm-button"], [data-test="dlg-primary"], button:has-text("OK"), button:has-text("Delete")';
+    // Destination header rows are keyed by the header's CURRENT key, so these are
+    // functions rather than constants — a blank row answers to the empty-key form.
+    this.destHeaderKeyField = (key = '') => `[data-test="add-destination-header-${key}-key-input-field"]`;
+    this.destHeaderValueField = (key = '') => `[data-test="add-destination-header-${key}-value-input-field"]`;
+    this.triggerBody = '[data-test="workflow-trigger-body"]';
+    this.triggerStructure = '[data-test="workflow-trigger-structure"]';
+    this.triggerVariantTrigger = '[data-test="workflow-trigger-sample-variant-trigger"]';
+    this.triggerVariantOption = '[data-test="workflow-trigger-sample-variant-option"]';
+    this.triggerCommonStructure = '[data-test="workflow-trigger-common-structure"]';
+    this.triggerSpecificStructure = '[data-test="workflow-trigger-specific-structure"]';
+    this.triggerNoExtras = '[data-test="workflow-trigger-no-extras"]';
+    // Condition node body + the shared ConditionBuilder. OFormSelect/OFormInput
+    // bind {...$attrs} onto OSelect/OInput, so the consumer data-test lands on the
+    // wrapper and the interactive child is `-trigger` (select) / `-field` (input).
+    // Options carry data-test-value, so a rule is picked by VALUE, not by label.
+    this.conditionBody = '[data-test="workflow-condition-body"]';
+    this.conditionNote = '[data-test="workflow-condition-note"]';
+    this.conditionNoteDismiss = '[data-test="workflow-condition-note-dismiss"]';
+    this.conditionBuilder = '[data-test="condition-builder"]';
+    this.condColumnTrigger = '[data-test="alert-conditions-select-column-trigger"]';
+    this.condColumnSearch = '[data-test="alert-conditions-select-column-search"]';
+    this.condColumnOption = '[data-test="alert-conditions-select-column-option"]';
+    this.condOperatorTrigger = '[data-test="alert-conditions-operator-select-trigger"]';
+    this.condOperatorOption = '[data-test="alert-conditions-operator-select-option"]';
+    // v-if'd away entirely for unary operators (is_null/is_empty/...) — absence,
+    // not an empty string, is what a unary operator looks like in the DOM.
+    this.condValueField = '[data-test="alert-conditions-value-input-field"]';
+    this.condAddBtn = '[data-test="alert-conditions-add-condition-btn"]';
+    this.condDeleteBtn = '[data-test="alert-conditions-delete-condition-btn"]';
   }
 
   // Workflows is an Enterprise-only feature: on a build without it the API answers 404/403.
@@ -270,7 +328,7 @@ class WorkflowsPage {
     const close = this.page.locator(this.drawerClose);
     if (await close.count()) {
       await close.first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
-      await this.page.locator('[data-test="o-dialog-overlay"]')
+      await this.page.locator(this.dialogOverlay)
         .waitFor({ state: 'detached', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
     }
   }
@@ -280,9 +338,9 @@ class WorkflowsPage {
    * config drawer. The palette is the reliable add path — the on-node hover-`+` is hidden.
    */
   async ensureNodePaletteOpen() {
-    const rail = this.page.locator('[data-test="workflow-palette"]');
+    const rail = this.page.locator(this.palette);
     if (await rail.isVisible().catch(() => false)) return;
-    await this.page.locator('[data-test="workflow-palette-collapse-btn"]').click();
+    await this.page.locator(this.paletteCollapseBtn).click();
     await rail.waitFor({ state: 'visible' });
   }
 
@@ -295,11 +353,162 @@ class WorkflowsPage {
     // does NOT auto-open the config panel. Click the freshly-added node to open
     // its drawer. Multiple nodes of the same type can coexist; last() picks the
     // newest for the caller's follow-up config.
-    const nodeSel = `[data-test="workflow-node-${type}"]`;
+    const nodeSel = this.nodeFor(type);
     const node = this.page.locator(nodeSel).last();
     await node.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
     await node.click({ timeout: DRAWER_TIMEOUT_MS });
     await this.page.locator(this.nodeDrawer).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  /**
+   * Add one header row to the inline create-destination form. The row's data-test is
+   * keyed by the header's CURRENT key, so the blank row is `...-header--key-input` and
+   * the value input only answers to its final name once the key has been typed.
+   * The backend forwards these on every send (batch_execution.rs applies
+   * `endpoint.headers` to the outbound request), which is what lets a workflow post
+   * into an authenticated endpoint.
+   */
+  async setDestinationHeader(key, value) {
+    await this.page.locator(this.destHeaderKeyField()).fill(key, { timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.destHeaderValueField(key)).fill(value, { timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  /** Pick an OSelect option by its VALUE (options stamp data-test-value). */
+  async pickSelectOption(triggerSel, optionSel, value) {
+    await this.page.locator(triggerSel).click({ timeout: DRAWER_TIMEOUT_MS });
+    const option = this.page.locator(`${optionSel}[data-test-value="${value}"]`).first();
+    await option.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await option.click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  /** Values of every option an OSelect currently offers. */
+  async selectOptionValues(triggerSel, optionSel) {
+    await this.page.locator(triggerSel).click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(optionSel).first().waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    const values = await this.page.locator(optionSel).evaluateAll((els) =>
+      els.map((e) => e.getAttribute('data-test-value'))
+    );
+    await this.page.keyboard.press('Escape');
+    return values.filter(Boolean);
+  }
+
+  // ---------- trigger config panel ----------
+  /** Open the trigger node's read-only payload reference. */
+  async openTriggerConfig() {
+    await this.page.locator(this.triggerNode).click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.nodeDrawer).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  /** The event_type values the incident trigger offers as sample variants. */
+  async triggerVariantValues() {
+    return this.selectOptionValues(this.triggerVariantTrigger, this.triggerVariantOption);
+  }
+
+  async selectTriggerVariant(eventType) {
+    await this.pickSelectOption(this.triggerVariantTrigger, this.triggerVariantOption, eventType);
+  }
+
+  /** Incident kinds split the payload into common + event-specific blocks. */
+  async expectSplitPayloadView() {
+    await expect(this.page.locator(this.triggerCommonStructure)).toBeVisible();
+  }
+
+  /**
+   * The trigger's payload as TEXT, independent of how it is laid out: main renders
+   * a common + event-specific pair, while an in-flight UX branch merges them into a
+   * single block. Reading every editor under the trigger body keeps assertions about
+   * WHAT the payload contains rather than which box it happens to sit in.
+   *
+   * Read through window.monaco rather than `.view-lines`: Monaco only renders the
+   * lines currently in view, so a scrolled payload would silently lose fields.
+   */
+  async triggerPayloadText() {
+    await this.page.locator(this.triggerBody).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await this.page.waitForFunction(
+      () => Boolean(window.monaco?.editor?.getEditors?.()?.length),
+      null,
+      { timeout: DRAWER_TIMEOUT_MS }
+    );
+    return this.page.evaluate(() => {
+      const body = document.querySelector('[data-test="workflow-trigger-body"]');
+      if (!body) return '';
+      return (window.monaco?.editor?.getEditors?.() || [])
+        .filter((ed) => body.contains(ed.getDomNode()))
+        .map((ed) => ed.getValue())
+        .join('\n');
+    });
+  }
+
+  /** An event_type whose `extras` are {} shows the no-extras note instead. */
+  async expectNoExtrasNote() {
+    await expect(this.page.locator(this.triggerNoExtras)).toBeVisible();
+  }
+
+  async expectSpecificStructure() {
+    await expect(this.page.locator(this.triggerSpecificStructure)).toBeVisible();
+  }
+
+  // ---------- condition node ----------
+  /**
+   * The guidelines box is a FIRST-RUN hint persisted to localStorage. On a fresh
+   * CI profile it renders every time and can sit over the builder, so dismiss it
+   * before driving the rows rather than letting it flake the click.
+   */
+  async dismissConditionGuidelinesIfPresent() {
+    const dismiss = this.page.locator(this.conditionNoteDismiss);
+    if (await dismiss.isVisible().catch(() => false)) {
+      await dismiss.click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
+      await this.page.locator(this.conditionNote)
+        .waitFor({ state: 'detached', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
+    }
+  }
+
+  /** Column values the condition builder offers — trigger-kind specific. */
+  async conditionColumnValues() {
+    return this.selectOptionValues(this.condColumnTrigger, this.condColumnOption);
+  }
+
+  /**
+   * Fill one condition rule. `value` is omitted for unary operators
+   * (is_null/is_not_null/is_empty/is_not_empty) — the input is not rendered at all.
+   */
+  async setCondition({ column, operator, value }) {
+    await this.page.locator(this.conditionBuilder).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await this.dismissConditionGuidelinesIfPresent();
+    await this.pickSelectOption(this.condColumnTrigger, this.condColumnOption, column);
+    await this.pickSelectOption(this.condOperatorTrigger, this.condOperatorOption, operator);
+    if (value !== undefined) {
+      await this.page.locator(this.condValueField).fill(value);
+    }
+  }
+
+  /**
+   * Change only the operator (and value) of an existing rule. Re-picking the column
+   * each time is needless work and an extra flake surface when a test sweeps a set of
+   * operators against one column.
+   */
+  async setConditionOperator(operator, value) {
+    await this.pickSelectOption(this.condOperatorTrigger, this.condOperatorOption, operator);
+    if (value !== undefined) {
+      await this.page.locator(this.condValueField).fill(value);
+    }
+  }
+
+  /** Unary operators remove the value input from the DOM (v-if), not just clear it. */
+  async expectConditionValueAbsent() {
+    await expect(this.page.locator(this.condValueField)).toHaveCount(0);
+  }
+
+  async expectConditionValueVisible() {
+    await expect(this.page.locator(this.condValueField)).toBeVisible();
+  }
+
+  async expectConditionBuilderVisible() {
+    await expect(this.page.locator(this.conditionBuilder)).toBeVisible();
+  }
+
+  async expectConditionGuidelinesAbsent() {
+    await expect(this.page.locator(this.conditionNote)).toHaveCount(0);
   }
 
   /**
@@ -313,13 +522,16 @@ class WorkflowsPage {
    * (name field present right after toggling create); we do NOT tolerate a type-selection step
    * here — if it reappears, the forced-type contract has changed and this should fail loudly.
    */
-  async createDestinationInline({ name, url }) {
+  async createDestinationInline({ name, url, headers }) {
     await this.page.locator(this.destPickerCreateToggle).click({ timeout: DRAWER_TIMEOUT_MS });
 
     const nameField = this.page.locator(this.destNameField);
     await nameField.waitFor({ state: 'attached', timeout: DRAWER_TIMEOUT_MS });
     await nameField.fill(name);
     await this.page.locator(this.destUrlField).fill(url);
+    for (const [key, value] of Object.entries(headers || {})) {
+      await this.setDestinationHeader(key, value);
+    }
     await this.page.locator(this.destSubmitBtn).click({ timeout: DRAWER_TIMEOUT_MS });
     // onDestinationCreated only STAGES the name (pendingSelection); the select is
     // bound after the refetch resolves. The trigger renders before that value lands,
@@ -337,23 +549,64 @@ class WorkflowsPage {
    */
   async testRunFromEditor() {
     await this.page.locator(this.testBtn).click({ timeout: DRAWER_TIMEOUT_MS });
-    await this.page.locator('[data-test="workflow-test-drawer"]').waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.testDrawer).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
     // The Test panel is still a real ODrawer (WorkflowTestDialog.vue) — only the NODE
     // config panel became an ODialog. Its buttons stay `o-drawer-*`.
-    await this.page.locator('[data-test="workflow-test-drawer"] [data-test="o-drawer-primary-btn"]')
-      .click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.testDrawerPrimary).click({ timeout: DRAWER_TIMEOUT_MS });
   }
 
   /** Assert a node painted an error badge after a test run (node_type e.g. 'destination','function').
    *  Generous timeout — on slow CI runners the run + failing send can take a while to resolve. */
   async expectNodeTestError(nodeType, timeout = 60000) {
-    await expect(this.page.locator(`[data-test="workflow-node-${nodeType}-test-error"]`))
+    await expect(this.page.locator(this.nodeTestErrorFor(nodeType)))
       .toBeVisible({ timeout });
+  }
+
+  /**
+   * A node's test-run OUTPUT, as text. On a successful destination send the backend
+   * sets the node's output to the sink's RESPONSE BODY (batch_execution.rs calls
+   * send_output with `body`), so pointing a destination at OpenObserve's own ingest
+   * endpoint makes this the ingest receipt — direct, synchronous proof of delivery
+   * with no polling and no follow-up search.
+   */
+  async nodeTestOutputText(nodeType) {
+    await this.page.locator(this.nodeFor(nodeType)).last()
+      .click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.nodeDrawer).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    const panel = this.page.locator(this.ndvOutput);
+    await panel.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await this.page.waitForFunction(
+      () => Boolean(window.monaco?.editor?.getEditors?.()?.length),
+      null,
+      { timeout: DRAWER_TIMEOUT_MS }
+    );
+    return this.page.evaluate(() => {
+      const out = document.querySelector('[data-test="workflow-ndv-output"]');
+      if (!out) return '';
+      return (window.monaco?.editor?.getEditors?.() || [])
+        .filter((ed) => out.contains(ed.getDomNode()))
+        .map((ed) => ed.getValue())
+        .join('\n');
+    });
+  }
+
+  /**
+   * The destination's response parsed into an object. The node output is an ARRAY of
+   * response bodies (one per send), each itself a JSON string, so it needs two parses
+   * — matching a regex against the escaped text is brittle and reads badly.
+   * For a self-ingest sink this resolves to OpenObserve's receipt:
+   *   { code: 200, status: [{ name, successful, failed }] }
+   */
+  async destinationIngestReceipt() {
+    const raw = await this.nodeTestOutputText('destination');
+    const outer = JSON.parse(raw);
+    const first = Array.isArray(outer) ? outer[0] : outer;
+    return typeof first === 'string' ? JSON.parse(first) : first;
   }
 
   /** Assert a node painted a success badge after a test run. */
   async expectNodeTestOk(nodeType, timeout = 60000) {
-    await expect(this.page.locator(`[data-test="workflow-node-${nodeType}-test-ok"]`))
+    await expect(this.page.locator(this.nodeTestOkFor(nodeType)))
       .toBeVisible({ timeout });
   }
 
@@ -385,7 +638,7 @@ class WorkflowsPage {
     // select; no create toggle. Clicking the editor WRAPPER does not focus Monaco —
     // the keystrokes go nowhere and the untouched seed template is what gets saved,
     // so an invalid-code test silently asserts nothing. Drive the real textarea.
-    const editor = this.page.locator('[data-test="logs-vrl-function-editor"]');
+    const editor = this.page.locator(this.functionEditor);
     const monaco = new MonacoEditorHelper(this.page);
     await monaco.focus(editor);
     await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
@@ -408,9 +661,22 @@ class WorkflowsPage {
     await nameInput.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
     await nameInput.fill(name);
     await this.page.locator(this.drawerPrimary).click({ timeout: DRAWER_TIMEOUT_MS });
-    const toast = this.page.locator('[role="alert"], .q-notification__message').first();
+    const toast = this.page.locator(this.anyToast).first();
     await toast.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
     return (await toast.textContent().catch(() => '') || '').trim();
+  }
+
+  /**
+   * The link-alerts prompt is offered ONLY for trigger kinds whose registry entry
+   * sets `linksAlerts` (alert_fired). Incident workflows must go straight back to
+   * the list instead — asserting both halves is what proves the flag is honoured.
+   */
+  async expectLinkAlertsPrompt() {
+    await expect(this.page.locator(this.linkAlertsDialog)).toBeVisible({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async expectNoLinkAlertsPrompt() {
+    await expect(this.page.locator(this.linkAlertsDialog)).toHaveCount(0);
   }
 
   /** After a successful create, the "Link to alerts" dialog appears — Skip it (secondary btn). */
@@ -433,7 +699,7 @@ class WorkflowsPage {
    */
   async publishAndExpectAccepted() {
     await this.clickPublish();
-    const warning = this.page.locator('[data-test^="o-toast-"][data-test-variant="warning"]').first();
+    const warning = this.page.locator(this.warningToast).first();
     const linkDialog = this.page.locator(this.linkAlertsDialog);
     const editor = this.page.locator(this.editorPage);
     await expect
@@ -455,11 +721,23 @@ class WorkflowsPage {
     }
   }
 
-  async buildTriggerToDestinationAndSave({ name, destName, url }) {
-    await this.goToAdd();
+  /**
+   * Publish expecting the app to REFUSE, and return the warning text. The mirror of
+   * publishAndExpectAccepted(): a blocked Publish never reaches the network, so the
+   * only evidence is the toast.
+   */
+  async publishAndCaptureRejection() {
+    await this.clickPublish();
+    const warning = this.page.locator(this.warningToast).first();
+    await warning.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    return ((await warning.getAttribute('data-test-message')) || '').trim();
+  }
+
+  async buildTriggerToDestinationAndSave({ name, destName, url, headers, kind = 'alert_fired' }) {
+    await this.goToAdd(kind);
     await this.setName(name);
     await this.addNodeFromPalette('destination');
-    await this.createDestinationInline({ name: destName, url });
+    await this.createDestinationInline({ name: destName, url, headers });
     await this.saveNodeDrawer();
     await this.publishAndExpectAccepted();
     await this.skipLinkAlerts();
@@ -472,7 +750,7 @@ class WorkflowsPage {
    */
   async saveAndCaptureResult() {
     await this.clickPublish();
-    const toast = this.page.locator('[role="alert"], .q-notification__message').first();
+    const toast = this.page.locator(this.anyToast).first();
     await toast.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
     return (await toast.textContent().catch(() => '') || '').trim();
   }
@@ -486,7 +764,7 @@ class WorkflowsPage {
   // workflow name: workflow-list-<name>-{view,edit,pause-start-action,more-options,delete}.
   // Match on that prefix so row lookup is independent of the table's DOM shape.
   rowByName(name) {
-    return this.page.locator(`[data-test^="workflow-list-${name}-"]`);
+    return this.page.locator(this.listRowPrefixFor(name));
   }
 
   async openEdit(name) {
@@ -494,18 +772,17 @@ class WorkflowsPage {
     // necessarily rendered — filter to it first, exactly as isPresent() does.
     await this.waitForListReady();
     await this.search(name);
-    await this.page.locator(`[data-test="workflow-list-${name}-edit"]`).first().click({ timeout: LIST_TIMEOUT_MS });
+    await this.page.locator(this.listRowActionFor(name, 'edit')).first().click({ timeout: LIST_TIMEOUT_MS });
     await this.page.locator(this.editorPage).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
   }
 
   /** Delete via row action (in the more-options menu). Returns any error toast (delete-protected
    *  when linked to an alert). */
   async deleteByName(name) {
-    await this.page.locator(`[data-test="workflow-list-${name}-more-options"]`).first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
-    await this.page.locator(`[data-test="workflow-list-${name}-delete"]`).first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
-    await this.page.locator('[data-test$="-confirm-button"], [data-test="dlg-primary"], button:has-text("OK"), button:has-text("Delete")')
-      .first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
-    const toast = this.page.locator('[role="alert"], .q-notification__message').first();
+    await this.page.locator(this.listRowActionFor(name, 'more-options')).first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
+    await this.page.locator(this.listRowActionFor(name, 'delete')).first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
+    await this.page.locator(this.confirmButton).first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
+    const toast = this.page.locator(this.anyToast).first();
     await toast.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
     return (await toast.textContent().catch(() => '') || '').trim();
   }
@@ -522,7 +799,7 @@ class WorkflowsPage {
 
   // ---------- enable / disable ----------
   async toggleEnable(name) {
-    await this.page.locator(`[data-test="workflow-list-${name}-pause-start-action"]`).first().click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.listRowActionFor(name, 'pause-start-action')).first().click({ timeout: DRAWER_TIMEOUT_MS });
   }
 }
 

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-conditions.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-conditions.spec.js
@@ -1,0 +1,166 @@
+/**
+ * Workflows v1 — Condition node coverage (COND-01..07)
+ *
+ * Enterprise-only feature: event(alert_fired|incident_event) -> optional Condition/Function
+ * -> action(remote/pipeline destination).
+ *
+ * Why this spec exists: the Condition node had NO coverage at all, and the four
+ * operators added in #13978 (is_null / is_not_null / is_empty / is_not_empty) were
+ * untested end-to-end anywhere in the suite — pipeline-conditions.spec.js only
+ * mentions them in a comment.
+ *
+ * Two behaviours here are non-obvious and are asserted deliberately:
+ *   - Unary operators REMOVE the value input from the DOM (FilterCondition.vue
+ *     wraps it in `v-if="!isUnaryOperator(...)"`), so absence — not an empty
+ *     string — is the correct assertion.
+ *   - A never-configured Condition is sent as a rule with an EMPTY column, which
+ *     the backend short-circuits to always-true (`Condition::evaluate`) before it
+ *     reads operator/value. So a dummy Condition must not block Publish.
+ *
+ * Self-cleaning: every artifact is namespaced `wf_auto_*`; cleanup.spec.js sweeps by prefix.
+ */
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+const uniq = () => `${Date.now().toString(36).slice(-5)}${Math.random().toString(36).slice(2, 5)}`;
+
+// Unary operators from #13978 — these take no value.
+const UNARY_OPERATORS = ['is_null', 'is_not_null', 'is_empty', 'is_not_empty'];
+// Value-taking operators, one per shape (equality, inequality, numeric, substring).
+const VALUE_OPERATORS = ['=', '!=', '>=', 'Contains'];
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe(
+  'Workflows condition node',
+  { tag: ['@workflows', '@workflowsConditions', '@enterprise', '@all'] },
+  () => {
+    let pm;
+
+    test.beforeEach(async ({ page }, testInfo) => {
+      testLogger.testStart(testInfo.title, testInfo.file);
+      await navigateToBase(page);
+      pm = new PageManager(page);
+      // Enterprise-only: fail loudly if the feature is off rather than skipping.
+      await pm.workflowsPage.assertEnabled();
+    });
+
+    // COND-01 — the node can be added, configured with a complete rule, and published.
+    test('COND-01: builds and publishes a workflow with a configured condition', async () => {
+      const id = uniq();
+      const name = `wf_auto_cond_${id}`;
+      await pm.workflowsPage.goToAdd();
+      await pm.workflowsPage.setName(name);
+      await pm.workflowsPage.addNodeFromPalette('condition');
+      await pm.workflowsPage.setCondition({
+        column: 'meta_alert_name',
+        operator: '=',
+        value: 'wf_auto_probe',
+      });
+      await pm.workflowsPage.saveNodeDrawer();
+      await pm.workflowsPage.addNodeFromPalette('destination');
+      await pm.workflowsPage.createDestinationInline({
+        name: `wf_auto_dest_${id}`,
+        url: `${process.env.ZO_BASE_URL}/api/${process.env.ORGNAME || 'default'}/wf_auto_sink_${id}/_json`,
+      });
+      await pm.workflowsPage.saveNodeDrawer();
+      await pm.workflowsPage.publishAndExpectAccepted();
+      await pm.workflowsPage.skipLinkAlerts();
+      await pm.workflowsPage.goToList();
+      expect(await pm.workflowsPage.isPresent(name)).toBeTruthy();
+      testLogger.info('condition workflow published', { name });
+    });
+
+    // COND-02 — every unary operator added in #13978 is selectable on a condition rule.
+    for (const operator of UNARY_OPERATORS) {
+      test(`COND-02: unary operator ${operator} is selectable`, async () => {
+        await pm.workflowsPage.goToAdd();
+        await pm.workflowsPage.setName(`wf_auto_cond_${uniq()}`);
+        await pm.workflowsPage.addNodeFromPalette('condition');
+        await pm.workflowsPage.setCondition({ column: 'meta_alert_name', operator });
+        // COND-03: the value input is v-if'd away for unary operators.
+        await pm.workflowsPage.expectConditionValueAbsent();
+        testLogger.info('unary operator applied with no value input', { operator });
+      });
+    }
+
+    // COND-04 — value-taking operators still render the value input and accept input.
+    test('COND-04: value operators keep the value input', async () => {
+      await pm.workflowsPage.goToAdd();
+      await pm.workflowsPage.setName(`wf_auto_cond_${uniq()}`);
+      await pm.workflowsPage.addNodeFromPalette('condition');
+      // Pick the column ONCE, then sweep operators against it — this test is about
+      // operators, and re-opening the column dropdown each pass only adds flake.
+      await pm.workflowsPage.setCondition({
+        column: 'meta_alert_name',
+        operator: VALUE_OPERATORS[0],
+        value: `wf_auto_${VALUE_OPERATORS[0]}`,
+      });
+      await pm.workflowsPage.expectConditionValueVisible();
+      for (const operator of VALUE_OPERATORS.slice(1)) {
+        await pm.workflowsPage.setConditionOperator(operator, `wf_auto_${operator}`);
+        await pm.workflowsPage.expectConditionValueVisible();
+        testLogger.info('value operator keeps its input', { operator });
+      }
+    });
+
+    // COND-05 — a never-configured Condition is an INCOMPLETE node, and Publish refuses
+    // it. WorkflowCondition.submit() calls setNodeIncomplete(node, !complete) when the
+    // rule is unfinished, which validate() turns into the "needs setup" block.
+    //
+    // The always-true passthrough group (an empty column, which the backend
+    // short-circuits in Condition::evaluate) is what a dummy node is SENT as on the
+    // Draft/Test paths — it is not a licence to publish. Verified live: publishing
+    // one is rejected with "1 step needs setup before publishing".
+    test('COND-05: an unconfigured condition blocks publish', async () => {
+      const id = uniq();
+      await pm.workflowsPage.goToAdd();
+      await pm.workflowsPage.setName(`wf_auto_cond_${id}`);
+      // Add the condition and close its drawer WITHOUT filling anything in.
+      await pm.workflowsPage.addNodeFromPalette('condition');
+      await pm.workflowsPage.saveNodeDrawer();
+      await pm.workflowsPage.addNodeFromPalette('destination');
+      await pm.workflowsPage.createDestinationInline({
+        name: `wf_auto_dest_${id}`,
+        url: `${process.env.ZO_BASE_URL}/api/${process.env.ORGNAME || 'default'}/wf_auto_sink_${id}/_json`,
+      });
+      await pm.workflowsPage.saveNodeDrawer();
+      const msg = await pm.workflowsPage.publishAndCaptureRejection();
+      testLogger.info('unconfigured condition publish result', { msg });
+      expect(msg.toLowerCase()).toContain('needs setup');
+      // The editor stays put so the user can finish the flagged step.
+      await pm.workflowsPage.expectEditorVisible();
+    });
+
+    // COND-06 — the pickable columns follow the TRIGGER kind: an alert workflow offers
+    // alert payload fields, never the incident ones.
+    test('COND-06: condition columns follow the alert trigger', async () => {
+      await pm.workflowsPage.goToAdd('alert_fired');
+      await pm.workflowsPage.setName(`wf_auto_cond_${uniq()}`);
+      await pm.workflowsPage.addNodeFromPalette('condition');
+      await pm.workflowsPage.dismissConditionGuidelinesIfPresent();
+      const columns = await pm.workflowsPage.conditionColumnValues();
+      testLogger.info('alert-trigger condition columns', { count: columns.length });
+      expect(columns).toContain('meta_alert_name');
+      // meta_event_type is incident-only — it must not leak into an alert workflow.
+      expect(columns).not.toContain('meta_event_type');
+    });
+
+    // COND-07 — the first-run guidelines box dismisses and stays dismissed (localStorage).
+    test('COND-07: condition guidelines dismiss and stay dismissed', async () => {
+      await pm.workflowsPage.goToAdd();
+      await pm.workflowsPage.setName(`wf_auto_cond_${uniq()}`);
+      await pm.workflowsPage.addNodeFromPalette('condition');
+      await pm.workflowsPage.dismissConditionGuidelinesIfPresent();
+      await pm.workflowsPage.expectConditionGuidelinesAbsent();
+      // Re-open a fresh condition node in the same browser context: the dismissal is
+      // remembered, so the hint must not nag again.
+      await pm.workflowsPage.addNodeFromPalette('condition');
+      await pm.workflowsPage.expectConditionGuidelinesAbsent();
+      await pm.workflowsPage.expectConditionBuilderVisible();
+      testLogger.info('guidelines stayed dismissed on a second condition node');
+    });
+  }
+);

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-conditions.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-conditions.spec.js
@@ -13,9 +13,11 @@
  *   - Unary operators REMOVE the value input from the DOM (FilterCondition.vue
  *     wraps it in `v-if="!isUnaryOperator(...)"`), so absence — not an empty
  *     string — is the correct assertion.
- *   - A never-configured Condition is sent as a rule with an EMPTY column, which
- *     the backend short-circuits to always-true (`Condition::evaluate`) before it
- *     reads operator/value. So a dummy Condition must not block Publish.
+ *   - A never-configured Condition BLOCKS Publish. submit() calls
+ *     setNodeIncomplete(node, !complete), which validate() turns into "N steps need
+ *     setup before publishing". The empty-column rule the backend short-circuits to
+ *     always-true (`Condition::evaluate`) is only how such a dummy node is SENT on
+ *     the Draft/Test paths — it is not a licence to publish one.
  *
  * Self-cleaning: every artifact is namespaced `wf_auto_*`; cleanup.spec.js sweeps by prefix.
  */

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-delivery.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-delivery.spec.js
@@ -1,0 +1,101 @@
+/**
+ * Workflows v1 — destination DELIVERY (DEL-01..02)
+ *
+ * Everything else in the suite proves the workflow was BUILT. These prove data
+ * actually reached the destination.
+ *
+ * How it works — the "self-ingest sink". The destination POST is made server-side
+ * (which is why NEG-06's 127.0.0.1:1 yields connection-refused), so pointing a
+ * destination at OpenObserve's OWN ingest endpoint makes the app deliver into a
+ * stream we control. Two facts make that assertable without polling:
+ *
+ *   1. batch_execution.rs applies `endpoint.headers` to every outbound request, so
+ *      an Authorization header lets the workflow post into an authenticated endpoint.
+ *   2. On a 2xx it calls send_output(body) — the destination node's OUTPUT *is* the
+ *      sink's response. For an ingest sink that response is OpenObserve's own
+ *      receipt, e.g. {"code":200,"status":[{"name":"...","successful":1,"failed":0}]}.
+ *
+ * So `successful: 1` is delivery confirmed by the receiving side, synchronously.
+ *
+ * Self-cleaning: `wf_auto_*` names and `wf_auto_sink_*` streams are both already
+ * swept by cleanup.spec.js.
+ */
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+const uniq = () => `${Date.now().toString(36).slice(-5)}${Math.random().toString(36).slice(2, 5)}`;
+
+const orgId = () => process.env.ORGNAME || 'default';
+const sinkStream = (id) => `wf_auto_sink_${id}`;
+const sinkUrl = (id) => `${process.env.ZO_BASE_URL}/api/${orgId()}/${sinkStream(id)}/_json`;
+// Ingest requires auth; the destination forwards whatever headers it carries.
+const basicAuth = () =>
+  'Basic ' +
+  Buffer.from(
+    `${process.env.ZO_ROOT_USER_EMAIL}:${process.env.ZO_ROOT_USER_PASSWORD}`
+  ).toString('base64');
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe(
+  'Workflows destination delivery',
+  { tag: ['@workflows', '@workflowsDelivery', '@enterprise', '@all'] },
+  () => {
+    let pm;
+
+    test.beforeEach(async ({ page }, testInfo) => {
+      testLogger.testStart(testInfo.title, testInfo.file);
+      await navigateToBase(page);
+      pm = new PageManager(page);
+      await pm.workflowsPage.assertEnabled();
+    });
+
+    // DEL-01 — a reachable destination paints the SUCCESS badge. This is the missing
+    // twin of NEG-06, which only ever asserted the error badge: without it, a change
+    // that made every send fail would still satisfy the negative test.
+    test('DEL-01: a live destination reports a successful send', async () => {
+      const id = uniq();
+      const name = `wf_auto_del_${id}`;
+      await pm.workflowsPage.buildTriggerToDestinationAndSave({
+        name,
+        destName: `wf_auto_dest_${id}`,
+        url: sinkUrl(id),
+        headers: { Authorization: basicAuth() },
+      });
+      await pm.workflowsPage.goToList();
+      await pm.workflowsPage.openEdit(name);
+      await pm.workflowsPage.testRunFromEditor();
+      await pm.workflowsPage.expectNodeTestOk('destination');
+      await pm.workflowsPage.expectNodeTestOk('workflow_trigger');
+      testLogger.info('destination reported a successful send', { name });
+    });
+
+    // DEL-02 — the payload actually landed. The destination node's output is the
+    // sink's response body, so for an ingest sink it is OpenObserve's own receipt.
+    test('DEL-02: the delivered payload is ingested by the sink', async () => {
+      const id = uniq();
+      const name = `wf_auto_del_${id}`;
+      await pm.workflowsPage.buildTriggerToDestinationAndSave({
+        name,
+        destName: `wf_auto_dest_${id}`,
+        url: sinkUrl(id),
+        headers: { Authorization: basicAuth() },
+      });
+      await pm.workflowsPage.goToList();
+      await pm.workflowsPage.openEdit(name);
+      await pm.workflowsPage.testRunFromEditor();
+      await pm.workflowsPage.expectNodeTestOk('destination');
+
+      // The receiving side confirms it stored the record. Verified live:
+      // {"code":200,"status":[{"name":"wf_auto_sink_...","successful":1,"failed":0}]}
+      const receipt = await pm.workflowsPage.destinationIngestReceipt();
+      testLogger.info('destination node output (ingest receipt)', { receipt });
+      const status = (receipt.status || [])[0] || {};
+      expect(status.name).toBe(sinkStream(id));
+      expect(status.successful).toBeGreaterThan(0);
+      expect(status.failed).toBe(0);
+    });
+  }
+);

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-incidents.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-incidents.spec.js
@@ -1,0 +1,178 @@
+/**
+ * Workflows v1 — Incident Event trigger coverage (INC-01..06)
+ *
+ * Enterprise-only. The `incident_event` trigger kind shipped in #13472 and has had
+ * no UI coverage: every existing spec builds an `alert_fired` workflow.
+ *
+ * What makes this kind different (plugins/workflows/triggers.ts):
+ *   - It defines `sampleVariants`, one per incident lifecycle event_type, so the
+ *     trigger drawer renders a variant picker rather than a single payload.
+ *   - It defines `commonMetaKeys`, so the payload is SPLIT into a stable common
+ *     block plus an event-specific block. An event_type whose `extras` are {} —
+ *     `created` — shows a "no extra fields" note instead of the specific block.
+ *   - It does NOT set `linksAlerts`, so the post-save link-alerts prompt must be
+ *     skipped entirely. Alert workflows must still show it. Asserting both halves
+ *     is what actually proves the flag is honoured.
+ *   - Its Condition columns are the incident payload fields, not the alert ones.
+ *
+ * Self-cleaning: every artifact is namespaced `wf_auto_*`; cleanup.spec.js sweeps by prefix.
+ */
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+const uniq = () => `${Date.now().toString(36).slice(-5)}${Math.random().toString(36).slice(2, 5)}`;
+
+// The incident lifecycle, in registry order (plugins/workflows/incidentSample.ts).
+// All 14 — the three ai_analysis_* phases are separate event types.
+const INCIDENT_EVENT_TYPES = [
+  'created',
+  'alert',
+  'severity_upgrade',
+  'severity_override',
+  'acknowledged',
+  'resolved',
+  'reopened',
+  'dimension_upgraded',
+  'title_changed',
+  'assignment_changed',
+  'comment',
+  'ai_analysis_begin',
+  'ai_analysis_complete',
+  'ai_analysis_failed',
+];
+
+const sinkUrl = (id) =>
+  `${process.env.ZO_BASE_URL}/api/${process.env.ORGNAME || 'default'}/wf_auto_sink_${id}/_json`;
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe(
+  'Workflows incident trigger',
+  { tag: ['@workflows', '@workflowsIncidents', '@enterprise', '@all'] },
+  () => {
+    let pm;
+
+    test.beforeEach(async ({ page }, testInfo) => {
+      testLogger.testStart(testInfo.title, testInfo.file);
+      await navigateToBase(page);
+      pm = new PageManager(page);
+      // Enterprise-only: fail loudly if the feature is off rather than skipping.
+      await pm.workflowsPage.assertEnabled();
+    });
+
+    // INC-01 — an incident-triggered workflow builds, publishes and lands in the list.
+    test('INC-01: builds and publishes an incident-triggered workflow', async () => {
+      const id = uniq();
+      const name = `wf_auto_inc_${id}`;
+      await pm.workflowsPage.goToAdd('incident_event');
+      await pm.workflowsPage.setName(name);
+      await pm.workflowsPage.addNodeFromPalette('destination');
+      await pm.workflowsPage.createDestinationInline({
+        name: `wf_auto_dest_${id}`,
+        url: sinkUrl(id),
+      });
+      await pm.workflowsPage.saveNodeDrawer();
+      await pm.workflowsPage.publishAndExpectAccepted();
+      await pm.workflowsPage.skipLinkAlerts();
+      await pm.workflowsPage.goToList();
+      expect(await pm.workflowsPage.isPresent(name)).toBeTruthy();
+      testLogger.info('incident workflow published', { name });
+    });
+
+    // INC-02 — the variant picker offers every lifecycle event_type. The dropdown value
+    // IS the event_type, so it doubles as the reference for `meta_event_type == "..."`.
+    test('INC-02: sample variant picker lists every incident event type', async () => {
+      await pm.workflowsPage.goToAdd('incident_event');
+      await pm.workflowsPage.openTriggerConfig();
+      const variants = await pm.workflowsPage.triggerVariantValues();
+      testLogger.info('incident sample variants', { count: variants.length, variants });
+      for (const type of INCIDENT_EVENT_TYPES) {
+        expect(variants).toContain(type);
+      }
+      expect(variants.length).toBe(INCIDENT_EVENT_TYPES.length);
+    });
+
+    // INC-03 — the previewed payload reflects the SELECTED event_type: an event with
+    // extras shows them, one without does not, and the common baseline is always there.
+    //
+    // Deliberately asserts payload CONTENT, not layout. main renders a common +
+    // event-specific pair; an in-flight UX branch merges them into one block ("common
+    // and event-specific fields merged in one `meta`"). Both designs must satisfy this
+    // test — pinning it to the two-block markup would break it the moment that lands,
+    // for a presentation change rather than a real regression.
+    test('INC-03: previewed payload reflects the selected event type', async () => {
+      await pm.workflowsPage.goToAdd('incident_event');
+      await pm.workflowsPage.openTriggerConfig();
+
+      // severity_upgrade carries old/new severity on top of the common fields.
+      await pm.workflowsPage.selectTriggerVariant('severity_upgrade');
+      const upgrade = await pm.workflowsPage.triggerPayloadText();
+      expect(upgrade).toContain('old_severity');
+      expect(upgrade).toContain('new_severity');
+
+      // created adds nothing, so those event-specific fields must disappear.
+      await pm.workflowsPage.selectTriggerVariant('created');
+      const created = await pm.workflowsPage.triggerPayloadText();
+      expect(created).not.toContain('old_severity');
+
+      // The common baseline is present for every event type.
+      expect(created).toContain('incident_id');
+      expect(created).toContain('event_type');
+      testLogger.info('payload tracked the selected event type', {
+        upgradeLen: upgrade.length,
+        createdLen: created.length,
+      });
+    });
+
+    // INC-04 — incident kinds do NOT associate with alerts, so no link prompt appears.
+    test('INC-04: incident workflow does not prompt to link alerts', async () => {
+      const id = uniq();
+      await pm.workflowsPage.goToAdd('incident_event');
+      await pm.workflowsPage.setName(`wf_auto_inc_${id}`);
+      await pm.workflowsPage.addNodeFromPalette('destination');
+      await pm.workflowsPage.createDestinationInline({
+        name: `wf_auto_dest_${id}`,
+        url: sinkUrl(id),
+      });
+      await pm.workflowsPage.saveNodeDrawer();
+      await pm.workflowsPage.publishAndExpectAccepted();
+      await pm.workflowsPage.expectNoLinkAlertsPrompt();
+      testLogger.info('no link-alerts prompt for incident trigger');
+    });
+
+    // INC-05 — the other half: alert_fired DOES prompt. Without this, INC-04 would
+    // pass even if the prompt were broken for every kind.
+    test('INC-05: alert workflow does prompt to link alerts', async () => {
+      const id = uniq();
+      await pm.workflowsPage.goToAdd('alert_fired');
+      await pm.workflowsPage.setName(`wf_auto_inc_${id}`);
+      await pm.workflowsPage.addNodeFromPalette('destination');
+      await pm.workflowsPage.createDestinationInline({
+        name: `wf_auto_dest_${id}`,
+        url: sinkUrl(id),
+      });
+      await pm.workflowsPage.saveNodeDrawer();
+      await pm.workflowsPage.publishAndExpectAccepted();
+      await pm.workflowsPage.expectLinkAlertsPrompt();
+      await pm.workflowsPage.skipLinkAlerts();
+      testLogger.info('link-alerts prompt shown for alert trigger');
+    });
+
+    // INC-06 — a Condition inside an incident workflow offers the INCIDENT fields.
+    // Pairs with COND-06 (the alert half) to prove the field set is trigger-driven.
+    test('INC-06: condition columns follow the incident trigger', async () => {
+      await pm.workflowsPage.goToAdd('incident_event');
+      await pm.workflowsPage.setName(`wf_auto_inc_${uniq()}`);
+      await pm.workflowsPage.addNodeFromPalette('condition');
+      await pm.workflowsPage.dismissConditionGuidelinesIfPresent();
+      const columns = await pm.workflowsPage.conditionColumnValues();
+      testLogger.info('incident-trigger condition columns', { count: columns.length });
+      expect(columns).toContain('meta_event_type');
+      expect(columns).toContain('meta_incident_id');
+      // meta_alert_type is alert-only — it must not leak into an incident workflow.
+      expect(columns).not.toContain('meta_alert_type');
+    });
+  }
+);


### PR DESCRIPTION
Adds **17 tests across three specs** for Workflows surfaces that shipped without any UI coverage, and closes the biggest gap in the suite: nothing previously proved a workflow actually *delivers* anything.

Follows #14048, which un-skipped the existing specs and fixed the builder page object.

## `workflows-conditions.spec.js` — 9 tests

The Condition node had **no coverage at all**, and the four operators added in #13978 (`is_null` / `is_not_null` / `is_empty` / `is_not_empty`) were untested end-to-end **anywhere** — `pipeline-conditions.spec.js` only mentions them in a comment.

Two behaviours are asserted deliberately because they are non-obvious:

- **Unary operators remove the value input.** `FilterCondition.vue` wraps it in `v-if="!isUnaryOperator(...)"`, so *absence* — not an empty string — is the correct assertion.
- **An unconfigured Condition blocks Publish.** `WorkflowCondition.submit()` calls `setNodeIncomplete(node, !complete)`, which `validate()` turns into `1 step needs setup before publishing`. The always-true passthrough group (an empty column, short-circuited in `Condition::evaluate`) is only how a dummy node is *sent* on the Draft/Test paths — not a licence to publish. I initially asserted the opposite; the live run corrected it.

## `workflows-incidents.spec.js` — 6 tests

The `incident_event` trigger (#13472) had no coverage — every existing spec builds an `alert_fired` workflow. Covers building/publishing one, all **14** lifecycle event types, and that the previewed payload tracks the selected event type.

- **INC-04 / INC-05 are a deliberate pair.** Incident kinds don't set `linksAlerts`, so they must **not** prompt to link alerts; alert kinds must. Asserting only the negative half would pass even if the prompt were broken for every kind.
- **INC-03 asserts payload content, not layout.** `main` renders a common + event-specific split; an in-flight UX branch merges them into one block (*"common and event-specific fields merged in one `meta`"*). Both designs satisfy the test, so a presentation change can't break it.

## `workflows-delivery.spec.js` — 2 tests

Proves data reaches the destination. The destination POST is made **server-side**, so pointing it at OpenObserve's own ingest endpoint delivers into a stream we control. On a 2xx the backend sets the node's output to the sink's **response body**, so the node itself carries OpenObserve's ingest receipt — delivery confirmed by the receiving side, synchronously, with no polling:

```json
{"code":200,"status":[{"name":"wf_auto_sink_...","successful":1,"failed":0}]}
```

**DEL-01 is also the missing twin of NEG-06**, which only ever asserted the *error* badge. Without a success assertion, a change that broke every send would still satisfy the negative test.

## Page object

Condition-builder driving (options picked by `data-test-value`), trigger-variant handling, destination headers (the row's `data-test` is keyed by its *current* key, so a blank row answers to the empty-key form), ingest-receipt parsing, and Monaco reads via `window.monaco` rather than `.view-lines` so a scrolled payload can't silently drop fields.

Also hoists **every** remaining inline locator into constructor constants or factories — including ones that predate this change — so the file is now fully Page-Object compliant.

## Verification

Run against an enterprise build, headless, serial:

- **32/32 green** (15 existing + 17 new). One flaky — a `beforeEach` navigation timeout that passed on retry.
- Delivery verified live: the ingest receipt above is real output, not a fixture.
- Sentinel audit: **PASS** — 0 critical, 0 warnings after fixes.

Three first-run failures were caught and fixed before this PR: a wrong event-type constant (12 vs 14), a wrong assumption about passthrough conditions, and a helper that silently dropped the auth header. **No product bugs were found** — the app behaved correctly throughout, including painting the error badge for an unauthorised send.

## Notes for reviewers

- **Requires the paired ENT PR** on the same branch name: `ci_matrix.ent.json`'s `Workflows` shard lists `run_files` explicitly, so all three new specs must be added there or they will never run in CI.
- **No new cleanup needed** — `wf_auto_*` names and `wf_auto_sink_*` streams are already swept by `cleanup.spec.js`.
- The single `waitForTimeout` flushes `QueryEditor`'s fixed 500 ms `update:query` debounce before Save reads `AddFunction`'s model. There is no observable signal to poll, and removing it reintroduces the bug where typed code never reached the payload.
