### PR TITLE
fix: llm chart renderer issue 

### DIFF
--- a/web/src/plugins/traces/LLMContentRenderer.spec.ts
+++ b/web/src/plugins/traces/LLMContentRenderer.spec.ts
@@ -459,6 +459,72 @@ describe("LLMContentRenderer", () => {
       expect(messages[0].content).toContain("I should check the weather.");
       expect(messages[0].content).toContain("get_weather");
     });
+
+    // Some SDKs don't use the spec's own field/type names literally, even
+    // when the shape (a typed `parts` array) is otherwise correct.
+    it("renders a `thinking`-typed part (a real-world alias for reasoning)", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            { role: "assistant", parts: [{ type: "thinking", content: "let me check" }] },
+          ]),
+          viewMode: "formatted",
+        },
+      });
+
+      expect(wrapper.vm.parsedMessages[0].content).toBe("let me check");
+    });
+
+    it("renders a tool_call_response part that uses a `result` field instead of `response`", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            {
+              role: "tool",
+              parts: [{ type: "tool_call_response", id: "call_1", result: "rainy, 57F" }],
+            },
+          ]),
+          viewMode: "formatted",
+        },
+      });
+
+      expect(wrapper.vm.parsedMessages[0].content).toBe("rainy, 57F");
+    });
+
+    it("renders a v5 single message object (not an array) that only has `parts`", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify({
+            role: "assistant",
+            parts: [{ type: "text", content: "Single v5 response" }],
+          }),
+          viewMode: "formatted",
+        },
+      });
+
+      const messages = wrapper.vm.parsedMessages;
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe("Single v5 response");
+    });
+
+    // Preview is a full-fidelity view: unlike the Thread tab, it still shows
+    // *something* for a part type with no text representation (blob/file/uri)
+    // instead of leaving the message blank.
+    it("still shows something for a blob part instead of leaving the message blank", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            {
+              role: "assistant",
+              parts: [{ type: "blob", modality: "image", content: "aGVsbG8=" }],
+            },
+          ]),
+          viewMode: "formatted",
+        },
+      });
+
+      expect(wrapper.vm.parsedMessages[0].content).toBeTruthy();
+    });
   });
 
   describe("Content Truncation", () => {
@@ -845,6 +911,26 @@ describe("LLMContentRenderer", () => {
       expect(result).toContain("get_weather");
       expect(result).toContain("Boston");
       expect(result).not.toContain('"type"');
+    });
+
+    it("formats a `thinking`-typed part the same as a reasoning part", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "dummy", viewMode: "formatted" },
+      });
+
+      const result = wrapper.vm.formatContent([{ type: "thinking", content: "let me check" }]);
+      expect(result).toBe("let me check");
+    });
+
+    it("formats a tool_call_response part that only has a `result` field", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "dummy", viewMode: "formatted" },
+      });
+
+      const result = wrapper.vm.formatContent([
+        { type: "tool_call_response", id: "call_1", result: "rainy, 57F" },
+      ]);
+      expect(result).toBe("rainy, 57F");
     });
   });
 

--- a/web/src/plugins/traces/LLMContentRenderer.spec.ts
+++ b/web/src/plugins/traces/LLMContentRenderer.spec.ts
@@ -421,6 +421,44 @@ describe("LLMContentRenderer", () => {
       const messages = wrapper.vm.parsedMessages;
       expect(messages[0].content).toContain("[Image: base64]");
     });
+
+    // OTel GenAI semconv v5 (issue #14127): a message carries `parts`
+    // instead of `content`. Preview must stay in sync with the Thread tab
+    // (threadView.utils.ts), which already understands these part types.
+    it("renders a v5 message that only has `parts`, no `content`", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            { role: "user", parts: [{ type: "text", content: "What's the weather?" }] },
+          ]),
+          viewMode: "formatted",
+        },
+      });
+
+      const messages = wrapper.vm.parsedMessages;
+      expect(messages[0].content).toBe("What's the weather?");
+    });
+
+    it("renders reasoning and tool_call v5 parts instead of leaving the turn blank", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            {
+              role: "assistant",
+              parts: [
+                { type: "reasoning", content: "I should check the weather." },
+                { type: "tool_call", name: "get_weather", arguments: { city: "Boston" } },
+              ],
+            },
+          ]),
+          viewMode: "formatted",
+        },
+      });
+
+      const messages = wrapper.vm.parsedMessages;
+      expect(messages[0].content).toContain("I should check the weather.");
+      expect(messages[0].content).toContain("get_weather");
+    });
   });
 
   describe("Content Truncation", () => {
@@ -785,6 +823,28 @@ describe("LLMContentRenderer", () => {
 
       const result = wrapper.vm.formatContent(content);
       expect(result).toBeTruthy();
+    });
+
+    it("formats a v5 text part keyed by `content` (not just legacy `text`)", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "dummy", viewMode: "formatted" },
+      });
+
+      const result = wrapper.vm.formatContent([{ type: "text", content: "hello there" }]);
+      expect(result).toBe("hello there");
+    });
+
+    it("formats a tool_call part as a readable call, not raw JSON", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "dummy", viewMode: "formatted" },
+      });
+
+      const result = wrapper.vm.formatContent([
+        { type: "tool_call", name: "get_weather", arguments: { city: "Boston" } },
+      ]);
+      expect(result).toContain("get_weather");
+      expect(result).toContain("Boston");
+      expect(result).not.toContain('"type"');
     });
   });
 

