### PR TITLE
fix(web): anchor table cell hover actions to the hovered row

### DIFF
--- a/web/src/lib/core/Table/OTable.spec.ts
+++ b/web/src/lib/core/Table/OTable.spec.ts
@@ -986,8 +986,8 @@ describe("OTable", () => {
         },
       });
 
-      // The toolbar floats above the pointer, so it lives in <body> and exists only
-      // while a cell is hovered — never one overlay per cell.
+      // The toolbar floats clear of the hovered row, so it lives in <body> and exists
+      // only while a cell is hovered — never one overlay per cell.
       const toolbars = () =>
         document.querySelectorAll('[data-test^="o2-table-cell-hover-actions-"]');
       expect(toolbars().length).toBe(0);
@@ -1047,6 +1047,99 @@ describe("OTable", () => {
       expect(document.querySelectorAll('[data-test^="o2-table-cell-hover-actions-"]').length).toBe(
         0,
       );
+    });
+
+    describe("placement", () => {
+      const realRect = Element.prototype.getBoundingClientRect;
+
+      // The td, the thead and the toolbar are the only rects the placement reads.
+      function stubRects(cellTop: number, cellBottom: number, headerBottom: number) {
+        Element.prototype.getBoundingClientRect = function () {
+          const el = this as HTMLElement;
+          if (el.tagName === "THEAD") {
+            return { top: 0, bottom: headerBottom, height: headerBottom } as DOMRect;
+          }
+          if (el.classList?.contains("o2-table-cell-hover-actions")) {
+            return { top: 0, bottom: 34, left: 0, right: 120, width: 120, height: 34 } as DOMRect;
+          }
+          if (el.tagName === "TD") {
+            return {
+              top: cellTop,
+              bottom: cellBottom,
+              left: 100,
+              right: 300,
+              width: 200,
+              height: cellBottom - cellTop,
+            } as DOMRect;
+          }
+          return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0 } as DOMRect;
+        } as any;
+      }
+
+      async function hoverCell(
+        cellTop: number,
+        cellBottom: number,
+        headerBottom: number,
+        clientX: number,
+      ) {
+        stubRects(cellTop, cellBottom, headerBottom);
+        wrapper = mount(OTable, {
+          props: { data: makeRows(3), columns: makeColumns() },
+          slots: { "cell-hover-actions": `<span class="hover-act">A</span>` },
+        });
+        await wrapper
+          .find('[data-test="o2-table-cell-id"]')
+          .trigger("mouseenter", { clientX, clientY: 999 });
+        await nextTick();
+        await nextTick();
+        await nextTick();
+        return document.querySelector('[data-test^="o2-table-cell-hover-actions-"]') as HTMLElement;
+      }
+
+      const arrowOf = (bar: HTMLElement) =>
+        bar.querySelector('[data-test^="o2-table-cell-hover-arrow-"]') as HTMLElement;
+
+      beforeEach(() => {
+        Object.defineProperty(window, "innerWidth", { value: 800, configurable: true });
+      });
+
+      afterEach(() => {
+        Element.prototype.getBoundingClientRect = realRect;
+        document.querySelectorAll(".o2-table-cell-hover-actions").forEach((n) => n.remove());
+      });
+
+      it("anchors to the row's top edge, not the pointer, and points the arrow down", async () => {
+        const bar = await hoverCell(300, 324, 40, 200);
+        // clientY was 999 — a pointer-anchored toolbar would have landed there.
+        expect(bar.style.top).toBe("300px");
+        expect(bar.style.transform).toBe("translate(-50%, -100%)");
+        expect(arrowOf(bar).className).toContain("-bottom-1");
+      });
+
+      it("flips below the row when the toolbar would cover the sticky header", async () => {
+        const bar = await hoverCell(50, 74, 40, 200);
+        expect(bar.style.top).toBe("74px");
+        expect(bar.style.transform).toBe("translate(-50%, 0)");
+        expect(arrowOf(bar).className).toContain("-top-1");
+      });
+
+      it("clamps the toolbar to the window but keeps the arrow over the pointer", async () => {
+        const bar = await hoverCell(300, 324, 40, 795);
+        // Half-width is 60, so the centre can go no further than 800 - 60.
+        expect(bar.style.left).toBe("740px");
+        // Pointer 795 sits 115px into a 120px bar; the arrow stops 10px short of the corner.
+        expect(arrowOf(bar).style.left).toBe("110px");
+      });
+
+      it("centres the arrow and clips it to the half outside the bar", async () => {
+        const bar = await hoverCell(300, 324, 40, 400);
+        expect(bar.style.left).toBe("400px");
+        // `left` is the arrow's centre (`-ml-1`); unclipped, the rotated square's
+        // upper half notches any filled control in the bar (the AI chip).
+        expect(arrowOf(bar).style.left).toBe("60px");
+        expect(arrowOf(bar).className).toContain("-ml-1");
+        expect(arrowOf(bar).className).toContain("[clip-path:polygon(0_100%");
+      });
     });
   });
 

