### PR TITLE
ci: authenticate github.com fetches during builds (backport to 1.0.0)

### DIFF
--- a/.github/actions/github-auth/action.yml
+++ b/.github/actions/github-auth/action.yml
@@ -1,0 +1,25 @@
+name: GitHub auth for git and cargo
+description: Authenticate every github.com fetch in this job (git clone, cargo git dependencies) so shared-IP anonymous rate limits do not apply
+inputs:
+  token:
+    description: Token with read access to the repositories fetched during the build
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.token }}
+      run: |
+        # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+        # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+        B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+        echo "::add-mask::$B64"
+        git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+        # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+        for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+          [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+        done
+        echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+        # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
+        echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -228,6 +229,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -355,6 +357,7 @@ jobs:
       - uses: actions/checkout@v5
         with: { fetch-depth: 0 }
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -467,6 +470,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/audit-checker.yml
+++ b/.github/workflows/audit-checker.yml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/github-auth
       - uses: taiki-e/install-action@v2.86.5
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: cargo-audit
       - name: run cargo audit

--- a/.github/workflows/build-fork-pr-image.yml
+++ b/.github/workflows/build-fork-pr-image.yml
@@ -48,6 +48,25 @@ jobs:
           # fetch-depth: 0
           # fetch-tags: true
 
+      # Inlined rather than `uses: ./.github/actions/github-auth`: this job checks out a caller-chosen
+      # ref, and running a local action from that checkout is a cache-poisoning vector (CodeQL).
+      - name: Authenticate github.com fetches
+        shell: bash
+        env:
+          TOKEN: ${{ github.token }}
+        run: |
+          # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+          # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+          B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$B64"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+          # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+          for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+            [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+          done
+          echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Set GIT_TAG env
         run: |
           git fetch -f --tags

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -34,6 +34,25 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Inlined rather than `uses: ./.github/actions/github-auth`: this job checks out a caller-chosen
+      # ref, and running a local action from that checkout is a cache-poisoning vector (CodeQL).
+      - name: Authenticate github.com fetches
+        shell: bash
+        env:
+          TOKEN: ${{ github.token }}
+        run: |
+          # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+          # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+          B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$B64"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+          # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+          for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+            [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+          done
+          echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Set GIT_TAG env
         id: set-git-tag
         run: |
@@ -103,6 +122,25 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Inlined rather than `uses: ./.github/actions/github-auth`: this job checks out a caller-chosen
+      # ref, and running a local action from that checkout is a cache-poisoning vector (CodeQL).
+      - name: Authenticate github.com fetches
+        shell: bash
+        env:
+          TOKEN: ${{ github.token }}
+        run: |
+          # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+          # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+          B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$B64"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+          # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+          for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+            [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+          done
+          echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -192,6 +230,25 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Inlined rather than `uses: ./.github/actions/github-auth`: this job checks out a caller-chosen
+      # ref, and running a local action from that checkout is a cache-poisoning vector (CodeQL).
+      - name: Authenticate github.com fetches
+        shell: bash
+        env:
+          TOKEN: ${{ github.token }}
+        run: |
+          # Sent on every github.com request, so throttled anonymous downloads never happen. A credential helper
+          # or a token in the URL is only used after a 401, and GitHub never challenges for a public repository.
+          B64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$B64"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $B64"
+          # actions/checkout keeps the same header in each checked-out repository; two copies make GitHub answer 400.
+          for d in "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE"/*/; do
+            [ -d "$d/.git" ] && git -C "$d" config --local --unset-all http.https://github.com/.extraheader || true
+          done
+          echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+          # cargo's libgit2 transport ignores http.extraheader; the git CLI honours it.
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/github-auth
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           # The command to run with cargo-deny

--- a/.github/workflows/db-testing.yml
+++ b/.github/workflows/db-testing.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/mobile-sdk-e2e.yml
+++ b/.github/workflows/mobile-sdk-e2e.yml
@@ -258,6 +258,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/github-auth
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -308,6 +309,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/github-auth
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -129,6 +129,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Install Node
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -115,6 +116,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -122,6 +124,8 @@ jobs:
           targets: x86_64-unknown-linux-gnu
 
       - uses: taiki-e/install-action@v2.86.5
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: nextest,cargo-llvm-cov
 
@@ -176,6 +180,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -183,6 +188,8 @@ jobs:
           targets: x86_64-unknown-linux-gnu
 
       - uses: taiki-e/install-action@v2.86.5
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: nextest,cargo-llvm-cov
 
@@ -244,6 +251,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/github-auth
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:

--- a/web/scripts/fetch-datasource-content.mjs
+++ b/web/scripts/fetch-datasource-content.mjs
@@ -48,6 +48,9 @@ const ATTEMPTS = STRICT ? 3 : 1;
 const TIMEOUT_MS =
   Number(process.env.DS_CONTENT_TIMEOUT_MS) || (STRICT ? 60_000 : 30_000);
 const GIT_OPTS = { stdio: "inherit", timeout: TIMEOUT_MS };
+const BACKOFF_MS = [2_000, 8_000, 30_000];
+const sleepMs = (ms) =>
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 
 // Validate the git inputs before they reach `git`. execFileSync already prevents
 // shell injection (no shell is spawned), but an attacker who can set these env
@@ -102,6 +105,8 @@ function cloneRepo() {
     } catch (e) {
       lastErr = e;
       log(`clone attempt ${attempt}/${ATTEMPTS} failed: ${e.message}`);
+      // Anonymous clones from shared CI egress IPs get throttled; a pause gives the limit time to clear.
+      if (attempt < ATTEMPTS) sleepMs(BACKOFF_MS[attempt - 1] ?? 30_000);
     }
   }
   throw lastErr;


### PR DESCRIPTION
Backport of #14139 and #14148 to `branch-v1.0.0`. Same mechanism as main: a global `http.https://github.com/.extraheader` set by `.github/actions/github-auth` after checkout in every job that runs cargo, protoc or the web build (inlined in the PR image builds), the per-repository header from `actions/checkout` removed to avoid a duplicate Authorization header, `CARGO_NET_GIT_FETCH_WITH_CLI` for cargo, `GITHUB_TOKEN` for `taiki-e/install-action`, and back-off in `fetch-datasource-content.mjs`. Verified on main: zero throttle lines in the Playwright, API and unit-test build logs of #14148.