### PR TITLE
ci: gate paid CI on the e2e label and run the merge queue with unit tests only

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -2,7 +2,8 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets the review.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -17,6 +18,8 @@ on:
 
 jobs:
   review:
+    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
     # Explicit name: without it GitHub serializes the whole matrix object (api_key_env, marker) into the public check name.
     name: review (${{ matrix.provider.name }})
     runs-on: ubuntu-latest
@@ -47,6 +50,9 @@ jobs:
             api_key_env: DEEPSEEK_API_KEY
             marker: "<!-- ai-code-review -->"
     steps:
+      # Debounce: a push inside this window cancels the run (concurrency) before anything paid starts.
+      - if: github.event_name == 'pull_request'
+        run: sleep 60
       - name: Checkout repository
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -8,8 +8,7 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing the 'e2e' label re-fires the run and
-    # re-evaluates the gate in api_tests_summary.
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
     types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
 
@@ -34,6 +33,8 @@ env:
 
 jobs:
   check_changes:
+    # Runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests only (see docs/ci).
+    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e')) }}
     name: check_changes
     runs-on: ubuntu-latest
     permissions:
@@ -41,6 +42,9 @@ jobs:
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
+      # Debounce: a push inside this window cancels the run (concurrency) before anything paid starts.
+      - if: github.event_name == 'pull_request'
+        run: sleep 60
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -69,10 +73,7 @@ jobs:
   build_api_binary:
     name: build_api_binary
     needs: [check_changes]
-    if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: needs.check_changes.outputs.has_changes == 'true'
     runs-on: ubicloud-standard-4
     env:
       # CI executes a stripped binary; omitting dependency debuginfo keeps the
@@ -135,14 +136,7 @@ jobs:
   api_integration_tests:
     name: api_integration_tests
     needs: [check_changes, build_api_binary]
-    # API-relevant changes are required in every case. On a pull_request the 'e2e'
-    # label is an ADDITIONAL opt-in, not a bypass: the label is shared with the
-    # Playwright suite, so a frontend-only PR carries it to run UI tests and must
-    # not drag the whole API suite along with it.
-    if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: needs.check_changes.outputs.has_changes == 'true'
     runs-on: ubicloud-standard-4
     permissions:
       actions: read
@@ -238,14 +232,7 @@ jobs:
   api_query_agent_tests:
     name: "api_query_agent / ${{ matrix.config.label }}"
     needs: [check_changes, build_api_binary]
-    # API-relevant changes are required in every case. On a pull_request the 'e2e'
-    # label is an ADDITIONAL opt-in, not a bypass: the label is shared with the
-    # Playwright suite, so a frontend-only PR carries it to run UI tests and must
-    # not drag the whole API suite along with it.
-    if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: needs.check_changes.outputs.has_changes == 'true'
     runs-on: ubicloud-standard-4
     # Run the full SQL regression suite with the single-node physical
     # optimizer both enabled (default) and disabled. The non-optimized
@@ -355,14 +342,7 @@ jobs:
   api_regression_tests:
     name: "api_regression / ${{ matrix.config.label }}"
     needs: [check_changes, build_api_binary]
-    # API-relevant changes are required in every case. On a pull_request the 'e2e'
-    # label is an ADDITIONAL opt-in, not a bypass: the label is shared with the
-    # Playwright suite, so a frontend-only PR carries it to run UI tests and must
-    # not drag the whole API suite along with it.
-    if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: needs.check_changes.outputs.has_changes == 'true'
     runs-on: ubicloud-standard-4
     permissions:
       actions: read
@@ -467,14 +447,7 @@ jobs:
   api_fuzz_tests:
     name: api_fuzz_tests
     needs: [check_changes, build_api_binary]
-    # API-relevant changes are required in every case. On a pull_request the 'e2e'
-    # label is an ADDITIONAL opt-in, not a bypass: the label is shared with the
-    # Playwright suite, so a frontend-only PR carries it to run UI tests and must
-    # not drag the whole API suite along with it.
-    if: >-
-      needs.check_changes.outputs.has_changes == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: needs.check_changes.outputs.has_changes == 'true'
     runs-on: ubicloud-standard-4
     continue-on-error: true
     permissions:
@@ -584,7 +557,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [check_changes, build_api_binary, api_integration_tests, api_query_agent_tests, api_regression_tests]
-    if: always()
+    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
     steps:
       - name: Check test results
         run: |
@@ -594,24 +567,13 @@ jobs:
             exit 1
           fi
 
-          # 2. Nothing API-relevant changed → nothing ran → allow, whatever the labels say.
-          #    This covers the frontend-only PR that carries the 'e2e' label to run the
-          #    Playwright suite: the API suite doesn't apply to it and isn't required.
+          # 2. Nothing API-relevant changed → nothing ran → allow.
           if [ "${{ needs.check_changes.outputs.has_changes }}" != "true" ]; then
             echo "✅ No API-relevant changes — suite not required."
             exit 0
           fi
 
-          # 3. API-relevant pull_request WITHOUT the 'e2e' label: the suite did not run,
-          #    so block until the author opts in by adding the label.
-          if [ "${{ github.event_name }}" == "pull_request" ] && \
-             [ "${{ contains(github.event.pull_request.labels.*.name, 'e2e') }}" != "true" ]; then
-            echo "::error::This PR changes API-relevant files but has no 'e2e' label, so the suite did not run."
-            echo "::error::Add the 'e2e' label to the PR to run the full test suite before merging."
-            exit 1
-          fi
-
-          # 4. Suite was expected to run — the run-scoped binary and all gating
+          # 3. Suite was expected to run — the run-scoped binary and all gating
           #    test jobs must have succeeded.
           if [ "${{ needs.build_api_binary.result }}" == "success" ] && \
              [ "${{ needs.api_integration_tests.result }}" == "success" ] && \
@@ -629,7 +591,7 @@ jobs:
   report_to_openobserve:
     name: Report run metrics to OpenObserve
     needs: [check_changes, api_integration_tests, api_query_agent_tests, api_regression_tests]
-    if: always()
+    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,43 @@
+name: CI gate
+
+# Required check on main: pending without the e2e label, so an untested PR cannot be queued.
+# A status is needed because skipped jobs count as passing for required checks.
+on:
+  # pull_request_target so fork PRs get a status too; no checkout, so nothing untrusted runs.
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  # The queue commit must carry every required check; the gate is already passed by then.
+  merge_group:
+
+permissions:
+  statuses: write
+
+concurrency:
+  group: ci-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          LABELED: ${{ github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$LABELED" = "true" ]; then
+            STATE=success; DESC="e2e label present; CI runs on every push"
+          else
+            STATE=pending; DESC="Add the e2e label to run CI. Required before this PR can be queued."
+          fi
+          gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
+            -f state="$STATE" -f context=ci-gate -f description="$DESC" -f target_url="$RUN_URL" \
+            --jq '"\(.context): \(.state)"'
+          # Forks cannot be built in o2-enterprise; report that required status as passed so the PR is not stuck.
+          if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+            gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
+              -f state=success -f context=ent-build-status-check -f description="fork PR: enterprise build not run" \
+              --jq '"\(.context): \(.state)"'
+          fi

--- a/.github/workflows/db-testing.yml
+++ b/.github/workflows/db-testing.yml
@@ -1,12 +1,15 @@
 name: Database Validation Tests
 
 on:
+  # Kept as the Rust cache writer on main: caches saved from merge-queue refs are never restored by PRs.
   push:
     branches:
       - "main"
   pull_request:
     branches:
       - "**"
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
 
 concurrency:
@@ -25,6 +28,8 @@ env:
 
 jobs:
   check_changes:
+    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
     name: check_changes
     runs-on: ubuntu-latest
     permissions:
@@ -32,6 +37,9 @@ jobs:
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
+      # Debounce: a push inside this window cancels the run (concurrency) before anything paid starts.
+      - if: github.event_name == 'pull_request'
+        run: sleep 60
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -39,9 +47,10 @@ jobs:
       - id: check
         run: |
           CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }} ${{ github.sha }})