--- a/web/src/lib/core/Table/sub-components/OTableBodyCell.vue
+++ b/web/src/lib/core/Table/sub-components/OTableBodyCell.vue
@@ -306,26 +306,42 @@ const hasCellActions = computed(() => !!slots["cell-hover-actions"]);
 const cellActionsCtx = inject(OTableCellActionsKey, null);
 const isCellActionActive = computed(() => cellActionsCtx?.activeCellKey.value === props.cell.id);
 
-// The actions float just above the pointer instead of pinning to the cell's right
-// edge, so they never sit on top of the value they act on. Escaping a cell that is
-// one row tall and clips overflow means teleporting to <body> and positioning from
-// the pointer, which is why the coordinates are an inline style rather than a class.
+// Anchored to the cell's top edge (not the pointer) with an arrow pointing back at
+// the row, so the toolbar can't be read as belonging to the row it is drawn over.
+// The cell is one row tall and clips overflow, hence <body> teleport + inline coords.
+const cellEl = ref<HTMLElement | null>(null);
 const cellActionsEl = ref<HTMLElement | null>(null);
 const cellActionsX = ref(0);
 const cellActionsY = ref(0);
 const cellActionsBelow = ref(false);
+const cellActionsPointerX = ref(0);
+const cellActionsArrowX = ref(0);
 
 const cellActionsStyle = computed(() => ({
-  // px because these are viewport coordinates read from MouseEvent.clientX/Y.
+  // px because these are viewport coordinates read off getBoundingClientRect.
   left: `${cellActionsX.value}px`,
   top: `${cellActionsY.value}px`,
   transform: cellActionsBelow.value ? "translate(-50%, 0)" : "translate(-50%, -100%)",
 }));
 
+// Clip the rotated square to the half outside the bar plus a ~1.5px sliver that hides
+// the bar's border; the full square would notch any filled control (the AI chip) 3px in.
+const cellActionsArrowClass = computed(() =>
+  cellActionsBelow.value
+    ? "-top-1 border-t border-l [clip-path:polygon(0_0,100%_0,100%_26%,26%_100%,0_100%)]"
+    : "-bottom-1 border-r border-b [clip-path:polygon(0_100%,100%_100%,100%_0,74%_0,0_74%)]",
+);
+
+// Arrow centre within the bar (`-ml-1` offsets its box), so it stays under the pointer
+// after the bar is clamped to the window.
+const cellActionsArrowStyle = computed(() => ({ left: `${cellActionsArrowX.value}px` }));
+
 function onCellActionsEnter(event: MouseEvent) {
   if (!hasCellActions.value) return;
-  cellActionsX.value = event.clientX ?? 0;
-  cellActionsY.value = event.clientY ?? 0;
+  cellActionsPointerX.value = event.clientX ?? 0;
+  cellActionsX.value = cellActionsPointerX.value;
+  // Pre-placed so the toolbar doesn't flash at the window origin before measurement.
+  cellActionsY.value = cellEl.value?.getBoundingClientRect().top ?? event.clientY ?? 0;
   cellActionsBelow.value = false;
   cellActionsCtx?.setActiveCell(props.cell.id);
 }