--- a/web/src/plugins/traces/LLMContentRenderer.spec.ts
+++ b/web/src/plugins/traces/LLMContentRenderer.spec.ts
@@ -517,7 +517,9 @@ describe("LLMContentRenderer", () => {
           content: JSON.stringify([
             {
               role: "assistant",
-              parts: [{ type: "blob", modality: "image", mime_type: "image/png", content: "aGVsbG8=" }],
+              parts: [
+                { type: "blob", modality: "image", mime_type: "image/png", content: "aGVsbG8=" },
+              ],
             },
           ]),
           viewMode: "formatted",

--- a/web/src/plugins/traces/LLMContentRenderer.spec.ts
+++ b/web/src/plugins/traces/LLMContentRenderer.spec.ts
@@ -918,7 +918,9 @@ describe("LLMContentRenderer", () => {
       expect(result).toContain("[Image: https://example.com/image.png]");
     });
 
-    it("should handle unknown part types gracefully", () => {
+    // Same "[type]" marker as the Thread tab (threadView.utils.ts) for a
+    // part type neither side has been taught about — never a raw JSON dump.
+    it("shows a [type] marker for unknown part types, matching the Thread tab", () => {
       const content = [{ type: "unknown_type", data: "some data" }];
 
       wrapper = mount(LLMContentRenderer, {
@@ -929,7 +931,18 @@ describe("LLMContentRenderer", () => {
       });
 
       const result = wrapper.vm.formatContent(content);
-      expect(result).toBeTruthy();
+      expect(result).toBe("[unknown_type]");
+    });
+
+    // A malformed array item with no `type` at all can't build a marker —
+    // raw JSON stays the last-resort fallback so nothing is silently lost.
+    it("still dumps raw JSON for a typeless/malformed array item", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "dummy", viewMode: "formatted" },
+      });
+
+      const result = wrapper.vm.formatContent([{ random: "field" }]);
+      expect(result).toContain('"random"');
     });
 
     it("formats a v5 text part keyed by `content` (not just legacy `text`)", () => {

--- a/web/src/plugins/traces/LLMContentRenderer.spec.ts
+++ b/web/src/plugins/traces/LLMContentRenderer.spec.ts
@@ -509,21 +509,60 @@ describe("LLMContentRenderer", () => {
 
     // Preview is a full-fidelity view: unlike the Thread tab, it still shows
     // *something* for a part type with no text representation (blob/file/uri)
-    // instead of leaving the message blank.
-    it("still shows something for a blob part instead of leaving the message blank", () => {
+    // — but a friendly placeholder (matching the existing image_url/image
+    // pattern), not a raw JSON dump of a base64 payload.
+    it("shows a placeholder for a blob part, not the raw base64 payload", () => {
       wrapper = mount(LLMContentRenderer, {
         props: {
           content: JSON.stringify([
             {
               role: "assistant",
-              parts: [{ type: "blob", modality: "image", content: "aGVsbG8=" }],
+              parts: [{ type: "blob", modality: "image", mime_type: "image/png", content: "aGVsbG8=" }],
             },
           ]),
           viewMode: "formatted",
         },
       });
 
-      expect(wrapper.vm.parsedMessages[0].content).toBeTruthy();
+      const content = wrapper.vm.parsedMessages[0].content;
+      expect(content).toBeTruthy();
+      expect(content).not.toContain("aGVsbG8=");
+    });
+
+    it("shows a placeholder for a file part", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            {
+              role: "assistant",
+              parts: [{ type: "file", modality: "document", file_id: "report.pdf" }],
+            },
+          ]),
+          viewMode: "formatted",
+        },
+      });
+
+      const content = wrapper.vm.parsedMessages[0].content;
+      expect(content).toContain("report.pdf");
+      expect(content).not.toContain('"type"');
+    });
+
+    it("shows a placeholder for a uri part", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            {
+              role: "assistant",
+              parts: [{ type: "uri", modality: "image", uri: "https://example.com/x.png" }],
+            },
+          ]),
+          viewMode: "formatted",
+        },
+      });
+
+      const content = wrapper.vm.parsedMessages[0].content;
+      expect(content).toContain("https://example.com/x.png");
+      expect(content).not.toContain('"type"');
     });
   });
 

