### PR TITLE
fix(i18n): match browser locale by language subtag

### DIFF
--- a/web/src/locales/index.spec.ts
+++ b/web/src/locales/index.spec.ts
@@ -25,7 +25,21 @@ vi.mock("@/utils/cookies", () => ({
 }));
 
 import { getNumberLocale, APP_LOCALE_TO_BCP47 } from "@/locales/numberFormat";
-import { localeFileMap } from "@/locales";
+import { getLocale, localeFileMap } from "@/locales";
+
+const withNavigatorLanguage = (language: string, assertion: () => void) => {
+  const descriptor = Object.getOwnPropertyDescriptor(navigator, "language");
+  Object.defineProperty(navigator, "language", { value: language, configurable: true });
+  try {
+    assertion();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(navigator, "language", descriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "language");
+    }
+  }
+};
 
 describe("locale registry stays in sync", () => {
   // locales/index.ts code-splits via import.meta.glob("./languages/*.json"), so
@@ -99,5 +113,31 @@ describe("getNumberLocale (locale format unit)", () => {
       maximumFractionDigits: 2,
     }).format(1234567.89);
     expect(en).toBe("1,234,567.89");
+  });
+});
+
+describe("navigator language detection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getLanguage as any).mockReturnValue(undefined);
+  });
+
+  it.each([
+    ["de-DE", "de"],
+    ["fr-IT", "fr"],
+    ["zh-TW", "zh-tw"],
+    ["en-DE", "en-us"],
+    ["en-IT", "en-us"],
+  ])("resolves %s to %s", (language, expected) => {
+    withNavigatorLanguage(language, () => expect(getLocale()).toBe(expected));
+  });
+
+  it.each([
+    ["de-DE", "de-DE"],
+    ["fr-IT", "fr-FR"],
+    ["en-DE", "en-US"],
+    ["en-IT", "en-US"],
+  ])("formats %s with %s", (language, expected) => {
+    withNavigatorLanguage(language, () => expect(getNumberLocale()).toBe(expected));
   });
 });

--- a/web/src/locales/index.ts
+++ b/web/src/locales/index.ts
@@ -52,7 +52,7 @@ export const getLocale = () => {
   const language = navigator.language.toLowerCase();
   const locales = Object.keys(localeFileMap);
   for (const locale of locales) {
-    if (language.indexOf(locale) > -1) {
+    if (language === locale || language.startsWith(`${locale}-`)) {
       return locale;
     }
   }

--- a/web/src/locales/numberFormat.ts
+++ b/web/src/locales/numberFormat.ts
@@ -42,8 +42,8 @@ const resolveAppLanguage = (): string => {
   if (cookieLanguage) return cookieLanguage;
 
   const navLanguage = (navigator.language || "").toLowerCase();
-  const match = Object.keys(APP_LOCALE_TO_BCP47).find((code) =>
-    navLanguage === code || navLanguage.startsWith(`${code}-`),
+  const match = Object.keys(APP_LOCALE_TO_BCP47).find(
+    (code) => navLanguage === code || navLanguage.startsWith(`${code}-`),
   );
   return match ?? "en-us";
 };

--- a/web/src/locales/numberFormat.ts
+++ b/web/src/locales/numberFormat.ts
@@ -42,7 +42,9 @@ const resolveAppLanguage = (): string => {
   if (cookieLanguage) return cookieLanguage;
 
   const navLanguage = (navigator.language || "").toLowerCase();
-  const match = Object.keys(APP_LOCALE_TO_BCP47).find((code) => navLanguage.indexOf(code) > -1);
+  const match = Object.keys(APP_LOCALE_TO_BCP47).find((code) =>
+    navLanguage === code || navLanguage.startsWith(`${code}-`),
+  );
   return match ?? "en-us";
 };
 


### PR DESCRIPTION
## Summary

- Match the browser language only against the leading language subtag instead of any substring.
- Apply the same matching rule to the UI locale and number formatting.
- Add regression tests for language tags whose region subtags collide with supported locale codes.

## Problem

The previous substring matching could mistake a region subtag for a language code.

For example:

- `en-DE` could incorrectly resolve to German (`de`).
- `en-IT` could incorrectly resolve to Italian (`it`).
- After adding Arabic, `es-AR` could incorrectly resolve to Arabic (`ar`) instead of Spanish.

The updated matching requires the locale code to match the full tag or appear at its beginning.

## Validation

- Locale unit tests passed: 14/14
- TypeScript type check passed
- ESLint passed

Follow-up to #14017.