-          if [ -z "$CHANGED" ]; then
+          # Same contract as playwright/api: other workflows' files are irrelevant, this file re-tests itself.
+          if [ -z "$CHANGED" ] || echo "$CHANGED" | grep -qE '^\.github/workflows/db-testing\.yml$'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
-          elif echo "$CHANGED" | grep -qvE '(\.md$|^docs/|^web/|^tests/ui-testing/|^tests/playwright-tests/)'; then
+          elif echo "$CHANGED" | grep -qvE '(\.md$|^docs/|^web/|^tests/ui-testing/|^tests/playwright-tests/|\.(png|jpe?g|gif|svg|webp)$|^\.github/workflows/)'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -220,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [check_changes, db_validation_tests]
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
     steps:
       - name: Check test results
         run: |

--- a/.github/workflows/dispatch-event-enterprise.yml
+++ b/.github/workflows/dispatch-event-enterprise.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - "**"
+    # Fires once per PR when "Merge when ready" is clicked, then only for pushes while auto-merge stays on.
+    types: [auto_merge_enabled, synchronize, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -14,11 +16,15 @@ env:
 
 jobs:
   initiate_enterprise_build:
-    if: ${{ github.event.pull_request.head.repo.fork == false }} # Only run for PRs which are not from forks
+    # A pre-merge gate: runs once auto-merge is enabled on a labelled PR, not on every push.
+    if: ${{ github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.auto_merge != null }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
+      # Debounce: a push inside this window cancels the run (concurrency) before anything paid starts.
+      - if: github.event_name == 'pull_request'
+        run: sleep 60
       - name: Generate token
         id: generate_token
         uses: actions/create-github-app-token@v3.2.0

--- a/.github/workflows/ent-e2e-gate.yml
+++ b/.github/workflows/ent-e2e-gate.yml
@@ -10,8 +10,7 @@ name: Playwright E2E Crosscheck
 # Behaviour (A+A+C design):
 #   - PR does NOT touch web/** or tests/ui-testing/**            → pass instantly (never blocks).
 #   - Touches them + `skip-ent-e2e` label                       → pass (explicit, auditable opt-out).
-#   - Touches them + NO `e2e` label                             → FAIL "add the e2e label" (blocks; no silent miss).
-#   - Touches them + `e2e` label:
+#   - Touches them (the e2e label gates the whole job, like every paid workflow):
 #       · open sister ENT PR (same-named branch) → DEFER to that PR's checks (link it, don't build here)
 #       · sister ENT branch only (no PR)          → build the enterprise binary against that branch
 #       · no ENT counterpart                      → build against ENT main
@@ -30,8 +29,8 @@ name: Playwright E2E Crosscheck
 
 on:
   pull_request:
-    # labeled/unlabeled so adding `e2e`/`skip-ent-e2e` re-fires and re-evaluates the gate.
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    # Fires once per PR when "Merge when ready" is clicked, then for pushes/labels while auto-merge stays on.
+    types: [auto_merge_enabled, synchronize, labeled, unlabeled]
 
 # PR-scoped: a new push/label supersedes the previous gate attempt for the same PR.
 concurrency:
@@ -44,6 +43,8 @@ permissions:
 
 jobs:
   playwright-e2e-crosscheck:
+    # A pre-merge gate: runs once auto-merge is enabled on a labelled PR, not on every push.
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.auto_merge != null }}
     name: Playwright E2E Crosscheck
     runs-on: ubuntu-latest
     # ~5 min to find the ENT run + up to ~75 min to poll. Generous on purpose: normal is ~20 min,
@@ -51,12 +52,11 @@ jobs:
     # the gate ("timed out") while ENT is still legitimately running.
     timeout-minutes: 90
     steps:
-      - name: Triage — relevant paths? which label?
+      - name: Triage — relevant paths? opted out?
         id: triage
         env:
           GH_TOKEN: ${{ github.token }}          # OSS is same-repo/public → default token can read PR files
           PR: ${{ github.event.pull_request.number }}