--- a/web/src/plugins/traces/LLMContentRenderer.vue
+++ b/web/src/plugins/traces/LLMContentRenderer.vue
@@ -495,6 +495,13 @@ const formatContent = (content: any): string => {
       } else if (part.type === "image" && part.source) {
         // Handle Anthropic-style image content
         parts.push(raw(`[Image: ${part.source.type || "base64"}]`));
+      } else if (part.type === "blob") {
+        // OTel GenAI v5 BlobPart — never show the raw base64 payload.
+        parts.push(raw(`[${part.modality ?? "Blob"}: ${part.mime_type ?? "binary"}]`));
+      } else if (part.type === "file") {
+        parts.push(raw(`[File: ${part.file_id ?? part.mime_type ?? "unknown"}]`));
+      } else if (part.type === "uri") {
+        parts.push(raw(`[${part.modality ?? "Uri"}: ${part.uri ?? ""}]`));
       } else {
         // Fallback for unknown part types
         parts.push(JSON.stringify(part));

--- a/web/src/plugins/traces/LLMContentRenderer.vue
+++ b/web/src/plugins/traces/LLMContentRenderer.vue
@@ -502,8 +502,12 @@ const formatContent = (content: any): string => {
         parts.push(raw(`[File: ${part.file_id ?? part.mime_type ?? "unknown"}]`));
       } else if (part.type === "uri") {
         parts.push(raw(`[${part.modality ?? "Uri"}: ${part.uri ?? ""}]`));
+      } else if (typeof part?.type === "string") {
+        // Unrecognised part type — same "[type]" marker as the Thread tab
+        // (threadView.utils.ts), not a raw JSON dump.
+        parts.push(raw(`[${part.type}]`));
       } else {
-        // Fallback for unknown part types
+        // No `type` at all to build a marker from — last-resort raw dump.
         parts.push(JSON.stringify(part));
       }
     }

--- a/web/src/plugins/traces/LLMContentRenderer.vue
+++ b/web/src/plugins/traces/LLMContentRenderer.vue
@@ -246,6 +246,7 @@ import { computed, defineAsyncComponent, ref } from "vue";
 import { raw, useI18nTyped } from "@/types/i18n";
 import DOMPurify from "dompurify";
 import { marked } from "marked";
+import { extractGenAiPartText } from "./genAiParts";
 
 const { t } = useI18nTyped();
 
