### PR TITLE
fix: create default folders idempotently under concurrency

### DIFF
--- a/src/core/src/alerts/alert.rs
+++ b/src/core/src/alerts/alert.rs
@@ -344,15 +344,12 @@ pub async fn save(
 /// `pub(crate)` because SLOs live in these same folders (§6b, D28) and their
 /// save path needs the identical create-on-demand behaviour.
 pub(crate) async fn create_default_alerts_folder(org_id: &str) -> Result<Folder, AlertError> {
-    let default_folder = Folder {
-        folder_id: DEFAULT_FOLDER.to_owned(),
-        name: "default".to_owned(),
-        description: "default".to_owned(),
-        icon: None,
-    };
-    folders::save_folder(org_id, default_folder, FolderType::Alerts, true)
+    folders::ensure_default_folder(org_id, FolderType::Alerts)
         .await
-        .map_err(|_| AlertError::CreateDefaultFolderError)
+        .map_err(|e| {
+            log::error!("[alerts] creating default folder for org {org_id}: {e}");
+            AlertError::CreateDefaultFolderError
+        })
 }
 
 /// Per-group alerting admissibility (M-9/M-10, §5.5 MN-11).

--- a/src/core/src/anomaly_detection.rs
+++ b/src/core/src/anomaly_detection.rs
@@ -152,13 +152,7 @@ async fn resolve_folder_pk(org_id: &str, name: &str) -> Option<String> {
 
     // Auto-create the default Alerts folder on first use, same as alert::create does.
     if name == DEFAULT_FOLDER {
-        let folder = Folder {
-            folder_id: DEFAULT_FOLDER.to_owned(),
-            name: "default".to_owned(),
-            description: "default".to_owned(),
-            icon: None,
-        };
-        if crate::folders::save_folder(org_id, folder, FolderType::Alerts, true)
+        if crate::folders::ensure_default_folder(org_id, FolderType::Alerts)
             .await
             .is_ok()
         {

--- a/src/core/src/anomaly_detection.rs
+++ b/src/core/src/anomaly_detection.rs
@@ -18,7 +18,7 @@ use chrono::Utc;
 use config::{
     meta::{
         destinations::{DestinationType, Module},
-        folder::{DEFAULT_FOLDER, Folder, FolderType},
+        folder::{DEFAULT_FOLDER, FolderType},
         stream::StreamType,
         triggers::{ScheduledTriggerData, TriggerModule},
     },

--- a/src/core/src/dashboards/mod.rs
+++ b/src/core/src/dashboards/mod.rs
@@ -363,15 +363,12 @@ pub async fn create_dashboard(
         .await;
         Ok(saved)
     } else if folder_id == DEFAULT_FOLDER {
-        let folder = Folder {
-            folder_id: DEFAULT_FOLDER.to_string(),
-            name: DEFAULT_FOLDER.to_string(),
-            description: DEFAULT_FOLDER.to_string(),
-            icon: None,
-        };
-        folders::save_folder(org_id, folder, FolderType::Dashboards, true)
+        folders::ensure_default_folder(org_id, FolderType::Dashboards)
             .await
-            .map_err(|_| DashboardError::CreateDefaultFolder)?;
+            .map_err(|e| {
+                log::error!("[dashboards] creating default folder for org {org_id}: {e}");
+                DashboardError::CreateDefaultFolder
+            })?;
         let dashboard_id = ider::generate();
         let saved = put(org_id, &dashboard_id, folder_id, None, dashboard, None).await?;
         set_ownership(

--- a/src/db/src/dashboards/reports.rs
+++ b/src/db/src/dashboards/reports.rs
@@ -163,13 +163,7 @@ pub async fn create_without_updating_trigger<C: ConnectionTrait + TransactionTra
 }
 
 async fn create_default_reports_folder(org_id: &str) -> Result<Folder, anyhow::Error> {
-    let default_folder = Folder {
-        folder_id: DEFAULT_FOLDER.to_owned(),
-        name: "default".to_owned(),
-        description: "default".to_owned(),
-        icon: None,
-    };
-    Ok(folders::save_folder(org_id, default_folder, FolderType::Reports, true).await?)
+    Ok(folders::ensure_default_folder(org_id, FolderType::Reports).await?)
 }
 
 pub async fn update_without_updating_trigger<C: ConnectionTrait + TransactionTrait>(

--- a/src/db/src/folders.rs
+++ b/src/db/src/folders.rs
@@ -117,12 +117,7 @@ pub async fn save_folder(
     }
 
     let (_id, folder) = table::folders::put(org_id, None, folder, folder_type).await?;
-    let folder_type_ofga = match folder_type {
-        FolderType::Dashboards => "folders",
-        FolderType::Alerts => "alert_folders",
-        FolderType::Reports => "report_folders",
-        FolderType::Synthetics => "synthetic_folder",
-    };
+    let folder_type_ofga = folder_type_ofga_name(folder_type);
     set_ownership(org_id, folder_type_ofga, Authz::new(&folder.folder_id)).await;
 
     #[cfg(feature = "enterprise")]
@@ -139,6 +134,56 @@ pub async fn save_folder(
             Some(folder.description.as_str()).filter(|d| !d.is_empty()),
         )
         .await;
+    }
+
+    Ok(folder)
+}
+
+/// Returns the org's default folder of the given type, creating it if this is the first use.
+///
+/// Safe to call concurrently: the folder is created idempotently, so a request that loses the race
+/// still gets the folder rather than a unique-constraint failure. Ownership and the super-cluster
+/// event only fire for the caller that actually inserted it.
+#[tracing::instrument]
+pub async fn ensure_default_folder(
+    org_id: &str,
+    folder_type: FolderType,
+) -> Result<Folder, FolderError> {
+    let default_folder = Folder {
+        folder_id: DEFAULT_FOLDER.to_owned(),
+        name: DEFAULT_FOLDER.to_owned(),
+        description: DEFAULT_FOLDER.to_owned(),
+        icon: None,
+    };
+
+    let (_id, folder, created) =
+        table::folders::get_or_create(org_id, default_folder, folder_type).await?;
+    if !created {
+        return Ok(folder);
+    }
+
+    set_ownership(
+        org_id,
+        folder_type_ofga_name(folder_type),
+        Authz::new(&folder.folder_id),
+    )
+    .await;
+
+    #[cfg(feature = "enterprise")]
+    if o2_enterprise::enterprise::common::config::get_config()
+        .super_cluster
+        .enabled
+    {
+        let _ = o2_enterprise::enterprise::super_cluster::queue::folders_create(
+            org_id,
+            _id,
+            &folder.folder_id,
+            folder_type,
+            &folder.name,
+            Some(folder.description.as_str()).filter(|d| !d.is_empty()),
+        )
+        .await
+        .map_err(|e| FolderError::InfraError(infra::errors::Error::Message(e.to_string())));
     }
 
     Ok(folder)
@@ -300,12 +345,7 @@ pub async fn delete_folder(
     }
 
     table::folders::delete(org_id, folder_id, folder_type).await?;
-    let folder_type_ofga = match folder_type {
-        FolderType::Dashboards => "folders",
-        FolderType::Alerts => "alert_folders",
-        FolderType::Reports => "report_folders",
-        FolderType::Synthetics => "synthetic_folder",
-    };
+    let folder_type_ofga = folder_type_ofga_name(folder_type);
     remove_ownership(org_id, folder_type_ofga, Authz::new(folder_id)).await;
 
     #[cfg(feature = "enterprise")]
@@ -322,6 +362,16 @@ pub async fn delete_folder(
     }
 
     Ok(())
+}
+
+/// OpenFGA object type that owns folders of the given kind.
+fn folder_type_ofga_name(folder_type: FolderType) -> &'static str {
+    match folder_type {
+        FolderType::Dashboards => "folders",
+        FolderType::Alerts => "alert_folders",
+        FolderType::Reports => "report_folders",
+        FolderType::Synthetics => "synthetic_folder",
+    }
 }
 
 #[cfg(not(feature = "enterprise"))]

--- a/src/db/src/folders.rs
+++ b/src/db/src/folders.rs
@@ -182,8 +182,7 @@ pub async fn ensure_default_folder(
             &folder.name,
             Some(folder.description.as_str()).filter(|d| !d.is_empty()),
         )
-        .await
-        .map_err(|e| FolderError::InfraError(infra::errors::Error::Message(e.to_string())));
+        .await;
     }
 
     Ok(folder)

--- a/src/infra/src/table/folders.rs
+++ b/src/infra/src/table/folders.rs
@@ -140,11 +140,51 @@ pub async fn put(
         }
     };
 
-    let ksuid = Ksuid::from_base62(&model.id).map_err(|_| FromStrError {
-        value: model.id.clone(),
-        ty: "svix_ksuid::Ksuid".to_owned(),
-    })?;
-    Ok((ksuid, model.into()))
+    Ok((model_ksuid(&model)?, model.into()))
+}
+
+/// Creates the folder if `(org, type, folder_id)` is still free, otherwise returns the folder that
+/// is already there. The bool reports whether this call is the one that inserted it.
+///
+/// Callers that auto-create a folder cannot check-then-insert: concurrent requests to a fresh org
+/// all see no folder and all insert, and every loser hits the unique index. Losing that race is not
+/// an error here, so the insert is attempted first and a failure is only reported when the row is
+/// still absent afterwards.
+pub async fn get_or_create(
+    org_id: &str,
+    folder: Folder,
+    folder_type: FolderType,
+) -> Result<(Ksuid, Folder, bool), errors::Error> {
+    let client = get_orm_client_rw().await;
+    let folder_id = folder.folder_id.clone();
+
+    if let Some(model) = get_model(client, org_id, &folder_id, folder_type).await? {
+        return Ok((model_ksuid(&model)?, model.into(), false));
+    }
+
+    let active = ActiveModel {
+        id: Set(Ksuid::new(None, None).to_string()),
+        org: Set(org_id.to_owned()),
+        folder_id: Set(folder.folder_id),
+        r#type: Set::<i16>(folder_type_into_i16(folder_type)),
+        name: Set(folder.name),
+        description: Set(Some(folder.description).filter(|d| !d.is_empty())),
+        icon: Set(folder.icon.filter(|i| !i.is_empty())),
+    };
+
+    match active.insert(client).await {
+        Ok(model) => {
+            let model: Model = model.try_into_model()?;
+            Ok((model_ksuid(&model)?, model.into(), true))
+        }
+        // A concurrent caller may have inserted the same folder between the read above and this
+        // write. Re-read before deciding: the row being there now means the folder exists, which is
+        // all the caller wanted. Only a still-missing row makes this a real failure.
+        Err(e) => match get_model(client, org_id, &folder_id, folder_type).await? {
+            Some(model) => Ok((model_ksuid(&model)?, model.into(), false)),
+            None => Err(e.into()),
+        },
+    }
 }
 
 /// Deletes a folder with the given `folder_id` surrogate key.
@@ -236,6 +276,16 @@ pub(crate) async fn get_model_by_name<C: ConnectionTrait>(
 }
 
 /// Lists all folder ORM models with the specified type.
+fn model_ksuid(model: &Model) -> Result<Ksuid, errors::Error> {
+    Ksuid::from_base62(&model.id).map_err(|_| {
+        FromStrError {
+            value: model.id.clone(),
+            ty: "svix_ksuid::Ksuid".to_owned(),
+        }
+        .into()
+    })
+}
+
 async fn list_models(
     db: &DatabaseConnection,
     org_id: &str,

--- a/src/infra/src/table/folders.rs
+++ b/src/infra/src/table/folders.rs
@@ -275,7 +275,7 @@ pub(crate) async fn get_model_by_name<C: ConnectionTrait>(
         .await
 }
 
-/// Lists all folder ORM models with the specified type.
+/// Parses the primary-key `id` column as a Ksuid.
 fn model_ksuid(model: &Model) -> Result<Ksuid, errors::Error> {
     Ksuid::from_base62(&model.id).map_err(|_| {
         FromStrError {
@@ -286,6 +286,7 @@ fn model_ksuid(model: &Model) -> Result<Ksuid, errors::Error> {
     })
 }
 
+/// Lists all folder ORM models with the specified type.
 async fn list_models(
     db: &DatabaseConnection,
     org_id: &str,

--- a/src/synthetics/src/service/checks.rs
+++ b/src/synthetics/src/service/checks.rs
@@ -439,20 +439,15 @@ pub async fn move_synthetics(
     // Resolve slug → KSUID PK. Auto-create the default folder when necessary,
     // matching the behaviour of create_synthetic.
     let dst_pk = if dst_folder_id == DEFAULT_FOLDER {
-        if !folders::exists(org_id, DEFAULT_FOLDER, FolderType::Synthetics)
+        let folder = Folder {
+            folder_id: DEFAULT_FOLDER.to_owned(),
+            name: "default".to_owned(),
+            description: "default".to_owned(),
+            icon: None,
+        };
+        folders::get_or_create(org_id, folder, FolderType::Synthetics)
             .await
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?
-        {
-            let folder = Folder {
-                folder_id: DEFAULT_FOLDER.to_owned(),
-                name: "default".to_owned(),
-                description: "default".to_owned(),
-                icon: None,
-            };
-            folders::put(org_id, None, folder, FolderType::Synthetics)
-                .await
-                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        }
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         folders::get_pk_by_name(org_id, DEFAULT_FOLDER, FolderType::Synthetics)
             .await
             .map_err(|e| anyhow::anyhow!(e.to_string()))?

--- a/src/synthetics/src/service/mod.rs
+++ b/src/synthetics/src/service/mod.rs
@@ -113,16 +113,17 @@ async fn create_default_synthetics_folder(org_id: &str) -> anyhow::Result<()> {
         description: "default".to_owned(),
         icon: None,
     };
-    folders::put(org_id, None, folder, FolderType::Synthetics)
+    let (_id, _folder, created) = folders::get_or_create(org_id, folder, FolderType::Synthetics)
         .await
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
     // Register the folder in OpenFGA — writes owningOrg + selfParent so a
     // Type-level "Synthetic Folders" grant cascades to checks in this folder.
-    // `folders::put` is the raw table write (no FGA); the OSS folders API goes
+    // `get_or_create` is the raw table write (no FGA); the OSS folders API goes
     // through `db::folders::save_folder` which does this, but that crate isn't
     // a dep here, so call set_ownership directly (same effect). Mirrors how
     // `create_default_alerts_folder` registers afolder:default.
-    if ofga_enabled() {
+    // Only the caller that inserted registers it, so a lost race writes no duplicate tuple.
+    if created && ofga_enabled() {
         let obj = format!("{}:{}", get_ofga_type("synthetic_folder"), DEFAULT_FOLDER);
         set_ownership(org_id, &obj, "", "").await;
     }


### PR DESCRIPTION
Fixes #14163

## The problem

Creating a dashboard in a brand-new org intermittently returned a bare **HTTP 500** in ~2ms with nothing in the logs. Retrying the same request worked.

An org's `default` folder is created lazily on first use, and the code looked before it leapt:

```
Request A: does "default" exist?  → no
Request B: does "default" exist?  → no      ← both read before either wrote
Request A: INSERT "default"       → ok
Request B: INSERT "default"       → unique-constraint violation → 500
```

The check-then-act is stacked three deep, and not one of the layers is atomic:

| Layer | The check |
|---|---|
| `core/src/dashboards/mod.rs:351` | `table::folders::exists(...)` |
| `db/src/folders.rs:112` | `get_folder_by_name(...)` |
| `infra/src/table/folders.rs:110` | `get_model(...)` |

Two requests interleave between any of those reads and the write that follows. The unique index on `(org, type, folder_id)` — `m20241217_154900_alter_folders_table_idx.rs:63` — is the only thing actually enforcing uniqueness, and it enforces it by erroring.

**Why the 500 was silent:** both the dashboards and alerts paths discarded the cause with `.map_err(|_| ...)`, so the real database error never reached the log.

## Scope — four sites, not one

The issue reports it for dashboards; the same pattern auto-creates a default folder in three more places:

| Site | Folder type |
|---|---|
| `core/src/dashboards/mod.rs:372` | Dashboards |
| `core/src/alerts/alert.rs:348` (also used by SLOs) | Alerts |
| `db/src/dashboards/reports.rs:172` | Reports |
| `core/src/anomaly_detection.rs:161` | Alerts |

## The fix

**`table::folders::get_or_create`** — attempt the insert, and only report failure if the row is *still* missing afterwards:

```rust
match active.insert(client).await {
    Ok(model) => Ok((.., true)),
    // A concurrent caller may have inserted between the read and this write.
    // The row being there now means the folder exists, which is all the caller wanted.
    Err(e) => match get_model(client, org_id, &folder_id, folder_type).await? {
        Some(model) => Ok((.., false)),
        None => Err(e.into()),
    },
}
```

Losing the race yields the winner's folder instead of an error. I chose catch-and-refetch over `ON CONFLICT DO NOTHING` deliberately: it needs no dialect-specific SQL and no special-casing of `DbErr::RecordNotInserted`, which sea-orm returns when a `do_nothing` conflict inserts nothing. Both supported backends, SQLite and Postgres, take the same path.

**`folders::ensure_default_folder`** wraps it for the four callers. The returned `created` flag matters: ownership and the super-cluster event fire only for the caller that actually inserted, so the loser doesn't emit a duplicate create event or re-set OpenFGA tuples.

User-created folders are untouched — `save_folder` keeps its "name already exists" validation. Only the internal default-folder path bypasses it, which is correct: that folder is created by the system, not named by a user.

**Error visibility:** the dashboards and alerts paths now log the cause before mapping to the public error, so a genuine DB failure is diagnosable instead of another anonymous 500.

Also folded the OpenFGA folder-type mapping — duplicated inline in two places — into one `folder_type_ofga_name` helper, since a third copy would have been needed.

## Testing

- `cargo fmt --all`, `cargo check --workspace --all-targets`: clean
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings`: **exit 0, zero diagnostics**

No unit test: the race only exists against a real database, and the existing tests in `table/folders.rs` are pure functions with no DB harness to hook into. The honest regression signal is the Dashboards e2e shard, which reproduced this ~38 times over 21 days with five parallel workers — it should stop.

Enterprise code is untouched apart from the `#[cfg(feature = "enterprise")]` super-cluster block inside `ensure_default_folder`, which mirrors what `save_folder` already does. Per the repo's rules I could not compile that path locally.

