### PR TITLE
fix(dashboards): say which check failed when a panel will not save

### DIFF
--- a/web/src/views/Dashboards/addPanel/AddPanel.spec.ts
+++ b/web/src/views/Dashboards/addPanel/AddPanel.spec.ts
@@ -67,7 +67,7 @@ vi.mock("@/composables/dashboard/useDashboardPanel", () => ({
     resetDashboardPanelData: vi.fn(),
     resetDashboardPanelDataAndAddTimeField: vi.fn(),
     resetAggregationFunction: vi.fn(),
-    validatePanel: vi.fn(),
+    validatePanel: validatePanelMock,
     makeAutoSQLQuery: vi.fn(),
   })),
 }));
@@ -79,12 +79,19 @@ vi.mock("@/composables/useLoading", () => ({
   })),
 }));
 
+// One stable object, so a test can assert on what the view actually notified.
+// Stable across the mock factory, so a test can make `validatePanel` fail the
+// way a real query/field error does.
+const validatePanelMock = vi.hoisted(() => vi.fn());
+
+const notificationMocks = vi.hoisted(() => ({
+  showErrorNotification: vi.fn(),
+  showPositiveNotification: vi.fn(),
+  showConfictErrorNotificationWithRefreshBtn: vi.fn(),
+}));
+
 vi.mock("@/composables/useNotifications", () => ({
-  default: vi.fn(() => ({
-    showErrorNotification: vi.fn(),
-    showPositiveNotification: vi.fn(),
-    showConfictErrorNotificationWithRefreshBtn: vi.fn(),
-  })),
+  default: vi.fn(() => notificationMocks),
 }));
 
 vi.mock("@/composables/useAiChat", () => ({
@@ -4606,6 +4613,74 @@ describe("AddPanel.vue", () => {
       // Save is a submit button bound to the OForm id (Enter + click submit).
       expect(saveBtn.attributes("form")).toBe("add-panel-form");
       expect(wrapper.find("#add-panel-form").exists()).toBe(true);
+    });
+  });
+
+  describe("Save validation reporting", () => {
+    const mountForValidation = async () => {
+      const w = mount(AddPanel, {
+        global: {
+          plugins: [store, router, i18n],
+          mocks: {
+            $route: { query: { dashboard: "test-dashboard" }, params: {} },
+            $router: { push: vi.fn(), replace: vi.fn() },
+          },
+          stubs: {
+            OPageHeader: true,
+            PanelEditor: true,
+            DateTimePickerDashboard: true,
+            QueryInspector: true,
+            AddSettingVariable: true,
+            ConfigDrawer: true,
+          },
+        },
+        props: { metaData: null },
+      });
+      await nextTick();
+      return w;
+    };
+
+    const lastErrorMessage = () => {
+      const calls = notificationMocks.showErrorNotification.mock.calls;
+      return calls.length ? calls[calls.length - 1][0] : undefined;
+    };
+
+    it("names the failing checks instead of the generic message", async () => {
+      // A query/field failure is what actually reaches this path: the OForm
+      // schema already blocks an empty title before submit.
+      validatePanelMock.mockImplementation((errors: string[]) => {
+        errors.push("There should be at least one field on Y-Axis");
+        errors.push("Add one field on X-Axis");
+      });
+      wrapper = await mountForValidation();
+      wrapper.vm.dashboardPanelData.data.title = "A panel";
+
+      try {
+        await wrapper.vm.savePanelChangesToDashboard("dash-1");
+      } catch (e) {
+        /* ignore: the save deps are mocked and may reject */
+      }
+
+      expect(lastErrorMessage()).toBe(
+        "There should be at least one field on Y-Axis, Add one field on X-Axis",
+      );
+    });
+
+    it("keeps the generic message for a custom chart, whose errors may be stale", async () => {
+      // `errorData.errors` is not cleared before that guard, so a leftover
+      // chart/save error must not be presented as the reason Save failed.
+      wrapper = await mountForValidation();
+      wrapper.vm.dashboardPanelData.data.type = "custom_chart";
+      wrapper.vm.errorData.errors.splice(0);
+      wrapper.vm.errorData.errors.push("a stale chart error");
+
+      try {
+        await wrapper.vm.savePanelChangesToDashboard("dash-1");
+      } catch (e) {
+        /* ignore: the save deps are mocked and may reject */
+      }
+
+      expect(lastErrorMessage()).toBe("dashboard.addPanel.fixErrors");
     });
   });
 });

