### PR TITLE
fix: keep search trace collection independent of log level and caller propagation

### DIFF
--- a/src/api/grpc/src/handler/grpc/flight/mod.rs
+++ b/src/api/grpc/src/handler/grpc/flight/mod.rs
@@ -36,7 +36,6 @@ use search::inspector::{SearchInspectorFieldsBuilder, search_inspector_fields};
 use search_service::{grpc::flight as grpcFlight, work_group::DeferredLock};
 use tonic::{Request, Response, Status, Streaming};
 use tracing::Instrument;
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 #[cfg(feature = "enterprise")]
 use {
     o2_enterprise::enterprise::{common::config::get_config as get_o2_config, search::TaskStatus},
@@ -89,7 +88,6 @@ impl FlightService for FlightServiceImpl {
             prop.extract(&MetadataMap(request.metadata()))
         });
         let span = tracing::info_span!("grpc:search:flight:do_get");
-        let _ = span.set_parent(parent_cx);
 
         // decode ticket to RemoteExecNode
         let ticket = request.into_inner();
@@ -99,6 +97,11 @@ impl FlightService for FlightServiceImpl {
             .map_err(|e| Status::internal(e.to_string()))?;
 
         let req: FlightSearchRequest = req.into();
+        common::meta::grpc::set_parent_or_trace_id(
+            &span,
+            parent_cx,
+            &req.query_identifier.trace_id,
+        );
         let trace_id = format!(
             "{}-{}",
             req.query_identifier.trace_id, req.query_identifier.job_id

--- a/src/api/grpc/src/handler/grpc/flight/mod.rs
+++ b/src/api/grpc/src/handler/grpc/flight/mod.rs
@@ -124,22 +124,25 @@ impl FlightService for FlightServiceImpl {
         .instrument(span.clone())
         .await;
 
-        log::info!(
-            "{}",
-            search_inspector_fields(
-                format!(
-                    "[trace_id {trace_id}] flight->do_get: get_ctx_and_physical_plan took: {} ms",
-                    _start.elapsed().as_millis(),
-                ),
-                SearchInspectorFieldsBuilder::new()
-                    .trace_id(trace_id.to_string())
-                    .node_name(LOCAL_NODE.name.clone())
-                    .component("flight::do_get get_ctx_and_physical_plan".to_string())
-                    .search_role("follower".to_string())
-                    .duration(_start.elapsed().as_millis() as usize)
-                    .build()
-            )
-        );
+        // runs after the instrumented future: without in_scope the event has no current span
+        span.in_scope(|| {
+            log::info!(
+                "{}",
+                search_inspector_fields(
+                    format!(
+                        "[trace_id {trace_id}] flight->do_get: get_ctx_and_physical_plan took: {} ms",
+                        _start.elapsed().as_millis(),
+                    ),
+                    SearchInspectorFieldsBuilder::new()
+                        .trace_id(trace_id.to_string())
+                        .node_name(LOCAL_NODE.name.clone())
+                        .component("flight::do_get get_ctx_and_physical_plan".to_string())
+                        .search_role("follower".to_string())
+                        .duration(_start.elapsed().as_millis() as usize)
+                        .build()
+                )
+            );
+        });
 
         // prepare dataufion context
         let (ctx, plan, lock, scan_stats) = match result {

--- a/src/common/src/meta/grpc.rs
+++ b/src/common/src/meta/grpc.rs
@@ -34,8 +34,7 @@ impl Extractor for MetadataMap<'_> {
     }
 }
 
-/// Attach `parent_cx` to `span`, synthesizing a remote parent from the logical
-/// `trace_id` when the caller propagated no usable trace context.
+/// Attach `parent_cx` to `span`, falling back to a remote parent built from the logical `trace_id`.
 pub fn set_parent_or_trace_id(
     span: &tracing::Span,
     parent_cx: opentelemetry::Context,

--- a/src/common/src/meta/grpc.rs
+++ b/src/common/src/meta/grpc.rs
@@ -13,7 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use opentelemetry::propagation::Extractor;
+use opentelemetry::{propagation::Extractor, trace::TraceContextExt};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 pub struct MetadataMap<'a>(pub &'a tonic::metadata::MetadataMap);
 
@@ -30,5 +31,63 @@ impl Extractor for MetadataMap<'_> {
                 tonic::metadata::KeyRef::Binary(value) => value.as_str(),
             })
             .collect()
