### PR TITLE
fix(search): honour an explicit SQL LIMIT on _search_stream

### DIFF
--- a/src/api/search/src/search/search_stream.rs
+++ b/src/api/search/src/search/search_stream.rs
@@ -517,9 +517,10 @@ pub async fn search_http2_stream(
         }
     }
 
-    // Hack for limit in query
-    if sql.limit != 0 {
-        req.query.size = sql.limit;
+    // Only the outermost LIMIT governs, as on /_search. sql.limit cannot be used as a
+    // fallback: it still absorbs a CTE's LIMIT when the request sets no size.
+    if let Some(size) = sql.sql_limit {
+        req.query.size = size;
     }
 
     let req_order_by = sql.order_by.first().map(|v| v.1).unwrap_or_default();

--- a/src/search/src/sql/mod.rs
+++ b/src/search/src/sql/mod.rs
@@ -77,6 +77,8 @@ pub struct Sql {
     pub aliases: Vec<(String, String)>,                    // field_name, alias
     pub schemas: HashMap<TableReference, Arc<SchemaCache>>,
     pub limit: i64,
+    /// Literal LIMIT on the outermost query; not a CTE's, a subquery's, or FETCH FIRST.
+    pub sql_limit: Option<i64>,
     pub offset: i64,
     pub time_range: (i64, i64),
     pub group_by: Vec<String>,
@@ -156,6 +158,10 @@ impl Sql {
         let mut match_all_raw_visitor = MatchAllRawVisitor::new();
         let _ = statement.visit(&mut match_all_raw_visitor);
         //********************Change the sql end*********************************//
+
+        // Read after the rewriters: track_total_hits drops the LIMIT for DISTINCT and set-op
+        // queries, and a stale value would not describe the statement actually run.
+        let sql_limit = top_level_limit(&statement);
 
         // 5. get column name, alias, group by, order by
         let mut column_visitor = ColumnVisitor::new(&total_schemas);
@@ -287,6 +293,7 @@ impl Sql {
             aliases,
             schemas: final_schemas,
             limit,
+            sql_limit,
             offset,
             time_range: (query.start_time, query.end_time),
             group_by,
@@ -325,7 +332,7 @@ impl std::fmt::Display for Sql {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "sql: {}, time_range: {:?}, stream: {}/{}/{:?}, has_match_all: {}, equal_items: {:?}, aliases: {:?}, limit: {}, offset: {}, group_by: {:?}, order_by: {:?}, histogram_interval: {:?}, sorted_by_time: {}, is_complex: {}",
+            "sql: {}, time_range: {:?}, stream: {}/{}/{:?}, has_match_all: {}, equal_items: {:?}, aliases: {:?}, limit: {}, sql_limit: {:?}, offset: {}, group_by: {:?}, order_by: {:?}, histogram_interval: {:?}, sorted_by_time: {}, is_complex: {}",
             self.sql,
             self.time_range,
             self.org_id,
@@ -335,6 +342,7 @@ impl std::fmt::Display for Sql {
             self.equal_items,
             self.aliases,
             self.limit,
+            self.sql_limit,
             self.offset,
             self.group_by,
             self.order_by,
@@ -343,6 +351,26 @@ impl std::fmt::Display for Sql {
             self.is_complex,
         )
     }
+}
+
+/// Outermost LIMIT only: one inside a CTE or set-op branch does not bound the result.
+fn top_level_limit(statement: &sqlparser::ast::Statement) -> Option<i64> {
+    let sqlparser::ast::Statement::Query(query) = statement else {
+        return None;
+    };
+    let sqlparser::ast::LimitClause::LimitOffset {
+        limit: Some(limit), ..
+    } = query.limit_clause.as_ref()?
+    else {
+        return None;
+    };
+    let sqlparser::ast::Expr::Value(sqlparser::ast::ValueWithSpan { value, .. }) = limit else {
+        return None;
+    };
+    let sqlparser::ast::Value::Number(n, _) = value else {
+        return None;
+    };
+    n.to_string().parse::<i64>().ok()
 }
 
 fn o2_id_is_needed(
@@ -465,5 +493,68 @@ mod tests {
         let query = SearchQuery::default();
         let result = parse_sampling_config(&query, None, (0, 0), false);
         assert!(result.is_none());
+    }
+    fn limit_of(sql: &str) -> Option<i64> {
+        let st = Parser::parse_sql(&PostgreSqlDialect {}, sql)
+            .unwrap()
+            .pop()
+            .unwrap();
+        top_level_limit(&st)
+    }
+
+    #[test]
+    fn top_level_limit_reads_the_outermost_limit() {
+        assert_eq!(limit_of("SELECT a FROM t LIMIT 99"), Some(99));
+    }
+
+    #[test]
+    fn top_level_limit_ignores_a_limit_inside_a_cte() {
+        // The CTE's LIMIT bounds the CTE, not the result, so it must not become the row budget.
+        assert_eq!(
+            limit_of("WITH a AS (SELECT x FROM t LIMIT 10) SELECT * FROM a"),
+            None
+        );
+    }
+
+    #[test]
+    fn top_level_limit_ignores_limits_inside_a_set_operation() {
+        assert_eq!(
+            limit_of("(SELECT a FROM t LIMIT 5) UNION ALL (SELECT a FROM t LIMIT 7)"),
+            None
+        );
+    }
+
+    #[test]
+    fn top_level_limit_ignores_a_subquery_limit_but_keeps_the_outer_one() {
+        assert_eq!(
+            limit_of("SELECT a FROM t WHERE b IN (SELECT b FROM t LIMIT 3) LIMIT 99"),
+            Some(99)
+        );
+    }
+
+    #[test]
+    fn top_level_limit_is_none_without_a_limit() {
+        assert_eq!(limit_of("SELECT a FROM t"), None);
+    }
+    #[test]
+    fn top_level_limit_keeps_the_limit_when_an_offset_follows_it() {
+        assert_eq!(limit_of("SELECT a FROM t LIMIT 10 OFFSET 5"), Some(10));
+    }
+
+    #[test]
+    fn top_level_limit_is_read_after_track_total_hits_has_rewritten_the_query() {
+        // That rewrite drops the LIMIT for DISTINCT queries, so a value read before it
+        // would describe a statement that is never executed.
+        let mut statement =
+            Parser::parse_sql(&PostgreSqlDialect {}, "SELECT DISTINCT a FROM t LIMIT 10")
+                .unwrap()
+                .pop()
+                .unwrap();
+        assert_eq!(top_level_limit(&statement), Some(10));
+
+        let mut visitor = TrackTotalHitsVisitor::new();
+        let _ = statement.visit(&mut visitor);
+
+        assert_eq!(top_level_limit(&statement), None);
     }
 }

--- a/src/search_service/src/cache/cacher.rs
+++ b/src/search_service/src/cache/cacher.rs
@@ -1164,6 +1164,7 @@ mod tests {
                 schemas
             },
             limit: 100,
+            sql_limit: None,
             offset: 0,
             time_range: (0, 0),
             group_by: vec![],

--- a/src/search_service/src/partition/sql_context.rs
+++ b/src/search_service/src/partition/sql_context.rs
@@ -149,6 +149,7 @@ mod tests {
                 aliases: Default::default(),
                 schemas: Default::default(),
                 limit: -1,
+                sql_limit: None,
                 offset: 0,
                 time_range: (0, 0),
                 group_by: Default::default(),


### PR DESCRIPTION
Closes #8372.

`_search` and `_search_stream` disagree on which of the SQL `LIMIT` and the request body `size` decides the row count. With `SELECT … LIMIT 1000` and `size: 100`, `_search` returns 1000 and `_search_stream` returns 100.

`_search` honours the LIMIT because `AddSortAndLimit` never rewrites the `fetch` of a `Limit` already in the plan (`datafusion/optimizer/utils.rs`), so an explicit LIMIT survives whatever `size` says.

Streaming collapsed the two. `Sql::new` starts `limit` at `query.size` and only lets the SQL's LIMIT override it when size is `-1` or `0` (`sql/mod.rs`), after which the two are indistinguishable. The handler then assigned that collapsed value back:

```rust
// Hack for limit in query
if sql.limit != 0 { req.query.size = sql.limit; }
```

That value becomes `req_size` in `streaming/execution.rs`, which truncates to it.

## Fix

`Sql` carries the outermost LIMIT as `sql_limit`, and the streaming handler uses that alone.

It is read from the parsed statement rather than from `ColumnVisitor`. The visitor's only guard is `self.limit.is_none()`, so it returns the first LIMIT it visits anywhere — `Some(10)` for `WITH a AS (SELECT … LIMIT 10) SELECT * FROM a` and `Some(5)` for `(SELECT … LIMIT 5) UNION ALL (SELECT … LIMIT 7)`. Neither bounds the result, so using one would truncate a result set that is legitimately larger.

`sql.limit` is deliberately **not** used as a fallback, for the same reason: when the request sets no size it still absorbs an inner LIMIT via the visitor.

The read happens after the rewriters run, because `track_total_hits` blanks `limit_clause` for DISTINCT and set-operation queries — a value read earlier would not describe the statement actually executed.

Streams whose SQL carries no top-level LIMIT are unaffected: `req.query.size` is left exactly as the caller sent it.

## Testing

- 1,454 pass across `search`, `openobserve-api-search` and `search_service`; 7 new on the extractor.
- Mutation-checked: requiring `offset: None` fails only the `LIMIT n OFFSET m` test; accepting an inner CTE limit fails only the CTE test.
- `cargo fmt --all -- --check` clean.
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` clean.

## Notes

Two gaps I would rather state than leave for review to find:

- **The placement of the read is not pinned by a test.** Moving it back before the rewriters passes all 7 tests — the test exercises `top_level_limit` on a statement it rewrites itself, so it documents why the ordering matters but cannot pin where `Sql::new` calls it. `Sql::new` needs `infra::schema::get`, so covering it would need an integration test.
- **The enterprise build is unverified.** `Sql` is `pub` with public fields and derives no `Default`, so any `Sql { … }` literal in `o2-enterprise` will fail to compile against this. Both in-repo literals are updated; per CLAUDE.md `--features enterprise` does not work in this repo, so I could not check the other side. Happy to add a constructor or `Default` if you would rather not touch the struct's shape.

Two further things worth your judgement:

- This changes row counts on a public endpoint. A caller treating `size` as a hard cap on `_search_stream` will now receive more rows when their SQL asks for them. That is the point — it matches `_search` — but it is a behaviour change, not a bug fix nobody notices.
- The reporter asked whether the current behaviour was intended, and I could not find the contract documented anywhere for either endpoint. The argument for changing streaming rather than documenting it is that the code already contradicts itself: `execution.rs` carries the comment "the limit in sql takes precedence over the requested size" directly above the truncation that ignores it.