--- a/web/src/views/Dashboards/addPanel/AddPanel.vue
+++ b/web/src/views/Dashboards/addPanel/AddPanel.vue
@@ -200,7 +200,7 @@ import {
   onMounted,
   defineAsyncComponent,
 } from "vue";
-import { useI18nTyped } from "@/types/i18n";
+import { raw, useI18nTyped } from "@/types/i18n";
 import {
   addPanel,
   checkIfVariablesAreLoaded,
@@ -1214,7 +1214,8 @@ export default defineComponent({
       validatePanel(errors, isFieldsValidationRequired);
 
       if (errors.length) {
-        showErrorNotification(t("dashboard.addPanel.fixErrors"));
+        // This view's `errorData` is rendered nowhere, so the toast is all the user gets.
+        showErrorNotification(raw(errors.join(", ")));
       }
 
       if (errors.length) {
@@ -1225,6 +1226,7 @@ export default defineComponent({
     };
 
     const savePanelChangesToDashboard = async (dashId: string) => {
+      // Left generic: these errors are never cleared before this guard, so they can be stale.
       if (dashboardPanelData.data.type === "custom_chart" && errorData.errors.length > 0) {
         showErrorNotification(t("dashboard.addPanel.fixErrors"));
         return;


### PR DESCRIPTION
Fixes #11283.

## Summary

A panel that fails query or field validation reports only "There are some errors, please fix them and try again", naming nothing. That message reads as a pointer to a list — and `DashboardErrors` is exactly that component: it renders the count, lists each message, and expands itself when one arrives.

It is bound to a different object:

| object | created | rendered |
| --- | --- | --- |
| `usePanelEditor`'s `errorData` | `usePanelEditor.ts:96` | yes — `DashboardErrorsComponent` in `PanelEditor.vue` (4 places) |
| AddPanel's `errorData` | `AddPanel.vue:310` | no — zero occurrences in its own template |

`isValid()` pushes every validation failure into the second one, so the messages are produced correctly and displayed nowhere. The toast is all that reaches the user.

## What changed

Four lines. The toast now carries the messages themselves, so a missing Y-axis field says so instead of the generic line. `raw()` marks the composed string as deliberately untranslated — the parts are already translated where they are pushed, and `I18nText` rejects composed strings by design.

The `custom_chart` branch keeps the generic line **on purpose**. Its errors are never cleared before that guard — `errorData.errors` is reset only on mount and at the top of `isValid`, which runs after it — so a leftover chart-query or failed-save error can still be sitting there. Naming it would assert a specific, possibly already-fixed reason the panel will not save. There is a test pinning that.

## Deliberately out of scope

- `usePanelEditor` emits the same English string, but on the Apply path, which populates the `errorData` that **is** rendered. The list appears there, so the wording holds and the generic message is correct.
- `PanelEditor` exposes its `errorData`, so this view's validation could instead be routed into the rendered list. That is the better fix and a larger one — it means a parent writing to state a child owns. Happy to do it that way if preferred.
- `dashboard.addPanel.fixErrors` is still used by the `custom_chart` branch, so the key stays.

## Testing

Two tests in `AddPanel.spec.ts`. The first fails without the change (verified by reverting it); the second pins the `custom_chart` decision so it is not "fixed" later by mistake. The `useNotifications` mock now returns one stable object so a test can assert what was notified — no existing test asserted on it.

- `AddPanel.spec.ts` — 174 passed, 0 failed
- `npm run verify` — clean (type-check:app, lint:ci, lint:styles, lint:tokens, lint:token-purity, lint:design:strict)

No Playwright test asserts this string; `dashboard-panel-actions.js` and `dashboard.spec.js` assert only that an error toast is visible, never its text.

## One caveat

The reporter is on v0.80.0-rc3 and this view has since been rewritten onto `OPageLayout`/`OForm`. I have shown the mechanism exists on current main by reading the code, but have not reproduced their screenshot against a running build — so this is offered as a fix for the generic-message defect on main rather than a confirmed reproduction of that report.

Opened as a draft: the routing-into-the-rendered-list question above is worth a maintainer's view before this is merged.