-          HAS_E2E: ${{ contains(github.event.pull_request.labels.*.name, 'e2e') }}
           HAS_SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-ent-e2e') }}
           DISABLED: ${{ vars.ENT_E2E_GATE_DISABLED }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
@@ -88,8 +88,6 @@ jobs:
           elif [ "$HAS_SKIP" = "true" ]; then
             echo "::warning::PR carries 'skip-ent-e2e' — enterprise gate explicitly opted out (auditable)."
             echo "mode=skip" >> "$GITHUB_OUTPUT"
-          elif [ "$HAS_E2E" != "true" ]; then
-            echo "mode=need-label" >> "$GITHUB_OUTPUT"
           else
             echo "mode=run" >> "$GITHUB_OUTPUT"
           fi
@@ -97,13 +95,6 @@ jobs:
       - name: Pass — no enterprise-relevant changes (or opted out / disabled)
         if: steps.triage.outputs.mode == 'pass' || steps.triage.outputs.mode == 'skip'
         run: echo "✅ Playwright E2E Crosscheck not required for this PR."
-
-      - name: Block — enterprise-relevant change without the e2e label
-        if: steps.triage.outputs.mode == 'need-label'
-        run: |
-          echo "::error::This PR changes web/** or tests/ui-testing/**, which can break enterprise-only e2e specs."
-          echo "::error::Add the 'e2e' label to run the enterprise gate (or 'skip-ent-e2e' to explicitly opt out)."
-          exit 1
 
       - name: Run — dispatch ENT engine, poll, mirror result
         if: steps.triage.outputs.mode == 'run'

--- a/.github/workflows/js-license-checker.yml
+++ b/.github/workflows/js-license-checker.yml
@@ -1,16 +1,11 @@
 name: "JS Licenses checker"
 
 on:
-  push:
-    branches:
-      - "main"
-    # paths-ignore:
-    #   - "**.md"
-    #   - "**.yml"
-    #   - "**.yaml"
   pull_request:
     branches:
       - "**"
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
+    types: [opened, reopened, synchronize, labeled, unlabeled]
     # paths-ignore:
     #   - "**.md"
     #   - "**.yml"
@@ -26,6 +21,8 @@ concurrency:
 
 jobs:
   js-license-check:
+    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
     runs-on: ubicloud-standard-4
     timeout-minutes: 10
     steps:

--- a/.github/workflows/mobile-sdk-e2e.yml
+++ b/.github/workflows/mobile-sdk-e2e.yml
@@ -107,6 +107,8 @@ jobs:
   # Self-contained model → no secrets to check.
   # -------------------------------------------------------------------------------------------
   preflight:
+    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
     name: Preflight & readiness
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -819,7 +821,7 @@ jobs:
   merge_reports:
     name: Merge Reports
     needs: [android, ios]
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,9 +8,9 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing the 'e2e' label re-fires the run and
-    # re-evaluates the gate in playwright_summary.
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
+    # auto_merge_enabled: the one full-matrix run per PR, at merge time (see generate_matrix).
+    types: [opened, reopened, synchronize, labeled, unlabeled, auto_merge_enabled]
   merge_group:
 
 concurrency:
@@ -70,6 +70,8 @@ env:
 
 jobs:
   check_changes:
+    # Runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests only (see docs/ci).
+    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e')) }}
     timeout-minutes: 5
     name: check_changes
     runs-on: ubuntu-latest
@@ -78,6 +80,9 @@ jobs:
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
+      # Debounce: a push inside this window cancels the run (concurrency) before anything paid starts.
+      - if: github.event_name == 'pull_request'
+        run: sleep 60
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -108,14 +113,7 @@ jobs:
     timeout-minutes: 45
     name: build_binary
     needs: [check_changes]
-    # Run when there are e2e-relevant changes AND either this is not a pull_request
-    # (push to main / merge_group always run) or the PR carries the 'e2e' label.
-    if: >-
-      (github.event_name == 'pull_request' &&
-       (contains(github.event.pull_request.labels.*.name, 'e2e') ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-full'))) ||
-      (github.event_name != 'pull_request' &&
-       needs.check_changes.outputs.has_changes == 'true')
+    if: needs.check_changes.outputs.has_changes == 'true'
     runs-on:
       labels: ubicloud-standard-16
     permissions:
@@ -205,12 +203,7 @@ jobs:
     timeout-minutes: 5
     name: generate_matrix
     needs: [check_changes]
-    if: >-
-      (github.event_name == 'pull_request' &&
-       (contains(github.event.pull_request.labels.*.name, 'e2e') ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-full'))) ||
-      (github.event_name != 'pull_request' &&
-       needs.check_changes.outputs.has_changes == 'true')
+    if: needs.check_changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -227,12 +220,12 @@ jobs:
         run: node --test .github/scripts/build-ci-matrix.test.js
       - id: gen
         env:
-          # Smoke selection runs only on PRs; merge_group ALWAYS gets the full matrix, so
-          # everything that merges is still covered by all shards. Escape hatches: the
-          # 'e2e-full' PR label forces the full matrix for one PR; the PW_SMOKE_DISABLED
-          # repo variable ('true') turns smoke off everywhere without a code change.
+          # Smoke selection runs on PR pushes; the merge queue no longer runs Playwright, so the
+          # full matrix runs once per PR when auto-merge is enabled ("Merge when ready").
+          # Escape hatches: the 'e2e-full' PR label forces the full matrix on every push; the
+          # PW_SMOKE_DISABLED repo variable ('true') turns smoke off everywhere without a code change.
           IS_PR: ${{ github.event_name == 'pull_request' }}
-          HAS_FULL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'e2e-full') }}
+          HAS_FULL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'e2e-full') || github.event.pull_request.auto_merge != null }}
           SMOKE_DISABLED: ${{ vars.PW_SMOKE_DISABLED }}
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -842,7 +835,7 @@ jobs:
         build_binary,
         ui_integration_tests,
       ]
