### PR TITLE
docs(alerts): stop promising the create body's folder_id places the alert

### DIFF
--- a/src/api/management/src/models/alerts/requests.rs
+++ b/src/api/management/src/models/alerts/requests.rs
@@ -52,8 +52,8 @@ use super::{Alert, QueryCondition, StreamType};
 /// ```
 #[derive(Clone, Debug, Deserialize, ToSchema)]
 pub struct CreateAlertRequestBody {
-    /// Optional folder ID indicating the folder in which to create the alert.
-    /// If omitted the alert will be created in the default folder.
+    /// Optional folder ID. Pass the destination folder in the `folder` query parameter;
+    /// the default folder is used when no folder is given.
     #[schema(example = "default")]
     pub folder_id: Option<String>,
 

--- a/src/api/management/src/request/alerts/mod.rs
+++ b/src/api/management/src/request/alerts/mod.rs
@@ -98,7 +98,7 @@ pub mod templates;
     ),
     params(
         ("org_id" = String, Path, description = "Organization name"),
-        ("folder" = Option<String>, Query, description = "Folder ID (Required if alert folder is not the default folder)"),
+        ("folder" = Option<String>, Query, description = "Folder ID for the alert. The default folder is used when absent."),
       ),
     request_body(content = inline(CreateAlertRequestBody), description = "Alert data", content_type = "application/json"),
     responses(


### PR DESCRIPTION
Docs only — no behaviour change. Addresses the `folder_id` half of #9428.

## The problem

`CreateAlertRequestBody.folder_id` is documented as "the folder in which to create the alert" and published in the OpenAPI schema, but `create_alert` takes the folder from the `folder` query parameter alone. A client following the schema sends `folder_id`, gets a 200, and finds the alert in the default folder — which is what #9428 reports.

## Why the wording changed rather than the handler

The query parameter stays authoritative because the permission gate resolves the folder from the query string too, and the two have to agree. `synthetics/mod.rs` documents that reasoning explicitly and cites this handler as the shape to copy:

> the destination folder MUST come from the same place — otherwise a crafted `body.folder_id` could create a check in a folder the user can't access

Making the body field effective would move that boundary, which is more than a docs fix should carry. So the schema was the thing out of step, not the handler.

## The change

Two doc strings:

- `CreateAlertRequestBody.folder_id` now points callers at the `folder` query parameter instead of claiming it places the alert.
- The `folder` param description drops "Required if alert folder is not the default folder" for a plain statement of the default, and deliberately avoids asserting exclusivity — the anomaly-detection branch reads the body first, so a blanket "this determines the folder" would not be true for every path through the endpoint.

## Testing

- `cargo test -p openobserve-api-management --lib` — 671 passed, 0 failed
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings`

The `request::status::enterprise_value` doctest fails on `main` as well; unrelated to this change.

The empty-conditions half of #9428 is not addressed here — it needs a maintainer decision on whether to reject empty conditions for both alert types or only realtime, which I asked on the issue.
