### PR TITLE
ci: draft PRs run no paid CI, even with the e2e label

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -3,7 +3,7 @@ name: AI Code Review
 on:
   pull_request:
     # labeled/unlabeled so adding or removing 'e2e' starts or resets the review.
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, converted_to_draft]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -19,7 +19,7 @@ on:
 jobs:
   review:
     # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     # Explicit name: without it GitHub serializes the whole matrix object (api_key_env, marker) into the public check name.
     name: review (${{ matrix.provider.name }})
     runs-on: ubuntu-latest

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   merge_group:
 
 concurrency:
@@ -34,7 +34,7 @@ env:
 jobs:
   check_changes:
     # Runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests only (see docs/ci).
-    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e')) }}
+    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false)) }}
     name: check_changes
     runs-on: ubuntu-latest
     permissions:
@@ -558,7 +558,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [check_changes, build_api_binary, api_integration_tests, api_query_agent_tests, api_regression_tests]
-    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
     steps:
       - name: Check test results
         run: |
@@ -592,7 +592,7 @@ jobs:
   report_to_openobserve:
     name: Report run metrics to OpenObserve
     needs: [check_changes, api_integration_tests, api_query_agent_tests, api_regression_tests]
-    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -5,7 +5,7 @@ name: CI gate
 on:
   # pull_request_target so fork PRs get a status too; no checkout, so nothing untrusted runs.
   pull_request_target:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   # The queue commit must carry every required check; the gate is already passed by then.
   merge_group:
 
@@ -25,9 +25,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           LABELED: ${{ github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
+          DRAFT: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == true }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ "$LABELED" = "true" ]; then
+          if [ "$DRAFT" = "true" ]; then
+            STATE=pending; DESC="Draft PR: paid CI does not run until it is marked ready for review."
+          elif [ "$LABELED" = "true" ]; then
             STATE=success; DESC="e2e label present; CI runs on every push"
           else
             STATE=pending; DESC="Add the e2e label to run CI. Required before this PR can be queued."

--- a/.github/workflows/db-testing.yml
+++ b/.github/workflows/db-testing.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   merge_group:
 
 concurrency:
@@ -29,7 +29,7 @@ env:
 jobs:
   check_changes:
     # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     name: check_changes
     runs-on: ubuntu-latest
     permissions:
@@ -230,7 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [check_changes, db_validation_tests]
-    if: always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: always() && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
     steps:
       - name: Check test results
         run: |

--- a/.github/workflows/dispatch-event-enterprise.yml
+++ b/.github/workflows/dispatch-event-enterprise.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "**"
     # Fires once per PR when "Merge when ready" is clicked, then only for pushes while auto-merge stays on.
-    types: [auto_merge_enabled, synchronize, labeled]
+    types: [auto_merge_enabled, synchronize, labeled, ready_for_review, converted_to_draft]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -17,7 +17,7 @@ env:
 jobs:
   initiate_enterprise_build:
     # A pre-merge gate: runs once auto-merge is enabled on a labelled PR, not on every push.
-    if: ${{ github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.auto_merge != null }}
+    if: ${{ github.event.pull_request.head.repo.fork == false && (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) && github.event.pull_request.auto_merge != null }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/ent-e2e-gate.yml
+++ b/.github/workflows/ent-e2e-gate.yml
@@ -30,7 +30,7 @@ name: Playwright E2E Crosscheck
 on:
   pull_request:
     # Fires once per PR when "Merge when ready" is clicked, then for pushes/labels while auto-merge stays on.
-    types: [auto_merge_enabled, synchronize, labeled, unlabeled]
+    types: [auto_merge_enabled, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   # A required check must also report on merge-queue commits; the gate already passed on the PR head.
   merge_group:
 
@@ -46,7 +46,7 @@ permissions:
 jobs:
   playwright-e2e-crosscheck:
     # A pre-merge gate: runs once auto-merge is enabled on a labelled PR, not on every push.
-    if: ${{ github.event_name == 'merge_group' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.auto_merge != null) }}
+    if: ${{ github.event_name == 'merge_group' || ((contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) && github.event.pull_request.auto_merge != null) }}
     name: Playwright E2E Crosscheck
     runs-on: ubuntu-latest
     # ~5 min to find the ENT run + up to ~75 min to poll. Generous on purpose: normal is ~20 min,

--- a/.github/workflows/js-license-checker.yml
+++ b/.github/workflows/js-license-checker.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
     # paths-ignore:
     #   - "**.md"
     #   - "**.yml"
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   js-license-check:
     # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     runs-on: ubicloud-standard-4
     timeout-minutes: 10
     steps:

--- a/.github/workflows/mobile-sdk-e2e.yml
+++ b/.github/workflows/mobile-sdk-e2e.yml
@@ -54,7 +54,7 @@ on:
   pull_request:
     # `labeled` so adding the 'mobile-e2e' label re-fires the run and turns the device jobs on
     # (lets you validate the full Android + iOS suite on a PR before merging).
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize, labeled, ready_for_review, converted_to_draft]
     paths:
       - "tests/mobile-testing/**"
       - ".github/workflows/mobile-sdk-e2e.yml"
