### PR TITLE
fix(dashboards): keep toolbar icon buttons square when the row overflows

### DIFF
--- a/web/src/components/dashboards/viewPanel/ViewPanel.vue
+++ b/web/src/components/dashboards/viewPanel/ViewPanel.vue
@@ -17,12 +17,12 @@
 <template>
   <div class="flex h-full flex-col overflow-hidden" data-test="view-panel-screen">
     <div class="flex items-center justify-between p-3">
-      <div class="mr-3 flex items-center text-xl tracking-[0.005em]">
-        <span data-test="dashboard-viewpanel-title">
+      <div class="mr-3 flex min-w-0 items-center text-xl tracking-[0.005em]">
+        <span class="truncate" data-test="dashboard-viewpanel-title">
           {{ dashboardPanelData.data.title }}
         </span>
       </div>
-      <div class="flex items-center gap-2">
+      <div class="flex shrink-0 items-center gap-2">
         <!-- histogram interval for sql queries -->
         <HistogramIntervalDropDown
           v-if="!promqlMode && histogramFields.length"

--- a/web/src/components/dbm/DbmRefreshButton.spec.ts
+++ b/web/src/components/dbm/DbmRefreshButton.spec.ts
@@ -61,23 +61,19 @@ describe("DbmRefreshButton", () => {
   });
 
   /**
-   * `shrink-0` pins the width inside the flex toolbar row. Table health puts a
-   * bare full-width input in the slot instead of that row and never carried the
-   * class; opting out has to keep it off, or that page's toolbar shifts.
+   * `shrink-0` pins the width inside the flex toolbar row.
    *
    * Asserted on BOTH the wrapper and the button. The staleness dot made this
    * control a flex row rather than a lone button, so the wrapper is what the
    * toolbar lays out now — but the button inside it must stay pinned too, or
-   * the dot can win the space and squash the control it annotates.
+   * the dot can win the space and squash the control it annotates. The button
+   * half now comes from OButton's icon sizes, which pin themselves.
    */
