### PR TITLE
fix: register experiment row sort OpenAPI schema

### DIFF
--- a/src/api/http/src/handler/http/router/openapi.rs
+++ b/src/api/http/src/handler/http/router/openapi.rs
@@ -571,6 +571,9 @@ pub struct ApiDoc;
     openobserve_api_management::request::remote_tasks::end_remote_task_signing_grace,
     openobserve_api_management::request::remote_tasks::revoke_remote_task_signing_secret,
 ))]
+#[openapi(components(schemas(
+    openobserve_api_management::models::experiments::ExperimentResultRowSortBody,
+)))]
 struct EnterpriseExperimentApiDoc;
 
 pub struct SecurityAddon;


### PR DESCRIPTION
Register `ExperimentResultRowSortBody` in the enterprise OpenAPI schemas so the `sort` query parameter on `GET /api/{org_id}/experiments/{experiment_id}/rows` resolves correctly. This fixes the deterministic Enterprise API fuzz failure reported in [the follow-up comment on #14114](https://github.com/openobserve/openobserve/pull/14114#issuecomment-5511271138).

Validation:
- `cargo fmt --all` and `git diff --check` passed.
- A focused Utoipa 5.5.0 reproduction using the repository's enum, query parameters, and OpenAPI declaration failed with the unresolved reference before the fix and passed afterward, including the `dataset` and `dispersion_desc` values.
- Enterprise `cargo check --all-targets` passed using `o2-enterprise` main at `fb1dbec8` and its `Cargo.toml.openobserve`; the manifest and lockfile were restored afterward.
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` stopped on an existing enterprise lint in `src/core/src/ofga/mod.rs:46`: `init` has cognitive complexity 149 against a limit of 100. That file is unchanged from the base.
