### PR TITLE
fix: reject client-forged session trust markers in auth

### DIFF
--- a/src/api/common/src/auth/validator.rs
+++ b/src/api/common/src/auth/validator.rs
@@ -31,7 +31,7 @@ use o2_dex::config::get_config as get_dex_config;
 pub use openobserve_core::auth::get_user_email_from_auth_str;
 pub use openobserve_core::authz::{check_permissions, list_objects_for_user};
 use openobserve_core::{
-    auth::{AuthExtractor, V2_API_PREFIX, get_hash, get_user_details},
+    auth::{AuthExtractor, SESSION_AUTH_MARKER, V2_API_PREFIX, get_hash, get_user_details},
     users,
 };
 
@@ -1101,21 +1101,25 @@ pub async fn validator_rum(req_data: &RequestData) -> Result<AuthValidationResul
     }
 }
 
+// The marker alone proves nothing: only a live session still holding this exact token does.
+async fn session_grants_token(session_id: &str, token: &str) -> bool {
+    matches!(db::session::get(session_id).await, Ok(stored) if stored == token)
+}
+
 async fn oo_validator_internal(
     req_data: &RequestData,
     auth_info: &AuthExtractor,
     path_prefix: &str,
 ) -> Result<AuthValidationResult, AuthError> {
-    // Check if this is a session-based auth (marked with Session:: prefix)
-    let (is_from_session, auth_str) = if let Some(rest) = auth_info.auth.strip_prefix("Session::") {
-        // Format: "Session::<session_id>::<actual_token>"
-        if let Some((_session_id, token)) = rest.split_once("::") {
-            (true, token.to_string())
-        } else {
-            (false, auth_info.auth.clone())
-        }
-    } else {
-        (false, auth_info.auth.clone())
+    // Format: "Session::<session_id>::<actual_token>"
+    let (is_from_session, auth_str) = match auth_info.auth.strip_prefix(SESSION_AUTH_MARKER) {
+        Some(rest) => match rest.split_once("::") {
+            Some((session_id, token)) if session_grants_token(session_id, token).await => {
+                (true, token.to_string())
+            }
+            _ => return Err(AuthError::Unauthorized("Unauthorized Access".to_string())),
+        },
+        None => (false, auth_info.auth.clone()),
     };
 
     if let Some(info) = auth_str.strip_prefix("Basic ").map(str::trim) {
@@ -1143,7 +1147,10 @@ async fn oo_validator_internal(
         .await
     } else if auth_str.starts_with("Bearer") {
         log::debug!("Bearer token found");
-        super::token::token_validator(req_data, auth_info).await
+        // token_validator unwraps a "Bearer" prefix, so it must not see the session marker.
+        let mut unwrapped_auth_info = auth_info.clone();
+        unwrapped_auth_info.auth = auth_str;
+        super::token::token_validator(req_data, &unwrapped_auth_info).await
     } else if let Ok(auth_tokens) = config::utils::json::from_str::<AuthTokensExt>(&auth_info.auth)
     {
         log::debug!("Auth ext token found");
@@ -1271,6 +1278,7 @@ fn _extract_full_url(req: &Request) -> String {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
     use infra::{
         db as infra_db,
         db::{get_orm_client_ro, get_orm_client_rw},
@@ -1280,7 +1288,7 @@ mod tests {
 
     use super::*;
     use crate::common::{
-        infra::config::{ORG_USERS, USERS},
+        infra::config::{ORG_USERS, USER_SESSIONS, USER_SESSIONS_EXPIRY, USERS},
         meta::user::UserRequest,
     };
 
@@ -1620,6 +1628,77 @@ mod tests {
                 .unwrap()
                 .is_valid,
             "assume_service_account sessions must still authenticate"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_forged_session_marker_cannot_bypass_allow_static_token() {
+        let org_id = "default";
+        let sa_email = "sa-forged-marker@example.com";
+        let token = "sa_static_token_forged_marker_test";
+
+        let _ = get_orm_client_rw().await;
+        let _ = infra_db::create_table().await;
+        let _ = infra_table::create_user_tables().await;
+        let _ = organization::check_and_create_org_without_ofga(org_id).await;
+
+        users::create_service_account_if_not_exists(sa_email)
+            .await
+            .unwrap();
+        db::org_users::add_with_flags(
+            org_id,
+            sa_email,
+            config::meta::user::UserRole::ServiceAccount,
+            token,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        let credentials = base64::encode(&format!("{sa_email}:{token}"));
+        let req_data = RequestData {
+            uri: "/api/default/users".parse().unwrap(),
+            method: Method::GET,
+            headers: HeaderMap::new(),
+        };
+        let plain = AuthExtractor {
+            auth: format!("Basic {credentials}"),
+            method: "GET".to_string(),
+            o2_type: String::new(),
+            org_id: String::new(),
+            bypass_check: false,
+            parent_id: String::new(),
+            use_all_org: false,
+            use_self_context: false,
+            use_self_parent: false,
+        };
+        assert!(
+            oo_validator(&req_data, &plain).await.is_err(),
+            "a disabled static token must be rejected"
+        );
+
+        // GHSA-3885-f5c9-86xr: the marker names no live session, so it must buy nothing.
+        let forged = AuthExtractor {
+            auth: format!("{SESSION_AUTH_MARKER}forged::Basic {credentials}"),
+            ..plain.clone()
+        };
+        assert!(
+            oo_validator(&req_data, &forged).await.is_err(),
+            "a forged session marker must not bypass the allow_static_token policy"
+        );
+
+        // The same marker backed by a real assume_service_account session still authenticates.
+        let session_id = "session-forged-marker-test";
+        USER_SESSIONS.insert(session_id.to_string(), format!("Basic {credentials}"));
+        USER_SESSIONS_EXPIRY.insert(session_id.to_string(), Utc::now().timestamp() + 3600);
+        let genuine = AuthExtractor {
+            auth: format!("{SESSION_AUTH_MARKER}{session_id}::Basic {credentials}"),
+            ..plain.clone()
+        };
+        assert!(
+            oo_validator(&req_data, &genuine).await.is_ok(),
+            "a marker backed by a live session must still authenticate"
         );
     }
 

--- a/src/core/src/auth.rs
+++ b/src/core/src/auth.rs
@@ -40,6 +40,7 @@ use {
 };
 
 pub const V2_API_PREFIX: &str = "v2";
+pub const SESSION_AUTH_MARKER: &str = "Session::";
 
 #[cfg(feature = "enterprise")]
 pub async fn get_user_email_from_auth_str(auth_str: &str) -> Option<String> {
@@ -303,7 +304,7 @@ where
                 && let Ok(auth_str) = auth_header.to_str()
             {
                 return Ok(AuthExtractor {
-                    auth: auth_str.to_owned(),
+                    auth: reject_forged_session_marker(auth_str.to_owned()),
                     method,
                     o2_type: String::new(),
                     org_id: org_id.clone(),
@@ -327,7 +328,7 @@ where
                 && let Ok(auth_str) = auth_header.to_str()
             {
                 return Ok(AuthExtractor {
-                    auth: auth_str.to_owned(),
+                    auth: reject_forged_session_marker(auth_str.to_owned()),
                     method,
                     o2_type: format!("stream:{org_id}"),
                     org_id,
@@ -434,7 +435,7 @@ where
             }
         } else if let Some(auth_header) = parts.headers.get("Authorization") {
             if let Ok(auth_str) = auth_header.to_str() {
-                auth_str.to_owned()
+                reject_forged_session_marker(auth_str.to_owned())
             } else {
                 "".to_string()
             }
@@ -458,6 +459,17 @@ where
         }
 
         Err(AuthExtractorRejection::unauthorized("Unauthorized Access"))
+    }
+}
+
+// Only server-side session resolution may emit the marker; from a client it is a forged trust
+// claim.
+fn reject_forged_session_marker(auth: String) -> String {
+    if auth.starts_with(SESSION_AUTH_MARKER) {
+        log::warn!("rejected client-supplied session trust marker in credentials");
+        String::new()
+    } else {
+        auth
     }
 }
 
@@ -495,7 +507,9 @@ pub async fn extract_auth_str_from_headers(headers: &HeaderMap) -> String {
                 .get("auth_ext")
                 .map(|cookie| {
                     let val = config::utils::base64::decode_raw(cookie).unwrap_or_default();
-                    std::str::from_utf8(&val).unwrap_or_default().to_string()
+                    reject_forged_session_marker(
+                        std::str::from_utf8(&val).unwrap_or_default().to_string(),
+                    )
                 })
                 .unwrap_or_default()
         } else if access_token.starts_with("Basic") || access_token.starts_with("Bearer") {
@@ -525,7 +539,7 @@ pub async fn extract_auth_str_from_headers(headers: &HeaderMap) -> String {
         }
     } else if let Some(cookie) = cookies.get("auth_ext") {
         let val = config::utils::base64::decode_raw(cookie).unwrap_or_default();
-        std::str::from_utf8(&val).unwrap_or_default().to_string()
+        reject_forged_session_marker(std::str::from_utf8(&val).unwrap_or_default().to_string())
     } else if let Some(auth_header) = headers.get("Authorization") {
         if let Ok(auth_str) = auth_header.to_str() {
             // Log auth type without exposing sensitive tokens
@@ -569,7 +583,7 @@ pub async fn extract_auth_str_from_headers(headers: &HeaderMap) -> String {
                     }
                 }
             } else {
-                auth_str.to_owned()
+                reject_forged_session_marker(auth_str.to_owned())
             }
         } else {
             "".to_string()
@@ -1094,5 +1108,26 @@ mod tests {
         )
         .unwrap();
         assert_eq!(decoded, ":");
+    }
+
+    #[test]
+    fn test_reject_forged_session_marker() {
+        assert_eq!(
+            reject_forged_session_marker("Session::forged::Basic dXNlcjpwYXNz".to_string()),
+            "",
+            "a client-supplied session marker must not survive extraction"
+        );
+        assert_eq!(
+            reject_forged_session_marker("Session::".to_string()),
+            "",
+            "a bare marker must not survive extraction either"
+        );
+        for untouched in ["Basic dXNlcjpwYXNz", "Bearer jwt", "session abc", ""] {
+            assert_eq!(
+                reject_forged_session_marker(untouched.to_string()),
+                untouched,
+                "ordinary credentials must pass through unchanged"
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes the authorization bypass reported in GHSA-3885-f5c9-86xr.

## Problem

`Session::<session_id>::<token>` is an internal marker meaning "this request was
already resolved to a server-side session". It was carried inside the auth
string itself — and on every path other than the lowercase `session ` prefix,
that string is copied verbatim from client input:

- the raw `Authorization` header (enterprise and OSS extractors)
- the `auth_ext` cookie (both branches)

A client could therefore write the marker itself. `oo_validator_internal` split
the marker, **discarded the session id without ever resolving it**, and treated
the request as session-authenticated. That fed two sinks:

- `bypass_check = true` short-circuits the OpenFGA permission check in
  `validator()` — enterprise builds with OpenFGA enabled.
- `from_session = true` skips the service-account `allow_static_token = false`
  policy in `validate_credentials()` — **all builds**, including default OSS.

Identity is still verified (the password/token must be valid), so this is an
authorization bypass within organizations the caller already belongs to, not a
cross-tenant one — `validate_credentials` resolves the user with
`get_user(Some(org_id), ..)` and non-members still fail.

## Fix

1. **Reject the marker at every client entry point.** A new
   `reject_forged_session_marker` drops any client-supplied string starting with
   `Session::`, applied to the raw header (both extractors, plus the synthetics
   and ingestion early returns) and to both `auth_ext` cookie branches. Only
   server-side session resolution may emit the marker.
2. **Stop trusting the marker on its face.** `oo_validator_internal` now
   re-resolves the session id and requires it to still hold exactly the token
   the marker carries; otherwise the request is rejected. A stale or revoked
   session no longer keeps its trust either.
3. Hand `token_validator` the marker-free string. It does
   `auth.strip_prefix("Bearer").unwrap()`, so a session-wrapped bearer token
   would panic there — reachable from the same forged input.

`assume_service_account` sessions, the only legitimate producer of the marker,
are unaffected; a test covers that path explicitly.

## Tests

- `test_reject_forged_session_marker` — the marker never survives extraction,
  ordinary credentials pass through untouched.
- `test_forged_session_marker_cannot_bypass_allow_static_token` — drives the real
  `oo_validator` entry point with the reported PoC shape: a disabled static token
  is rejected, the forged marker no longer rescues it, and the same marker backed
  by a live session still authenticates.

Both tests fail on the parent commit and pass here.
