### PR TITLE
fix: stop quick mode dropping the RUM identity fields, and deflake 5 UI tests

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1737,7 +1737,11 @@ pub struct Common {
         help = "Comma-separated fields to build bloom filter on for all streams, replaces the deprecated ZO_BLOOM_FILTER_DEFAULT_FIELDS"
     )]
     pub feature_bloom_filter_extra_fields: String,
-    #[env_config(name = "ZO_FEATURE_QUICK_MODE_FIELDS", default = "")]
+    #[env_config(
+        name = "ZO_FEATURE_QUICK_MODE_FIELDS",
+        default = "service,version,session_id,view_url",
+        help = "Comma-separated fields quick mode always returns when the stream has them; the RUM defaults identify which app an event came from, and dropping them silently degrades sourcemap translation, breadcrumbs and session replay"
+    )]
     pub feature_quick_mode_fields: String,
     #[env_config(name = "ZO_FEATURE_QUERY_QUEUE_ENABLED", default = true)]
     pub feature_query_queue_enabled: bool,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -208,20 +208,25 @@ pub static SQL_SECONDARY_INDEX_SEARCH_FIELDS: Lazy<Vec<String>> = Lazy::new(|| {
     fields
 });
 
+// Losing these silently degrades sourcemap translation, breadcrumbs and session replay.
+const _DEFAULT_QUICK_MODE_FIELDS: [&str; 4] = ["service", "version", "session_id", "view_url"];
 pub static QUICK_MODEL_FIELDS: Lazy<Vec<String>> = Lazy::new(|| {
-    let mut fields = get_config()
-        .common
-        .feature_quick_mode_fields
-        .split(',')
-        .filter_map(|s| {
-            let s = s.trim();
-            if s.is_empty() {
-                None
-            } else {
-                Some(s.to_string())
-            }
-        })
-        .collect::<Vec<_>>();
+    let mut fields = chain(
+        _DEFAULT_QUICK_MODE_FIELDS.iter().map(|s| s.to_string()),
+        get_config()
+            .common
+            .feature_quick_mode_fields
+            .split(',')
+            .filter_map(|s| {
+                let s = s.trim();
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s.to_string())
+                }
+            }),
+    )
+    .collect::<Vec<_>>();
     fields.sort();
     fields.dedup();
     fields
@@ -1739,8 +1744,8 @@ pub struct Common {
     pub feature_bloom_filter_extra_fields: String,
     #[env_config(
         name = "ZO_FEATURE_QUICK_MODE_FIELDS",
-        default = "service,version,session_id,view_url",
-        help = "Comma-separated fields quick mode always returns when the stream has them; the RUM defaults identify which app an event came from, and dropping them silently degrades sourcemap translation, breadcrumbs and session replay"
+        default = "",
+        help = "Comma-separated extra fields quick mode always returns when the stream has them, on top of the built-in defaults"
     )]
     pub feature_quick_mode_fields: String,
     #[env_config(name = "ZO_FEATURE_QUERY_QUEUE_ENABLED", default = true)]

