### PR TITLE
fix(iam): skip roles API calls on Users page when RBAC is disabled

### DIFF
--- a/web/src/components/iam/users/User.vue
+++ b/web/src/components/iam/users/User.vue
@@ -703,7 +703,11 @@ export default defineComponent({
       });
     };
     const getCustomRoles = async (options: { silent?: boolean } = {}) => {
-      if (config.isEnterprise !== "true" && config.isCloud !== "true") return;
+      if (
+        (config.isEnterprise !== "true" && config.isCloud !== "true") ||
+        !store.state.zoConfig.rbac_enabled
+      )
+        return;
       try {
         const res = await getCustomRolesApi(store.state.selectedOrganization.identifier);
         customRoles.value = Array.isArray(res.data) ? res.data : [];
@@ -836,7 +840,7 @@ export default defineComponent({
             // fire-and-forget — and re-render the rows when it resolves,
             // keeping the table responsive instead of blocking the whole UI
             // on the role API.
-            if (isEnterpriseOrCloud) {
+            if (isEnterpriseOrCloud && store.state.zoConfig.rbac_enabled) {
               const orgId = store.state.selectedOrganization.identifier;
               // Don't await — let the batched role fetch run in the background.
               usersService


### PR DESCRIPTION
getCustomRoles() and getAllUserRoles() were gated only on config.isEnterprise/isCloud, so an enterprise build with O2_OPENFGA_ENABLED=false still called /roles and /users/roles/all, which 500 because the OpenFGA store is never initialized. Guard both on store.state.zoConfig.rbac_enabled too, matching the check already used in IdentityAccessManagement.vue.