### PR TITLE
fix(web): restore npm 10 lockfile entry

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11649,6 +11649,21 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/jsdom/node_modules/entities": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",


### PR DESCRIPTION
## What changed

- restore the npm 10 lockfile entry for `jsdom/node_modules/@noble/hashes@2.4.0`
- keep the hotfix lockfile-only: 15 added lines and no package version changes

## Why

OSS main currently fails under the Node 22 / npm 10.9.8 toolchain used by the Enterprise runtime producer:

```text
npm ci can only install packages when package.json and package-lock.json are in sync
Missing: @noble/hashes@2.4.0 from lock file
```

The nested optional peer entry was removed when `web/package-lock.json` was regenerated in #14072. npm 11 accepts the resulting lockfile, but npm 10.9.8 rejects it before the frontend build starts.

This broke both sides of the fail-closed Enterprise runtime path after #2528 merged:

- main producer: https://github.com/openobserve/o2-enterprise/actions/runs/33574734382
- API same-recipe fallback: https://github.com/openobserve/o2-enterprise/actions/runs/33574734613

## Validation

- reproduced the failure with `npx --yes npm@10.9.3 ci --ignore-scripts --dry-run`
- regenerated only `package-lock.json` with npm 10.9.8, matching the failing CI runner
- full `npx --yes npm@10.9.8 ci` passes, including both `patch-package` patches
- `npm run build` passes (`vue-tsc` + Vite production build)
- `git diff --check` passes

## Risk

Low. The manifest is unchanged; this restores one missing nested optional-peer lock entry required by npm 10.