-  it("pins its width in a flex toolbar, and lets table health opt out", () => {
+  it("pins its width in a flex toolbar", () => {
     const pinned = mountButton();
+
     expect(pinned.classes()).toContain("shrink-0");
     expect(pinned.findComponent(OButton).classes()).toContain("shrink-0");
-
-    const loose = mountButton({ shrink: false });
-    expect(loose.classes()).not.toContain("shrink-0");
-    expect(loose.findComponent(OButton).classes()).not.toContain("shrink-0");
   });
 
   it("emits refresh on click so the page can force its reload", async () => {

--- a/web/src/components/dbm/DbmRefreshButton.vue
+++ b/web/src/components/dbm/DbmRefreshButton.vue
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   "stale" means.
 -->
 <template>
-  <div class="inline-flex items-center gap-1.5" :class="shrink ? 'shrink-0' : undefined">
+  <div class="inline-flex shrink-0 items-center gap-1.5">
     <!-- Rendered only after a successful load: a grey dot on first paint would read
          as a verdict rather than the absence of one. -->
     <span
@@ -67,7 +67,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       size="icon-sm"
       icon-left="refresh"
       :loading="loading"
-      :class="shrink ? 'shrink-0' : undefined"
       :data-test="dataTest"
       @click="emit('refresh')"
     >
@@ -90,12 +89,6 @@ const props = withDefaults(
     loading?: boolean;
     dataTest: string;
     /**
-     * `shrink-0` pins the button's width inside the flex toolbar. Table health
-     * puts a bare search input in the slot rather than a flex row, so it never
-     * carried the class and opts out here.
-     */
-    shrink?: boolean;
-    /**
      * Epoch milliseconds of the page's last SUCCESSFUL load. Optional: a page
      * that does not track one renders exactly what this button always did, so
      * adopting the timestamp is per-page rather than a flag day.
@@ -104,7 +97,7 @@ const props = withDefaults(
     /** Which halves to render: `full` (dot + age + button), `status` (dot + age), or `button` (just the reload). */
     mode?: "full" | "status" | "button";
   }>(),
-  { loading: false, shrink: true, lastRunAt: null, mode: "full" },
+  { loading: false, lastRunAt: null, mode: "full" },
 );
 
 const emit = defineEmits<{ refresh: [] }>();

--- a/web/src/lib/core/Button/OButton.vue
+++ b/web/src/lib/core/Button/OButton.vue
@@ -268,25 +268,26 @@ const sizeClasses: Record<NonNullable<ButtonProps["size"]>, string> = {
   "sm-action": "h-[2.125rem] ps-3 pe-3 min-w-20 text-sm gap-2 rounded-default",
   md: "h-10 ps-4 pe-4 text-sm gap-2 rounded-default",
   lg: "h-12 ps-6 pe-6 text-base gap-3 rounded-default",
-  icon: "size-6 p-0 rounded-default gap-x-0",
-  "icon-xs": "h-7.5 px-2 text-lg rounded-default gap-x-0",
+  // shrink-0: without it min-width:auto lets a tight flex row squash these fixed squares to icon width.
+  icon: "size-6 shrink-0 p-0 rounded-default gap-x-0",
+  "icon-xs": "h-7.5 shrink-0 px-2 text-lg rounded-default gap-x-0",
   // 24px round circle — for small inline add/action icon buttons (e.g. + Joins, + Filters)
-  "icon-xs-circle": "size-6 p-0 rounded-full gap-x-0",
+  "icon-xs-circle": "size-6 shrink-0 p-0 rounded-full gap-x-0",
   // 28px square — matches xs chip height for paired close/remove buttons
-  "icon-xs-sq": "h-7 w-7 p-0 rounded-default gap-x-0",
+  "icon-xs-sq": "h-7 w-7 shrink-0 p-0 rounded-default gap-x-0",
   // 24px square — matches chip size for paired close/remove buttons
-  "icon-chip": "h-6 w-6 p-0 rounded-default gap-x-0",
-  "icon-sm": "h-8 w-8 p-0 rounded-default gap-x-0",
-  "icon-md": "h-10 w-10 p-0 rounded-default gap-x-0",
-  "icon-lg": "h-12 w-12 p-0 rounded-default gap-x-0",
-  "icon-circle": "size-8 p-0 rounded-full gap-x-0",
-  "icon-circle-sm": "size-7 p-0 rounded-full gap-x-0",
+  "icon-chip": "h-6 w-6 shrink-0 p-0 rounded-default gap-x-0",
+  "icon-sm": "h-8 w-8 shrink-0 p-0 rounded-default gap-x-0",
+  "icon-md": "h-10 w-10 shrink-0 p-0 rounded-default gap-x-0",
+  "icon-lg": "h-12 w-12 shrink-0 p-0 rounded-default gap-x-0",
+  "icon-circle": "size-8 shrink-0 p-0 rounded-full gap-x-0",
+  "icon-circle-sm": "size-7 shrink-0 p-0 rounded-full gap-x-0",
   // 30×30px square — for toolbar icon buttons (auto-refresh, share, hamburger)
-  "icon-toolbar": "size-[1.875rem] p-0 rounded-default gap-x-0",
+  "icon-toolbar": "size-[1.875rem] shrink-0 p-0 rounded-default gap-x-0",
   // 26px rounded-default — compact modern icon button for panel header collapse/expand
-  "icon-panel": "size-[1.625rem] p-0 rounded-default gap-x-0",
+  "icon-panel": "size-[1.625rem] shrink-0 p-0 rounded-default gap-x-0",
   // Tall narrow vertical rectangle — 32px × 20px for splitter collapse/expand buttons
-  "sidebar-button": "h-8 w-3 p-0 rounded-default overflow-hidden gap-x-0",
+  "sidebar-button": "h-8 w-3 shrink-0 p-0 rounded-default overflow-hidden gap-x-0",
 };
 
 const activeClasses = [


### PR DESCRIPTION
Icon OButtons carried a fixed size but no flex-shrink guard. A flex item defaults to min-width:auto, so a w-8 icon button was free to collapse to its icon's min-content width whenever its row overflowed. Text buttons are held up by whitespace-nowrap; icon-only buttons had nothing defending them.

The view-panel header made this visible: it is justify-between with a title that could neither shrink nor truncate, so once a panel had histogram fields and the Histogram Interval dropdown rendered, all the overflow pressure landed on the refresh and close buttons and squashed them into clipped slivers.

Add shrink-0 to every fixed-size icon variant, and let the view-panel title truncate so it absorbs the pressure instead of the controls. No usage in the repo gives an icon button a flexible width class, so this only affects rows that were already drawing clipped buttons.