### PR TITLE
chore: bump browser SDK to 0.4.2 

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@joakimono/echarts-extension-leaflet": "^1.1.0",
-        "@openobserve/browser-logs": "0.4.2-beta.3",
-        "@openobserve/browser-rum": "0.4.2-beta.3",
+        "@openobserve/browser-logs": "0.4.2",
+        "@openobserve/browser-rum": "0.4.2",
         "@openobserve/node-sql-parser": "^0.1.5",
         "@openobserve/rrweb-player": "^0.2.1",
         "@rudderstack/analytics-js": "3.6.0",
@@ -2735,25 +2735,25 @@
       "license": "MIT"
     },
     "node_modules/@openobserve/browser-core": {
-      "version": "0.4.2-beta.3",
-      "resolved": "https://registry.npmjs.org/@openobserve/browser-core/-/browser-core-0.4.2-beta.3.tgz",
-      "integrity": "sha512-aXV4HgaXRrPeWE4ZyyMx/NaeJLzv/yyW9B4wONGwdAdLX9+S1IWNuMfPbuJpJO7rybYBFTwOMVY0hox818Dt6w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@openobserve/browser-core/-/browser-core-0.4.2.tgz",
+      "integrity": "sha512-zRqa7Ve5Xgulq8gLkMRzcX0f1piYgJkX8eDonCAf76I2AiV652LxyJIVfHGovM+2XEB0OFChdNmqSdzeCgZkig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openobserve/js-core": "0.4.2-beta.3"
+        "@openobserve/js-core": "0.4.2"
       }
     },
     "node_modules/@openobserve/browser-logs": {
-      "version": "0.4.2-beta.3",
-      "resolved": "https://registry.npmjs.org/@openobserve/browser-logs/-/browser-logs-0.4.2-beta.3.tgz",
-      "integrity": "sha512-mx6R5c6M7pThXhwJWoqrLHi1E03LU4KqMWzBB2xW9wGYtLzThEhbdgwOLR84WXLH82MruyLWLo4jxsoHjbNXbQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@openobserve/browser-logs/-/browser-logs-0.4.2.tgz",
+      "integrity": "sha512-9H7WXjHmyHnHi3joAO4OkAP5QLGfRMVPqo8JW7beJv891wyOCwqEINlQBXUV6jYFzU/v1TE3UlPcA27YB1QtDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openobserve/browser-core": "0.4.2-beta.3",
-        "@openobserve/js-core": "0.4.2-beta.3"
+        "@openobserve/browser-core": "0.4.2",
+        "@openobserve/js-core": "0.4.2"
       },
       "peerDependencies": {
-        "@openobserve/browser-rum": "0.4.2-beta.3"
+        "@openobserve/browser-rum": "0.4.2"
       },
       "peerDependenciesMeta": {
         "@openobserve/browser-rum": {
@@ -2762,17 +2762,17 @@
       }
     },
     "node_modules/@openobserve/browser-rum": {
-      "version": "0.4.2-beta.3",
-      "resolved": "https://registry.npmjs.org/@openobserve/browser-rum/-/browser-rum-0.4.2-beta.3.tgz",
-      "integrity": "sha512-Jjt/gtjrSLPLD8Zhof5B6VfmUWmWCsR+MjItV8H0lRYOwGo6w2GXTJ5Z1OmXMkeiUs1dCBBMoH3M+Lqf9yUQDQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@openobserve/browser-rum/-/browser-rum-0.4.2.tgz",
+      "integrity": "sha512-ot/6iA3205KmmPSr/7fnXc+NKjLPna7kEqJL6EcDa6yXuSqGX4iLuBMffXrsp7irJF4NBejDFSzVW2fJWXXKXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openobserve/browser-core": "0.4.2-beta.3",
-        "@openobserve/browser-rum-core": "0.4.2-beta.3",
-        "@openobserve/js-core": "0.4.2-beta.3"
+        "@openobserve/browser-core": "0.4.2",
+        "@openobserve/browser-rum-core": "0.4.2",
+        "@openobserve/js-core": "0.4.2"
       },
       "peerDependencies": {
-        "@openobserve/browser-logs": "0.4.2-beta.3"
+        "@openobserve/browser-logs": "0.4.2"
       },
       "peerDependenciesMeta": {
         "@openobserve/browser-logs": {
@@ -2781,19 +2781,19 @@
       }
     },
     "node_modules/@openobserve/browser-rum-core": {
-      "version": "0.4.2-beta.3",
-      "resolved": "https://registry.npmjs.org/@openobserve/browser-rum-core/-/browser-rum-core-0.4.2-beta.3.tgz",
-      "integrity": "sha512-ssWgUCS+Y/N4vhQ/TAEQp4Xj2fh5G8vZiSmgnakUbdS0tzrBD/VDkVbW3Bvz4ETzPeq2QgHJQwpzi5S/auLEkQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@openobserve/browser-rum-core/-/browser-rum-core-0.4.2.tgz",
+      "integrity": "sha512-7UmzJ+Y1hmpcYyN38Cr6pcM6eh9AXhWAbgLx5wVy6fIVg5NmdzJ5bkegeEdFbqiN5OZ7Fie7aZzYn9LII0AOFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openobserve/browser-core": "0.4.2-beta.3",
-        "@openobserve/js-core": "0.4.2-beta.3"
+        "@openobserve/browser-core": "0.4.2",
+        "@openobserve/js-core": "0.4.2"
       }
     },
     "node_modules/@openobserve/js-core": {
-      "version": "0.4.2-beta.3",
-      "resolved": "https://registry.npmjs.org/@openobserve/js-core/-/js-core-0.4.2-beta.3.tgz",
-      "integrity": "sha512-3hwDzBPj0ZTpBleqJL0ZgRw+EBN7Jx1wRQFX/jgKRANbCUsII8y0EsdBS6zLZpTNDUWH1Nmv+8uQ5S5+wLFeMg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@openobserve/js-core/-/js-core-0.4.2.tgz",
+      "integrity": "sha512-J0kOdpHdYssngc1fYD7lfm9QuHgyHiXZ1rAiqTNwKcosHbx8x3gFhKImRNZzE95KajqTlu13kfZzR03GE4Yiew==",
       "license": "Apache-2.0"
     },
     "node_modules/@openobserve/node-sql-parser": {

--- a/web/package.json
+++ b/web/package.json
@@ -42,8 +42,8 @@
   "dependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@joakimono/echarts-extension-leaflet": "^1.1.0",
-    "@openobserve/browser-logs": "0.4.2-beta.3",
-    "@openobserve/browser-rum": "0.4.2-beta.3",
+    "@openobserve/browser-logs": "0.4.2",
+    "@openobserve/browser-rum": "0.4.2",
     "@openobserve/node-sql-parser": "^0.1.5",
     "@openobserve/rrweb-player": "^0.2.1",
     "@rudderstack/analytics-js": "3.6.0",


### PR DESCRIPTION
`branch-v1.0.0` counterpart of #14101.

Bumps `@openobserve/browser-rum` and `@openobserve/browser-logs` from the
`0.4.2-beta.3` prerelease to the released `0.4.2`, now published as npm's
`latest` dist-tag.

The lockfile picks up the same bump transitively for `@openobserve/browser-core`,
`@openobserve/browser-rum-core` and `@openobserve/js-core`. No other dependency
is touched.

Out of scope: the RUM E2E fixture (`tests/ui-testing/fixtures/rum/npm-app`) keeps
its deliberate hermetic pin at `0.4.1`.

## Verification

- `npm view @openobserve/browser-rum dist-tags` → `latest: 0.4.2`
- `npm install --package-lock-only` regenerated the lockfile; diff is confined to
  the five `@openobserve` SDK packages, and the resolved integrity hashes match
  #14101 exactly.