### PR TITLE
fix(compactor): keep legacy metrics files out of hash-ordered merges

### DIFF
--- a/src/compaction/src/merge/mod.rs
+++ b/src/compaction/src/merge/mod.rs
@@ -16,6 +16,7 @@
 mod file;
 mod job;
 mod metrics;
+mod plan;
 mod stream;
 
 pub use file::merge_files;

--- a/src/compaction/src/merge/plan.rs
+++ b/src/compaction/src/merge/plan.rs
@@ -1,0 +1,275 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Turns one partition's files into merge batches: size-bounded groups, and
+//! for metrics the split that keeps legacy files out of hash-ordered merges.
+
+use config::meta::stream::{FileKey, MergeStrategy};
+use metrics_index::MetricsFileLayout;
+use search::datafusion::merge::MergeMode;
+
+use super::metrics::{MetricsIndexMergeScope, metrics_index_merge_scope};
+
+/// One planned merge: the files and the mode they merge in.
+type PlannedBatch = (Vec<FileKey>, MergeMode);
+
+/// Splits a partition's files into merge batches. Legacy metrics files never
+/// join a hash-ordered batch: sorting them would be a full sort of the hour,
+/// so they keep their classic size-bounded merges beside the hash group.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn plan_batches(
+    mut files: Vec<FileKey>,
+    mode: &MergeMode,
+    job_strategy: &MergeStrategy,
+    max_file_size: usize,
+    max_group_files: usize,
+    is_incremental: bool,
+    stream: &str,
+) -> Vec<PlannedBatch> {
+    let mut batches = Vec::new();
+    if mode.metrics_file_layout().is_some() {
+        let (hash_files, legacy_files): (Vec<_>, Vec<_>) = files
+            .into_iter()
+            .partition(|f| MetricsFileLayout::of(&f.key).is_some());
+        files = hash_files;
+        for group in size_bounded_groups(
+            &legacy_files,
+            job_strategy,
+            max_file_size,
+            max_group_files,
+            is_incremental,
+        ) {
+            batches.push((group, MergeMode::Classic));
+        }
+    }
+    // what a closed indexed metrics hour merges, see [`MetricsIndexMergeScope`]
+    if mode.is_metrics_indexed() {
+        match metrics_index_merge_scope(&files, max_file_size) {
+            MetricsIndexMergeScope::Skip => files.clear(),
+            MetricsIndexMergeScope::LateFilesOnly => {
+                files.retain(|f| MetricsFileLayout::of(&f.key) != Some(MetricsFileLayout::Indexed));
+                log::debug!(
+                    "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed late merge of {} files, indexed files untouched",
+                    files.len()
+                );
+            }
+            MetricsIndexMergeScope::WholeHour => {
+                log::debug!(
+                    "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed fragmentation cap hit, full rewrite of {} files",
+                    files.len()
+                );
+            }
+        }
+    }
+    if mode.merges_whole_batch() {
+        if !files.is_empty() {
+            batches.push((files, mode.clone()));
+        }
+    } else {
+        for group in size_bounded_groups(
+            &files,
+            job_strategy,
+            max_file_size,
+            max_group_files,
+            is_incremental,
+        ) {
+            batches.push((group, mode.clone()));
+        }
+    }
+    batches
+}
+
+/// Size-bounded merge groups in the planner's file order.
+fn size_bounded_groups(
+    files: &[FileKey],
+    job_strategy: &MergeStrategy,
+    max_file_size: usize,
+    max_group_files: usize,
+    is_incremental: bool,
+) -> Vec<Vec<FileKey>> {
+    let max_file_size = max_file_size as i64;
+    let mut groups = Vec::new();
+    let mut new_file_list: Vec<FileKey> = Vec::new();
+    let mut new_file_size = 0;
+    for file in files {
+        if new_file_size + file.meta.original_size > max_file_size
+            || (max_group_files > 0 && new_file_list.len() >= max_group_files)
+        {
+            if new_file_list.len() <= 1 {
+                if *job_strategy == MergeStrategy::FileSize {
+                    break;
+                }
+                new_file_list.clear();
+                new_file_size = file.meta.original_size;
+                new_file_list.push(file.clone());
+                continue; // replace previous file with current file
+            }
+            groups.push(std::mem::take(&mut new_file_list));
+            new_file_size = 0;
+        }
+        new_file_size += file.meta.original_size;
+        new_file_list.push(file.clone());
+    }
+    // The trailing batch is always below max_file_size (the loop flushes a group
+    // only when adding the next file would exceed it). In incremental mode we do
+    // NOT seal this remainder: more files will arrive in the still-open hour, and
+    // sealing now would force re-merging it later (write amplification). Carry it
+    // to the next round; the scheduled hour-end pass seals whatever is left.
+    if new_file_list.len() > 1 && !is_incremental {
+        groups.push(new_file_list);
+    }
+    groups
+}
+
+#[cfg(test)]
+mod tests {
+    use config::meta::stream::FileMeta;
+
+    use super::*;
+
+    fn create_file_key(key: &str, min_ts: i64, max_ts: i64, original_size: i64) -> FileKey {
+        FileKey {
+            id: 0,
+            account: "test_account".to_string(),
+            key: key.to_string(),
+            meta: FileMeta {
+                min_ts,
+                max_ts,
+                records: 100,
+                original_size,
+                compressed_size: original_size / 2,
+                index_size: 0,
+                flattened: false,
+                bloom_ver: 0,
+            },
+            deleted: false,
+            selection: None,
+            row_group_size: None,
+        }
+    }
+
+    fn metrics_file(name: &str, size: i64) -> FileKey {
+        create_file_key(
+            &format!("files/default/metrics/m/2026/08/18/10/{name}"),
+            10,
+            20,
+            size,
+        )
+    }
+
+    fn names(files: &[FileKey]) -> Vec<&str> {
+        files
+            .iter()
+            .map(|f| f.key.rsplit('/').next().unwrap())
+            .collect()
+    }
+
+    /// A closed hour with legacy and hash-ordered files: the legacy files get
+    /// their classic size-bounded merge, the hash files one indexed batch, and
+    /// no batch mixes the layouts (that would sort the whole hour).
+    #[test]
+    fn test_plan_batches_keeps_legacy_metrics_out_of_the_indexed_merge() {
+        let files = vec![
+            metrics_file("1.parquet", 300),
+            metrics_file("hash-sorted-v1-2.parquet", 300),
+            metrics_file("3.parquet", 300),
+            metrics_file("hash-sorted-v1-4.parquet", 300),
+        ];
+        let batches = plan_batches(
+            files,
+            &MergeMode::MetricsIndexed,
+            &MergeStrategy::FileSize,
+            1000,
+            0,
+            false,
+            "test",
+        );
+        assert_eq!(batches.len(), 2, "{batches:?}");
+        let (legacy, mode) = &batches[0];
+        assert!(matches!(mode, MergeMode::Classic), "{mode}");
+        assert_eq!(names(legacy), ["1.parquet", "3.parquet"]);
+        let (hash, mode) = &batches[1];
+        assert!(matches!(mode, MergeMode::MetricsIndexed), "{mode}");
+        assert_eq!(
+            names(hash),
+            ["hash-sorted-v1-2.parquet", "hash-sorted-v1-4.parquet"]
+        );
+    }
+
+    /// In the still-open hour the legacy files keep the incremental rules:
+    /// a full group is sealed, the remainder waits, and the hash files never
+    /// join it.
+    #[test]
+    fn test_plan_batches_incremental_legacy_group_seals_only_full_groups() {
+        let mut files: Vec<FileKey> = (1..=4)
+            .map(|i| metrics_file(&format!("{i}.parquet"), 300))
+            .collect();
+        files.push(metrics_file("hash-sorted-v1-5.parquet", 300));
+        files.push(metrics_file("hash-sorted-v1-6.parquet", 300));
+        let batches = plan_batches(
+            files,
+            &MergeMode::MetricsHashSorted,
+            &MergeStrategy::FileTime,
+            1000,
+            0,
+            true,
+            "test",
+        );
+        assert_eq!(batches.len(), 1, "{batches:?}");
+        let (legacy, mode) = &batches[0];
+        assert!(matches!(mode, MergeMode::Classic), "{mode}");
+        assert_eq!(names(legacy), ["1.parquet", "2.parquet", "3.parquet"]);
+    }
+
+    #[test]
+    fn test_plan_batches_all_indexed_hour_is_skipped() {
+        let files = vec![
+            metrics_file("indexed-v1-1.parquet", 300),
+            metrics_file("indexed-v1-2.parquet", 300),
+            metrics_file("7.parquet", 300),
+            metrics_file("8.parquet", 300),
+        ];
+        let batches = plan_batches(
+            files,
+            &MergeMode::MetricsIndexed,
+            &MergeStrategy::FileSize,
+            1000,
+            0,
+            false,
+            "test",
+        );
+        // the indexed files are left alone; the legacy pair still merges classic
+        assert_eq!(batches.len(), 1, "{batches:?}");
+        assert!(matches!(batches[0].1, MergeMode::Classic));
+        assert_eq!(names(&batches[0].0), ["7.parquet", "8.parquet"]);
+    }
+
+    #[test]
+    fn test_size_bounded_groups_seal_rules() {
+        let files: Vec<FileKey> = (1..=5)
+            .map(|i| metrics_file(&format!("{i}.parquet"), 300))
+            .collect();
+        // closed hour: [1,2,3] sealed by size, the [4,5] remainder sealed too
+        let closed = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 0, false);
+        assert_eq!(closed.len(), 2);
+        assert_eq!(names(&closed[1]), ["4.parquet", "5.parquet"]);
+        // open hour: the remainder waits for more files
+        let open = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 0, true);
+        assert_eq!(open.len(), 1);
+        // a group cap seals every two files
+        let capped = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 2, false);
+        assert_eq!(capped.len(), 2);
+    }
+}

