### PR TITLE
test: deflake metrics promql-builder tests (batch 3, part 1)

### DIFF
--- a/tests/ui-testing/pages/metricsPages/metricsBuilderPage.js
+++ b/tests/ui-testing/pages/metricsPages/metricsBuilderPage.js
@@ -574,6 +574,20 @@ export class MetricsBuilderPage {
         return false;
     }
 
+    /** Select the first available label value, gating on the async values fetch; returns the value or ''. */
+    async selectFirstLabelValue() {
+        if (await this.isValueSelectDisabled()) return '';
+        await this.valueSelectLast.click();
+        await this.valuePopover.waitFor({ state: 'visible', timeout: 5000 });
+        // Values load async after the popover opens; wait for the first option to attach before reading, else a one-shot count races the fetch and selects nothing (→ metric{label=""} matches nothing).
+        await this.valueOptions.first().waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+        if (await this.valueOptions.count() === 0) return '';
+        const value = (await this.valueOptions.first().textContent()).trim();
+        await this.valueOptions.first().click();
+        await this.valuePopover.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+        return value;
+    }
+
     /**
      * Remove a label filter at the given index
      * @param {number} index - 0-based index

--- a/tests/ui-testing/pages/metricsPages/metricsBuilderPage.js
+++ b/tests/ui-testing/pages/metricsPages/metricsBuilderPage.js
@@ -1383,20 +1383,16 @@ export class MetricsBuilderPage {
         const visible = await this.dashboardPanelTable.isVisible({ timeout: 5000 }).catch(() => false);
         if (!visible) return { visible: false, rowCount: 0, headers: [] };
 
-        // Wait for the table to settle (rows hydrated, or loading complete) BEFORE counting.
-        // Loading attribute `data-test-loading="false"` on `o2-table` signals query completion.
-        await this.page.locator('[data-test="o2-table"][data-test-loading="false"]')
-            .first()
-            .waitFor({ state: 'attached', timeout: 15000 })
-            .catch(() => {});
-
-        // `data-test-loading="false"` is not enough on its own: switching the chart
-        // type re-mounts the panel, so a table left over from the previous render is
-        // already attached and "not loading" while the new one has yet to hydrate its
-        // rows — we would measure that stale, empty table. Wait for the first row to
-        // actually exist. Times out quietly when the query legitimately has no data,
-        // leaving the caller's rowCount assertion to fail on the real state.
-        await this.tableRows.first().waitFor({ state: 'attached', timeout: 15000 }).catch(() => {});
+        // Switching chart type + re-running leaves a stale table (loading=false but empty)
+        // attached while the new one hydrates, and under CI load the query response can land
+        // late — so wait for a table that is BOTH done-loading AND has rows, not either alone.
+        // Times out quietly when the query legitimately has no data, leaving the caller's
+        // rowCount assertion to fail on the real state.
+        await this.page.waitForFunction(() => {
+            const doneLoading = document.querySelector('[data-test="o2-table"][data-test-loading="false"]');
+            const hasRows = document.querySelectorAll('[data-test^="o2-table-row-"]').length > 0;
+            return !!doneLoading && hasRows;
+        }, undefined, { timeout: 25000 }).catch(() => {});
 
         // Get header texts via the data-test header cells
         const headers = [];

--- a/tests/ui-testing/playwright-tests/Metrics/metrics-promql-builder.spec.js
+++ b/tests/ui-testing/playwright-tests/Metrics/metrics-promql-builder.spec.js
@@ -816,19 +816,10 @@ test.describe("Metrics PromQL Builder Mode testcases", () => {
       selectedOperator = operatorText.trim();
       testLogger.info(`Operator: ${selectedOperator}`);
 
-      // Select a value
-      const isDisabled = await builder.isValueSelectDisabled();
-      if (!isDisabled) {
-        await builder.valueSelectLast.click();
-        await builder.valuePopover.waitFor({ state: 'visible', timeout: 5000 });
-
-        const valueCount = await builder.valueOptions.count();
-        if (valueCount > 0) {
-          selectedValue = (await builder.valueOptions.first().textContent()).trim();
-          await builder.valueOptions.first().click();
-          await builder.valuePopover.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
-          testLogger.info(`Selected value: ${selectedValue}`);
-        }
+      // Select a value (gates on the async values fetch so the filter isn't left empty)
+      selectedValue = await builder.selectFirstLabelValue();
+      if (selectedValue) {
+        testLogger.info(`Selected value: ${selectedValue}`);
       }
 
       // Close the filter menu — LabelFilterEditor chip menu is ODropdown post-migration
@@ -1018,17 +1009,10 @@ test.describe("Metrics PromQL Builder Mode testcases", () => {
       const operatorText = await builder.operatorSelectLast.textContent().catch(() => '');
       expect(operatorText).toContain('=');
 
-      // Select value
-      const isDisabled = await builder.isValueSelectDisabled();
-      if (!isDisabled) {
-        await builder.valueSelectLast.click();
-        await builder.valuePopover.waitFor({ state: 'visible', timeout: 5000 });
-        if (await builder.valueOptions.count() > 0) {
-          selectedValue = (await builder.valueOptions.first().textContent()).trim();
-          await builder.valueOptions.first().click();
-          await builder.valuePopover.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
-          testLogger.info(`Value: ${selectedValue}`);
-        }
+      // Select value (gates on the async values fetch so the filter isn't left empty)
+      selectedValue = await builder.selectFirstLabelValue();
+      if (selectedValue) {
+        testLogger.info(`Value: ${selectedValue}`);
       }
 
       await page.keyboard.press('Escape');
@@ -1197,17 +1181,10 @@ test.describe("Metrics PromQL Builder Mode testcases", () => {
       await builder.labelPopover.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
       testLogger.info(`Label: ${selectedLabel}`);
 
-      // Select value
-      const isDisabled = await builder.isValueSelectDisabled();
-      if (!isDisabled) {
-        await builder.valueSelectLast.click();
-        await builder.valuePopover.waitFor({ state: 'visible', timeout: 5000 });
-        if (await builder.valueOptions.count() > 0) {
-          selectedValue = (await builder.valueOptions.first().textContent()).trim();
-          await builder.valueOptions.first().click();
-          await builder.valuePopover.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
-          testLogger.info(`Value: ${selectedValue}`);
-        }
+      // Select value (gates on the async values fetch so the filter isn't left empty)
+      selectedValue = await builder.selectFirstLabelValue();
+      if (selectedValue) {
+        testLogger.info(`Value: ${selectedValue}`);
       }
       await page.keyboard.press('Escape');
       // LabelFilterEditor chip menu = ODropdown post-migration

--- a/tests/ui-testing/playwright-tests/utils/metrics-ingestion.js
+++ b/tests/ui-testing/playwright-tests/utils/metrics-ingestion.js
@@ -390,6 +390,38 @@ class MetricsIngestion {
     }
 
     /**
+     * Poll the PromQL query API until an ingested metric is actually queryable
+     * (WAL indexing lags the ingest ack). Best-effort: returns false on timeout
+     * so callers proceed and let the test's own data assertion fail loudly.
+     */
+    async waitForMetricQueryable(metricName, maxRetries = 30, interval = 1000) {
+        const base = this.config.endpoint.replace('/v1/metrics', '');
+        const url = `${base}/prometheus/api/v1/query?query=${encodeURIComponent(metricName)}`;
+        const headers = getAuthHeaders();
+        for (let i = 0; i < maxRetries; i++) {
+            try {
+                const controller = new AbortController();
+                const timeoutId = setTimeout(() => controller.abort(), 5000);
+                const response = await fetch(url, { method: 'GET', headers, signal: controller.signal });
+                clearTimeout(timeoutId);
+                if (response.ok) {
+                    const body = await response.json();
+                    const result = body?.data?.result;
+                    if (Array.isArray(result) && result.length > 0) {
+                        testLogger.info(`Metric "${metricName}" queryable after ${i + 1} poll(s)`, { series: result.length });
+                        return true;
+                    }
+                }
+            } catch (error) {
+                testLogger.debug(`waitForMetricQueryable attempt ${i + 1} error`, { error: error.message });
+            }
+            await new Promise(resolve => setTimeout(resolve, interval));
+        }
+        testLogger.warn(`Metric "${metricName}" not queryable after ${maxRetries} polls`);
+        return false;
+    }
+
+    /**
      * Send metrics to OpenObserve using OTLP format with retry logic
      */
     async sendMetrics(metricsData, useExternal = false, maxRetries = 3) {

--- a/tests/ui-testing/playwright-tests/utils/shared-metrics-setup.js
+++ b/tests/ui-testing/playwright-tests/utils/shared-metrics-setup.js
@@ -76,10 +76,10 @@ async function performIngestion() {
             });
         }
 
