### PR TITLE
refactor(ingester): report a missing entry schema instead of unwrapping it

### DIFF
--- a/src/ingester/src/errors.rs
+++ b/src/ingester/src/errors.rs
@@ -122,6 +122,15 @@ pub enum Error {
     MemoryCircuitBreakerError {},
     #[snafu(display("DiskCircuitBreakerError"))]
     DiskCircuitBreakerError {},
+    #[snafu(display(
+        "Entry for stream {}/{} reached the writer without a schema",
+        org_id,
+        stream
+    ))]
+    MissingSchemaError {
+        org_id: String,
+        stream: String,
+    },
     ExternalError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -147,6 +156,18 @@ mod tests {
     fn test_disk_circuit_breaker_error_display() {
         let e = Error::DiskCircuitBreakerError {};
         assert_eq!(e.to_string(), "DiskCircuitBreakerError");
+    }
+
+    #[test]
+    fn test_missing_schema_error_display() {
+        let e = Error::MissingSchemaError {
+            org_id: "default".to_string(),
+            stream: "k8s_logs".to_string(),
+        };
+        assert_eq!(
+            e.to_string(),
+            "Entry for stream default/k8s_logs reached the writer without a schema"
+        );
     }
 
     #[test]

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -448,9 +448,7 @@ impl Writer {
         // Bulk convert to Arrow RecordBatch
         let batch_entries = entries
             .iter()
-            .map(|entry| {
-                entry.into_batch(self.key.stream_type.clone(), entry.schema.clone().unwrap())
-            })
+            .map(|entry| entry.into_batch(self.key.stream_type.clone(), entry_schema(entry)?))
             .collect::<Result<Vec<_>>>()?;
 
         // Serialize entries to bytes for WAL writing, reusing the RecordBatch
@@ -531,6 +529,7 @@ impl Writer {
             if batch_entry.data.num_rows() == 0 {
                 continue;
             }
+            // preprocess_batch rejected any schema-less entry before the WAL write above
             mem.write(entry.schema.clone().unwrap(), entry, batch_entry)?;
             tokio::task::coop::consume_budget().await;
         }
@@ -748,6 +747,17 @@ impl MemorySize for WriterKey {
     }
 }
 
+/// Only `Writer::write` populates the schema, so a batch assembled elsewhere may lack it.
+fn entry_schema(entry: &Entry) -> Result<Arc<Schema>> {
+    entry
+        .schema
+        .clone()
+        .ok_or_else(|| Error::MissingSchemaError {
+            org_id: entry.org_id.to_string(),
+            stream: entry.stream.to_string(),
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -770,5 +780,24 @@ mod tests {
         let key = WriterKey::new_replay("abc", "xyz");
         let min_expected = std::mem::size_of::<WriterKey>() + "abc".len() + "xyz".len();
         assert_eq!(key.mem_size(), min_expected);
+    }
+
+    #[test]
+    fn entry_schema_returns_the_schema_when_present() {
+        let mut entry = Entry::new();
+        entry.schema = Some(Arc::new(Schema::empty()));
+        assert!(entry_schema(&entry).is_ok());
+    }
+
+    #[test]
+    fn entry_schema_names_the_stream_when_absent() {
+        let mut entry = Entry::new();
+        entry.org_id = "default".into();
+        entry.stream = "k8s_logs".into();
+        let err = entry_schema(&entry).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Entry for stream default/k8s_logs reached the writer without a schema"
+        );
     }
 }


### PR DESCRIPTION
### What

`Writer::write` takes the schema as an argument and sets it on the entry itself, so it cannot be absent by the time that entry is written:

```rust
entry.schema = Some(schema);
self.write_batch(vec![entry], fsync).await
```

`write_batch` takes whatever the caller assembled, and `preprocess_batch` unwrapped `entry.schema` while converting to Arrow. An entry built without one would panic the ingest path rather than fail the request.

That conversion now returns `MissingSchemaError`, naming the org and stream so an offending entry can be traced back to its producer.

### Scope, honestly

**This is hardening, not a bug fix — nothing builds such an entry today.** The one external caller (`src/core/src/ingestion/mod.rs`) sets `schema: Some(...)` on every entry it constructs. The invariant is just held by construction in one function and by convention in its sibling, with nothing at the boundary to say so.

The later unwrap in `consume_processed` is deliberately left alone. It sits downstream of this check so it cannot fire, and by the time it runs the WAL write has already completed — returning an error there would leave entries durable in the WAL and missing from the memtable, which is worse than the panic. It has a comment now saying why it is safe.

### Testing

- `entry_schema_returns_the_schema_when_present` / `entry_schema_names_the_stream_when_absent` — exercise both branches of the new check
- `test_missing_schema_error_display` — pins the message operators will see

`cargo test -p ingester`: 63 passed, 0 failed. `cargo fmt --all -- --check` clean. `cargo clippy --workspace --all-targets` with the CI flags exits 0.

No behaviour change for any current caller.