### PR TITLE
[perf] coalesce object storage range reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5311,6 +5311,7 @@ dependencies = [
  "hashlink",
  "itertools 0.14.0",
  "log",
+ "moka",
  "object_store",
  "once_cell",
  "opentelemetry 0.31.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,6 +293,7 @@ lettre = { version = "0.11", default-features = false, features = [
 log = "0.4"
 md5 = "0.8.0"
 memchr = "2.7"
+moka = { version = "0.12.8", features = ["future"] }
 murmur3 = "0.5"
 once_cell = "1.20"
 ordered-float = { version = "5.0.0", features = ["serde"] }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -482,6 +482,7 @@ pub struct Config {
     pub compact: Compact,
     pub cache_latest_files: CacheLatestFiles,
     pub memory_cache: MemoryCache,
+    pub block_cache: BlockCache,
     pub disk_cache: DiskCache,
     pub log: Log,
     pub nats: Nats,
@@ -1792,6 +1793,36 @@ pub struct MemoryCache {
 }
 
 #[derive(Serialize, EnvConfig, Default)]
+pub struct BlockCache {
+    #[env_config(name = "ZO_BLOCK_CACHE_ENABLED", default = false)]
+    pub enabled: bool,
+    #[env_config(
+        name = "ZO_BLOCK_CACHE_BLOCK_SIZE",
+        default = 1024,
+        help = "Block size in KiB"
+    )]
+    pub block_size: usize,
+    #[env_config(
+        name = "ZO_BLOCK_CACHE_RETENTION",
+        default = 15,
+        help = "Retention in seconds; zero uses the 15 second default"
+    )]
+    pub retention: u64,
+    #[env_config(
+        name = "ZO_BLOCK_CACHE_BYPASS_THRESHOLD",
+        default = 8,
+        help = "Bypass threshold in MiB"
+    )]
+    pub bypass_threshold: usize,
+    #[env_config(
+        name = "ZO_BLOCK_CACHE_MAX_SIZE",
+        default = 512,
+        help = "Memory budget in MiB; requires a restart"
+    )]
+    pub max_size: usize,
+}
+
+#[derive(Serialize, EnvConfig, Default)]
 pub struct DiskCache {
     #[env_config(name = "ZO_DISK_CACHE_ENABLED", default = true)]
     pub enabled: bool,
@@ -1820,6 +1851,10 @@ pub struct DiskCache {
     pub gc_size: usize,
     #[env_config(name = "ZO_DISK_CACHE_GC_INTERVAL", default = 60)] // seconds
     pub gc_interval: u64,
+    // Bytes, files at or below this size are downloaded synchronously before a query starts.
+    // Set to 0 to disable inline downloading.
+    #[env_config(name = "ZO_DISK_CACHE_INLINE_DOWNLOAD_MAX_SIZE", default = 2097152)]
+    pub inline_download_max_size: usize,
     // Days, files with data older than this will not be downloaded into the cache,
     // queries read them directly from object storage. default 0 means no limit
     #[env_config(name = "ZO_DISK_CACHE_MAX_AGE_DAYS", default = 0)]
@@ -2322,6 +2357,8 @@ pub fn init() -> Config {
     if let Err(e) = check_memory_config(&mut cfg) {
         panic!("memory cache config error: {e}");
     }
+
+    check_block_cache_config(&mut cfg);
 
     // check disk cache
     if let Err(e) = check_disk_cache_config(&mut cfg) {
@@ -2846,6 +2883,33 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+fn check_block_cache_config(cfg: &mut Config) {
+    const KIB: usize = 1024;
+    const MIB: usize = 1024 * 1024;
+
+    cfg.block_cache.block_size = cfg.block_cache.block_size.saturating_mul(KIB);
+    cfg.block_cache.bypass_threshold = cfg.block_cache.bypass_threshold.saturating_mul(MIB);
+    let requested = cfg.block_cache.max_size.saturating_mul(MIB);
+    let memory_cache_size = cfg
+        .memory_cache
+        .max_size
+        .saturating_mul(cfg.memory_cache.bucket_num);
+    let effective = if memory_cache_size.saturating_add(requested) >= cfg.limit.mem_total {
+        cfg.limit
+            .mem_total
+            .saturating_sub(memory_cache_size)
+            .saturating_sub(1)
+    } else {
+        requested
+    };
+    if effective != requested {
+        log::warn!(
+            "ZO_BLOCK_CACHE_MAX_SIZE reduced from {requested} to {effective} bytes to stay below the memory limit"
+        );
+    }
+    cfg.block_cache.max_size = effective;
+}
+
 fn check_disk_cache_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(&cfg.common.data_cache_dir).expect("create cache dir success");
     let cache_dir = Path::new(&cfg.common.data_cache_dir)
@@ -3310,6 +3374,25 @@ mod tests {
 
         cfg.route.dispatch_strategy = RouteDispatchStrategy::Other;
         assert!(check_route_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn block_cache_budget_accounts_for_each_memory_cache_bucket() {
+        const MIB: usize = 1024 * 1024;
+
+        let mut cfg = Config::init().unwrap();
+        cfg.limit.mem_total = 10 * MIB;
+        cfg.memory_cache.max_size = 4 * MIB;
+        cfg.memory_cache.bucket_num = 2;
+        cfg.block_cache.block_size = 256;
+        cfg.block_cache.bypass_threshold = 8;
+        cfg.block_cache.max_size = 4;
+
+        check_block_cache_config(&mut cfg);
+
+        assert_eq!(cfg.block_cache.block_size, 256 * 1024);
+        assert_eq!(cfg.block_cache.bypass_threshold, 8 * MIB);
+        assert_eq!(cfg.block_cache.max_size, 2 * MIB - 1);
     }
 
     #[test]

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -1170,6 +1170,118 @@ pub static QUERY_DISK_CACHE_MISS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+pub static QUERY_BLOCK_CACHE_BLOCKS_REQUESTED: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_block_cache_blocks_requested",
+            "query block cache blocks requested".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_BLOCK_CACHE_BLOCKS_FETCHED: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_block_cache_blocks_fetched",
+            "query block cache blocks fetched".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_BLOCK_CACHE_REQUESTS_BYPASSED: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_block_cache_requests_bypassed",
+            "query block cache requests bypassed".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_BLOCK_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "query_block_cache_used_bytes",
+            "query block cache used bytes".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_BLOCK_CACHE_RANGE_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_block_cache_range_requests",
+            "query block cache range requests".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+pub static QUERY_DISK_CACHE_INLINE_DOWNLOAD_FILES_CONSIDERED: Lazy<IntCounterVec> =
+    Lazy::new(|| {
+        IntCounterVec::new(
+            Opts::new(
+                "query_disk_cache_inline_download_files_considered",
+                "query disk cache inline download files considered".to_owned() + HELP_SUFFIX,
+            )
+            .namespace(NAMESPACE)
+            .const_labels(create_const_labels()),
+            &["file_type"],
+        )
+        .expect("Metric created")
+    });
+pub static QUERY_DISK_CACHE_INLINE_DOWNLOAD_FILES_FETCHED: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_disk_cache_inline_download_files_fetched",
+            "query disk cache inline download files fetched".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["file_type", "status"],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_DISK_CACHE_INLINE_DOWNLOAD_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_disk_cache_inline_download_bytes",
+            "query disk cache inline download bytes".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["file_type"],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_DISK_CACHE_INLINE_DOWNLOAD_DURATION_SECONDS: Lazy<HistogramVec> =
+    Lazy::new(|| {
+        HistogramVec::new(
+            HistogramOpts::new(
+                "query_disk_cache_inline_download_duration_seconds",
+                "query disk cache inline download duration in seconds".to_owned() + HELP_SUFFIX,
+            )
+            .namespace(NAMESPACE)
+            .const_labels(create_const_labels()),
+            &["file_type"],
+        )
+        .expect("Metric created")
+    });
+
 // file downloader metrics
 pub static FILE_DOWNLOADER_NORMAL_QUEUE_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
@@ -1986,6 +2098,39 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(QUERY_DISK_CACHE_MISS_COUNT.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_BLOCK_CACHE_BLOCKS_REQUESTED.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_BLOCK_CACHE_BLOCKS_FETCHED.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_BLOCK_CACHE_REQUESTS_BYPASSED.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_BLOCK_CACHE_USED_BYTES.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_BLOCK_CACHE_RANGE_REQUESTS.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(
+            QUERY_DISK_CACHE_INLINE_DOWNLOAD_FILES_CONSIDERED.clone(),
+        ))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(
+            QUERY_DISK_CACHE_INLINE_DOWNLOAD_FILES_FETCHED.clone(),
+        ))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_DISK_CACHE_INLINE_DOWNLOAD_BYTES.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(
+            QUERY_DISK_CACHE_INLINE_DOWNLOAD_DURATION_SECONDS.clone(),
+        ))
         .expect("Metric registered");
     // file downloader metrics
     registry

--- a/src/infra/Cargo.toml
+++ b/src/infra/Cargo.toml
@@ -26,6 +26,7 @@ hashbrown.workspace = true
 hashlink.workspace = true
 itertools.workspace = true
 log.workspace = true
+moka.workspace = true
 async-nats.workspace = true
 object_store.workspace = true
 once_cell.workspace = true

--- a/src/infra/src/cache/block_cache.rs
+++ b/src/infra/src/cache/block_cache.rs
@@ -1,0 +1,503 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Caches range reads in fixed-size blocks, so concurrent requests for the same block share one
+//! Moka initializer. The caller checks the whole-file memory and disk caches first, so this cache
+//! sits directly in front of object storage. A cold multi-block range costs one fetch, because the
+//! first missing block pulls the whole remaining span and stores the siblings. Each request reads
+//! live settings, so reloads change behavior.
+
+use std::{
+    future::Future,
+    ops::Range,
+    time::{Duration, Instant},
+};
+
+use bytes::Bytes;
+use config::metrics::{
+    QUERY_BLOCK_CACHE_BLOCKS_FETCHED, QUERY_BLOCK_CACHE_BLOCKS_REQUESTED,
+    QUERY_BLOCK_CACHE_RANGE_REQUESTS, QUERY_BLOCK_CACHE_REQUESTS_BYPASSED,
+    QUERY_BLOCK_CACHE_USED_BYTES,
+};
+use moka::{future::Cache, policy::Expiry};
+use once_cell::sync::Lazy;
+
+const DEFAULT_BLOCK_SIZE: u64 = 1024 * 1024;
+const DEFAULT_RETENTION: Duration = Duration::from_secs(15);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct BlockKey {
+    account: String,
+    file: String,
+    block_size: u64,
+    block_index: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Settings {
+    pub enabled: bool,
+    pub block_size: u64,
+    pub bypass_threshold: u64,
+}
+
+impl Settings {
+    pub(crate) fn current() -> Self {
+        let block_cache = &config::get_config().block_cache;
+        Self {
+            enabled: block_cache.enabled,
+            block_size: block_cache.block_size as u64,
+            bypass_threshold: block_cache.bypass_threshold as u64,
+        }
+    }
+}
+
+struct BlockExpiry;
+
+impl Expiry<BlockKey, Bytes> for BlockExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &BlockKey,
+        _value: &Bytes,
+        _created_at: Instant,
+    ) -> Option<Duration> {
+        Some(retention(config::get_config().block_cache.retention))
+    }
+}
+
+static BLOCKS: Lazy<Cache<BlockKey, Bytes>> = Lazy::new(|| {
+    let max_size = config::get_config().block_cache.max_size as u64;
+    Cache::builder()
+        .max_capacity(max_size)
+        .weigher(|_, bytes: &Bytes| u32::try_from(bytes.len()).unwrap_or(u32::MAX))
+        .expire_after(BlockExpiry)
+        .build()
+});
+
+fn retention(seconds: u64) -> Duration {
+    if seconds == 0 {
+        DEFAULT_RETENTION
+    } else {
+        Duration::from_secs(seconds)
+    }
+}
+
+pub(crate) async fn get_range<F, Fut>(
+    account: &str,
+    file: &str,
+    range: Range<u64>,
+    fetch: F,
+) -> object_store::Result<Bytes>
+where
+    F: Fn(Range<u64>) -> Fut,
+    Fut: Future<Output = object_store::Result<Bytes>>,
+{
+    get_range_with_cache(&BLOCKS, account, file, range, Settings::current(), fetch)
+        .await
+        .map_err(|source| object_store::Error::Generic {
+            store: "block cache",
+            source: Box::new(source),
+        })
+}
+
+async fn get_range_with_cache<F, Fut, E>(
+    cache: &Cache<BlockKey, Bytes>,
+    account: &str,
+    file: &str,
+    range: Range<u64>,
+    settings: Settings,
+    fetch: F,
+) -> Result<Bytes, std::sync::Arc<E>>
+where
+    F: Fn(Range<u64>) -> Fut,
+    Fut: Future<Output = Result<Bytes, E>>,
+    E: Send + Sync + 'static,
+{
+    if !settings.enabled || range.is_empty() {
+        return fetch(range).await.map_err(std::sync::Arc::new);
+    }
+
+    let range_len = range.end - range.start;
+    if range_len > settings.bypass_threshold {
+        QUERY_BLOCK_CACHE_REQUESTS_BYPASSED
+            .with_label_values(&[] as &[&str])
+            .inc();
+        return fetch(range).await.map_err(std::sync::Arc::new);
+    }
+
+    // Counted after the bypass check, so this is the denominator for the blob-call reduction:
+    // without the block cache each of these ranges would cost one remote call.
+    QUERY_BLOCK_CACHE_RANGE_REQUESTS
+        .with_label_values(&[] as &[&str])
+        .inc();
+
+    let block_size = if settings.block_size == 0 {
+        DEFAULT_BLOCK_SIZE
+    } else {
+        settings.block_size
+    };
+    let first_block = range.start / block_size;
+    let last_block = (range.end - 1) / block_size;
+    let span_end = last_block.saturating_add(1).saturating_mul(block_size);
+    let mut result = Vec::with_capacity(range_len as usize);
+    let key_of = |block_index: u64| BlockKey {
+        account: account.to_owned(),
+        file: file.to_owned(),
+        block_size,
+        block_index,
+    };
+
+    for block_index in first_block..=last_block {
+        QUERY_BLOCK_CACHE_BLOCKS_REQUESTED
+            .with_label_values(&[] as &[&str])
+            .inc();
+        let block_start = block_index * block_size;
+        let block_end = block_start.saturating_add(block_size);
+        let block = cache
+            .try_get_with(key_of(block_index), async {
+                QUERY_BLOCK_CACHE_BLOCKS_FETCHED
+                    .with_label_values(&[] as &[&str])
+                    .inc();
+                // One fetch covers every block left in the range, so a cold multi-block read
+                // costs a single remote call. The loop then hits the siblings stored below.
+                let span = fetch(block_start..span_end).await?;
+                for sibling in block_index.saturating_add(1)..=last_block {
+                    let offset = ((sibling - block_index) * block_size) as usize;
+                    if offset >= span.len() {
+                        break;
+                    }
+                    let end = offset.saturating_add(block_size as usize).min(span.len());
+                    cache.insert(key_of(sibling), span.slice(offset..end)).await;
+                }
+                Ok(span.slice(0..(block_size as usize).min(span.len())))
+            })
+            .await?;
+        let start = (range.start.max(block_start) - block_start) as usize;
+        let end = ((range.end.min(block_end) - block_start) as usize).min(block.len());
+        if start < end {
+            result.extend_from_slice(&block[start..end]);
+        }
+    }
+
+    // moka updates weighted_size during housekeeping, so this gauge lags a write by up to one
+    // maintenance cycle.
+    QUERY_BLOCK_CACHE_USED_BYTES
+        .with_label_values(&[] as &[&str])
+        .set(cache.weighted_size() as i64);
+
+    Ok(Bytes::from(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+
+    fn settings(enabled: bool, block_size: u64, bypass_threshold: u64) -> Settings {
+        Settings {
+            enabled,
+            block_size,
+            bypass_threshold,
+        }
+    }
+
+    fn cache() -> Cache<BlockKey, Bytes> {
+        Cache::new(1024 * 1024)
+    }
+
+    #[tokio::test]
+    async fn block_cache_collapses_concurrent_reads() {
+        let cache = cache();
+        let bytes = Bytes::from_static(b"0123456789abcdef");
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(tokio::sync::Barrier::new(32));
+        let (ready, fetch_ready) = tokio::sync::watch::channel(false);
+        let mut reads = Vec::new();
+
+        for _ in 0..32 {
+            let cache = cache.clone();
+            let bytes = bytes.clone();
+            let fetches = fetches.clone();
+            let starts = starts.clone();
+            let barrier = barrier.clone();
+            let ready = ready.clone();
+            let fetch_ready = fetch_ready.clone();
+            reads.push(tokio::spawn(async move {
+                barrier.wait().await;
+                if starts.fetch_add(1, Ordering::SeqCst) == 31 {
+                    ready.send_replace(true);
+                }
+                get_range_with_cache(
+                    &cache,
+                    "default",
+                    "file",
+                    2..3,
+                    settings(true, 4, 1024),
+                    move |block| {
+                        let bytes = bytes.clone();
+                        let fetches = fetches.clone();
+                        let mut fetch_ready = fetch_ready.clone();
+                        async move {
+                            fetches.fetch_add(1, Ordering::SeqCst);
+                            if !*fetch_ready.borrow_and_update() {
+                                assert!(fetch_ready.changed().await.is_ok());
+                            }
+                            Ok::<_, &'static str>(
+                                bytes.slice(block.start as usize..block.end as usize),
+                            )
+                        }
+                    },
+                )
+                .await
+            }));
+        }
+
+        for read in reads {
+            assert_eq!(read.await.unwrap().unwrap(), Bytes::from_static(b"2"));
+        }
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn block_cache_returns_unaligned_multi_block_ranges() {
+        let cache = cache();
+        let bytes = Bytes::from((0..16).collect::<Vec<u8>>());
+        let result = get_range_with_cache(
+            &cache,
+            "default",
+            "file",
+            3..14,
+            settings(true, 4, 1024),
+            move |block| {
+                let bytes = bytes.clone();
+                async move {
+                    Ok::<_, &'static str>(bytes.slice(block.start as usize..block.end as usize))
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, Bytes::from((3..14).collect::<Vec<u8>>()));
+    }
+
+    #[tokio::test]
+    async fn block_cache_handles_a_short_final_block() {
+        let cache = cache();
+        let bytes = Bytes::from_static(b"abcdefghij");
+        let result =
+            get_range_with_cache(
+                &cache,
+                "default",
+                "file",
+                9..10,
+                settings(true, 4, 1024),
+                move |block| {
+                    let bytes = bytes.clone();
+                    async move {
+                        Ok::<_, &'static str>(bytes.slice(
+                            block.start as usize..block.end.min(bytes.len() as u64) as usize,
+                        ))
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, Bytes::from_static(b"j"));
+    }
+
+    #[tokio::test]
+    async fn block_cache_disabled_uses_the_fetcher() {
+        let cache = cache();
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let result = get_range_with_cache(
+            &cache,
+            "default",
+            "file",
+            0..2,
+            settings(false, 4, 1024),
+            |range| {
+                let fetches = fetches.clone();
+                async move {
+                    fetches.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, &'static str>(Bytes::from(vec![range.start as u8, range.end as u8]))
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, Bytes::from_static(&[0, 2]));
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn block_cache_bypasses_oversized_requests() {
+        let cache = cache();
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let before = QUERY_BLOCK_CACHE_REQUESTS_BYPASSED
+            .with_label_values(&[] as &[&str])
+            .get();
+        let result = get_range_with_cache(
+            &cache,
+            "default",
+            "file",
+            0..9,
+            settings(true, 4, 8),
+            |_| {
+                let fetches = fetches.clone();
+                async move {
+                    fetches.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, &'static str>(Bytes::from_static(b"oversized"))
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, Bytes::from_static(b"oversized"));
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            QUERY_BLOCK_CACHE_REQUESTS_BYPASSED
+                .with_label_values(&[] as &[&str])
+                .get(),
+            before + 1
+        );
+    }
+
+    #[tokio::test]
+    async fn block_cache_separates_accounts() {
+        let cache = cache();
+        let fetches = AtomicUsize::new(0);
+        for account in ["one", "two"] {
+            get_range_with_cache(
+                &cache,
+                account,
+                "file",
+                0..2,
+                settings(true, 4, 1024),
+                |_| async {
+                    fetches.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, &'static str>(Bytes::from_static(b"ok"))
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        assert_eq!(fetches.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn block_cache_does_not_cache_initializer_errors() {
+        let cache = cache();
+        let fetches = AtomicUsize::new(0);
+        for _ in 0..2 {
+            let error = get_range_with_cache(
+                &cache,
+                "default",
+                "file",
+                0..2,
+                settings(true, 4, 1024),
+                |_| async {
+                    fetches.fetch_add(1, Ordering::SeqCst);
+                    Err::<Bytes, _>("fetch failed")
+                },
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(*error, "fetch failed");
+        }
+
+        assert_eq!(fetches.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn block_cache_fetches_a_cold_multi_block_range_once() {
+        let cache = cache();
+        let bytes = Bytes::from((0..16).collect::<Vec<u8>>());
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let read = || {
+            let bytes = bytes.clone();
+            let fetches = fetches.clone();
+            let cache = cache.clone();
+            async move {
+                get_range_with_cache(
+                    &cache,
+                    "default",
+                    "file",
+                    1..14,
+                    settings(true, 4, 1024),
+                    move |block| {
+                        let bytes = bytes.clone();
+                        let fetches = fetches.clone();
+                        async move {
+                            fetches.fetch_add(1, Ordering::SeqCst);
+                            Ok::<_, &'static str>(
+                                bytes.slice(block.start as usize..block.end as usize),
+                            )
+                        }
+                    },
+                )
+                .await
+            }
+        };
+
+        let expected = Bytes::from((1..14).collect::<Vec<u8>>());
+        assert_eq!(read().await.unwrap(), expected);
+        assert_eq!(fetches.load(Ordering::SeqCst), 1, "cold read spans one fetch");
+
+        assert_eq!(read().await.unwrap(), expected);
+        assert_eq!(fetches.load(Ordering::SeqCst), 1, "warm read fetches nothing");
+    }
+
+    /// The gauge is fed from `weighted_size`, so this covers both the reported value and the
+    /// capacity bound. The gauge itself is a process-wide static that every other test in this
+    /// module also writes, so asserting on it here would be racy.
+    #[tokio::test]
+    async fn block_cache_stays_within_capacity() {
+        let cache: Cache<BlockKey, Bytes> = Cache::builder()
+            .max_capacity(8)
+            .weigher(|_, bytes: &Bytes| u32::try_from(bytes.len()).unwrap_or(u32::MAX))
+            .build();
+
+        for file in 0..8 {
+            get_range_with_cache(
+                &cache,
+                "default",
+                &format!("file{file}"),
+                0..4,
+                settings(true, 4, 1024),
+                |_| async { Ok::<_, &'static str>(Bytes::from_static(b"abcd")) },
+            )
+            .await
+            .unwrap();
+        }
+        cache.run_pending_tasks().await;
+
+        assert!(cache.weighted_size() > 0);
+        assert!(cache.weighted_size() <= 8);
+    }
+
+    #[test]
+    fn block_cache_zero_retention_uses_the_default() {
+        assert_eq!(retention(0), DEFAULT_RETENTION);
+    }
+}

--- a/src/infra/src/cache/file_data/mod.rs
+++ b/src/infra/src/cache/file_data/mod.rs
@@ -19,17 +19,23 @@ pub mod memory;
 
 use std::{
     collections::{BTreeMap, VecDeque},
+    future::Future,
     ops::Range,
+    time::Duration,
 };
 
 use bytes::Bytes;
 use config::utils::time::get_ymdh_from_micros;
 use hashbrown::HashSet;
 use hashlink::lru_cache::LruCache;
+use moka::future::Cache;
 use object_store::{GetOptions, GetResult};
+use once_cell::sync::Lazy;
 
 const DOWNLOAD_RETRY_TIMES: usize = 3;
 const INITIAL_CACHE_SIZE: usize = 128;
+const DOWNLOAD_GATE_CAPACITY: u64 = 1_024;
+const DOWNLOAD_GATE_TTL: Duration = Duration::from_secs(30);
 pub const TRACE_ID_FOR_CACHE_LATEST_FILE: &str = "cache_latest_file";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -37,6 +43,45 @@ pub enum CacheType {
     Disk,
     Memory,
     None,
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct DownloadKey {
+    account: String,
+    file: String,
+    cache_type: CacheType,
+}
+
+// This stores only completed download byte counts, not file data.
+static DOWNLOAD_GATE: Lazy<Cache<DownloadKey, usize>> = Lazy::new(|| {
+    Cache::builder()
+        .max_capacity(DOWNLOAD_GATE_CAPACITY)
+        .time_to_live(DOWNLOAD_GATE_TTL)
+        .build()
+});
+
+#[derive(Debug)]
+pub struct DownloadToCacheError {
+    caller_ran_fetch: bool,
+    source: std::sync::Arc<anyhow::Error>,
+}
+
+impl DownloadToCacheError {
+    pub fn caller_ran_fetch(&self) -> bool {
+        self.caller_ran_fetch
+    }
+}
+
+impl std::fmt::Display for DownloadToCacheError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(formatter)
+    }
+}
+
+impl std::error::Error for DownloadToCacheError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.root_cause())
+    }
 }
 
 enum CacheStrategy {
@@ -133,7 +178,7 @@ impl CacheStrategy {
                 let mut index = 0;
                 while index < queue.len() {
                     if queue[index].0 == key {
-                        let (k, v) = queue.remove(index).unwrap();
+                        let (k, v) = queue.remove(index)?;
                         set.remove(&k);
                         return Some((k, v));
                     }
@@ -200,6 +245,68 @@ pub async fn download(
     }
 }
 
+pub async fn download_to_cache(
+    account: &str,
+    file: &str,
+    size: Option<usize>,
+    cache_type: CacheType,
+) -> Result<(usize, bool), DownloadToCacheError> {
+    if cache_type == CacheType::None {
+        return Ok((0, false));
+    }
+
+    let fetched = std::sync::atomic::AtomicBool::new(false);
+    let key = DownloadKey {
+        account: account.to_owned(),
+        file: file.to_owned(),
+        cache_type,
+    };
+    let result = download_with_gate(&DOWNLOAD_GATE, key, || async {
+        match cache_type {
+            CacheType::Memory => {
+                if memory::exist(file).await {
+                    Ok(0)
+                } else {
+                    fetched.store(true, std::sync::atomic::Ordering::SeqCst);
+                    memory::download(account, file, size).await
+                }
+            }
+            CacheType::Disk => {
+                if disk::exist(file).await {
+                    Ok(0)
+                } else {
+                    fetched.store(true, std::sync::atomic::Ordering::SeqCst);
+                    disk::download(account, file, size).await
+                }
+            }
+            CacheType::None => Ok(0),
+        }
+    })
+    .await;
+    let caller_ran_fetch = fetched.load(std::sync::atomic::Ordering::SeqCst);
+
+    match result {
+        Ok(bytes) => Ok((bytes, caller_ran_fetch)),
+        Err(source) => Err(DownloadToCacheError {
+            caller_ran_fetch,
+            source,
+        }),
+    }
+}
+
+async fn download_with_gate<F, Fut, E>(
+    gate: &Cache<DownloadKey, usize>,
+    key: DownloadKey,
+    download: F,
+) -> Result<usize, std::sync::Arc<E>>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<usize, E>>,
+    E: Send + Sync + 'static,
+{
+    gate.try_get_with(key, download()).await
+}
+
 async fn validate_file(bytes: &[u8], ftype: FileType) -> Result<(), anyhow::Error> {
     match ftype {
         FileType::Parquet => {
@@ -215,7 +322,7 @@ async fn validate_file(bytes: &[u8], ftype: FileType) -> Result<(), anyhow::Erro
             if footer[8..12] != [0x50, 0x46, 0x41, 0x31] {
                 return Err(anyhow::anyhow!("puffin footer magic mismatch"));
             }
-            let payload_size = i32::from_le_bytes(footer[0..4].try_into().unwrap());
+            let payload_size = i32::from_le_bytes(footer[0..4].try_into()?);
             if bytes.len() < 12 + payload_size as usize {
                 return Err(anyhow::anyhow!("payload size mismatch"));
             }
@@ -454,7 +561,69 @@ fn get_file_time(file: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
     use super::*;
+
+    #[tokio::test]
+    async fn download_gate_collapses_concurrent_downloads() {
+        let cache = Cache::new(1_024);
+        let key = DownloadKey {
+            account: "default".to_owned(),
+            file: "file".to_owned(),
+            cache_type: CacheType::Memory,
+        };
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(tokio::sync::Barrier::new(32));
+        let (ready, fetch_ready) = tokio::sync::watch::channel(false);
+        let mut downloads = Vec::new();
+
+        for _ in 0..32 {
+            let cache = cache.clone();
+            let key = key.clone();
+            let fetches = fetches.clone();
+            let starts = starts.clone();
+            let barrier = barrier.clone();
+            let ready = ready.clone();
+            let fetch_ready = fetch_ready.clone();
+            downloads.push(tokio::spawn(async move {
+                barrier.wait().await;
+                if starts.fetch_add(1, Ordering::SeqCst) == 31 {
+                    ready.send_replace(true);
+                }
+                let fetched = std::sync::atomic::AtomicBool::new(false);
+                download_with_gate(&cache, key, || async {
+                    fetched.store(true, std::sync::atomic::Ordering::SeqCst);
+                    fetches.fetch_add(1, Ordering::SeqCst);
+                    let mut fetch_ready = fetch_ready.clone();
+                    if !*fetch_ready.borrow_and_update() {
+                        assert!(fetch_ready.changed().await.is_ok());
+                    }
+                    Ok::<_, &'static str>(42)
+                })
+                .await
+                .map(|bytes| (bytes, fetched.load(std::sync::atomic::Ordering::SeqCst)))
+            }));
+        }
+
+        let mut callers_that_fetched = 0;
+        for download in downloads {
+            match download.await {
+                Ok(Ok((bytes, fetched))) => {
+                    assert_eq!(bytes, 42);
+                    callers_that_fetched += usize::from(fetched);
+                }
+                Ok(Err(error)) => assert!(false, "download gate failed: {error}"),
+                Err(error) => assert!(false, "download task failed: {error}"),
+            }
+        }
+        assert_eq!(callers_that_fetched, 1);
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+    }
 
     #[test]
     fn test_file_data_lru_cache_miss() {

--- a/src/infra/src/cache/mod.rs
+++ b/src/infra/src/cache/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+pub(crate) mod block_cache;
 pub mod file_data;
 pub mod meta;
 pub mod stats;

--- a/src/infra/src/cache/storage.rs
+++ b/src/infra/src/cache/storage.rs
@@ -27,7 +27,7 @@ use object_store::{
 use once_cell::sync::Lazy;
 
 use crate::{
-    cache::file_data,
+    cache::{block_cache, file_data},
     storage::{self, ObjectStoreExt},
 };
 
@@ -119,14 +119,22 @@ impl ObjectStoreExt for CacheFS {
         if range.start > range.end {
             return Err(crate::storage::Error::BadRange(location.to_string()).into());
         }
+        let path = location.to_string();
+        // Serve from the whole-file memory and disk caches first, so the block cache spends its
+        // memory budget only on bytes that would otherwise cost a remote round trip.
         let options = GetOptions {
-            range: Some(range.into()),
+            range: Some(range.clone().into()),
             ..Default::default()
         };
-        self.get_opts(account, location, options)
-            .await?
-            .bytes()
-            .await
+        if let Ok(res) = file_data::get_opts(account, &path, options, false).await
+            && let Ok(bytes) = res.bytes().await
+        {
+            return Ok(bytes);
+        }
+        block_cache::get_range(account, &path, range, |block_range| {
+            storage::get_range(account, &path, block_range)
+        })
+        .await
     }
 
     async fn get_ranges(

--- a/src/infra/src/storage/remote.rs
+++ b/src/infra/src/storage/remote.rs
@@ -174,7 +174,7 @@ impl ObjectStore for Remote {
             })?;
 
         // metrics
-        let data_len = result.meta.size;
+        let data_len = result.range.end - result.range.start;
         let columns = file.split('/').collect::<Vec<&str>>();
         if columns[0] == "files" {
             metrics::STORAGE_READ_BYTES
@@ -407,4 +407,93 @@ pub async fn test_config() -> Result<(), anyhow::Error> {
         return Err(anyhow::anyhow!("S3 upload test failed: {e}"));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use object_store::memory::InMemory;
+
+    use super::*;
+
+    const TEST_DATA: &[u8] = b"0123456789";
+
+    async fn remote_with_file(location: &Path) -> Remote {
+        let client = InMemory::new();
+        client
+            .put(
+                &format_key(location.as_ref(), true).into(),
+                PutPayload::from(Bytes::from_static(TEST_DATA)),
+            )
+            .await
+            .unwrap();
+
+        Remote {
+            client: LimitStore::new(Box::new(client), CONCURRENT_REQUESTS),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_opts_counts_bounded_range_bytes() {
+        let org = "remote_get_opts_bounded_range";
+        let location = Path::from(format!("files/{org}/logs/test.parquet"));
+        let remote = remote_with_file(&location).await;
+        let labels = [org, "logs", "get_opts", "remote"];
+        let before = metrics::STORAGE_READ_BYTES.with_label_values(&labels).get();
+        let options = GetOptions {
+            range: Some((2..6).into()),
+            ..Default::default()
+        };
+
+        let result = remote.get_opts(&location, options).await.unwrap();
+
+        assert_eq!(result.range, 2..6);
+        assert_eq!(result.bytes().await.unwrap(), Bytes::from_static(b"2345"));
+        assert_eq!(
+            metrics::STORAGE_READ_BYTES.with_label_values(&labels).get() - before,
+            4
+        );
+    }
+
+    #[tokio::test]
+    async fn get_opts_counts_clamped_range_bytes() {
+        let org = "remote_get_opts_clamped_range";
+        let location = Path::from(format!("files/{org}/logs/test.parquet"));
+        let remote = remote_with_file(&location).await;
+        let labels = [org, "logs", "get_opts", "remote"];
+        let before = metrics::STORAGE_READ_BYTES.with_label_values(&labels).get();
+        let options = GetOptions {
+            range: Some((8..20).into()),
+            ..Default::default()
+        };
+
+        let result = remote.get_opts(&location, options).await.unwrap();
+
+        assert_eq!(result.range, 8..10);
+        assert_eq!(result.bytes().await.unwrap(), Bytes::from_static(b"89"));
+        assert_eq!(
+            metrics::STORAGE_READ_BYTES.with_label_values(&labels).get() - before,
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn get_opts_counts_whole_object_bytes() {
+        let org = "remote_get_opts_whole_object";
+        let location = Path::from(format!("files/{org}/logs/test.parquet"));
+        let remote = remote_with_file(&location).await;
+        let labels = [org, "logs", "get_opts", "remote"];
+        let before = metrics::STORAGE_READ_BYTES.with_label_values(&labels).get();
+
+        let result = remote
+            .get_opts(&location, GetOptions::default())
+            .await
+            .unwrap();
+
+        assert_eq!(result.range, 0..TEST_DATA.len() as u64);
+        assert_eq!(result.bytes().await.unwrap(), Bytes::from_static(TEST_DATA));
+        assert_eq!(
+            metrics::STORAGE_READ_BYTES.with_label_values(&labels).get() - before,
+            TEST_DATA.len() as u64
+        );
+    }
 }

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -36,28 +36,6 @@ use tonic::{codec::CompressionEncoding, metadata::MetadataValue};
 /// (trace_id, file_id, account, file, size, cache_type)
 type FileInfo = (String, i64, String, String, usize, file_data::CacheType);
 
-mod processing_files {
-    use hashbrown::HashSet;
-    use parking_lot::RwLock;
-
-    use super::*;
-
-    static PROCESSING_FILES: Lazy<RwLock<HashSet<String>>> =
-        Lazy::new(|| RwLock::new(HashSet::new()));
-
-    pub fn is_processing(file_name: &str) -> bool {
-        PROCESSING_FILES.read().contains(file_name)
-    }
-
-    pub fn add(file_name: &str) {
-        PROCESSING_FILES.write().insert(file_name.to_string());
-    }
-
-    pub fn remove(file_name: &str) {
-        PROCESSING_FILES.write().remove(file_name);
-    }
-}
-
 struct DownloadQueue {
     sender: Sender<FileInfo>,
     receiver: Arc<Mutex<Receiver<FileInfo>>>,
@@ -119,22 +97,6 @@ pub async fn run() -> Result<(), anyhow::Error> {
                         break;
                     }
                     Some((trace_id, id, account, file, file_size, cache)) => {
-                        // check if the file is already being downloaded
-                        if processing_files::is_processing(&file) {
-                            log::warn!(
-                                "[trace_id {trace_id}] [thread {thread}] search->storage: file {file} is already being downloaded, will skip it"
-                            );
-                            // update metrics
-                            metrics::FILE_DOWNLOADER_NORMAL_QUEUE_SIZE
-                                .with_label_values::<&str>(&[])
-                                .dec();
-                            continue;
-                        }
-
-                        // add the file to processing set
-                        processing_files::add(&file);
-
-                        // download the file
                         match download_file(
                             thread, &trace_id, id, &account, &file, file_size, cache,
                         )
@@ -153,9 +115,6 @@ pub async fn run() -> Result<(), anyhow::Error> {
                                 );
                             }
                         }
-
-                        // remove the file from processing set
-                        processing_files::remove(&file);
 
                         // update metrics
                         metrics::FILE_DOWNLOADER_NORMAL_QUEUE_SIZE
@@ -209,22 +168,6 @@ pub async fn run() -> Result<(), anyhow::Error> {
                         let file_info = PRIORITY_FILE_DOWNLOAD_CHANNEL.pop().await;
                         match file_info {
                             Some((trace_id, id, account, file, file_size, cache)) => {
-                                 // check if the file is already being downloaded
-                                if processing_files::is_processing(&file) {
-                                    log::warn!(
-                                        "[trace_id {trace_id}] [thread {thread}] search->storage: file {file} is already being downloaded, will skip it"
-                                    );
-                                    // update metrics
-                                    metrics::FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE
-                                        .with_label_values::<&str>(&[])
-                                        .dec();
-                                    return;
-                                }
-
-                                // add the file to processing set
-                                processing_files::add(&file);
-
-                                // download the file
                                 match download_file(thread, &trace_id, id, &account, &file, file_size, cache).await {
                                     Ok(data_len) => {
                                         if data_len > 0 && data_len != file_size {
@@ -239,9 +182,6 @@ pub async fn run() -> Result<(), anyhow::Error> {
                                         );
                                     }
                                 }
-
-                                // remove the file from processing set
-                                processing_files::remove(&file);
 
                                 // update metrics
                                 metrics::FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE
@@ -280,30 +220,20 @@ async fn download_file(
         return Ok(file_size);
     }
 
-    // download from object store
+    // download into the cache
     let size = if file_size > 0 { Some(file_size) } else { None };
     let start = std::time::Instant::now();
-    let ret = match cache_type {
-        file_data::CacheType::Memory => {
-            let mut disk_exists = false;
-            let mem_exists = file_data::memory::exist(file_name).await;
-            if !mem_exists && !cfg.memory_cache.skip_disk_check {
-                disk_exists = file_data::disk::exist(file_name).await;
-            }
-            if !mem_exists && (cfg.memory_cache.skip_disk_check || !disk_exists) {
-                file_data::memory::download(account, file_name, size).await
-            } else {
-                Ok(0)
-            }
-        }
-        file_data::CacheType::Disk => {
-            if !file_data::disk::exist(file_name).await {
-                file_data::disk::download(account, file_name, size).await
-            } else {
-                Ok(0)
-            }
-        }
-        _ => Ok(0),
+    let ret = if cache_type == file_data::CacheType::Memory
+        && !cfg.memory_cache.skip_disk_check
+        && !file_data::memory::exist(file_name).await
+        && file_data::disk::exist(file_name).await
+    {
+        Ok(0)
+    } else {
+        file_data::download_to_cache(account, file_name, size, cache_type)
+            .await
+            .map(|(bytes, _)| bytes)
+            .map_err(anyhow::Error::new)
     };
     log::debug!(
         "[FILE_CACHE_DOWNLOAD:JOB:{thread}] [trace_id {trace_id}] download file: {file_name}, ret: {:?}, took: {} ms",

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -348,6 +348,81 @@ pub async fn cache_files(
         );
     }
 
+    let cfg = get_config();
+    let inline_start = std::time::Instant::now();
+    let inline_files = files
+        .iter()
+        .filter_map(|(_id, account, file, size, ts, _records)| {
+            let size = match usize::try_from(*size) {
+                Ok(size) => size,
+                Err(_) => return None,
+            };
+            if is_inline_download_eligible(
+                cached_files.contains(file),
+                cfg.disk_cache.enabled,
+                is_local_disk_storage(),
+                cfg.disk_cache.inline_download_max_size,
+                size,
+                crate::job::exceeds_cache_max_age(*ts, file_data::CacheType::Disk),
+            ) {
+                // Each future owns these strings so the bounded stream remains Send.
+                Some(((*account).clone(), (*file).clone(), size))
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+    metrics::QUERY_DISK_CACHE_INLINE_DOWNLOAD_FILES_CONSIDERED
+        .with_label_values(&[file_type])
+        .inc_by(inline_files.len() as u64);
+
+    let mut inline_cached_files: HashSet<String> = HashSet::with_capacity(inline_files.len());
+    let mut inline_downloads = futures::StreamExt::map(
+        stream::iter(inline_files),
+        |(account, file, size)| async move {
+            let result = file_data::download_to_cache(
+                &account,
+                &file,
+                Some(size),
+                file_data::CacheType::Disk,
+            )
+            .await;
+            (file, result)
+        },
+    )
+    .buffer_unordered(cfg.limit.cpu_num);
+    while let Some((file, result)) = futures::StreamExt::next(&mut inline_downloads).await {
+        match result {
+            Ok((bytes, caller_ran_fetch)) => {
+                inline_cached_files.insert(file);
+                scan_stats.querier_disk_cached_files += 1;
+                cache_hits += 1;
+                cache_misses -= 1;
+                if caller_ran_fetch {
+                    metrics::QUERY_DISK_CACHE_INLINE_DOWNLOAD_FILES_FETCHED
+                        .with_label_values(&[file_type, "success"])
+                        .inc();
+                    metrics::QUERY_DISK_CACHE_INLINE_DOWNLOAD_BYTES
+                        .with_label_values(&[file_type])
+                        .inc_by(bytes as u64);
+                }
+            }
+            Err(error) => {
+                if error.caller_ran_fetch() {
+                    metrics::QUERY_DISK_CACHE_INLINE_DOWNLOAD_FILES_FETCHED
+                        .with_label_values(&[file_type, "error"])
+                        .inc();
+                }
+                log::debug!(
+                    "[trace_id {trace_id}] search->storage: inline cache download failed for {file}: {error}"
+                );
+            }
+        }
+    }
+    metrics::QUERY_DISK_CACHE_INLINE_DOWNLOAD_DURATION_SECONDS
+        .with_label_values(&[file_type])
+        .observe(inline_start.elapsed().as_secs_f64());
+
     let files_num = files.len() as i64;
     if files_num == scan_stats.querier_memory_cached_files + scan_stats.querier_disk_cached_files {
         // all files are cached
@@ -355,7 +430,6 @@ pub async fn cache_files(
     }
 
     // check cache size
-    let cfg = get_config();
     let cache_type = if cfg.memory_cache.enabled
         && scan_stats.compressed_size < cfg.memory_cache.skip_size as i64
     {
@@ -376,7 +450,10 @@ pub async fn cache_files(
     let files = files
         .iter()
         .filter_map(|(id, account, file, size, ts, records)| {
-            if cached_files.contains(file) || !crate::job::should_download(*records) {
+            if cached_files.contains(file)
+                || inline_cached_files.contains(file.as_str())
+                || !crate::job::should_download(*records)
+            {
                 None
             } else {
                 Some((*id, account.to_string(), file.to_string(), *size, *ts))
@@ -415,6 +492,22 @@ pub async fn cache_files(
     } else {
         (cache_type, cache_hits, cache_misses)
     }
+}
+
+fn is_inline_download_eligible(
+    is_cached: bool,
+    disk_cache_enabled: bool,
+    local_disk_storage: bool,
+    inline_download_max_size: usize,
+    file_size: usize,
+    exceeds_max_age: bool,
+) -> bool {
+    !is_cached
+        && disk_cache_enabled
+        && !local_disk_storage
+        && inline_download_max_size > 0
+        && file_size <= inline_download_max_size
+        && !exceeds_max_age
 }
 
 /// Filter file list using inverted index
@@ -1138,6 +1231,61 @@ mod tests {
             },
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn test_is_inline_download_eligible() {
+        assert!(is_inline_download_eligible(
+            false,
+            true,
+            false,
+            2 * 1024 * 1024,
+            2 * 1024 * 1024,
+            false
+        ));
+        assert!(!is_inline_download_eligible(
+            true,
+            true,
+            false,
+            2 * 1024 * 1024,
+            1,
+            false
+        ));
+        assert!(!is_inline_download_eligible(
+            false,
+            false,
+            false,
+            2 * 1024 * 1024,
+            1,
+            false
+        ));
+        assert!(!is_inline_download_eligible(
+            false,
+            true,
+            true,
+            2 * 1024 * 1024,
+            1,
+            false
+        ));
+        assert!(!is_inline_download_eligible(
+            false, true, false, 0, 1, false
+        ));
+        assert!(!is_inline_download_eligible(
+            false,
+            true,
+            false,
+            2 * 1024 * 1024,
+            2 * 1024 * 1024 + 1,
+            false
+        ));
+        assert!(!is_inline_download_eligible(
+            false,
+            true,
+            false,
+            2 * 1024 * 1024,
+            1,
+            true
+        ));
     }
 
     #[test]


### PR DESCRIPTION
When a parquet or tantivy file is uploaded to blob store by ingesters or compactors, it takes queriers anywhere between 5s to a minute (depending on depth of download manager queue) to download that file to disk cache. With high volume of queries, this issues 1000s of RANGE calls to blob store.

This change is to address the thundering herd using connection coalesce (singleflight). 

It also does inline download of small files (size is configurable) before datafusion runtime starts, thereby avoiding RANGE requests to blob store.

Both are feature flagged:
```
ZO_DISK_CACHE_INLINE_DOWNLOAD_MAX_SIZE="0" # disables inline download
ZO_BLOCK_CACHE_ENABLED="false" # disables coalesce
```

- Download small parquet and tantivy files inline before the DataFusion runtime starts
- Route background downloader through the shared deduplication gate
- fetch a cold multi-block range in one call
- put the block cache in front of remote storage
- coalesce object storage range reads