### PR TITLE
test: deflake 6 new-entrant merge-queue flakes (Logs/Reports/Metrics/Dashboards/Alerts)

### DIFF
--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -1415,6 +1415,15 @@ export class AlertsPage {
         testLogger.info('Evaluation history Retries column and cells present');
     }
 
+    /** Reload the detail page until the evaluation-history table has >=1 data row — its fetch is single-shot on load, so a lagging row leaves headers but no cells. */
+    async waitForEvaluationHistoryRow({ attempts = 6 } = {}) {
+        const row = this.getAlertHistoryRowsLocator().first();
+        for (let i = 0; i < attempts; i++) {
+            if (await row.isVisible({ timeout: 5000 }).catch(() => false)) return;
+            await this.page.reload({ waitUntil: 'networkidle' }).catch(() => {});
+        }
+    }
+
     /**
      * Assert the newest evaluation's retries cell renders the given integer (0 for a clean
      * self-delivery). Newest-first row ordering means `.first()` is the latest run.

--- a/tests/ui-testing/pages/dashboardPages/dashboard-legends-copy.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-legends-copy.js
@@ -140,6 +140,8 @@ export default class DashboardLegendsCopy {
    * Click the "Copy all" button
    */
   async clickCopyAll() {
+    // writeText() stays pending until the page has OS focus; under parallel CI the tab loses it and the "Copied" .then() never fires.
+    await this.page.bringToFront();
     await this.copyAllBtn.click();
     testLogger.info('Clicked Copy All legends');
   }

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -4771,7 +4771,9 @@ export class LogsPage {
     }
 
     async clickMenuLinkLogsItem() {
-        return await this.clickMenuLinkByType('logs');
+        await this.clickMenuLinkByType('logs');
+        // Sidebar nav is an in-SPA route change; gate on the Logs view toggle re-mounting (present in every tab mode) before callers read persisted state.
+        await expect(this.page.locator(this.visualizeToggle)).toBeVisible({ timeout: 15000 });
     }
 
     async clickMenuLinkTracesItem() {

--- a/tests/ui-testing/pages/metricsPages/metricsPage.js
+++ b/tests/ui-testing/pages/metricsPages/metricsPage.js
@@ -1186,6 +1186,8 @@ export class MetricsPage {
     async closeConfigSidebar() {
         const btn = this.dashboardSidebarCollapseButton;
         if (await btn.isVisible({ timeout: 500 }).catch(() => false)) {
+            // A config-control toggle can leave an OSelect popover open over the header, intercepting this click.
+            await this.dismissOverlay();
             await btn.click();
             await this.panelSidebarExpandedHeader.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
         }

--- a/tests/ui-testing/pages/reportsPages/reportsPage.js
+++ b/tests/ui-testing/pages/reportsPages/reportsPage.js
@@ -186,8 +186,12 @@ export class ReportsPage {
 
   async createReportReportNameInput(TEST_REPORT_NAME) {
     await this.reportNameInputField.waitFor({ state: 'visible', timeout: 10000 });
-    await this.reportNameInputField.fill(TEST_REPORT_NAME);
-    await this.page.waitForTimeout(5000);
+    // onBeforeMount seeds the form via an async form.reset() that can land after this fill and wipe name to "" — re-fill until it survives, else the submit is silently blocked by "Name is required".
+    await expect(async () => {
+      await this.reportNameInputField.fill(TEST_REPORT_NAME);
+      await this.page.waitForTimeout(1000);
+      await expect(this.reportNameInputField).toHaveValue(TEST_REPORT_NAME);
+    }).toPass({ timeout: 20000, intervals: [1000, 2000, 3000] });
   }
 
   async createReportFolderInput() {

--- a/tests/ui-testing/playwright-tests/Alerts/alerts-priority-tags.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alerts-priority-tags.spec.js
@@ -258,6 +258,8 @@ test.describe('Alerts — priority, tags & additional variables', {
         await pm.alertDetailPage.open(id);
         await pm.alertsPage.expectAlertDetailsHistorySectionVisible();
 
+        // The per-alert history fetch is single-shot on page load; re-fetch until the row lands.
+        await pm.alertsPage.waitForEvaluationHistoryRow();
         await pm.alertsPage.expectEvaluationHistoryRetriesColumn();
         await pm.alertsPage.expectEvaluationHistoryRetriesValue(0);
         testLogger.info('Retries column renders a numeric value in evaluation history');

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboards-form-validation.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboards-form-validation.spec.js
@@ -1127,10 +1127,14 @@ test.describe("Dashboard AddPanel panel name form validation", () => {
         const nameError  = pm.dashboardsFormValidation.getPanelNameErrorLocator();
         const saveBtn    = pm.dashboardsFormValidation.getPanelSaveBtnLocator();
 
+        // Validation error / disabled-state resolves a tick after submit; poll instead of sampling once.
+        await expect
+            .poll(async () =>
+                (await nameError.isVisible().catch(() => false)) ||
+                (await saveBtn.isDisabled().catch(() => false)),
+            { timeout: 10000, intervals: [200, 500, 1000] })
+            .toBe(true);
         const errorVisible = await nameError.isVisible().catch(() => false);
-        const btnDisabled  = await saveBtn.isDisabled().catch(() => false);
-
-        expect(errorVisible || btnDisabled).toBe(true);
         if (errorVisible) {
             await expect(nameError).toContainText(/required/i);
         }


### PR DESCRIPTION
Deflake campaign (ref #14025). Six tests flaking in the CI **merge-queue** (the merged-code gate), root-caused from attempt-1 traces — all test-side readiness/interaction gates, no product code, no skips, no weakened assertions.

- **logsVisualizePersistence (×6)** — `clickMenuLinkLogsItem()` returned before the in-SPA Logs remount → gate on the view-toggle re-mounting.
- **Reports (CSV / ScheduleNow / ScheduleLater)** — create form's async `form.reset()` in onBeforeMount wipes the typed name → submit silently blocked (name required), POST never fires → re-fill the name until it survives the reset.
- **metrics-config-tabs** — leftover OSelect popover intercepted the 45s sidebar-collapse click → dismiss overlay first.
- **dashboards-form-validation** — one-shot sampling of async validation → `expect.poll`.
- **dashboard-legends-copy** — `clipboard.writeText()` hangs without OS focus → `bringToFront()`.
- **alerts-priority-tags** — per-alert eval-history fetch is single-shot → re-fetch until the row lands (CI-gated: local scheduler can't evaluate the alert).

Local: metrics 2/2, form-validation 6/6, legends 2/2, logs 18/18, reports 8/8. Excluded: `dashboard-table-chart` (same reka operator-dropdown swallowed-click class — re-click fix verified NOT to hold under load) and `crossLinkMultiStream` (backend eventual-consistency, already heavily mitigated).