### PR TITLE
fix(rum): scope sourcemap lookup by service/env/version (cross-service leak)

### DIFF
--- a/src/infra/src/table/source_maps.rs
+++ b/src/infra/src/table/source_maps.rs
@@ -224,16 +224,23 @@ pub async fn get_sourcemap_file(
         .filter(Column::Org.eq(org))
         .filter(Column::SourceFileName.eq(source_file));
 
+    // None must match IS NULL (mirror delete_group); a dropped filter leaks another scope's map.
     if let Some(s) = service.as_ref() {
         stmt = stmt.filter(Column::Service.eq(s));
+    } else {
+        stmt = stmt.filter(Column::Service.is_null());
     }
 
     if let Some(e) = env.as_ref() {
         stmt = stmt.filter(Column::Env.eq(e));
+    } else {
+        stmt = stmt.filter(Column::Env.is_null());
     }
 
     if let Some(v) = version.as_ref() {
         stmt = stmt.filter(Column::Version.eq(v));
+    } else {
+        stmt = stmt.filter(Column::Version.is_null());
     }
 
     let res = stmt.one(client).await?.map(|model| model.into());


### PR DESCRIPTION
Fixes #14117.

`get_sourcemap_file` (src/infra/src/table/source_maps.rs) applied the `service`/`env`/`version` filters only when present, so a stack-trace translate request that omits `service` (e.g. the RUM Pretty tab firing before the error detail loads) degraded to an `(org, source_file_name)` match. Because every RUM error frame shares the same minified filename, `.one()` then returned **another service's** sourcemap — a translated frame + HTTP 200 instead of "Source Maps Not Available".

Fix: make absent `service`/`env`/`version` match `IS NULL`, mirroring the write path (`delete_group`) and the unique index `(org, service, env, version, source_file_name)`. With an exact match the unique index guarantees ≤1 row, so `.one()` stays deterministic — no other change needed.

Scope: backend-only, minimal. The frontend guard (don't translate before `service` loads) and the secondary cache issues noted in #14117 are intentionally left out of this PR.

Verification: covered by the existing e2e `tests/ui-testing/playwright-tests/RUM/sourcemap-upload-pretty.spec.js` (the `e2e / RUM` shard); with this fix the unmapped-service test should pass for the right reason under parallel load.