### PR TITLE
ci: nothing runs on an unlabelled or draft PR except ci-gate

### DIFF
--- a/.github/workflows/audit-checker.yml
+++ b/.github/workflows/audit-checker.yml
@@ -1,19 +1,23 @@
 name: Security audit
 on:
-  # On PRs it follows the e2e gate like every other check; on main it runs once per merge.
+  # Advisories only matter when the dependency set changes, so PRs and main runs are path-filtered
+  # to the Cargo manifests; the weekly run catches advisories published against unchanged deps.
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
-    paths-ignore:
-      - "**.md"
-      - "**.yml"
-      - "**.yaml"
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/audit-checker.yml"
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "**.md"
-      - "**.yml"
-      - "**.yaml"
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/audit-checker.yml"
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/audit-checker.yml
+++ b/.github/workflows/audit-checker.yml
@@ -1,6 +1,9 @@
 name: Security audit
 on:
+  # main only: a PR branch push is covered by the PR's own gated checks, and this ran on every branch push.
   push:
+    branches:
+      - "main"
     paths-ignore:
       - "**.md"
       - "**.yml"

--- a/.github/workflows/audit-checker.yml
+++ b/.github/workflows/audit-checker.yml
@@ -1,6 +1,12 @@
 name: Security audit
 on:
-  # main only: a PR branch push is covered by the PR's own gated checks, and this ran on every branch push.
+  # On PRs it follows the e2e gate like every other check; on main it runs once per merge.
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
+    paths-ignore:
+      - "**.md"
+      - "**.yml"
+      - "**.yaml"
   push:
     branches:
       - "main"
@@ -18,6 +24,8 @@ concurrency:
 
 jobs:
   security_audit:
+    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/audit-checker.yml
+++ b/.github/workflows/audit-checker.yml
@@ -1,16 +1,9 @@
 name: Security audit
 on:
-  # Advisories only matter when the dependency set changes, so PRs and main runs are path-filtered
-  # to the Cargo manifests; the weekly run catches advisories published against unchanged deps.
+  # Advisories only matter when the dependency set changes, so PR runs are path-filtered to the
+  # Cargo manifests; the weekly run catches advisories published against unchanged deps.
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - ".github/workflows/audit-checker.yml"
-  push:
-    branches:
-      - "main"
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"

--- a/.github/workflows/db-schema-version-check.yml
+++ b/.github/workflows/db-schema-version-check.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - "**"
+    # labeled/unlabeled/ready_for_review/converted_to_draft so the gate re-evaluates when the state changes.
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   merge_group:
 
 concurrency:
@@ -12,6 +14,8 @@ concurrency:
 
 jobs:
   db_schema_version_check:
+    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     name: db_schema_version_check
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/feat-design-checker.yml
+++ b/.github/workflows/feat-design-checker.yml
@@ -2,7 +2,8 @@ name: "Feature Design Comment Checker"
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    # labeled/unlabeled/ready_for_review/converted_to_draft so the gate re-evaluates when the state changes.
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   issue_comment:
     types: [created, edited]
   pull_request_review_comment:
@@ -14,7 +15,8 @@ jobs:
       pull-requests: read
       statuses: write
     # Only run on pull requests
-    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request) || github.event_name == 'pull_request_review_comment'
+    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
+    if: (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false)) || (github.event_name == 'issue_comment' && github.event.issue.pull_request) || github.event_name == 'pull_request_review_comment'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,7 +1,8 @@
 name: "PR Title Checker"
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    # labeled/unlabeled/ready_for_review/converted_to_draft so the gate re-evaluates when the state changes.
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -9,6 +10,8 @@ concurrency:
 
 jobs:
   check:
+    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/verify-translations.yml
+++ b/.github/workflows/verify-translations.yml
@@ -19,6 +19,8 @@ on:
   # was filtered out sits at "Expected — waiting for status" forever, which would
   # block every PR that doesn't touch en-US.json. It is cheap enough to just run.
   pull_request:
+    # labeled/unlabeled/ready_for_review/converted_to_draft so the gate re-evaluates when the state changes.
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   merge_group:
 
 concurrency:
@@ -27,6 +29,8 @@ concurrency:
 
 jobs:
   verify:
+    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     name: Verify translations are up to date
     runs-on: ubuntu-latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,8 @@ reworded:
 
 ## PR conventions
 
-- Paid CI runs on a PR only while it carries the `e2e` label and is not a draft
-  (no label or draft = no builds or test suites, and no red checks). Add the
+- CI runs on a PR only while it carries the `e2e` label and is not a draft
+  (no label or draft = nothing runs except `ci-gate`, and no red checks). Add the
   label when you want the run, not when you open the PR. Which suites run is decided by path detection, never by
   a label. The merge queue only compiles and unit-tests the merged code, so the
   labelled PR run is the one that has to be green.


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/infrastructure/CI/e2e-gate-design.md

Follow-up to #14126, #14140. Principle: if it can be off, it is off. On a PR without the `e2e` label, or on a draft, nothing runs except `ci-gate`.

## What changes

| Check | Before | After |
|---|---|---|
| DB Schema Version Check | every PR push | label and not draft; merge_group unchanged |
| Feature Design Comment Checker | every PR push | label and not draft; comment triggers unchanged |
| PR Title Checker | every PR push | label and not draft; now also re-checks on `edited` |
| Verify Translations | every PR push | label and not draft; merge_group unchanged |
| Security audit (cargo-audit) | every push to any branch | labelled non-draft PRs that change `Cargo.toml`/`Cargo.lock`, plus a weekly run for advisories against unchanged deps; no post-merge rerun |
| CodeQL | default setup | untouched by decision; default setup cannot be gated |

All gated jobs report skipped, never red. `labeled`, `unlabeled`, `ready_for_review` and `converted_to_draft` are added to their trigger types so the state re-evaluates when it changes.

## Verification

Workflow YAML validated locally. This PR carries `e2e`, so every gated check runs on it once.



