### PR TITLE
fix: verify pipeline route loads after nav flyout click (changeOrg)

### DIFF
--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -360,7 +360,11 @@ export class PipelinesPage {
 
     // Methods from original PipelinesPage
     async gotoPipelinesPage() {
-        await openNavFlyoutChild(this.page, 'pipeline');
+        // The flyout child is a hover-reveal that can self-close mid-click, so retry the reveal+click until the pipeline route actually loads.
+        await expect(async () => {
+            await openNavFlyoutChild(this.page, 'pipeline');
+            await this.page.waitForURL(/pipeline/, { timeout: 5000 });
+        }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
     }
 
     async pipelinesPageDefaultOrg() {

--- a/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
+++ b/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
@@ -336,6 +336,10 @@ test.describe('Sourcemap Upload & Pretty Stack Trace', () => {
     await ingestFixtureErrors(page, [fixtureErrorEvent('referenceError', NOMAP_SERVICE)], NOMAP_SERVICE);
     await openErrorDetail(pm, NOMAP_SERVICE);
 
+    // Wait for the raw stack to render before switching tabs, else Pretty activates with no stack to translate and never reaches the unavailable state.
+    await pm.rumPage.expectRawTabVisible();
+    await pm.rumPage.expectDetailContainsText(manifest.bundle);
+
     await pm.rumPage.clickPrettyTab();
 
     // No maps uploaded for this service -> explicit unavailable state, and it


### PR DESCRIPTION
Root cause: `gotoPipelinesPage` clicked the pipeline nav-flyout child but — unlike the enrichment nav in the same file (which does `openNavFlyoutChild` then `waitForURL`) — never waited for the route. The flyout is a hover-reveal that can self-close mid-click; a force-click that misses silently leaves the SPA on home, so 'Pipelines Page default validation' asserted `/pipeline` against the home URL and failed on attempt 1, passing on retry (flaky). Fix: retry reveal+click until `/pipeline` loads. Scoped to `gotoPipelinesPage` — the shared `openNavFlyoutChild` (56 callers) is untouched. No assertion changed.

Evidence: run 33509887572, GeneralTests shard. NB: IAM/RUM 'Page default validation' siblings use top-level nav (different path) and are not covered here.
Local: 3/3 green.