-    if: always()
+    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
     steps:
       - name: Check test results
         run: |
@@ -853,28 +846,13 @@ jobs:
             exit 1
           fi
 
-          # 2. On a pull_request WITHOUT the 'e2e' label the suite did not run: block (fail)
-          #    when the change is Playwright-relevant so the author opts in, else bypass (pass).
-          #    Adding the 'e2e' label always runs the suite (see build_binary's if).
-          if [ "${{ github.event_name }}" == "pull_request" ] && \
-             [ "${{ contains(github.event.pull_request.labels.*.name, 'e2e') || contains(github.event.pull_request.labels.*.name, 'e2e-full') }}" != "true" ]; then
-            if [ "${{ needs.check_changes.outputs.has_changes }}" == "true" ]; then
-              echo "::error::This PR changes Playwright-relevant files but has no 'e2e' label, so the suite did not run."
-              echo "::error::Add the 'e2e' label to the PR to run the full Playwright suite before merging."
-              exit 1
-            fi
-            echo "✅ No Playwright-relevant changes and no 'e2e' label — suite not required for this PR."
-            exit 0
-          fi
-
-          # 3. Non-PR event (push / merge queue) with nothing relevant → nothing ran → allow.
-          if [ "${{ github.event_name }}" != "pull_request" ] && \
-             [ "${{ needs.check_changes.outputs.has_changes }}" != "true" ]; then
+          # 2. Nothing Playwright-relevant changed → nothing ran → allow.
+          if [ "${{ needs.check_changes.outputs.has_changes }}" != "true" ]; then
             echo "✅ No Playwright-relevant changes — suite not required."
             exit 0
           fi
 
-          # 4. Suite was expected to run — pass only if build + tests actually succeeded.
+          # 3. Suite was expected to run — pass only if build + tests actually succeeded.
           if [ "${{ needs.build_binary.result }}" == "success" ] && \
              [ "${{ needs.ui_integration_tests.result }}" == "success" ]; then
             echo "All Playwright tests completed successfully"

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -2,9 +2,8 @@ name: Playwright Regression Tests
 
 on:
   schedule:
-    # Daytime IST only (9 AM, 1 PM, 5 PM, 9 PM IST) — the 1 AM and 5 AM IST slots were
-    # dropped: main rarely moves overnight, so those runs mostly re-tested unchanged code.
-    - cron: '30 3,7,11,15 * * *'  # 9 AM, 1 PM, 5 PM, 9 PM IST (3:30, 7:30, 11:30, 15:30 UTC)
+    # Once a day, after the previous day's merges and before either team starts (08:00 Beijing, 05:30 IST).
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -181,8 +180,11 @@ jobs:
       - uses: actions/checkout@v5
       - id: gen
         run: |
