### PR TITLE
test: fix residual query-inspector flake in visualize Table/Line tests

### DIFF
--- a/tests/ui-testing/pages/dashboardPages/visualise.js
+++ b/tests/ui-testing/pages/dashboardPages/visualise.js
@@ -685,11 +685,13 @@ export default class LogsVisualise {
 
     const inspectorBtn = this.page.locator('[data-test="dashboard-query-inspector-panel"]');
     // Opening the menu before the item mounts leaves it absent for that open, so re-open until it appears.
+    // Escape first each retry: the dropdown is a toggle, so a blind re-click on an already-open menu closes it — fighting itself while metaData populates.
     await expect(async () => {
       if (await inspectorBtn.isVisible().catch(() => false)) return;
+      await this.page.keyboard.press("Escape").catch(() => {});
       await dropdown.click();
-      await expect(inspectorBtn).toBeVisible({ timeout: 2000 });
-    }).toPass({ timeout: 20000, intervals: [300, 700, 1500] });
+      await expect(inspectorBtn).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
 
     await inspectorBtn.click();
     await this.waitForQueryInspector(this.page);


### PR DESCRIPTION
Follow-up to #14113. Those visualize tests still showed a residual on main (reconfirmed on multiple runs): `openPanelQueryInspector` failed at `visualise.js:697` — `dashboard-query-inspector-panel` not found after 20s.

Root cause: the re-open loop blindly re-clicked the panel dropdown each retry, but the dropdown is a **toggle** — re-clicking an already-open menu closes it, so under slow metaData population the loop fought itself. Fix: press Escape to reset before each re-open (so a retry always opens fresh, never toggles shut), raise the inner item wait 2s→3s and the loop budget 20s→30s. Method per #14025.

Local: #3 + #7 green ×2.