### PR TITLE
fix(promql): keep the cancel and timeout error codes through DataFusion

### DIFF
--- a/src/infra/src/errors/grpc.rs
+++ b/src/infra/src/errors/grpc.rs
@@ -17,8 +17,34 @@ use datafusion::{common::SchemaError, error::DataFusionError};
 
 use super::{Error, ErrorCodes};
 
+/// Carries an `ErrorCodes` through DataFusion so the HTTP status survives the round trip.
+#[derive(Debug)]
+struct DataFusionErrorCode(ErrorCodes);
+
+impl std::fmt::Display for DataFusionErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for DataFusionErrorCode {}
+
+impl From<ErrorCodes> for DataFusionError {
+    fn from(code: ErrorCodes) -> Self {
+        Self::External(Box::new(DataFusionErrorCode(code)))
+    }
+}
+
 impl From<DataFusionError> for Error {
     fn from(err: DataFusionError) -> Self {
+        let err = match err {
+            DataFusionError::External(external) => match external.downcast::<DataFusionErrorCode>()
+            {
+                Ok(code) => return Error::ErrorCode(code.0),
+                Err(external) => DataFusionError::External(external),
+            },
+            err => err,
+        };
         if let DataFusionError::SchemaError(schema_err, _) = &err
             && let SchemaError::FieldNotFound {
                 field,
@@ -116,6 +142,15 @@ mod tests {
         assert!(matches!(
             err,
             Error::ErrorCode(ErrorCodes::SearchSQLExecuteError(_))
+        ));
+    }
+
+    #[test]
+    fn test_from_datafusion_error_code_round_trips() {
+        let df_err: DataFusionError = ErrorCodes::SearchCancelQuery("canceled".to_string()).into();
+        assert!(matches!(
+            Error::from(df_err),
+            Error::ErrorCode(ErrorCodes::SearchCancelQuery(message)) if message == "canceled"
         ));
     }
 

--- a/src/promql/src/engine/selector.rs
+++ b/src/promql/src/engine/selector.rs
@@ -22,7 +22,7 @@ use config::meta::promql::{NAME_LABEL, value::*};
 use datafusion::error::{DataFusionError, Result};
 use futures::future::{pending, try_join_all};
 use hashbrown::HashMap;
-use infra::errors::{Error, ErrorCodes};
+use infra::errors::ErrorCodes;
 use promql_parser::{
     label::{MatchOp, Matchers},
     parser::{LabelModifier, MatrixSelector, Offset, VectorSelector},
@@ -414,9 +414,10 @@ impl Engine {
                                 Ok(Ok(data)) => unwrapped_results.push(data),
                                 Ok(Err(_)) => {
                                     log::error!("[trace_id {trace_id}] [PromQL] grpc search load data task timeout");
-                                    return Err(DataFusionError::Plan(
-                                        Error::ErrorCode(ErrorCodes::SearchTimeout("[PromQL] grpc search load data task timeout".to_string())).to_string()
-                                    ));
+                                    return Err(ErrorCodes::SearchTimeout(
+                                        "[PromQL] grpc search load data task timeout".to_string(),
+                                    )
+                                    .into());
                                 }
                                 Err(err) => {
                                     log::error!("[trace_id {trace_id}] [PromQL] grpc search execute error: {err}");
@@ -428,7 +429,7 @@ impl Engine {
                     },
                     Err(err) => {
                         log::error!("[trace_id {trace_id}] [PromQL] grpc search execute error: {err}");
-                        Err(Error::Message(err.to_string()))
+                        Err(DataFusionError::Execution(err.to_string()))
                     }
                 }
             },
@@ -437,7 +438,7 @@ impl Engine {
                     handle.abort();
                 }
                 log::error!("[trace_id {trace_id}] [PromQL] grpc search timeout");
-                Err(Error::ErrorCode(ErrorCodes::SearchTimeout("[PromQL] grpc search timeout".to_string())))
+                Err(ErrorCodes::SearchTimeout("[PromQL] grpc search timeout".to_string()).into())
             },
             _ = async {
                 match abort_receiver.as_mut() {
@@ -451,12 +452,11 @@ impl Engine {
                     handle.abort();
                 }
                 log::info!("[trace_id {trace_id}] [PromQL] grpc search canceled");
-                Err(Error::ErrorCode(ErrorCodes::SearchCancelQuery("[PromQL] grpc search canceled".to_string())))
+                Err(ErrorCodes::SearchCancelQuery("[PromQL] grpc search canceled".to_string()).into())
             }
         };
 
-        let task_results =
-            task_results.map_err(|e| DataFusionError::Plan(format!("task error: {e}")))?;
+        let task_results = task_results?;
 
         // check for super cluster
         #[cfg(feature = "enterprise")]
@@ -629,21 +629,17 @@ impl Engine {
                 }
             } => {
                 log::info!("[trace_id {trace_id}] [PromQL] streaming fused agg canceled");
-                Err(DataFusionError::Plan(
-                    Error::ErrorCode(ErrorCodes::SearchCancelQuery(
-                        "[PromQL] streaming fused agg canceled".to_string(),
-                    ))
-                    .to_string(),
-                ))
+                Err(ErrorCodes::SearchCancelQuery(
+                    "[PromQL] streaming fused agg canceled".to_string(),
+                )
+                .into())
             }
             _ = tokio::time::sleep(Duration::from_secs(timeout)) => {
                 log::error!("[trace_id {trace_id}] [PromQL] streaming fused agg timeout");
-                Err(DataFusionError::Plan(
-                    Error::ErrorCode(ErrorCodes::SearchTimeout(
-                        "[PromQL] streaming fused agg timeout".to_string(),
-                    ))
-                    .to_string(),
-                ))
+                Err(ErrorCodes::SearchTimeout(
+                    "[PromQL] streaming fused agg timeout".to_string(),
+                )
+                .into())
             }
             ret = &mut run => ret,
         }
@@ -1253,20 +1249,20 @@ mod tests {
 
         #[tokio::test]
         async fn test_streaming_run_stops_on_cancel() {
-            let err = eval_sum_rate(provider(true), 30)
-                .await
-                .unwrap_err()
-                .to_string();
-            assert!(err.contains("canceled"), "unexpected error: {err}");
+            let err = eval_sum_rate(provider(true), 30).await.unwrap_err();
+            assert!(matches!(
+                infra::errors::Error::from(err),
+                infra::errors::Error::ErrorCode(ErrorCodes::SearchCancelQuery(_))
+            ));
         }
 
         #[tokio::test]
         async fn test_streaming_run_stops_on_timeout() {
-            let err = eval_sum_rate(provider(false), 0)
-                .await
-                .unwrap_err()
-                .to_string();
-            assert!(err.contains("timeout"), "unexpected error: {err}");
+            let err = eval_sum_rate(provider(false), 0).await.unwrap_err();
+            assert!(matches!(
+                infra::errors::Error::from(err),
+                infra::errors::Error::ErrorCode(ErrorCodes::SearchTimeout(_))
+            ));
         }
     }
 }