+    }
+}
+
+/// Attach `parent_cx` to `span`, synthesizing a remote parent from the logical
+/// `trace_id` when the caller propagated no usable trace context.
+pub fn set_parent_or_trace_id(
+    span: &tracing::Span,
+    parent_cx: opentelemetry::Context,
+    trace_id: &str,
+) {
+    let cx = if !parent_cx.span().span_context().is_valid()
+        && let Some(base) = logical_trace_id_base(trace_id)
+    {
+        // same synthetic-traceparent trick get_or_create_trace_id uses for RUM headers
+        let carrier = std::collections::HashMap::from([(
+            "traceparent".to_string(),
+            format!("00-{base}-{}-01", config::ider::generate_span_id()),
+        )]);
+        opentelemetry::global::get_text_map_propagator(|prop| prop.extract(&carrier))
+    } else {
+        parent_cx
+    };
+    let _ = span.set_parent(cx);
+}
+
+// sub-search ids look like `{base}-{n}-{suffix}`; only the 32-hex base is a trace id
+fn logical_trace_id_base(trace_id: &str) -> Option<&str> {
+    let base = trace_id.split('-').next().unwrap_or_default();
+    (base.len() == 32
+        && base.chars().all(|c| c.is_ascii_hexdigit())
+        && !base.chars().all(|c| c == '0'))
+    .then_some(base)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_logical_trace_id_base() {
+        assert_eq!(
+            logical_trace_id_base("01a05c4446cc71ac872a7b594bcdc883"),
+            Some("01a05c4446cc71ac872a7b594bcdc883")
+        );
+        assert_eq!(
+            logical_trace_id_base("01a05c4446cc71ac872a7b594bcdc883-7-yQou3Fe"),
+            Some("01a05c4446cc71ac872a7b594bcdc883")
+        );
+        assert_eq!(logical_trace_id_base(""), None);
+        assert_eq!(logical_trace_id_base("abc123"), None);
+        assert_eq!(
+            logical_trace_id_base("00000000000000000000000000000000"),
+            None
+        );
+        assert_eq!(
+            logical_trace_id_base("01a05c4446cc71ac872a7b594bcdc88z"),
+            None
+        );
     }
 }

--- a/src/common/src/meta/grpc.rs
+++ b/src/common/src/meta/grpc.rs
@@ -55,13 +55,13 @@ pub fn set_parent_or_trace_id(
     let _ = span.set_parent(cx);
 }
 
