### PR TITLE
ci: send the token on the first github.com request, not only after a 401

### DIFF
--- a/.github/actions/github-auth/action.yml
+++ b/.github/actions/github-auth/action.yml
@@ -15,6 +15,9 @@ runs:
         # header actions/checkout keeps for the checked-out repository.
         echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
         git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+        # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
+        # the token has to go on the first request: rewrite every github.com URL to carry it.
+        git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
         echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
         # cargo's libgit2 path does not always consult the helper; the git CLI always does.
         echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"

--- a/.github/actions/github-auth/action.yml
+++ b/.github/actions/github-auth/action.yml
@@ -11,13 +11,15 @@ runs:
       env:
         TOKEN: ${{ inputs.token }}
       run: |
-        # A credential helper is consulted only when GitHub answers 401, so it never conflicts with the
-        # header actions/checkout keeps for the checked-out repository.
-        echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
-        git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
-        # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
-        # the token has to go on the first request: rewrite every github.com URL to carry it.
-        git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
+        # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+        # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+        B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+        echo "::add-mask::$B64"
+        git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+        # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+        for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+          [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+        done
         echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
-        # cargo's libgit2 path does not always consult the helper; the git CLI always does.
+        # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
         echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"

--- a/.github/workflows/build-fork-pr-image.yml
+++ b/.github/workflows/build-fork-pr-image.yml
@@ -57,6 +57,9 @@ jobs:
         run: |
           echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
           git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+          # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
+          # the token has to go on the first request: rewrite every github.com URL to carry it.
+          git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Set GIT_TAG env

--- a/.github/workflows/build-fork-pr-image.yml
+++ b/.github/workflows/build-fork-pr-image.yml
@@ -55,12 +55,17 @@ jobs:
         env:
           TOKEN: ${{ github.token }}
         run: |
-          echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
-          git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
-          # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
-          # the token has to go on the first request: rewrite every github.com URL to carry it.
-          git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
+          # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+          # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+          B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$B64"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+          # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+          for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+            [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+          done
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Set GIT_TAG env
         run: |

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -43,6 +43,9 @@ jobs:
         run: |
           echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
           git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+          # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
+          # the token has to go on the first request: rewrite every github.com URL to carry it.
+          git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Set GIT_TAG env
@@ -123,6 +126,9 @@ jobs:
         run: |
           echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
           git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+          # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
+          # the token has to go on the first request: rewrite every github.com URL to carry it.
+          git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Setup Rust Toolchain
@@ -223,6 +229,9 @@ jobs:
         run: |
           echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
           git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
+          # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
+          # the token has to go on the first request: rewrite every github.com URL to carry it.
+          git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Setup Rust Toolchain

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -41,12 +41,17 @@ jobs:
         env:
           TOKEN: ${{ github.token }}
         run: |
-          echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
-          git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
-          # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
-          # the token has to go on the first request: rewrite every github.com URL to carry it.
-          git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
+          # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+          # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+          B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$B64"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+          # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+          for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+            [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+          done
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Set GIT_TAG env
         id: set-git-tag
@@ -124,12 +129,17 @@ jobs:
         env:
           TOKEN: ${{ github.token }}
         run: |
-          echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
-          git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
-          # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
-          # the token has to go on the first request: rewrite every github.com URL to carry it.
-          git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
+          # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+          # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+          B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$B64"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+          # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+          for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+            [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+          done
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
@@ -227,12 +237,17 @@ jobs:
         env:
           TOKEN: ${{ github.token }}
         run: |
-          echo "GH_AUTH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
-          git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_AUTH_TOKEN"; }; f'
-          # The helper only answers a 401; GitHub's download throttling is a protocol error with no challenge, so
-          # the token has to go on the first request: rewrite every github.com URL to carry it.
-          git config --global "url.https://x-access-token:${TOKEN}@github.com/.insteadOf" "https://github.com/"
+          # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+          # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+          B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$B64"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+          # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+          for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+            [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+          done
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/infrastructure/CI/e2e-gate-design.md

Follow-up to #14139.

## Why

The credential helper from #14139 never fires for a public repository. Git only consults a helper, or credentials embedded in the URL, after a 401 challenge, and GitHub never challenges for public repositories: it answers 200, or an in-band throttle error with no challenge at all. o2-enterprise#2546 showed it on the unit-tests job, which already had the helper:

```
fatal: remote error: GitHub is temporarily limiting some unauthenticated downloads to protect the stability of the platform. Please retry later or authenticate.
error: failed to load source for dependency `datafusion`
```

Verified locally: with an **invalid** token in a `url.insteadOf` rewrite the request still succeeds (nothing was sent); with an invalid `http.extraheader` GitHub rejects it at once. The header is what actually goes out on the first request.

## What changes

`.github/actions/github-auth` (and the two inlined copies in the PR image builds) now:

- sets `http.https://github.com/.extraheader` globally to `AUTHORIZATION: basic base64(x-access-token:GITHUB_TOKEN)`, the same header `actions/checkout` uses, masked in logs;
- removes the identical header that `actions/checkout` stores in each checked-out repository under `$GITHUB_WORKSPACE`, because two copies make GitHub answer `400 Duplicate header: "Authorization"` (verified locally);
- keeps `CARGO_NET_GIT_FETCH_WITH_CLI=true`, since cargo's libgit2 transport ignores `http.extraheader` and the git CLI honours it.

The action must run after the last `actions/checkout` of a job; it already does in every job that uses it.

## Verification

Workflow YAML validated locally; local git experiments above. This PR carries `e2e`, and the watcher on it counts throttle and duplicate-header lines in the Playwright, API and unit-test build logs. The same change is on o2-enterprise#2546.
