### PR TITLE
fix(promql): return an error for a range selector with no metric name

### DIFF
--- a/src/promql/src/engine/selector.rs
+++ b/src/promql/src/engine/selector.rs
@@ -160,13 +160,14 @@ impl Engine {
 
         let mut selector = selector.clone();
         if selector.name.is_none() {
-            let name = selector
-                .matchers
-                .find_matchers(NAME_LABEL)
-                .first()
-                .unwrap()
-                .value
-                .clone();
+            let name = match selector.matchers.find_matchers(NAME_LABEL).first() {
+                Some(mat) => mat.value.clone(),
+                None => {
+                    return Err(DataFusionError::Plan(
+                        "MatrixSelector: metric name is required".into(),
+                    ));
+                }
+            };
 
             selector.name = Some(name);
             // see eval_vector_selector: the matcher is consumed by stream selection
@@ -829,6 +830,90 @@ mod tests {
         assert!(result.is_ok());
         let values = result.unwrap();
         assert_eq!(values.len(), 0); // Mock provider returns empty data
+    }
+
+    #[tokio::test]
+    async fn test_eval_vector_selector_without_a_metric_name_is_an_error() {
+        let trace_id = "test_trace";
+        let org_id = "test_org";
+        let mut engine = Engine::new(
+            trace_id,
+            Arc::new(PromqlContext::new(
+                create_test_query_ctx(trace_id, org_id, 30),
+                SimpleMockProvider,
+                vec![],
+            )),
+            create_test_eval_ctx(),
+        );
+
+        // `{env="prod"}` -- no name and no __name__ matcher to fall back on.
+        let selector = VectorSelector {
+            name: None,
+            matchers: Matchers {
+                matchers: vec![promql_parser::label::Matcher {
+                    name: "env".to_string(),
+                    op: MatchOp::Equal,
+                    value: "prod".to_string(),
+                }],
+                or_matchers: vec![],
+            },
+            offset: None,
+            at: None,
+        };
+
+        let result = engine.eval_vector_selector(&selector).await;
+
+        assert!(result.is_err(), "expected an error, not a panic");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("VectorSelector: metric name is required"),
+            "the error should name the vector selector"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_eval_matrix_selector_without_a_metric_name_is_an_error() {
+        let trace_id = "test_trace";
+        let org_id = "test_org";
+        let mut engine = Engine::new(
+            trace_id,
+            Arc::new(PromqlContext::new(
+                create_test_query_ctx(trace_id, org_id, 30),
+                SimpleMockProvider,
+                vec![],
+            )),
+            create_test_eval_ctx(),
+        );
+
+        // `{env="prod"}[5m]` -- no name and no __name__ matcher to fall back on.
+        let selector = VectorSelector {
+            name: None,
+            matchers: Matchers {
+                matchers: vec![promql_parser::label::Matcher {
+                    name: "env".to_string(),
+                    op: MatchOp::Equal,
+                    value: "prod".to_string(),
+                }],
+                or_matchers: vec![],
+            },
+            offset: None,
+            at: None,
+        };
+
+        let result = engine
+            .eval_matrix_selector(&selector, Duration::from_secs(300))
+            .await;
+
+        assert!(result.is_err(), "expected an error, not a panic");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("MatrixSelector: metric name is required"),
+            "the error should name the matrix selector"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

#8970 fixed two panics on the metrics path, one of them in `eval_vector_selector`: a selector carrying neither a name nor a `__name__` matcher unwrapped an empty result. It now returns `"VectorSelector: metric name is required"`.

The sibling `eval_matrix_selector` has the same shape and was not touched by that change, so it still unwraps and still panics the querier's `grpc_runtime` thread:

```
panicked at src/promql/src/engine/selector.rs:167:18:
called `Option::unwrap()` on a `None` value
```

## How it is reached

Nothing rejects a nameless range selector before evaluation:

- the parser rejects `name: None` only when the matcher set is empty, so `{env="dev"}[5m]` parses fine
- there is no result-type or name check between parse and eval
- `engine/mod.rs` gates only `or_matchers` and the `@` modifier before calling into the selector

So `rate({env="dev"}[5m])` and `count_over_time({env="dev"}[5m])` reach it directly.

The likelier route is a dashboard. `remove_filter_all` runs immediately before this code and drops any matcher whose value equals the dashboard placeholder (`ZO_DASHBOARD_PLACEHOLDER`, default `_o2_all_`). A panel whose metric variable is set to "All" arrives as `{__name__="_o2_all_", env="dev"}[5m]`, has that matcher removed, and lands in exactly the state that unwraps.

## The change

One guard, mirroring the vector one, using the message shape already used for `"MatrixSelector: or_matchers is not supported"` a few lines up. The error reaches the client as a 400 `bad_data` via the catch-all mapping in the promql handler — though it arrives wrapped (`Error during planning: …`, then a tonic `Internal` status), so this improves the failure from a downed stream to a reported error rather than to a polished message.

`selector_load_data_owned` is the only thing downstream that assumes `selector.name` is set, and it is reached only from the two guarded call sites, so the query cannot panic further along.

## Testing

Both halves now assert their specific message. They are a pair that has drifted once, and the vector guard had no coverage either — the existing `name: None` test covers matcher-stripping, not the missing-name case.

- `cargo test -p promql` — 392 passed, 0 failed (the matrix test panics without the change)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings`
- `git diff origin/main...HEAD --check`

The `#[cfg(feature = "enterprise")]` super-cluster branch in this function does not compile locally, so it is unverified here; it receives the already-guarded selector.

## Note on #5152

This is **not** a fix for #5152 — that report's query is an instant selector, which #8970 already covers. This is the range half of the same defect, found while reading that issue. #5152 can be closed on its own merits.

Opened as a draft in case you would rather reject the nameless selector earlier (in `engine/mod.rs` alongside the `or_matchers` and `@` checks) so both selector types share one gate.
