### PR TITLE
fix: keep trace columns in quick mode projections (#13376)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11074,6 +11074,7 @@ dependencies = [
  "rayon",
  "regex",
  "regex-syntax",
+ "schema",
  "serde",
  "serde_json",
  "sqlparser",

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -208,8 +208,19 @@ pub static SQL_SECONDARY_INDEX_SEARCH_FIELDS: Lazy<Vec<String>> = Lazy::new(|| {
     fields
 });
 
-// Losing these silently degrades sourcemap translation, breadcrumbs and session replay.
-const _DEFAULT_QUICK_MODE_FIELDS: [&str; 4] = ["service", "version", "session_id", "view_url"];
+const _DEFAULT_QUICK_MODE_FIELDS: [&str; 9] = [
+    // Losing these silently degrades sourcemap translation, breadcrumbs and session replay.
+    "service",
+    "version",
+    "session_id",
+    "view_url",
+    // Losing these leaves the trace detail page without spans to build a waterfall from.
+    "service_name",
+    "operation_name",
+    "trace_id",
+    "span_id",
+    "duration",
+];
 pub static QUICK_MODEL_FIELDS: Lazy<Vec<String>> = Lazy::new(|| {
     let mut fields = chain(
         _DEFAULT_QUICK_MODE_FIELDS.iter().map(|s| s.to_string()),

--- a/src/search/Cargo.toml
+++ b/src/search/Cargo.toml
@@ -50,6 +50,7 @@ rand.workspace = true
 rayon.workspace = true
 regex.workspace = true
 regex-syntax.workspace = true
+schema.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlparser.workspace = true

--- a/src/search/src/sql/mod.rs
+++ b/src/search/src/sql/mod.rs
@@ -219,7 +219,7 @@ impl Sql {
                 &columns,
                 has_original_column,
                 query.quick_mode || cfg.limit.quick_mode_force_enabled,
-                cfg.limit.quick_mode_num_fields,
+                stream_type,
                 &search_event_type,
                 match_visitor.has_match_all,
             );

--- a/src/search/src/sql/schema.rs
+++ b/src/search/src/sql/schema.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use arrow_schema::FieldRef;
 use config::{
     ALL_VALUES_COL_NAME, ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME, get_config,
-    meta::search::SearchEventType,
+    meta::{search::SearchEventType, sql::TableReferenceExt, stream::StreamType},
 };
 use datafusion::{arrow::datatypes::Schema, common::TableReference};
 use hashbrown::{HashMap, HashSet};
@@ -26,17 +26,19 @@ use infra::schema::{
     SchemaCache, get_stream_setting_defined_schema_fields, get_stream_setting_fts_fields,
     unwrap_stream_settings,
 };
+use schema::check_schema_for_defined_schema_fields;
 
 pub fn generate_select_star_schema(
     schemas: HashMap<TableReference, Arc<SchemaCache>>,
     columns: &HashMap<TableReference, HashSet<String>>,
     has_original_column: HashMap<TableReference, bool>,
     quick_mode: bool,
-    quick_mode_num_fields: usize,
+    stream_type: StreamType,
     search_event_type: &Option<SearchEventType>,
     need_fst_fields: bool,
 ) -> HashMap<TableReference, Arc<SchemaCache>> {
     let cfg = get_config();
+    let quick_mode_num_fields = cfg.limit.quick_mode_num_fields;
     let mut used_schemas = HashMap::new();
     for (name, schema) in schemas {
         let stream_settings = unwrap_stream_settings(schema.schema());
@@ -71,6 +73,7 @@ pub fn generate_select_star_schema(
                         &fts_fields,
                         skip_original_column,
                         need_fst_fields,
+                        name.get_stream_type(stream_type),
                     )
                 } else {
                     // skip selecting "_original" column if `SELECT * ...`
@@ -133,6 +136,7 @@ pub fn generate_quick_mode_fields(
     fts_fields: &[String],
     skip_original_column: bool,
     need_fst_fields: bool,
+    stream_type: StreamType,
 ) -> Vec<Arc<arrow_schema::Field>> {
     let cfg = get_config();
     let strategy = cfg.limit.quick_mode_strategy.to_lowercase();
@@ -221,6 +225,16 @@ pub fn generate_quick_mode_fields(
         {
             fields.push(Arc::new(field.clone()));
             fields_name.insert(field.to_string());
+        }
+    }
+
+    // truncation must not drop the columns a stream type is rendered from
+    for field in check_schema_for_defined_schema_fields(stream_type, schema, Vec::new()) {
+        if !fields_name.contains(&field)
+            && let Ok(field) = schema.field_with_name(&field)
+        {
+            fields.push(Arc::new(field.clone()));
+            fields_name.insert(field.name().to_string());
         }
     }
 
@@ -419,7 +433,7 @@ mod tests {
         let schema = Schema::new(fields);
 
         // Mock config - default strategy is "first"
-        let result = generate_quick_mode_fields(&schema, None, &[], false, false);
+        let result = generate_quick_mode_fields(&schema, None, &[], false, false, StreamType::Logs);
 
         // Should include timestamp and some fields (exact count depends on config)
         assert!(!result.is_empty());
@@ -439,7 +453,8 @@ mod tests {
         let mut columns = HashSet::new();
         columns.insert("selected_field".to_string());
 
-        let result = generate_quick_mode_fields(&schema, Some(columns), &[], false, false);
+        let result =
+            generate_quick_mode_fields(&schema, Some(columns), &[], false, false, StreamType::Logs);
 
         // Should include timestamp and selected field
         assert!(result.iter().any(|f| f.name() == TIMESTAMP_COL_NAME));
@@ -456,9 +471,38 @@ mod tests {
         fields.push(Arc::new(Field::new("service", DataType::Utf8, true)));
         let schema = Schema::new(fields);
 
-        let result = generate_quick_mode_fields(&schema, None, &[], false, false);
+        let result = generate_quick_mode_fields(&schema, None, &[], false, false, StreamType::Logs);
 
         assert!(result.iter().any(|f| f.name() == "service"));
+    }
+
+    #[test]
+    fn test_generate_quick_mode_fields_keeps_trace_fields() {
+        // Not in the built-in default list, so only the stream type guard can bring them back.
+        let trace_fields = [
+            "span_status",
+            "span_kind",
+            "events",
+            "reference_parent_span_id",
+        ];
+        let over_cutoff = get_config().limit.quick_mode_num_fields + 100;
+        let mut fields = (0..over_cutoff)
+            .map(|i| Arc::new(Field::new(format!("field{i}"), DataType::Utf8, true)))
+            .collect::<Vec<_>>();
+        for name in trace_fields {
+            fields.push(Arc::new(Field::new(name, DataType::Utf8, true)));
+        }
+        let schema = Schema::new(fields);
+
+        let result =
+            generate_quick_mode_fields(&schema, None, &[], false, false, StreamType::Traces);
+
+        for name in trace_fields {
+            assert!(result.iter().any(|f| f.name() == name), "missing {name}");
+        }
+
+        let logs = generate_quick_mode_fields(&schema, None, &[], false, false, StreamType::Logs);
+        assert!(!logs.iter().any(|f| f.name() == "span_status"));
     }
 
     #[test]
@@ -476,6 +520,7 @@ mod tests {
             &[],
             true, // skip_original_column = true
             false,
+            StreamType::Logs,
         );
 
         // Should not include original data column
@@ -501,6 +546,7 @@ mod tests {
             &fts_fields,
             false,
             true, // need_fst_fields = true
+            StreamType::Logs,
         );
 
         // Should include FTS fields


### PR DESCRIPTION
Fixes #13376

## Problem

On a stream wider than `ZO_QUICK_MODE_NUM_FIELDS` (default 500), quick mode truncates a `SELECT *` projection to the first N schema fields in alphabetical order. For traces that silently drops most of the span row — `service_name`, `span_id`, `operation_name`, `span_status`, `duration`, `events`, `reference_*` all sort after the bulk of the `attributes_*` columns. Columns named in the SQL are re-added from the full schema, which is why `trace_id` (WHERE) and `start_time` (ORDER BY) are the only span columns that survive.

The traces list still renders because it names its columns explicitly; the trace detail page gets spans with no id and no service and cannot build the waterfall.

## Fix

Two layers, both no-ops for streams that do not carry the columns:

1. `check_schema_for_defined_schema_fields` already defines, per stream type, the columns that must survive projection truncation — it is what the user-defined-schema path uses, and quick mode never consulted it. `generate_quick_mode_fields` now applies the same guard, so a stream type's own columns are restored after truncation exactly as the UDS path does. This also covers the metrics branch of that guard, and #11451, which is the same root cause.
2. The built-in `QUICK_MODEL_FIELDS` defaults gain `service_name`, `operation_name`, `trace_id`, `span_id` and `duration` alongside the RUM identity fields, so the columns a span is identified by survive regardless of the stream type a query resolves to.

Both paths add a field only when `schema.field_with_name` finds it, so a stream without those columns is unaffected, and `StreamType::Logs` (the empty branch of the guard) keeps its current behaviour.

## Notes

- `stream_type` is threaded through `generate_select_star_schema`, resolved per stream with `TableReference::get_stream_type` so a query joining streams of different types keeps each stream's own guard. The redundant `quick_mode_num_fields` argument is dropped instead of silencing `clippy::too_many_arguments` — callers passed `cfg.limit.quick_mode_num_fields` and the function already reads the config.
- The `search` crate gains a dependency on the `schema` crate; no cycle (`schema` does not depend on `search`).
- Not covered here, from the same issue: `buildTracesTree` writes `formattedSpanMap` with a fallback key but reads it back with the raw `span_id`, so a span still missing `span_id` throws inside an un-awaited async call and the page renders blank instead of "trace not found". That one goes to the frontend separately.

## Verification

- `cargo test -p search --lib sql::schema::` — 19 passed, including a new test asserting the guard restores trace columns past the cutoff for `StreamType::Traces` and leaves `StreamType::Logs` unchanged.
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings`
