### PR TITLE
test: deflake ingestion-token toggle (follow-up to #14124)

### DIFF
--- a/tests/ui-testing/pages/iamPages/ingestionTokensPage.js
+++ b/tests/ui-testing/pages/iamPages/ingestionTokensPage.js
@@ -123,10 +123,12 @@ export class IngestionTokensPage {
     // ----- toggle -----
 
     async toggleToken(name) {
-        // Table client-paginates at 20/page; filter to the unique name so the target row is on page 1 before we click.
-        await this.searchInput.fill(name);
         const toggle = this.tokenToggleByName(name);
-        await toggle.waitFor({ state: 'visible', timeout: 10000 });
+        // Token list loads async after reload and is client-paginated (20/page); re-apply the name filter until the row surfaces so a slow list load or search re-mount can't leave the toggle off-page.
+        await expect.poll(async () => {
+            await this.searchInput.fill(name);
+            return await toggle.isVisible().catch(() => false);
+        }, { timeout: 20000, intervals: [500, 1000, 1500, 2000, 3000] }).toBe(true);
         await toggle.click();
     }
 


### PR DESCRIPTION
Follow-up to #14124. The one-shot search filter in `toggleToken` was insufficient — CI Run showed a first-try flake: after `page.reload()` the token list loads async and the search toolbar re-mounts, so a single `searchInput.fill` gets dropped and the client-paginated (20/page) row stays off-page (`TimeoutError` waiting for the toggle at `ingestionTokensPage.js:129`).

Fix: re-apply the name filter inside an `expect.poll` until the row surfaces (20s; non-masking — fails loudly if the row never appears). Method per #14025.