-// sub-search ids look like `{base}-{n}-{suffix}`; only the 32-hex base is a trace id
-fn logical_trace_id_base(trace_id: &str) -> Option<&str> {
+// 32-hex base of `{base}-{n}-{suffix}` sub-search ids, lowercased for the W3C propagator
+fn logical_trace_id_base(trace_id: &str) -> Option<String> {
     let base = trace_id.split('-').next().unwrap_or_default();
     (base.len() == 32
         && base.chars().all(|c| c.is_ascii_hexdigit())
         && !base.chars().all(|c| c == '0'))
-    .then_some(base)
+    .then(|| base.to_ascii_lowercase())
 }
 
 #[cfg(test)]
@@ -71,11 +71,16 @@ mod tests {
     #[test]
     fn test_logical_trace_id_base() {
         assert_eq!(
-            logical_trace_id_base("01a05c4446cc71ac872a7b594bcdc883"),
+            logical_trace_id_base("01a05c4446cc71ac872a7b594bcdc883").as_deref(),
             Some("01a05c4446cc71ac872a7b594bcdc883")
         );
         assert_eq!(
-            logical_trace_id_base("01a05c4446cc71ac872a7b594bcdc883-7-yQou3Fe"),
+            logical_trace_id_base("01a05c4446cc71ac872a7b594bcdc883-7-yQou3Fe").as_deref(),
+            Some("01a05c4446cc71ac872a7b594bcdc883")
+        );
+        // uppercase is accepted but lowercased for the W3C propagator
+        assert_eq!(
+            logical_trace_id_base("01A05C4446CC71AC872A7B594BCDC883").as_deref(),
             Some("01a05c4446cc71ac872a7b594bcdc883")
         );
         assert_eq!(logical_trace_id_base(""), None);

--- a/src/common/src/utils/http.rs
+++ b/src/common/src/utils/http.rs
@@ -141,6 +141,8 @@ pub fn get_or_create_trace_id(headers: &HeaderMap, span: &tracing::Span) -> Stri
         && trace_id_str.chars().all(|c| c.is_ascii_hexdigit())
         && !trace_id_str.chars().all(|c| c == '0')
     {
+        // the W3C propagator rejects uppercase traceparent fields, so normalize
+        let trace_id_str = trace_id_str.to_ascii_lowercase();
         // Set as parent context if tracing is enabled
         if cfg.common.should_create_span() && !span.is_none() {
             // Check for x-openobserve-span-id header (parent span ID from RUM SDK)
@@ -152,7 +154,7 @@ pub fn get_or_create_trace_id(headers: &HeaderMap, span: &tracing::Span) -> Stri
                 && !span_id_str.chars().all(|c| c == '0')
             {
                 // Use the provided span ID from RUM SDK
-                span_id_str.to_string()
+                span_id_str.to_ascii_lowercase()
             } else {
                 // Generate a new span ID if not provided or invalid
                 config::ider::generate_span_id()
@@ -165,7 +167,7 @@ pub fn get_or_create_trace_id(headers: &HeaderMap, span: &tracing::Span) -> Stri
             let parent_ctx = global::get_text_map_propagator(|prop| prop.extract(&headers_map));
             let _ = span.set_parent(parent_ctx);
         }
-        return trace_id_str.to_string();
+        return trace_id_str;
     }
 
     // Check for traceparent header (W3C standard)
@@ -552,6 +554,18 @@ mod tests {
         // Should generate a new trace ID (32 characters hex)
         assert_eq!(trace_id.len(), 32);
         assert!(trace_id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_get_or_create_trace_id_lowercases_rum_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-openobserve-trace-id"),
+            HeaderValue::from_static("01A05C4446CC71AC872A7B594BCDC883"),
+        );
+        let span = tracing::Span::none();
+        let trace_id = get_or_create_trace_id(&headers, &span);
+        assert_eq!(trace_id, "01a05c4446cc71ac872a7b594bcdc883");
     }
 
     #[test]

--- a/src/search_service/src/grpc_server.rs
+++ b/src/search_service/src/grpc_server.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use common::meta::grpc::MetadataMap;
+use common::meta::grpc::{MetadataMap, set_parent_or_trace_id};
 use config::{
     meta::{search, stream::StreamType},
     utils::json,
@@ -27,7 +27,6 @@ use proto::cluster_rpc::{
     search_server::Search,
 };
 use tonic::{Request, Response, Status};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 #[cfg(feature = "enterprise")]
 use {
     config::metrics,
@@ -52,10 +51,10 @@ impl Search for Searcher {
         let parent_cx = opentelemetry::global::get_text_map_propagator(|prop| {
             prop.extract(&MetadataMap(req.metadata()))
         });
-        let _ = tracing::Span::current().set_parent(parent_cx.clone());
 
         let start = std::time::Instant::now();
         let req = req.into_inner();
+        set_parent_or_trace_id(&tracing::Span::current(), parent_cx, &req.trace_id);
         let request = json::from_slice::<search::Request>(&req.request)
             .map_err(|e| Status::internal(format!("failed to parse search request: {e}")))?;
         let stream_type = StreamType::from(req.stream_type.as_str());
@@ -95,9 +94,9 @@ impl Search for Searcher {
         let parent_cx = opentelemetry::global::get_text_map_propagator(|prop| {
             prop.extract(&MetadataMap(req.metadata()))
         });
-        let _ = tracing::Span::current().set_parent(parent_cx.clone());
 
         let req = req.into_inner();
+        set_parent_or_trace_id(&tracing::Span::current(), parent_cx, &req.trace_id);
         let request =
             json::from_slice::<search::MultiStreamRequest>(&req.request).map_err(|e| {
                 Status::internal(format!("failed to parse multi-stream search request: {e}"))

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -37,7 +37,10 @@ use tonic::{
 };
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{
-    EnvFilter, Registry, filter::LevelFilter as TracingLevelFilter, fmt::Layer, prelude::*,
+    EnvFilter, Registry,
+    filter::{FilterExt, LevelFilter as TracingLevelFilter},
+    fmt::Layer,
+    prelude::*,
 };
 
 /// Setup the tracing related components
@@ -565,13 +568,20 @@ pub fn enable_tracing() -> Result<opentelemetry_sdk::trace::SdkTracerProvider, a
         tracing_subscriber::fmt::layer().with_ansi(false).boxed()
     };
 
+    // search inspector needs info-level spans/events: RUST_LOG must not gate the OTel layer
+    let otel_filter = if cfg.common.search_inspector_enabled {
+        FilterExt::boxed(EnvFilter::new(&cfg.log.level).or(TracingLevelFilter::INFO))
+    } else {
+        FilterExt::boxed(EnvFilter::new(&cfg.log.level))
+    };
+
     global::set_tracer_provider(tracer.clone());
     Registry::default()
-        .with(tracing_subscriber::EnvFilter::new(&cfg.log.level))
-        .with(layer)
-        .with(OpenTelemetryLayer::new(
-            tracer.tracer("tracing-otel-subscriber"),
-        ))
+        .with(layer.with_filter(EnvFilter::new(&cfg.log.level)))
+        .with(
+            OpenTelemetryLayer::new(tracer.tracer("tracing-otel-subscriber"))
+                .with_filter(otel_filter),
+        )
         .init();
 
     // Return the tracer provider


### PR DESCRIPTION
Fixes #14070, fixes #14071.

## What

Two related fixes for search traces going missing from the search inspector (`_meta/traces/default`):

**1. RUST_LOG no longer gates trace collection when the search inspector is enabled (#14070)**

`enable_tracing()` used one registry-level `EnvFilter(RUST_LOG)` for the whole subscriber stack, so a node with a quiet log level (e.g. `RUST_LOG=warn,...`) created no search spans and recorded no inspector events at all — and, having no active span, propagated no `traceparent` to follower nodes. The stack now uses per-layer filters: the fmt layer keeps `EnvFilter(RUST_LOG)` (log output unchanged), and the `OpenTelemetryLayer` gets its own filter with an INFO floor (`EnvFilter(RUST_LOG).or(LevelFilter::INFO)`) when `ZO_SEARCH_INSPECTOR_ENABLED` is set. Deployments without the inspector keep today's behavior exactly.

**2. Search gRPC handlers fall back to the logical trace id as remote parent (#14071)**

`grpc:search:flight:do_get`, `grpc:search:search` and `grpc:search:search_multi` set their span parent from the propagated context; when the caller sent no usable `traceparent` (leader with no active span, internal callers like alert evaluation), the span rooted a brand-new random trace while all its events referenced the request's logical `trace_id` — one streaming search could scatter into dozens of single-shard traces that are unfindable by trace id. A new `common::meta::grpc::set_parent_or_trace_id` helper keeps the propagated context when it is valid and otherwise synthesizes a remote parent from the request's logical trace id (base 32-hex segment), the same synthetic-traceparent technique `get_or_create_trace_id` already uses for RUM headers.

## Observed impact

On a cluster whose API hostname routes to ingesters (ingester = search leader) with `RUST_LOG=warn`: the leader produced zero spans/summary events (profile endpoint empty for every search), and one HTTP2 streaming search scattered into 50 disconnected follower root traces. With both fixes the leader records spans/events regardless of log level, and follower fragments stay under the logical trace id even when propagation is absent.

## Verification

- `cargo check` (default features) — clean
- CI clippy command (`cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings`) — clean
- `cargo fmt --all` — clean
- New unit test for the trace-id base validation (`common::meta::grpc::tests`) — pass
- Enterprise `cargo check --all-targets` against o2-enterprise main (swapped `Cargo.toml.openobserve`) — clean
