### PR TITLE
ci: drop the queue translation check; gate cargo-deny like cargo-audit

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,11 +1,17 @@
 name: "Licenses checker"
 on:
-  push:
+  # Licences only change with the dependency set: labelled, non-draft PRs that touch the Cargo manifests,
+  # plus a weekly run for advisories against unchanged dependencies. No post-merge rerun.
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
     paths:
       - "**/Cargo.lock"
       - "**/Cargo.toml"
       - "deny.toml"
-      - ".github/workflows/cargo-deny.yml" # run when this file changes, so we know nothing is broken
+      - ".github/workflows/cargo-deny.yml"
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,6 +19,8 @@ concurrency:
 
 jobs:
   check:
+    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
     runs-on: ubicloud-standard-8
     timeout-minutes: 10
     steps:

--- a/.github/workflows/verify-translations.yml
+++ b/.github/workflows/verify-translations.yml
@@ -21,7 +21,6 @@ on:
   pull_request:
     # labeled/unlabeled/ready_for_review/converted_to_draft so the gate re-evaluates when the state changes.
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
-  merge_group:
 
 concurrency:
   group: verify-translations-${{ github.event.pull_request.number || github.ref }}
@@ -53,13 +52,6 @@ jobs:
           python-version: '3.11'
 
       - name: Check for untranslated strings
-        env:
-          # In the merge queue this is the last chance to stop untranslated
-          # strings reaching main, so pending keys are a hard failure. On the PR
-          # itself they are expected for most of its life — translations are
-          # generated at "Merge when ready" — so we report and stay green rather
-          # than painting every in-progress PR red.
-          IS_QUEUE: ${{ github.event_name == 'merge_group' }}
         run: |
           cd scripts/translations
 
@@ -87,17 +79,7 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "$IS_QUEUE" = "true" ]; then
-            echo "::error::This merge would land English-only strings on main. Run the **Update Translations** workflow on the PR branch (or click 'Merge when ready' again, which triggers it) before re-queueing."
-            {
-              echo
-              echo "❌ **Blocked.** Merging this would leave \`main\` with untranslated strings."
-              echo "Run the **Update Translations** workflow on the PR branch, then re-queue."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-          echo "::notice::${OUTPUT##*$'\n'} These are generated automatically when you click 'Merge when ready'. This check only blocks in the merge queue."
+          echo "::notice::${OUTPUT##*$'\n'} These are generated automatically when you click 'Merge when ready'. Nothing blocks on this check."
           {
             echo
             echo "ℹ️ Expected while the PR is in progress — translations are generated when you"


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/infrastructure/CI/e2e-gate-design.md

Two of the follow-ups from the design's section 8.

**Verify Translations in the merge queue.** It failed on all 15 queue commits since the gate landed and blocked none: it is not a required check, so the hard-fail branch only ever painted a red mark on commits that merged anyway. The `merge_group` trigger and the queue-only hard failure are removed; on labelled PRs it keeps reporting untranslated strings in the step summary. Whether it should become a real gate is a separate decision.

**cargo-deny.** It ran on every push to any branch that touched a Cargo manifest, on ubicloud-standard-8. Same rule as cargo-audit now: labelled, non-draft PRs that touch `Cargo.toml`/`Cargo.lock`/`deny.toml`, a weekly run, manual dispatch, no post-merge rerun.