--- a/src/promql/src/fused/matrix.rs
+++ b/src/promql/src/fused/matrix.rs
@@ -20,7 +20,7 @@ use config::meta::promql::{
     value::{EvalContext, Value},
 };
 use datafusion::error::{DataFusionError, Result};
-use infra::errors::{Error, ErrorCodes};
+use infra::errors::ErrorCodes;
 use promql_parser::parser::LabelModifier;
 use rayon::prelude::*;
 
@@ -94,12 +94,9 @@ pub(crate) async fn fused_agg(
         tokio::time::timeout(Duration::from_secs(timeout), fold_sources(sources, params))
             .await
             .map_err(|_| {
-                DataFusionError::Plan(
-                    Error::ErrorCode(ErrorCodes::SearchTimeout(
-                        "[PromQL] fused agg timeout".to_string(),
-                    ))
-                    .to_string(),
-                )
+                DataFusionError::from(ErrorCodes::SearchTimeout(
+                    "[PromQL] fused agg timeout".to_string(),
+                ))
             })??;
 
     log::info!(

--- a/src/promql_service/src/search/grpc/mod.rs
+++ b/src/promql_service/src/search/grpc/mod.rs
@@ -104,14 +104,10 @@ impl TableProvider for StorageProvider {
             .is_err()
         {
             log::info!("[trace_id {trace_id}] [PromQL] grpc search canceled before execution plan");
-            return Err(DataFusionError::Plan(
-                infra::errors::Error::ErrorCode(infra::errors::ErrorCodes::SearchCancelQuery(
-                    format!(
-                        "[trace_id {trace_id}] [PromQL] grpc search canceled before execution plan"
-                    ),
-                ))
-                .to_string(),
-            ));
+            return Err(infra::errors::ErrorCodes::SearchCancelQuery(format!(
+                "[trace_id {trace_id}] [PromQL] grpc search canceled before execution plan"
+            ))
+            .into());
         }
         Ok(Some(abort_receiver))
     }


### PR DESCRIPTION
## Problem

Inside the PromQL engine every cancel and timeout is raised as a `DataFusionError` because the engine's `Result` type is DataFusion's. Until now the sites did this by stringifying an `Error::ErrorCode(SearchCancelQuery | SearchTimeout)` into `DataFusionError::Plan(..)`. When the querier converts that back with `From<DataFusionError> for Error`, the string no longer matches any code and lands in `SearchSQLExecuteError`, so a canceled query reaches the client as HTTP 500 / code 20008 instead of 429 / 20009, and a timeout as 500 instead of 408 / 20010. The leader parses the gRPC status message with `ErrorCodes::from_json`, so once the code is lost on the node it cannot be recovered upstream.

## Fix

- `infra::errors::grpc`: add `impl From<ErrorCodes> for DataFusionError`, carrying the code as a `DataFusionError::External` payload, and downcast it back first thing in `From<DataFusionError> for Error`. Everything else in that conversion is unchanged.
- `promql` engine (`selector.rs` grpc load + `run_cancellable`), `fused::matrix` fold timeout, and `promql_service` `register_cancellation`: build the `DataFusionError` from the code with `.into()` instead of stringifying.
- The `try_join_all` join error now maps to `DataFusionError::Execution` (it was `Error::Message` re-wrapped as `Plan("task error: ..")`); still a 500.

## Tests

- `infra`: round trip `ErrorCodes -> DataFusionError -> Error` keeps the variant and message.
- `promql` streaming cancel/timeout engine tests now assert the recovered `ErrorCodes` variant rather than a substring of the message.

Ran `cargo fmt --all` and the CI clippy command (`-W too_many_lines -W cognitive_complexity -W excessive_nesting -D warnings`) clean. No enterprise-only code touched (`register_cancellation` is behind `cfg(feature = "enterprise")` but the change is a pure expression rewrite; not verified against the o2-enterprise workspace).