-        // CRITICAL: Add delay to allow metrics to be indexed
-        testLogger.info('Waiting 5 seconds for metrics to be fully indexed...');
-        await new Promise(resolve => setTimeout(resolve, 5000));
-        testLogger.info('Indexing delay complete, metrics should be queryable');
+        // Gate on the seeded metric actually being queryable (WAL indexing lags the
+        // ingest ack) instead of a blind sleep — the data-rendering tests pin to cpu_usage.
+        testLogger.info('Waiting for seeded metric cpu_usage to become queryable...');
+        await metricsIngestion.waitForMetricQueryable('cpu_usage');
 
         return result;
     } catch (error) {


### PR DESCRIPTION
Batch 3 (metrics). Method per #14025. Test-side only.

- **#6 (wal-lag)**: metrics `beforeAll` waited a blind 5s for indexing, so the seeded `cpu_usage` was sometimes still not queryable → PromQL `query_range` returned empty → the P2 table rendered 0 rows. Replaced the sleep with `waitForMetricQueryable('cpu_usage')` that polls `/api/{org}/prometheus/api/v1/query` until the metric returns series.
- **#9 (empty-filter race)**: the P1/P2 label-value pickers read `valueOptions.count()` one-shot right after the popover opened, racing the async values fetch → no value selected → `metric{label=""}` matches nothing → empty table. New `selectFirstLabelValue()` gates on the first option attaching before selecting.

Local verify pending (local server was down); relying on the CI 3× first-try gate.