--- a/src/compaction/src/merge/plan.rs
+++ b/src/compaction/src/merge/plan.rs
@@ -25,81 +25,93 @@ use super::metrics::{MetricsIndexMergeScope, metrics_index_merge_scope};
 /// One planned merge: the files and the mode they merge in.
 type PlannedBatch = (Vec<FileKey>, MergeMode);
 
-/// Splits a partition's files into merge batches. Legacy metrics files never
-/// join a hash-ordered batch: sorting them would be a full sort of the hour,
-/// so they keep their classic size-bounded merges beside the hash group.
-#[allow(clippy::too_many_arguments)]
+/// The size rules one merge round batches files under.
+pub(super) struct BatchLimits<'a> {
+    pub strategy: &'a MergeStrategy,
+    pub max_file_size: usize,
+    pub max_group_files: usize,
+    /// The hour is still open: an unfilled trailing group waits for more files.
+    pub is_incremental: bool,
+    /// The classic merge query's cap: larger files are at their target size.
+    pub merge_max_original_size: i64,
+}
+
+/// Splits a partition's files into merge batches: the legacy metrics files
+/// keep their classic size-bounded merges, everything else merges in `mode`.
 pub(super) fn plan_batches(
-    mut files: Vec<FileKey>,
+    files: Vec<FileKey>,
     mode: &MergeMode,
-    job_strategy: &MergeStrategy,
-    max_file_size: usize,
-    max_group_files: usize,
-    is_incremental: bool,
+    limits: &BatchLimits<'_>,
     stream: &str,
 ) -> Vec<PlannedBatch> {
-    let mut batches = Vec::new();
-    if mode.metrics_file_layout().is_some() {
-        let (hash_files, legacy_files): (Vec<_>, Vec<_>) = files
-            .into_iter()
-            .partition(|f| MetricsFileLayout::of(&f.key).is_some());
-        files = hash_files;
-        for group in size_bounded_groups(
-            &legacy_files,
-            job_strategy,
-            max_file_size,
-            max_group_files,
-            is_incremental,
-        ) {
-            batches.push((group, MergeMode::Classic));
-        }
-    }
-    // what a closed indexed metrics hour merges, see [`MetricsIndexMergeScope`]
-    if mode.is_metrics_indexed() {
-        match metrics_index_merge_scope(&files, max_file_size) {
-            MetricsIndexMergeScope::Skip => files.clear(),
-            MetricsIndexMergeScope::LateFilesOnly => {
-                files.retain(|f| MetricsFileLayout::of(&f.key) != Some(MetricsFileLayout::Indexed));
-                log::debug!(
-                    "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed late merge of {} files, indexed files untouched",
-                    files.len()
-                );
-            }
-            MetricsIndexMergeScope::WholeHour => {
-                log::debug!(
-                    "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed fragmentation cap hit, full rewrite of {} files",
-                    files.len()
-                );
-            }
-        }
-    }
+    let (mode_files, mut legacy_files) = split_legacy_metrics(files, mode);
+    // a whole-hour query lists every file; the classic merge never rewrites the full-sized ones
+    legacy_files.retain(|f| f.meta.original_size <= limits.merge_max_original_size);
+    let mut batches: Vec<PlannedBatch> = size_bounded_groups(&legacy_files, limits)
+        .into_iter()
+        .map(|group| (group, MergeMode::Classic))
+        .collect();
+
+    let mode_files = indexed_hour_scope(mode_files, mode, limits.max_file_size, stream);
     if mode.merges_whole_batch() {
-        if !files.is_empty() {
-            batches.push((files, mode.clone()));
+        if !mode_files.is_empty() {
+            batches.push((mode_files, mode.clone()));
         }
     } else {
-        for group in size_bounded_groups(
-            &files,
-            job_strategy,
-            max_file_size,
-            max_group_files,
-            is_incremental,
-        ) {
-            batches.push((group, mode.clone()));
-        }
+        batches.extend(
+            size_bounded_groups(&mode_files, limits)
+                .into_iter()
+                .map(|group| (group, mode.clone())),
+        );
     }
     batches
 }
 
-/// Size-bounded merge groups in the planner's file order.
-fn size_bounded_groups(
-    files: &[FileKey],
-    job_strategy: &MergeStrategy,
+/// Legacy metrics files never join a hash-ordered batch: sorting them would
+/// be a full sort of the hour. Returns `(files for the mode, legacy files)`.
+fn split_legacy_metrics(files: Vec<FileKey>, mode: &MergeMode) -> (Vec<FileKey>, Vec<FileKey>) {
+    if mode.metrics_file_layout().is_none() {
+        return (files, Vec::new());
+    }
+    files
+        .into_iter()
+        .partition(|f| MetricsFileLayout::of(&f.key).is_some())
+}
+
+/// What a closed indexed metrics hour merges, see [`MetricsIndexMergeScope`].
+fn indexed_hour_scope(
+    mut files: Vec<FileKey>,
+    mode: &MergeMode,
     max_file_size: usize,
-    max_group_files: usize,
-    is_incremental: bool,
-) -> Vec<Vec<FileKey>> {
-    let max_file_size = max_file_size as i64;
+    stream: &str,
+) -> Vec<FileKey> {
+    if !mode.is_metrics_indexed() {
+        return files;
+    }
+    match metrics_index_merge_scope(&files, max_file_size) {
+        MetricsIndexMergeScope::Skip => Vec::new(),
+        MetricsIndexMergeScope::LateFilesOnly => {
+            files.retain(|f| MetricsFileLayout::of(&f.key) != Some(MetricsFileLayout::Indexed));
+            log::debug!(
+                "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed late merge of {} files, indexed files untouched",
+                files.len()
+            );
+            files
+        }
+        MetricsIndexMergeScope::WholeHour => {
+            log::debug!(
+                "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed fragmentation cap hit, full rewrite of {} files",
+                files.len()
+            );
+            files
+        }
+    }
+}
+
+/// Size-bounded merge groups in the planner's file order.
+fn size_bounded_groups(files: &[FileKey], limits: &BatchLimits<'_>) -> Vec<Vec<FileKey>> {
+    let max_file_size = limits.max_file_size as i64;
+    let max_group_files = limits.max_group_files;
     let mut groups = Vec::new();
     let mut new_file_list: Vec<FileKey> = Vec::new();
     let mut new_file_size = 0;
@@ -108,7 +120,7 @@ fn size_bounded_groups(
             || (max_group_files > 0 && new_file_list.len() >= max_group_files)
         {
             if new_file_list.len() <= 1 {
-                if *job_strategy == MergeStrategy::FileSize {
+                if *limits.strategy == MergeStrategy::FileSize {
                     break;
                 }
                 new_file_list.clear();
@@ -127,7 +139,7 @@ fn size_bounded_groups(
     // NOT seal this remainder: more files will arrive in the still-open hour, and
     // sealing now would force re-merging it later (write amplification). Carry it
     // to the next round; the scheduled hour-end pass seals whatever is left.
-    if new_file_list.len() > 1 && !is_incremental {
+    if new_file_list.len() > 1 && !limits.is_incremental {
         groups.push(new_file_list);
     }
     groups
@@ -157,6 +169,20 @@ mod tests {
             deleted: false,
             selection: None,
             row_group_size: None,
+        }
+    }
+
+    fn limits(
+        strategy: &MergeStrategy,
+        max_group_files: usize,
+        is_incremental: bool,
+    ) -> BatchLimits<'_> {
+        BatchLimits {
+            strategy,
+            max_file_size: 1000,
+            max_group_files,
+            is_incremental,
+            merge_max_original_size: 950,
         }
     }
 
@@ -190,10 +216,7 @@ mod tests {
         let batches = plan_batches(
             files,
             &MergeMode::MetricsIndexed,
-            &MergeStrategy::FileSize,
-            1000,
-            0,
-            false,
+            &limits(&MergeStrategy::FileSize, 0, false),
             "test",
         );
         assert_eq!(batches.len(), 2, "{batches:?}");
@@ -221,16 +244,33 @@ mod tests {
         let batches = plan_batches(
             files,
             &MergeMode::MetricsHashSorted,
-            &MergeStrategy::FileTime,
-            1000,
-            0,
-            true,
+            &limits(&MergeStrategy::FileTime, 0, true),
             "test",
         );
         assert_eq!(batches.len(), 1, "{batches:?}");
         let (legacy, mode) = &batches[0];
         assert!(matches!(mode, MergeMode::Classic), "{mode}");
         assert_eq!(names(legacy), ["1.parquet", "2.parquet", "3.parquet"]);
+    }
+
+    /// The whole-hour listing includes legacy files the classic query caps
+    /// away; they stay untouched instead of being rewritten with a small file.
+    #[test]
+    fn test_plan_batches_legacy_files_at_target_size_are_left_alone() {
+        let files = vec![
+            metrics_file("1.parquet", 960),
+            metrics_file("2.parquet", 10),
+            metrics_file("hash-sorted-v1-3.parquet", 300),
+        ];
+        let batches = plan_batches(
+            files,
+            &MergeMode::MetricsIndexed,
+            &limits(&MergeStrategy::FileTime, 0, false),
+            "test",
+        );
+        assert_eq!(batches.len(), 1, "{batches:?}");
+        assert!(matches!(batches[0].1, MergeMode::MetricsIndexed));
+        assert_eq!(names(&batches[0].0), ["hash-sorted-v1-3.parquet"]);
     }
 
     #[test]
@@ -244,10 +284,7 @@ mod tests {
         let batches = plan_batches(
             files,
             &MergeMode::MetricsIndexed,
-            &MergeStrategy::FileSize,
-            1000,
-            0,
-            false,
+            &limits(&MergeStrategy::FileSize, 0, false),
             "test",
         );
         // the indexed files are left alone; the legacy pair still merges classic
@@ -262,14 +299,14 @@ mod tests {
             .map(|i| metrics_file(&format!("{i}.parquet"), 300))
             .collect();
         // closed hour: [1,2,3] sealed by size, the [4,5] remainder sealed too
-        let closed = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 0, false);
+        let closed = size_bounded_groups(&files, &limits(&MergeStrategy::FileTime, 0, false));
         assert_eq!(closed.len(), 2);
         assert_eq!(names(&closed[1]), ["4.parquet", "5.parquet"]);
         // open hour: the remainder waits for more files
-        let open = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 0, true);
+        let open = size_bounded_groups(&files, &limits(&MergeStrategy::FileTime, 0, true));
         assert_eq!(open.len(), 1);
         // a group cap seals every two files
-        let capped = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 2, false);
+        let capped = size_bounded_groups(&files, &limits(&MergeStrategy::FileTime, 2, false));
         assert_eq!(capped.len(), 2);
     }
 }

--- a/src/compaction/src/merge/stream.rs
+++ b/src/compaction/src/merge/stream.rs
@@ -170,95 +170,29 @@ pub async fn merge_by_stream(
                 }
             }
 
-            if files_with_size.len() <= 1 && !mode.merges_whole_batch() {
-                return Ok(vec![]);
-            }
-            // what a closed indexed metrics hour merges, see [`MetricsIndexMergeScope`]
-            if mode.is_metrics_indexed() {
-                match metrics_index_merge_scope(&files_with_size, cfg.compact.max_file_size) {
-                    MetricsIndexMergeScope::Skip => return Ok(vec![]),
-                    MetricsIndexMergeScope::LateFilesOnly => {
-                        files_with_size.retain(|f| {
-                            MetricsFileLayout::of(&f.key) != Some(MetricsFileLayout::Indexed)
-                        });
-                        log::debug!(
-                            "[COMPACTOR] merge_by_stream [{org_id}/{stream_type}/{stream_name}] metrics_indexed late merge of {} files, indexed files untouched",
-                            files_with_size.len()
-                        );
-                    }
-                    MetricsIndexMergeScope::WholeHour => {
-                        log::debug!(
-                            "[COMPACTOR] merge_by_stream [{org_id}/{stream_type}/{stream_name}] metrics_indexed fragmentation cap hit, full rewrite of {} files",
-                            files_with_size.len()
-                        );
-                    }
-                }
-            }
-
-            // group files need to merge
-            let mut batch_groups = Vec::new();
-            if mode.merges_whole_batch() {
-                batch_groups.push(MergeBatch {
-                    batch_id: 0,
-                    org_id: org_id.clone(),
-                    stream_type,
-                    stream_name: stream_name.clone(),
-                    prefix: prefix.clone(),
-                    files: files_with_size.clone(),
-                    mode: mode.clone(),
-                });
-            } else {
-                let mut new_file_list = Vec::new();
-                let mut new_file_size = 0;
-                for file in files_with_size.iter() {
-                    if new_file_size + file.meta.original_size > cfg.compact.max_file_size as i64
-                        || (cfg.compact.max_group_files > 0
-                            && new_file_list.len() >= cfg.compact.max_group_files)
-                    {
-                        if new_file_list.len() <= 1 {
-                            if job_strategy == MergeStrategy::FileSize {
-                                break;
-                            }
-                            new_file_list.clear();
-                            new_file_size = file.meta.original_size;
-                            new_file_list.push(file.clone());
-                            continue; // replace previous file with current file
-                        }
-                        batch_groups.push(MergeBatch {
-                            batch_id: batch_groups.len(),
-                            org_id: org_id.clone(),
-                            stream_type,
-                            stream_name: stream_name.clone(),
-                            prefix: prefix.clone(),
-                            files: new_file_list.clone(),
-                            mode: mode.clone(),
-                        });
-                        new_file_size = 0;
-                        new_file_list.clear();
-                    }
-                    new_file_size += file.meta.original_size;
-                    new_file_list.push(file.clone());
-                }
-                // The trailing batch is always below max_file_size (the loop flushes a group
-                // only when adding the next file would exceed it). In incremental mode we do
-                // NOT seal this remainder: more files will arrive in the still-open hour, and
-                // sealing now would force re-merging it later (write amplification). Carry it
-                // to the next round; the scheduled hour-end pass seals whatever is left.
-                if new_file_list.len() > 1 && !is_incremental {
-                    batch_groups.push(MergeBatch {
-                        batch_id: batch_groups.len(),
-                        org_id: org_id.clone(),
-                        stream_type,
-                        stream_name: stream_name.clone(),
-                        prefix: prefix.clone(),
-                        files: new_file_list.clone(),
-                        mode: mode.clone(),
-                    });
-                }
-
-                if batch_groups.is_empty() {
-                    return Ok(vec![]); // no files need to merge
-                }
+            let batch_groups: Vec<MergeBatch> = plan_batches(
+                files_with_size,
+                &mode,
+                &job_strategy,
+                cfg.compact.max_file_size,
+                cfg.compact.max_group_files,
+                is_incremental,
+                &format!("{org_id}/{stream_type}/{stream_name}"),
+            )
+            .into_iter()
+            .enumerate()
+            .map(|(batch_id, (files, mode))| MergeBatch {
+                batch_id,
+                org_id: org_id.clone(),
+                stream_type,
+                stream_name: stream_name.clone(),
+                prefix: prefix.clone(),
+                files,
+                mode,
+            })
+            .collect();
+            if batch_groups.is_empty() {
+                return Ok(vec![]); // no files need to merge
             }
 
             // send to worker
@@ -496,6 +430,117 @@ fn sort_by_time_range(mut file_list: Vec<FileKey>) -> Vec<FileKey> {
     files
 }
 
+/// One planned merge: the files and the mode they merge in.
+type PlannedBatch = (Vec<FileKey>, MergeMode);
+
+/// Splits a partition's files into merge batches. Legacy metrics files never
+/// join a hash-ordered batch: sorting them would be a full sort of the hour,
+/// so they keep their classic size-bounded merges beside the hash group.
+#[allow(clippy::too_many_arguments)]
+fn plan_batches(
+    mut files: Vec<FileKey>,
+    mode: &MergeMode,
+    job_strategy: &MergeStrategy,
+    max_file_size: usize,
+    max_group_files: usize,
+    is_incremental: bool,
+    stream: &str,
+) -> Vec<PlannedBatch> {
+    let mut batches = Vec::new();
+    if mode.metrics_file_layout().is_some() {
+        let (hash_files, legacy_files): (Vec<_>, Vec<_>) = files
+            .into_iter()
+            .partition(|f| MetricsFileLayout::of(&f.key).is_some());
+        files = hash_files;
+        for group in size_bounded_groups(
+            &legacy_files,
+            job_strategy,
+            max_file_size,
+            max_group_files,
+            is_incremental,
+        ) {
+            batches.push((group, MergeMode::Classic));
+        }
+    }
+    // what a closed indexed metrics hour merges, see [`MetricsIndexMergeScope`]
+    if mode.is_metrics_indexed() {
+        match metrics_index_merge_scope(&files, max_file_size) {
+            MetricsIndexMergeScope::Skip => files.clear(),
+            MetricsIndexMergeScope::LateFilesOnly => {
+                files.retain(|f| MetricsFileLayout::of(&f.key) != Some(MetricsFileLayout::Indexed));
+                log::debug!(
+                    "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed late merge of {} files, indexed files untouched",
+                    files.len()
+                );
+            }
+            MetricsIndexMergeScope::WholeHour => {
+                log::debug!(
+                    "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed fragmentation cap hit, full rewrite of {} files",
+                    files.len()
+                );
+            }
+        }
+    }
+    if mode.merges_whole_batch() {
+        if !files.is_empty() {
+            batches.push((files, mode.clone()));
+        }
+    } else {
+        for group in size_bounded_groups(
+            &files,
+            job_strategy,
+            max_file_size,
+            max_group_files,
+            is_incremental,
+        ) {
+            batches.push((group, mode.clone()));
+        }
+    }
+    batches
+}
+
+/// Size-bounded merge groups in the planner's file order.
+fn size_bounded_groups(
+    files: &[FileKey],
+    job_strategy: &MergeStrategy,
+    max_file_size: usize,
+    max_group_files: usize,
+    is_incremental: bool,
+) -> Vec<Vec<FileKey>> {
+    let max_file_size = max_file_size as i64;
+    let mut groups = Vec::new();
+    let mut new_file_list: Vec<FileKey> = Vec::new();
+    let mut new_file_size = 0;
+    for file in files {
+        if new_file_size + file.meta.original_size > max_file_size
+            || (max_group_files > 0 && new_file_list.len() >= max_group_files)
+        {
+            if new_file_list.len() <= 1 {
+                if *job_strategy == MergeStrategy::FileSize {
+                    break;
+                }
+                new_file_list.clear();
+                new_file_size = file.meta.original_size;
+                new_file_list.push(file.clone());
+                continue; // replace previous file with current file
+            }
+            groups.push(std::mem::take(&mut new_file_list));
+            new_file_size = 0;
+        }
+        new_file_size += file.meta.original_size;
+        new_file_list.push(file.clone());
+    }
+    // The trailing batch is always below max_file_size (the loop flushes a group
+    // only when adding the next file would exceed it). In incremental mode we do
+    // NOT seal this remainder: more files will arrive in the still-open hour, and
+    // sealing now would force re-merging it later (write amplification). Carry it
+    // to the next round; the scheduled hour-end pass seals whatever is left.
+    if new_file_list.len() > 1 && !is_incremental {
+        groups.push(new_file_list);
+    }
+    groups
+}
+
 #[cfg(test)]
 mod tests {
     use config::meta::stream::{FileKey, FileMeta};
@@ -522,6 +567,119 @@ mod tests {
             selection: None,
             row_group_size: None,
         }
+    }
+
+    fn metrics_file(name: &str, size: i64) -> FileKey {
+        create_file_key(
+            &format!("files/default/metrics/m/2026/08/18/10/{name}"),
+            10,
+            20,
+            size,
+        )
+    }
+
+    fn names(files: &[FileKey]) -> Vec<&str> {
+        files
+            .iter()
+            .map(|f| f.key.rsplit('/').next().unwrap())
+            .collect()
+    }
+
+    /// A closed hour with legacy and hash-ordered files: the legacy files get
+    /// their classic size-bounded merge, the hash files one indexed batch, and
+    /// no batch mixes the layouts (that would sort the whole hour).
+    #[test]
+    fn test_plan_batches_keeps_legacy_metrics_out_of_the_indexed_merge() {
+        let files = vec![
+            metrics_file("1.parquet", 300),
+            metrics_file("hash-sorted-v1-2.parquet", 300),
+            metrics_file("3.parquet", 300),
+            metrics_file("hash-sorted-v1-4.parquet", 300),
+        ];
+        let batches = plan_batches(
+            files,
+            &MergeMode::MetricsIndexed,
+            &MergeStrategy::FileSize,
+            1000,
+            0,
+            false,
+            "test",
+        );
+        assert_eq!(batches.len(), 2, "{batches:?}");
+        let (legacy, mode) = &batches[0];
+        assert!(matches!(mode, MergeMode::Classic), "{mode}");
+        assert_eq!(names(legacy), ["1.parquet", "3.parquet"]);
+        let (hash, mode) = &batches[1];
+        assert!(matches!(mode, MergeMode::MetricsIndexed), "{mode}");
+        assert_eq!(
+            names(hash),
+            ["hash-sorted-v1-2.parquet", "hash-sorted-v1-4.parquet"]
+        );
+    }
+
+    /// In the still-open hour the legacy files keep the incremental rules:
+    /// a full group is sealed, the remainder waits, and the hash files never
+    /// join it.
+    #[test]
+    fn test_plan_batches_incremental_legacy_group_seals_only_full_groups() {
+        let mut files: Vec<FileKey> = (1..=4)
+            .map(|i| metrics_file(&format!("{i}.parquet"), 300))
+            .collect();
+        files.push(metrics_file("hash-sorted-v1-5.parquet", 300));
+        files.push(metrics_file("hash-sorted-v1-6.parquet", 300));
+        let batches = plan_batches(
+            files,
+            &MergeMode::MetricsHashSorted,
+            &MergeStrategy::FileTime,
+            1000,
+            0,
+            true,
+            "test",
+        );
+        assert_eq!(batches.len(), 1, "{batches:?}");
+        let (legacy, mode) = &batches[0];
+        assert!(matches!(mode, MergeMode::Classic), "{mode}");
+        assert_eq!(names(legacy), ["1.parquet", "2.parquet", "3.parquet"]);
+    }
+
+    #[test]
+    fn test_plan_batches_all_indexed_hour_is_skipped() {
+        let files = vec![
+            metrics_file("indexed-v1-1.parquet", 300),
+            metrics_file("indexed-v1-2.parquet", 300),
+            metrics_file("7.parquet", 300),
+            metrics_file("8.parquet", 300),
+        ];
+        let batches = plan_batches(
+            files,
+            &MergeMode::MetricsIndexed,
+            &MergeStrategy::FileSize,
+            1000,
+            0,
+            false,
+            "test",
+        );
+        // the indexed files are left alone; the legacy pair still merges classic
+        assert_eq!(batches.len(), 1, "{batches:?}");
+        assert!(matches!(batches[0].1, MergeMode::Classic));
+        assert_eq!(names(&batches[0].0), ["7.parquet", "8.parquet"]);
+    }
+
+    #[test]
+    fn test_size_bounded_groups_seal_rules() {
+        let files: Vec<FileKey> = (1..=5)
+            .map(|i| metrics_file(&format!("{i}.parquet"), 300))
+            .collect();
+        // closed hour: [1,2,3] sealed by size, the [4,5] remainder sealed too
+        let closed = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 0, false);
+        assert_eq!(closed.len(), 2);
+        assert_eq!(names(&closed[1]), ["4.parquet", "5.parquet"]);
+        // open hour: the remainder waits for more files
+        let open = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 0, true);
+        assert_eq!(open.len(), 1);
+        // a group cap seals every two files
+        let capped = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 2, false);
+        assert_eq!(capped.len(), 2);
     }
 
     #[test]

--- a/src/compaction/src/merge/stream.rs
+++ b/src/compaction/src/merge/stream.rs
@@ -23,7 +23,6 @@ use config::{
 };
 use hashbrown::{HashMap, HashSet};
 use infra::{cache::file_data, file_list as infra_file_list, schema::get_partition_time_level};
-use metrics_index::MetricsFileLayout;
 use search::datafusion::merge::MergeMode;
 use search_service::file_list;
 use tokio::{
@@ -31,10 +30,7 @@ use tokio::{
     task::JoinHandle,
 };
 
-use super::{
-    job::job_range_end,
-    metrics::{MetricsIndexMergeScope, metrics_index_merge_scope},
-};
+use super::{job::job_range_end, plan::plan_batches};
 use crate::worker::{MergeBatch, MergeSender};
 
 /// compactor run steps on a stream:
@@ -430,117 +426,6 @@ fn sort_by_time_range(mut file_list: Vec<FileKey>) -> Vec<FileKey> {
     files
 }
 
-/// One planned merge: the files and the mode they merge in.
-type PlannedBatch = (Vec<FileKey>, MergeMode);
-
-/// Splits a partition's files into merge batches. Legacy metrics files never
-/// join a hash-ordered batch: sorting them would be a full sort of the hour,
-/// so they keep their classic size-bounded merges beside the hash group.
-#[allow(clippy::too_many_arguments)]
-fn plan_batches(
-    mut files: Vec<FileKey>,
-    mode: &MergeMode,
-    job_strategy: &MergeStrategy,
-    max_file_size: usize,
-    max_group_files: usize,
-    is_incremental: bool,
-    stream: &str,
-) -> Vec<PlannedBatch> {
-    let mut batches = Vec::new();
-    if mode.metrics_file_layout().is_some() {
-        let (hash_files, legacy_files): (Vec<_>, Vec<_>) = files
-            .into_iter()
-            .partition(|f| MetricsFileLayout::of(&f.key).is_some());
-        files = hash_files;
-        for group in size_bounded_groups(
-            &legacy_files,
-            job_strategy,
-            max_file_size,
-            max_group_files,
-            is_incremental,
-        ) {
-            batches.push((group, MergeMode::Classic));
-        }
-    }
-    // what a closed indexed metrics hour merges, see [`MetricsIndexMergeScope`]
-    if mode.is_metrics_indexed() {
-        match metrics_index_merge_scope(&files, max_file_size) {
-            MetricsIndexMergeScope::Skip => files.clear(),
-            MetricsIndexMergeScope::LateFilesOnly => {
-                files.retain(|f| MetricsFileLayout::of(&f.key) != Some(MetricsFileLayout::Indexed));
-                log::debug!(
-                    "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed late merge of {} files, indexed files untouched",
-                    files.len()
-                );
-            }
-            MetricsIndexMergeScope::WholeHour => {
-                log::debug!(
-                    "[COMPACTOR] merge_by_stream [{stream}] metrics_indexed fragmentation cap hit, full rewrite of {} files",
-                    files.len()
-                );
-            }
-        }
-    }
-    if mode.merges_whole_batch() {
-        if !files.is_empty() {
-            batches.push((files, mode.clone()));
-        }
-    } else {
-        for group in size_bounded_groups(
-            &files,
-            job_strategy,
-            max_file_size,
-            max_group_files,
-            is_incremental,
-        ) {
-            batches.push((group, mode.clone()));
-        }
-    }
-    batches
-}
-
-/// Size-bounded merge groups in the planner's file order.
-fn size_bounded_groups(
-    files: &[FileKey],
-    job_strategy: &MergeStrategy,
-    max_file_size: usize,
-    max_group_files: usize,
-    is_incremental: bool,
-) -> Vec<Vec<FileKey>> {
-    let max_file_size = max_file_size as i64;
-    let mut groups = Vec::new();
-    let mut new_file_list: Vec<FileKey> = Vec::new();
-    let mut new_file_size = 0;
-    for file in files {
-        if new_file_size + file.meta.original_size > max_file_size
-            || (max_group_files > 0 && new_file_list.len() >= max_group_files)
-        {
-            if new_file_list.len() <= 1 {
-                if *job_strategy == MergeStrategy::FileSize {
-                    break;
-                }
-                new_file_list.clear();
-                new_file_size = file.meta.original_size;
-                new_file_list.push(file.clone());
-                continue; // replace previous file with current file
-            }
-            groups.push(std::mem::take(&mut new_file_list));
-            new_file_size = 0;
-        }
-        new_file_size += file.meta.original_size;
-        new_file_list.push(file.clone());
-    }
-    // The trailing batch is always below max_file_size (the loop flushes a group
-    // only when adding the next file would exceed it). In incremental mode we do
-    // NOT seal this remainder: more files will arrive in the still-open hour, and
-    // sealing now would force re-merging it later (write amplification). Carry it
-    // to the next round; the scheduled hour-end pass seals whatever is left.
-    if new_file_list.len() > 1 && !is_incremental {
-        groups.push(new_file_list);
-    }
-    groups
-}
-
 #[cfg(test)]
 mod tests {
     use config::meta::stream::{FileKey, FileMeta};
@@ -567,119 +452,6 @@ mod tests {
             selection: None,
             row_group_size: None,
         }
-    }
-
-    fn metrics_file(name: &str, size: i64) -> FileKey {
-        create_file_key(
-            &format!("files/default/metrics/m/2026/08/18/10/{name}"),
-            10,
-            20,
-            size,
-        )
-    }
-
-    fn names(files: &[FileKey]) -> Vec<&str> {
-        files
-            .iter()
-            .map(|f| f.key.rsplit('/').next().unwrap())
-            .collect()
-    }
-
-    /// A closed hour with legacy and hash-ordered files: the legacy files get
-    /// their classic size-bounded merge, the hash files one indexed batch, and
-    /// no batch mixes the layouts (that would sort the whole hour).
-    #[test]
-    fn test_plan_batches_keeps_legacy_metrics_out_of_the_indexed_merge() {
-        let files = vec![
-            metrics_file("1.parquet", 300),
-            metrics_file("hash-sorted-v1-2.parquet", 300),
-            metrics_file("3.parquet", 300),
-            metrics_file("hash-sorted-v1-4.parquet", 300),
-        ];
-        let batches = plan_batches(
-            files,
-            &MergeMode::MetricsIndexed,
-            &MergeStrategy::FileSize,
-            1000,
-            0,
-            false,
-            "test",
-        );
-        assert_eq!(batches.len(), 2, "{batches:?}");
-        let (legacy, mode) = &batches[0];
-        assert!(matches!(mode, MergeMode::Classic), "{mode}");
-        assert_eq!(names(legacy), ["1.parquet", "3.parquet"]);
-        let (hash, mode) = &batches[1];
-        assert!(matches!(mode, MergeMode::MetricsIndexed), "{mode}");
-        assert_eq!(
-            names(hash),
-            ["hash-sorted-v1-2.parquet", "hash-sorted-v1-4.parquet"]
-        );
-    }
-
-    /// In the still-open hour the legacy files keep the incremental rules:
-    /// a full group is sealed, the remainder waits, and the hash files never
-    /// join it.
-    #[test]
-    fn test_plan_batches_incremental_legacy_group_seals_only_full_groups() {
-        let mut files: Vec<FileKey> = (1..=4)
-            .map(|i| metrics_file(&format!("{i}.parquet"), 300))
-            .collect();
-        files.push(metrics_file("hash-sorted-v1-5.parquet", 300));
-        files.push(metrics_file("hash-sorted-v1-6.parquet", 300));
-        let batches = plan_batches(
-            files,
-            &MergeMode::MetricsHashSorted,
-            &MergeStrategy::FileTime,
-            1000,
-            0,
-            true,
-            "test",
-        );
-        assert_eq!(batches.len(), 1, "{batches:?}");
-        let (legacy, mode) = &batches[0];
-        assert!(matches!(mode, MergeMode::Classic), "{mode}");
-        assert_eq!(names(legacy), ["1.parquet", "2.parquet", "3.parquet"]);
-    }
-
-    #[test]
-    fn test_plan_batches_all_indexed_hour_is_skipped() {
-        let files = vec![
-            metrics_file("indexed-v1-1.parquet", 300),
-            metrics_file("indexed-v1-2.parquet", 300),
-            metrics_file("7.parquet", 300),
-            metrics_file("8.parquet", 300),
-        ];
-        let batches = plan_batches(
-            files,
-            &MergeMode::MetricsIndexed,
-            &MergeStrategy::FileSize,
-            1000,
-            0,
-            false,
-            "test",
-        );
-        // the indexed files are left alone; the legacy pair still merges classic
-        assert_eq!(batches.len(), 1, "{batches:?}");
-        assert!(matches!(batches[0].1, MergeMode::Classic));
-        assert_eq!(names(&batches[0].0), ["7.parquet", "8.parquet"]);
-    }
-
-    #[test]
-    fn test_size_bounded_groups_seal_rules() {
-        let files: Vec<FileKey> = (1..=5)
-            .map(|i| metrics_file(&format!("{i}.parquet"), 300))
-            .collect();
-        // closed hour: [1,2,3] sealed by size, the [4,5] remainder sealed too
-        let closed = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 0, false);
-        assert_eq!(closed.len(), 2);
-        assert_eq!(names(&closed[1]), ["4.parquet", "5.parquet"]);
-        // open hour: the remainder waits for more files
-        let open = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 0, true);
-        assert_eq!(open.len(), 1);
-        // a group cap seals every two files
-        let capped = size_bounded_groups(&files, &MergeStrategy::FileTime, 1000, 2, false);
-        assert_eq!(capped.len(), 2);
     }
 
     #[test]

--- a/src/compaction/src/merge/stream.rs
+++ b/src/compaction/src/merge/stream.rs
@@ -30,7 +30,10 @@ use tokio::{
     task::JoinHandle,
 };
 
-use super::{job::job_range_end, plan::plan_batches};
+use super::{
+    job::job_range_end,
+    plan::{BatchLimits, plan_batches},
+};
 use crate::worker::{MergeBatch, MergeSender};
 
 /// compactor run steps on a stream:
@@ -166,13 +169,17 @@ pub async fn merge_by_stream(
                 }
             }
 
