### PR TITLE
fix(migration): refuse to start when the db schema is newer than the build

### DIFF
--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -66,6 +66,7 @@ pub async fn init_db() -> std::result::Result<(), anyhow::Error> {
         log::info!("DB_SCHEMA_VERSION match, skipping db upgrade");
         return Ok(());
     }
+    check_schema_not_newer(db_schema_version, DB_SCHEMA_VERSION)?;
     log::info!(
         "DB_SCHEMA_VERSION mismatch : expected {}, found {db_schema_version}; running db upgrade",
         DB_SCHEMA_VERSION
@@ -105,4 +106,45 @@ pub async fn init_db() -> std::result::Result<(), anyhow::Error> {
     log::info!("DB upgrade completed to version {}", DB_SCHEMA_VERSION);
 
     Ok(())
+}
+
+/// The migrator only moves forward: a newer database carries migrations this build lacks.
+fn check_schema_not_newer(db_version: u64, build_version: u64) -> Result<(), anyhow::Error> {
+    if db_version <= build_version {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "db schema version {db_version} is newer than the {build_version} this build supports: \
+         the database has already been through a newer OpenObserve and its schema cannot be \
+         downgraded. Go back to the version you were running before, or restore a backup taken \
+         from before that upgrade. Do not edit the stored version by hand: the schema itself is \
+         still {db_version}, so lowering the number only hides the mismatch."
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matching_and_older_schemas_are_upgradable() {
+        assert!(check_schema_not_newer(0, 78).is_ok(), "fresh install");
+        assert!(check_schema_not_newer(77, 78).is_ok(), "one behind");
+        assert!(check_schema_not_newer(78, 78).is_ok(), "same version");
+    }
+
+    #[test]
+    fn newer_schema_is_rejected_with_both_versions_named() {
+        let err = check_schema_not_newer(35, 32)
+            .expect_err("a database newer than the build must not be migrated")
+            .to_string();
+        assert!(err.contains("35") && err.contains("32"), "got: {err}");
+        assert!(err.contains("cannot be"), "got: {err}");
+    }
+
+    #[test]
+    fn rejection_starts_one_version_above_the_build() {
+        assert!(check_schema_not_newer(78, 78).is_ok());
+        assert!(check_schema_not_newer(79, 78).is_err());
+    }
 }


### PR DESCRIPTION
Fixes #11099

### The failure

`init_db` compared the stored schema version against the build's for equality only:

```rust
if db_schema_version == DB_SCHEMA_VERSION { ... return Ok(()); }
// any other value, higher or lower, falls through to "running db upgrade"
```

So a database written by a *newer* OpenObserve takes the upgrade path. The migrator only moves forward — it finds migrations recorded as applied whose files this build doesn't carry, and dies with:

```
DB_SCHEMA_VERSION mismatch : expected 32, found 35; running db upgrade
db init failed: Custom Error: Migration file of version
'm20260310_000001_create_anomaly_detection_config_table' is missing,
this migration has been applied but its file is missing
```

Nothing there tells an operator that they are running an older build against a newer database.

Operators reach this by running the `latest` tag, which upgrades the schema, then pinning back to an older image. It has come up three times — #7029, a downgrade thread on #9829, and #11099, where five people hit the same restart loop. Each was answered by pointing at a newer release rather than by making the failure legible, and users had begun hand-editing the stored version, which only desynchronises the number from the schema it describes.

### The change

A three-way decision instead of two: equal → skip, newer → refuse, older → upgrade. This mirrors the existing guard a few lines above, which also refuses rather than guessing when the version can't be read.

Placement matters. It runs before `dist_lock` and `db_init`, so nothing is attempted against a database this build cannot migrate. It also sits ahead of `set_db_schema_version`, which writes this build's constant unconditionally — a migration that did somehow succeed would have recorded `32` over a schema that is really `35`.

The message names both versions, says the schema cannot be downgraded, points at the version they came from, and warns against the hand-edit.

### Scope

**Downgrading stays unsupported** — this doesn't try to enable it. It replaces an unreadable failure with an actionable one, which is what the existing guidance on those issues already said.

Two things worth a maintainer's eye:

- **No rolling-upgrade regression.** `init_db` isn't role-gated, so old nodes restarting mid-upgrade do reach this. They already hard-fail there today via the missing-migration error; this makes the death immediate and legible. I checked all 14 consecutive bumps (63→78) and every one shipped at least one migration file, so "version bumped without migrations", where an old build might have started by luck, does not occur in practice.
- `o2 upgrade-db` / `init-db` now also fail fast against a newer database, rather than attempting the migration.

### Testing

Three unit tests on the comparison: fresh install and older versions pass, equal passes, and rejection starts exactly one version above the build. They take the build version as an argument rather than reading `DB_SCHEMA_VERSION`, so they don't rot on the next bump.

`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets` with the CI flags exits 0.