### PR TITLE
fix: gate fts stream-change retry loop on FTS header re-resolution

### DIFF
--- a/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
@@ -332,15 +332,17 @@ test.describe("FTS Default Column Selection testcases", () => {
     let resultsReady = false;
     for (let attempt = 1; attempt <= 3 && !resultsReady; attempt++) {
       await pm.logsPage.clickSearchBarRefreshButton();
+      // The results body can render before the FTS default column re-resolves, so gate on the FTS header too.
       resultsReady = await pm.logsPage
         .waitForSearchResults(20000)
+        .then(() => pm.logsPage.resolveFtsDefaultField(15000))
         .then(() => true)
         .catch(() => false);
       if (!resultsReady) {
         testLogger.info(`TC-FTS-008 search results not ready (attempt ${attempt}/3), retrying refresh...`);
       }
     }
-    expect(resultsReady, 'Search results did not render on second stream').toBe(true);
+    expect(resultsReady, 'Search results / FTS default did not render on second stream').toBe(true);
 
     // Assert that the FTS default column re-resolved on the new stream.
     const secondFtsField = await pm.logsPage.resolveFtsDefaultField(15000);

--- a/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
@@ -76,15 +76,17 @@ test.describe("FTS Default Column Selection testcases", () => {
     let resultsReady = false;
     for (let attempt = 1; attempt <= 3 && !resultsReady; attempt++) {
       await pm.logsPage.clickSearchBarRefreshButton();
+      // The results body can render before the FTS default column resolves, so gate on the FTS header too.
       resultsReady = await pm.logsPage
         .waitForSearchResults(20000)
+        .then(() => pm.logsPage.resolveFtsDefaultField(15000))
         .then(() => true)
         .catch(() => false);
       if (!resultsReady) {
         testLogger.info(`Search results not ready (attempt ${attempt}/3), retrying refresh...`);
       }
     }
-    expect(resultsReady, 'Search results did not render after retries').toBe(true);
+    expect(resultsReady, 'Search results / FTS default did not render after retries').toBe(true);
 
     testLogger.info('FTS default column test setup completed');
   });

--- a/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
+++ b/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
@@ -336,6 +336,10 @@ test.describe('Sourcemap Upload & Pretty Stack Trace', () => {
     await ingestFixtureErrors(page, [fixtureErrorEvent('referenceError', NOMAP_SERVICE)], NOMAP_SERVICE);
     await openErrorDetail(pm, NOMAP_SERVICE);
 
+    // Wait for the raw stack to render before switching tabs, else Pretty activates with no stack to translate and never reaches the unavailable state.
+    await pm.rumPage.expectRawTabVisible();
+    await pm.rumPage.expectDetailContainsText(manifest.bundle);
+
     await pm.rumPage.clickPrettyTab();
 
     // No maps uploaded for this service -> explicit unavailable state, and it


### PR DESCRIPTION
Root cause: after switching streams, `waitForSearchResults` gates only the results body (table + first row cell), but the FTS default column header re-resolves as a separate reactive step that can lag past that gate — so `resolveFtsDefaultField(15000)` on the next line raced the header re-render and timed out at 15s, then passed on retry (flaky). Fix: gate the existing retry loop on the FTS header too, so a refresh re-fires until the FTS column actually re-resolves. All assertions unchanged; no timeout widened.

Evidence: run 33499678342 (post-merge, main-based), Logs-Core shard. Complements #14025 (which fixed stream availability, not this re-resolution race).
Local: 3/3 green; one run exercised the retry path and recovered.