### PR TITLE
test(alerts): add Alert Library e2e suite

### DIFF
--- a/tests/ui-testing/ci-matrix/ci_matrix.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix.json
@@ -15,7 +15,8 @@
       "alerts-form-validation.spec.js",
       "anomaly-detection-form-validation.spec.js",
       "alerts-priority-tags.spec.js",
-      "alerts-multialert-ui.spec.js"
+      "alerts-multialert-ui.spec.js",
+      "alert-library.spec.js"
     ],
     "disabled": [
       {

--- a/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
@@ -114,6 +114,19 @@ export class AlertLibraryPage {
     await this.page.locator(`[data-test="alert-library-rail-category-${id}"]`).click();
   }
 
+  async searchCategories(text) {
+    const root = this.page.locator(this.l.railSearchCategories);
+    await root.waitFor({ state: 'attached', timeout: 10000 });
+    const inner = root.locator('input');
+    const target = (await inner.count()) ? inner.first() : root;
+    await target.fill(text, { force: true });
+    await this.page.waitForTimeout(300);
+  }
+
+  async clearCategories() {
+    await this.page.locator(this.l.railClearCategories).click();
+  }
+
   async cardCount() {
     return this.page.locator('[data-test^="alert-library-card-"][data-selected]').count();
   }

--- a/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
@@ -170,6 +170,16 @@ export class AlertLibraryPage {
     return Number((await bar.getAttribute('data-selected')) || 0);
   }
 
+  async offscreenCountInBar() {
+    const bar = this.page.locator(this.l.selectionBar);
+    if (!(await bar.isVisible().catch(() => false))) return 0;
+    return Number((await bar.getAttribute('data-offscreen')) || 0);
+  }
+
+  async firstSelectGroup() {
+    await this.page.locator('[data-test^="alert-library-select-group-"]').first().click();
+  }
+
   // ── drawer ────────────────────────────────────────────────────────────────
   async openCard(id) {
     await this.cardTitle(id).click();
@@ -234,6 +244,12 @@ export class AlertLibraryPage {
   isLargeConfirmVisible() { return this.page.locator(this.l.confirmLarge).isVisible(); }
 
   async run() { await this.page.locator(this.l.run).click(); }
+  async retryFailed() { await this.page.locator(this.l.retry).click(); }
+  async clearInDialog() { await this.page.locator(this.l.installClear).click(); }
+  async selectAllInDialog() { await this.page.locator(this.l.installSelectAll).click(); }
+  async toggleAlertInDialog(id) {
+    await this.page.locator(`[data-test="alert-library-install-alert-${id}"]`).click();
+  }
 
   async waitResult(id, status = 'installed', timeout = 30000) {
     await expect(this.page.locator(`[data-test="alert-library-install-result-${id}"]`))

--- a/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
@@ -86,7 +86,11 @@ export class AlertLibraryPage {
   }
 
   async openViaTab() {
-    await this.page.locator(this.l.tab).click();
+    // Wait for the tab to render before clicking — under cloud load the section
+    // tab strip can take longer than the click's own actionability window.
+    const tab = this.page.locator(this.l.tab);
+    await tab.waitFor({ state: 'visible', timeout: 30000 });
+    await tab.click();
     await this.waitForGallery();
   }
 

--- a/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
@@ -49,6 +49,8 @@ export class AlertLibraryPage {
       drawerLoadFailed: '[data-test="alert-library-drawer-load-failed"]',
       drawerPreview: '[data-test="alert-library-drawer-preview"]',
       drawerEvaluation: '[data-test="alert-library-drawer-evaluation"]',
+      drawerNeedsData: '[data-test="alert-library-drawer-needs-data"]',
+      drawerAvailability: '[data-test="alert-library-drawer-availability"]',
       drawerInstall: '[data-test="alert-library-drawer-install"]',
       drawerCustomize: '[data-test="alert-library-drawer-customize"]',
       // install wizard
@@ -56,6 +58,9 @@ export class AlertLibraryPage {
       destinationStep: '[data-test="alert-library-install-destination-step"]',
       destination: '[data-test="alert-library-install-destination"]',
       destinationsEmpty: '[data-test="alert-library-install-destinations-empty"]',
+      destinationsFailed: '[data-test="alert-library-install-destinations-failed"]',
+      destinationsRetry: '[data-test="alert-library-install-destinations-retry"]',
+      openDestinations: '[data-test="alert-library-install-open-destinations"]',
       installSelectAll: '[data-test="alert-library-install-select-all"]',
       installClear: '[data-test="alert-library-install-clear"]',
       installCount: '[data-test="alert-library-install-count"]',
@@ -216,13 +221,10 @@ export class AlertLibraryPage {
     }
     const options = this.page.locator('[data-test$="-popover"] [data-test$="-option"]');
     await expect(options.first()).toBeVisible({ timeout: 8000 });
+    // Fail loudly if the named destination is absent — never silently pick another.
     const match = options.filter({ hasText: name }).first();
-    if (await match.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await match.click();
-    } else {
-      testLogger.warn('destination option not found by name; selecting first', { name });
-      await options.first().click();
-    }
+    await expect(match, `destination "${name}" not in the wizard's list`).toBeVisible({ timeout: 8000 });
+    await match.click();
   }
 
   async next() { await this.page.locator(this.l.next).click(); }
@@ -240,8 +242,6 @@ export class AlertLibraryPage {
     const box = this.page.locator(this.l.confirmLarge);
     if ((await box.getAttribute('aria-checked')) !== 'true') await box.click();
   }
-
-  isLargeConfirmVisible() { return this.page.locator(this.l.confirmLarge).isVisible(); }
 
   async run() { await this.page.locator(this.l.run).click(); }
   async retryFailed() { await this.page.locator(this.l.retry).click(); }
@@ -283,6 +283,72 @@ export class AlertLibraryPage {
     if (!detailResp.ok()) return meta;
     return (await detailResp.json().catch(() => meta)) || meta;
   }
+
+  // ── assertions (selectors + expects live here, never in the spec) ─────────
+  async expectGalleryVisible() { await expect(this.page.locator(this.l.grid)).toBeVisible(); }
+  async expectCardVisible(id) { await expect(this.card(id)).toBeVisible(); }
+  async expectCardAbsent(id) { await expect(this.card(id)).toHaveCount(0); }
+  async expectCardNeedsData(id) { await expect(this.needsDataChip(id)).toBeVisible(); }
+  async expectCardReady(id) { await expect(this.needsDataChip(id)).toHaveCount(0); }
+  async expectDrawerPreviewVisible() { await expect(this.page.locator(this.l.drawerPreview)).toBeVisible(); }
+  async expectDrawerNeedsData() { await expect(this.page.locator(this.l.drawerNeedsData)).toBeVisible(); }
+  async expectDrawerAvailability() { await expect(this.page.locator(this.l.drawerAvailability)).toBeVisible(); }
+
+  async closeDrawer() {
+    await this.page.keyboard.press('Escape');
+    await expect(this.page.locator(this.l.drawer)).toBeHidden();
+  }
+
+  async expectNextDisabled() { await expect(this.page.locator(this.l.next)).toBeDisabled(); }
+  async expectNextEnabled() { await expect(this.page.locator(this.l.next)).toBeEnabled(); }
+  async expectRunDisabled() { await expect(this.page.locator(this.l.run)).toBeDisabled(); }
+  async expectRunEnabled() { await expect(this.page.locator(this.l.run)).toBeEnabled(); }
+  async expectLargeConfirmVisible() { await expect(this.page.locator(this.l.confirmLarge)).toBeVisible(); }
+  async expectLargeConfirmAbsent() { await expect(this.page.locator(this.l.confirmLarge)).toHaveCount(0); }
+
+  async expectErrorState(label) {
+    await expect(this.page.locator(this.l.error), label).toBeVisible({ timeout: 20000 });
+  }
+  async expectEmptyCatalog() {
+    await expect(this.page.locator(this.l.emptyCatalog)).toBeVisible({ timeout: 20000 });
+  }
+  async clickEmptyCatalogRetry() {
+    await this.page
+      .locator(`${this.l.emptyCatalog} [data-test$="-action"], ${this.l.emptyCatalog} button`)
+      .first()
+      .click();
+  }
+  async expectNoResults() { await expect(this.page.locator(this.l.noResults)).toBeVisible(); }
+
+  async expectRailCategoryVisible(id) {
+    await expect(this.page.locator(`[data-test="alert-library-rail-category-${id}"]`)).toBeVisible();
+  }
+  async expectRailCategoryAbsent(id) {
+    await expect(this.page.locator(`[data-test="alert-library-rail-category-${id}"]`)).toHaveCount(0);
+  }
+
+  async expectPageHeaderVisible() {
+    await expect(this.page.locator(this.l.page)).toBeVisible();
+    await expect(this.page.locator(this.l.title)).toBeVisible();
+    await expect(this.page.locator(this.l.refresh)).toBeVisible();
+    await expect(this.page.locator(this.l.contribute)).toBeVisible();
+  }
+
+  async expectInstallResultCount(status, count) {
+    await expect(
+      this.page.locator(`[data-test^="alert-library-install-result-"][data-status="${status}"]`),
+    ).toHaveCount(count);
+  }
+  async expectInstallErrorVisible() {
+    await expect(this.page.locator('[data-test^="alert-library-install-error-"]').first()).toBeVisible();
+  }
+  async expectRetryVisible() { await expect(this.page.locator(this.l.retry)).toBeVisible(); }
+
+  async expectDestinationsFailed() { await expect(this.page.locator(this.l.destinationsFailed)).toBeVisible(); }
+  async expectDestinationsRetryVisible() { await expect(this.page.locator(this.l.destinationsRetry)).toBeVisible(); }
+  async clickDestinationsRetry() { await this.page.locator(this.l.destinationsRetry).click(); }
+  async expectDestinationsEmpty() { await expect(this.page.locator(this.l.destinationsEmpty)).toBeVisible(); }
+  async expectOpenDestinationsVisible() { await expect(this.page.locator(this.l.openDestinations)).toBeVisible(); }
 
   // ── internals ─────────────────────────────────────────────────────────────
   async _fillField(rootSelector, value) {

--- a/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertLibraryPage.js
@@ -1,0 +1,267 @@
+/**
+ * AlertLibraryPage - Page object for the Alert Library (browse / filter / preview / install).
+ *
+ * Covers the gallery page, the left rail (severity + category facets), the
+ * readiness stat strip, cross-surface selection, the detail drawer and the
+ * 5-step install wizard. Selectors are the feature's own data-test attributes.
+ *
+ * Reuses: OSelect dropdown helper (reka trigger gotcha) and the O2 OInput
+ * `-field` inner-input gotcha for text/number inputs.
+ */
+
+import { expect } from '@playwright/test';
+import { openOSelectDropdown } from './oselectHelpers.js';
+const testLogger = require('../../playwright-tests/utils/test-logger.js');
+const { getAuthHeaders, getOrgIdentifier } = require('../../playwright-tests/utils/cloud-auth.js');
+
+export class AlertLibraryPage {
+  constructor(page) {
+    this.page = page;
+    this.l = {
+      page: '[data-test="alert-library-page"]',
+      title: '[data-test="alert-library-title"]',
+      refresh: '[data-test="alert-library-refresh"]',
+      contribute: '[data-test="alert-library-contribute"]',
+      tab: '[data-test="alert-section-tab-alertLibrary"]',
+      // toolbar
+      search: '[data-test="alert-library-search"]',
+      searchField: '[data-test="alert-library-search"] input',
+      selectAllInView: '[data-test="alert-library-select-all-in-view"]',
+      selectionBar: '[data-test="alert-library-selection-bar"]',
+      clearSelection: '[data-test="alert-library-clear-selection"]',
+      addSelected: '[data-test="alert-library-add-selected"]',
+      // stat strip (readiness filter)
+      statReady: '[data-test="alert-library-stat-ready"]',
+      statNeedsData: '[data-test="alert-library-stat-missing"]',
+      statAll: '[data-test="alert-library-stat-all"]',
+      // grid + rail
+      grid: '[data-test="alert-library-grid"]',
+      railSeverity: '[data-test="alert-library-rail-severity"]',
+      railSearchCategories: '[data-test="alert-library-rail-search-categories"]',
+      railClearCategories: '[data-test="alert-library-rail-clear-categories"]',
+      // page states
+      error: '[data-test="alert-library-error"]',
+      emptyCatalog: '[data-test="alert-library-empty-catalog"]',
+      noResults: '[data-test="alert-library-no-results"]',
+      // drawer
+      drawer: '[data-test="alert-library-drawer"]',
+      drawerLoading: '[data-test="alert-library-drawer-loading"]',
+      drawerLoadFailed: '[data-test="alert-library-drawer-load-failed"]',
+      drawerPreview: '[data-test="alert-library-drawer-preview"]',
+      drawerEvaluation: '[data-test="alert-library-drawer-evaluation"]',
+      drawerInstall: '[data-test="alert-library-drawer-install"]',
+      drawerCustomize: '[data-test="alert-library-drawer-customize"]',
+      // install wizard
+      dialog: '[data-test="alert-library-install-dialog"]',
+      destinationStep: '[data-test="alert-library-install-destination-step"]',
+      destination: '[data-test="alert-library-install-destination"]',
+      destinationsEmpty: '[data-test="alert-library-install-destinations-empty"]',
+      installSelectAll: '[data-test="alert-library-install-select-all"]',
+      installClear: '[data-test="alert-library-install-clear"]',
+      installCount: '[data-test="alert-library-install-count"]',
+      tuneToggle: '[data-test="alert-library-install-tune-toggle"]',
+      tuneFrequency: '[data-test="alert-library-install-tune-frequency"]',
+      tuneSilence: '[data-test="alert-library-install-tune-silence"]',
+      summary: '[data-test="alert-library-install-summary"]',
+      confirmLarge: '[data-test="alert-library-install-confirm-large"]',
+      next: '[data-test="alert-library-install-next"]',
+      back: '[data-test="alert-library-install-back"]',
+      run: '[data-test="alert-library-install-run"]',
+      retry: '[data-test="alert-library-install-retry"]',
+      done: '[data-test="alert-library-install-done"]',
+      cancel: '[data-test="alert-library-install-cancel"]',
+    };
+  }
+
+  // ── navigation ────────────────────────────────────────────────────────────
+  async openViaUrl() {
+    const base = process.env.ZO_BASE_URL || 'http://localhost:5080';
+    await this.page.goto(`${base}/web/alert-library?org_identifier=${getOrgIdentifier()}`);
+    await this.waitForGallery();
+  }
+
+  async openViaTab() {
+    await this.page.locator(this.l.tab).click();
+    await this.waitForGallery();
+  }
+
+  async waitForGallery() {
+    await expect(this.page.locator(this.l.page)).toBeVisible({ timeout: 30000 });
+    // Grid OR a terminal empty/error state — never hang on the skeleton.
+    await this.page
+      .locator(`${this.l.grid}, ${this.l.error}, ${this.l.emptyCatalog}, ${this.l.noResults}`)
+      .first()
+      .waitFor({ state: 'visible', timeout: 30000 });
+  }
+
+  // ── browse / filter / search ──────────────────────────────────────────────
+  async search(text) {
+    const field = this.page.locator(this.l.searchField);
+    await field.waitFor({ state: 'attached', timeout: 10000 });
+    await field.fill(text, { force: true });
+    await this.page.waitForTimeout(400); // 200ms debounce + render
+  }
+
+  async filterReady() { await this.page.locator(this.l.statReady).click(); }
+  async filterNeedsData() { await this.page.locator(this.l.statNeedsData).click(); }
+  async filterAll() { await this.page.locator(this.l.statAll).click(); }
+
+  async selectSeverity(id) {
+    await this.page.locator(`[data-test="alert-library-rail-severity-${id}"]`).click();
+  }
+
+  async toggleCategory(id) {
+    await this.page.locator(`[data-test="alert-library-rail-category-${id}"]`).click();
+  }
+
+  async cardCount() {
+    return this.page.locator('[data-test^="alert-library-card-"][data-selected]').count();
+  }
+
+  // ── cards / selection ─────────────────────────────────────────────────────
+  card(id) { return this.page.locator(`[data-test="alert-library-card-${id}"]`); }
+  cardTitle(id) { return this.page.locator(`[data-test="alert-library-card-title-${id}"]`); }
+  needsDataChip(id) {
+    return this.card(id).locator('[data-test="alert-library-card-needs-data"]');
+  }
+
+  async firstCardId() {
+    const first = this.page.locator('[data-test^="alert-library-card-title-"]').first();
+    await first.waitFor({ state: 'visible', timeout: 15000 });
+    const dt = await first.getAttribute('data-test');
+    return dt.replace('alert-library-card-title-', '');
+  }
+
+  async selectCard(id) {
+    await this.page.locator(`[data-test="alert-library-select-${id}"]`).click();
+  }
+
+  async selectAllInViewToggle() {
+    await this.page.locator(this.l.selectAllInView).click();
+  }
+
+  async selectGroup(id) {
+    await this.page.locator(`[data-test="alert-library-select-group-${id}"]`).click();
+  }
+
+  async addSelected() {
+    await this.page.locator(this.l.addSelected).click();
+    await expect(this.page.locator(this.l.dialog)).toBeVisible({ timeout: 15000 });
+  }
+
+  async clearSelection() { await this.page.locator(this.l.clearSelection).click(); }
+
+  async selectedCountInBar() {
+    const bar = this.page.locator(this.l.selectionBar);
+    if (!(await bar.isVisible().catch(() => false))) return 0;
+    return Number((await bar.getAttribute('data-selected')) || 0);
+  }
+
+  // ── drawer ────────────────────────────────────────────────────────────────
+  async openCard(id) {
+    await this.cardTitle(id).click();
+    await expect(this.page.locator(this.l.drawer)).toBeVisible({ timeout: 15000 });
+    await this.waitDrawerLoaded();
+  }
+
+  async waitDrawerLoaded() {
+    // Install button enables only once the file GET resolves.
+    await expect(this.page.locator(this.l.drawerInstall)).toBeEnabled({ timeout: 20000 });
+  }
+
+  async installFromDrawer() {
+    await this.page.locator(this.l.drawerInstall).click();
+    await expect(this.page.locator(this.l.dialog)).toBeVisible({ timeout: 15000 });
+  }
+
+  async customizeFromDrawer() {
+    await this.page.locator(this.l.drawerCustomize).click();
+  }
+
+  // ── install wizard ────────────────────────────────────────────────────────
+  async pickDestination(name) {
+    const root = this.page.locator(this.l.destination);
+    await root.waitFor({ state: 'visible', timeout: 10000 });
+    await openOSelectDropdown(this.page, root);
+    await this.page.waitForTimeout(500);
+    // Options are virtualized; narrow via the popover search box (the -search
+    // data-test IS the input) so the target row is actually rendered.
+    const search = this.page.locator('[data-test="alert-library-install-destination-search"]');
+    if (await search.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await search.fill(name, { force: true });
+      await this.page.waitForTimeout(400);
+    }
+    const options = this.page.locator('[data-test$="-popover"] [data-test$="-option"]');
+    await expect(options.first()).toBeVisible({ timeout: 8000 });
+    const match = options.filter({ hasText: name }).first();
+    if (await match.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await match.click();
+    } else {
+      testLogger.warn('destination option not found by name; selecting first', { name });
+      await options.first().click();
+    }
+  }
+
+  async next() { await this.page.locator(this.l.next).click(); }
+  async back() { await this.page.locator(this.l.back).click(); }
+
+  async enableTune() {
+    const toggle = this.page.locator(this.l.tuneToggle);
+    if ((await toggle.getAttribute('aria-checked')) !== 'true') await toggle.click();
+  }
+
+  async setFrequency(minutes) { await this._fillField(this.l.tuneFrequency, minutes); }
+  async setSilence(minutes) { await this._fillField(this.l.tuneSilence, minutes); }
+
+  async confirmLargeBatch() {
+    const box = this.page.locator(this.l.confirmLarge);
+    if ((await box.getAttribute('aria-checked')) !== 'true') await box.click();
+  }
+
+  isLargeConfirmVisible() { return this.page.locator(this.l.confirmLarge).isVisible(); }
+
+  async run() { await this.page.locator(this.l.run).click(); }
+
+  async waitResult(id, status = 'installed', timeout = 30000) {
+    await expect(this.page.locator(`[data-test="alert-library-install-result-${id}"]`))
+      .toHaveAttribute('data-status', status, { timeout });
+  }
+
+  async done() {
+    await this.page.locator(this.l.done).click();
+    await expect(this.page.locator(this.l.dialog)).toBeHidden({ timeout: 10000 });
+  }
+
+  // ── API verification (read the installed alert back) ──────────────────────
+  async getInstalledAlert(alertName) {
+    const base = process.env.ZO_BASE_URL || 'http://localhost:5080';
+    const org = getOrgIdentifier();
+    const headers = getAuthHeaders();
+    // The list endpoint returns a summary; fetch the alert detail for the full
+    // body (destinations, context_attributes, trigger_condition).
+    const listResp = await this.page.request.get(`${base}/api/v2/${org}/alerts`, { headers });
+    if (!listResp.ok()) {
+      testLogger.warn('alerts list read-back not ok', { status: listResp.status() });
+      return null;
+    }
+    const listBody = await listResp.json().catch(() => null);
+    const arr = Array.isArray(listBody) ? listBody : listBody?.list || [];
+    const meta = arr.find((a) => (a.name || a.alert_name) === alertName);
+    if (!meta) return null;
+    const id = meta.alert_id || meta.id;
+    if (!id) return meta;
+    const detailResp = await this.page.request.get(`${base}/api/v2/${org}/alerts/${id}`, { headers });
+    if (!detailResp.ok()) return meta;
+    return (await detailResp.json().catch(() => meta)) || meta;
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────────
+  async _fillField(rootSelector, value) {
+    // O2 OInput: the data-test is on a wrapper; the real input is the inner node.
+    const inner = this.page.locator(`${rootSelector} input`);
+    await inner.waitFor({ state: 'attached', timeout: 10000 });
+    await inner.fill(String(value), { force: true });
+  }
+}
+
+export default AlertLibraryPage;

--- a/tests/ui-testing/pages/apiCleanup.js
+++ b/tests/ui-testing/pages/apiCleanup.js
@@ -2303,7 +2303,8 @@ class APICleanup {
             'viewer_delete_test_',    // RBAC viewer delete test alerts (orphaned)
             'viewer_update_test_',    // RBAC viewer update test alerts (orphaned)
             'editor_create_test_',    // RBAC editor create test alerts (orphaned)
-            'editor_delete_test_'     // RBAC editor delete test alerts (orphaned)
+            'editor_delete_test_',    // RBAC editor delete test alerts (orphaned)
+            'pw_lib_'                 // alert-library.spec.js (Alert Library e2e installed alerts)
         ];
 
         try {

--- a/tests/ui-testing/pages/page-manager.js
+++ b/tests/ui-testing/pages/page-manager.js
@@ -27,6 +27,7 @@ import LogsVisualise from "./dashboardPages/visualise";
 import { DashboardPage } from "./dashboardPages/dashboardPage.js";
 import { ScheduledReportsDrawerPage } from "./dashboardPages/scheduledReportsDrawer.js";
 import { AlertsPage } from "./alertsPages/alertsPage.js";
+import { AlertLibraryPage } from "./alertsPages/alertLibraryPage.js";
 import { AlertHistoryPage } from "./alertsPages/alertHistoryPage.js";
 import { AlertDetailPage } from "./alertsPages/alertDetailPage.js";
 import { CompositeAlertsPage } from "./alertsPages/compositeAlertsPage.js";
@@ -158,6 +159,7 @@ class PageManager {
 
     // ===== EXISTING ALERTS PAGE OBJECT =====
     this.alertsPage = new AlertsPage(page);
+    this.alertLibraryPage = new AlertLibraryPage(page);
     this.alertHistoryPage = new AlertHistoryPage(page);
     this.alertDetailPage = new AlertDetailPage(page);
     this.compositeAlertsPage = new CompositeAlertsPage(page);

--- a/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
@@ -46,18 +46,20 @@ test.describe('Alert Library', () => {
 
     // Deterministic gallery: 1 ready card, 1 not-ready (missing) card, and a
     // bulk pack of 51 ready cards (> LARGE_BATCH=50) for the large-batch guard.
+    // All installable names share the pw_lib_ prefix so cleanup.spec.js sweeps
+    // the alerts they create (see apiCleanup alertPrefixes).
     const ready = makeEntry(1, {
-      name: `pw_ready_${rand}`, title: 'PW Ready Alert', severity: 'critical',
+      name: `pw_lib_ready_${rand}`, title: 'PW Ready Alert', severity: 'critical',
       pack: 'observability', category: 'ready-signals', stream: readyStream,
       required_streams: [readyStream],
     });
     const missing = makeEntry(2, {
-      name: `pw_missing_${rand}`, title: 'PW Missing Alert', severity: 'info',
+      name: `pw_lib_missing_${rand}`, title: 'PW Missing Alert', severity: 'info',
       pack: 'observability', category: 'absent-signals', stream: missingStream,
       required_streams: [missingStream],
     });
     const bulk = makeEntries(51, {
-      namePrefix: `pw_bulk_${rand}`, pack: 'infrastructure', category: 'bulk-signals',
+      namePrefix: `pw_lib_bulk_${rand}`, pack: 'infrastructure', category: 'bulk-signals',
       severity: 'warning', stream: readyStream, required_streams: [readyStream],
     });
     entries = [ready, missing, ...bulk];

--- a/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
@@ -1,0 +1,135 @@
+const { test, expect } = require('../utils/enhanced-baseFixtures.js');
+const PageManager = require('../../pages/page-manager.js');
+const testLogger = require('../utils/test-logger.js');
+const { getOrgIdentifier } = require('../utils/cloud-auth.js');
+const {
+  makeEntry,
+  makeEntries,
+  buildManifest,
+  routeLibrary,
+} = require('../fixtures/alertLibraryFixture.js');
+
+// Combined-journey e2e for the Alert Library. The manifest + alert files are
+// mocked (deterministic readiness / bulk counts / states); install hits the
+// real alert API and is verified by reading the created alert back.
+test.describe('Alert Library', () => {
+  let pm;
+  let readyStream;
+  let missingStream;
+  let templateName;
+  let destinationName;
+  let entries;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    pm = new PageManager(page);
+
+    const rand = pm.alertsPage.generateRandomString().toLowerCase();
+    readyStream = `pw_lib_ready_${rand}`.toLowerCase();
+    missingStream = `pw_lib_absent_${rand}`.toLowerCase(); // never created → "missing"
+    templateName = `pw_lib_tmpl_${rand}`;
+    destinationName = `pw_lib_dest_${rand}`;
+
+    // A stream with data → its cards read "ready" / fresh.
+    await pm.commonActions.initializeAlertTestStream(readyStream);
+    await pm.commonActions.queryStream(readyStream).catch(() => {}); // let it become searchable
+
+    // Install requires a real destination (template first). example.com avoids
+    // the SSRF guard that blocks self-host URLs.
+    await pm.alertTemplatesPage.ensureTemplateExists(templateName);
+    await pm.alertDestinationsPage.ensureDestinationExists(
+      destinationName, 'http://example.com/webhook', templateName,
+    );
+
+    // Deterministic gallery: 1 ready card, 1 not-ready (missing) card, and a
+    // bulk pack of 51 ready cards (> LARGE_BATCH=50) for the large-batch guard.
+    const ready = makeEntry(1, {
+      name: `pw_ready_${rand}`, title: 'PW Ready Alert', severity: 'critical',
+      pack: 'observability', category: 'ready-signals', stream: readyStream,
+      required_streams: [readyStream],
+    });
+    const missing = makeEntry(2, {
+      name: `pw_missing_${rand}`, title: 'PW Missing Alert', severity: 'info',
+      pack: 'observability', category: 'absent-signals', stream: missingStream,
+      required_streams: [missingStream],
+    });
+    const bulk = makeEntries(51, {
+      namePrefix: `pw_bulk_${rand}`, pack: 'infrastructure', category: 'bulk-signals',
+      severity: 'warning', stream: readyStream, required_streams: [readyStream],
+    });
+    entries = [ready, missing, ...bulk];
+
+    await routeLibrary(page, { manifest: buildManifest(entries), entries });
+  });
+
+  test('browse, filter, preview and install a single curated alert', async ({ page }) => {
+    const ready = entries[0];
+    const missing = entries[1];
+
+    // Gallery renders from the mocked manifest.
+    await pm.alertLibraryPage.openViaUrl();
+    await expect(page.locator('[data-test="alert-library-grid"]')).toBeVisible();
+
+    // Readiness: missing card shows the "not ingested" chip, ready card doesn't.
+    await expect(pm.alertLibraryPage.needsDataChip(missing.id)).toBeVisible();
+    await expect(pm.alertLibraryPage.needsDataChip(ready.id)).toHaveCount(0);
+
+    // Readiness filter (stat strip) narrows to not-ready, then back.
+    await pm.alertLibraryPage.filterNeedsData();
+    await expect(pm.alertLibraryPage.card(missing.id)).toBeVisible();
+    await expect(pm.alertLibraryPage.card(ready.id)).toHaveCount(0);
+    await pm.alertLibraryPage.filterAll();
+
+    // Search narrows to the ready alert by title.
+    await pm.alertLibraryPage.search('PW Ready');
+    await expect(pm.alertLibraryPage.card(ready.id)).toBeVisible();
+
+    // Drawer: opens, lazy-loads the (mocked) file, shows preview + install.
+    await pm.alertLibraryPage.openCard(ready.id);
+    await expect(page.locator('[data-test="alert-library-drawer-preview"]')).toBeVisible();
+
+    // Install wizard: destination → alerts → folder(default) → tune → run.
+    await pm.alertLibraryPage.installFromDrawer();
+    await pm.alertLibraryPage.pickDestination(destinationName);
+    await pm.alertLibraryPage.next(); // → alerts
+    await pm.alertLibraryPage.next(); // → folder
+    await pm.alertLibraryPage.next(); // → tune
+    await pm.alertLibraryPage.enableTune();
+    await pm.alertLibraryPage.setFrequency(15);
+    await pm.alertLibraryPage.setSilence(20);
+    await pm.alertLibraryPage.next(); // → review
+    await pm.alertLibraryPage.run();
+    await pm.alertLibraryPage.waitResult(ready.id, 'installed');
+    await pm.alertLibraryPage.done();
+
+    // Verify via API: the alert exists with the OVERRIDDEN destination, the
+    // provenance tag, and the mapped priority (critical → 1).
+    const created = await pm.alertLibraryPage.getInstalledAlert(ready.name);
+    expect(created, 'installed alert should be readable via API').toBeTruthy();
+    expect(created.destinations).toContain(destinationName);
+    expect(JSON.stringify(created.tags || [])).toContain(`pack:${ready.pack}`);
+    expect(created.context_attributes?.library_id).toBe(ready.id);
+    expect(created.trigger_condition?.frequency).toBe(15);
+  });
+
+  test('bulk select via select-all-in-view triggers the >50 large-batch guard', async ({ page }) => {
+    await pm.alertLibraryPage.openViaUrl();
+
+    // Select every card in view (1 ready + 1 missing + 51 bulk = 53 > 50).
+    await pm.alertLibraryPage.selectAllInViewToggle();
+    expect(await pm.alertLibraryPage.selectedCountInBar()).toBeGreaterThan(50);
+
+    await pm.alertLibraryPage.addSelected();
+    await pm.alertLibraryPage.pickDestination(destinationName);
+    await pm.alertLibraryPage.next(); // alerts
+    await pm.alertLibraryPage.next(); // folder
+    await pm.alertLibraryPage.next(); // tune
+    await pm.alertLibraryPage.next(); // review
+
+    // Guard: confirm checkbox present, Run disabled until it is ticked.
+    await expect(page.locator('[data-test="alert-library-install-confirm-large"]')).toBeVisible();
+    await expect(page.locator('[data-test="alert-library-install-run"]')).toBeDisabled();
+    await pm.alertLibraryPage.confirmLargeBatch();
+    await expect(page.locator('[data-test="alert-library-install-run"]')).toBeEnabled();
+  });
+});

--- a/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
@@ -14,9 +14,11 @@ const {
 
 // Combined-journey e2e for the Alert Library. The manifest + alert files are
 // mocked (deterministic readiness / bulk counts / states); install hits the
-// real alert API and is verified by reading the created alert back.
+// real alert API and is verified by reading the created alert back. Selectors
+// and element assertions live in alertLibraryPage — never inline here.
 test.describe('Alert Library', () => {
   let pm;
+  let lib;
   let readyStream;
   let missingStream;
   let templateName;
@@ -26,6 +28,7 @@ test.describe('Alert Library', () => {
   test.beforeEach(async ({ page }, testInfo) => {
     testLogger.testStart(testInfo.title, testInfo.file);
     pm = new PageManager(page);
+    lib = pm.alertLibraryPage;
 
     const rand = pm.alertsPage.generateRandomString().toLowerCase();
     readyStream = `pw_lib_ready_${rand}`.toLowerCase();
@@ -44,8 +47,6 @@ test.describe('Alert Library', () => {
       destinationName, 'http://example.com/webhook', templateName,
     );
 
-    // Deterministic gallery: 1 ready card, 1 not-ready (missing) card, and a
-    // bulk pack of 51 ready cards (> LARGE_BATCH=50) for the large-batch guard.
     // All installable names share the pw_lib_ prefix so cleanup.spec.js sweeps
     // the alerts they create (see apiCleanup alertPrefixes).
     const ready = makeEntry(1, {
@@ -67,51 +68,50 @@ test.describe('Alert Library', () => {
     await routeLibrary(page, { manifest: buildManifest(entries), entries });
   });
 
-  test('browse, filter, preview and install a single curated alert', async ({ page }) => {
+  test('browse, filter, preview and install a single curated alert', async () => {
     const ready = entries[0];
     const missing = entries[1];
 
     // Gallery renders from the mocked manifest.
-    await pm.alertLibraryPage.openViaUrl();
-    await expect(page.locator('[data-test="alert-library-grid"]')).toBeVisible();
+    await lib.openViaUrl();
+    await lib.expectGalleryVisible();
 
     // Readiness: missing card shows the "not ingested" chip, ready card doesn't.
-    await expect(pm.alertLibraryPage.needsDataChip(missing.id)).toBeVisible();
-    await expect(pm.alertLibraryPage.needsDataChip(ready.id)).toHaveCount(0);
+    await lib.expectCardNeedsData(missing.id);
+    await lib.expectCardReady(ready.id);
 
     // Readiness filter (stat strip) narrows to not-ready, then back.
-    await pm.alertLibraryPage.filterNeedsData();
-    await expect(pm.alertLibraryPage.card(missing.id)).toBeVisible();
-    await expect(pm.alertLibraryPage.card(ready.id)).toHaveCount(0);
-    await pm.alertLibraryPage.filterAll();
+    await lib.filterNeedsData();
+    await lib.expectCardVisible(missing.id);
+    await lib.expectCardAbsent(ready.id);
+    await lib.filterAll();
 
     // Search narrows to the ready alert by title.
-    await pm.alertLibraryPage.search('PW Ready');
-    await expect(pm.alertLibraryPage.card(ready.id)).toBeVisible();
+    await lib.search('PW Ready');
+    await lib.expectCardVisible(ready.id);
 
     // Drawer: opens, lazy-loads the (mocked) file, shows preview + install.
-    await pm.alertLibraryPage.openCard(ready.id);
-    await expect(page.locator('[data-test="alert-library-drawer-preview"]')).toBeVisible();
+    await lib.openCard(ready.id);
+    await lib.expectDrawerPreviewVisible();
 
     // Install wizard: destination → alerts → folder(default) → tune → run.
-    await pm.alertLibraryPage.installFromDrawer();
-    // F2: cannot advance until a destination is chosen.
-    await expect(page.locator('[data-test="alert-library-install-next"]')).toBeDisabled();
-    await pm.alertLibraryPage.pickDestination(destinationName);
-    await expect(page.locator('[data-test="alert-library-install-next"]')).toBeEnabled();
-    await pm.alertLibraryPage.next(); // → alerts
-    await pm.alertLibraryPage.next(); // → folder
-    await pm.alertLibraryPage.next(); // → tune
-    await pm.alertLibraryPage.enableTune();
-    await pm.alertLibraryPage.setFrequency(15);
-    await pm.alertLibraryPage.setSilence(20);
-    await pm.alertLibraryPage.next(); // → review
-    await pm.alertLibraryPage.run();
-    await pm.alertLibraryPage.waitResult(ready.id, 'installed');
-    await pm.alertLibraryPage.done();
+    await lib.installFromDrawer();
+    await lib.expectNextDisabled(); // F2: cannot advance until a destination is chosen
+    await lib.pickDestination(destinationName);
+    await lib.expectNextEnabled();
+    await lib.next(); // → alerts
+    await lib.next(); // → folder
+    await lib.next(); // → tune
+    await lib.enableTune();
+    await lib.setFrequency(15);
+    await lib.setSilence(20);
+    await lib.next(); // → review
+    await lib.run();
+    await lib.waitResult(ready.id, 'installed');
+    await lib.done();
 
     // Verify via API the transformations the UI never shows.
-    const created = await pm.alertLibraryPage.getInstalledAlert(ready.name);
+    const created = await lib.getInstalledAlert(ready.name);
     expect(created, 'installed alert should be readable via API').toBeTruthy();
     // I2 destination overridden (author's o2_to_slack replaced)
     expect(created.destinations).toContain(destinationName);
@@ -121,68 +121,67 @@ test.describe('Alert Library', () => {
     expect(created.context_attributes?.library_hash).toBe(ready.content_hash);
     // I4 severity critical → priority 1 (integer on the wire)
     expect(created.priority).toBe(1);
-    // I5 owner is the installing user; I1 lands in the chosen (default) folder
+    // I5 owner is the installing user
     expect(typeof created.owner === 'string' && created.owner.length).toBeTruthy();
     // I7 tuning applied
     expect(created.trigger_condition?.frequency).toBe(15);
     expect(created.trigger_condition?.silence).toBe(20);
   });
 
-  test('bulk select via select-all-in-view triggers the >50 large-batch guard', async ({ page }) => {
-    await pm.alertLibraryPage.openViaUrl();
+  test('bulk select via select-all-in-view triggers the >50 large-batch guard', async () => {
+    await lib.openViaUrl();
 
     // Select every card in view (1 ready + 1 missing + 51 bulk = 53 > 50).
-    await pm.alertLibraryPage.selectAllInViewToggle();
-    expect(await pm.alertLibraryPage.selectedCountInBar()).toBeGreaterThan(50);
+    await lib.selectAllInViewToggle();
+    expect(await lib.selectedCountInBar()).toBeGreaterThan(50);
 
-    await pm.alertLibraryPage.addSelected();
-    await pm.alertLibraryPage.pickDestination(destinationName);
-    await pm.alertLibraryPage.next(); // alerts
-    await pm.alertLibraryPage.next(); // folder
-    await pm.alertLibraryPage.next(); // tune
-    await pm.alertLibraryPage.next(); // review
+    await lib.addSelected();
+    await lib.pickDestination(destinationName);
+    await lib.next(); // alerts
+    await lib.next(); // folder
+    await lib.next(); // tune
+    await lib.next(); // review
 
     // Guard: confirm checkbox present, Run disabled until it is ticked.
-    await expect(page.locator('[data-test="alert-library-install-confirm-large"]')).toBeVisible();
-    await expect(page.locator('[data-test="alert-library-install-run"]')).toBeDisabled();
-    await pm.alertLibraryPage.confirmLargeBatch();
-    await expect(page.locator('[data-test="alert-library-install-run"]')).toBeEnabled();
+    await lib.expectLargeConfirmVisible();
+    await lib.expectRunDisabled();
+    await lib.confirmLargeBatch();
+    await lib.expectRunEnabled();
 
     // H5: the confirmation auto-resets when the run's shape changes (here, the
     // alert selection), so it always describes the run about to happen.
-    await pm.alertLibraryPage.back(); // → tune
-    await pm.alertLibraryPage.back(); // → folder
-    await pm.alertLibraryPage.back(); // → alerts
-    await pm.alertLibraryPage.clearInDialog();
-    await pm.alertLibraryPage.selectAllInDialog();
-    await pm.alertLibraryPage.next(); // folder
-    await pm.alertLibraryPage.next(); // tune
-    await pm.alertLibraryPage.next(); // review
-    await expect(page.locator('[data-test="alert-library-install-run"]')).toBeDisabled();
+    await lib.back(); // → tune
+    await lib.back(); // → folder
+    await lib.back(); // → alerts
+    await lib.clearInDialog();
+    await lib.selectAllInDialog();
+    await lib.next(); // folder
+    await lib.next(); // tune
+    await lib.next(); // review
+    await lib.expectRunDisabled();
   });
 
-  test('readiness surfaces on the card and in the drawer (fresh vs missing)', async ({ page }) => {
+  test('readiness surfaces on the card and in the drawer (fresh vs missing)', async () => {
     const ready = entries[0];
     const missing = entries[1];
 
-    await pm.alertLibraryPage.openViaUrl();
+    await lib.openViaUrl();
 
     // Card: missing → "not ingested" chip; fresh → none.
-    await expect(pm.alertLibraryPage.needsDataChip(missing.id)).toBeVisible();
-    await expect(pm.alertLibraryPage.needsDataChip(ready.id)).toHaveCount(0);
+    await lib.expectCardNeedsData(missing.id);
+    await lib.expectCardReady(ready.id);
 
-    // Drawer: missing → availability warning banner; fresh → no banner.
-    await pm.alertLibraryPage.openCard(missing.id);
-    await expect(page.locator('[data-test="alert-library-drawer-needs-data"]')).toBeVisible();
-    await expect(page.locator('[data-test="alert-library-drawer-availability"]')).toBeVisible();
-    await page.keyboard.press('Escape');
-    await expect(page.locator('[data-test="alert-library-drawer"]')).toBeHidden();
+    // Drawer: missing → availability warning banner; fresh → preview renders.
+    await lib.openCard(missing.id);
+    await lib.expectDrawerNeedsData();
+    await lib.expectDrawerAvailability();
+    await lib.closeDrawer();
 
     // The ready card's drawer renders the preview. (Its exact availability
     // sub-state — fresh vs stale — depends on stream-stats propagation timing,
     // which is covered deterministically by the useAlertLibrary unit tests.)
-    await pm.alertLibraryPage.openCard(ready.id);
-    await expect(page.locator('[data-test="alert-library-drawer-preview"]')).toBeVisible();
+    await lib.openCard(ready.id);
+    await lib.expectDrawerPreviewVisible();
   });
 
   test('a broken manifest shows a recovery state, not an empty gallery', async ({ page }) => {
@@ -198,10 +197,10 @@ test.describe('Alert Library', () => {
       await page.route(MANIFEST_GLOB, (route) =>
         route.fulfill({ status: m.status, contentType: 'application/json', body: m.body }),
       );
-      if (i === 0) await pm.alertLibraryPage.openViaUrl();
+      if (i === 0) await lib.openViaUrl();
       else await page.reload();
       // Distinct error surface with a retry, never a silent empty catalog.
-      await expect(page.locator('[data-test="alert-library-error"]'), m.label).toBeVisible({ timeout: 20000 });
+      await lib.expectErrorState(m.label);
     }
 
     // B3: a valid-but-empty manifest is its OWN state, not an error.
@@ -213,88 +212,87 @@ test.describe('Alert Library', () => {
       }),
     );
     await page.reload();
-    await expect(page.locator('[data-test="alert-library-empty-catalog"]')).toBeVisible({ timeout: 20000 });
+    await lib.expectEmptyCatalog();
 
     // B7: restoring a good manifest and hitting Retry recovers the gallery.
     await page.unroute(MANIFEST_GLOB);
     await page.route(MANIFEST_GLOB, (route) =>
       route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(buildManifest(entries)) }),
     );
-    await page.locator('[data-test="alert-library-empty-catalog"] [data-test$="-action"], [data-test="alert-library-empty-catalog"] button').first().click();
-    await expect(page.locator('[data-test="alert-library-grid"]')).toBeVisible({ timeout: 20000 });
+    await lib.clickEmptyCatalogRetry();
+    await lib.expectGalleryVisible();
   });
 
   test('Customize opens the alert editor prefilled from the library file', async ({ page }) => {
     const ready = entries[0];
 
-    await pm.alertLibraryPage.openViaUrl();
-    await pm.alertLibraryPage.openCard(ready.id);
-    await pm.alertLibraryPage.customizeFromDrawer();
+    await lib.openViaUrl();
+    await lib.openCard(ready.id);
+    await lib.customizeFromDrawer();
 
     // Customize hands the alert to the full editor via the library prefill
     // (route "addAlert" with ?prefill=library) — not a customizeFailed toast.
     await expect(page).toHaveURL(/prefill=library/, { timeout: 15000 });
   });
 
-  test('the rail filters the gallery by severity and by category', async ({ page }) => {
+  test('the rail filters the gallery by severity and by category', async () => {
     const ready = entries[0]; // critical, category ready-signals
     const missing = entries[1]; // info, category absent-signals
     const bulk = entries[2]; // warning, category bulk-signals
 
-    await pm.alertLibraryPage.openViaUrl();
+    await lib.openViaUrl();
 
     // Severity is single-select: critical → only the critical card.
-    await pm.alertLibraryPage.selectSeverity('critical');
-    await expect(pm.alertLibraryPage.card(ready.id)).toBeVisible();
-    await expect(pm.alertLibraryPage.card(missing.id)).toHaveCount(0);
-    await pm.alertLibraryPage.selectSeverity('all'); // widen back
-    await expect(pm.alertLibraryPage.card(missing.id)).toBeVisible();
+    await lib.selectSeverity('critical');
+    await lib.expectCardVisible(ready.id);
+    await lib.expectCardAbsent(missing.id);
+    await lib.selectSeverity('all'); // widen back
+    await lib.expectCardVisible(missing.id);
 
     // Category search narrows the rail list (nothing selected yet).
-    await pm.alertLibraryPage.searchCategories('bulk');
-    await expect(page.locator('[data-test="alert-library-rail-category-bulk-signals"]')).toBeVisible();
-    await expect(page.locator('[data-test="alert-library-rail-category-absent-signals"]')).toHaveCount(0);
-    await pm.alertLibraryPage.searchCategories('');
+    await lib.searchCategories('bulk');
+    await lib.expectRailCategoryVisible('bulk-signals');
+    await lib.expectRailCategoryAbsent('absent-signals');
+    await lib.searchCategories('');
 
     // Category multi-select filters the gallery; clear resets it.
-    await pm.alertLibraryPage.toggleCategory('bulk-signals');
-    await expect(pm.alertLibraryPage.card(bulk.id)).toBeVisible();
-    await expect(pm.alertLibraryPage.card(ready.id)).toHaveCount(0);
-    await pm.alertLibraryPage.clearCategories();
-    await expect(pm.alertLibraryPage.card(ready.id)).toBeVisible();
+    await lib.toggleCategory('bulk-signals');
+    await lib.expectCardVisible(bulk.id);
+    await lib.expectCardAbsent(ready.id);
+    await lib.clearCategories();
+    await lib.expectCardVisible(ready.id);
 
     // C13: a search matching nothing shows the no-results state.
-    await pm.alertLibraryPage.search('zzz_no_such_alert_zzz');
-    await expect(page.locator('[data-test="alert-library-no-results"]')).toBeVisible();
+    await lib.search('zzz_no_such_alert_zzz');
+    await lib.expectNoResults();
   });
 
-  test('bulk install a small selection runs each alert and reports success', async ({ page }) => {
+  test('bulk install a small selection runs each alert and reports success', async () => {
     const picks = [entries[2], entries[3], entries[4]]; // three bulk cards on the ready stream
 
-    await pm.alertLibraryPage.openViaUrl();
-    for (const e of picks) await pm.alertLibraryPage.selectCard(e.id);
-    expect(await pm.alertLibraryPage.selectedCountInBar()).toBe(picks.length);
+    await lib.openViaUrl();
+    for (const e of picks) await lib.selectCard(e.id);
+    expect(await lib.selectedCountInBar()).toBe(picks.length);
 
-    await pm.alertLibraryPage.addSelected();
-    await pm.alertLibraryPage.pickDestination(destinationName);
-    await pm.alertLibraryPage.next(); // alerts
+    await lib.addSelected();
+    await lib.pickDestination(destinationName);
+    await lib.next(); // alerts
     // F5: clearing the selection blocks advancing until at least one is re-picked
     // (re-check the three specific rows — select-all would pull the whole gallery).
-    await pm.alertLibraryPage.clearInDialog();
-    await expect(page.locator('[data-test="alert-library-install-next"]')).toBeDisabled();
-    for (const e of picks) await pm.alertLibraryPage.toggleAlertInDialog(e.id);
-    await expect(page.locator('[data-test="alert-library-install-next"]')).toBeEnabled();
-    await pm.alertLibraryPage.next(); // folder
-    await pm.alertLibraryPage.next(); // tune
-    await pm.alertLibraryPage.next(); // review
-    // <= 50, so no large-batch confirm is required.
-    await expect(page.locator('[data-test="alert-library-install-confirm-large"]')).toHaveCount(0);
-    await pm.alertLibraryPage.run();
-    for (const e of picks) await pm.alertLibraryPage.waitResult(e.id, 'installed');
-    await pm.alertLibraryPage.done();
+    await lib.clearInDialog();
+    await lib.expectNextDisabled();
+    for (const e of picks) await lib.toggleAlertInDialog(e.id);
+    await lib.expectNextEnabled();
+    await lib.next(); // folder
+    await lib.next(); // tune
+    await lib.next(); // review
+    await lib.expectLargeConfirmAbsent(); // <= 50, so no confirm required
+    await lib.run();
+    for (const e of picks) await lib.waitResult(e.id, 'installed');
+    await lib.done();
 
     // Spot-check one installed alert via API.
-    const created = await pm.alertLibraryPage.getInstalledAlert(picks[0].name);
+    const created = await lib.getInstalledAlert(picks[0].name);
     expect(created, 'a bulk-installed alert should be readable via API').toBeTruthy();
     expect(created.destinations).toContain(destinationName);
     expect(created.context_attributes?.library_id).toBe(picks[0].id);
@@ -303,32 +301,28 @@ test.describe('Alert Library', () => {
   test('opens from the section tab and shows the header actions', async ({ page }) => {
     const base = process.env.ZO_BASE_URL || 'http://localhost:5080';
     await page.goto(`${base}/web/alerts?org_identifier=${getOrgIdentifier()}`);
-    await pm.alertLibraryPage.openViaTab();
-
-    await expect(page.locator('[data-test="alert-library-page"]')).toBeVisible();
-    await expect(page.locator('[data-test="alert-library-title"]')).toBeVisible();
-    await expect(page.locator('[data-test="alert-library-refresh"]')).toBeVisible();
-    await expect(page.locator('[data-test="alert-library-contribute"]')).toBeVisible();
+    await lib.openViaTab();
+    await lib.expectPageHeaderVisible();
   });
 
-  test('selection persists across filters via group-select, off-screen count and clear', async ({ page }) => {
-    await pm.alertLibraryPage.openViaUrl();
+  test('selection persists across filters via group-select, off-screen count and clear', async () => {
+    await lib.openViaUrl();
 
     // G2: a group's select button selects that group's cards.
-    await pm.alertLibraryPage.firstSelectGroup();
-    expect(await pm.alertLibraryPage.selectedCountInBar()).toBeGreaterThan(0);
-    await pm.alertLibraryPage.clearSelection();
-    expect(await pm.alertLibraryPage.selectedCountInBar()).toBe(0);
+    await lib.firstSelectGroup();
+    expect(await lib.selectedCountInBar()).toBeGreaterThan(0);
+    await lib.clearSelection();
+    expect(await lib.selectedCountInBar()).toBe(0);
 
     // G4: a selected card that a filter pushes out of view is reported off-screen.
-    await pm.alertLibraryPage.selectCard(entries[2].id); // a warning bulk card
-    await pm.alertLibraryPage.selectSeverity('critical'); // hides warning cards
-    expect(await pm.alertLibraryPage.offscreenCountInBar()).toBeGreaterThan(0);
+    await lib.selectCard(entries[2].id); // a warning bulk card
+    await lib.selectSeverity('critical'); // hides warning cards
+    expect(await lib.offscreenCountInBar()).toBeGreaterThan(0);
 
     // G5: clear empties the selection.
-    await pm.alertLibraryPage.selectSeverity('all');
-    await pm.alertLibraryPage.clearSelection();
-    expect(await pm.alertLibraryPage.selectedCountInBar()).toBe(0);
+    await lib.selectSeverity('all');
+    await lib.clearSelection();
+    expect(await lib.selectedCountInBar()).toBe(0);
   });
 
   test('a per-alert install failure is shown per-row and can be retried', async ({ page }) => {
@@ -357,26 +351,26 @@ test.describe('Alert Library', () => {
       fileFor: (entry) => (entry.id === b.id ? brokenFile(entry) : buildAlertFile(entry)),
     });
 
-    await pm.alertLibraryPage.openViaUrl();
-    await pm.alertLibraryPage.selectCard(a.id);
-    await pm.alertLibraryPage.selectCard(b.id);
-    await pm.alertLibraryPage.addSelected();
-    await pm.alertLibraryPage.pickDestination(destinationName);
-    await pm.alertLibraryPage.next(); // alerts
-    await pm.alertLibraryPage.next(); // folder
-    await pm.alertLibraryPage.next(); // tune
-    await pm.alertLibraryPage.next(); // review
-    await pm.alertLibraryPage.run();
+    await lib.openViaUrl();
+    await lib.selectCard(a.id);
+    await lib.selectCard(b.id);
+    await lib.addSelected();
+    await lib.pickDestination(destinationName);
+    await lib.next(); // alerts
+    await lib.next(); // folder
+    await lib.next(); // tune
+    await lib.next(); // review
+    await lib.run();
 
     // H6: exactly one installed, one failed, with the server message shown.
-    await expect(page.locator('[data-test^="alert-library-install-result-"][data-status="installed"]')).toHaveCount(1);
-    await expect(page.locator('[data-test^="alert-library-install-result-"][data-status="failed"]')).toHaveCount(1);
-    await expect(page.locator('[data-test^="alert-library-install-error-"]').first()).toBeVisible();
+    await lib.expectInstallResultCount('installed', 1);
+    await lib.expectInstallResultCount('failed', 1);
+    await lib.expectInstallErrorVisible();
 
     // H7: the failed row can be retried (it collides again and stays failed).
-    await expect(page.locator('[data-test="alert-library-install-retry"]')).toBeVisible();
-    await pm.alertLibraryPage.retryFailed();
-    await expect(page.locator('[data-test^="alert-library-install-result-"][data-status="failed"]')).toHaveCount(1);
+    await lib.expectRetryVisible();
+    await lib.retryFailed();
+    await lib.expectInstallResultCount('failed', 1);
   });
 
   test('install blocks when the org has no usable destinations', async ({ page }) => {
@@ -386,19 +380,19 @@ test.describe('Alert Library', () => {
     await page.route('**/api/*/alerts/destinations**', (route) =>
       route.fulfill({ status: 500, contentType: 'application/json', body: '{}' }),
     );
-    await pm.alertLibraryPage.openViaUrl();
-    await pm.alertLibraryPage.openCard(ready.id);
-    await pm.alertLibraryPage.installFromDrawer();
-    await expect(page.locator('[data-test="alert-library-install-destinations-failed"]')).toBeVisible();
-    await expect(page.locator('[data-test="alert-library-install-destinations-retry"]')).toBeVisible();
+    await lib.openViaUrl();
+    await lib.openCard(ready.id);
+    await lib.installFromDrawer();
+    await lib.expectDestinationsFailed();
+    await lib.expectDestinationsRetryVisible();
 
     // F3: retry against an empty list → the no-destinations banner + open-destinations.
     await page.unroute('**/api/*/alerts/destinations**');
     await page.route('**/api/*/alerts/destinations**', (route) =>
       route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
     );
-    await page.locator('[data-test="alert-library-install-destinations-retry"]').click();
-    await expect(page.locator('[data-test="alert-library-install-destinations-empty"]')).toBeVisible();
-    await expect(page.locator('[data-test="alert-library-install-open-destinations"]')).toBeVisible();
+    await lib.clickDestinationsRetry();
+    await lib.expectDestinationsEmpty();
+    await lib.expectOpenDestinationsVisible();
   });
 });

--- a/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
@@ -4,9 +4,11 @@ const testLogger = require('../utils/test-logger.js');
 const { getOrgIdentifier } = require('../utils/cloud-auth.js');
 const {
   MANIFEST_GLOB,
+  FILE_GLOB,
   makeEntry,
   makeEntries,
   buildManifest,
+  buildAlertFile,
   routeLibrary,
 } = require('../fixtures/alertLibraryFixture.js');
 
@@ -143,6 +145,18 @@ test.describe('Alert Library', () => {
     await expect(page.locator('[data-test="alert-library-install-run"]')).toBeDisabled();
     await pm.alertLibraryPage.confirmLargeBatch();
     await expect(page.locator('[data-test="alert-library-install-run"]')).toBeEnabled();
+
+    // H5: the confirmation auto-resets when the run's shape changes (here, the
+    // alert selection), so it always describes the run about to happen.
+    await pm.alertLibraryPage.back(); // → tune
+    await pm.alertLibraryPage.back(); // → folder
+    await pm.alertLibraryPage.back(); // → alerts
+    await pm.alertLibraryPage.clearInDialog();
+    await pm.alertLibraryPage.selectAllInDialog();
+    await pm.alertLibraryPage.next(); // folder
+    await pm.alertLibraryPage.next(); // tune
+    await pm.alertLibraryPage.next(); // review
+    await expect(page.locator('[data-test="alert-library-install-run"]')).toBeDisabled();
   });
 
   test('readiness surfaces on the card and in the drawer (fresh vs missing)', async ({ page }) => {
@@ -187,6 +201,25 @@ test.describe('Alert Library', () => {
       // Distinct error surface with a retry, never a silent empty catalog.
       await expect(page.locator('[data-test="alert-library-error"]'), m.label).toBeVisible({ timeout: 20000 });
     }
+
+    // B3: a valid-but-empty manifest is its OWN state, not an error.
+    await page.unroute(MANIFEST_GLOB);
+    await page.route(MANIFEST_GLOB, (route) =>
+      route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ format_version: '1.0', alert_count: 0, packs: [], alerts: [] }),
+      }),
+    );
+    await page.reload();
+    await expect(page.locator('[data-test="alert-library-empty-catalog"]')).toBeVisible({ timeout: 20000 });
+
+    // B7: restoring a good manifest and hitting Retry recovers the gallery.
+    await page.unroute(MANIFEST_GLOB);
+    await page.route(MANIFEST_GLOB, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(buildManifest(entries)) }),
+    );
+    await page.locator('[data-test="alert-library-empty-catalog"] [data-test$="-action"], [data-test="alert-library-empty-catalog"] button').first().click();
+    await expect(page.locator('[data-test="alert-library-grid"]')).toBeVisible({ timeout: 20000 });
   });
 
   test('Customize opens the alert editor prefilled from the library file', async ({ page }) => {
@@ -227,6 +260,10 @@ test.describe('Alert Library', () => {
     await expect(pm.alertLibraryPage.card(ready.id)).toHaveCount(0);
     await pm.alertLibraryPage.clearCategories();
     await expect(pm.alertLibraryPage.card(ready.id)).toBeVisible();
+
+    // C13: a search matching nothing shows the no-results state.
+    await pm.alertLibraryPage.search('zzz_no_such_alert_zzz');
+    await expect(page.locator('[data-test="alert-library-no-results"]')).toBeVisible();
   });
 
   test('bulk install a small selection runs each alert and reports success', async ({ page }) => {
@@ -239,6 +276,12 @@ test.describe('Alert Library', () => {
     await pm.alertLibraryPage.addSelected();
     await pm.alertLibraryPage.pickDestination(destinationName);
     await pm.alertLibraryPage.next(); // alerts
+    // F5: clearing the selection blocks advancing until at least one is re-picked
+    // (re-check the three specific rows — select-all would pull the whole gallery).
+    await pm.alertLibraryPage.clearInDialog();
+    await expect(page.locator('[data-test="alert-library-install-next"]')).toBeDisabled();
+    for (const e of picks) await pm.alertLibraryPage.toggleAlertInDialog(e.id);
+    await expect(page.locator('[data-test="alert-library-install-next"]')).toBeEnabled();
     await pm.alertLibraryPage.next(); // folder
     await pm.alertLibraryPage.next(); // tune
     await pm.alertLibraryPage.next(); // review
@@ -253,5 +296,107 @@ test.describe('Alert Library', () => {
     expect(created, 'a bulk-installed alert should be readable via API').toBeTruthy();
     expect(created.destinations).toContain(destinationName);
     expect(created.context_attributes?.library_id).toBe(picks[0].id);
+  });
+
+  test('opens from the section tab and shows the header actions', async ({ page }) => {
+    const base = process.env.ZO_BASE_URL || 'http://localhost:5080';
+    await page.goto(`${base}/web/alerts?org_identifier=${getOrgIdentifier()}`);
+    await pm.alertLibraryPage.openViaTab();
+
+    await expect(page.locator('[data-test="alert-library-page"]')).toBeVisible();
+    await expect(page.locator('[data-test="alert-library-title"]')).toBeVisible();
+    await expect(page.locator('[data-test="alert-library-refresh"]')).toBeVisible();
+    await expect(page.locator('[data-test="alert-library-contribute"]')).toBeVisible();
+  });
+
+  test('selection persists across filters via group-select, off-screen count and clear', async ({ page }) => {
+    await pm.alertLibraryPage.openViaUrl();
+
+    // G2: a group's select button selects that group's cards.
+    await pm.alertLibraryPage.firstSelectGroup();
+    expect(await pm.alertLibraryPage.selectedCountInBar()).toBeGreaterThan(0);
+    await pm.alertLibraryPage.clearSelection();
+    expect(await pm.alertLibraryPage.selectedCountInBar()).toBe(0);
+
+    // G4: a selected card that a filter pushes out of view is reported off-screen.
+    await pm.alertLibraryPage.selectCard(entries[2].id); // a warning bulk card
+    await pm.alertLibraryPage.selectSeverity('critical'); // hides warning cards
+    expect(await pm.alertLibraryPage.offscreenCountInBar()).toBeGreaterThan(0);
+
+    // G5: clear empties the selection.
+    await pm.alertLibraryPage.selectSeverity('all');
+    await pm.alertLibraryPage.clearSelection();
+    expect(await pm.alertLibraryPage.selectedCountInBar()).toBe(0);
+  });
+
+  test('a per-alert install failure is shown per-row and can be retried', async ({ page }) => {
+    // Entry `a` is a valid alert; entry `b` ships an unreadable conditions shape
+    // ({and: <non-array>}), so buildInstallPayload rejects it client-side — a
+    // deterministic per-row failure without depending on backend validation.
+    const a = makeEntry(1, { pack: 'observability', category: 'dup',
+      stream: readyStream, required_streams: [readyStream] });
+    const b = makeEntry(2, { pack: 'infrastructure', category: 'dup',
+      stream: readyStream, required_streams: [readyStream] });
+    const brokenFile = (entry) => ({
+      name: entry.name,
+      stream_type: entry.stream_type,
+      stream_name: entry.stream,
+      is_real_time: false,
+      query_condition: { type: 'custom', conditions: { and: 'not-an-array' },
+        sql: '', promql: null, promql_condition: null, aggregation: null },
+      trigger_condition: { period: 10, operator: '>=', threshold: 3, frequency: 10, silence: 10, timezone: 'UTC' },
+      destinations: ['x'], context_attributes: {}, tags: [],
+    });
+    await page.unroute(MANIFEST_GLOB);
+    await page.unroute(FILE_GLOB);
+    await routeLibrary(page, {
+      manifest: buildManifest([a, b]),
+      entries: [a, b],
+      fileFor: (entry) => (entry.id === b.id ? brokenFile(entry) : buildAlertFile(entry)),
+    });
+
+    await pm.alertLibraryPage.openViaUrl();
+    await pm.alertLibraryPage.selectCard(a.id);
+    await pm.alertLibraryPage.selectCard(b.id);
+    await pm.alertLibraryPage.addSelected();
+    await pm.alertLibraryPage.pickDestination(destinationName);
+    await pm.alertLibraryPage.next(); // alerts
+    await pm.alertLibraryPage.next(); // folder
+    await pm.alertLibraryPage.next(); // tune
+    await pm.alertLibraryPage.next(); // review
+    await pm.alertLibraryPage.run();
+
+    // H6: exactly one installed, one failed, with the server message shown.
+    await expect(page.locator('[data-test^="alert-library-install-result-"][data-status="installed"]')).toHaveCount(1);
+    await expect(page.locator('[data-test^="alert-library-install-result-"][data-status="failed"]')).toHaveCount(1);
+    await expect(page.locator('[data-test^="alert-library-install-error-"]').first()).toBeVisible();
+
+    // H7: the failed row can be retried (it collides again and stays failed).
+    await expect(page.locator('[data-test="alert-library-install-retry"]')).toBeVisible();
+    await pm.alertLibraryPage.retryFailed();
+    await expect(page.locator('[data-test^="alert-library-install-result-"][data-status="failed"]')).toHaveCount(1);
+  });
+
+  test('install blocks when the org has no usable destinations', async ({ page }) => {
+    const ready = entries[0];
+
+    // F4: destinations fail to load → failed banner + retry.
+    await page.route('**/api/*/alerts/destinations**', (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{}' }),
+    );
+    await pm.alertLibraryPage.openViaUrl();
+    await pm.alertLibraryPage.openCard(ready.id);
+    await pm.alertLibraryPage.installFromDrawer();
+    await expect(page.locator('[data-test="alert-library-install-destinations-failed"]')).toBeVisible();
+    await expect(page.locator('[data-test="alert-library-install-destinations-retry"]')).toBeVisible();
+
+    // F3: retry against an empty list → the no-destinations banner + open-destinations.
+    await page.unroute('**/api/*/alerts/destinations**');
+    await page.route('**/api/*/alerts/destinations**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    );
+    await page.locator('[data-test="alert-library-install-destinations-retry"]').click();
+    await expect(page.locator('[data-test="alert-library-install-destinations-empty"]')).toBeVisible();
+    await expect(page.locator('[data-test="alert-library-install-open-destinations"]')).toBeVisible();
   });
 });

--- a/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
@@ -3,6 +3,7 @@ const PageManager = require('../../pages/page-manager.js');
 const testLogger = require('../utils/test-logger.js');
 const { getOrgIdentifier } = require('../utils/cloud-auth.js');
 const {
+  MANIFEST_GLOB,
   makeEntry,
   makeEntries,
   buildManifest,
@@ -131,5 +132,61 @@ test.describe('Alert Library', () => {
     await expect(page.locator('[data-test="alert-library-install-run"]')).toBeDisabled();
     await pm.alertLibraryPage.confirmLargeBatch();
     await expect(page.locator('[data-test="alert-library-install-run"]')).toBeEnabled();
+  });
+
+  test('readiness surfaces on the card and in the drawer (fresh vs missing)', async ({ page }) => {
+    const ready = entries[0];
+    const missing = entries[1];
+
+    await pm.alertLibraryPage.openViaUrl();
+
+    // Card: missing → "not ingested" chip; fresh → none.
+    await expect(pm.alertLibraryPage.needsDataChip(missing.id)).toBeVisible();
+    await expect(pm.alertLibraryPage.needsDataChip(ready.id)).toHaveCount(0);
+
+    // Drawer: missing → availability warning banner; fresh → no banner.
+    await pm.alertLibraryPage.openCard(missing.id);
+    await expect(page.locator('[data-test="alert-library-drawer-needs-data"]')).toBeVisible();
+    await expect(page.locator('[data-test="alert-library-drawer-availability"]')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-test="alert-library-drawer"]')).toBeHidden();
+
+    // The ready card's drawer renders the preview. (Its exact availability
+    // sub-state — fresh vs stale — depends on stream-stats propagation timing,
+    // which is covered deterministically by the useAlertLibrary unit tests.)
+    await pm.alertLibraryPage.openCard(ready.id);
+    await expect(page.locator('[data-test="alert-library-drawer-preview"]')).toBeVisible();
+  });
+
+  test('a broken manifest shows a recovery state, not an empty gallery', async ({ page }) => {
+    const badManifests = [
+      { label: 'http 500', status: 500, body: '{}' },
+      { label: 'unsupported version', status: 200,
+        body: JSON.stringify({ format_version: '2.0', alert_count: 0, packs: [], alerts: [] }) },
+      { label: 'malformed / not JSON', status: 200, body: '<Error>not json</Error>' },
+    ];
+
+    for (const [i, m] of badManifests.entries()) {
+      await page.unroute(MANIFEST_GLOB);
+      await page.route(MANIFEST_GLOB, (route) =>
+        route.fulfill({ status: m.status, contentType: 'application/json', body: m.body }),
+      );
+      if (i === 0) await pm.alertLibraryPage.openViaUrl();
+      else await page.reload();
+      // Distinct error surface with a retry, never a silent empty catalog.
+      await expect(page.locator('[data-test="alert-library-error"]'), m.label).toBeVisible({ timeout: 20000 });
+    }
+  });
+
+  test('Customize opens the alert editor prefilled from the library file', async ({ page }) => {
+    const ready = entries[0];
+
+    await pm.alertLibraryPage.openViaUrl();
+    await pm.alertLibraryPage.openCard(ready.id);
+    await pm.alertLibraryPage.customizeFromDrawer();
+
+    // Customize hands the alert to the full editor via the library prefill
+    // (route "addAlert" with ?prefill=library) — not a customizeFailed toast.
+    await expect(page).toHaveURL(/prefill=library/, { timeout: 15000 });
   });
 });

--- a/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alert-library.spec.js
@@ -91,7 +91,10 @@ test.describe('Alert Library', () => {
 
     // Install wizard: destination → alerts → folder(default) → tune → run.
     await pm.alertLibraryPage.installFromDrawer();
+    // F2: cannot advance until a destination is chosen.
+    await expect(page.locator('[data-test="alert-library-install-next"]')).toBeDisabled();
     await pm.alertLibraryPage.pickDestination(destinationName);
+    await expect(page.locator('[data-test="alert-library-install-next"]')).toBeEnabled();
     await pm.alertLibraryPage.next(); // → alerts
     await pm.alertLibraryPage.next(); // → folder
     await pm.alertLibraryPage.next(); // → tune
@@ -103,14 +106,22 @@ test.describe('Alert Library', () => {
     await pm.alertLibraryPage.waitResult(ready.id, 'installed');
     await pm.alertLibraryPage.done();
 
-    // Verify via API: the alert exists with the OVERRIDDEN destination, the
-    // provenance tag, and the mapped priority (critical → 1).
+    // Verify via API the transformations the UI never shows.
     const created = await pm.alertLibraryPage.getInstalledAlert(ready.name);
     expect(created, 'installed alert should be readable via API').toBeTruthy();
+    // I2 destination overridden (author's o2_to_slack replaced)
     expect(created.destinations).toContain(destinationName);
+    // I3 provenance stamped
     expect(JSON.stringify(created.tags || [])).toContain(`pack:${ready.pack}`);
     expect(created.context_attributes?.library_id).toBe(ready.id);
+    expect(created.context_attributes?.library_hash).toBe(ready.content_hash);
+    // I4 severity critical → priority 1 (integer on the wire)
+    expect(created.priority).toBe(1);
+    // I5 owner is the installing user; I1 lands in the chosen (default) folder
+    expect(typeof created.owner === 'string' && created.owner.length).toBeTruthy();
+    // I7 tuning applied
     expect(created.trigger_condition?.frequency).toBe(15);
+    expect(created.trigger_condition?.silence).toBe(20);
   });
 
   test('bulk select via select-all-in-view triggers the >50 large-batch guard', async ({ page }) => {
@@ -188,5 +199,59 @@ test.describe('Alert Library', () => {
     // Customize hands the alert to the full editor via the library prefill
     // (route "addAlert" with ?prefill=library) — not a customizeFailed toast.
     await expect(page).toHaveURL(/prefill=library/, { timeout: 15000 });
+  });
+
+  test('the rail filters the gallery by severity and by category', async ({ page }) => {
+    const ready = entries[0]; // critical, category ready-signals
+    const missing = entries[1]; // info, category absent-signals
+    const bulk = entries[2]; // warning, category bulk-signals
+
+    await pm.alertLibraryPage.openViaUrl();
+
+    // Severity is single-select: critical → only the critical card.
+    await pm.alertLibraryPage.selectSeverity('critical');
+    await expect(pm.alertLibraryPage.card(ready.id)).toBeVisible();
+    await expect(pm.alertLibraryPage.card(missing.id)).toHaveCount(0);
+    await pm.alertLibraryPage.selectSeverity('all'); // widen back
+    await expect(pm.alertLibraryPage.card(missing.id)).toBeVisible();
+
+    // Category search narrows the rail list (nothing selected yet).
+    await pm.alertLibraryPage.searchCategories('bulk');
+    await expect(page.locator('[data-test="alert-library-rail-category-bulk-signals"]')).toBeVisible();
+    await expect(page.locator('[data-test="alert-library-rail-category-absent-signals"]')).toHaveCount(0);
+    await pm.alertLibraryPage.searchCategories('');
+
+    // Category multi-select filters the gallery; clear resets it.
+    await pm.alertLibraryPage.toggleCategory('bulk-signals');
+    await expect(pm.alertLibraryPage.card(bulk.id)).toBeVisible();
+    await expect(pm.alertLibraryPage.card(ready.id)).toHaveCount(0);
+    await pm.alertLibraryPage.clearCategories();
+    await expect(pm.alertLibraryPage.card(ready.id)).toBeVisible();
+  });
+
+  test('bulk install a small selection runs each alert and reports success', async ({ page }) => {
+    const picks = [entries[2], entries[3], entries[4]]; // three bulk cards on the ready stream
+
+    await pm.alertLibraryPage.openViaUrl();
+    for (const e of picks) await pm.alertLibraryPage.selectCard(e.id);
+    expect(await pm.alertLibraryPage.selectedCountInBar()).toBe(picks.length);
+
+    await pm.alertLibraryPage.addSelected();
+    await pm.alertLibraryPage.pickDestination(destinationName);
+    await pm.alertLibraryPage.next(); // alerts
+    await pm.alertLibraryPage.next(); // folder
+    await pm.alertLibraryPage.next(); // tune
+    await pm.alertLibraryPage.next(); // review
+    // <= 50, so no large-batch confirm is required.
+    await expect(page.locator('[data-test="alert-library-install-confirm-large"]')).toHaveCount(0);
+    await pm.alertLibraryPage.run();
+    for (const e of picks) await pm.alertLibraryPage.waitResult(e.id, 'installed');
+    await pm.alertLibraryPage.done();
+
+    // Spot-check one installed alert via API.
+    const created = await pm.alertLibraryPage.getInstalledAlert(picks[0].name);
+    expect(created, 'a bulk-installed alert should be readable via API').toBeTruthy();
+    expect(created.destinations).toContain(destinationName);
+    expect(created.context_attributes?.library_id).toBe(picks[0].id);
   });
 });

--- a/tests/ui-testing/playwright-tests/cleanup.spec.js
+++ b/tests/ui-testing/playwright-tests/cleanup.spec.js
@@ -41,7 +41,8 @@ test.describe("Pre-Test Cleanup", () => {
         'test_fv_alerts_slack_',   // alerts-form-validation.spec.js (slack destination created by the test cases)
         /^destination\d{1,3}$/,    // destination4, destination44, destination444, etc.
         'wf_auto_dest_',           // Workflows v1 test destinations
-        'wf_auto_'                 // Workflows v1 generic test destinations
+        'wf_auto_',                // Workflows v1 generic test destinations
+        'pw_lib_dest_'             // alert-library.spec.js (Alert Library e2e destinations)
       ],
       // Template prefixes to clean up
       [
@@ -65,7 +66,8 @@ test.describe("Pre-Test Cleanup", () => {
         'e2e_sched_',              // alerts-scheduled-features.spec.js (scheduled alert tests)
         'e2e_metrics_',            // alerts-metrics-notification.spec.js (metrics notification tests)
         'e2e_alertfv_',            // alerts-form-validation.spec.js (seeded prerequisite templates)
-        'test_fv_alerts_tmpl_'     // alerts-form-validation.spec.js (templates created by the test cases)
+        'test_fv_alerts_tmpl_',    // alerts-form-validation.spec.js (templates created by the test cases)
+        'pw_lib_tmpl_'             // alert-library.spec.js (Alert Library e2e templates)
       ],
       // Folder prefixes to clean up
       ['auto_', 'incident_e2e_folder_', 'E2E Incidents ', 'E2E Scheduled ', 'wf_auto_']
@@ -333,7 +335,8 @@ test.describe("Pre-Test Cleanup", () => {
         /^backfill_source_\d+$/,                       // Backfill source streams (backfill_source_<number>)
         /^backfill_dest_\d+$/,                         // Backfill dest streams (backfill_dest_<number>)
         /^e2e_backfill_dest_\d+$/,                     // e2e_backfill_dest_<timestamp> (pipeline-backfill.spec.js)
-        /^e2e_time_test_\d+$/                       // e2e_time_test_<timestamp>
+        /^e2e_time_test_\d+$/,                      // e2e_time_test_<timestamp>
+        /^pw_lib_(ready|absent)_/                   // alert-library.spec.js (Alert Library e2e readiness streams)
       ],
       // Protected streams to never delete
       ['default', 'sensitive', 'important', 'critical', 'production', 'staging', 'automation', 'e2e_automate', 'k8s_json']

--- a/tests/ui-testing/playwright-tests/fixtures/alertLibraryFixture.js
+++ b/tests/ui-testing/playwright-tests/fixtures/alertLibraryFixture.js
@@ -5,8 +5,8 @@
  * For CI-stable e2e we intercept the manifest (and the per-alert files) with a
  * fixture we fully control, so readiness states, the >50 large-batch boundary
  * and error states are all reachable on demand. Install still hits the real
- * alert API — the served file body is a real, backend-valid alert (pass one
- * captured at setup via `fileTemplate`).
+ * alert API — the served file body is a backend-valid SQL alert, so it installs
+ * as-is; pass `fileTemplate` only when a test needs an exact captured body.
  */
 
 const MANIFEST_GLOB = '**/alerts/manifest.json';
@@ -68,9 +68,9 @@ function buildManifest(entries, o = {}) {
 /**
  * A minimal, backend-valid scheduled SQL alert file for one entry.
  *
- * Prefer passing a `fileTemplate` captured from a real alert at setup — this
- * fallback is only for specs that never install (browse / filter / readiness),
- * where the body only has to render in the drawer.
+ * This is what the install tests actually POST — it is a complete, installable
+ * alert body, not a placeholder. Pass `o.fileTemplate` only when a test needs
+ * an exact captured body instead of this default.
  */
 function buildAlertFile(entry, o = {}) {
   if (o.fileTemplate) {

--- a/tests/ui-testing/playwright-tests/fixtures/alertLibraryFixture.js
+++ b/tests/ui-testing/playwright-tests/fixtures/alertLibraryFixture.js
@@ -1,0 +1,147 @@
+/**
+ * Deterministic Alert Library fixtures.
+ *
+ * The gallery reads a public S3 manifest whose entries/streams drift upstream.
+ * For CI-stable e2e we intercept the manifest (and the per-alert files) with a
+ * fixture we fully control, so readiness states, the >50 large-batch boundary
+ * and error states are all reachable on demand. Install still hits the real
+ * alert API — the served file body is a real, backend-valid alert (pass one
+ * captured at setup via `fileTemplate`).
+ */
+
+const MANIFEST_GLOB = '**/alerts/manifest.json';
+const FILE_GLOB = '**/alerts/packs/**';
+
+/** One manifest entry with sensible defaults; override any field. */
+function makeEntry(i, o = {}) {
+  const pack = o.pack || 'observability';
+  const category = o.category || 'test-signals';
+  const name = o.name || `pw_lib_${i}`;
+  const stream = o.stream || 'default';
+  return {
+    id: `${pack}/${name}`,
+    name,
+    pack,
+    category,
+    title: o.title || `PW Library Alert ${i}`,
+    severity: o.severity || 'critical',
+    description: o.description || `Synthetic library alert ${i} for e2e.`,
+    stream,
+    stream_type: o.stream_type || 'logs',
+    query_type: o.query_type || 'sql',
+    required_streams: o.required_streams || [stream],
+    path: `packs/${pack}/alerts/${category}/${name}.json`,
+    content_hash: o.content_hash || `pwhash${i}`,
+  };
+}
+
+/** N entries sharing options — for the bulk / large-batch flows. */
+function makeEntries(n, o = {}) {
+  const prefix = o.namePrefix || 'pw_bulk';
+  return Array.from({ length: n }, (_, i) =>
+    makeEntry(i, { ...o, name: `${prefix}_${i}`, title: `${o.titlePrefix || 'Bulk Alert'} ${i}` }),
+  );
+}
+
+/** A well-formed manifest around a set of entries. `packs` is derived. */
+function buildManifest(entries, o = {}) {
+  const byPack = new Map();
+  for (const e of entries) {
+    const p = byPack.get(e.pack) || { id: e.pack, alert_count: 0, categories: new Map() };
+    p.alert_count += 1;
+    p.categories.set(e.category, (p.categories.get(e.category) || 0) + 1);
+    byPack.set(e.pack, p);
+  }
+  const packs = [...byPack.values()].map((p) => ({
+    id: p.id,
+    alert_count: p.alert_count,
+    categories: [...p.categories.entries()].map(([id, alert_count]) => ({ id, alert_count })),
+  }));
+  return {
+    format_version: o.format_version || '1.0',
+    alert_count: entries.length,
+    packs,
+    alerts: entries,
+  };
+}
+
+/**
+ * A minimal, backend-valid scheduled SQL alert file for one entry.
+ *
+ * Prefer passing a `fileTemplate` captured from a real alert at setup — this
+ * fallback is only for specs that never install (browse / filter / readiness),
+ * where the body only has to render in the drawer.
+ */
+function buildAlertFile(entry, o = {}) {
+  if (o.fileTemplate) {
+    const clone = JSON.parse(JSON.stringify(o.fileTemplate));
+    clone.name = entry.name;
+    clone.stream_name = entry.stream;
+    clone.stream_type = entry.stream_type;
+    delete clone.id;
+    return clone;
+  }
+  return {
+    name: entry.name,
+    org_id: o.orgId || 'default',
+    stream_type: entry.stream_type,
+    stream_name: entry.stream,
+    is_real_time: false,
+    enabled: true,
+    description: entry.description,
+    query_condition: {
+      type: 'custom',
+      conditions: { or: [{ column: 'level', operator: '=', value: 'error', ignore_case: false }] },
+      sql: '',
+      promql: null,
+      promql_condition: null,
+      aggregation: null,
+      vrl_function: null,
+    },
+    trigger_condition: {
+      period: 10,
+      operator: '>=',
+      threshold: 3,
+      frequency: 10,
+      silence: 10,
+      timezone: 'UTC',
+    },
+    destinations: ['pw_placeholder_destination'],
+    context_attributes: {},
+    tags: [],
+  };
+}
+
+/**
+ * Intercept the manifest + alert files. `fileFor(entry)` yields the body served
+ * for that entry's path; defaults to `buildAlertFile`. Pass `manifestBody` /
+ * `status` to force an error state (malformed body, 500, bad version, …).
+ */
+async function routeLibrary(page, { manifest, entries = [], fileFor, manifestBody, status = 200 } = {}) {
+  await page.route(MANIFEST_GLOB, (route) =>
+    route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: manifestBody !== undefined ? manifestBody : JSON.stringify(manifest),
+    }),
+  );
+  const byPath = new Map(entries.map((e) => [e.path, e]));
+  await page.route(FILE_GLOB, (route) => {
+    const url = new URL(route.request().url());
+    const key = url.pathname.replace(/^\/alerts\//, '');
+    const entry = byPath.get(key) || entries.find((e) => url.pathname.endsWith(e.path));
+    if (!entry) return route.fulfill({ status: 404, body: 'not found' });
+    const body = fileFor ? fileFor(entry) : buildAlertFile(entry);
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+module.exports = {
+  MANIFEST_GLOB,
+  FILE_GLOB,
+  makeEntry,
+  makeEntries,
+  buildManifest,
+  buildAlertFile,
+  routeLibrary,
+};

--- a/tests/ui-testing/playwright-tests/fixtures/alertLibraryFixture.js
+++ b/tests/ui-testing/playwright-tests/fixtures/alertLibraryFixture.js
@@ -90,13 +90,13 @@ function buildAlertFile(entry, o = {}) {
     enabled: true,
     description: entry.description,
     query_condition: {
-      type: 'custom',
-      conditions: { or: [{ column: 'level', operator: '=', value: 'error', ignore_case: false }] },
-      sql: '',
+      type: 'sql',
+      sql: `SELECT count(*) AS cnt FROM "${entry.stream}"`,
       promql: null,
       promql_condition: null,
       aggregation: null,
       vrl_function: null,
+      conditions: null,
     },
     trigger_condition: {
       period: 10,


### PR DESCRIPTION
11 combined-journey e2e for the Alert Library (browse / filter / preview / install / bulk / rail facets / errors), mocked S3 manifest with real-backend install verified via API read-back. Page-object-driven, cleanup wired in cleanup.spec.js, in ci_matrix.json (Alerts shard).

Green: local 3x + alpha 11/11 (5 workers). Paired ENT branch: test/alert-library-e2e (#adds spec to alpha matrix).