-          MATRIX=$(node .github/scripts/build-ci-matrix.js tests/ui-testing/ci-matrix/ci_matrix_regression.json)
-          if [ -z "$MATRIX" ]; then echo "::error::matrix generation failed (build-ci-matrix produced no output)"; exit 1; fi
+          # The queue no longer runs Playwright, so this daily run covers the full CI matrix plus the RegressionSet.
+          CI=$(node .github/scripts/build-ci-matrix.js tests/ui-testing/ci-matrix/ci_matrix.json)
+          RG=$(node .github/scripts/build-ci-matrix.js tests/ui-testing/ci-matrix/ci_matrix_regression.json)
+          if [ -z "$CI" ] || [ -z "$RG" ]; then echo "::error::matrix generation failed (build-ci-matrix produced no output)"; exit 1; fi
+          MATRIX=$(node -e 'const [a,b]=process.argv.slice(1).map(JSON.parse); console.log(JSON.stringify({include:[...a.include,...b.include]}))' "$CI" "$RG")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "$MATRIX" | node -e "const m=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log('generated',m.include.length,'shards:', m.include.map(s=>s.testfolder).join(', '))"
 
@@ -317,8 +319,13 @@ jobs:
               FILE_PATHS="$FILE_PATHS $FILE_PATH"
             done
 
-            echo "DEBUG: Final command: npx playwright test $FILE_PATHS"
-            npx playwright test $FILE_PATHS
+            # Per-shard worker pin from the matrix, same contract as playwright.yml.
+            WORKERS_ARG=""
+            if [ -n "${{ matrix.workers }}" ]; then
+              WORKERS_ARG="--workers=${{ matrix.workers }}"
+            fi
+            echo "DEBUG: Final command: npx playwright test $FILE_PATHS $WORKERS_ARG"
+            npx playwright test $FILE_PATHS $WORKERS_ARG
           else
             echo "No files specified to run for ${{ matrix.testfolder }} folder"
           fi
@@ -702,4 +709,47 @@ jobs:
             echo "  ui_integration_tests: ${{ needs.ui_integration_tests.result }}"
             echo "  merge_reports: ${{ needs.merge_reports.result }}"
             exit 1
