### PR TITLE
fix(dashboards): keep rows whose other y column is null [v1.0]

### DIFF
--- a/web/src/utils/dashboard/convertSQLData.spec.ts
+++ b/web/src/utils/dashboard/convertSQLData.spec.ts
@@ -10843,4 +10843,91 @@ describe("convertSQLData", () => {
       expect(result.options.grid.bottom).toBeGreaterThan(0);
     });
   });
+  // A conditional overlay series (`CASE WHEN ... THEN value END`) is NULL on
+  // every healthy bucket. Filtering rows on ALL y keys being non-null deleted
+  // those rows outright, taking the base series' value and the x category with
+  // them — the anomaly detection charts lost their whole baseline.
+  describe("sparse y column does not delete the row", () => {
+    const sparsePanel = () => ({
+      queries: [
+        {
+          fields: {
+            x: [{ alias: "zo_sql_key" }],
+            y: [{ alias: "zo_sql_num" }, { alias: "anomaly_value" }],
+            z: [],
+            breakdown: [],
+          },
+        },
+      ],
+      config: { top_results: 10, top_results_others: false, connect_nulls: false },
+      type: "line",
+    });
+
+    // Ten buckets, three of them flagged; the overlay column is null on the rest.
+    const rows = [
+      { zo_sql_key: "16:25", zo_sql_num: 1900, anomaly_value: null },
+      { zo_sql_key: "16:30", zo_sql_num: 2000, anomaly_value: null },
+      { zo_sql_key: "16:35", zo_sql_num: 2050, anomaly_value: null },
+      { zo_sql_key: "16:40", zo_sql_num: 2140, anomaly_value: null },
+      { zo_sql_key: "16:45", zo_sql_num: 3000, anomaly_value: 3000 },
+      { zo_sql_key: "16:50", zo_sql_num: 3000, anomaly_value: 3000 },
+      { zo_sql_key: "16:55", zo_sql_num: 2100, anomaly_value: null },
+      { zo_sql_key: "17:00", zo_sql_num: 2980, anomaly_value: 2980 },
+      { zo_sql_key: "17:05", zo_sql_num: 2000, anomaly_value: null },
+      { zo_sql_key: "17:10", zo_sql_num: 1950, anomaly_value: null },
+    ];
+
+    const render = async (panel: any, data: any[]) =>
+      await convertSQLData(
+        panel,
+        [data],
+        mockStore,
+        mockChartPanelRef,
+        mockHoveredSeriesState,
+        mockResultMetaData,
+        mockMetadata,
+        mockChartPanelStyle,
+        mockAnnotations,
+      );
+
+    it("keeps every bucket on the x axis", async () => {
+      const result = await render(sparsePanel(), rows);
+      expect(result.options.xAxis[0].data).toHaveLength(10);
+    });
+
+    it("keeps the dense series complete", async () => {
+      const result = await render(sparsePanel(), rows);
+      const base = result.options.series.find((s: any) => s.data.includes(1900));
+      expect(base.data).toEqual([1900, 2000, 2050, 2140, 3000, 3000, 2100, 2980, 2000, 1950]);
+    });
+
+    // The gap is what breaks the overlay line at a bucket that is NOT flagged.
+    it("holds the sparse series null where it has no value", async () => {
+      const result = await render(sparsePanel(), rows);
+      const overlay = result.options.series.find((s: any) => !s.data.includes(1900));
+      expect(overlay.data).toHaveLength(10);
+      expect(overlay.data[6]).toBeNull();
+      expect(overlay.data[4]).toBe(3000);
+    });
+
+    // Unchanged behaviour: a row carrying no y value at all is still dropped.
+    it("still drops a row where every y column is null", async () => {
+      const withEmptyRow = [
+        ...rows.slice(0, 2),
+        { zo_sql_key: "16:33", zo_sql_num: null, anomaly_value: null },
+        ...rows.slice(2),
+      ];
+      const result = await render(sparsePanel(), withEmptyRow);
+      expect(result.options.xAxis[0].data).toHaveLength(10);
+      expect(result.options.xAxis[0].data).not.toContain("16:33");
+    });
+
+    // A single-y panel takes the same path; `some` and `every` agree there.
+    it("leaves a single-y panel unchanged", async () => {
+      const panel = sparsePanel();
+      panel.queries[0].fields.y = [{ alias: "zo_sql_num" }];
+      const result = await render(panel, rows);
+      expect(result.options.xAxis[0].data).toHaveLength(10);
+    });
+  });
 });

--- a/web/src/utils/dashboard/sql/shared/contextBuilder.ts
+++ b/web/src/utils/dashboard/sql/shared/contextBuilder.ts
@@ -175,7 +175,8 @@ export function buildSQLContext(
       missingValueData?.filter((item: any) => {
         return (
           xAxisKeys.every((key: any) => getDataValue(item, key) != null) &&
-          yAxisKeys.every((key: any) => getDataValue(item, key) != null) &&
+          // some, not every: one null y must not erase the row, its x category and the other series
+          (!yAxisKeys.length || yAxisKeys.some((key: any) => getDataValue(item, key) != null)) &&
           breakDownKeys.every((key: any) => getDataValue(item, key) != null)
         );
       }) || [];


### PR DESCRIPTION
Backport of #14184 to `branch-v1.0.0`. Clean cherry-pick — the target line was identical on this branch.

> **Note:** #14184 is still open against `main` at the time of writing. If it changes during review, this backport needs the same change applied.

## The problem

A panel with two y columns, where one is conditionally NULL, lost most of its data. The case that surfaced it is an anomaly overlay:

```sql
max(actual_value)                                      AS zo_sql_num     -- the metric
CASE WHEN <bucket flagged> THEN max(actual_value) END  AS anomaly_value  -- overlay, NULL when healthy
```

`getAxisDataFromKey` kept a row only if **every** y key on it was non-null. `anomaly_value` is NULL on every healthy bucket by design, so every healthy bucket was deleted — and because the x axis is built from that same filtered set, the bucket left the axis too, taking the other series with it.

Two visible symptoms:

- **The dense series looked missing.** On the surviving rows both columns hold the same number, so the overlay drew on top of it.
- **The overlay ran through unflagged buckets.** They weren't nulls in the series, they were absent from the axis, so neighbouring flagged points connected straight across the gap.

Not anomaly-specific — any panel with 2+ y columns where one is conditionally NULL was affected.

## The fix

`web/src/utils/dashboard/sql/shared/contextBuilder.ts` — keep a row when *some* y column has a value, drop it only when they are all null:

```diff
-          yAxisKeys.every((key: any) => getDataValue(item, key) != null) &&
+          // some, not every: one null y must not erase the row, its x category and the other series
+          (!yAxisKeys.length || yAxisKeys.some((key: any) => getDataValue(item, key) != null)) &&
```

## Testing

- `convertSQLData.spec.ts`: **269 pass, 0 fail** — includes the four new cases from the PR (x axis keeps every bucket, dense series stays complete, sparse series holds null where it has no value, and a row with *all* y columns null is still dropped)
- Full `src/utils/dashboard/` suite: **2618 pass, 0 fail**
- `vue-tsc` clean, `npm run format:check` clean
