### PR TITLE
ci: report both enterprise gates on merge-queue commits

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -35,9 +35,10 @@ jobs:
           gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
             -f state="$STATE" -f context=ci-gate -f description="$DESC" -f target_url="$RUN_URL" \
             --jq '"\(.context): \(.state)"'
-          # Forks cannot be built in o2-enterprise; report that required status as passed so the PR is not stuck.
-          if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+          # o2-enterprise posts ent-build-status-check on PR heads only; a queue commit never gets one, and
+          # a fork PR cannot be built there. Report it as passed in both cases so a required check cannot deadlock the queue.
+          if [ "${{ github.event_name }}" = "merge_group" ] || [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
             gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
-              -f state=success -f context=ent-build-status-check -f description="fork PR: enterprise build not run" \
+              -f state=success -f context=ent-build-status-check -f description="gate passed on the PR head; not re-run on this commit" \
               --jq '"\(.context): \(.state)"'
           fi

--- a/.github/workflows/ent-e2e-gate.yml
+++ b/.github/workflows/ent-e2e-gate.yml
@@ -31,10 +31,12 @@ on:
   pull_request:
     # Fires once per PR when "Merge when ready" is clicked, then for pushes/labels while auto-merge stays on.
     types: [auto_merge_enabled, synchronize, labeled, unlabeled]
+  # A required check must also report on merge-queue commits; the gate already passed on the PR head.
+  merge_group:
 
 # PR-scoped: a new push/label supersedes the previous gate attempt for the same PR.
 concurrency:
-  group: playwright-e2e-crosscheck-${{ github.event.pull_request.number }}
+  group: playwright-e2e-crosscheck-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -44,7 +46,7 @@ permissions:
 jobs:
   playwright-e2e-crosscheck:
     # A pre-merge gate: runs once auto-merge is enabled on a labelled PR, not on every push.
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.auto_merge != null }}
+    if: ${{ github.event_name == 'merge_group' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.auto_merge != null) }}
     name: Playwright E2E Crosscheck
     runs-on: ubuntu-latest
     # ~5 min to find the ENT run + up to ~75 min to poll. Generous on purpose: normal is ~20 min,
@@ -62,6 +64,10 @@ jobs:
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           set -euo pipefail
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "::notice::merge queue commit — gate already passed on the PR head."
+            echo "mode=pass" >> "$GITHUB_OUTPUT"; exit 0
+          fi
           if [ "$DISABLED" = "true" ]; then
             echo "::notice::ENT_E2E_GATE_DISABLED=true — passing without dispatch."
             echo "mode=pass" >> "$GITHUB_OUTPUT"; exit 0


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/infrastructure/CI/e2e-gate-design.md

Follow-up to #14126.

## Why

A required check that never reports on a merge_group commit deadlocks the merge queue: every entry waits out the 2-hour check timeout, is dequeued with `CI_TIMEOUT`, gets re-queued by the auto-requeue bot, and rebuilds every entry behind it. That is what happened yesterday between 15:00 and 00:10 UTC after `ent-build-status-check` and `Playwright E2E Crosscheck` were added to the required checks: four PRs cycled through the queue for nine hours with every Playwright run green, and nothing merged until the two checks were removed again.

- `ent-build-status-check` is a commit status that o2-enterprise posts on the PR head only.
- `Playwright E2E Crosscheck` only triggered on `pull_request`.

## What changes

- `ci-gate.yml` posts `ent-build-status-check = success` on merge_group commits, the same path it already uses for fork PRs. The gate ran on the PR head when "Merge when ready" was clicked; the queue commit inherits that result.
- `ent-e2e-gate.yml` also triggers on `merge_group` and passes immediately for it. Its once-per-PR behaviour on the PR (auto-merge enabled + `e2e` label) is unchanged.

## After merge (admin)

Add the two gates to main's required checks. With this change both report on queue commits, so the queue cannot deadlock on them:

```
gh api -X POST repos/openobserve/openobserve/branches/main/protection/required_status_checks/contexts --input - <<< '["ent-build-status-check", "Playwright E2E Crosscheck"]'
```

Rule going forward: anything made a required check must report on `merge_group` commits as well as on PR heads.
