### PR TITLE
fix(search): read a parenthesised query the same as a bare one

### DIFF
--- a/src/config/src/utils/sql/eligible_for_histogram.rs
+++ b/src/config/src/utils/sql/eligible_for_histogram.rs
@@ -51,6 +51,50 @@ mod tests {
     use super::*;
 
     #[test]
+    fn check_redundant_parentheses_do_not_change_eligibility() {
+        // A wrapped query is the same query, so it must not slip past a clause check.
+        let pairs = [
+            (
+                r#"SELECT * FROM "olympics""#,
+                r#"(SELECT * FROM "olympics")"#,
+                true,
+            ),
+            (
+                r#"SELECT * FROM "olympics" LIMIT 100"#,
+                r#"(SELECT * FROM "olympics" LIMIT 100)"#,
+                false,
+            ),
+            (
+                r#"SELECT * FROM "olympics" LIMIT 100"#,
+                r#"(SELECT * FROM "olympics") LIMIT 100"#,
+                false,
+            ),
+            (
+                r#"WITH cte AS (SELECT * FROM "olympics") SELECT * FROM cte"#,
+                r#"(WITH cte AS (SELECT * FROM "olympics") SELECT * FROM cte)"#,
+                false,
+            ),
+            (
+                r#"SELECT * FROM "a" JOIN "b" ON a.id = b.id"#,
+                r#"(SELECT * FROM "a" JOIN "b" ON a.id = b.id)"#,
+                false,
+            ),
+        ];
+        for (bare, wrapped, expected) in pairs {
+            assert_eq!(
+                is_eligible_for_histogram(bare, false).unwrap().0,
+                expected,
+                "unexpected eligibility for {bare}"
+            );
+            assert_eq!(
+                is_eligible_for_histogram(wrapped, false).unwrap().0,
+                expected,
+                "eligibility diverged for {wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn check_is_eligible_for_histogram_for_queries_should_be_true() {
         let queries = [
             r#"SELECT * FROM "olympics" WHERE _timestamp >= 1716854400000 AND _timestamp <= 1716940800000"#,

--- a/src/config/src/utils/sql/helpers.rs
+++ b/src/config/src/utils/sql/helpers.rs
@@ -63,7 +63,7 @@ pub(super) fn is_aggregate_expression(expr: &Expr) -> bool {
 }
 
 pub(super) fn has_group_by(query: &Query) -> bool {
-    if let SetExpr::Select(ref select) = *query.body {
+    if let SetExpr::Select(ref select) = *innermost_query(query).body {
         match &select.group_by {
             GroupByExpr::All(v) => !v.is_empty(),
             GroupByExpr::Expressions(v, _) => !v.is_empty(),
@@ -74,7 +74,7 @@ pub(super) fn has_group_by(query: &Query) -> bool {
 }
 
 pub(super) fn has_join(query: &Query) -> bool {
-    if let SetExpr::Select(ref select) = *query.body {
+    if let SetExpr::Select(ref select) = *innermost_query(query).body {
         select.from.len() > 1
             || select
                 .from
@@ -86,9 +86,32 @@ pub(super) fn has_join(query: &Query) -> bool {
 }
 
 pub(super) fn has_cte(query: &Query) -> bool {
-    query.with.is_some()
+    at_any_depth(query, |query| query.with.is_some())
 }
 
 pub(super) fn has_limit(query: &Query) -> bool {
-    query.limit_clause.is_some()
+    at_any_depth(query, |query| query.limit_clause.is_some())
+}
+
+/// The query that redundant parentheses wrap, since they carry no meaning of their own.
+fn innermost_query(query: &Query) -> &Query {
+    let mut current = query;
+    while let SetExpr::Query(inner) = current.body.as_ref() {
+        current = inner;
+    }
+    current
+}
+
+/// Either side of a redundant pair of parentheses can hold the clause, so test every level.
+fn at_any_depth(query: &Query, predicate: fn(&Query) -> bool) -> bool {
+    let mut current = query;
+    loop {
+        if predicate(current) {
+            return true;
+        }
+        match current.body.as_ref() {
+            SetExpr::Query(inner) => current = inner,
+            _ => return false,
+        }
+    }
 }

--- a/src/search/src/sql/histogram.rs
+++ b/src/search/src/sql/histogram.rs
@@ -18,7 +18,7 @@ use config::{
 };
 use infra::errors::{Error, ErrorCodes};
 use sqlparser::{
-    ast::{SetExpr, Statement},
+    ast::{Query, Select, SetExpr, Statement},
     dialect::PostgreSqlDialect,
     parser::Parser,
 };
@@ -206,7 +206,7 @@ fn multi_stream_histogram_query(
 /// Extract WHERE clause from SQL statement
 fn extract_where_clause(statement: &Statement) -> Result<String, Error> {
     if let Statement::Query(query) = statement {
-        if let SetExpr::Select(select) = &*query.body {
+        if let Some(select) = innermost_select(query) {
             // Extract WHERE clause
             let where_clause = select
                 .selection
@@ -226,6 +226,18 @@ fn extract_where_clause(statement: &Statement) -> Result<String, Error> {
             "Statement is not a query".to_string(),
         ));
         Err(error)
+    }
+}
+
+/// The SELECT a query really runs, seen through however many parentheses wrap it.
+fn innermost_select(query: &Query) -> Option<&Select> {
+    let mut body = query.body.as_ref();
+    loop {
+        match body {
+            SetExpr::Select(select) => return Some(select),
+            SetExpr::Query(inner) => body = inner.body.as_ref(),
+            _ => return None,
+        }
     }
 }
 
@@ -558,5 +570,48 @@ mod tests {
         let result = single_stream_histogram_query(&statements, &stream_names, true, None).unwrap();
         // WHERE clause must be absent when is_sub_query is true
         assert!(!result.contains("WHERE"), "expected no WHERE: {result}");
+    }
+
+    #[test]
+    fn test_histogram_query_matches_across_redundant_parentheses() {
+        let streams = vec!["fortigate".to_string()];
+        for (bare, wrapped) in [
+            (
+                r#"SELECT * FROM "fortigate""#,
+                r#"(SELECT * FROM "fortigate")"#,
+            ),
+            (
+                r#"SELECT * FROM "fortigate" WHERE level = 'error'"#,
+                r#"((SELECT * FROM "fortigate" WHERE level = 'error'))"#,
+            ),
+        ] {
+            assert_eq!(
+                convert_to_histogram_query(bare, &streams, false, None).unwrap(),
+                convert_to_histogram_query(wrapped, &streams, false, None).unwrap(),
+            );
+        }
+    }
+
+    #[test]
+    fn test_histogram_query_keeps_where_clause_inside_parentheses() {
+        let result = convert_to_histogram_query(
+            r#"(SELECT * FROM "fortigate" WHERE level = 'error')"#,
+            &["fortigate".to_string()],
+            false,
+            None,
+        )
+        .unwrap();
+        assert!(result.contains("WHERE level = 'error'"), "got: {result}");
+    }
+
+    #[test]
+    fn test_histogram_query_still_rejects_a_set_operation() {
+        // Unwrapping parentheses must not make a UNION look like a plain SELECT.
+        let statements = Parser::parse_sql(
+            &PostgreSqlDialect {},
+            "(SELECT * FROM a) UNION (SELECT * FROM b)",
+        )
+        .unwrap();
+        assert!(extract_where_clause(statements.first().unwrap()).is_err());
     }
 }

--- a/src/search/src/sql/rewriter/add_new_filter.rs
+++ b/src/search/src/sql/rewriter/add_new_filter.rs
@@ -112,6 +112,13 @@ impl VisitorMut for AddNewFiltersWithAndOperatorVisitor {
                     });
                 }
             },
+            // Filter the wrapped query here, then stop: continuing the walk would reach it a
+            // second time and conjoin the same filter twice.
+            SetExpr::Query(inner) => {
+                let inner = inner.as_mut();
+                let _ = self.pre_visit_query(inner);
+                return ControlFlow::Break(());
+            }
             _ => {
                 return ControlFlow::Break(());
             }
@@ -296,5 +303,30 @@ mod tests {
 
         // we support this type of query
         assert_eq!(result, sql.to_string());
+    }
+
+    #[test]
+    fn test_add_new_filters_reaches_a_parenthesized_query() {
+        // Parentheses used to end the walk here, dropping the filter without a word.
+        let filters = HashMap::from([("k8s_namespace".to_string(), "prod".to_string())]);
+        let result =
+            add_new_filters_with_and_operator("(SELECT * FROM t WHERE a = 1)", filters).unwrap();
+
+        assert_eq!(
+            result,
+            "(SELECT * FROM t WHERE a = 1 AND k8s_namespace = 'prod')"
+        );
+    }
+
+    #[test]
+    fn test_add_new_filters_applies_once_to_a_nested_parenthesized_query() {
+        let filters = HashMap::from([("k8s_namespace".to_string(), "prod".to_string())]);
+        let result =
+            add_new_filters_with_and_operator("((SELECT * FROM t WHERE a = 1))", filters).unwrap();
+
+        assert_eq!(
+            result,
+            "((SELECT * FROM t WHERE a = 1 AND k8s_namespace = 'prod'))"
+        );
     }
 }

--- a/src/search/src/sql/rewriter/add_ordering_term.rs
+++ b/src/search/src/sql/rewriter/add_ordering_term.rs
@@ -18,7 +18,7 @@ use std::ops::ControlFlow;
 use config::{TIMESTAMP_COL_NAME, utils::sql::is_complex_query_stmt};
 use infra::errors::Error;
 use sqlparser::{
-    ast::{Expr, Ident, OrderByExpr, OrderByKind, Query, VisitMut, VisitorMut},
+    ast::{Expr, Ident, OrderByExpr, OrderByKind, Query, SetExpr, VisitMut, VisitorMut},
     dialect::PostgreSqlDialect,
     parser::Parser,
 };
@@ -52,7 +52,9 @@ impl VisitorMut for AddOrderingTermVisitor {
     type Break = ();
 
     fn pre_visit_query(&mut self, query: &mut Query) -> ControlFlow<Self::Break> {
-        if query.order_by.is_none() {
+        // An ORDER BY inside the parentheses still orders this query, and one added outside
+        // them would override it.
+        if !orders_itself(query) {
             query.order_by = Some(sqlparser::ast::OrderBy {
                 kind: OrderByKind::Expressions(vec![OrderByExpr {
                     expr: Expr::Identifier(Ident::new(self.field.clone())),
@@ -65,7 +67,22 @@ impl VisitorMut for AddOrderingTermVisitor {
                 interpolate: None,
             });
         }
-        ControlFlow::Continue(())
+        // Only the outermost query is ordered; continuing would order each nesting level too.
+        ControlFlow::Break(())
+    }
+}
+
+/// Whether the query already carries its own ORDER BY, at any parenthesis depth.
+fn orders_itself(query: &Query) -> bool {
+    let mut current = query;
+    loop {
+        if current.order_by.is_some() {
+            return true;
+        }
+        match current.body.as_ref() {
+            SetExpr::Query(inner) => current = inner,
+            _ => return false,
+        }
     }
 }
 
@@ -155,5 +172,28 @@ mod tests {
     fn test_check_or_add_order_by_timestamp_invalid_sql() {
         let result = check_or_add_order_by_timestamp("NOT VALID SQL !!!", true);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_check_or_add_order_by_timestamp_parenthesized_query() {
+        assert_eq!(
+            check_or_add_order_by_timestamp("(SELECT * FROM users)", true).unwrap(),
+            "(SELECT * FROM users) ORDER BY _timestamp ASC"
+        );
+    }
+
+    #[test]
+    fn test_check_or_add_order_by_timestamp_keeps_ordering_inside_parentheses() {
+        // The inner ORDER BY is the user's; adding one outside would silently override it.
+        let sql = "(SELECT * FROM users ORDER BY age ASC)";
+        assert_eq!(check_or_add_order_by_timestamp(sql, true).unwrap(), sql);
+    }
+
+    #[test]
+    fn test_check_or_add_order_by_timestamp_orders_only_the_outermost_query() {
+        assert_eq!(
+            check_or_add_order_by_timestamp("((SELECT * FROM users))", false).unwrap(),
+            "((SELECT * FROM users)) ORDER BY _timestamp DESC"
+        );
     }
 }

--- a/src/search/src/sql/rewriter/track_total_hits.rs
+++ b/src/search/src/sql/rewriter/track_total_hits.rs
@@ -199,6 +199,13 @@ impl VisitorMut for TrackTotalHitsVisitor {
                     pipe_operators: vec![],
                 };
             }
+            // Rewrite the wrapped query here: `with` is visited before `body`, so continuing
+            // the walk would reach the CTE definitions and count one of those instead.
+            SetExpr::Query(inner) => {
+                let inner = inner.as_mut();
+                query.order_by = None;
+                return self.pre_visit_query(inner);
+            }
             _ => {}
         }
         ControlFlow::Break(())
@@ -346,5 +353,75 @@ mod tests {
         // For DISTINCT queries with multiple columns, we wrap in a subquery to count results
         let expected_sql = "SELECT count(*) AS zo_sql_num FROM (SELECT DISTINCT unique_id, continent, bronze_medals FROM oly WHERE continent = 'ASI')";
         assert_eq!(statement.to_string(), expected_sql);
+    }
+
+    fn rewritten(sql: &str) -> String {
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+            .unwrap()
+            .pop()
+            .unwrap();
+        let mut track_total_hits_visitor = TrackTotalHitsVisitor::new();
+        let _ = statement.visit(&mut track_total_hits_visitor);
+        statement.to_string()
+    }
+
+    #[test]
+    fn test_track_total_hits_parenthesized_query() {
+        assert_eq!(
+            rewritten("(SELECT * FROM t WHERE name = 'a')"),
+            "(SELECT count(*) AS zo_sql_num FROM t WHERE name = 'a')"
+        );
+    }
+
+    #[test]
+    fn test_track_total_hits_nested_parentheses() {
+        assert_eq!(
+            rewritten("((SELECT * FROM t))"),
+            "((SELECT count(*) AS zo_sql_num FROM t))"
+        );
+    }
+
+    #[test]
+    fn test_track_total_hits_parenthesized_query_drops_outer_order_by() {
+        // The count projects no `name`, so an ORDER BY left outside would not resolve.
+        assert_eq!(
+            rewritten("(SELECT * FROM t) ORDER BY name"),
+            "(SELECT count(*) AS zo_sql_num FROM t)"
+        );
+    }
+
+    #[test]
+    fn test_track_total_hits_parenthesized_query_leaves_inner_subquery_alone() {
+        // Only the outermost SELECT becomes a count, exactly as without the parentheses.
+        assert_eq!(
+            rewritten("(SELECT * FROM (SELECT * FROM u))"),
+            "(SELECT count(*) AS zo_sql_num FROM (SELECT * FROM u))"
+        );
+    }
+
+    #[test]
+    fn test_track_total_hits_parenthesized_query_leaves_cte_definitions_alone() {
+        // `with` is visited before `body`, so the count must not land on a CTE.
+        assert_eq!(
+            rewritten("WITH cte AS (SELECT * FROM t) (SELECT * FROM cte WHERE x = 1)"),
+            "WITH cte AS (SELECT * FROM t) (SELECT count(*) AS zo_sql_num FROM cte WHERE x = 1)"
+        );
+        assert_eq!(
+            rewritten("(WITH cte AS (SELECT * FROM t) SELECT * FROM cte)"),
+            "(WITH cte AS (SELECT * FROM t) SELECT count(*) AS zo_sql_num FROM cte)"
+        );
+    }
+
+    #[test]
+    fn test_track_total_hits_parenthesized_query_matches_bare_form() {
+        for (bare, wrapped) in [
+            ("SELECT * FROM t", "(SELECT * FROM t)"),
+            (
+                "SELECT * FROM t WHERE a = 1 LIMIT 5",
+                "(SELECT * FROM t WHERE a = 1 LIMIT 5)",
+            ),
+        ] {
+            assert_eq!(format!("({})", rewritten(bare)), rewritten(wrapped));
+        }
     }
 }

--- a/src/search/src/sql/visitor/streaming_aggregate.rs
+++ b/src/search/src/sql/visitor/streaming_aggregate.rs
@@ -21,7 +21,7 @@ use std::{
 use config::TIMESTAMP_COL_NAME;
 use sqlparser::ast::{
     BinaryOperator, Expr, Function, FunctionArg, FunctionArgExpr, FunctionArguments, GroupByExpr,
-    Query, SelectItem, SetExpr, Statement, TableFactor, Visitor,
+    Query, Select, SelectItem, SetExpr, Statement, TableFactor, Visitor,
 };
 
 use super::utils::get_object_name_value;
@@ -813,7 +813,7 @@ impl Visitor for CacheAggregationVisitor {
         // Determine if this is the main query
         let is_main_query = query.with.is_some() || (query.with.is_none() && is_outermost);
 
-        if let SetExpr::Select(select) = query.body.as_ref() {
+        if let Some(select) = select_within_parentheses(query) {
             // Process FROM clause first to handle subqueries
             for table in &select.from {
                 self.pre_visit_table_factor(&table.relation)?;
@@ -871,6 +871,20 @@ pub fn matches_streaming_aggregate_pattern(sql: &str) -> Result<bool, String> {
     }
 }
 
+/// The SELECT this query runs, seen through parentheses that add nothing of their own.
+fn select_within_parentheses(query: &Query) -> Option<&Select> {
+    let mut body = query.body.as_ref();
+    loop {
+        match body {
+            SetExpr::Select(select) => return Some(select),
+            // A CTE declared inside the parentheses would go unanalyzed, and matching the
+            // pattern without it could enable the rewrite for a query it does not fit.
+            SetExpr::Query(inner) if inner.with.is_none() => body = inner.body.as_ref(),
+            _ => return None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -892,6 +906,35 @@ mod tests {
 
         let result = matches_streaming_aggregate_pattern(sql).unwrap();
         assert!(result);
+    }
+
+    #[test]
+    fn test_parenthesized_query_matches_the_same_pattern() {
+        let inner = r#"
+            SELECT k8s_namespace_name, SUM(request_count) as total_requests
+            FROM (
+                SELECT k8s_namespace_name, count(_timestamp) as request_count
+                FROM "default"
+                WHERE k8s_namespace_name IS NOT NULL
+                GROUP BY k8s_namespace_name
+            )
+            GROUP BY k8s_namespace_name
+            ORDER BY total_requests DESC
+            LIMIT 10
+        "#;
+
+        assert!(matches_streaming_aggregate_pattern(inner).unwrap());
+        assert!(matches_streaming_aggregate_pattern(&format!("({inner})")).unwrap());
+        assert!(matches_streaming_aggregate_pattern(&format!("(({inner}))")).unwrap());
+    }
+
+    #[test]
+    fn test_parenthesized_cte_is_left_unmatched() {
+        // The CTE inside the parentheses is never analyzed, so the pattern must not match.
+        let sql = r#"(WITH cte AS (SELECT k8s_namespace_name FROM "default")
+                      SELECT k8s_namespace_name FROM cte GROUP BY k8s_namespace_name)"#;
+
+        assert!(!matches_streaming_aggregate_pattern(sql).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #8082.

## Summary

`(SELECT * FROM "stream")` parses to a `Query` whose `body` is another `Query` rather than a `Select`. Six places on the search path only ever looked at a `Select`, so the same query behaved differently with and without the outer brackets.

## The reported symptoms

The count rewriter stopped first. `TrackTotalHitsVisitor::pre_visit_query` ends in an unconditional `Break` — deliberate, so only the outermost SELECT becomes a count — but a wrapped query matched no arm and the `Break` then ended the traversal before the inner SELECT was reached:

| input | before |
| --- | --- |
| `SELECT * FROM t WHERE name = 'a'` | `SELECT count(*) AS zo_sql_num FROM t WHERE name = 'a'` |
| `(SELECT * FROM t WHERE name = 'a')` | unchanged |

So a request that should have returned one `zo_sql_num` row instead ran an unbounded scan of the stream. The total is read from that column (`search_service/src/cluster/http.rs`), and a missing column reads as zero — the reported "0 of 0 events", with the oversized, slow response beside it. Both screenshots in the issue come from this one line.

## What changed

- **`track_total_hits`** — new `SetExpr::Query` arm that recurses into the wrapped query. It recurses rather than continuing the walk because `Query.with` is declared before `Query.body`, so the derived visitor reaches the CTE definitions first; continuing would rewrite a CTE into the count and leave the outer SELECT reading a column the CTE no longer has. The outer `ORDER BY` is dropped, since the count no longer projects the column it names — the same thing the `Select` arm already does.
- **`add_new_filter`** — same defect in its `_` arm, so search-around filters were silently dropped for a wrapped query. This visitor ends in `Continue`, so it filters the wrapped query and then stops; continuing would reach the same query again and conjoin the filter twice.
- **`check_or_add_order_by_timestamp`** — only inspected the outermost `order_by`, so `(SELECT * FROM t ORDER BY age)` had `ORDER BY _timestamp` appended *outside* the brackets, overriding an ordering the bare form leaves alone. It now looks through the brackets before deciding, and orders only the outermost query.
- **`extract_where_clause`** — failed the same way and returned `"Query is not a SELECT statement"`, so the histogram errored outright for a wrapped query.
- **`matches_streaming_aggregate_pattern`** — calls `pre_visit_query` directly instead of walking the statement, so a wrapped query was a dead end and never matched. It now looks through the brackets, except where they declare a CTE: that CTE would go unanalyzed, and matching without it could enable the rewrite for a query it does not fit.
- **`has_limit` / `has_cte` / `has_join` / `has_group_by`** — read only the outermost `Query` (or `Select`), so a wrapped `LIMIT`, CTE or JOIN slipped past the histogram eligibility check. This was masked before, because such queries died earlier in `extract_where_clause`. `has_limit` and `has_cte` now test every level, since either side of the brackets can carry the clause.

`is_aggregate_in_select` is deliberately left alone. It still matches the outermost body, so it is false for any wrapped query and short-circuits `is_simple_aggregate_query` before the fixed helpers are consulted. Unwrapping it would instead move queries *onto* the simple-aggregate fast path, which is the riskier direction and is not needed here.

## Testing

19 unit tests added, covering each site plus the shapes that are easy to get wrong: nested brackets, an outer `ORDER BY`, a wrapped `DISTINCT`, brackets around a CTE, and a derived subquery that must stay untouched. Several are written as parity assertions — the wrapped form must produce exactly what the bare form produces — since that is the property the issue is about.

- `cargo test -p search` — 1091 passed
- `cargo test -p config --lib` — 3267 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` — clean

Five `config` doctest failures (`async_walkdir`, `contains_query`, `pausable_job`) are pre-existing on `main` and unrelated to this change.

Opened as a draft: the behaviour questions above are worth a maintainer's view before this is merged, in particular whether a wrapped `LIMIT`/CTE/JOIN should become ineligible for a histogram (matching the bare form, which is what this does) or should keep working, and whether `is_aggregate_in_select` should be brought in line separately.