--- a/src/search/src/sql/schema.rs
+++ b/src/search/src/sql/schema.rs
@@ -447,6 +447,21 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_quick_mode_fields_keeps_builtin_fields() {
+        // Past the cutoff by construction, so only the built-in list can bring it back.
+        let over_cutoff = get_config().limit.quick_mode_num_fields + 100;
+        let mut fields = (0..over_cutoff)
+            .map(|i| Arc::new(Field::new(format!("field{i}"), DataType::Utf8, true)))
+            .collect::<Vec<_>>();
+        fields.push(Arc::new(Field::new("service", DataType::Utf8, true)));
+        let schema = Schema::new(fields);
+
+        let result = generate_quick_mode_fields(&schema, None, &[], false, false);
+
+        assert!(result.iter().any(|f| f.name() == "service"));
+    }
+
+    #[test]
     fn test_generate_quick_mode_fields_skip_original() {
         let fields = vec![
             Arc::new(Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false)),

--- a/tests/ui-testing/pages/dashboardPages/visualise.js
+++ b/tests/ui-testing/pages/dashboardPages/visualise.js
@@ -675,15 +675,20 @@ export default class LogsVisualise {
 
   // Open query inspector from a panel dropdown
   async openPanelQueryInspector(panelName) {
-    // Wait for the dashboard view to fully load after panel save
-    await this.page.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
+    // The Query Inspector item is v-if-gated on the panel's metaData, populated only after its query executes, so wait for the panel to render before opening the menu.
+    await this.verifyChartRenders(this.page);
 
     const dropdown = this.getPanelDropdown(panelName);
     await dropdown.waitFor({ state: "visible", timeout: 20000 });
-    await dropdown.click();
 
     const inspectorBtn = this.page.locator('[data-test="dashboard-query-inspector-panel"]');
-    await inspectorBtn.waitFor({ state: "visible", timeout: 10000 });
+    // Opening the menu before the item mounts leaves it absent for that open, so re-open until it appears.
+    await expect(async () => {
+      if (await inspectorBtn.isVisible().catch(() => false)) return;
+      await dropdown.click();
+      await expect(inspectorBtn).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 20000, intervals: [300, 700, 1500] });
+
     await inspectorBtn.click();
     await this.waitForQueryInspector(this.page);
   }

--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -360,7 +360,11 @@ export class PipelinesPage {
 
     // Methods from original PipelinesPage
     async gotoPipelinesPage() {
-        await openNavFlyoutChild(this.page, 'pipeline');
+        // The flyout child is a hover-reveal that can self-close mid-click, so retry the reveal+click until the pipeline route actually loads.
+        await expect(async () => {
+            await openNavFlyoutChild(this.page, 'pipeline');
+            await this.page.waitForURL(/pipeline/, { timeout: 5000 });
+        }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
     }
 
     async pipelinesPageDefaultOrg() {

--- a/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
@@ -332,15 +332,17 @@ test.describe("FTS Default Column Selection testcases", () => {
     let resultsReady = false;
     for (let attempt = 1; attempt <= 3 && !resultsReady; attempt++) {
       await pm.logsPage.clickSearchBarRefreshButton();
+      // The results body can render before the FTS default column re-resolves, so gate on the FTS header too.
       resultsReady = await pm.logsPage
         .waitForSearchResults(20000)
+        .then(() => pm.logsPage.resolveFtsDefaultField(15000))
         .then(() => true)
         .catch(() => false);
       if (!resultsReady) {
         testLogger.info(`TC-FTS-008 search results not ready (attempt ${attempt}/3), retrying refresh...`);
       }
     }
-    expect(resultsReady, 'Search results did not render on second stream').toBe(true);
+    expect(resultsReady, 'Search results / FTS default did not render on second stream').toBe(true);
 
     // Assert that the FTS default column re-resolved on the new stream.
     const secondFtsField = await pm.logsPage.resolveFtsDefaultField(15000);

--- a/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
@@ -76,15 +76,17 @@ test.describe("FTS Default Column Selection testcases", () => {
     let resultsReady = false;
     for (let attempt = 1; attempt <= 3 && !resultsReady; attempt++) {
       await pm.logsPage.clickSearchBarRefreshButton();
+      // The results body can render before the FTS default column resolves, so gate on the FTS header too.
       resultsReady = await pm.logsPage
         .waitForSearchResults(20000)
+        .then(() => pm.logsPage.resolveFtsDefaultField(15000))
         .then(() => true)
         .catch(() => false);
       if (!resultsReady) {
         testLogger.info(`Search results not ready (attempt ${attempt}/3), retrying refresh...`);
       }
     }
-    expect(resultsReady, 'Search results did not render after retries').toBe(true);
+    expect(resultsReady, 'Search results / FTS default did not render after retries').toBe(true);
 
     testLogger.info('FTS default column test setup completed');
   });

--- a/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
+++ b/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
@@ -56,6 +56,8 @@ const RUN_ID = Date.now();
 // service name would break reruns against the same instance.
 const SERVICE = `e2e-smap-${RUN_ID}`;
 const NOMAP_SERVICE = `e2e-smap-nomap-${RUN_ID}`;
+// Unique filename so this "no sourcemap" case can't collide with a sibling's map for the shared bundle (prod uses unique hashed names).
+const NOMAP_FILE = `main.nomap-${RUN_ID}.js`;
 // Dedicated group for the delete-flow test. Its stack trace must NEVER be
 // translated before the group is deleted: the backend memoizes translations
 // in an in-process LRU keyed by the exact (service, version, env) params of
@@ -72,13 +74,13 @@ let zipPath;
 let invalidZipPath;
 
 /** Build the raw browser-style stacktrace string for a manifest error. */
-function fixtureStack(errorKey) {
+function fixtureStack(errorKey, sourceFile = manifest.bundle) {
   const e = manifest.errors[errorKey];
-  return `${e.message}\n    at fn @ ${manifest.bundleUrlPrefix}/${manifest.bundle}:1:${e.generatedColumn}`;
+  return `${e.message}\n    at fn @ ${manifest.bundleUrlPrefix}/${sourceFile}:1:${e.generatedColumn}`;
 }
 
 /** SDK-shaped RUM error event pointing at the fixture bundle. */
-function fixtureErrorEvent(errorKey, service, index = 0) {
+function fixtureErrorEvent(errorKey, service, index = 0, sourceFile = manifest.bundle) {
   const e = manifest.errors[errorKey];
   const [type, ...msg] = e.message.split(': ');
   return {
@@ -88,7 +90,7 @@ function fixtureErrorEvent(errorKey, service, index = 0) {
     error: {
       message: msg.join(': '),
       type,
-      stack: fixtureStack(errorKey),
+      stack: fixtureStack(errorKey, sourceFile),
       source: 'source',
       is_crash: false,
       resource: { url: `${manifest.bundleUrlPrefix}/` },
@@ -333,7 +335,7 @@ test.describe('Sourcemap Upload & Pretty Stack Trace', () => {
     tag: ['@rum', '@sourcemapPretty', '@ui', '@P0'],
   }, async ({ page }) => {
     const pm = new PageManager(page);
-    await ingestFixtureErrors(page, [fixtureErrorEvent('referenceError', NOMAP_SERVICE)], NOMAP_SERVICE);
+    await ingestFixtureErrors(page, [fixtureErrorEvent('referenceError', NOMAP_SERVICE, 0, NOMAP_FILE)], NOMAP_SERVICE);
     await openErrorDetail(pm, NOMAP_SERVICE);
 
     await pm.rumPage.clickPrettyTab();

--- a/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
+++ b/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
@@ -65,11 +65,14 @@ const NOMAP_FILE = `main.nomap-${RUN_ID}.js`;
 // translation under a different param combination keeps resolving from stale
 // cache forever (see CACHE in src/core/src/service/db/sourcemaps.rs).
 const DELMAP_SERVICE = `e2e-smap-del-${RUN_ID}`;
+// Own filename too: the shared bundle stays mapped by SERVICE, so a post-delete lookup that omits `service` would still resolve.
+const DELMAP_FILE = `main.del-${RUN_ID}.js`;
 const VERSION = '1.0.0-e2e';
 const ENV = 'e2e';
 
 // Generated at test time from the committed dist/ text files (see beforeAll).
 let zipBuffer;
+let delZipBuffer;
 let zipPath;
 let invalidZipPath;
 
@@ -106,14 +109,14 @@ function fixtureErrorEvent(errorKey, service, index = 0, sourceFile = manifest.b
 }
 
 /** Upload the fixture sourcemaps zip for a service via the REST API. */
-async function uploadFixtureGroup(page, service) {
+async function uploadFixtureGroup(page, service, buffer = zipBuffer) {
   const res = await page.request.post(`${BASE}/api/${ORG}/sourcemaps`, {
     headers: { Authorization: AUTH_HEADER },
     multipart: {
       service,
       version: VERSION,
       env: ENV,
-      file: { name: manifest.zip, mimeType: 'application/zip', buffer: zipBuffer },
+      file: { name: manifest.zip, mimeType: 'application/zip', buffer },
     },
   });
   expect(res.ok(), `sourcemaps upload for ${service} should succeed (HTTP ${res.status()})`).toBe(true);
@@ -175,6 +178,11 @@ test.describe('Sourcemap Upload & Pretty Stack Trace', () => {
     zipBuffer = buildZip([
       { name: manifest.bundle, content: bundle },
       { name: `${manifest.bundle}.map`, content: map },
+    ]);
+    // Same fixture contents; the backend takes source_file_name from the zip entry names.
+    delZipBuffer = buildZip([
+      { name: DELMAP_FILE, content: bundle },
+      { name: `${DELMAP_FILE}.map`, content: map },
     ]);
     zipPath = createTempFile(manifest.zip, zipBuffer);
     invalidZipPath = createTempFile(
@@ -359,8 +367,9 @@ test.describe('Sourcemap Upload & Pretty Stack Trace', () => {
     // note above): translating this stack before the delete would poison the
     // backend's translation cache and keep resolving after the group is gone,
     // making the fallback assertion flaky-by-design.
-    await uploadFixtureGroup(page, DELMAP_SERVICE);
-    await ingestFixtureErrors(page, [fixtureErrorEvent('typeError', DELMAP_SERVICE)], DELMAP_SERVICE);
+    await uploadFixtureGroup(page, DELMAP_SERVICE, delZipBuffer);
+    const event = fixtureErrorEvent('typeError', DELMAP_SERVICE, 0, DELMAP_FILE);
+    await ingestFixtureErrors(page, [event], DELMAP_SERVICE);
 
     // Delete the group through the real UI flow (the page object waits for
     // the backing DELETE response before asserting the row is gone).
@@ -387,7 +396,7 @@ test.describe('Sourcemap Upload & Pretty Stack Trace', () => {
     const translateRes = await page.request.post(`${BASE}/api/${ORG}/sourcemaps/stacktrace`, {
       headers: { Authorization: AUTH_HEADER, 'Content-Type': 'application/json' },
       data: {
-        stacktrace: fixtureStack('typeError'),
+        stacktrace: fixtureStack('typeError', DELMAP_FILE),
         service: DELMAP_SERVICE,
         version: VERSION,
         env: ENV,

--- a/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
+++ b/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
@@ -336,10 +336,6 @@ test.describe('Sourcemap Upload & Pretty Stack Trace', () => {
     await ingestFixtureErrors(page, [fixtureErrorEvent('referenceError', NOMAP_SERVICE)], NOMAP_SERVICE);
     await openErrorDetail(pm, NOMAP_SERVICE);
 
-    // Wait for the raw stack to render before switching tabs, else Pretty activates with no stack to translate and never reaches the unavailable state.
-    await pm.rumPage.expectRawTabVisible();
-    await pm.rumPage.expectDetailContainsText(manifest.bundle);
-
     await pm.rumPage.clickPrettyTab();
 
     // No maps uploaded for this service -> explicit unavailable state, and it

--- a/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
+++ b/tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js
@@ -336,6 +336,10 @@ test.describe('Sourcemap Upload & Pretty Stack Trace', () => {
     await ingestFixtureErrors(page, [fixtureErrorEvent('referenceError', NOMAP_SERVICE)], NOMAP_SERVICE);
     await openErrorDetail(pm, NOMAP_SERVICE);
 
+    // Wait for the raw stack to render before switching tabs, else Pretty activates with no stack to translate and never reaches the unavailable state.
+    await pm.rumPage.expectRawTabVisible();
+    await pm.rumPage.expectDetailContainsText(manifest.bundle);
+
     await pm.rumPage.clickPrettyTab();
 
     // No maps uploaded for this service -> explicit unavailable state, and it


### PR DESCRIPTION
Consolidates #14098, #14099, #14100 and the RUM sourcemap failure they surfaced (#14117). Ref #14025.

The RUM item turned out not to be a test-timing problem, so this PR is no longer test-side only — it carries the backend fix plus the fixture changes that make the test model reality.

## Fix — quick mode drops the fields the RUM error detail page needs

`ZO_QUICK_MODE_FORCE_ENABLED` defaults to **true** (`config.rs`), and `sql/mod.rs` ORs it with the request's own flag, so quick mode applies to every request. `generate_quick_mode_fields` then reduces `select *` to the first `ZO_QUICK_MODE_NUM_FIELDS` schema fields plus the columns the query names. Once `_rumdata` grew past that cutoff, the error detail page's `select * from _rumdata where type='error' and _timestamp=?` stopped returning `service`, `version`, `session_id` and `view_url` — it names none of them.

From the Playwright trace of the failing `e2e / RUM` shard (run 33608206016):

- translate request body: `{"stacktrace":"...","env":"e2e"}` — `env` present, `service` and `version` absent;
- the detail search response carried 16 fields, without `service`/`version`/`session_id`;
- the errors-list query in the same session, which names `max(service) AS service`, got `service` back.

Consequences: the Pretty tab translated without a `service`, so the backend's deliberate filename-only fallback could answer with another service's sourcemap; breadcrumbs and session replay lost the `session_id` they key on.

`ZO_FEATURE_QUICK_MODE_FIELDS` already existed for exactly this — the fields it lists are added back after truncation whenever the stream has them — but it defaulted to empty and nothing set it. The built-in list now lives in a `_DEFAULT_QUICK_MODE_FIELDS` constant chained with the env var, the same shape the full-text, secondary-index and bloom-filter defaults use, so the env var stays the deployment's own additions.

The backend's lenient `get_sourcemap_file` fallback is unchanged — it is intended, and requiring an exact `IS NULL` match would regress the legitimate "RUM error without a configured service" case. No frontend change is needed.

## Test deflakes

- **ftsDefaultColumn** `should clear FTS selection on stream change`: the initial-search and stream-switch retry loops gated on the results body only, but the FTS column header re-resolves separately and lags → `resolveFtsDefaultField` timed out. Gate both loops on the FTS header.
- **visualize** `saved from a Table/Line chart`: `openPanelQueryInspector` opened the panel menu before the Query-Inspector item mounted (v-if on panel metaData) → 10s timeout. Gate on `verifyChartRenders` + re-open until the item appears.
- **changeOrg** `Pipelines Page default validation`: `gotoPipelinesPage` clicked the nav-flyout child without waiting for the route (unlike the enrichment nav in the same file) → a missed force-click left the SPA on home. Retry reveal+click until `/pipeline` loads.
- **rum** `Pretty tab reports missing sourcemaps for an unmapped service`: the fixtures shared one bundle filename across services, so the un-mapped service could resolve a sibling's map — a collision production avoids with content-hashed filenames. Give the unmapped case its own filename.
- **rum** `deletes the sourcemaps group and Pretty tab falls back to unavailable`: same trap one test down — the shared bundle stays mapped by `SERVICE` for the whole run, so a post-delete lookup could still resolve. Upload the delete-flow group under its own filename (same fixture contents; the backend derives `source_file_name` from the zip entry names) so the assertion still proves the delete removed the only map for that file.

## Verification

- deflakes: each verified green locally (repeat-each); CI 3x first-try verification per branch before consolidating.
- quick mode fix: `cargo test -p search --lib sql::schema::tests::test_generate_quick_mode_fields` (5 passed, including the new `test_generate_quick_mode_fields_keeps_builtin_fields`, which puts `service` past the cutoff and asserts it comes back), `cargo clippy -p config -p search --all-targets` with the CI lint flags, `cargo fmt --all`.
