### PR TITLE
feat(metrics): register hash-sorted metrics tables and prune band scans

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1532,6 +1532,12 @@ pub struct Search {
     )]
     pub feature_metrics_fused_agg_enabled: bool,
     #[env_config(
+        name = "ZO_FEATURE_METRICS_STREAMING_AGG_ENABLED",
+        default = false,
+        help = "Register the hash-sorted metrics table for streaming PromQL aggregation over hash-sorted metrics files; off by default until the streaming evaluator lands"
+    )]
+    pub feature_metrics_streaming_agg_enabled: bool,
+    #[env_config(
         name = "ZO_FEATURE_DYNAMIC_PUSHDOWN_FILTER_ENABLED",
         default = true,
         help = "Enable dynamic pushdown filter"

--- a/src/config/src/meta/promql/mod.rs
+++ b/src/config/src/meta/promql/mod.rs
@@ -76,6 +76,8 @@ pub const BUCKET_LABEL: &str = "le";
 pub const QUANTILE_LABEL: &str = "quantile";
 pub const METADATA_LABEL: &str = "prom_metadata"; // for schema metadata key
 pub const EXEMPLARS_LABEL: &str = "exemplars";
+/// Suffix of the extra table that declares the `(__hash__, _timestamp)` file order.
+pub const STREAMING_AGG_TABLE_SUFFIX: &str = "__hash_sorted";
 
 /// Columns that metrics ingestion may exclude when deriving [`HASH_LABEL`].
 ///

--- a/src/promql_service/src/search/grpc/storage.rs
+++ b/src/promql_service/src/search/grpc/storage.rs
@@ -30,9 +30,10 @@ use infra::{
     schema::{get_partition_time_level, unwrap_stream_settings},
 };
 use itertools::Itertools;
+use metrics_index::MetricsFileLayout;
 use promql_parser::label::Matchers;
 use search::{
-    datafusion::exec::register_metrics_table,
+    datafusion::{exec::register_metrics_table, sort_order::FileSortOrder},
     file_cache::{cache_files, calc_target_partitions},
 };
 use search_service::match_source;
@@ -232,7 +233,19 @@ pub(crate) async fn create_context(
         target_partitions,
     };
 
-    let ctx = register_metrics_table(&session, schema.clone(), stream_name, files).await?;
+    // one legacy file voids the (__hash__, _timestamp) ordering guarantee
+    let sort_order = if cfg.search.feature_metrics_streaming_agg_enabled
+        && files
+            .iter()
+            .all(|file| MetricsFileLayout::of(&file.key).is_some())
+    {
+        FileSortOrder::HashTimestampAsc
+    } else {
+        FileSortOrder::None
+    };
+
+    let ctx =
+        register_metrics_table(&session, schema.clone(), stream_name, files, sort_order).await?;
 
     // keep_filters=false only when the pruner proved its selections exact
     Ok(Some((ctx, schema, scan_stats, keep_filters)))

