### PR TITLE
test: retry dashboard create on transient 5xx (cross-worker folder race)

### DIFF
--- a/tests/ui-testing/pages/dashboardPages/dashboard-create.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-create.js
@@ -281,6 +281,12 @@ export default class DashboardCreate {
       createRequest = await requestPromise;
       if (createRequest) {
         createResponse = await responsePromise;
+        // Fresh-org concurrent creates race server-side default-folder creation → the loser 500s on a unique-constraint; the folder now exists so a re-submit lands. Retry transient 5xx while attempts remain (nothing was created, so no duplicate); a persistent error still throws below.
+        if (createResponse && createResponse.status() >= 500 && attempt < submitAttempts) {
+          const stillOpen = await this.submitBtn.isVisible().catch(() => false);
+          if (!stillOpen) await this.openCreateDashboardDialog();
+          continue;
+        }
         break;
       }
 


### PR DESCRIPTION
Deflake campaign (ref #14025). Many Dashboards specs flake on `createDashboard` → `POST /dashboards` returning **500** (~2ms). Root cause is server-side: a fresh-org first burst of parallel workers all pass `folders::exists()==false` then race `save_folder(default)` → the loser hits a unique-constraint on the second folder INSERT. The folder then exists, so a re-submit succeeds — the helper turned a transient collision into a hard flake. Fix retries the create only on transient 5xx while attempts remain (nothing created on a 500 → no duplicate); persistent error still throws. Validated with a forced-500 route (retries once, reaches /dashboards/view). Product bug filed separately for the server-side race.