### PR TITLE
test: deflake 5 UI tests (batch 2)

### DIFF
--- a/tests/ui-testing/pages/iamPages/ingestionTokensPage.js
+++ b/tests/ui-testing/pages/iamPages/ingestionTokensPage.js
@@ -17,7 +17,7 @@ export class IngestionTokensPage {
         // ============================================================
         this.titleHeading = page.locator('[data-test="ingestion-tokens-title-text"]');
         this.createTokenButton = page.locator('[data-test="add-ingestion-token"]');
-        this.searchInput = page.getByPlaceholder('Search...');
+        this.searchInput = page.locator('[data-test="ingestion-tokens-search-input-field"]');
 
         // ============================================================
         // Create Token dialog (ODialog — no custom data-test, uses ODialog built-ins)
@@ -123,7 +123,11 @@ export class IngestionTokensPage {
     // ----- toggle -----
 
     async toggleToken(name) {
-        await this.tokenToggleByName(name).click();
+        // Table client-paginates at 20/page; filter to the unique name so the target row is on page 1 before we click.
+        await this.searchInput.fill(name);
+        const toggle = this.tokenToggleByName(name);
+        await toggle.waitFor({ state: 'visible', timeout: 10000 });
+        await toggle.click();
     }
 
     // ----- assertions -----

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -2232,7 +2232,8 @@ export class LogsPage {
     }
 
     async kubernetesContainerNameJoin(streamA = 'default', streamB = 'e2e_automate') {
-        await this.clearAndFillQueryEditor(`SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "${streamA}" as a join "${streamB}" as b on a.kubernetes_container_name  = b.kubernetes_container_name`);
+        // setQueryEditorContent atomically replaces the model; clearAndFillQueryEditor's select-all no-ops under CI load, leaving stale text.
+        await this.setQueryEditorContent(`SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "${streamA}" as a join "${streamB}" as b on a.kubernetes_container_name  = b.kubernetes_container_name`);
         await this.waitForEditorValue(`FROM "${streamA}"`);
     }
 
@@ -2247,7 +2248,8 @@ export class LogsPage {
     }
 
     async kubernetesContainerNameLeftJoin() {
-        await this.clearAndFillQueryEditor('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a LEFT JOIN "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name');
+        // setQueryEditorContent atomically replaces the model; clearAndFillQueryEditor's select-all no-ops under CI load, leaving the LEFT JOIN unwritten.
+        await this.setQueryEditorContent('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a LEFT JOIN "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name');
         await this.waitForEditorValue('LEFT JOIN');
     }
 
@@ -2556,7 +2558,21 @@ export class LogsPage {
 
 
     async clickRelative15MinButton() {
-        return await this.page.locator(this.relative15MinButton).click({ force: true });
+        const btn = this.page.locator(this.relative15MinButton);
+        await btn.waitFor({ state: 'visible', timeout: 10000 });
+        // Mirror clickRelative6WeeksButton: settle the toolbar then verify the label so an in-flight-search reflow can't drop the click off-target.
+        await this._waitForQueryButtonIdle();
+        await btn.click();
+        const applied = await this.page
+            .locator(this.dateTimeButton)
+            .filter({ hasText: 'Past 15 Minutes' })
+            .first()
+            .waitFor({ state: 'visible', timeout: 3000 })
+            .then(() => true)
+            .catch(() => false);
+        if (!applied) {
+            await btn.click().catch(() => {});
+        }
     }
 
     /**

--- a/tests/ui-testing/pages/pipelinesPages/pipelinesFormValidationPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesFormValidationPage.js
@@ -487,42 +487,6 @@ export class PipelinesFormValidationPage {
     }
 
     /**
-     * Tries every edit-pipeline button in the list, opens the editor, and looks
-     * for an Associate Function drawer.  If found, returns true.
-     */
-    async openFirstAssociateFunctionNode() {
-        testLogger.info('Searching for a pipeline with an Associate Function node');
-        await this.navigateToPipelines();
-        const editBtns = this.page.locator('[data-test$="-update-pipeline"]');
-        const count = await editBtns.count();
-        for (let i = 0; i < count; i++) {
-            await this.navigateToPipelines();
-            const btns = this.page.locator('[data-test$="-update-pipeline"]');
-            // The pipeline list is shared org-wide, so other parallel test files create
-            // and delete rows while we scan. Re-check the current row count and skip this
-            // index if the list has shrunk past it, instead of clicking a row that no
-            // longer exists (which would hang until the 45s action timeout and flake).
-            if (i >= await btns.count()) break;
-            const target = btns.nth(i);
-            if (!(await target.isVisible({ timeout: 5000 }).catch(() => false))) continue;
-            await target.click();
-            await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
-            // Function nodes have a click target on the node header area
-            const funcNode = this.page.locator('[data-test$="-function-node"]').first();
-            if (await funcNode.isVisible({ timeout: 3000 }).catch(() => false)) {
-                await funcNode.click();
-                const drawer = this.page.locator(this.associateFunctionDrawer);
-                if (await drawer.isVisible({ timeout: 5000 }).catch(() => false)) {
-                    testLogger.info('Associate Function drawer opened successfully');
-                    return true;
-                }
-            }
-        }
-        testLogger.warn('No pipeline with Associate Function node found');
-        return false;
-    }
-
-    /**
      * Navigates to the backfill jobs list and clicks the Edit button on the
      * first job found.  Returns true if the Edit Backfill Job dialog is visible.
      */

--- a/tests/ui-testing/playwright-tests/Pipelines/pipelines-form-validation.spec.js
+++ b/tests/ui-testing/playwright-tests/Pipelines/pipelines-form-validation.spec.js
@@ -268,13 +268,15 @@ test.describe(
 
         test.describe.configure({ mode: 'parallel' });
 
-        let nodeOpened = false;
-
         test.beforeEach(async ({ page }, testInfo) => {
             testLogger.testStart(testInfo.title, testInfo.file);
             await navigateToBase(page);
             pm = new PageManager(page);
-            nodeOpened = await pm.pipelinesFormValidation.openFirstAssociateFunctionNode();
+            await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+            // Build a fresh Associate Function node so the drawer opens with no function selected — the old shared-node path prefilled one under parallel load.
+            await pm.pipelinesPage.openPipelineMenu();
+            await pm.pipelinesPage.addPipeline();
+            await pm.pipelinesPage.selectAndDragFunction();
         });
 
         // ── Test: open drawer without selecting function => error or save disabled
@@ -283,8 +285,6 @@ test.describe(
             'should show function-required error or disable save when no function is selected in Associate Function drawer',
             { tag: ['@domainFormValidation', '@P0', '@smoke'] },
             async ({ page }) => {
-                test.skip(!nodeOpened, 'No pipeline with Associate Function node found in this environment');
-
                 // Verify drawer is visible
                 await expect(
                     pm.pipelinesFormValidation.getAssociateFunctionDrawerLocator()
@@ -311,8 +311,6 @@ test.describe(
             'should change form mode when create-function toggle is activated',
             { tag: ['@domainFormValidation', '@P0', '@smoke'] },
             async ({ page }) => {
-                test.skip(!nodeOpened, 'No pipeline with Associate Function node found in this environment');
-
                 await expect(
                     pm.pipelinesFormValidation.getAssociateFunctionDrawerLocator()
                 ).toBeVisible({ timeout: 10000 });

--- a/tests/ui-testing/playwright-tests/Pipelines/pipelines-form-validation.spec.js
+++ b/tests/ui-testing/playwright-tests/Pipelines/pipelines-form-validation.spec.js
@@ -273,7 +273,7 @@ test.describe(
             await navigateToBase(page);
             pm = new PageManager(page);
             await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
-            // Build a fresh Associate Function node so the drawer opens with no function selected — the old shared-node path prefilled one under parallel load.
+            // Build a fresh Associate Function node so the drawer opens with no function selected.
             await pm.pipelinesPage.openPipelineMenu();
             await pm.pipelinesPage.addPipeline();
             await pm.pipelinesPage.selectAndDragFunction();


### PR DESCRIPTION
Deflake batch 2 (method per #14025). Test-side only, no product code.

- **Logs/join** join queries & **Streams/streaming** Left join: racy `clearAndFillQueryEditor` select-all no-ops under CI load → atomic `setQueryEditorContent`.
- **Logs/indexquery** custom timestamps: hardened `clickRelative15MinButton` to mirror `clickRelative6WeeksButton` (settle toolbar, verify label, retry).
- **GeneralTests/ingestionTokens** toggle: table client-paginates 20/page → filter to the token name so the row is on page 1 before clicking.
- **Pipelines/pipelines-form-validation** associate-function: build a fresh node so the drawer opens with no function selected (was scanning the shared org-wide list, which prefilled a function under parallel load); dropped 2 `test.skip`.

Local ≥2 green each; full Logs/join 10/10, no regressions.