### PR TITLE
ci: run regression workflow the way the full CI matrix does

### DIFF
--- a/.github/workflows/playwright_regression.yml
+++ b/.github/workflows/playwright_regression.yml
@@ -28,6 +28,7 @@ env:
   ZO_QUICK_MODE_STRATEGY: first
   ZO_ALLOW_USER_DEFINED_SCHEMAS: true
   ZO_INGEST_ALLOWED_UPTO: 5
+  ZO_SLO_BACKFILL_CHUNK_SECS: 86400 # matches the server default; per-shard override below
   ZO_FEATURE_QUERY_EXCLUDE_ALL: false
   ZO_USAGE_BATCH_SIZE: 200
   ZO_USAGE_PUBLISH_INTERVAL: 2
@@ -179,11 +180,8 @@ jobs:
       - uses: actions/checkout@v5
       - id: gen
         run: |
-          # The queue no longer runs Playwright, so this daily run covers the full CI matrix plus the RegressionSet.
-          CI=$(node .github/scripts/build-ci-matrix.js tests/ui-testing/ci-matrix/ci_matrix.json)
-          RG=$(node .github/scripts/build-ci-matrix.js tests/ui-testing/ci-matrix/ci_matrix_regression.json)
-          if [ -z "$CI" ] || [ -z "$RG" ]; then echo "::error::matrix generation failed (build-ci-matrix produced no output)"; exit 1; fi
-          MATRIX=$(node -e 'const [a,b]=process.argv.slice(1).map(JSON.parse); console.log(JSON.stringify({include:[...a.include,...b.include]}))' "$CI" "$RG")
+          MATRIX=$(node .github/scripts/build-ci-matrix.js tests/ui-testing/ci-matrix/ci_matrix_regression.json)
+          if [ -z "$MATRIX" ]; then echo "::error::matrix generation failed (build-ci-matrix produced no output)"; exit 1; fi
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "$MATRIX" | node -e "const m=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log('generated',m.include.length,'shards:', m.include.map(s=>s.testfolder).join(', '))"
 
@@ -225,6 +223,11 @@ jobs:
           path: /tmp/dist
 
       - name: Start OpenObserve
+        # Per-shard server flags from the matrix, same contract as playwright.yml — each is read once at server start.
+        env:
+          ZO_QUICK_MODE_ENABLED: ${{ matrix.quick_mode_enabled || 'false' }}
+          ZO_INGEST_ALLOWED_UPTO: ${{ matrix.ingest_allowed_upto || env.ZO_INGEST_ALLOWED_UPTO }}
+          ZO_SLO_BACKFILL_CHUNK_SECS: ${{ matrix.slo_backfill_chunk_secs || env.ZO_SLO_BACKFILL_CHUNK_SECS }}
         run: chmod +x ./release-ci-binary/openobserve && ./release-ci-binary/openobserve > o2.log 2>&1 &
 
       - name: Wait for start


### PR DESCRIPTION
Regression runs only the RegressionSet (dropped the bundled full CI matrix; that runs on every PR via playwright.yml). Wires per-shard `ZO_QUICK_MODE_ENABLED`/`ZO_INGEST_ALLOWED_UPTO`/`ZO_SLO_BACKFILL_CHUNK_SECS` at server start, matching playwright.yml. Paired: o2-enterprise#same-branch.