### PR TITLE
fix: stop two handler panics the API fuzzer reaches through query params

### DIFF
--- a/src/api/search/src/promql/mod.rs
+++ b/src/api/search/src/promql/mod.rs
@@ -181,7 +181,20 @@ async fn query(
 
         use crate::service::auth::AuthExtractor;
 
-        let ast = parser::parse(&req.query.clone().unwrap()).unwrap();
+        let ast = match parser::parse(&req.query.clone().unwrap_or_default()) {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("[trace_id: {trace_id}] parse promql error: {e}");
+                return (
+                    StatusCode::BAD_REQUEST,
+                    axum::Json(config::meta::promql::ApiFuncResponse::<()>::err_bad_data(
+                        e.to_string(),
+                        Some(trace_id),
+                    )),
+                )
+                    .into_response();
+            }
+        };
         let mut visitor = promql::promql::name_visitor::MetricNameVisitor::default();
         promql_parser::util::walk_expr(&mut visitor, &ast).unwrap();
 

--- a/src/infra/src/table/alert_incidents.rs
+++ b/src/infra/src/table/alert_incidents.rs
@@ -263,9 +263,10 @@ pub async fn list(
         query = query.filter(alert_incidents::Column::Status.eq(s));
     }
 
+    let page_size = limit.max(1);
     query
-        .paginate(client, limit.max(1))
-        .fetch_page(offset / limit)
+        .paginate(client, page_size)
+        .fetch_page(offset / page_size)
         .await
         .map_err(|e| Error::DbError(DbError::SeaORMError(e.to_string())))
 }


### PR DESCRIPTION
## Problem

o2-enterprise's `api_fuzz_tests` job (schemathesis, `--checks not_a_server_error`) has two remaining errors after [openobserve/o2-enterprise#2532](https://github.com/openobserve/o2-enterprise/pull/2532) clears the OpenFGA 500s. They show up as **`Network Error — Connection aborted. Remote end closed connection without response`** rather than as 5xx, because the tokio worker panics and the connection is dropped:

| Request | Panic (from the uploaded `o2-fuzz` server log) |
|---|---|
| `GET /api/v2/{org_id}/alerts/incidents?limit=0` | `src/infra/src/table/alert_incidents.rs:268` — `attempt to divide by zero` |
| `GET /api/{org_id}/prometheus/api/v1/query?query=` | `src/api/search/src/promql/mod.rs:184` — `called Result::unwrap() on an Err value: "no expression found in input"` |

Both are pre-existing: the same two errors appear in fuzz runs from before the OpenFGA change.

## Fixes

**`alert_incidents::list`** — the page size was already clamped with `limit.max(1)`, but the page index on the next line still divided by the raw `limit`. Bind the clamped value once and use it for both.

**`promql::query`** (enterprise branch) — the instant-query handler unwrapped `req.query` and the promql parse before walking the AST for the permission check. `query_range`'s enterprise branch already handles exactly this with a 400 `bad_data` response carrying the trace id; this mirrors that block, so an empty or unparseable expression now gets the same answer on both endpoints.

## Verification

- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` — clean.
- The promql change is under `#[cfg(feature = "enterprise")]`, so it was also checked with o2-enterprise's `Cargo.toml.openobserve` swapped in (ent branch `hf/openfga-tuple-control-chars`): `cargo check --all-targets` finishes clean.