### PR TITLE
ci: authenticate github.com fetches during builds

### DIFF
--- a/.github/actions/github-auth/action.yml
+++ b/.github/actions/github-auth/action.yml
@@ -1,0 +1,20 @@
+name: GitHub auth for git and cargo
+description: Authenticate every github.com fetch in this job (git clone, cargo git dependencies) so shared-IP anonymous rate limits do not apply
+inputs:
+  token:
+    description: Token with read access to the repositories fetched during the build
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.token }}
+      run: |
+        # A credential helper is consulted only when GitHub answers 401, so it never conflicts with the
+        # header actions/checkout keeps for the checked-out repository.
+        echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+        git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+        echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+        # cargo's libgit2 path does not always consult the helper; the git CLI always does.
+        echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/audit-checker.yml
+++ b/.github/workflows/audit-checker.yml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/github-auth
       - uses: taiki-e/install-action@v2.87.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: cargo-audit
       - name: run cargo audit

--- a/.github/workflows/build-fork-pr-image.yml
+++ b/.github/workflows/build-fork-pr-image.yml
@@ -48,7 +48,17 @@ jobs:
           # fetch-depth: 0
           # fetch-tags: true
 
-      - uses: ./.github/actions/github-auth
+      # Inlined rather than `uses: ./.github/actions/github-auth`: this job checks out a caller-chosen
+      # ref, and running a local action from that checkout is a cache-poisoning vector (CodeQL).
+      - name: Authenticate github.com fetches
+        shell: bash
+        env:
+          TOKEN: ${{ github.token }}
+        run: |
+          echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+          git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+          echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Set GIT_TAG env
         run: |
           git fetch -f --tags

--- a/.github/workflows/build-fork-pr-image.yml
+++ b/.github/workflows/build-fork-pr-image.yml
@@ -48,6 +48,7 @@ jobs:
           # fetch-depth: 0
           # fetch-tags: true
 
+      - uses: ./.github/actions/github-auth
       - name: Set GIT_TAG env
         run: |
           git fetch -f --tags

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -34,7 +34,17 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: ./.github/actions/github-auth
+      # Inlined rather than `uses: ./.github/actions/github-auth`: this job checks out a caller-chosen
+      # ref, and running a local action from that checkout is a cache-poisoning vector (CodeQL).
+      - name: Authenticate github.com fetches
+        shell: bash
+        env:
+          TOKEN: ${{ github.token }}
+        run: |
+          echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+          git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+          echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Set GIT_TAG env
         id: set-git-tag
         run: |
@@ -104,7 +114,17 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: ./.github/actions/github-auth
+      # Inlined rather than `uses: ./.github/actions/github-auth`: this job checks out a caller-chosen
+      # ref, and running a local action from that checkout is a cache-poisoning vector (CodeQL).
+      - name: Authenticate github.com fetches
+        shell: bash
+        env:
+          TOKEN: ${{ github.token }}
+        run: |
+          echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+          git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+          echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -194,7 +214,17 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: ./.github/actions/github-auth
+      # Inlined rather than `uses: ./.github/actions/github-auth`: this job checks out a caller-chosen
+      # ref, and running a local action from that checkout is a cache-poisoning vector (CodeQL).
+      - name: Authenticate github.com fetches
+        shell: bash
+        env:
+          TOKEN: ${{ github.token }}
+        run: |
+          echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+          git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+          echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -34,6 +34,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - uses: ./.github/actions/github-auth
       - name: Set GIT_TAG env
         id: set-git-tag
         run: |
@@ -103,6 +104,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -192,6 +194,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/github-auth
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           # The command to run with cargo-deny

--- a/.github/workflows/db-testing.yml
+++ b/.github/workflows/db-testing.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/mobile-sdk-e2e.yml
+++ b/.github/workflows/mobile-sdk-e2e.yml
@@ -343,6 +343,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/github-auth
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -393,6 +394,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/github-auth
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -132,6 +132,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -116,6 +116,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Install Node
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -123,6 +124,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -130,6 +132,8 @@ jobs:
           targets: x86_64-unknown-linux-gnu
 
       - uses: taiki-e/install-action@v2.87.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: nextest,cargo-llvm-cov
 