@@ -482,8 +483,13 @@ const formatContent = (content: any): string => {
   if (Array.isArray(content)) {
     const parts: string[] = [];
     for (const part of content) {
+      const genAiText = extractGenAiPartText(part);
       if (part.type === "text" && part.text) {
         parts.push(part.text);
+      } else if (genAiText != null) {
+        // OTel GenAI v5 parts (reasoning, tool_call, tool_call_response, ...) —
+        // kept in sync with the Thread tab via genAiParts.ts.
+        parts.push(genAiText);
       } else if (part.type === "image_url" && part.image_url?.url) {
         parts.push(raw(`[Image: ${part.image_url.url}]`));
       } else if (part.type === "image" && part.source) {
@@ -514,13 +520,18 @@ const parsedContentJson = computed(() => {
   return JSON.stringify(parsedContent.value, null, 2);
 });
 
+// A message body is either the legacy `content` field or, for OTel GenAI
+// semconv v5 messages, the `parts` array — `formatContent` already knows how
+// to render both shapes.
+const messageBody = (msg: any) => formatContent(msg.content ?? msg.parts);
+
 // Extract messages
 const parsedMessages = computed(() => {
   // Handle array of messages (input format)
   if (isMessagesArray.value) {
     return (parsedContent.value as any[]).map((msg: any) => ({
       role: msg.role || "unknown",
-      content: formatContent(msg.content),
+      content: messageBody(msg),
     }));
   }
 
@@ -530,7 +541,7 @@ const parsedMessages = computed(() => {
     return [
       {
         role: msg.role || "assistant",
-        content: formatContent(msg.content),
+        content: messageBody(msg),
       },
     ];
   }

--- a/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
+++ b/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
@@ -644,6 +644,25 @@ describe("TraceDetailsSidebar", async () => {
     });
   });
 
+  // OTel GenAI semconv v5 (issue #14127): gen_ai_system_instructions is a
+  // Part[] array. This must recognise the same part types as the Preview
+  // message renderer (LLMContentRenderer.vue) and the Thread tab
+  // (threadView.utils.ts), not just `type: "text"`.
+  describe("System instructions parsing (parsedSystemInstructions)", () => {
+    it("renders a reasoning part, not just text parts", () => {
+      const w = mountSidebar({
+        span: {
+          ...mockSpan,
+          gen_ai_system_instructions: JSON.stringify([
+            { type: "reasoning", content: "Always be concise." },
+          ]),
+        },
+      });
+
+      expect(w.vm.parsedSystemInstructions).toBe("Always be concise.");
+    });
+  });
+
   describe("Service information in Attributes tab", () => {
     it("should display service information", () => {
       const attributesTable = wrapper.find('[data-test="trace-details-sidebar-attributes-table"]');

--- a/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
+++ b/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
@@ -661,6 +661,54 @@ describe("TraceDetailsSidebar", async () => {
 
       expect(w.vm.parsedSystemInstructions).toBe("Always be concise.");
     });
+
+    it("still renders a plain text part (regression check)", () => {
+      const w = mountSidebar({
+        span: {
+          ...mockSpan,
+          gen_ai_system_instructions: JSON.stringify([
+            { type: "text", content: "Always be concise." },
+          ]),
+        },
+      });
+
+      expect(w.vm.parsedSystemInstructions).toBe("Always be concise.");
+    });
+
+    it("joins multiple parts with a newline", () => {
+      const w = mountSidebar({
+        span: {
+          ...mockSpan,
+          gen_ai_system_instructions: JSON.stringify([
+            { type: "text", content: "Be concise." },
+            { type: "text", content: "Never make up facts." },
+          ]),
+        },
+      });
+
+      expect(w.vm.parsedSystemInstructions).toBe("Be concise.\nNever make up facts.");
+    });
+
+    it("renders a `thinking`-typed part (a real-world alias for reasoning)", () => {
+      const w = mountSidebar({
+        span: {
+          ...mockSpan,
+          gen_ai_system_instructions: JSON.stringify([
+            { type: "thinking", content: "Always be concise." },
+          ]),
+        },
+      });
+
+      expect(w.vm.parsedSystemInstructions).toBe("Always be concise.");
+    });
+
+    it("returns null when there are no system instructions", () => {
+      const w = mountSidebar({
+        span: { ...mockSpan, gen_ai_system_instructions: undefined },
+      });
+
+      expect(w.vm.parsedSystemInstructions).toBe(null);
+    });
   });
 
   describe("Service information in Attributes tab", () => {

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -952,6 +952,7 @@ import {
 import DeployedCode from "@/components/icons/DeployedCode.vue";
 import { getServiceIconDataUrl } from "@/utils/traces/convertTraceData";
 import LLMContentRenderer from "@/plugins/traces/LLMContentRenderer.vue";
+import { extractGenAiPartText } from "@/plugins/traces/genAiParts";
 import OTable from "@/lib/core/Table/OTable.vue";
 import {
   hasTracePreview,
@@ -2179,8 +2180,8 @@ export default defineComponent({
         if (Array.isArray(parsed)) {
           return (
             parsed
-              .filter((p: any) => p.type === "text" && p.content)
-              .map((p: any) => p.content)
+              .map((p: any) => extractGenAiPartText(p))
+              .filter((text): text is string => !!text)
               .join("\n") || null
           );
         }

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -2178,6 +2178,7 @@ export default defineComponent({
           parsed = raw;
         }
         if (Array.isArray(parsed)) {
+          // filter drops both null (unsupported part type) and "" (no content); "" from join -> null so callers get one consistent falsy value.
           return (
             parsed
               .map((p: any) => extractGenAiPartText(p))

--- a/web/src/plugins/traces/genAiParts.spec.ts
+++ b/web/src/plugins/traces/genAiParts.spec.ts
@@ -1,0 +1,130 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, it, expect } from "vitest";
+import { extractGenAiPartText, isSuppressedGenAiPartType } from "./genAiParts";
+
+describe("extractGenAiPartText", () => {
+  it("reads a text part via the OTel v5 `content` field", () => {
+    expect(extractGenAiPartText({ type: "text", content: "hi" })).toBe("hi");
+  });
+
+  it("reads a text part via the legacy OpenAI `text` field", () => {
+    expect(extractGenAiPartText({ type: "text", text: "hi" })).toBe("hi");
+  });
+
+  it("reads a reasoning part", () => {
+    expect(extractGenAiPartText({ type: "reasoning", content: "thinking about it" })).toBe(
+      "thinking about it",
+    );
+  });
+
+  it("reads a compaction part", () => {
+    expect(extractGenAiPartText({ type: "compaction", content: "summary of prior turns" })).toBe(
+      "summary of prior turns",
+    );
+  });
+
+  it("formats a tool_call part with its name and arguments", () => {
+    const result = extractGenAiPartText({
+      type: "tool_call",
+      name: "get_weather",
+      arguments: { city: "Boston" },
+    });
+    expect(result).toContain("get_weather");
+    expect(result).toContain("Boston");
+  });
+
+  it("formats a string tool_call_response part", () => {
+    expect(extractGenAiPartText({ type: "tool_call_response", response: "rainy, 57F" })).toBe(
+      "rainy, 57F",
+    );
+  });
+
+  // pydantic-ai (the SDK from issue #14127) does not follow the OTel spec's
+  // field names literally — verified against its own _otel_messages.py /
+  // messages.py source, not the spec doc. It emits `type: "thinking"`
+  // (spec calls it "reasoning") and a tool_call_response `result` field
+  // (spec calls it "response"). Both must render, or the fix doesn't
+  // actually work against the SDK that triggered the issue.
+  it("reads a pydantic-ai `thinking` part (vendor spelling of reasoning)", () => {
+    expect(extractGenAiPartText({ type: "thinking", content: "let me check" })).toBe(
+      "let me check",
+    );
+  });
+
+  it("reads a pydantic-ai tool_call_response `result` field", () => {
+    expect(extractGenAiPartText({ type: "tool_call_response", result: "rainy, 57F" })).toBe(
+      "rainy, 57F",
+    );
+  });
+
+  it("formats an object tool_call_response part as JSON", () => {
+    const result = extractGenAiPartText({
+      type: "tool_call_response",
+      response: { temp: 57 },
+    });
+    expect(result).toContain("57");
+  });
+
+  it("formats a server_tool_call part", () => {
+    const result = extractGenAiPartText({
+      type: "server_tool_call",
+      name: "web_search",
+      server_tool_call: { query: "weather" },
+    });
+    expect(result).toContain("web_search");
+  });
+
+  it("formats a server_tool_call_response part", () => {
+    const result = extractGenAiPartText({
+      type: "server_tool_call_response",
+      server_tool_call_response: { result: "ok" },
+    });
+    expect(result).toContain("ok");
+  });
+
+  it("returns null for blob/file/uri parts (no text representation)", () => {
+    expect(extractGenAiPartText({ type: "blob", modality: "image", content: "aGVsbG8=" })).toBe(
+      null,
+    );
+    expect(extractGenAiPartText({ type: "file", modality: "image", file_id: "f1" })).toBe(null);
+    expect(extractGenAiPartText({ type: "uri", modality: "image", uri: "https://x" })).toBe(null);
+  });
+
+  it("returns null for a future/unrecognised part type", () => {
+    expect(extractGenAiPartText({ type: "some_new_part_type", data: 1 })).toBe(null);
+  });
+
+  it("returns null for a non-object or typeless input", () => {
+    expect(extractGenAiPartText(null)).toBe(null);
+    expect(extractGenAiPartText("plain string")).toBe(null);
+    expect(extractGenAiPartText({ no_type: true })).toBe(null);
+  });
+});
+
+describe("isSuppressedGenAiPartType", () => {
+  it("is true for blob/file/uri — these have first-class rendering elsewhere", () => {
+    expect(isSuppressedGenAiPartType("blob")).toBe(true);
+    expect(isSuppressedGenAiPartType("file")).toBe(true);
+    expect(isSuppressedGenAiPartType("uri")).toBe(true);
+  });
+
+  it("is false for every other known or unknown type", () => {
+    expect(isSuppressedGenAiPartType("text")).toBe(false);
+    expect(isSuppressedGenAiPartType("tool_call")).toBe(false);
+    expect(isSuppressedGenAiPartType("some_new_part_type")).toBe(false);
+  });
+});

--- a/web/src/plugins/traces/genAiParts.spec.ts
+++ b/web/src/plugins/traces/genAiParts.spec.ts
@@ -53,22 +53,28 @@ describe("extractGenAiPartText", () => {
     );
   });
 
-  // pydantic-ai (the SDK from issue #14127) does not follow the OTel spec's
-  // field names literally — verified against its own _otel_messages.py /
-  // messages.py source, not the spec doc. It emits `type: "thinking"`
-  // (spec calls it "reasoning") and a tool_call_response `result` field
-  // (spec calls it "response"). Both must render, or the fix doesn't
-  // actually work against the SDK that triggered the issue.
-  it("reads a pydantic-ai `thinking` part (vendor spelling of reasoning)", () => {
+  // A real-world SDK behind issue #14127 does not follow the OTel spec's
+  // field names literally (verified against its own source, not the spec
+  // doc): it emits `type: "thinking"` (spec calls it "reasoning") and a
+  // tool_call_response `result` field (spec calls it "response"). Both must
+  // render, or the fix doesn't actually work against the SDK that triggered
+  // the issue.
+  it("reads a `thinking`-typed part (a real-world alias for reasoning)", () => {
     expect(extractGenAiPartText({ type: "thinking", content: "let me check" })).toBe(
       "let me check",
     );
   });
 
-  it("reads a pydantic-ai tool_call_response `result` field", () => {
+  it("reads a tool_call_response part via its `result` field", () => {
     expect(extractGenAiPartText({ type: "tool_call_response", result: "rainy, 57F" })).toBe(
       "rainy, 57F",
     );
+  });
+
+  it("prefers the spec's `response` field over the `result` alias when both are present", () => {
+    expect(
+      extractGenAiPartText({ type: "tool_call_response", response: "spec-says-this", result: "vendor-says-this" }),
+    ).toBe("spec-says-this");
   });
 
   it("formats an object tool_call_response part as JSON", () => {
@@ -94,6 +100,27 @@ describe("extractGenAiPartText", () => {
       server_tool_call_response: { result: "ok" },
     });
     expect(result).toContain("ok");
+  });
+
+  it("defaults tool_call's name to \"tool\" when missing", () => {
+    expect(extractGenAiPartText({ type: "tool_call", arguments: { x: 1 } })).toContain("tool(");
+  });
+
+  it("defaults server_tool_call's name to \"tool\" when missing", () => {
+    expect(extractGenAiPartText({ type: "server_tool_call", server_tool_call: {} })).toContain(
+      "tool(",
+    );
+  });
+
+  it("returns an empty string (not the literal 'undefined') for tool_call_response with neither `response` nor `result`", () => {
+    expect(extractGenAiPartText({ type: "tool_call_response" })).toBe("");
+  });
+
+  it("returns null for text/reasoning/compaction/thinking parts with no content or text field", () => {
+    expect(extractGenAiPartText({ type: "text" })).toBe(null);
+    expect(extractGenAiPartText({ type: "reasoning" })).toBe(null);
+    expect(extractGenAiPartText({ type: "compaction" })).toBe(null);
+    expect(extractGenAiPartText({ type: "thinking" })).toBe(null);
   });
 
   it("returns null for blob/file/uri parts (no text representation)", () => {

--- a/web/src/plugins/traces/genAiParts.spec.ts
+++ b/web/src/plugins/traces/genAiParts.spec.ts
@@ -73,7 +73,11 @@ describe("extractGenAiPartText", () => {
 
   it("prefers the spec's `response` field over the `result` alias when both are present", () => {
     expect(
-      extractGenAiPartText({ type: "tool_call_response", response: "spec-says-this", result: "vendor-says-this" }),
+      extractGenAiPartText({
+        type: "tool_call_response",
+        response: "spec-says-this",
+        result: "vendor-says-this",
+      }),
     ).toBe("spec-says-this");
   });
 
@@ -102,11 +106,11 @@ describe("extractGenAiPartText", () => {
     expect(result).toContain("ok");
   });
 
-  it("defaults tool_call's name to \"tool\" when missing", () => {
+  it('defaults tool_call\'s name to "tool" when missing', () => {
     expect(extractGenAiPartText({ type: "tool_call", arguments: { x: 1 } })).toContain("tool(");
   });
 
-  it("defaults server_tool_call's name to \"tool\" when missing", () => {
+  it('defaults server_tool_call\'s name to "tool" when missing', () => {
     expect(extractGenAiPartText({ type: "server_tool_call", server_tool_call: {} })).toContain(
       "tool(",
     );

--- a/web/src/plugins/traces/genAiParts.ts
+++ b/web/src/plugins/traces/genAiParts.ts
@@ -57,12 +57,12 @@ export function extractGenAiPartText(part: unknown): string | null {
   const type = typeof part.type === "string" ? part.type : "";
   if (!type) return null;
 
+  // A real-world SDK behind issue #14127 spells the spec's "reasoning" part
+  // as "thinking" instead — verified against its own source.
   switch (type) {
     case "text":
     case "reasoning":
     case "compaction":
-    // pydantic-ai (the SDK from issue #14127) spells the spec's "reasoning"
-    // part as "thinking" — verified against its own _otel_messages.py.
     case "thinking":
       if (typeof part.content === "string") return part.content;
       if (typeof part.text === "string") return part.text;
@@ -72,7 +72,7 @@ export function extractGenAiPartText(part: unknown): string | null {
       return `Called ${name}(${safeStringify(part.arguments ?? {})})`;
     }
     case "tool_call_response":
-      // pydantic-ai emits `result`, not the spec's `response` field.
+      // That same SDK emits `result`, not the spec's `response` field.
       return safeStringify(part.response ?? part.result);
     case "server_tool_call": {
       const name = typeof part.name === "string" ? part.name : "tool";

--- a/web/src/plugins/traces/genAiParts.ts
+++ b/web/src/plugins/traces/genAiParts.ts
@@ -1,0 +1,86 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Shared "message part -> display text" logic for the OTel GenAI semconv v5
+ * `parts` model (https://github.com/open-telemetry/semantic-conventions-genai,
+ * docs/gen-ai/non-normative/models.py), used by both the span sidebar Preview
+ * pane (LLMContentRenderer.vue / TraceDetailsSidebar.vue) and the trace
+ * detail Thread tab (threadView.utils.ts) so the two surfaces stay in sync
+ * on which part types render as text.
+ *
+ * `blob` / `file` / `uri` intentionally return null (not a fallback string):
+ * they carry binary/external-reference payloads with first-class rendering
+ * elsewhere, not a text body — callers decide the appropriate treatment via
+ * `isSuppressedGenAiPartType`. Every other unrecognised type also returns
+ * null, but is NOT suppressed, so a caller can still surface a generic
+ * marker instead of silently dropping the turn when the spec grows a new
+ * part type.
+ */
+
+const SUPPRESSED_PART_TYPES = new Set(["blob", "file", "uri"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined) return "";
+  try {
+    // JSON.stringify can itself return undefined (functions, symbols) despite
+    // its declared `string` return type — fall back to String() for those.
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function isSuppressedGenAiPartType(type: string): boolean {
+  return SUPPRESSED_PART_TYPES.has(type);
+}
+
+export function extractGenAiPartText(part: unknown): string | null {
+  if (!isRecord(part)) return null;
+  const type = typeof part.type === "string" ? part.type : "";
+  if (!type) return null;
+
+  switch (type) {
+    case "text":
+    case "reasoning":
+    case "compaction":
+    // pydantic-ai (the SDK from issue #14127) spells the spec's "reasoning"
+    // part as "thinking" — verified against its own _otel_messages.py.
+    case "thinking":
+      if (typeof part.content === "string") return part.content;
+      if (typeof part.text === "string") return part.text;
+      return null;
+    case "tool_call": {
+      const name = typeof part.name === "string" ? part.name : "tool";
+      return `Called ${name}(${safeStringify(part.arguments ?? {})})`;
+    }
+    case "tool_call_response":
+      // pydantic-ai emits `result`, not the spec's `response` field.
+      return safeStringify(part.response ?? part.result);
+    case "server_tool_call": {
+      const name = typeof part.name === "string" ? part.name : "tool";
+      return `Called ${name}(${safeStringify(part.server_tool_call ?? {})})`;
+    }
+    case "server_tool_call_response":
+      return safeStringify(part.server_tool_call_response);
+    default:
+      return null;
+  }
+}

--- a/web/src/plugins/traces/genAiParts.ts
+++ b/web/src/plugins/traces/genAiParts.ts
@@ -48,10 +48,12 @@ function safeStringify(value: unknown): string {
   }
 }
 
+/** True for part types with no text representation (binary/reference payloads) that callers should drop rather than render. */
 export function isSuppressedGenAiPartType(type: string): boolean {
   return SUPPRESSED_PART_TYPES.has(type);
 }
 
+/** Returns null when the part has no textual representation at all (unknown/suppressed type); "" is a valid result (e.g. an empty tool_call_response). */
 export function extractGenAiPartText(part: unknown): string | null {
   if (!isRecord(part)) return null;
   const type = typeof part.type === "string" ? part.type : "";

--- a/web/src/plugins/traces/threadView.utils.spec.ts
+++ b/web/src/plugins/traces/threadView.utils.spec.ts
@@ -397,6 +397,12 @@ describe("extractContent", () => {
     expect(extractContent([{ type: "some_new_part_type", data: 1 }])).toBe("[some_new_part_type]");
   });
 
+  // The same marker applies to a *recognised* type with nothing to render
+  // (empty content) — not just genuinely unrecognised ones.
+  it("renders a generic marker for a recognised type that yields no text", () => {
+    expect(extractContent([{ type: "text" }])).toBe("[text]");
+  });
+
   // Real-world SDK field-name aliases (verified against actual instrumentation
   // source, not the spec doc) — same coverage as genAiParts.spec.ts, exercised
   // through the Thread tab's actual entry point so a regression is caught here too.

--- a/web/src/plugins/traces/threadView.utils.spec.ts
+++ b/web/src/plugins/traces/threadView.utils.spec.ts
@@ -363,6 +363,43 @@ describe("extractContent", () => {
   it("returns empty string for unrecognised object shapes", () => {
     expect(extractContent({ random: "field" })).toBe("");
   });
+
+  // OTel GenAI semconv v5 part types (issue #14127) — a "thinking then call
+  // a tool" turn must survive instead of vanishing entirely.
+  it("renders a reasoning part", () => {
+    expect(extractContent([{ type: "reasoning", content: "let me check" }])).toBe(
+      "let me check",
+    );
+  });
+
+  it("renders a tool_call part instead of dropping the turn", () => {
+    const result = extractContent([
+      { type: "reasoning", content: "checking the weather" },
+      { type: "tool_call", name: "get_weather", arguments: { city: "Boston" } },
+    ]);
+    expect(result).toContain("checking the weather");
+    expect(result).toContain("get_weather");
+  });
+
+  it("renders a tool_call_response part", () => {
+    expect(extractContent([{ type: "tool_call_response", response: "rainy, 57F" }])).toBe(
+      "rainy, 57F",
+    );
+  });
+
+  // blob/file/uri stay suppressed — they have first-class rendering
+  // elsewhere and would just dump binary/reference JSON into the chat.
+  it("still drops blob/file/uri parts", () => {
+    expect(extractContent([{ type: "blob", modality: "image", content: "aGVsbG8=" }])).toBe("");
+  });
+
+  // A part type the spec hasn't been taught about yet must not make the
+  // whole turn disappear — show a generic marker instead of "".
+  it("renders a generic marker for an unrecognised future part type", () => {
+    expect(extractContent([{ type: "some_new_part_type", data: 1 }])).toBe(
+      "[some_new_part_type]",
+    );
+  });
 });
 
 // ===========================================================================

--- a/web/src/plugins/traces/threadView.utils.spec.ts
+++ b/web/src/plugins/traces/threadView.utils.spec.ts
@@ -367,9 +367,7 @@ describe("extractContent", () => {
   // OTel GenAI semconv v5 part types (issue #14127) — a "thinking then call
   // a tool" turn must survive instead of vanishing entirely.
   it("renders a reasoning part", () => {
-    expect(extractContent([{ type: "reasoning", content: "let me check" }])).toBe(
-      "let me check",
-    );
+    expect(extractContent([{ type: "reasoning", content: "let me check" }])).toBe("let me check");
   });
 
   it("renders a tool_call part instead of dropping the turn", () => {
@@ -396,9 +394,7 @@ describe("extractContent", () => {
   // A part type the spec hasn't been taught about yet must not make the
   // whole turn disappear — show a generic marker instead of "".
   it("renders a generic marker for an unrecognised future part type", () => {
-    expect(extractContent([{ type: "some_new_part_type", data: 1 }])).toBe(
-      "[some_new_part_type]",
-    );
+    expect(extractContent([{ type: "some_new_part_type", data: 1 }])).toBe("[some_new_part_type]");
   });
 
   // Real-world SDK field-name aliases (verified against actual instrumentation

--- a/web/src/plugins/traces/threadView.utils.spec.ts
+++ b/web/src/plugins/traces/threadView.utils.spec.ts
@@ -400,6 +400,39 @@ describe("extractContent", () => {
       "[some_new_part_type]",
     );
   });
+
+  // Real-world SDK field-name aliases (verified against actual instrumentation
+  // source, not the spec doc) — same coverage as genAiParts.spec.ts, exercised
+  // through the Thread tab's actual entry point so a regression is caught here too.
+  it("renders a `thinking`-typed part", () => {
+    expect(extractContent([{ type: "thinking", content: "let me check" }])).toBe("let me check");
+  });
+
+  it("renders a tool_call_response part via its `result` field", () => {
+    expect(extractContent([{ type: "tool_call_response", result: "rainy, 57F" }])).toBe(
+      "rainy, 57F",
+    );
+  });
+
+  // The exact shape ingested by repro_14127.py's turn 3 (issue-14127-repro/):
+  // a real tool-calling turn, end to end through extractContent.
+  it("renders a full tool-calling turn (thinking + tool_call)", () => {
+    const result = extractContent([
+      { type: "thinking", content: "I should call get_weather for Boston." },
+      { type: "tool_call", id: "call_1", name: "get_weather", arguments: { city: "Boston" } },
+    ]);
+    expect(result).toContain("I should call get_weather for Boston.");
+    expect(result).toContain("Called get_weather");
+    expect(result).toContain("Boston");
+  });
+
+  it("renders the tool response side of that turn (tool_call_response with `result`)", () => {
+    expect(
+      extractContent([
+        { type: "tool_call_response", id: "call_1", name: "get_weather", result: "rainy, 57F" },
+      ]),
+    ).toBe("rainy, 57F");
+  });
 });
 
 // ===========================================================================

--- a/web/src/plugins/traces/threadView.utils.ts
+++ b/web/src/plugins/traces/threadView.utils.ts
@@ -202,8 +202,8 @@ export function normalizeRole(raw: unknown): Role {
  *   - generic `{text}` / `{content}` objects
  *
  * OTel GenAI v5 `reasoning`/`tool_call`/`tool_call_response`/`server_tool_call*`
- * parts render as text, including SDK vendor spellings (pydantic-ai's
- * `thinking`/`result`) that don't match the spec's own field names — kept in
+ * parts render as text, including real-world SDK field-name aliases
+ * (`thinking`/`result`) that don't match the spec's own names — kept in
  * sync with LLMContentRenderer.vue via genAiParts.ts. `blob`/`file`/`uri`
  * stay suppressed (first-class rendering elsewhere), and any other
  * unrecognised type falls back to a `[type]` marker instead of vanishing.

--- a/web/src/plugins/traces/threadView.utils.ts
+++ b/web/src/plugins/traces/threadView.utils.ts
@@ -23,6 +23,7 @@
 
 import { raw } from "@/types/i18n";
 import type { TurnDetail, TurnMessage } from "./composables/useSessions";
+import { extractGenAiPartText, isSuppressedGenAiPartType } from "./genAiParts";
 
 // ---------------------------------------------------------------------------
 // Field resolvers — read OTEL gen_ai_* attributes.
@@ -200,10 +201,12 @@ export function normalizeRole(raw: unknown): Role {
  *   - Vertex/ADK `parts` arrays
  *   - generic `{text}` / `{content}` objects
  *
- * Non-text parts (function_call objects, image blobs, etc.) are silently
- * dropped — those have first-class rendering elsewhere (tool spans),
- * and including them as raw stringified JSON would cover several screens
- * in a chat UI.
+ * OTel GenAI v5 `reasoning`/`tool_call`/`tool_call_response`/`server_tool_call*`
+ * parts render as text, including SDK vendor spellings (pydantic-ai's
+ * `thinking`/`result`) that don't match the spec's own field names — kept in
+ * sync with LLMContentRenderer.vue via genAiParts.ts. `blob`/`file`/`uri`
+ * stay suppressed (first-class rendering elsewhere), and any other
+ * unrecognised type falls back to a `[type]` marker instead of vanishing.
  *
  * @example extractContent("hello")                 // "hello"
  * @example extractContent([{ text: "a" },
@@ -219,7 +222,9 @@ export function extractContent(content: unknown): string {
         if (typeof part === "string") return part;
         if (!isRecord(part)) return "";
         if (part.text) return String(part.text);
-        if (part.type === "text") return String(part.content ?? "");
+
+        const genAiText = extractGenAiPartText(part);
+        if (genAiText != null) return genAiText;
 
         const functionResponse = part.function_response;
         if (isRecord(functionResponse)) {
@@ -228,6 +233,9 @@ export function extractContent(content: unknown): string {
             return extractContent(response.content);
           }
         }
+
+        const partType = typeof part.type === "string" ? part.type : "";
+        if (partType && !isSuppressedGenAiPartType(partType)) return `[${partType}]`;
         return "";
       })
       .filter(Boolean)

--- a/web/src/plugins/traces/threadView.utils.ts
+++ b/web/src/plugins/traces/threadView.utils.ts
@@ -205,8 +205,9 @@ export function normalizeRole(raw: unknown): Role {
  * parts render as text, including real-world SDK field-name aliases
  * (`thinking`/`result`) that don't match the spec's own names — kept in
  * sync with LLMContentRenderer.vue via genAiParts.ts. `blob`/`file`/`uri`
- * stay suppressed (first-class rendering elsewhere), and any other
- * unrecognised type falls back to a `[type]` marker instead of vanishing.
+ * stay suppressed (first-class rendering elsewhere), and any part type that
+ * yields no text (unrecognised, or recognised but empty) falls back to a
+ * `[type]` marker instead of vanishing.
  *
  * @example extractContent("hello")                 // "hello"
  * @example extractContent([{ text: "a" },


### PR DESCRIPTION
This PR fixes #14127 

LLM trace Preview and Thread tabs rendered blank/missing content for messages using the OTel GenAI semconv v5 parts model (instead of a legacy content string) — including real-world SDK field-name variants (thinking, result) that don't match the spec literally.