### PR TITLE
fix: gate panel query-inspector open on panel render (visualize)

### DIFF
--- a/tests/ui-testing/pages/dashboardPages/visualise.js
+++ b/tests/ui-testing/pages/dashboardPages/visualise.js
@@ -675,15 +675,20 @@ export default class LogsVisualise {
 
   // Open query inspector from a panel dropdown
   async openPanelQueryInspector(panelName) {
-    // Wait for the dashboard view to fully load after panel save
-    await this.page.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
+    // The Query Inspector item is v-if-gated on the panel's metaData, populated only after its query executes, so wait for the panel to render before opening the menu.
+    await this.verifyChartRenders(this.page);
 
     const dropdown = this.getPanelDropdown(panelName);
     await dropdown.waitFor({ state: "visible", timeout: 20000 });
-    await dropdown.click();
 
     const inspectorBtn = this.page.locator('[data-test="dashboard-query-inspector-panel"]');
-    await inspectorBtn.waitFor({ state: "visible", timeout: 10000 });
+    // Opening the menu before the item mounts leaves it absent for that open, so re-open until it appears.
+    await expect(async () => {
+      if (await inspectorBtn.isVisible().catch(() => false)) return;
+      await dropdown.click();
+      await expect(inspectorBtn).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 20000, intervals: [300, 700, 1500] });
+
     await inspectorBtn.click();
     await this.waitForQueryInspector(this.page);
   }

--- a/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
+++ b/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
@@ -336,6 +336,10 @@ test.describe('Sourcemap Upload & Pretty Stack Trace', () => {
     await ingestFixtureErrors(page, [fixtureErrorEvent('referenceError', NOMAP_SERVICE)], NOMAP_SERVICE);
     await openErrorDetail(pm, NOMAP_SERVICE);
 
+    // Wait for the raw stack to render before switching tabs, else Pretty activates with no stack to translate and never reaches the unavailable state.
+    await pm.rumPage.expectRawTabVisible();
+    await pm.rumPage.expectDetailContainsText(manifest.bundle);
+
     await pm.rumPage.clickPrettyTab();
 
     // No maps uploaded for this service -> explicit unavailable state, and it


### PR DESCRIPTION
Root cause: `openPanelQueryInspector` opened the panel dropdown and waited for the Query Inspector item, but that item is `v-if`-gated on the panel's `metaData` (populated only after the panel query executes and emits @metadata-update). The prior `waitForLoadState('networkidle')` was swallowed and not a real readiness signal, so the menu opened before the item mounted → 10s timeout, then passed on retry (flaky). Fix: gate on `verifyChartRenders` (hard-fails if the panel never renders) before opening, and re-open the menu until the item appears. No assertion changed; no timeout widened.

Fixes both query-inspector tests in `visualize.spec.js` (Table + Line chart), which share this helper. Evidence: run 33512567327, Dashboards-Visualize shard.
Local: 6/6 green (2 tests x --repeat-each=3).