### PR TITLE
ci: rename the CI gate label from e2e to ready-for-ci

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -2,7 +2,7 @@ name: AI Code Review
 
 on:
   pull_request:
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets the review.
+    # labeled/unlabeled so adding or removing 'ready-for-ci' starts or resets the review.
     types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, converted_to_draft]
   workflow_dispatch:
     inputs:
@@ -18,8 +18,8 @@ on:
 
 jobs:
   review:
-    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Paid CI runs only on PRs carrying the 'ready-for-ci' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     # Explicit name: without it GitHub serializes the whole matrix object (api_key_env, marker) into the public check name.
     name: review (${{ matrix.provider.name }})
     runs-on: ubuntu-latest

--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
+    # labeled/unlabeled so adding or removing 'ready-for-ci' starts or resets CI; drafts never run paid CI.
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   merge_group:
 
@@ -33,8 +33,8 @@ env:
 
 jobs:
   check_changes:
-    # Runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests only (see docs/ci).
-    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false)) }}
+    # Runs only on PRs carrying the 'ready-for-ci' label; the merge queue runs unit tests only (see docs/ci).
+    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false)) }}
     name: check_changes
     runs-on: ubuntu-latest
     permissions:
@@ -551,7 +551,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [check_changes, build_api_binary, api_integration_tests, api_query_agent_tests, api_regression_tests]
-    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
+    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false))
     steps:
       - name: Check test results
         run: |
@@ -585,7 +585,7 @@ jobs:
   report_to_openobserve:
     name: Report run metrics to OpenObserve
     needs: [check_changes, api_integration_tests, api_query_agent_tests, api_regression_tests]
-    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
+    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false))
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/audit-checker.yml
+++ b/.github/workflows/audit-checker.yml
@@ -21,8 +21,8 @@ concurrency:
 
 jobs:
   security_audit:
-    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Nothing runs on a PR without the 'ready-for-ci' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/auto-assign-metadata.yml
+++ b/.github/workflows/auto-assign-metadata.yml
@@ -251,7 +251,7 @@ jobs:
               || echo "::warning::Could not label stranger PR #$NUMBER"
           fi
 
-      # ── Dependabot: label e2e to unlock gated CI, approve any held runs ──
+      # ── Dependabot: label ready-for-ci to unlock gated CI, approve any held runs ──
       - name: Enable CI for dependabot PR
         if: github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]'
         env:
@@ -260,8 +260,8 @@ jobs:
           NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          gh pr edit "$NUMBER" --add-label "e2e" \
-            && echo "Labeled dependabot PR #$NUMBER with e2e" \
+          gh pr edit "$NUMBER" --add-label "ready-for-ci" \
+            && echo "Labeled dependabot PR #$NUMBER with ready-for-ci" \
             || echo "::warning::Could not label dependabot PR #$NUMBER"
           for id in $(gh api "repos/$GH_REPO/actions/runs?head_sha=$HEAD_SHA&status=action_required" --jq '.workflow_runs[].id'); do
             gh api -X POST "repos/$GH_REPO/actions/runs/$id/approve" \

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -19,8 +19,8 @@ concurrency:
 
 jobs:
   check:
-    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Nothing runs on a PR without the 'ready-for-ci' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     runs-on: ubicloud-standard-8
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,6 +1,6 @@
 name: CI gate
 
-# Required check on main: pending without the e2e label, so an untested PR cannot be queued.
+# Required check on main: pending without the ready-for-ci label, so an untested PR cannot be queued.
 # A status is needed because skipped jobs count as passing for required checks.
 on:
   # pull_request_target so fork PRs get a status too; no checkout, so nothing untrusted runs.
@@ -24,16 +24,16 @@ jobs:
       - env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          LABELED: ${{ github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
+          LABELED: ${{ github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'ready-for-ci') }}
           DRAFT: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == true }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           if [ "$DRAFT" = "true" ]; then
             STATE=pending; DESC="Draft PR: paid CI does not run until it is marked ready for review."
           elif [ "$LABELED" = "true" ]; then
