### PR TITLE
fix(search): run search job queries on background queriers

### DIFF
--- a/src/search_service/src/search_jobs.rs
+++ b/src/search_service/src/search_jobs.rs
@@ -216,7 +216,7 @@ async fn run_partition_job(
         stream_type,
         Some(job.user_id.clone()),
         &req,
-        Some(RoleGroup::Interactive),
+        Some(RoleGroup::Background),
     )
     .await;
     if let Err(e) = res {


### PR DESCRIPTION
## Problem

An external tool calling `search_job/<id>/result` gets an empty `hits` array for a time range that returns data from the logs UI.

Tracing one such job (`trace_id 01a05666ebfa73038dd139d0a777ce6e`) through a two-region super cluster: the r2 alert manager dispatched the partition query to a **normal (interactive) querier** in r2. That querier became the query leader, and then queried *only* the remote background cluster in r1 — it never fanned out to its own region's queriers and ingesters:

```
super get clusters: 1
flight->search: request node: http://oo-alertquerierr1...:4000, name: gcpuscr1_aq, query_type: search_job, is_super: true, files: 0
flight->search: response node: ... files: 0, scan_size: 0 mb, num_rows: 0
search->result: total: 0, scan_size: 0 mb, took: 1016 ms
```

## Cause

`run_partition_job` picks the query leader from the **interactive** querier pool, while every other background workload picks from the **background** pool. Both call sites received their role-group argument in 88eb0ded69 ("perf: use querier as leader for AlertManager"); alerts got `Background`, search jobs got `Interactive`.

That contradicts the repo's own classification — `SearchEventType::SearchJob → RoleGroup::Background` (`config/src/meta/cluster.rs`) and `SearchJob.is_background() == true`.

The interactive leader then loses the local region:

1. The leader recomputes its own role group from the request payload. `search_type` is `SearchEventType::SearchJob` (set in `api/search/src/search/search_job.rs` before the payload is persisted), so `RoleGroup::from` yields **Background** (`search_service/src/super_cluster/leader.rs`).
2. `get_cluster_nodes` → `list_by_role_group(Background)` keeps only clusters labelled empty or `"background"`.
3. The local cluster's label comes from **whichever node is asking** — `get_local_cluster()` reads `common.node_role_group`, and `list_from_nats()` pushes that local entry first, deduping the rest by `region-name`.

On an interactive querier that label is `"interactive"`, so **the local cluster fails its own Background filter and excludes itself from the search**. Only the remote background cluster answers, the job stores zero hits, and the result endpoint serves them back.

Alerts and pipelines are unaffected because they land on a background node, whose local-cluster label matches.

## Fix

One line: dispatch the search-job partition query to the background pool, matching `core/src/alerts/mod.rs`.

`handle_search_partition` is deliberately left on `Interactive`. The node it picks only plans the time-range split, and `search_partition` already derives its own role group from `req.search_type` independently of the caller, so the plan is computed as Background either way.

## Behaviour change worth noting

If a deployment runs interactive queriers but no background ones, search jobs now fail with `no querier node online` instead of quietly returning nothing. That is the better failure mode, but it is a change.

## Follow-up not included here

The underlying fragility is in enterprise: labelling an entire cluster with the role group of whichever node happens to evaluate `get_local_cluster()` means *any* role-group mismatch silently excludes the local region. This PR removes the only mismatch found in this repo; a guard in `list_by_role_group` to never filter out the local cluster would rule out the whole class.

## Testing

`cargo fmt --all` is clean. The full `--features enterprise` compile check was **not** run — the local o2-enterprise checkout is on an unrelated branch and repointing it would have disturbed in-progress work. The change is a single enum variant, and `core/src/alerts/mod.rs:911` already calls this same `grpc_search` with `Some(RoleGroup::Background)` at the same argument position, so it is type-identical to existing code. Please confirm via CI's enterprise build.
