### PR TITLE
fix: dismiss nav flyout before folder hover in alerts deleteFolder

### DIFF
--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -1485,6 +1485,7 @@ export class AlertsPage {
     }
 
     async deleteFolder(folderName) {
+        await this.dismissNavFlyout();
         const folderRow = this.page.locator(`div.folder-item:has-text("${folderName}")`);
         await folderRow.hover();
         await this.page.waitForTimeout(500);


### PR DESCRIPTION
Root cause: `deleteFolder()` hovered a folder row while the left-rail nav flyout still overlaid the folder sidebar, so the hover was intercepted (`nav-group-flyout-reliability … intercepts pointer events`), timed out at 45s, then passed on retry — flaky. Reuse the existing `dismissNavFlyout()` helper before the hover, exactly as `navigateToFolder` already does.

Evidence: run 33502851197 (post-merge, main-based) — the test body passes; only the cleanup fails. Ref #14025.
Local: 3/3 green (`--repeat-each=3`).