-            STATE=success; DESC="e2e label present; CI runs on every push"
+            STATE=success; DESC="ready-for-ci label present; CI runs on every push"
           else
-            STATE=pending; DESC="Add the e2e label to run CI. Required before this PR can be queued."
+            STATE=pending; DESC="Add the ready-for-ci label to run CI. Required before this PR can be queued."
           fi
           gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
             -f state="$STATE" -f context=ci-gate -f description="$DESC" -f target_url="$RUN_URL" \

--- a/.github/workflows/db-schema-version-check.yml
+++ b/.github/workflows/db-schema-version-check.yml
@@ -14,8 +14,8 @@ concurrency:
 
 jobs:
   db_schema_version_check:
-    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Nothing runs on a PR without the 'ready-for-ci' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     name: db_schema_version_check
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/db-testing.yml
+++ b/.github/workflows/db-testing.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
+    # labeled/unlabeled so adding or removing 'ready-for-ci' starts or resets CI; drafts never run paid CI.
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   merge_group:
 
@@ -28,8 +28,8 @@ env:
 
 jobs:
   check_changes:
-    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Paid CI runs only on PRs carrying the 'ready-for-ci' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     name: check_changes
     runs-on: ubuntu-latest
     permissions:
@@ -233,7 +233,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [check_changes, db_validation_tests]
-    if: always() && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
+    if: always() && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false))
     steps:
       - name: Check test results
         run: |

--- a/.github/workflows/dispatch-event-enterprise.yml
+++ b/.github/workflows/dispatch-event-enterprise.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   initiate_enterprise_build:
     # A pre-merge gate: runs once auto-merge is enabled on a labelled PR, not on every push.
-    if: ${{ github.event.pull_request.head.repo.fork == false && (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) && github.event.pull_request.auto_merge != null }}
+    if: ${{ github.event.pull_request.head.repo.fork == false && (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) && github.event.pull_request.auto_merge != null }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/ent-e2e-gate.yml
+++ b/.github/workflows/ent-e2e-gate.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   playwright-e2e-crosscheck:
     # A pre-merge gate: runs once auto-merge is enabled on a labelled PR, not on every push.
-    if: ${{ github.event_name == 'merge_group' || ((contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) && github.event.pull_request.auto_merge != null) }}
+    if: ${{ github.event_name == 'merge_group' || ((contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) && github.event.pull_request.auto_merge != null) }}
     name: Playwright E2E Crosscheck
     runs-on: ubuntu-latest
     # ~5 min to find the ENT run + up to ~75 min to poll. Generous on purpose: normal is ~20 min,

--- a/.github/workflows/feat-design-checker.yml
+++ b/.github/workflows/feat-design-checker.yml
@@ -15,8 +15,8 @@ jobs:
       pull-requests: read
       statuses: write
     # Only run on pull requests
-    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
-    if: (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false)) || (github.event_name == 'issue_comment' && github.event.issue.pull_request) || github.event_name == 'pull_request_review_comment'
+    # Nothing runs on a PR without the 'ready-for-ci' label, or on a draft; ci-gate alone reports the state.
+    if: (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false)) || (github.event_name == 'issue_comment' && github.event.issue.pull_request) || github.event_name == 'pull_request_review_comment'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/js-license-checker.yml
+++ b/.github/workflows/js-license-checker.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
+    # labeled/unlabeled so adding or removing 'ready-for-ci' starts or resets CI; drafts never run paid CI.
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
     # paths-ignore:
     #   - "**.md"
@@ -21,8 +21,8 @@ concurrency:
 
 jobs:
   js-license-check:
-    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Paid CI runs only on PRs carrying the 'ready-for-ci' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     runs-on: ubicloud-standard-4
     timeout-minutes: 10
     steps:

--- a/.github/workflows/mobile-sdk-e2e.yml
+++ b/.github/workflows/mobile-sdk-e2e.yml
@@ -107,8 +107,8 @@ jobs:
   # Self-contained model → no secrets to check.
   # -------------------------------------------------------------------------------------------
   preflight:
-    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Paid CI runs only on PRs carrying the 'ready-for-ci' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     name: Preflight & readiness
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -821,7 +821,7 @@ jobs:
   merge_reports:
     name: Merge Reports
     needs: [android, ios]
-    if: always() && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
+    if: always() && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
+    # labeled/unlabeled so adding or removing 'ready-for-ci' starts or resets CI; drafts never run paid CI.
     # auto_merge_enabled: the one full-matrix run per PR, at merge time (see generate_matrix).
     types: [opened, reopened, synchronize, labeled, unlabeled, auto_merge_enabled, ready_for_review, converted_to_draft]
   merge_group:
@@ -70,8 +70,8 @@ env:
 
 jobs:
   check_changes:
-    # Runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests only (see docs/ci).
-    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false)) }}
+    # Runs only on PRs carrying the 'ready-for-ci' label; the merge queue runs unit tests only (see docs/ci).
+    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false)) }}
     timeout-minutes: 5
     name: check_changes
     runs-on: ubuntu-latest
@@ -911,7 +911,7 @@ jobs:
         build_binary,
         ui_integration_tests,
       ]
-    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
+    if: always() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false))
     steps:
       - name: Check test results
         run: |

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -10,8 +10,8 @@ concurrency:
 
 jobs:
   check:
-    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Nothing runs on a PR without the 'ready-for-ci' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - "**"
-    # labeled/unlabeled so adding or removing 'e2e' starts or resets CI; drafts never run paid CI.
+    # labeled/unlabeled so adding or removing 'ready-for-ci' starts or resets CI; drafts never run paid CI.
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review, converted_to_draft]
   merge_group:
 
@@ -24,8 +24,8 @@ env:
 
 jobs:
   check_changes:
-    # Paid CI runs only on PRs carrying the 'e2e' label; the merge queue runs unit tests on the merged code.
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Paid CI runs only on PRs carrying the 'ready-for-ci' label; the merge queue runs unit tests on the merged code.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     name: check_changes
     runs-on: ubuntu-latest
     permissions:
@@ -321,7 +321,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [check_changes, backend_unit_tests, ui_unit_tests, ui_code_quality]
-    if: always() && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false))
+    if: always() && (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false))
     steps:
       - name: Check test results
         run: |

--- a/.github/workflows/verify-translations.yml
+++ b/.github/workflows/verify-translations.yml
@@ -28,8 +28,8 @@ concurrency:
 
 jobs:
   verify:
-    # Nothing runs on a PR without the 'e2e' label, or on a draft; ci-gate alone reports the state.
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'e2e') && github.event.pull_request.draft == false) }}
+    # Nothing runs on a PR without the 'ready-for-ci' label, or on a draft; ci-gate alone reports the state.
+    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && github.event.pull_request.draft == false) }}
     name: Verify translations are up to date
     runs-on: ubuntu-latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ reworded:
 
 ## PR conventions
 
-- CI runs on a PR only while it carries the `e2e` label and is not a draft
+- CI runs on a PR only while it carries the `ready-for-ci` label and is not a draft
   (no label or draft = nothing runs except `ci-gate`, and no red checks). Add the
   label when you want the run, not when you open the PR. Which suites run is decided by path detection, never by
   a label. The merge queue only compiles and unit-tests the merged code, so the


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/infrastructure/CI/e2e-gate-design.md (rollout step 7)

The label gates all paid CI, not only Playwright, and its name kept suggesting one suite. This renames it everywhere it is read or written: the gate condition in every workflow, the `ci-gate` status messages, the dependabot auto-label in auto-assign-metadata, and the PR convention in CLAUDE.md. `e2e-full` (force the full Playwright matrix) is unchanged.

Cut-over: the `ready-for-ci` label already exists. This PR carries both labels so `ci-gate` (which runs from main and still reads `e2e`) and the PR-head workflows (which read `ready-for-ci`) both see it. After the merge, every open PR carrying `e2e` gets `ready-for-ci` added and the `e2e` label is deleted. The paired o2-enterprise PR uses the same branch name.