+            let limits = BatchLimits {
+                strategy: &job_strategy,
+                max_file_size: cfg.compact.max_file_size,
+                max_group_files: cfg.compact.max_group_files,
+                is_incremental,
+                merge_max_original_size: infra_file_list::merge_max_original_size(),
+            };
             let batch_groups: Vec<MergeBatch> = plan_batches(
                 files_with_size,
                 &mode,
-                &job_strategy,
-                cfg.compact.max_file_size,
-                cfg.compact.max_group_files,
-                is_incremental,
+                &limits,
                 &format!("{org_id}/{stream_type}/{stream_name}"),
             )
             .into_iter()


### PR DESCRIPTION
## Problem

A metrics hour that mixes legacy (`_timestamp DESC`) files with hash-sorted ones was merged as **one batch with no assumed order** (`input_sort_order` → `None` on any mix), so the hour-end `MetricsIndexed` merge ran a `SortExec` over the whole hour. Enable the metrics index layout shortly before an hour closes and that is nearly the full hour through a sort — for a 300 GB/hour stream, hours of work and a disk spill once the DataFusion memory limit is exceeded.

## Fix

The merge planner (`merge_by_stream`) now splits each partition's files **by layout** before batching:

- legacy files keep their classic size-bounded merges (`MergeMode::Classic`, same rules as before the layout existed: `max_file_size`, `max_group_files`, unsealed remainder in the open hour);
- hash-sorted / indexed files merge in the hash mode as before (whole batch for the closed hour, `MetricsIndexMergeScope` applied to them alone);
- **no batch ever mixes the two layouts**, so no merge sorts across them.

The batching loop is extracted into `size_bounded_groups` and the layout split into `plan_batches`, both pure functions with tests.

## Consequence

The transition hour stays mixed: its legacy files are not converted and age out with retention. Until then the query side's all-or-nothing gate keeps that hour on the materializing path — exactly the pre-upgrade behavior. Every later hour is pure hash layout. `input_sort_order`'s "mix → no order" branch is now unreachable from the planner and kept only as a guard.

## Tests

- closed hour, mixed input → one `Classic` batch of the legacy files + one `MetricsIndexed` batch of the hash files, nothing mixed;
- open hour, mixed input → legacy files follow the incremental seal rule (full group sealed, remainder waits), hash files untouched;
- all-indexed hour with a legacy pair → indexed files skipped, legacy pair merges classic;
- `size_bounded_groups` seal rules (closed vs open hour, group cap).