+          fi
+
+  # GitHub emails assignees and @-mentioned users, so a tracking issue is the notification:
+  # one open issue per breakage, a comment per further failing day, closed by the next green run.
+  report_result:
+    name: Report result
+    needs: [ui_integration_tests, playwright_summary]
+    if: ${{ always() && needs.ui_integration_tests.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      LABEL: ci-regression-failure
+      NOTIFY: hengfeiyang,oasisk,Shrinath-O2
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      RESULT: ${{ needs.playwright_summary.result }}
+    steps:
+      - name: Open or update the failure issue, or close it on green
+        run: |
+          OPEN=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // ""')
+          if [ "$RESULT" = "success" ]; then
+            if [ -n "$OPEN" ]; then
+              gh issue close "$OPEN" --comment "Regression is green again on main (${{ github.sha }}): $RUN_URL"
+            fi
+            exit 0
+          fi
+          FAILED=$(gh api --paginate "repos/$GH_REPO/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
+            --jq '[.jobs[] | select(.name | startswith("e2e /")) | select(.conclusion == "failure" or .conclusion == "timed_out") | .name] | join(", ")')
+          MENTIONS=$(echo "$NOTIFY" | sed 's/[^,]*/@&/g; s/,/ /g')
+          BODY="Playwright regression failed on main at ${{ github.sha }}.
+          Failed shards: ${FAILED:-none listed (build or report merge failed)}
+          Run: $RUN_URL
+
+          $MENTIONS"
+          if [ -n "$OPEN" ]; then
+            gh issue comment "$OPEN" --body "$BODY"
+          else
+            gh label create "$LABEL" --color B60205 --description "Daily Playwright regression on main is failing" 2>/dev/null || true
+            gh issue create --title "Playwright regression failing on main" --label "$LABEL" --assignee "$NOTIFY" --body "$BODY"
           fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,12 +1,15 @@
 name: Unit tests
 
 on:
+  # Kept as the Rust cache writer on main: caches saved from merge-queue refs are never restored by PRs.
   push:
     branches:
       - "main"
   pull_request:
     branches:
       - "**"
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
 
 concurrency:
@@ -21,6 +24,8 @@ env:
 
 jobs:
   check_changes:
+    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
     name: check_changes
     runs-on: ubuntu-latest
     permissions:
@@ -29,6 +34,9 @@ jobs:
       has_backend_changes: ${{ steps.check.outputs.has_backend_changes }}
       has_ui_changes: ${{ steps.check.outputs.has_ui_changes }}
     steps:
+      # Debounce: a push inside this window cancels the run (concurrency) before anything paid starts.
+      - if: github.event_name == 'pull_request'
+        run: sleep 60
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -298,7 +306,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [check_changes, backend_unit_tests, ui_unit_tests, ui_code_quality]
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
     steps:
       - name: Check test results
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,11 @@ reworded:
 
 ## PR conventions
 
+- Paid CI runs on a PR only while it carries the `e2e` label (no label = no
+  builds or test suites, and no red checks). Add it when you want the run, not
+  when you open the PR. Which suites run is decided by path detection, never by
+  a label. The merge queue only compiles and unit-tests the merged code, so the
+  labelled PR run is the one that has to be green.
 - PR titles starting with `feat:` require `Design at: #xxx` as the FIRST line
   of the description (enforced by `.github/workflows/feat-design-checker.yml`);
   `fix:`/`chore:`/`test:` PRs skip the check.


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/infrastructure/CI/e2e-gate-design.md

## What changes

Paid CI runs on a PR only while it carries the `e2e` label. Without the label every paid job is **skipped**, never red. Which suites run is still decided by path detection, never by a label.

- **Gate expression** on the root `check_changes` job (and the `always()` summaries) of every paid workflow: Playwright, API, unit tests, DB validation, JS license, enterprise dispatch, enterprise e2e gate, mobile SDK, AI review.
- **60 s free debounce** before any paid work on `pull_request` events, so back-to-back pushes cancel a run that has not started anything.
- **`ci-gate.yml` (new)** posts a `ci-gate` commit status: pending without the label, success with it, success on merge-queue commits. Once required, an unlabelled PR cannot enter the merge queue (skipped checks count as passing on their own). Also reports `ent-build-status-check` as passed for fork PRs, which cannot be built in o2-enterprise.
- **Merge queue runs unit tests and DB validation only.** Playwright and API skip on `merge_group`. In 15 days every queue failure was a flaky shard or a cascade from one; the queue spent 546 runner hours on these two suites and caught nothing. Instead, enabling auto-merge ("Merge when ready") triggers the one full-matrix Playwright run per PR (pushes before that get the changed-path smoke subset from #14107); the PR cannot be queued until it passes.
- **Enterprise checks once per PR.** `initiate_enterprise_build` and `Playwright E2E Crosscheck` fire on `auto_merge_enabled` (and pushes while auto-merge stays on) instead of on every push: about 200 enterprise dispatches per 15 days instead of 1,300.
- **Daily Playwright run on main** (`playwright_regression.yml`): once a day at 00:00 UTC instead of four times, full CI matrix plus the RegressionSet, and a failure opens an issue labelled `ci-regression-failure` assigned to @hengfeiyang @oasisk @Shrinath-O2 (closed automatically by the next green run).
- `push: main` rerun of JS license dropped. Unit tests and DB validation keep theirs for now: they are the Rust cache writers on a ref that PR runs can restore from (merge-queue refs are not).
- CLAUDE.md states the one-sentence rule. CONTRIBUTING.md is untouched: external PRs run only after a maintainer approves them, and the label is ours to add.

Nothing changes for dependabot (auto-labelled `e2e`), `skip-ent-e2e` or `mobile-e2e`. Open PRs that already carry `e2e` keep working.

## After merge (admin)

1. Confirm the `ci-gate` status appears on one or two new PRs.
2. Add the gate and the two enterprise checks to main's required status checks:
   `gh api -X POST repos/openobserve/openobserve/branches/main/protection/required_status_checks/contexts --input - <<< '["ci-gate", "ent-build-status-check", "Playwright E2E Crosscheck"]'`
3. Dispatch **Playwright Regression Tests** once by hand to confirm the combined matrix and the issue path.
4. Paired o2-enterprise PR on the same branch name (its own PR CI still uses the old `e2e` semantics).

## Verification

Workflow YAML validated locally; the gate expressions, the `auto_merge_enabled` trigger and the issue-reporting job have not run in CI yet. The first PR through the new flow should be watched: label added → runs start after 60 s; "Merge when ready" → full Playwright + enterprise checks → queue → unit tests only.

Data and rationale, including the alternatives that were rejected (draft-based gating, forced draft, renaming the label now, dropping the merge queue), are in the design doc.


