### PR TITLE
test(logs): cover multi-stream match_all pagination

### DIFF
--- a/tests/ui-testing/ci-matrix/ci_matrix_regression.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix_regression.json
@@ -7,7 +7,8 @@
       "logs-regression.spec.js",
       "logs-bugs.spec.js",
       "logs-9754.spec.js",
-      "logs-9044-7354.spec.js"
+      "logs-9044-7354.spec.js",
+      "logs-multistream-matchall-pagination.spec.js"
     ],
     "disabled": []
   },

--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -333,6 +333,7 @@ export class AlertsPage {
             errorOrNegativeElements: '[class*="error"], [class*="negative"]',
             errorToastOrAlert: '[data-test-variant="error"], [role="alert"]',
             monacoEditor: '.monaco-editor',
+            alertInlineSqlEditor: '#alert-inline-sql-editor-sql',
             alertDestinationsSelectPopover: '[data-test="alert-destinations-select-popover"]',
             alertDestinationsSelectOption: '[data-test="alert-destinations-select-option"]',
             groupBySelectFirstTrigger: '[data-test="alert-group-by-select-0-trigger"]',
@@ -476,9 +477,10 @@ export class AlertsPage {
         return this.page.locator(this.locators.queryTabsContainer).locator(this.locators.tabSql);
     }
 
-    /** Last Monaco editor on the page (alert creation wizard pattern). */
-    getMonacoEditorLast() {
-        return this.page.locator(this.locators.monacoEditor).last();
+    /** The step-2 inline SQL editor. The wizard mounts several Monaco instances and
+     * the DOM-last one is an offscreen editor, so target this one by its editor id. */
+    getInlineSqlEditor() {
+        return this.page.locator(this.locators.alertInlineSqlEditor);
     }
 
     /** Elements matching error/negative CSS classes (bug pre-check). */

--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -333,7 +333,8 @@ export class AlertsPage {
             errorOrNegativeElements: '[class*="error"], [class*="negative"]',
             errorToastOrAlert: '[data-test-variant="error"], [role="alert"]',
             monacoEditor: '.monaco-editor',
-            alertInlineSqlEditor: '#alert-inline-sql-editor-sql',
+            alertInlineSqlEditorId: 'alert-inline-sql-editor-sql',
+            monacoViewLines: '.view-lines',
             alertDestinationsSelectPopover: '[data-test="alert-destinations-select-popover"]',
             alertDestinationsSelectOption: '[data-test="alert-destinations-select-option"]',
             groupBySelectFirstTrigger: '[data-test="alert-group-by-select-0-trigger"]',
@@ -479,7 +480,31 @@ export class AlertsPage {
 
     /** Step-2 inline SQL editor; the wizard's DOM-last Monaco instance is offscreen. */
     getInlineSqlEditor() {
-        return this.page.locator(this.locators.alertInlineSqlEditor);
+        return this.page.locator(`#${this.locators.alertInlineSqlEditorId}`);
+    }
+
+    /** Sets the inline SQL editor via the Monaco API; Monaco swallows synthesized keystrokes. */
+    async setInlineSqlEditorValue(sql) {
+        await expect(async () => {
+            const content = await this.page.evaluate(({ id, value }) => {
+                const container = document.getElementById(id);
+                const editors = window.monaco?.editor?.getEditors?.() || [];
+                const editor = editors.find((e) => container?.contains(e.getContainerDomNode()));
+                if (!editor) return null;
+                editor.setValue(value);
+                return editor.getValue();
+            }, { id: this.locators.alertInlineSqlEditorId, value: sql });
+            expect(content).toContain(sql);
+        }).toPass({ timeout: 10000, intervals: [1000] });
+    }
+
+    /** Rendered text of the inline SQL editor. */
+    async getInlineSqlEditorLinesText() {
+        return await this.getInlineSqlEditor()
+            .locator(this.locators.monacoViewLines)
+            .first()
+            .textContent()
+            .catch(() => '');
     }
 
     /** Elements matching error/negative CSS classes (bug pre-check). */

--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -477,8 +477,7 @@ export class AlertsPage {
         return this.page.locator(this.locators.queryTabsContainer).locator(this.locators.tabSql);
     }
 
-    /** The step-2 inline SQL editor. The wizard mounts several Monaco instances and
-     * the DOM-last one is an offscreen editor, so target this one by its editor id. */
+    /** Step-2 inline SQL editor; the wizard's DOM-last Monaco instance is offscreen. */
     getInlineSqlEditor() {
         return this.page.locator(this.locators.alertInlineSqlEditor);
     }

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -4516,6 +4516,10 @@ export class LogsPage {
         return await expect(this.page.locator(this.resultPagination)).toBeVisible();
     }
 
+    async expectSearchResultTextContains(expectedText, timeout = 15000) {
+        return await expect(this.page.locator(this.searchResultText)).toContainText(expectedText, { timeout });
+    }
+
     async clickPaginationPage(pageNumber) {
         return await this.page.locator(this.resultPaginationPageBtn(pageNumber)).first().click();
     }

--- a/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-bugs.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-bugs.spec.js
@@ -360,10 +360,12 @@ test.describe("Alerts Regression Bugs — Batch 1", () => {
     await page.waitForTimeout(1000);
     testLogger.info('Switched to SQL tab');
 
-    // Click into the inline Monaco editor (use .last() per alert creation wizard pattern)
-    // then type via keyboard — same approach used by the POM wizard methods
-    const sqlEditor = pm.alertsPage.getMonacoEditorLast();
-    await expect(sqlEditor, 'SQL editor should be visible').toBeVisible({ timeout: 5000 });
+    // Target the step-2 inline SQL editor by its editor id: the wizard mounts several
+    // Monaco instances and the DOM-last one is an offscreen editor that never shows.
+    const sqlEditor = pm.alertsPage.getInlineSqlEditor();
+    // QueryEditor is a lazily loaded async component, so allow the chunk to arrive;
+    // 5s is not enough on a loaded runner. Matches the POM's SQL-dialog wait.
+    await expect(sqlEditor, 'SQL editor should be visible').toBeVisible({ timeout: 30000 });
     await sqlEditor.click({ force: true });
     await page.waitForTimeout(500);
 
@@ -375,13 +377,12 @@ test.describe("Alerts Regression Bugs — Batch 1", () => {
     // may delay Monaco boot).
     await expect(async () => {
       const content = await page.evaluate(() => {
-        const editors = window.monaco?.editor?.getEditors?.();
-        if (editors && editors.length > 0) {
-          const editor = editors[editors.length - 1];
-          editor.setValue('SELECT * FROM default');
-          return editor.getValue();
-        }
-        return null;
+        const container = document.getElementById('alert-inline-sql-editor-sql');
+        const editors = window.monaco?.editor?.getEditors?.() || [];
+        const editor = editors.find((e) => container?.contains(e.getContainerDomNode()));
+        if (!editor) return null;
+        editor.setValue('SELECT * FROM default');
+        return editor.getValue();
       });
       expect(content).toContain('default');
     }).toPass({ timeout: 10000, intervals: [1000] });

--- a/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-bugs.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-bugs.spec.js
@@ -367,27 +367,11 @@ test.describe("Alerts Regression Bugs — Batch 1", () => {
     await sqlEditor.click({ force: true });
     await page.waitForTimeout(500);
 
-    // Use Monaco API to set editor content reliably.
-    // Keyboard shortcuts (Cmd/Ctrl+A + type) are unreliable
-    // with Monaco because the virtualised viewport, focus management,
-    // and IME handling can swallow synthesized keystrokes.
-    // Retry until Monaco editors are fully initialized (parallel test runs
-    // may delay Monaco boot).
-    await expect(async () => {
-      const content = await page.evaluate(() => {
-        const container = document.getElementById('alert-inline-sql-editor-sql');
-        const editors = window.monaco?.editor?.getEditors?.() || [];
-        const editor = editors.find((e) => container?.contains(e.getContainerDomNode()));
-        if (!editor) return null;
-        editor.setValue('SELECT * FROM default');
-        return editor.getValue();
-      });
-      expect(content).toContain('default');
-    }).toPass({ timeout: 10000, intervals: [1000] });
+    // Monaco swallows synthesized keystrokes, so the value is set through its API.
+    await pm.alertsPage.setInlineSqlEditorValue('SELECT * FROM default');
     await page.waitForTimeout(500);
 
-    // Verify the rendered .view-lines contain "default"
-    const linesText = await sqlEditor.locator('.view-lines').first().textContent().catch(() => '');
+    const linesText = await pm.alertsPage.getInlineSqlEditorLinesText();
     testLogger.info(`Monaco view-lines content: "${linesText.substring(0, 100)}"`);
 
     expect(linesText,

--- a/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-bugs.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Alerts/alerts-bugs.spec.js
@@ -360,11 +360,9 @@ test.describe("Alerts Regression Bugs — Batch 1", () => {
     await page.waitForTimeout(1000);
     testLogger.info('Switched to SQL tab');
 
-    // Target the step-2 inline SQL editor by its editor id: the wizard mounts several
-    // Monaco instances and the DOM-last one is an offscreen editor that never shows.
+    // Editor id, not .last(): the wizard's DOM-last Monaco instance is offscreen.
     const sqlEditor = pm.alertsPage.getInlineSqlEditor();
-    // QueryEditor is a lazily loaded async component, so allow the chunk to arrive;
-    // 5s is not enough on a loaded runner. Matches the POM's SQL-dialog wait.
+    // QueryEditor is lazily loaded, so 5s is not enough on a loaded runner.
     await expect(sqlEditor, 'SQL editor should be visible').toBeVisible({ timeout: 30000 });
     await sqlEditor.click({ force: true });
     await page.waitForTimeout(500);

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-multistream-matchall-pagination.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-multistream-matchall-pagination.spec.js
@@ -36,6 +36,8 @@ test.describe("Multi-stream match_all pagination", () => {
     await pm.logsPage.selectIndexAndStreamJoinUnion(streamA, streamB);
     await pm.logsPage.clickDateTimeButton();
     await pm.logsPage.clickRelative15MinButton();
+    // The reported repro is histogram mode with SQL off and match_all as the whole query.
+    await pm.logsPage.ensureHistogramState(true);
     await pm.logsPage.clickQueryEditor();
     await pm.logsPage.typeInQueryEditor(`match_all('${MATCH_TERM}')`);
     // Monaco commits on a debounce; refreshing before the text lands runs the
@@ -57,22 +59,24 @@ test.describe("Multi-stream match_all pagination", () => {
     testLogger.info('Union total verified', { expected: UNION_TOTAL });
   });
 
-  // Paginating re-issues the union without the match_all WHERE clause: the request
-  // goes out with UNION ALL BY NAME but no filter, so the total drifts off 78.
-  // Unskip once the paginated re-query preserves the filter.
-  test.fixme("should return records on the second page of a multi-stream match_all query", {
+  test("should return records on page 3 with 10 results per page", {
     tag: ['@multiStreamPagination', '@regressionBugs', '@P0', '@logs']
   }, async () => {
-    // The regression: each stream was queried separately with the same offset, so
-    // any page past the first skipped both streams entirely and rendered empty.
-    testLogger.info('Verifying the second page is populated');
+    // The reported bug: with two streams, histogram on and only match_all, each
+    // stream was queried at the same offset, so page 3 skipped past both 39-record
+    // streams and rendered "no result found".
+    testLogger.info('Verifying page 3 at 10 results per page');
 
     await pm.logsPage.expectSearchResultTextContains(`out of ${UNION_TOTAL}`);
-    await pm.logsPage.clickPaginationPage(2);
-    await pm.logsPage.expectSearchResultTextContains(`51 to ${UNION_TOTAL} out of ${UNION_TOTAL}`);
+    await pm.logsPage.clickResultsPerPage();
+    await pm.logsPage.clickPaginationPage(3);
+    await pm.logsPage.expectSearchResultTextContains('21 to 30');
     await pm.logsPage.expectLogTableColumnSourceVisible();
+    // The total is deliberately not asserted here: changing rows-per-page re-issues
+    // the union without the match_all filter, so it reads 7.7K instead of 78. The
+    // filtered total is covered by the first test, at the default page size.
 
-    testLogger.info('Second page returned records');
+    testLogger.info('Page 3 returned records');
   });
 
 });

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-multistream-matchall-pagination.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-multistream-matchall-pagination.spec.js
@@ -1,0 +1,78 @@
+const { test, navigateToBase } = require('../../utils/enhanced-baseFixtures.js');
+const testLogger = require('../../utils/test-logger.js');
+const PageManager = require('../../../pages/page-manager.js');
+
+// The shared fixture holds 39 records carrying this exact phrase (note the double
+// space); ingesting it into both streams is what makes the union total 78.
+const MATCH_TERM = '2022-12-27T14:11:27Z INFO  zinc_enl';
+const MATCHES_PER_STREAM = 39;
+const UNION_TOTAL = MATCHES_PER_STREAM * 2;
+
+test.describe("Multi-stream match_all pagination", () => {
+  // Serial: the two streams are ingested once and every test paginates the same
+  // result set, so a shared ingestion keeps the totals identical across tests.
+  test.describe.configure({ mode: 'serial' });
+
+  let pm;
+  let streamA;
+  let streamB;
+  let streamsReady = false;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    if (!streamsReady) {
+      const ingested = await pm.ingestionPage.ingestionJoinUnion();
+      streamA = ingested.streamA;
+      streamB = ingested.streamB;
+      streamsReady = true;
+      testLogger.info(`Ingested multi-stream fixtures`, { streamA, streamB });
+    }
+
+    await pm.logsPage.selectIndexAndStreamJoinUnion(streamA, streamB);
+    await pm.logsPage.clickDateTimeButton();
+    await pm.logsPage.clickRelative15MinButton();
+    await pm.logsPage.clickQueryEditor();
+    await pm.logsPage.typeInQueryEditor(`match_all('${MATCH_TERM}')`);
+    // Monaco commits on a debounce; refreshing before the text lands runs the
+    // union unfiltered and the totals become the whole fixture instead of 78.
+    await pm.logsPage.getQueryEditorTextWhenReady(MATCH_TERM);
+    await pm.logsPage.clickSearchBarRefreshButton();
+
+    testLogger.info('Multi-stream match_all setup completed');
+  });
+
+  test("should report the combined total of both streams for a match_all query", {
+    tag: ['@multiStreamPagination', '@regressionBugs', '@P0', '@logs']
+  }, async () => {
+    testLogger.info('Verifying union total across both streams');
+
+    await pm.logsPage.expectLogTableColumnSourceVisible();
+    await pm.logsPage.expectSearchResultTextContains(`out of ${UNION_TOTAL}`);
+
+    testLogger.info('Union total verified', { expected: UNION_TOTAL });
+  });
+
+  // Paginating re-issues the union without the match_all WHERE clause: the request
+  // goes out with UNION ALL BY NAME but no filter, so the total drifts off 78.
+  // Unskip once the paginated re-query preserves the filter.
+  test.fixme("should return records on the second page of a multi-stream match_all query", {
+    tag: ['@multiStreamPagination', '@regressionBugs', '@P0', '@logs']
+  }, async () => {
+    // The regression: each stream was queried separately with the same offset, so
+    // any page past the first skipped both streams entirely and rendered empty.
+    testLogger.info('Verifying the second page is populated');
+
+    await pm.logsPage.expectSearchResultTextContains(`out of ${UNION_TOTAL}`);
+    await pm.logsPage.clickPaginationPage(2);
+    await pm.logsPage.expectSearchResultTextContains(`51 to ${UNION_TOTAL} out of ${UNION_TOTAL}`);
+    await pm.logsPage.expectLogTableColumnSourceVisible();
+
+    testLogger.info('Second page returned records');
+  });
+
+});

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-multistream-matchall-pagination.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-multistream-matchall-pagination.spec.js
@@ -2,15 +2,13 @@ const { test, navigateToBase } = require('../../utils/enhanced-baseFixtures.js')
 const testLogger = require('../../utils/test-logger.js');
 const PageManager = require('../../../pages/page-manager.js');
 
-// The shared fixture holds 39 records carrying this exact phrase (note the double
-// space); ingesting it into both streams is what makes the union total 78.
+// Fixture holds 39 records with this exact phrase (note the double space), so two streams make 78.
 const MATCH_TERM = '2022-12-27T14:11:27Z INFO  zinc_enl';
 const MATCHES_PER_STREAM = 39;
 const UNION_TOTAL = MATCHES_PER_STREAM * 2;
 
 test.describe("Multi-stream match_all pagination", () => {
-  // Serial: the two streams are ingested once and every test paginates the same
-  // result set, so a shared ingestion keeps the totals identical across tests.
+  // Serial: one shared ingestion keeps the union total identical across tests.
   test.describe.configure({ mode: 'serial' });
 
   let pm;
@@ -40,8 +38,7 @@ test.describe("Multi-stream match_all pagination", () => {
     await pm.logsPage.ensureHistogramState(true);
     await pm.logsPage.clickQueryEditor();
     await pm.logsPage.typeInQueryEditor(`match_all('${MATCH_TERM}')`);
-    // Monaco commits on a debounce; refreshing before the text lands runs the
-    // union unfiltered and the totals become the whole fixture instead of 78.
+    // Monaco commits on a debounce; refreshing early runs the union unfiltered.
     await pm.logsPage.getQueryEditorTextWhenReady(MATCH_TERM);
     await pm.logsPage.clickSearchBarRefreshButton();
 
@@ -62,9 +59,7 @@ test.describe("Multi-stream match_all pagination", () => {
   test("should return records on page 3 with 10 results per page", {
     tag: ['@multiStreamPagination', '@regressionBugs', '@P0', '@logs']
   }, async () => {
-    // The reported bug: with two streams, histogram on and only match_all, each
-    // stream was queried at the same offset, so page 3 skipped past both 39-record
-    // streams and rendered "no result found".
+    // Reported bug: each stream was queried at the same offset, so page 3 came back empty.
     testLogger.info('Verifying page 3 at 10 results per page');
 
     await pm.logsPage.expectSearchResultTextContains(`out of ${UNION_TOTAL}`);
@@ -72,9 +67,7 @@ test.describe("Multi-stream match_all pagination", () => {
     await pm.logsPage.clickPaginationPage(3);
     await pm.logsPage.expectSearchResultTextContains('21 to 30');
     await pm.logsPage.expectLogTableColumnSourceVisible();
-    // The total is deliberately not asserted here: changing rows-per-page re-issues
-    // the union without the match_all filter, so it reads 7.7K instead of 78. The
-    // filtered total is covered by the first test, at the default page size.
+    // Total is not asserted here: the rows-per-page re-query drops match_all, so it reads 7.7K.
 
     testLogger.info('Page 3 returned records');
   });


### PR DESCRIPTION
Adds a Playwright regression test for multi-stream logs search with `match_all`, covering the bug fixed in #14057 (backported in #14063 / #14064).

## The scenario

The reported bug: **histogram mode on, SQL mode off, `match_all(...)` as the whole query, two streams selected, 10 results per page — page 3 rendered "no result found".** Multi-stream search sent one query per stream and copied `from` into each, so page 3 skipped past both streams and came back empty.

The test drives exactly that path through the UI:

1. Ingest the shared fixture into two fresh streams via the existing `ingestionJoinUnion()` helper — `match_all` matches **39 records in each**, so the union total is a deterministic **78**.
2. Select both streams (`selectIndexAndStreamJoinUnion`), histogram state set explicitly, SQL mode off.
3. Type only `match_all('2022-12-27T14:11:27Z INFO  zinc_enl')`, so the UI itself builds the `UNION ALL BY NAME` query.

| Test | Asserts |
|---|---|
| combined total | the search reports **78**, not one stream's 39 |
| page 3 at 10 per page | page 3 shows rows at offsets **21 to 30** — the reported repro |

Both pass against a build carrying #14057.

## Known defect this test works around

Changing rows-per-page re-issues the union **without** the `match_all` filter. The outgoing request carries `UNION ALL BY NAME` but no `match_all`, so the displayed total reads 7.7K (the whole fixture, 3848 × 2) instead of 78.

This is a wrong-count bug, not the empty-page bug — **page 3 still returns the correct records**, which is why the test asserts the offsets and leaves the total to the first test at the default page size. Flagging it for a maintainer rather than fixing it here.

I could not determine the mechanism from the outside: I confirmed at the request level that the filter is absent, but could not tell whether the query is rebuilt without the `WHERE` or the editor's contents are lost, because the POM's editor-text helper returns `""` regardless of state. Worth a look by someone who knows `getPageData('recordsPerPage')`.

## Also in this PR: an unrelated CI failure in the Alerts shard

`alerts-bugs.spec.js` "Alert SQL editor should accept 'default' keyword" was failing all three retries:

```
expect(locator).toBeVisible() failed
Locator: locator('.monaco-editor').last()
Received: hidden
9 × locator resolved to <div role="code" data-uri="inmemory://model/1" ...>
```

The alert wizard mounts several Monaco instances and the DOM-last one is offscreen, so `.last()` always resolved to a hidden element. Fixed by targeting the step-2 inline editor by its editor id, `#alert-inline-sql-editor-sql` (`QueryEditor.vue` renders `data-test-prefix` + language into the DOM `id`). The same scoping is applied inside the `page.evaluate` that calls `setValue` — it made the identical "last editor" assumption and would otherwise have written to the wrong editor while the visible one stayed empty.

`getMonacoEditorLast()` had exactly one caller and is replaced by `getInlineSqlEditor()`.

The 5s visibility wait is also raised to 30s: `UnifiedQueryEditor` is a lazily loaded async component, and the test still failed at 5s on a loaded runner even with the correct locator. 30s matches the POM's existing SQL-dialog wait.

## CI registration

Added to `ci_matrix_regression.json` under the `Logs-Regression` shard. No enterprise change is needed — ENT's `playwright_regression.yml` builds its matrix from this same OSS base plus an append-only overlay, verified by running the merge script against both files.

## Testing

- `logs-multistream-matchall-pagination.spec.js`: **2 passed**
- Full `alerts-bugs.spec.js`: **4 passed**, twice
- Verified `build-ci-matrix.js` emits the new spec in the `Logs-Regression` shard for both OSS and ENT

Run against `main.common-dev`, which carries #14057. Not yet exercised under CI's parallel sharding; the setup does a real two-stream ingestion per worker.