@@ -108,7 +108,7 @@ jobs:
   # -------------------------------------------------------------------------------------------
   preflight:
     # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     name: Preflight & readiness
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -823,7 +823,7 @@ jobs:
   merge_reports:
     name: Merge Reports
     needs: [android, ios]
-    if: always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: always() && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,9 +8,9 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
     # auto_merge_enabled: the one full-matrix run per PR, at merge time (see generate_matrix).
-    types: [opened, reopened, synchronize, labeled, unlabeled, auto_merge_enabled]
+    types: [opened, reopened, synchronize, labeled, unlabeled, auto_merge_enabled, ready_for_review, converted_to_draft]
   merge_group:
 
 concurrency:
@@ -71,7 +71,7 @@ env:
 jobs:
   check_changes:
     # Runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests only (see docs/ci).
-    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e')) }}
+    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false)) }}
     timeout-minutes: 5
     name: check_changes
     runs-on: ubuntu-latest
@@ -836,7 +836,7 @@ jobs:
         build_binary,
         ui_integration_tests,
       ]
-    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
     steps:
       - name: Check test results
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI.
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   merge_group:
 
 concurrency:
@@ -25,7 +25,7 @@ env:
 jobs:
   check_changes:
     # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     name: check_changes
     runs-on: ubuntu-latest
     permissions:
@@ -314,7 +314,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [check_changes, backend_unit_tests, ui_unit_tests, ui_code_quality]
-    if: always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e'))
+    if: always() && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
     steps:
       - name: Check test results
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,9 @@ reworded:
 
 ## PR conventions
 
-- Paid CI runs on a PR only while it carries the `e2e` label (no label = no
-  builds or test suites, and no red checks). Add it when you want the run, not
-  when you open the PR. Which suites run is decided by path detection, never by
+- Paid CI runs on a PR only while it carries the `e2e` label and is not a draft
+  (no label or draft = no builds or test suites, and no red checks). Add the
+  label when you want the run, not when you open the PR. Which suites run is decided by path detection, never by
   a label. The merge queue only compiles and unit-tests the merged code, so the
   labelled PR run is the one that has to be green.
 - PR titles starting with `feat:` require `Design at: #xxx` as the FIRST line


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/infrastructure/CI/e2e-gate-design.md

Follow-up to #14126.

## What changes

A draft PR runs no paid CI, even if it carries the `e2e` label. Every paid gate (Playwright, API, unit tests, DB validation, JS license, enterprise dispatch, enterprise e2e gate, mobile, AI review) now requires the label **and** `draft == false`.

- `ready_for_review` is added to the trigger types, so marking a PR ready starts CI immediately if it is labelled.
- `converted_to_draft` is added too: converting back to draft fires a run whose paid jobs are skipped, and the per-PR concurrency group cancels any run still in flight.
- `ci-gate` reports **pending** on a draft regardless of the label ("Draft PR: paid CI does not run until it is marked ready for review"), so a draft can never be queued.
- CLAUDE.md states the rule.

The rule for authors is now: open as draft while you iterate, add `e2e` and mark ready when you want the run. Either half alone is not enough.

## Verification

Workflow YAML validated locally. This PR is opened as a normal (non-draft) PR with `e2e` so its own CI runs under the new gates; the draft path itself can be checked on the next draft PR.
