### PR TITLE
chore: add pr1sm8 to CI workflow allowlists

### DIFF
--- a/.github/workflows/auto-assign-metadata.yml
+++ b/.github/workflows/auto-assign-metadata.yml
@@ -25,7 +25,7 @@ jobs:
           ORG: ${{ github.repository_owner }}
           CREATOR: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.user.login || github.event.issue.user.login }}
         run: |
-          ALLOWLIST=" bjp232004 hengfeiyang prabhatsharma uddhavdave oasisk haohuaijin Subhra264 Loaki07 007harshmahajan chaitanya-sistla ktx-kirtan omkarK06 ktx-vaidehi ktx-abhay neha00290 ktx-akshay ktx-sadhna nikhilsaikethe YashodhanJoshi1 ktx-riya mmosarafO2 Shrinath-O2 ktx-mihir vamsikarthikr "
+          ALLOWLIST=" bjp232004 hengfeiyang prabhatsharma uddhavdave oasisk haohuaijin Subhra264 Loaki07 007harshmahajan chaitanya-sistla ktx-kirtan omkarK06 ktx-vaidehi ktx-abhay neha00290 ktx-akshay ktx-sadhna nikhilsaikethe YashodhanJoshi1 ktx-riya mmosarafO2 Shrinath-O2 ktx-mihir vamsikarthikr pr1sm8 "
           CREATOR_LOWER=$(echo "$CREATOR" | tr '[:upper:]' '[:lower:]')
           ALLOWLIST_LOWER=$(echo "$ALLOWLIST" | tr '[:upper:]' '[:lower:]')
           if echo "$ALLOWLIST_LOWER" | grep -q " $CREATOR_LOWER "; then

--- a/.github/workflows/query-agent.yml
+++ b/.github/workflows/query-agent.yml
@@ -80,7 +80,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.issue.pull_request &&
        contains(fromJSON('["/query-agent","/qa-generate"]'), github.event.comment.body) &&
-       contains(fromJSON('["bjp232004","hengfeiyang","prabhatsharma","uddhavdave","oasisk","haohuaijin","Subhra264","Loaki07","007harshmahajan","chaitanya-sistla","ktx-kirtan","omkarK06","ktx-vaidehi","ktx-abhay","neha00290","ktx-akshay","ktx-sadhna","nikhilsaikethe","YashodhanJoshi1","ktx-riya","mmosarafO2","Shrinath-O2","ktx-mihir","vamsikarthikr"]'), github.actor))
+       contains(fromJSON('["bjp232004","hengfeiyang","prabhatsharma","uddhavdave","oasisk","haohuaijin","Subhra264","Loaki07","007harshmahajan","chaitanya-sistla","ktx-kirtan","omkarK06","ktx-vaidehi","ktx-abhay","neha00290","ktx-akshay","ktx-sadhna","nikhilsaikethe","YashodhanJoshi1","ktx-riya","mmosarafO2","Shrinath-O2","ktx-mihir","vamsikarthikr","pr1sm8"]'), github.actor))
     uses: openobserve/o2-enterprise/.github/workflows/query-agent.yml@cb74bab8b9da410f525f7931a9396ec8cd885665
     with:
       source_repo: openobserve


### PR DESCRIPTION
Add `pr1sm8` (Nikith Sai, org member) to hardcoded actor allowlists: `query-agent.yml`, `auto-assign-metadata.yml`. Paired with o2-enterprise same branch.