--- a/src/search/src/datafusion/exec.rs
+++ b/src/search/src/datafusion/exec.rs
@@ -106,7 +106,9 @@ fn create_session_config(
             .options_mut()
             .execution
             .split_file_groups_by_statistics = true;
-        // a round-robin exchange would trade the chains' ordering for a re-sort
+    }
+    // a round-robin exchange would trade the hash chains' ordering for a re-sort
+    if sort_order == FileSortOrder::HashTimestampAsc {
         config
             .options_mut()
             .optimizer
@@ -513,6 +515,9 @@ pub fn catalog_functions(org_id: &str) -> Vec<CatalogFunction> {
     by_name.into_values().collect()
 }
 
+/// Registers the metrics files as `table_name`; an all-hash-sorted file set
+/// additionally registers `{table_name}__hash_sorted` with the file order
+/// declared, for the streaming aggregation path.
 pub async fn register_metrics_table(
     session: &SearchSession,
     schema: Arc<Schema>,

--- a/src/search/src/datafusion/exec.rs
+++ b/src/search/src/datafusion/exec.rs
@@ -19,7 +19,7 @@ use arrow_schema::Field;
 use config::{
     FileFormat, TIMESTAMP_COL_NAME, get_batch_size, get_config,
     meta::{
-        promql::{EXEMPLARS_LABEL, HASH_LABEL},
+        promql::{EXEMPLARS_LABEL, HASH_LABEL, STREAMING_AGG_TABLE_SUFFIX},
         search::{Session as SearchSession, StorageType},
         stream::{FileKey, StreamType},
     },
@@ -51,7 +51,7 @@ use datafusion::{
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::search::WorkGroup;
 use vortex::{VortexSessionDefault, io::session::RuntimeSessionExt, session::VortexSession};
-use vortex_datafusion::VortexFormat;
+use vortex_datafusion::{VortexFormat, VortexTableOptions};
 
 use super::{
     peak_memory_pool::PeakMemoryPool, planner::extension_planner::OpenobserveQueryPlanner,
@@ -100,13 +100,17 @@ fn create_session_config(
         };
     // config = config.set_bool("datafusion.execution.parquet.reorder_filters", true);
 
-    // sorted inputs: let DataFusion chain non-overlapping files into ordered
-    // partitions instead of adding a global sort
+    // chain non-overlapping sorted files into ordered partitions instead of sorting
     if sort_order.is_sorted() {
         config
             .options_mut()
             .execution
             .split_file_groups_by_statistics = true;
+        // a round-robin exchange would trade the chains' ordering for a re-sort
+        config
+            .options_mut()
+            .optimizer
+            .enable_round_robin_repartition = false;
     }
 
     // When set to true, skips verifying that the schema produced by planning the input of
@@ -514,17 +518,34 @@ pub async fn register_metrics_table(
     schema: Arc<Schema>,
     table_name: &str,
     files: Vec<FileKey>,
+    sort_order: FileSortOrder,
 ) -> Result<SessionContext> {
     let schema = metrics_query_schema(schema);
     let ctx = DataFusionContextBuilder::new()
         .trace_id(&session.id)
         .work_group(session.work_group.clone())
         .stream_type(StreamType::Metrics)
+        .sort_order(sort_order)
         .build(session.target_partitions)
         .await?;
 
+    let file_stat_cache = ctx.runtime_env().cache_manager.get_file_statistic_cache();
+    // a separate table: declaring the order on the main table would change its file grouping
+    if sort_order.is_sorted() {
+        let tables = TableBuilder::new()
+            .sort_order(sort_order)
+            .file_stat_cache(file_stat_cache.clone())
+            .build(session.clone(), files.clone(), schema.clone())
+            .await?;
+        let union_table = Arc::new(NewUnionTable::new(schema.clone(), tables));
+        ctx.register_table(
+            format!("{table_name}{STREAMING_AGG_TABLE_SUFFIX}"),
+            union_table,
+        )?;
+    }
+
     let tables = TableBuilder::new()
-        .file_stat_cache(ctx.runtime_env().cache_manager.get_file_statistic_cache())
+        .file_stat_cache(file_stat_cache)
         .build(session.clone(), files, schema.clone())
         .await?;
     let union_table = Arc::new(NewUnionTable::new(schema, tables));
@@ -708,7 +729,14 @@ impl TableBuilder {
             FileFormat::Parquet => Arc::new(ParquetFormat::default()),
             FileFormat::Vortex => {
                 let vortex_session = VortexSession::default().with_tokio();
-                Arc::new(VortexFormat::new(vortex_session))
+                if self.sort_order.is_sorted() {
+                    // bands already parallelize; per-file spawned read-ahead only buys memory
+                    let mut options = VortexTableOptions::default();
+                    options.scan_concurrency = Some(1);
+                    Arc::new(VortexFormat::new_with_options(vortex_session, options))
+                } else {
+                    Arc::new(VortexFormat::new(vortex_session))
+                }
             }
         };
 
@@ -1481,7 +1509,9 @@ mod tests {
                 row_group_size: None,
             }];
 
-            let result = register_metrics_table(&session, schema, "test_table", files).await;
+            let result =
+                register_metrics_table(&session, schema, "test_table", files, FileSortOrder::None)
+                    .await;
 
             // Should create context successfully
             assert!(result.is_ok());

--- a/src/search/src/datafusion/sort_order.rs
+++ b/src/search/src/datafusion/sort_order.rs
@@ -80,8 +80,9 @@ pub enum FileSortOrder {
     /// compactor for logs, traces and non-indexed metrics.
     TimestampDesc,
     /// `__hash__ ASC, _timestamp ASC` — indexed metrics layout: all samples of
-    /// one series are contiguous and time-ordered inside a file. Only used by
-    /// the compactor merge; distributed query plans never carry it.
+    /// one series are contiguous and time-ordered inside a file. Used by the
+    /// compactor merge and, behind `ZO_FEATURE_METRICS_STREAMING_AGG_ENABLED`,
+    /// by the PromQL session's ordered table; distributed plans never carry it.
     HashTimestampAsc,
 }
 

--- a/src/search/src/datafusion/table_provider/helpers.rs
+++ b/src/search/src/datafusion/table_provider/helpers.rs
@@ -19,8 +19,12 @@ use arrow::buffer::BooleanBuffer;
 use arrow_schema::{DataType, SchemaRef};
 use config::{FileFormat, TIMESTAMP_COL_NAME, meta::stream::FileSelection};
 use datafusion::{
+    catalog::memory::DataSourceExec,
     common::{DataFusionError, Result, project_schema, stats::Precision},
-    datasource::{listing::PartitionedFile, physical_plan::parquet::ParquetAccessPlan},
+    datasource::{
+        listing::PartitionedFile,
+        physical_plan::{FileGroup, FileScanConfig, parquet::ParquetAccessPlan},
+    },
     logical_expr::Operator,
     parquet::arrow::arrow_reader::RowSelection,
     physical_expr::conjunction,
@@ -35,6 +39,7 @@ use datafusion::{
 use hashbrown::HashMap;
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::search::sampling::execution::generate_row_group_access_plan;
+use rayon::prelude::*;
 
 use crate::{
     datafusion::{
@@ -319,6 +324,52 @@ pub fn apply_combined_filter(
             .apply_projection(filter_projection.cloned())?
             .build()?,
     ))
+}
+
+/// Attaches the tantivy access plans to every file and rebuilds the scan over
+/// the given groups.
+pub(crate) fn with_access_plans(
+    trace_id: &str,
+    config: &FileScanConfig,
+    file_groups: Vec<FileGroup>,
+    target_partitions: usize,
+) -> Arc<dyn ExecutionPlan> {
+    let start = std::time::Instant::now();
+    let new_file_groups: Vec<_> = file_groups
+        .into_par_iter()
+        .map(|file_group| {
+            let group: Vec<_> = file_group
+                .into_inner()
+                .into_iter()
+                .map(|mut file| {
+                    generate_access_plan(&mut file);
+                    file
+                })
+                .collect();
+            // TODO: check if we need statistics for FileGroup
+            // the statistics in FileGroup is used in ExecutionPlan::partition_statistics
+            FileGroup::new(group)
+        })
+        .collect();
+
+    let groups_len = new_file_groups.len();
+    let max_group_len = new_file_groups.iter().map(|g| g.len()).max().unwrap_or(0);
+    let files_nums = new_file_groups.iter().map(|g| g.len()).sum::<usize>();
+
+    log::info!(
+        "[trace_id {trace_id}] listing table adapter, target_partitions: {target_partitions}, file groups: {groups_len}, max group len: {max_group_len}, total files: {files_nums}, took: {} ms",
+        start.elapsed().as_millis() as usize,
+    );
+
+    let mut config = config.clone();
+    config.file_groups = new_file_groups;
+    Arc::new(DataSourceExec::new(Arc::new(config)))
+}
+
+pub(crate) fn file_scan_config(plan: &Arc<dyn ExecutionPlan>) -> Option<&FileScanConfig> {
+    plan.downcast_ref::<DataSourceExec>()?
+        .data_source()
+        .downcast_ref::<FileScanConfig>()
 }
 
 #[cfg(test)]

--- a/src/search/src/datafusion/table_provider/listing_adapter.rs
+++ b/src/search/src/datafusion/table_provider/listing_adapter.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use arrow_schema::SchemaRef;
 use config::{TIMESTAMP_COL_NAME, get_config};
 use datafusion::{
-    catalog::{Session, TableProvider, memory::DataSourceExec},
+    catalog::{Session, TableProvider},
     common::Result,
     datasource::{
         TableType,
@@ -30,13 +30,15 @@ use datafusion::{
     physical_plan::ExecutionPlan,
     prelude::Expr,
 };
-use rayon::prelude::*;
 use tonic::async_trait;
 
 use crate::{
     datafusion::{
         sort_order::FileSortOrder,
-        table_provider::helpers::{apply_combined_filter, generate_access_plan},
+        table_provider::{
+            helpers::{apply_combined_filter, file_scan_config, with_access_plans},
+            metrics::{handler_metrics_band_scan, hash_interval},
+        },
     },
     index::IndexCondition,
 };
@@ -139,19 +141,30 @@ impl TableProvider for ListingTableAdapter {
             .scan(state, parquet_projection, filters, limit)
             .await?;
 
-        // The files are sorted but DataFusion dropped the ordering (overlapping
-        // files in one group): regroup them by statistics ourselves.
-        let regroup_order = (self.sort_order.is_sorted()
-            && parquet_exec.properties().output_ordering().is_none())
-        .then_some(self.sort_order);
         let target_partitions = self.listing_table.options().target_partitions;
-        let parquet_exec = handler_tantivy_index(
-            &self.trace_id,
-            state,
-            parquet_exec,
-            regroup_order,
-            target_partitions,
-        );
+        let parquet_exec = match hash_interval(filters) {
+            Some(hash_range) if self.sort_order.is_sorted() => handler_metrics_band_scan(
+                &self.trace_id,
+                parquet_exec,
+                self.sort_order,
+                hash_range,
+                target_partitions,
+            ),
+            _ => {
+                // The files are sorted but DataFusion dropped the ordering (overlapping
+                // files in one group): regroup them by statistics ourselves.
+                let regroup_order = (self.sort_order.is_sorted()
+                    && parquet_exec.properties().output_ordering().is_none())
+                .then_some(self.sort_order);
+                handler_tantivy_index(
+                    &self.trace_id,
+                    state,
+                    parquet_exec,
+                    regroup_order,
+                    target_partitions,
+                )
+            }
+        };
 
         // if the index condition can remove filter, we can skip the config
         // feature_query_remove_filter_with_index
@@ -193,95 +206,62 @@ fn handler_tantivy_index(
     regroup_order: Option<FileSortOrder>,
     target_partitions: usize,
 ) -> Arc<dyn ExecutionPlan> {
-    if let Some(data_source_exec) = plan.downcast_ref::<DataSourceExec>()
-        && let Some(config) = data_source_exec
-            .data_source()
-            .downcast_ref::<FileScanConfig>()
-    {
-        let mut file_groups = config.file_groups.clone();
+    let Some(config) = file_scan_config(&plan) else {
+        return plan;
+    };
+    let mut file_groups = config.file_groups.clone();
 
-        if let Some(sort_order) = regroup_order {
-            let schema = config.file_source().table_schema().table_schema();
-            match sort_order.physical_ordering(schema) {
-                Some(ordering) => {
-                    match FileScanConfig::split_groups_by_statistics_with_target_partitions(
-                        schema,
-                        &file_groups,
-                        &ordering,
-                        target_partitions,
-                    ) {
-                        Ok(new_file_groups) => {
-                            file_groups = new_file_groups;
-                        }
-                        Err(e) if sort_order.is_timestamp_desc() => {
-                            // files are listed oldest first; reversing each group
-                            // is the best effort approximation of `_timestamp DESC`
-                            log::warn!(
-                                "[trace_id {trace_id}] failed to split file groups by statistics: {e}, falling back to reversing file groups"
-                            );
-                            file_groups = file_groups
-                                .into_iter()
-                                .map(|file_group| {
-                                    let mut files = file_group.into_inner();
-                                    files.reverse();
-                                    FileGroup::new(files)
-                                })
-                                .collect();
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                "[trace_id {trace_id}] failed to split file groups by statistics for {sort_order}: {e}, keeping file groups as is"
-                            );
-                        }
+    if let Some(sort_order) = regroup_order {
+        let schema = config.file_source().table_schema().table_schema();
+        match sort_order.physical_ordering(schema) {
+            Some(ordering) => {
+                match FileScanConfig::split_groups_by_statistics_with_target_partitions(
+                    schema,
+                    &file_groups,
+                    &ordering,
+                    target_partitions,
+                ) {
+                    Ok(new_file_groups) => {
+                        file_groups = new_file_groups;
+                    }
+                    Err(e) if sort_order.is_timestamp_desc() => {
+                        // files are listed oldest first; reversing each group
+                        // is the best effort approximation of `_timestamp DESC`
+                        log::warn!(
+                            "[trace_id {trace_id}] failed to split file groups by statistics: {e}, falling back to reversing file groups"
+                        );
+                        file_groups = file_groups
+                            .into_iter()
+                            .map(|file_group| {
+                                let mut files = file_group.into_inner();
+                                files.reverse();
+                                FileGroup::new(files)
+                            })
+                            .collect();
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "[trace_id {trace_id}] failed to split file groups by statistics for {sort_order}: {e}, keeping file groups as is"
+                        );
                     }
                 }
-                None => {
-                    log::warn!(
-                        "[trace_id {trace_id}] sort columns of {sort_order} not found in schema, skipping split_groups_by_statistics"
-                    );
-                }
+            }
+            None => {
+                log::warn!(
+                    "[trace_id {trace_id}] sort columns of {sort_order} not found in schema, skipping split_groups_by_statistics"
+                );
             }
         }
+    }
 
-        let start = std::time::Instant::now();
-        let new_file_groups: Vec<_> = file_groups
-            .into_par_iter()
-            .map(|file_group| {
-                let group: Vec<_> = file_group
-                    .into_inner()
-                    .into_iter()
-                    .map(|mut file| {
-                        generate_access_plan(&mut file);
-                        file
-                    })
-                    .collect();
-                // TODO: check if we need statistics for FileGroup
-                // the statistics in FileGroup is used in ExecutionPlan::partition_statistics
-                FileGroup::new(group)
-            })
-            .collect();
-
-        let groups_len = new_file_groups.len();
-        let max_group_len = new_file_groups.iter().map(|g| g.len()).max().unwrap_or(0);
-        let files_nums = new_file_groups.iter().map(|g| g.len()).sum::<usize>();
-
-        log::info!(
-            "[trace_id {trace_id}] listing table adapter, target_partitions: {target_partitions}, file groups: {groups_len}, max group len: {max_group_len}, total files: {files_nums}, took: {} ms",
-            start.elapsed().as_millis() as usize,
-        );
-
-        let mut config = config.clone();
-        config.file_groups = new_file_groups;
-        let mut plan = Arc::new(DataSourceExec::new(Arc::new(config))) as Arc<dyn ExecutionPlan>;
-        // skip repartitioning when the files were regrouped by statistics: the
-        // groups already carry the ordering and there are plenty of them
-        if regroup_order.is_none()
-            && let Ok(Some(repartition_plan)) =
-                plan.repartitioned(target_partitions, state.config_options())
-        {
-            plan = repartition_plan;
-        }
-        return plan;
+    let mut plan = with_access_plans(trace_id, config, file_groups, target_partitions);
+    // skip repartitioning when the files were regrouped by statistics: the
+    // groups already carry the ordering and there are plenty of them
+    if regroup_order.is_none()
+        && let Ok(Some(repartition_plan)) =
+            plan.repartitioned(target_partitions, state.config_options())
+    {
+        plan = repartition_plan;
     }
     plan
 }
@@ -321,6 +301,89 @@ mod tests {
             Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
             Field::new("value", DataType::Float64, false),
         ]))
+    }
+
+    #[tokio::test]
+    async fn test_scan_prunes_files_outside_hash_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        write_hash_sorted_file(
+            dir.path(),
+            "a.parquet",
+            &[(1, 10), (3, 20)],
+            FileFormat::Parquet,
+        )
+        .await;
+        write_hash_sorted_file(
+            dir.path(),
+            "b.parquet",
+            &[(5, 10), (7, 20)],
+            FileFormat::Parquet,
+        )
+        .await;
+        write_hash_sorted_file(
+            dir.path(),
+            "c.parquet",
+            &[(9, 10), (11, 20)],
+            FileFormat::Parquet,
+        )
+        .await;
+
+        let sort_order = FileSortOrder::HashTimestampAsc;
+        let ctx = DataFusionContextBuilder::new()
+            .trace_id("test_hash_prune")
+            .sort_order(sort_order)
+            .build(2)
+            .await
+            .unwrap();
+        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+            .with_target_partitions(2)
+            .with_collect_stat(true)
+            .with_file_sort_order(vec![sort_order.logical_sort_exprs()]);
+        let url = ListingTableUrl::parse(format!("file://{}/", dir.path().display())).unwrap();
+        let config = ListingTableConfig::new(url)
+            .with_listing_options(listing_options)
+            .with_schema(hash_sorted_schema());
+        let table = ListingTableAdapter::try_new(
+            config,
+            "test_hash_prune".to_string(),
+            sort_order,
+            None,
+            vec![],
+            None,
+        )
+        .unwrap();
+        ctx.register_table("t", Arc::new(table)).unwrap();
+
+        let plan = ctx
+            .state()
+            .create_logical_plan(&format!(
+                "SELECT * FROM t WHERE {HASH_LABEL} >= 5 AND {HASH_LABEL} <= 7 ORDER BY {}",
+                sort_order.order_by_clause().unwrap()
+            ))
+            .await
+            .unwrap();
+        let physical_plan = ctx.state().create_physical_plan(&plan).await.unwrap();
+        let display = displayable(physical_plan.as_ref()).indent(true).to_string();
+        assert!(
+            display.contains("b.parquet") && !display.contains("a.parquet"),
+            "expected only the intersecting file in the scan, got:\n{display}"
+        );
+        assert!(!display.contains("c.parquet"), "got:\n{display}");
+
+        let batches = collect(physical_plan, ctx.task_ctx()).await.unwrap();
+        let hashes: Vec<u64> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(hashes, vec![5, 7]);
     }
 
     /// Write one file whose rows are ordered by (__hash__, _timestamp).

--- a/src/search/src/datafusion/table_provider/listing_adapter.rs
+++ b/src/search/src/datafusion/table_provider/listing_adapter.rs
@@ -37,7 +37,7 @@ use crate::{
         sort_order::FileSortOrder,
         table_provider::{
             helpers::{apply_combined_filter, file_scan_config, with_access_plans},
-            metrics::{handler_metrics_band_scan, hash_interval},
+            metrics::{handler_metrics_scan, hash_interval},
         },
     },
     index::IndexCondition,
@@ -143,7 +143,7 @@ impl TableProvider for ListingTableAdapter {
 
         let target_partitions = self.listing_table.options().target_partitions;
         let parquet_exec = match hash_interval(filters) {
-            Some(hash_range) if self.sort_order.is_sorted() => handler_metrics_band_scan(
+            Some(hash_range) if self.sort_order.is_sorted() => handler_metrics_scan(
                 &self.trace_id,
                 parquet_exec,
                 self.sort_order,

--- a/src/search/src/datafusion/table_provider/metrics.rs
+++ b/src/search/src/datafusion/table_provider/metrics.rs
@@ -103,7 +103,7 @@ fn prune_groups_by_hash_range(
 /// A metrics band scan keeps only the files whose `__hash__` statistics
 /// intersect the band and chains them into the fewest ordered chains; one
 /// task merges them all, so the scan is never repartitioned.
-pub(super) fn handler_metrics_band_scan(
+pub(super) fn handler_metrics_scan(
     trace_id: &str,
     plan: Arc<dyn ExecutionPlan>,
     sort_order: FileSortOrder,

--- a/src/search/src/datafusion/table_provider/metrics.rs
+++ b/src/search/src/datafusion/table_provider/metrics.rs
@@ -1,0 +1,181 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Metrics band scans: the `__hash__` interval a band filter pushes down,
+//! the file pruning it allows, and the scan rebuilt over the fewest ordered
+//! chains of the surviving files.
+
+use std::sync::Arc;
+
+use config::meta::promql::HASH_LABEL;
+use datafusion::{
+    common::ScalarValue,
+    datasource::{
+        listing::PartitionedFile,
+        physical_plan::{FileGroup, FileScanConfig},
+    },
+    logical_expr::Operator,
+    physical_plan::ExecutionPlan,
+    prelude::Expr,
+};
+
+use crate::datafusion::{
+    sort_order::FileSortOrder,
+    table_provider::helpers::{file_scan_config, with_access_plans},
+};
+
+/// The closed `__hash__` interval implied by the pushed-down filters, if any.
+pub(super) fn hash_interval(filters: &[Expr]) -> Option<(u64, u64)> {
+    let mut lo = 0u64;
+    let mut hi = u64::MAX;
+    let mut found = false;
+    for filter in filters {
+        let Expr::BinaryExpr(binary) = filter else {
+            continue;
+        };
+        let Expr::Column(column) = binary.left.as_ref() else {
+            continue;
+        };
+        if column.name != HASH_LABEL {
+            continue;
+        }
+        let Expr::Literal(ScalarValue::UInt64(Some(value)), _) = binary.right.as_ref() else {
+            continue;
+        };
+        match binary.op {
+            Operator::GtEq => lo = lo.max(*value),
+            Operator::Gt => lo = lo.max(value.saturating_add(1)),
+            Operator::LtEq => hi = hi.min(*value),
+            Operator::Lt => hi = hi.min(value.saturating_sub(1)),
+            Operator::Eq => {
+                lo = lo.max(*value);
+                hi = hi.min(*value);
+            }
+            _ => continue,
+        }
+        found = true;
+    }
+    found.then_some((lo, hi))
+}
+
+/// Keeps files whose `__hash__` statistics may intersect `[lo, hi]`; a file
+/// without usable statistics always survives.
+fn prune_groups_by_hash_range(
+    file_groups: Vec<FileGroup>,
+    schema: &arrow_schema::Schema,
+    (lo, hi): (u64, u64),
+) -> Vec<FileGroup> {
+    let Ok(hash_index) = schema.index_of(HASH_LABEL) else {
+        return file_groups;
+    };
+    let mut pruned: Vec<FileGroup> = file_groups
+        .into_iter()
+        .map(|group| {
+            FileGroup::new(
+                group
+                    .into_inner()
+                    .into_iter()
+                    .filter(|file| file_may_intersect(file, hash_index, lo, hi))
+                    .collect(),
+            )
+        })
+        .filter(|group| !group.is_empty())
+        .collect();
+    // a scan needs at least one (empty) partition
+    if pruned.is_empty() {
+        pruned.push(FileGroup::new(vec![]));
+    }
+    pruned
+}
+
+/// A metrics band scan keeps only the files whose `__hash__` statistics
+/// intersect the band and chains them into the fewest ordered chains; one
+/// task merges them all, so the scan is never repartitioned.
+pub(super) fn handler_metrics_band_scan(
+    trace_id: &str,
+    plan: Arc<dyn ExecutionPlan>,
+    sort_order: FileSortOrder,
+    hash_range: (u64, u64),
+    target_partitions: usize,
+) -> Arc<dyn ExecutionPlan> {
+    let Some(config) = file_scan_config(&plan) else {
+        return plan;
+    };
+    let schema = config.file_source().table_schema().table_schema();
+    let mut file_groups =
+        prune_groups_by_hash_range(config.file_groups.clone(), schema, hash_range);
+
+    // an all-pruned band keeps its single empty group: a scan needs a partition
+    if file_groups.iter().any(|group| !group.is_empty()) {
+        match sort_order.physical_ordering(schema) {
+            Some(ordering) => {
+                match FileScanConfig::split_groups_by_statistics(schema, &file_groups, &ordering) {
+                    Ok(chains) => file_groups = chains,
+                    Err(e) => log::warn!(
+                        "[trace_id {trace_id}] failed to chain band files by statistics for {sort_order}: {e}, keeping file groups as is"
+                    ),
+                }
+            }
+            None => log::warn!(
+                "[trace_id {trace_id}] sort columns of {sort_order} not found in schema, skipping band chaining"
+            ),
+        }
+    }
+
+    with_access_plans(trace_id, config, file_groups, target_partitions)
+}
+
+fn file_may_intersect(file: &PartitionedFile, hash_index: usize, lo: u64, hi: u64) -> bool {
+    let Some(statistics) = file.statistics.as_ref() else {
+        return true;
+    };
+    let Some(column) = statistics.column_statistics.get(hash_index) else {
+        return true;
+    };
+    match (column.min_value.get_value(), column.max_value.get_value()) {
+        (Some(ScalarValue::UInt64(Some(min))), Some(ScalarValue::UInt64(Some(max)))) => {
+            *max >= lo && *min <= hi
+        }
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::prelude::{col, lit};
+
+    use super::*;
+
+    #[test]
+    fn test_hash_interval_extraction() {
+        let ge = col(HASH_LABEL).gt_eq(lit(5u64));
+        let le = col(HASH_LABEL).lt_eq(lit(9u64));
+        assert_eq!(hash_interval(&[ge.clone(), le.clone()]), Some((5, 9)));
+        assert_eq!(hash_interval(&[ge]), Some((5, u64::MAX)));
+        assert_eq!(hash_interval(&[le]), Some((0, 9)));
+        assert_eq!(
+            hash_interval(&[col(HASH_LABEL).gt(lit(5u64)), col(HASH_LABEL).lt(lit(9u64))]),
+            Some((6, 8))
+        );
+        assert_eq!(
+            hash_interval(&[col(HASH_LABEL).eq(lit(7u64))]),
+            Some((7, 7))
+        );
+        // other columns, non-u64 literals, and unrelated ops leave no interval
+        assert_eq!(hash_interval(&[col("other").gt_eq(lit(5u64))]), None);
+        assert_eq!(hash_interval(&[col(HASH_LABEL).gt_eq(lit("5"))]), None);
+        assert_eq!(hash_interval(&[]), None);
+    }
+}

--- a/src/search/src/datafusion/table_provider/metrics.rs
+++ b/src/search/src/datafusion/table_provider/metrics.rs
@@ -73,21 +73,21 @@ pub(super) fn hash_interval(filters: &[Expr]) -> Option<(u64, u64)> {
 /// Keeps files whose `__hash__` statistics may intersect `[lo, hi]`; a file
 /// without usable statistics always survives.
 fn prune_groups_by_hash_range(
-    file_groups: Vec<FileGroup>,
+    file_groups: &[FileGroup],
     schema: &arrow_schema::Schema,
     (lo, hi): (u64, u64),
 ) -> Vec<FileGroup> {
     let Ok(hash_index) = schema.index_of(HASH_LABEL) else {
-        return file_groups;
+        return file_groups.to_vec();
     };
     let mut pruned: Vec<FileGroup> = file_groups
-        .into_iter()
+        .iter()
         .map(|group| {
             FileGroup::new(
                 group
-                    .into_inner()
-                    .into_iter()
+                    .iter()
                     .filter(|file| file_may_intersect(file, hash_index, lo, hi))
+                    .cloned()
                     .collect(),
             )
         })
@@ -114,8 +114,7 @@ pub(super) fn handler_metrics_scan(
         return plan;
     };
     let schema = config.file_source().table_schema().table_schema();
-    let mut file_groups =
-        prune_groups_by_hash_range(config.file_groups.clone(), schema, hash_range);
+    let mut file_groups = prune_groups_by_hash_range(&config.file_groups, schema, hash_range);
 
     // an all-pruned band keeps its single empty group: a scan needs a partition
     if file_groups.iter().any(|group| !group.is_empty()) {

--- a/src/search/src/datafusion/table_provider/mod.rs
+++ b/src/search/src/datafusion/table_provider/mod.rs
@@ -36,4 +36,5 @@ pub mod enrich_table;
 mod helpers;
 pub mod listing_adapter;
 pub mod memtable;
+mod metrics;
 pub mod uniontable;


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/metrics/metrics-streaming-fused-aggregation.md

## What

Storage-side groundwork for streaming PromQL aggregation over hash-sorted metrics files. No query changes behaviour yet: this PR only makes the ordered scan available to a consumer that lands in a follow-up.

- **Ordered table registration.** When `ZO_FEATURE_METRICS_STREAMING_AGG_ENABLED` is on (**default off** until the evaluator lands) and every file of a metrics query is a hash-sorted/indexed file, `register_metrics_table` additionally registers `{table}__hash_sorted`, declaring the `(__hash__, _timestamp)` file sort order. It is a separate registration so the main table's partitioning is untouched.
- **Band scans pruned to their intersecting files.** The listing adapter reads the `__hash__` interval from pushed-down filters, drops files whose statistics cannot intersect it, and re-chains the survivors into the fewest ordered chains (first-fit over `split_groups_by_statistics`). Files without hash statistics survive pruning unchanged.
- **Ordered sessions disable round-robin repartitioning.** With fewer partitions than the target, the optimizer would otherwise trade the chains' ordering for an exchange plus a sort.
- **Vortex read-ahead capped on the ordered table.** The vortex scan spawns `concurrency × cores` decode tasks per file detached from consumer backpressure; the ordered table uses `scan_concurrency = 1` (the consumer parallelizes across bands instead). The main table keeps the default.

## Verification

- Listing adapter tests: hash-interval extraction, band pruning keeps only intersecting files, non-hash filters leave scans untouched, declared sort order yields a merge without a `SortExec`.
- With the flag off (the default) no query path changes: no ordered table is registered, the session config is untouched, and the hash-interval pruning only triggers on the `__hash__` range filters that band plans produce. Flag-on numbers ship with the evaluator PR, which flips the default.

## Notes

- Enterprise: the o2-enterprise tree has no reference to `register_metrics_table`, `FileSortOrder`, or the new flag; the enterprise workspace combination was not compile-verified.