@@ -378,12 +394,24 @@ watch(isCellActionActive, async (active) => {
   }
   window.addEventListener("scroll", onScrollDismiss, { capture: true, passive: true });
   await nextTick();
-  const rect = cellActionsEl.value?.getBoundingClientRect();
-  if (!rect) return;
-  // Flip below the pointer when the row is too close to the top of the window.
-  if (rect.top < 0) cellActionsBelow.value = true;
-  const half = rect.width / 2;
-  cellActionsX.value = Math.min(Math.max(cellActionsX.value, half), window.innerWidth - half);
+  const bar = cellActionsEl.value?.getBoundingClientRect();
+  const cellRect = cellEl.value?.getBoundingClientRect();
+  if (!bar || !cellRect) return;
+  // The sticky header, not the window edge, is the ceiling: flip below rather than cover it.
+  const headerBottom =
+    cellEl.value?.closest("table")?.querySelector("thead")?.getBoundingClientRect().bottom ?? 0;
+  cellActionsBelow.value = cellRect.top - bar.height < Math.max(headerBottom, 0);
+  cellActionsY.value = cellActionsBelow.value ? cellRect.bottom : cellRect.top;
+  const half = bar.width / 2;
+  cellActionsX.value = Math.min(
+    Math.max(cellActionsPointerX.value, half),
+    window.innerWidth - half,
+  );
+  // Keep the arrow clear of the bar's rounded corners once the bar has been clamped.
+  cellActionsArrowX.value = Math.min(
+    Math.max(cellActionsPointerX.value - (cellActionsX.value - half), 10),
+    Math.max(bar.width - 10, 10),
+  );
 });
 
 onBeforeUnmount(() => window.removeEventListener("scroll", onScrollDismiss, true));