@@ -184,6 +188,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -191,6 +196,8 @@ jobs:
           targets: x86_64-unknown-linux-gnu
 
       - uses: taiki-e/install-action@v2.87.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: nextest,cargo-llvm-cov
 
@@ -252,6 +259,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:

--- a/web/scripts/fetch-datasource-content.mjs
+++ b/web/scripts/fetch-datasource-content.mjs
@@ -48,6 +48,9 @@ const ATTEMPTS = STRICT ? 3 : 1;
 const TIMEOUT_MS =
   Number(process.env.DS_CONTENT_TIMEOUT_MS) || (STRICT ? 60_000 : 30_000);
 const GIT_OPTS = { stdio: "inherit", timeout: TIMEOUT_MS };
+const BACKOFF_MS = [2_000, 8_000, 30_000];
+const sleepMs = (ms) =>
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 
 // Validate the git inputs before they reach `git`. execFileSync already prevents
 // shell injection (no shell is spawned), but an attacker who can set these env
@@ -102,6 +105,8 @@ function cloneRepo() {
     } catch (e) {
       lastErr = e;
       log(`clone attempt ${attempt}/${ATTEMPTS} failed: ${e.message}`);
+      // Anonymous clones from shared CI egress IPs get throttled; a pause gives the limit time to clear.
+      if (attempt < ATTEMPTS) sleepMs(BACKOFF_MS[attempt - 1] ?? 30_000);
     }
   }
   throw lastErr;


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/infrastructure/CI/e2e-gate-design.md

## Why

Anonymous git and API requests are rate limited by GitHub per egress IP. Every ubicloud and eks runner shares its IP with all of our other jobs (and, on ubicloud, with other customers), so the more CI we run the more often anonymous fetches fail. Yesterday the web build's clone of `openobserve/o2-datasource` failed three times within one second on o2-enterprise#2543, twice in a row:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
```

The same anonymous path is used by the 43 Cargo git dependencies whenever the Rust cache is cold, and by `taiki-e/install-action`, which calls the GitHub API without a token unless given one. Retries do not fix a per-IP limit; authenticating does, because authenticated requests are metered per token.

## What changes

- **`.github/actions/github-auth`** (new composite action): installs a global git credential helper backed by the job's `GITHUB_TOKEN`. A helper is consulted only when GitHub answers 401, so it never conflicts with the `extraheader` that `actions/checkout` keeps for the checked-out repository. It also sets `CARGO_NET_GIT_FETCH_WITH_CLI=true` so cargo's git dependencies go through the same helper, and `GIT_TERMINAL_PROMPT=0`.
- Every job that runs cargo, protoc or the web build uses the action right after checkout: unit tests (4 jobs), API build, Playwright build, daily regression build, DB validation, PR image builds, fork PR image, release, mobile builds, cargo-deny, cargo-audit.
- `taiki-e/install-action` gets `GITHUB_TOKEN`.
- `web/scripts/fetch-datasource-content.mjs` backs off 2 s, 8 s, 30 s between clone attempts instead of retrying three times inside one second. Defence in depth; the helper is the fix.

`GITHUB_TOKEN` can read public repositories and the workflow's own repository, which covers everything fetched today. No new secret.

## Not in this PR

- Release-asset downloads (protoc, mailpit) stay anonymous; the asset CDN is not the endpoint that throttles. Can be switched to `gh release download` later.
- The datasource content is 79 MB and last changed on 2026-08-20. Vendoring the generated output into the repo, refreshed by a scheduled PR, would take this fetch off the build path entirely. Separate proposal.
- o2-enterprise needs the same action in its runtime build job (paired PR follows).

## Verification

Workflow YAML validated locally; the action has not run in CI yet. This PR carries `e2e`, so its own builds exercise the helper on the datasource clone and on the cargo git dependencies.
