### PR TITLE
ci: smoke-config overlay support for the enterprise manifest

### DIFF
--- a/.github/scripts/build-ci-matrix.js
+++ b/.github/scripts/build-ci-matrix.js
@@ -15,7 +15,9 @@
  *       global_paths glob emits the FULL matrix; a file matching nothing pulls in the
  *       core_shards cross-section (never zero shards) — safe because merge_group always
  *       runs the full matrix before anything lands. Without the flag the full matrix is
- *       emitted; ENT does not pass the flag, so the flag is OSS-only for now.
+ *       emitted. With an overlay manifest, a sibling smoke_config.ent.json (same dir as
+ *       the overlay) refines selection for ENT shards — folder_paths and path lists
+ *       concatenate onto the base smoke config, core_shards/always_run replace it.
  *
  * The base (OSS tests/ui-testing/ci-matrix/ci_matrix.json) is the ONLY place shared shards are
  * listed. ENT never re-lists shared specs — its overlay (ci_matrix.ent.json) carries
@@ -265,6 +267,23 @@ if (changedFilesPath) {
     die(`--select-for-changes is pull_request-only (GITHUB_EVENT_NAME=${event})`);
   }
   const config = readJson(path.join(path.dirname(basePath), "smoke_config.json"));
+  // With a manifest overlay (ENT), a sibling smoke_config.ent.json refines selection for
+  // enterprise shards: folder_paths/path lists concatenate, core_shards/always_run replace.
+  if (overlayPath) {
+    const entConfigPath = path.join(path.dirname(overlayPath), "smoke_config.ent.json");
+    if (fs.existsSync(entConfigPath)) {
+      const ent = readJson(entConfigPath);
+      for (const key of ["always_ignore_paths", "global_paths", "ignore_paths"]) {
+        if (ent[key]) config[key] = [...(config[key] || []), ...ent[key]];
+      }
+      for (const [folder, globs] of Object.entries(ent.folder_paths || {})) {
+        config.folder_paths[folder] = [...(config.folder_paths[folder] || []), ...globs];
+      }
+      if (ent.core_shards) config.core_shards = ent.core_shards;
+      if (ent.always_run) config.always_run = ent.always_run;
+      log(`merged smoke config overlay ${entConfigPath}`);
+    }
+  }
   validateSmokeConfig(include, config);
   let raw;
   try {

--- a/.github/scripts/build-ci-matrix.test.js
+++ b/.github/scripts/build-ci-matrix.test.js
@@ -172,6 +172,49 @@ test("config errors die eagerly, even when the changed file is global", () => {
   assert.throws(() => run(["web/global/app.ts"], { base }), /unreachable by source changes/);
 });
 
+test("ENT smoke overlay: adds folders, replaces core, dies without it", () => {
+  const dir = path.join(TMP, "ent-overlay");
+  fs.mkdirSync(dir, { recursive: true });
+  const base = path.join(dir, "ci_matrix.json");
+  fs.writeFileSync(
+    base,
+    JSON.stringify([{ testfolder: "X", actual_folder: "X", run_files: ["a.spec.js"] }])
+  );
+  fs.writeFileSync(
+    path.join(dir, "smoke_config.json"),
+    JSON.stringify({ core_shards: ["X"], folder_paths: { X: ["web/x/**"] } })
+  );
+  const entDir = path.join(dir, "ent");
+  fs.mkdirSync(entDir, { recursive: true });
+  const overlay = path.join(entDir, "ci_matrix.ent.json");
+  fs.writeFileSync(
+    overlay,
+    JSON.stringify({ shards: [{ testfolder: "W", actual_folder: "W", run_files: ["w.spec.js"] }] })
+  );
+  const changed = path.join(dir, "changed.txt");
+  const env = { ...process.env, GITHUB_EVENT_NAME: "pull_request" };
+  const runEnt = () =>
+    JSON.parse(
+      execFileSync("node", [SCRIPT, base, overlay, "--select-for-changes", changed], {
+        encoding: "utf8",
+        env,
+      })
+    ).include.map((s) => s.testfolder);
+
+  // Without the ENT smoke config the ENT shard is unreachable — validation refuses.
+  fs.writeFileSync(changed, "web/x/app.ts\n");
+  assert.throws(runEnt, /unreachable by source changes/);
+
+  fs.writeFileSync(
+    path.join(entDir, "smoke_config.ent.json"),
+    JSON.stringify({ folder_paths: { W: ["o2_enterprise/src/w/**"] }, core_shards: ["X", "W"] })
+  );
+  fs.writeFileSync(changed, "o2_enterprise/src/w/mod.rs\n");
+  assert.deepStrictEqual(runEnt().sort(), ["W"]);
+  fs.writeFileSync(changed, "unmapped/file.rs\n");
+  assert.deepStrictEqual(runEnt().sort(), ["W", "X"]);
+});
+
 test("every selection glob matches at least one tracked file", () => {
   const tracked = execFileSync("git", ["-C", REPO, "ls-files"], { encoding: "utf8" })
     .split("\n")


### PR DESCRIPTION
Stacked on #14107 (merge that first; this PR then retargets main or merges into the stack).

Adds ENT opt-in plumbing to `build-ci-matrix.js`: when the enterprise manifest overlay is passed with `--select-for-changes`, a sibling `smoke_config.ent.json` is merged over the OSS smoke config — `folder_paths`/path lists concatenate, `core_shards`/`always_run` replace. Without that file, eager validation still refuses unreachable ENT shards, so ENT cannot opt in half-configured. Zero behavior change for OSS (22/22 contract tests, full-matrix output unchanged).

Paired with o2-enterprise branch `ci-smoke-ent` (same name, per CI pairing convention). **Merge order: this side first** — the ENT workflow probes the checked-out OSS script for overlay support and keeps selection off until it's present.