### PR TITLE
ci: extend mobile runtime artifact wait

### DIFF
--- a/.github/workflows/mobile-sdk-e2e.yml
+++ b/.github/workflows/mobile-sdk-e2e.yml
@@ -254,7 +254,10 @@ jobs:
     needs: [preflight, decide]
     if: needs.decide.outputs.run_android == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # Allow 15 minutes of artifact polling plus setup/API overhead. A recent
+    # cold Playwright build published its pair 55 seconds after the old
+    # 40-attempt window expired, which forced a redundant 36-minute fallback.
+    timeout-minutes: 18
     permissions:
       actions: read
       contents: read
@@ -289,8 +292,9 @@ jobs:
           fi
 
           # When both workflows started for the same PR update, Mobile reaches this
-          # resolver before Playwright finishes its ~3-7 minute build. Wait for that
-          # active run instead of immediately starting a duplicate ~35 minute cold build.
+          # resolver before Playwright publishes its artifact pair. Wait up to
+          # 15 minutes for that active run instead of starting a duplicate
+          # ~35 minute cold build; completed producers still exit early.
           if [ -z "$RUN_ID" ]; then
             PLAYWRIGHT_RUN_ID=$(gh api --method GET \
               "repos/${GITHUB_REPOSITORY}/actions/workflows/playwright.yml/runs?head_sha=${SOURCE_HEAD_SHA}&per_page=20" \
@@ -299,7 +303,7 @@ jobs:
 
             if [ -n "$PLAYWRIGHT_RUN_ID" ]; then
               echo "Waiting for Playwright run $PLAYWRIGHT_RUN_ID to publish exact-SHA artifacts"
-              for _ in $(seq 1 40); do
+              for _ in $(seq 1 60); do
                 READY=$(artifacts_ready "$PLAYWRIGHT_RUN_ID")
                 if [ "$READY" -ge 2 ]; then
                   RUN_ID="$PLAYWRIGHT_RUN_ID"


### PR DESCRIPTION
## What changed

- extend the Android runtime-artifact polling window from 40 to 60 attempts at 15-second intervals (about 10 minutes to 15 minutes)
- extend the resolver job timeout from 12 to 18 minutes to cover polling plus setup/API overhead
- retain exact-SHA artifact-pair validation, completed-producer early exit, and the existing source-build fallback

## Why

Mobile can reuse the exact Playwright Linux runtime instead of compiling another OpenObserve binary. A recent same-SHA run missed that artifact by less than one minute:

- Mobile resolver ended at 15:16:15 after about 10m28s
- Playwright binary build completed at 15:16:47
- the exact-SHA artifact finished uploading at 15:17:10

The old window therefore expired 32 seconds before the build completed and 55 seconds before upload completed. Mobile then ran the 36m31s Linux source-build fallback, and the workflow took 68m42s.

Evidence: https://github.com/openobserve/openobserve/actions/runs/33646085354

## Safety

- only waits when a Playwright run exists for the exact source SHA
- requires both the exact-SHA binary and frontend artifact before reuse
- exits polling early when the producer completes without a usable pair
- preserves the source-build fallback after timeout/failure
- does not change artifact names, retention, binary recipe, or Mobile test coverage

## Validation

- rebased onto current main
- workflow YAML parsed successfully
- actionlint passed
- git diff --check passed

## CI success criteria

The labeled PR run should show:

1. resolver waits for the same-SHA Playwright producer when necessary
2. both artifacts are selected from one exact producer run
3. Linux fallback is skipped after reuse
4. Android Mobile E2E and merge reports complete successfully

If no same-SHA producer is available or it fails, the existing fallback should still run.