### PR TITLE
test: deflake VRL table-chart warning + join-family siblings (batch 4)

### DIFF
--- a/tests/ui-testing/pages/dashboardPages/visualise.js
+++ b/tests/ui-testing/pages/dashboardPages/visualise.js
@@ -311,7 +311,7 @@ export default class LogsVisualise {
     await this.queryEditor.fill(vrl);
   }
 
-  async runQueryAndWaitForCompletion() {
+  async runQueryAndWaitForCompletion({ expectTable = false } = {}) {
     const runBtn = this.page.locator(
       '[data-test="logs-search-bar-visualize-refresh-btn"]'
     );
@@ -323,6 +323,11 @@ export default class LogsVisualise {
     // Wait for query to start (cancel btn appears) then complete (cancel btn disappears)
     await cancelBtn.waitFor({ state: "visible", timeout: 5000 }).catch(() => {});
     await cancelBtn.waitFor({ state: "hidden", timeout: 30000 }).catch(() => {});
+    // The cancel button is enterprise-gated (SearchBar.vue config.isEnterprise), so on OSS the waits above are no-ops that don't gate completion — wait for the result to actually render (the table specifically when the caller expects one, so a transient chart-renderer can't satisfy the gate early).
+    const resultSelector = expectTable
+      ? '[data-test="dashboard-panel-table"]'
+      : '[data-test="chart-renderer"], [data-test="dashboard-panel-table"]';
+    await this.page.locator(resultSelector).first().waitFor({ state: "visible", timeout: 30000 }).catch(() => {});
   }
 
   // Helper function to check for dashboard errors

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -2238,12 +2238,14 @@ export class LogsPage {
     }
 
     async kubernetesContainerNameJoinLimit() {
-        await this.clearAndFillQueryEditor('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a left join "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name LIMIT 10');
+        // setQueryEditorContent atomically replaces the model; clearAndFillQueryEditor's select-all no-ops under CI load, leaving stale text.
+        await this.setQueryEditorContent('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a left join "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name LIMIT 10');
         await this.waitForEditorValue('LIMIT 10');
     }
 
     async kubernetesContainerNameJoinLike() {
-        await this.clearAndFillQueryEditor('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a join "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name WHERE a.kubernetes_container_name LIKE \'%ziox%\'');
+        // setQueryEditorContent atomically replaces the model; clearAndFillQueryEditor's select-all no-ops under CI load, leaving stale text.
+        await this.setQueryEditorContent('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a join "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name WHERE a.kubernetes_container_name LIKE \'%ziox%\'');
         await this.waitForEditorValue("LIKE '%ziox%'");
     }
 
@@ -2254,12 +2256,14 @@ export class LogsPage {
     }
 
     async kubernetesContainerNameRightJoin() {
-        await this.clearAndFillQueryEditor('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a RIGHT JOIN "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name');
+        // setQueryEditorContent atomically replaces the model; clearAndFillQueryEditor's select-all no-ops under CI load, leaving the RIGHT JOIN unwritten.
+        await this.setQueryEditorContent('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a RIGHT JOIN "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name');
         await this.waitForEditorValue('RIGHT JOIN');
     }
 
     async kubernetesContainerNameFullJoin() {
-        await this.clearAndFillQueryEditor('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a FULL JOIN "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name');
+        // setQueryEditorContent atomically replaces the model; clearAndFillQueryEditor's select-all no-ops under CI load, leaving the FULL JOIN unwritten.
+        await this.setQueryEditorContent('SELECT a.kubernetes_container_name , b.kubernetes_container_name  FROM "default" as a FULL JOIN "e2e_automate" as b on a.kubernetes_container_name  = b.kubernetes_container_name');
         await this.waitForEditorValue('FULL JOIN');
     }
 

--- a/tests/ui-testing/playwright-tests/Dashboards/visualize-vrl.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/visualize-vrl.spec.js
@@ -546,11 +546,8 @@ test.describe("VRL visualization support testcases", () => {
     await pm.logsVisualise.openVisualiseTabWithVrl();
 
     // IMPORTANT: Run query in visualization tab to populate vrlFunctionFieldList
-    await pm.logsVisualise.runQueryAndWaitForCompletion();
+    await pm.logsVisualise.runQueryAndWaitForCompletion({ expectTable: true });
     await pm.logsVisualise.verifyChartRenders(page);
-
-    // Wait for table to render with data
-    // await waitForTableData(page);
 
     // Verify table panel is displayed
     const tablePanel = pm.logsVisualise.getTablePanel();


### PR DESCRIPTION
Batch 4. Method per #14025. Test-side only.

- **#21 [P1] table-chart selection without VRL warning** *(Dashboards)*: root cause — `runQueryAndWaitForCompletion` gated on the `logs-search-bar-visualize-cancel-btn`, which is **enterprise-gated** (SearchBar.vue `config.isEnterprise`), so on OSS both waits are no-ops and it returns without waiting for the query. `verifyChartRenders`' loose `.first()` OR-gate then resolves on a transient `chart-renderer` while the actual `dashboard-panel-table` (asserted next) isn't up → `spec:557` element-not-found. Fix: add an OSS-safe positive completion gate, with an `expectTable` option so table tests wait on the table specifically.
- **Join-family siblings** *(Logs/join + Streams/streaming)*: Full-join, Right-join, join-like, join-limit still used the racy `clearAndFillQueryEditor` select-all → converted to atomic `setQueryEditorContent` (same fix already shipped for join/left-join in #14124).

Local: #21 green ×2 + full visualize-vrl 16/16 (no regression from the shared helper change); Logs/join 10/10 + siblings ×2; Streams join 6/6.