### PR TITLE
fix: strip HTTP framing headers in gRPC router ingest proxies

### DIFF
--- a/src/api/grpc/src/router/grpc/ingest/logs.rs
+++ b/src/api/grpc/src/router/grpc/ingest/logs.rs
@@ -33,7 +33,8 @@ impl LogsService for LogsServer {
         request: Request<ExportLogsServiceRequest>,
     ) -> Result<Response<ExportLogsServiceResponse>, Status> {
         let start = std::time::Instant::now();
-        let (metadata, extensions, message) = request.into_parts();
+        let (mut metadata, extensions, message) = request.into_parts();
+        super::strip_http_framing_headers(&mut metadata);
 
         let cfg = config::get_config();
         // basic validation

--- a/src/api/grpc/src/router/grpc/ingest/metrics.rs
+++ b/src/api/grpc/src/router/grpc/ingest/metrics.rs
@@ -34,7 +34,8 @@ impl MetricsService for MetricsServer {
     ) -> Result<Response<ExportMetricsServiceResponse>, Status> {
         let start = std::time::Instant::now();
         let cfg = config::get_config();
-        let (metadata, extensions, message) = request.into_parts();
+        let (mut metadata, extensions, message) = request.into_parts();
+        super::strip_http_framing_headers(&mut metadata);
 
         // basic validation
         if !metadata.contains_key(&cfg.grpc.org_header_key) {

--- a/src/api/grpc/src/router/grpc/ingest/mod.rs
+++ b/src/api/grpc/src/router/grpc/ingest/mod.rs
@@ -16,3 +16,43 @@
 pub mod logs;
 pub mod metrics;
 pub mod traces;
+
+// The proxy re-encodes the body, so a forwarded content-length is stale and h2 rejects it
+const SKIP_FORWARD_HEADERS: &[&str] = &[
+    "content-length",
+    "transfer-encoding",
+    "connection",
+    "keep-alive",
+    "host",
+];
+
+fn strip_http_framing_headers(metadata: &mut tonic::metadata::MetadataMap) {
+    for key in SKIP_FORWARD_HEADERS {
+        metadata.remove(*key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_http_framing_headers() {
+        let mut metadata = tonic::metadata::MetadataMap::new();
+        metadata.insert("content-length", "123".parse().unwrap());
+        metadata.insert("transfer-encoding", "chunked".parse().unwrap());
+        metadata.insert("connection", "keep-alive".parse().unwrap());
+        metadata.insert("keep-alive", "timeout=5".parse().unwrap());
+        metadata.insert("host", "example.com".parse().unwrap());
+        metadata.insert("organization", "default".parse().unwrap());
+        metadata.insert("authorization", "Basic abc".parse().unwrap());
+
+        strip_http_framing_headers(&mut metadata);
+
+        for key in SKIP_FORWARD_HEADERS {
+            assert!(!metadata.contains_key(*key), "{key} should be stripped");
+        }
+        assert!(metadata.contains_key("organization"));
+        assert!(metadata.contains_key("authorization"));
+    }
+}

--- a/src/api/grpc/src/router/grpc/ingest/traces.rs
+++ b/src/api/grpc/src/router/grpc/ingest/traces.rs
@@ -34,7 +34,8 @@ impl TraceService for TraceServer {
     ) -> Result<Response<ExportTraceServiceResponse>, Status> {
         let start = std::time::Instant::now();
         let cfg = config::get_config();
-        let (metadata, extensions, message) = request.into_parts();
+        let (mut metadata, extensions, message) = request.into_parts();
+        super::strip_http_framing_headers(&mut metadata);
 
         // basic validation
         if !metadata.contains_key(&cfg.grpc.org_header_key) {


### PR DESCRIPTION
Fixes openobserve/o2-enterprise#2071

## Problem

The router's OTLP gRPC ingest proxies (logs/metrics/traces) forward the entire incoming metadata map to the ingester via `Request::into_parts()` → `Request::from_parts()`. tonic's metadata map contains every HTTP/2 header from the original request, and tonic's client-side sanitization strips only `te`, `content-type`, and `grpc-*` — so a `content-length` header sent by the client is forwarded verbatim.

The proxy re-encodes the body (protobuf re-serialization + gzip via `send_compressed`), so the forwarded `content-length` no longer matches the actual body and h2 on the ingester rejects the stream.

Standard gRPC clients (tonic, grpc-go, OTel SDK/Collector) never send `content-length`, which is why this went unnoticed. fluent-bit implements gRPC over its own HTTP/2 client and does send it, breaking fluent-bit gRPC ingestion through the router (works fine directly against an ingester).

## Fix

Strip HTTP framing headers (`content-length`, `transfer-encoding`, `connection`, `keep-alive`, `host`) from the metadata before forwarding, in all three proxies — mirroring what the HTTP router proxy already does in its `SKIP_REQUEST_HEADERS` list. `grpc-encoding`/`grpc-accept-encoding` need no stripping since tonic overwrites them on send.

## Testing

- Unit test covering the header stripping (framing headers removed, `organization`/`authorization` preserved).
- Workspace clippy with CI flags: clean.
- Enterprise `cargo check --all-targets`: clean.