@@ -391,6 +419,7 @@ onBeforeUnmount(() => window.removeEventListener("scroll", onScrollDismiss, true
 
 <template>
   <td
+    ref="cellEl"
     :data-test="`o2-table-cell-${cell.column.id}`"
     :class="[
       // Base text color for the whole cell so custom `#cell-*` slots (which skip
@@ -548,11 +577,11 @@ onBeforeUnmount(() => window.removeEventListener("scroll", onScrollDismiss, true
       </span>
     </template>
 
-    <!-- Hover-action toolbar, floated just above the pointer and teleported out of
+    <!-- Hover-action toolbar, floated clear of the hovered row and teleported out of
          the cell, which is one row tall and clips overflow. The wrapper's padding is
-         the gap the user sees AND the hover bridge from the pointer up to the
-         buttons — without it the pointer would cross bare table on the way and
-         activate the row above. -->
+         the gap the user sees AND the hover bridge from the row up to the buttons —
+         without it the pointer would cross bare table on the way and activate the
+         row above. -->
     <Teleport v-if="hasCellActions && isCellActionActive && hasCellActionsContent" to="body">
       <div
         ref="cellActionsEl"
@@ -563,17 +592,28 @@ onBeforeUnmount(() => window.removeEventListener("scroll", onScrollDismiss, true
         @mouseenter="onCellActionsHoverEnter"
         @mouseleave="onCellActionsLeave"
       >
-        <!-- empty:hidden covers what the vnode walk can't see: slot content that IS a
-             component but renders nothing, e.g. the AI button on a non-AI build. -->
-        <div
-          class="bg-surface-overlay border-border-default rounded-default flex items-center gap-1 border border-solid px-1 py-0.5 shadow-lg empty:hidden"
-        >
-          <slot
-            name="cell-hover-actions"
-            :row="row.original"
-            :column="cell.column.columnDef"
-            :value="rawValue"
-            :active="isCellActionActive"
+        <div class="relative">
+          <!-- empty:hidden covers what the vnode walk can't see: slot content that IS a
+               component but renders nothing, e.g. the AI button on a non-AI build. -->
+          <div
+            class="peer bg-surface-overlay border-border-default rounded-default flex items-center gap-1 border border-solid px-1 py-0.5 shadow-lg empty:hidden"
+          >
+            <slot
+              name="cell-hover-actions"
+              :row="row.original"
+              :column="cell.column.columnDef"
+              :value="rawValue"
+              :active="isCellActionActive"
+            />
+          </div>
+          <!-- The bar sits clear of the hovered row, so this arrow is the only thing
+               tying it to the row it acts on. -->
+          <span
+            class="bg-surface-overlay border-border-default absolute -ml-1 size-2 rotate-45 border-solid peer-empty:hidden"
+            :class="cellActionsArrowClass"
+            :style="cellActionsArrowStyle"
+            :data-test="`o2-table-cell-hover-arrow-${cell.column.id}`"
+            aria-hidden="true"
           />
         </div>
       </div>

--- a/web/src/lib/core/Table/sub-components/OTableBodyCell.vue
+++ b/web/src/lib/core/Table/sub-components/OTableBodyCell.vue
@@ -407,7 +407,7 @@ watch(isCellActionActive, async (active) => {
     Math.max(cellActionsPointerX.value, half),
     window.innerWidth - half,
   );
-  // Keep the arrow clear of the bar's rounded corners once the bar has been clamped.
+  // Keep the arrow clear of the bar's corner radius once the bar has been clamped.
   cellActionsArrowX.value = Math.min(
     Math.max(cellActionsPointerX.value - (cellActionsX.value - half), 10),
     Math.max(bar.width - 10, 10),

--- a/web/src/plugins/logs/SearchResult.spec.ts
+++ b/web/src/plugins/logs/SearchResult.spec.ts
@@ -224,6 +224,34 @@ describe("SearchResult Component", () => {
     });
   });
 
+  describe("showLogCellActions", () => {
+    // The default grid (no fields selected) is timestamp + one `source` column
+    // holding the whole row as JSON, and `source` is not closable.
+    it("shows actions on the source column even though it is not closable", () => {
+      expect(
+        wrapper.vm.showLogCellActions({ id: "source", meta: { closable: false } }, { a: 1 }),
+      ).toBe(true);
+    });
+
+    it("shows actions on a closable field column that has a value", () => {
+      expect(
+        wrapper.vm.showLogCellActions({ id: "level", meta: { closable: true } }, { level: "info" }),
+      ).toBe(true);
+    });
+
+    it("hides actions on a closable field column with no value in this row", () => {
+      expect(
+        wrapper.vm.showLogCellActions({ id: "level", meta: { closable: true } }, { level: null }),
+      ).toBe(false);
+    });
+
+    it("hides actions on other non-closable columns", () => {
+      expect(
+        wrapper.vm.showLogCellActions({ id: "index", meta: { closable: false } }, { a: 1 }),
+      ).toBe(false);
+    });
+  });
+
   describe("Computed Properties", () => {
     it("should compute toggleWrapFlag", () => {
       wrapper.vm.searchObj.meta.toggleSourceWrap = true;

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -540,26 +540,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                   <!-- Per-cell hover actions: AI button on the timestamp cell; copy /
                  add-search-term on closable field cells. -->
-                  <template #cell-hover-actions="{ row, column, active }">
+                  <template #cell-hover-actions="{ row, column, value, active }">
                     <O2AIContextAddBtn
                       v-if="active && !contextMenuOpen && column.id === logsTimestampCol"
-                      class="size-6!"
-                      :imageHeight="'14'"
-                      :imageWidth="'14'"
                       data-test="logs-search-result-ai-btn"
                       @send-to-ai-chat="sendToAiChat(JSON.stringify(row), true)"
                     />
                     <CellActions
-                      v-else-if="
-                        active &&
-                        !contextMenuOpen &&
-                        column.meta?.closable &&
-                        row[column.id] != null
-                      "
+                      v-else-if="active && !contextMenuOpen && showLogCellActions(column, row)"
                       :column="column"
                       :row="row"
+                      :value="value"
                       :selected-stream-fields="searchObj.data.stream.selectedStreamFields"
                       :hide-search-term-actions="false"
+                      :hide-ai="column.id === 'source'"
                       @copy="copyLogToClipboard"
                       @add-search-term="addSearchTerm"
                       @send-to-ai-chat="sendToAiChat"
@@ -2186,6 +2180,10 @@ export default defineComponent({
 
     const logsTimestampCol = computed(() => store.state.zoConfig.timestamp_column || "_timestamp");
 
+    // `source` (whole-row JSON) is not closable but still gets copy; AI stays on the timestamp cell.
+    const showLogCellActions = (column: any, row: any) =>
+      column.meta?.closable ? row[column.id] != null : column.id === "source";
+
     // ── Right-click cell actions ──────────────────────────────────────────────
     // The cell the user last right-clicked, held as plain values (not the
     // TanStack cell) so the menu keeps rendering correctly even if the
@@ -2363,6 +2361,7 @@ export default defineComponent({
       addSearchTerm,
       removeSearchTerm,
       logsTimestampCol,
+      showLogCellActions,
       logsCellHtml,
       logsRowIndex,
       logsRowKey,

--- a/web/src/plugins/logs/data-table/CellActions.spec.ts
+++ b/web/src/plugins/logs/data-table/CellActions.spec.ts
@@ -248,6 +248,35 @@ describe("CellActions", () => {
   });
 
   // ── Props defaults ────────────────────────────────────────────────────────────
+  describe("value prop", () => {
+    // Logs' `source` column is JSON.stringify(row): nothing sits under
+    // row["source"], so the caller hands the rendered value in.
+    it("acts on the passed value when the row has nothing under column.id", async () => {
+      const wrapper = mountComponent({
+        column: { id: "source" },
+        row: { status: "200", message: "OK" },
+        value: '{"status":"200"}',
+        selectedStreamFields: [],
+      });
+
+      await wrapper.find("button").trigger("click");
+
+      expect(wrapper.emitted("copy")?.[0]).toEqual(['{"status":"200"}']);
+      // The title/data-test follow the same value, so they never read "undefined".
+      expect(wrapper.find(".table-cell-actions").attributes("data-test")).toBe(
+        'log-add-data-from-column-{"status":"200"}',
+      );
+    });
+
+    it("falls back to row[column.id] when no value is passed", async () => {
+      const wrapper = mountComponent();
+
+      await wrapper.find("button").trigger("click");
+
+      expect(wrapper.emitted("copy")?.[0]).toEqual(["200"]);
+    });
+  });
+
   describe("Props defaults", () => {
     it("defaults hideSearchTermActions to false", () => {
       const wrapper = mountComponent();

--- a/web/src/plugins/logs/data-table/CellActions.vue
+++ b/web/src/plugins/logs/data-table/CellActions.vue
@@ -3,14 +3,14 @@
        positioning, so this is just the button row. -->
   <div
     class="field_overlay table-cell-actions flex items-center"
-    :title="row[column.id]"
-    :data-test="`log-add-data-from-column-${row[column.id]}`"
+    :title="cellValue"
+    :data-test="`log-add-data-from-column-${cellValue}`"
   >
     <span class="mx-1">
       <OButton
         variant="ghost"
         size="icon-xs-circle"
-        @click.prevent.stop="copyLogToClipboard(row[column.id])"
+        @click.prevent.stop="copyLogToClipboard(cellValue)"
         :title="t('logs.cellActions.copy')"
       >
         <OIcon name="content-copy" size="xs" />
@@ -20,8 +20,8 @@
       <OButton
         variant="ghost"
         size="icon-xs-circle"
-        @click.prevent.stop="addSearchTerm(column.id, row[column.id], 'include')"
-        :data-test="`log-details-include-field-${row[column.id]}`"
+        @click.prevent.stop="addSearchTerm(column.id, cellValue, 'include')"
+        :data-test="`log-details-include-field-${cellValue}`"
         :title="t('logs.cellActions.includeTerm')"
       >
         <OIcon name="" style="height: 0.5rem; width: 0.5rem">
@@ -33,9 +33,9 @@
       <OButton
         variant="ghost"
         size="icon-xs-circle"
-        @click.prevent.stop="addSearchTerm(column.id, row[column.id], 'exclude')"
+        @click.prevent.stop="addSearchTerm(column.id, cellValue, 'exclude')"
         :title="t('logs.cellActions.excludeTerm')"
-        :data-test="`log-details-exclude-field-${row[column.id]}`"
+        :data-test="`log-details-exclude-field-${cellValue}`"
       >
         <OIcon name="" style="height: 0.5rem; width: 0.5rem">
           <NotEqualIcon class="size-full" />
@@ -46,7 +46,7 @@
      then we show some options there we need this  -->
     <O2AIContextAddBtn
       v-if="!hideAi"
-      @send-to-ai-chat="sendToAiChat(JSON.stringify(row[column.id]))"
+      @send-to-ai-chat="sendToAiChat(JSON.stringify(cellValue))"
       class="size-6! border border-solid border-white"
       :imageHeight="'14'"
       :imageWidth="'14'"
@@ -86,7 +86,16 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  /** Rendered cell value, for columns with nothing under `row[column.id]` (logs' `source`). */
+  value: {
+    type: null as unknown as PropType<unknown>,
+    default: undefined,
+  },
 });
+
+const cellValue = computed(() =>
+  props.value === undefined ? props.row[props.column.id] : props.value,
+);
 
 const { t } = useI18nTyped();
 


### PR DESCRIPTION
## Problem

The `OTable` cell hover-action toolbar (copy / include / exclude / AI) was positioned from `MouseEvent.clientX/Y` with `translate(-50%, -100%)`, so it rendered **one row above** the cell it acts on. On dense logs rows the bar is taller than a row and covered the previous row completely, leaving no way to tell which row the buttons applied to.

Two logs-specific defects surfaced alongside it:

- The **`source` column** (whole-row JSON, rendered when no fields are selected) had **no hover actions at all**. It is not `closable`, so the slot skipped it — and even past that gate `CellActions` read `row[column.id]`, which is empty for a column whose value comes from an `accessorFn`.
- The **AI button on the timestamp cell** had been shrunk with `size-6!` + `imageHeight/Width="14"` by the commit that first gave the toolbar a surface (#13704). `O2AIContextAddBtn` is written to always render at `icon-toolbar` size — its own comment says the `size` prop is "accepted for backward compatibility but deliberately not applied" — so the override was fighting the component.

## Approach

Four placements were prototyped and compared before implementing; the chosen one anchors to the row and keeps the value uncovered.

- **Anchor to the hovered cell's rect, not the pointer.** `top` comes from the `<td>`'s `getBoundingClientRect().top`, so the toolbar always clears the hovered row whole and no longer drifts as the pointer moves within a row.
- **Arrow pointing back at the row**, tracking the pointer's x and clamped clear of the bar's corners.
- **The flip ceiling is the sticky header**, not the window edge — previously the toolbar only flipped at `y = 0`, which let it cover the column names on the top visible row.

The arrow is a rotated square, so it is clipped to the half that leaves the bar plus a ~1.5px sliver that hides the bar's border. Painted whole it notched a white wedge ~2.7px into the AI button's filled chip (ghost buttons are transparent, so it only ever showed there).

`CellActions` now accepts the rendered `value`, falling back to `row[column.id]` when absent — so existing `data-test` attributes are byte-identical for field columns and the e2e selectors are unaffected. On `source` it narrows itself to **copy**: include/exclude cannot apply to a whole object, and the row's AI action already sits on the timestamp cell.

Positioning lives entirely in `OTableBodyCell`, so **logs, traces and dashboard table panels** all pick it up (as do correlation, pipelines and the service-graph side panel).

## Verification

Checked against a live instance in all three surfaces:

| Surface | Toolbar | Arrow centred | Anchoring |
|---|---|---|---|
| Logs — `source` (1 btn) | 42px | 550 / 550 | bar bottom == row top |
| Logs — field column (4 btns) | 122px | 542 / 542 | bar bottom == row top |
| Traces — operation name (3 btns) | 98px | 606 / 606 | bar bottom == row top |
| Dashboard table panel (1 btn) | 34px | 550 / 550 | flipped below (row under sticky header) |

Copy on the `source` cell confirmed to place the row JSON on the clipboard.

3,047 tests pass across the table, logs, traces, dashboard-panel and logs-composable suites; ESLint and `vue-tsc` clean. Ten regression tests added for behaviour that was previously untested: row-edge anchoring (asserted with a `clientY` a pointer-anchored toolbar would follow), the header flip, window clamping, arrow centring and clipping, `CellActions` value resolution, and the `showLogCellActions` gate.

## Notes

No enterprise-gated code is touched.
