### PR TITLE
fix: answer an unknown pattern id in stream settings with 400

### DIFF
--- a/src/db/src/re_pattern.rs
+++ b/src/db/src/re_pattern.rs
@@ -169,19 +169,11 @@ pub async fn process_association_changes(
 
     let mgr = get_pattern_manager().await?;
 
-    for item in &update.add {
+    // An unknown id is caller input, so it must not surface as a server error.
+    for item in update.add.iter().chain(&update.remove) {
         if !mgr.check_pattern_exists(&item.pattern_id) {
-            return Err(errors::Error::Message(format!(
-                "pattern with id {} not found",
-                item.pattern_id
-            )));
-        }
-    }
-    for item in &update.remove {
-        if !mgr.check_pattern_exists(&item.pattern_id) {
-            return Err(errors::Error::Message(format!(
-                "pattern with id {} not found",
-                item.pattern_id
+            return Err(errors::Error::ErrorCode(errors::ErrorCodes::InvalidParams(
+                format!("pattern with id {} not found", item.pattern_id),
             )));
         }
     }

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -728,9 +728,14 @@ pub async fn update_stream_settings(
         )
         .await
         {
-            return Ok(MetaHttpResponse::internal_error(format!(
-                "Internal server error while updating pattern associations {e}",
-            )));
+            return Ok(match e {
+                infra::errors::Error::ErrorCode(infra::errors::ErrorCodes::InvalidParams(msg)) => {
+                    MetaHttpResponse::bad_request(msg)
+                }
+                e => MetaHttpResponse::internal_error(format!(
+                    "Internal server error while updating pattern associations {e}",
+                )),
+            });
         }
     }
 


### PR DESCRIPTION
## Problem

After [openobserve/o2-enterprise#2532](https://github.com/openobserve/o2-enterprise/pull/2532) and #14089 cleared the earlier failures, a re-run of o2-enterprise's `api_fuzz_tests` reached one more 500:

```
PUT /api/{org_id}/streams/{stream_name}/settings
{"code":500,"message":"Internal server error while updating pattern associations Error# pattern with id 𬻴 not found"}
```

The pattern id comes straight from the request body. `process_association_changes` already refuses an unknown id before touching the store — but it reported that refusal as `Error::Message`, and the settings handler maps everything the call returns to `internal_error`.

## Fix

- `src/db/src/re_pattern.rs`: report the two existence checks as `Error::ErrorCode(ErrorCodes::InvalidParams(..))`, the variant infra already maps to 400 (`Error::http_status`). The `add` / `remove` loops were identical and are folded into one.
- `src/stream/src/lib.rs`: the settings handler answers `bad_request` for exactly that variant and keeps every other failure of the call a 500, as before.

Both sites are under `#[cfg(feature = "vectorscan")]`, so OSS CI does not compile them.

## Verification

- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` — clean.
- Enterprise + vectorscan build checked with o2-enterprise's `Cargo.toml.openobserve` swapped in (ent branch `hf/openfga-tuple-control-chars` at `5f593824`): `cargo check --all-targets` clean.
- Branch name matches the o2-enterprise PR so its api-testing run picks this side up; the fuzz result will be on that run.