### PR TITLE
test: deflake visualize-vrl + SLO language-switch tests (batch 3, part 2)

### DIFF
--- a/tests/ui-testing/pages/dashboardPages/visualise.js
+++ b/tests/ui-testing/pages/dashboardPages/visualise.js
@@ -77,6 +77,8 @@ export default class LogsVisualise {
     if (isTableSelected !== "true") {
       await tableChartItem.click();
     }
+    // The chart-type switch is reactive and lags the click; gate on it actually applying so downstream steps don't run against the wrong chart type.
+    await expect(tableChartItem).toHaveAttribute("data-selected", "true", { timeout: 10000 });
   }
 
   //Apply: Logs

--- a/tests/ui-testing/playwright-tests/Dashboards/visualize-vrl.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/visualize-vrl.spec.js
@@ -287,6 +287,9 @@ test.describe("VRL visualization support testcases", () => {
     const tablePanel = pm.logsVisualise.getTablePanel();
     await expect(tablePanel).toBeVisible({ timeout: 15000 });
 
+    // Let the edit panel's initial chart settle before changing the time range, else the
+    // time change races the in-flight first render and the re-query can be dropped.
+    await pm.dashboardPanelActions.waitForChartToRender(page);
     await pm.dashboardTimeRefresh.setRelative("8", "h");
     // await pm.dashboardPanelActions.applyDashboardBtn();
     await pm.dashboardPanelActions.waitForChartToRender(page);

--- a/tests/ui-testing/playwright-tests/utils/MonacoEditorHelper.js
+++ b/tests/ui-testing/playwright-tests/utils/MonacoEditorHelper.js
@@ -52,6 +52,8 @@ class MonacoEditorHelper {
      */
     async focus(container) {
         const inputArea = this.getInputArea(container);
+        // The textarea lags the container when the editor is revealed via v-if; wait for it to attach so a one-shot count() can't miss it and skip focusing (→ typed text lands nowhere).
+        await inputArea.waitFor({ state: 'attached', timeout: 10000 }).catch(() => {});
         if (await inputArea.count() > 0) {
             await inputArea.focus();
         } else {


### PR DESCRIPTION
Batch 3 pt.2. Method per #14025. Test-side only.

- **#11 [P1] save VRL panel** (`visualize-vrl.spec.js`): after re-opening the edit panel, `setRelative(8h)` fired before the initial chart settled → the re-query could be dropped. Added a `waitForChartToRender` gate BEFORE the time change (kept the one after).
- **#20 [P1] complex VRL multiple fields** (`visualise.js` `openVisualiseTabWithVrl`): the table-chart-type click wasn't confirmed → downstream steps could run against the wrong chart type. Gate on `data-selected="true"` applying.
- **#13 SLO switching query language** (`MonacoEditorHelper.focus`): one-shot `inputArea.count()` right after the editor is revealed via v-if could read 0 → force-click that doesn't focus → typed text lands nowhere. Wait for the textarea to attach first.

Local: #11 & #20 green ×2 + full visualize-vrl 16/16 + logs-autocomplete 18/0 (focus regression check). #13 not locally runnable (SLO backfill engine doesn't process on local) → CI-gated.