### PR TITLE
perf(promql): stream instant aggregations as last_over_time over the lookback

### DIFF
--- a/src/promql/src/engine/aggregate.rs
+++ b/src/promql/src/engine/aggregate.rs
@@ -15,20 +15,28 @@
 
 //! Aggregation dispatch over the fused and generic evaluators.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use config::meta::promql::value::*;
 use datafusion::error::{DataFusionError, Result};
-use promql_parser::parser::{Call, Expr as PromExpr, LabelModifier, token};
+use promql_parser::parser::{
+    Call, Expr as PromExpr, LabelModifier, MatrixSelector, VectorSelector, token,
+};
 
 use super::Engine;
 use crate::{aggregations, functions, fused};
 
-/// A recognized `agg(range_func(...))` expression, the shape the fused evaluators accept.
+/// A recognized fused shape: `agg(range_func(...))`, or `agg(instant_selector)` read as
+/// `last_over_time` over the lookback window.
 struct FusedAggShape<'a> {
     op: fused::FusedAggOp,
     func: Arc<dyn functions::RangeFunc>,
-    range_arg: &'a PromExpr,
+    /// The range function's argument to materialize; `None` for the instant shape, which has
+    /// no range function and stays generic when it cannot stream.
+    range_arg: Option<&'a PromExpr>,
+    /// The plain selector under the shape, when it can be planned as ordered shard streams;
+    /// a `None` range is the instant lookback.
+    selector: Option<(&'a VectorSelector, Option<Duration>)>,
 }
 
 impl Engine {
@@ -41,29 +49,34 @@ impl Engine {
     ) -> Result<Value> {
         // fused shapes fold the range function into the aggregation; others stay generic
         if let Some(shape) = fused_agg_shape(op, expr) {
-            // only a plain matrix selector can be planned as ordered shard streams
-            if let PromExpr::MatrixSelector(matrix_selector) = shape.range_arg
-                && let Some(value) = self
+            if let Some((selector, range)) = shape.selector {
+                let range =
+                    range.unwrap_or_else(|| Duration::from_micros(self.ctx.lookback_delta as u64));
+                if let Some(value) = self
                     .try_streaming_fused_agg(
-                        matrix_selector,
+                        selector,
+                        range,
                         modifier,
                         shape.func.clone(),
                         shape.op,
                     )
                     .await?
-            {
-                return Ok(value);
+                {
+                    return Ok(value);
+                }
             }
-            let range_input = self.exec_expr(shape.range_arg).await?;
-            return fused::matrix::fused_agg(
-                modifier,
-                range_input,
-                shape.func,
-                shape.op,
-                &self.eval_ctx,
-                self.ctx.query_ctx.timeout,
-            )
-            .await;
+            if let Some(range_arg) = shape.range_arg {
+                let range_input = self.exec_expr(range_arg).await?;
+                return fused::matrix::fused_agg(
+                    modifier,
+                    range_input,
+                    shape.func,
+                    shape.op,
+                    &self.eval_ctx,
+                    self.ctx.query_ctx.timeout,
+                )
+                .await;
+            }
         }
 
         let input = self.exec_expr(expr).await?;
@@ -148,16 +161,75 @@ fn fused_agg_shape<'a>(op: &token::TokenType, expr: &'a PromExpr) -> Option<Fuse
         return None;
     }
     let agg_op = fused::FusedAggOp::from_token(op.id())?;
-    let PromExpr::Call(Call { func, args }) = expr else {
-        return None;
-    };
-    let [range_arg] = args.args.as_slice() else {
-        return None;
-    };
-    let range_func = functions::fusable_range_func(func.name)?;
-    Some(FusedAggShape {
-        op: agg_op,
-        func: Arc::from(range_func),
-        range_arg,
-    })
+    match expr {
+        PromExpr::Call(Call { func, args }) => {
+            let [range_arg] = args.args.as_slice() else {
+                return None;
+            };
+            let range_arg: &PromExpr = range_arg;
+            let range_func = functions::fusable_range_func(func.name)?;
+            let selector = match range_arg {
+                PromExpr::MatrixSelector(MatrixSelector { vs, range }) => Some((vs, Some(*range))),
+                _ => None,
+            };
+            Some(FusedAggShape {
+                op: agg_op,
+                func: Arc::from(range_func),
+                range_arg: Some(range_arg),
+                selector,
+            })
+        }
+        // an instant selector picks the last sample in the lookback window and keeps the metric
+        // name, which is exactly last_over_time
+        PromExpr::VectorSelector(selector) => Some(FusedAggShape {
+            op: agg_op,
+            func: Arc::from(functions::fusable_range_func("last_over_time")?),
+            range_arg: None,
+            selector: Some((selector, None)),
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use promql_parser::parser::{AggregateExpr, parse};
+
+    use super::*;
+
+    fn shape(query: &str) -> Option<(String, bool, Option<Option<Duration>>)> {
+        let PromExpr::Aggregate(AggregateExpr { op, expr, .. }) = parse(query).unwrap() else {
+            panic!("{query} is not an aggregation");
+        };
+        fused_agg_shape(&op, &expr).map(|shape| {
+            (
+                shape.func.name().to_string(),
+                shape.range_arg.is_some(),
+                shape.selector.map(|(_, range)| range),
+            )
+        })
+    }
+
+    #[test]
+    fn test_fused_agg_shape_recognizes_range_and_instant_selectors() {
+        assert_eq!(
+            shape("sum(rate(m[5m]))"),
+            Some((
+                "rate".to_string(),
+                true,
+                Some(Some(Duration::from_secs(300)))
+            ))
+        );
+        // a range function over a non-selector materializes but cannot stream
+        assert_eq!(
+            shape("sum(rate((m)[5m:1m]))"),
+            Some(("rate".to_string(), true, None))
+        );
+        assert_eq!(
+            shape("sum by(instance) (m{job=\"a\"} offset 1m)"),
+            Some(("last_over_time".to_string(), false, Some(None)))
+        );
+        assert_eq!(shape("sum(abs(m))"), None);
+        assert_eq!(shape("topk(3, rate(m[5m]))"), None);
+    }
 }

--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -17,6 +17,7 @@ mod aggregate;
 mod call;
 mod columns;
 mod selector;
+mod streaming;
 use std::sync::Arc;
 
 use async_recursion::async_recursion;

--- a/src/promql/src/engine/selector.rs
+++ b/src/promql/src/engine/selector.rs
@@ -32,7 +32,7 @@ use hashbrown::HashMap;
 use infra::errors::ErrorCodes;
 use promql_parser::{
     label::{MatchOp, Matchers},
-    parser::{LabelModifier, MatrixSelector, Offset, VectorSelector},
+    parser::{LabelModifier, Offset, VectorSelector},
 };
 use rayon::iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 
@@ -483,7 +483,8 @@ impl Engine {
     /// same contexts; `None` only when the query shape rules the streaming path out up front.
     pub(super) async fn try_streaming_fused_agg(
         &mut self,
-        matrix_selector: &MatrixSelector,
+        vs: &VectorSelector,
+        range: Duration,
         modifier: &Option<LabelModifier>,
         func: Arc<dyn functions::RangeFunc>,
         op: fused::FusedAggOp,
@@ -501,8 +502,6 @@ impl Engine {
         {
             return Ok(None);
         }
-        let MatrixSelector { vs, range } = matrix_selector;
-        let range = *range;
         let selector = named_selector(plain_selector(vs, "MatrixSelector")?, "MatrixSelector")?;
         let table_name = selector.name.clone().unwrap();
         let timeout = query_ctx.timeout;
@@ -1244,7 +1243,7 @@ mod tests {
             });
         }
 
-        async fn eval_sum_rate(provider: StreamingProvider, timeout: u64) -> Result<Value> {
+        fn engine(provider: StreamingProvider, timeout: u64) -> Engine {
             enable_streaming();
             let eval_ctx = EvalContext::new(
                 BASE + 60 * SECOND,
@@ -1259,9 +1258,83 @@ mod tests {
             );
             ctx.start = eval_ctx.start;
             ctx.end = eval_ctx.end;
-            let mut engine = Engine::new("test_trace", Arc::new(ctx), eval_ctx);
-            let expr = promql_parser::parser::parse("sum(rate(m[1m]))").unwrap();
+            Engine::new("test_trace", Arc::new(ctx), eval_ctx)
+        }
+
+        async fn eval_query(
+            provider: StreamingProvider,
+            timeout: u64,
+            query: &str,
+        ) -> Result<Value> {
+            let mut engine = engine(provider, timeout);
+            let expr = promql_parser::parser::parse(query).unwrap();
             engine.exec(&expr).await.map(|(value, _)| value)
+        }
+
+        async fn eval_sum_rate(provider: StreamingProvider, timeout: u64) -> Result<Value> {
+            eval_query(provider, timeout, "sum(rate(m[1m]))").await
+        }
+
+        /// The generic instant path: `eval_vector_selector` then the plain aggregation.
+        async fn generic_instant_agg(
+            provider: StreamingProvider,
+            selector: &str,
+            modifier: &Option<LabelModifier>,
+            agg: fn(&Option<LabelModifier>, Value, &EvalContext) -> Result<Value>,
+        ) -> Value {
+            let mut engine = engine(provider, 30);
+            let promql_parser::parser::Expr::VectorSelector(vs) =
+                promql_parser::parser::parse(selector).unwrap()
+            else {
+                panic!("{selector} is not a vector selector");
+            };
+            let data = engine.eval_vector_selector(&vs).await.unwrap();
+            let eval_ctx = engine.eval_ctx.clone();
+            agg(modifier, Value::Matrix(data), &eval_ctx).unwrap()
+        }
+
+        /// (sorted labels, (timestamp, value)) per series, sorted by labels.
+        type CanonicalSeries = (Vec<(String, String)>, Vec<(i64, f64)>);
+
+        fn canonical(value: Value) -> Vec<CanonicalSeries> {
+            let Value::Matrix(matrix) = value else {
+                panic!("expected a matrix, got {}", value.get_type());
+            };
+            let mut series: Vec<_> = matrix
+                .into_iter()
+                .map(|series| {
+                    let mut labels: Vec<_> = series
+                        .labels
+                        .iter()
+                        .map(|label| (label.name.clone(), label.value.clone()))
+                        .collect();
+                    labels.sort();
+                    let samples = series
+                        .samples
+                        .iter()
+                        .map(|sample| (sample.timestamp, sample.value))
+                        .collect();
+                    (labels, samples)
+                })
+                .collect();
+            series.sort_by(|a, b| a.0.cmp(&b.0));
+            series
+        }
+
+        fn assert_same_matrix(expected: Value, actual: Value, context: &str) {
+            let (expected, actual) = (canonical(expected), canonical(actual));
+            assert_eq!(expected.len(), actual.len(), "{context}: series count");
+            for (expected, actual) in expected.iter().zip(&actual) {
+                assert_eq!(expected.0, actual.0, "{context}: labels");
+                assert_eq!(expected.1.len(), actual.1.len(), "{context}: sample count");
+                for ((ts_e, v_e), (ts_a, v_a)) in expected.1.iter().zip(&actual.1) {
+                    assert_eq!(ts_e, ts_a, "{context}: timestamp");
+                    assert!(
+                        (v_e - v_a).abs() <= 1e-9,
+                        "{context}: {v_e} vs {v_a} at {ts_e}"
+                    );
+                }
+            }
         }
 
         #[tokio::test]
@@ -1279,6 +1352,46 @@ mod tests {
             assert!(matches!(
                 infra::errors::Error::from(err),
                 infra::errors::Error::ErrorCode(ErrorCodes::SearchTimeout(_))
+            ));
+        }
+
+        /// `agg(m)` streams as `agg(last_over_time(m[lookback]))` and must match the generic
+        /// instant path, both when it streams and when it materializes on the same context.
+        #[tokio::test]
+        async fn test_instant_agg_matches_generic_streaming_and_materialized() {
+            type Agg = fn(&Option<LabelModifier>, Value, &EvalContext) -> Result<Value>;
+            let cases: [(&str, &str, Agg); 4] = [
+                ("sum(m)", "m", crate::aggregations::sum),
+                ("count(m)", "m", crate::aggregations::count),
+                (
+                    "avg(m offset 30s)",
+                    "m offset 30s",
+                    crate::aggregations::avg,
+                ),
+                (
+                    "max(m offset 30s)",
+                    "m offset 30s",
+                    crate::aggregations::max,
+                ),
+            ];
+            for (query, selector, agg) in cases {
+                let expected =
+                    generic_instant_agg(provider(false, false), selector, &None, agg).await;
+                let streamed = eval_query(provider(true, false), 30, query).await.unwrap();
+                assert_same_matrix(expected.clone(), streamed, &format!("streamed {query}"));
+                let materialized = eval_query(provider(false, false), 30, query).await.unwrap();
+                assert_same_matrix(expected, materialized, &format!("materialized {query}"));
+            }
+        }
+
+        #[tokio::test]
+        async fn test_instant_agg_takes_the_streaming_path() {
+            let err = eval_query(provider(true, true), 30, "sum(m)")
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                infra::errors::Error::from(err),
+                infra::errors::Error::ErrorCode(ErrorCodes::SearchCancelQuery(_))
             ));
         }
 

--- a/src/promql/src/engine/selector.rs
+++ b/src/promql/src/engine/selector.rs
@@ -27,25 +27,24 @@ use datafusion::{
     error::{DataFusionError, Result},
     prelude::SessionContext,
 };
-use futures::future::{pending, try_join_all};
+use futures::future::try_join_all;
 use hashbrown::HashMap;
 use infra::errors::ErrorCodes;
 use promql_parser::{
     label::{MatchOp, Matchers},
-    parser::{LabelModifier, Offset, VectorSelector},
+    parser::{Offset, VectorSelector},
 };
 use rayon::iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 
 use super::Engine;
 use crate::{
-    functions, fused,
     load_series::{LoadedMetrics, PartitionedMetrics, selector_load_data_from_datafusion},
     micros,
     promql::rewrite::remove_filter_all,
 };
 
 /// One context per selected schema with its scan stats and whether the matchers still apply.
-type SelectorContexts = Vec<(SessionContext, Arc<Schema>, ScanStats, bool)>;
+pub(super) type SelectorContexts = Vec<(SessionContext, Arc<Schema>, ScanStats, bool)>;
 
 impl Engine {
     /// Instant vector selector --- select a single sample at each evaluation
@@ -478,140 +477,6 @@ impl Engine {
 
         Ok(metrics)
     }
-
-    /// Streams the fused aggregation when the layout allows it, otherwise materializes on the
-    /// same contexts; `None` only when the query shape rules the streaming path out up front.
-    pub(super) async fn try_streaming_fused_agg(
-        &mut self,
-        vs: &VectorSelector,
-        range: Duration,
-        modifier: &Option<LabelModifier>,
-        func: Arc<dyn functions::RangeFunc>,
-        op: fused::FusedAggOp,
-    ) -> Result<Option<Value>> {
-        let query_ctx = &self.ctx.query_ctx;
-        // need_wal bails early: WAL would split series across contexts
-        if !config::get_config()
-            .search
-            .feature_metrics_streaming_agg_enabled
-            || query_ctx.query_exemplars
-            || query_ctx.query_data
-            || query_ctx.is_super_cluster
-            || query_ctx.need_wal
-            || matches!(modifier, Some(LabelModifier::Exclude(_)))
-        {
-            return Ok(None);
-        }
-        let selector = named_selector(plain_selector(vs, "MatrixSelector")?, "MatrixSelector")?;
-        let table_name = selector.name.clone().unwrap();
-        let timeout = query_ctx.timeout;
-
-        let offset = get_offset_modifier(selector.offset.clone());
-        let start = self.ctx.start - micros(range) - offset;
-        let end = self.ctx.end - offset;
-        let mut filters = equal_matcher_filters(&selector.matchers);
-        let mut label_selector = self.label_selector.clone();
-        label_selector.extend(self.ctx.label_selector.iter().cloned());
-
-        let ctxs = self
-            .ctx
-            .table_provider
-            .create_context(
-                &query_ctx.org_id,
-                &table_name,
-                (start, end),
-                selector.matchers.clone(),
-                label_selector,
-                &mut filters,
-            )
-            .await?;
-        // a second context would split series and evaluate rate windows on partial data
-        if let [(ctx, schema, scan_stats, keep_filters)] = ctxs.as_slice() {
-            let matchers = if *keep_filters {
-                selector.matchers.clone()
-            } else {
-                Matchers::empty()
-            };
-            let run = fused::stream::fused_agg(
-                ctx,
-                schema,
-                fused::stream::StreamingSelector {
-                    table_name: &table_name,
-                    matchers: &matchers,
-                    offset,
-                },
-                fused::stream::FusedShape {
-                    op,
-                    func: func.clone(),
-                    range,
-                },
-                modifier,
-                &self.eval_ctx,
-            );
-            if let Some(value) = self.run_cancellable(run, timeout).await? {
-                self.ctx.scan_stats.write().await.add(scan_stats);
-                if self.result_type.is_none() {
-                    self.result_type = Some("matrix".to_string());
-                }
-                return Ok(Some(value));
-            }
-        }
-
-        // the layout cannot stream: materialize on the contexts already created
-        let matrix = self
-            .eval_matrix_selector(&selector, range, Some(ctxs))
-            .await?;
-        let input = if matrix.is_empty() {
-            Value::None
-        } else {
-            Value::Matrix(matrix)
-        };
-        fused::matrix::fused_agg(modifier, input, func, op, &self.eval_ctx, timeout)
-            .await
-            .map(Some)
-    }
-
-    /// Runs the streaming fold under the query timeout and the host's cancel signal; dropping
-    /// the future aborts the shard folds.
-    async fn run_cancellable<T>(
-        &self,
-        run: impl Future<Output = Result<T>>,
-        timeout: u64,
-    ) -> Result<T> {
-        let trace_id = &self.ctx.query_ctx.trace_id;
-        let mut abort_receiver = self
-            .ctx
-            .table_provider
-            .register_cancellation(trace_id)
-            .await?;
-        tokio::pin!(run);
-        // a cancel or an expired budget wins over a fold that happens to be ready
-        tokio::select! {
-            biased;
-            _ = async {
-                match abort_receiver.as_mut() {
-                    Some(receiver) => {
-                        let _ = receiver.await;
-                    }
-                    None => pending::<()>().await,
-                }
-            } => {
-                log::info!("[trace_id {trace_id}] [PromQL] streaming fused agg canceled");
-                Err(ErrorCodes::SearchCancelQuery(
-                    "[PromQL] streaming fused agg canceled".to_string(),
-                )
-                .into())
-            }
-            _ = tokio::time::sleep(Duration::from_secs(timeout)) => {
-                log::error!("[trace_id {trace_id}] [PromQL] streaming fused agg timeout");
-                Err(ErrorCodes::SearchTimeout(
-                    "[PromQL] streaming fused agg timeout".to_string(),
-                )
-                .into())
-            }
-            ret = &mut run => ret,
-        }
-    }
 }
 
 /// Strips placeholder matchers and rejects the selector forms no loader supports.
@@ -633,7 +498,7 @@ pub(super) fn plain_selector(selector: &VectorSelector, kind: &str) -> Result<Ve
 
 /// Lifts the `__name__` matcher into the selector name; kept as a matcher it would filter the
 /// stored column, which may hold the pre-`format_stream_name` case.
-fn named_selector(mut selector: VectorSelector, kind: &str) -> Result<VectorSelector> {
+pub(super) fn named_selector(mut selector: VectorSelector, kind: &str) -> Result<VectorSelector> {
     if selector.name.is_some() {
         return Ok(selector);
     }
@@ -685,7 +550,7 @@ fn collect_loaded_metrics(mut results: Vec<LoadedMetrics>) -> Vec<RangeValue> {
     }
 }
 
-fn equal_matcher_filters(matchers: &Matchers) -> Vec<(String, Vec<String>)> {
+pub(super) fn equal_matcher_filters(matchers: &Matchers) -> Vec<(String, Vec<String>)> {
     matchers
         .matchers
         .iter()
@@ -727,7 +592,7 @@ fn merge_loaded_metrics(results: Vec<LoadedMetrics>) -> HashMap<u64, RangeValue>
     metrics
 }
 
-fn get_offset_modifier(offset: Option<Offset>) -> i64 {
+pub(super) fn get_offset_modifier(offset: Option<Offset>) -> i64 {
     if let Some(offset) = offset {
         match offset {
             Offset::Pos(offset) => micros(offset),
@@ -1117,300 +982,5 @@ mod tests {
     fn test_get_offset_modifier_negative() {
         let result = get_offset_modifier(Some(Offset::Neg(Duration::from_secs(30))));
         assert_eq!(result, -30_000_000); // -30s in micros
-    }
-
-    mod streaming_fused_agg {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        use config::{
-            TIMESTAMP_COL_NAME,
-            meta::{
-                promql::{HASH_LABEL, HASH_SORTED_TABLE_SUFFIX, VALUE_LABEL},
-                search::ScanStats,
-            },
-        };
-        use datafusion::{
-            arrow::{
-                array::{Float64Array, Int64Array, RecordBatch, UInt64Array},
-                datatypes::{DataType, Field, Schema},
-            },
-            datasource::MemTable,
-            prelude::{SessionConfig, SessionContext, col},
-        };
-        use hashbrown::HashSet;
-        use tokio::sync::oneshot;
-
-        use super::*;
-
-        const SECOND: i64 = 1_000_000;
-        const BASE: i64 = 1_000 * SECOND;
-
-        /// Serves one hash-sorted context and can hand out an already-fired cancel signal.
-        struct StreamingProvider {
-            ctx: SessionContext,
-            calls: Arc<AtomicUsize>,
-            canceled: bool,
-            // a dropped sender reads as a cancel, so a live registration keeps it
-            cancel: std::sync::Mutex<Option<oneshot::Sender<()>>>,
-        }
-
-        #[async_trait::async_trait]
-        impl crate::TableProvider for StreamingProvider {
-            async fn create_context(
-                &self,
-                _org_id: &str,
-                _stream_name: &str,
-                _time_range: (i64, i64),
-                _matchers: Matchers,
-                _label_selector: HashSet<String>,
-                _filters: &mut [(String, Vec<String>)],
-            ) -> Result<Vec<(SessionContext, Arc<Schema>, ScanStats, bool)>> {
-                self.calls.fetch_add(1, Ordering::SeqCst);
-                Ok(vec![(
-                    self.ctx.clone(),
-                    metrics_schema(),
-                    ScanStats::default(),
-                    true,
-                )])
-            }
-
-            async fn register_cancellation(
-                &self,
-                _trace_id: &str,
-            ) -> Result<Option<oneshot::Receiver<()>>> {
-                let (sender, receiver) = oneshot::channel();
-                if self.canceled {
-                    let _ = sender.send(());
-                } else {
-                    *self.cancel.lock().unwrap() = Some(sender);
-                }
-                Ok(Some(receiver))
-            }
-        }
-
-        fn metrics_schema() -> Arc<Schema> {
-            Arc::new(Schema::new(vec![
-                Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
-                Field::new(HASH_LABEL, DataType::UInt64, false),
-                Field::new(VALUE_LABEL, DataType::Float64, false),
-            ]))
-        }
-
-        /// Two counters sampled every 20 s; the hash-sorted table exists only when `streams`.
-        fn provider(streams: bool, canceled: bool) -> StreamingProvider {
-            let rows: Vec<(i64, u64, f64)> = [7u64, u64::MAX / 2]
-                .into_iter()
-                .flat_map(|hash| {
-                    (0..10).map(move |step| (BASE + step * 20 * SECOND, hash, (step * 3) as f64))
-                })
-                .collect();
-            let batch = RecordBatch::try_new(
-                metrics_schema(),
-                vec![
-                    Arc::new(Int64Array::from_iter_values(rows.iter().map(|row| row.0))),
-                    Arc::new(UInt64Array::from_iter_values(rows.iter().map(|row| row.1))),
-                    Arc::new(Float64Array::from_iter_values(rows.iter().map(|row| row.2))),
-                ],
-            )
-            .unwrap();
-            let table = || MemTable::try_new(metrics_schema(), vec![vec![batch.clone()]]).unwrap();
-            let mut config = SessionConfig::new().with_target_partitions(3);
-            config.options_mut().optimizer.prefer_existing_sort = true;
-            let ctx = SessionContext::new_with_config(config);
-            ctx.register_table("m", Arc::new(table())).unwrap();
-            if streams {
-                let sorted = table().with_sort_order(vec![vec![
-                    col(HASH_LABEL).sort(true, false),
-                    col(TIMESTAMP_COL_NAME).sort(true, false),
-                ]]);
-                ctx.register_table(format!("m{HASH_SORTED_TABLE_SUFFIX}"), Arc::new(sorted))
-                    .unwrap();
-            }
-            StreamingProvider {
-                ctx,
-                calls: Default::default(),
-                canceled,
-                cancel: Default::default(),
-            }
-        }
-
-        /// Pins the flag on so a local env override cannot turn the streaming path off.
-        fn enable_streaming() {
-            static ENABLE: std::sync::Once = std::sync::Once::new();
-            ENABLE.call_once(|| {
-                unsafe { std::env::set_var("ZO_FEATURE_METRICS_STREAMING_AGG_ENABLED", "true") };
-                config::refresh_config().expect("config refresh");
-            });
-        }
-
-        fn engine(provider: StreamingProvider, timeout: u64) -> Engine {
-            enable_streaming();
-            let eval_ctx = EvalContext::new(
-                BASE + 60 * SECOND,
-                BASE + 180 * SECOND,
-                60 * SECOND,
-                "test_trace".into(),
-            );
-            let mut ctx = PromqlContext::new(
-                create_test_query_ctx("test_trace", "test_org", timeout),
-                provider,
-                vec![],
-            );
-            ctx.start = eval_ctx.start;
-            ctx.end = eval_ctx.end;
-            Engine::new("test_trace", Arc::new(ctx), eval_ctx)
-        }
-
-        async fn eval_query(
-            provider: StreamingProvider,
-            timeout: u64,
-            query: &str,
-        ) -> Result<Value> {
-            let mut engine = engine(provider, timeout);
-            let expr = promql_parser::parser::parse(query).unwrap();
-            engine.exec(&expr).await.map(|(value, _)| value)
-        }
-
-        async fn eval_sum_rate(provider: StreamingProvider, timeout: u64) -> Result<Value> {
-            eval_query(provider, timeout, "sum(rate(m[1m]))").await
-        }
-
-        /// The generic instant path: `eval_vector_selector` then the plain aggregation.
-        async fn generic_instant_agg(
-            provider: StreamingProvider,
-            selector: &str,
-            modifier: &Option<LabelModifier>,
-            agg: fn(&Option<LabelModifier>, Value, &EvalContext) -> Result<Value>,
-        ) -> Value {
-            let mut engine = engine(provider, 30);
-            let promql_parser::parser::Expr::VectorSelector(vs) =
-                promql_parser::parser::parse(selector).unwrap()
-            else {
-                panic!("{selector} is not a vector selector");
-            };
-            let data = engine.eval_vector_selector(&vs).await.unwrap();
-            let eval_ctx = engine.eval_ctx.clone();
-            agg(modifier, Value::Matrix(data), &eval_ctx).unwrap()
-        }
-
-        /// (sorted labels, (timestamp, value)) per series, sorted by labels.
-        type CanonicalSeries = (Vec<(String, String)>, Vec<(i64, f64)>);
-
-        fn canonical(value: Value) -> Vec<CanonicalSeries> {
-            let Value::Matrix(matrix) = value else {
-                panic!("expected a matrix, got {}", value.get_type());
-            };
-            let mut series: Vec<_> = matrix
-                .into_iter()
-                .map(|series| {
-                    let mut labels: Vec<_> = series
-                        .labels
-                        .iter()
-                        .map(|label| (label.name.clone(), label.value.clone()))
-                        .collect();
-                    labels.sort();
-                    let samples = series
-                        .samples
-                        .iter()
-                        .map(|sample| (sample.timestamp, sample.value))
-                        .collect();
-                    (labels, samples)
-                })
-                .collect();
-            series.sort_by(|a, b| a.0.cmp(&b.0));
-            series
-        }
-
-        fn assert_same_matrix(expected: Value, actual: Value, context: &str) {
-            let (expected, actual) = (canonical(expected), canonical(actual));
-            assert_eq!(expected.len(), actual.len(), "{context}: series count");
-            for (expected, actual) in expected.iter().zip(&actual) {
-                assert_eq!(expected.0, actual.0, "{context}: labels");
-                assert_eq!(expected.1.len(), actual.1.len(), "{context}: sample count");
-                for ((ts_e, v_e), (ts_a, v_a)) in expected.1.iter().zip(&actual.1) {
-                    assert_eq!(ts_e, ts_a, "{context}: timestamp");
-                    assert!(
-                        (v_e - v_a).abs() <= 1e-9,
-                        "{context}: {v_e} vs {v_a} at {ts_e}"
-                    );
-                }
-            }
-        }
-
-        #[tokio::test]
-        async fn test_streaming_run_stops_on_cancel() {
-            let err = eval_sum_rate(provider(true, true), 30).await.unwrap_err();
-            assert!(matches!(
-                infra::errors::Error::from(err),
-                infra::errors::Error::ErrorCode(ErrorCodes::SearchCancelQuery(_))
-            ));
-        }
-
-        #[tokio::test]
-        async fn test_streaming_run_stops_on_timeout() {
-            let err = eval_sum_rate(provider(true, false), 0).await.unwrap_err();
-            assert!(matches!(
-                infra::errors::Error::from(err),
-                infra::errors::Error::ErrorCode(ErrorCodes::SearchTimeout(_))
-            ));
-        }
-
-        /// `agg(m)` streams as `agg(last_over_time(m[lookback]))` and must match the generic
-        /// instant path, both when it streams and when it materializes on the same context.
-        #[tokio::test]
-        async fn test_instant_agg_matches_generic_streaming_and_materialized() {
-            type Agg = fn(&Option<LabelModifier>, Value, &EvalContext) -> Result<Value>;
-            let cases: [(&str, &str, Agg); 4] = [
-                ("sum(m)", "m", crate::aggregations::sum),
-                ("count(m)", "m", crate::aggregations::count),
-                (
-                    "avg(m offset 30s)",
-                    "m offset 30s",
-                    crate::aggregations::avg,
-                ),
-                (
-                    "max(m offset 30s)",
-                    "m offset 30s",
-                    crate::aggregations::max,
-                ),
-            ];
-            for (query, selector, agg) in cases {
-                let expected =
-                    generic_instant_agg(provider(false, false), selector, &None, agg).await;
-                let streamed = eval_query(provider(true, false), 30, query).await.unwrap();
-                assert_same_matrix(expected.clone(), streamed, &format!("streamed {query}"));
-                let materialized = eval_query(provider(false, false), 30, query).await.unwrap();
-                assert_same_matrix(expected, materialized, &format!("materialized {query}"));
-            }
-        }
-
-        #[tokio::test]
-        async fn test_instant_agg_takes_the_streaming_path() {
-            let err = eval_query(provider(true, true), 30, "sum(m)")
-                .await
-                .unwrap_err();
-            assert!(matches!(
-                infra::errors::Error::from(err),
-                infra::errors::Error::ErrorCode(ErrorCodes::SearchCancelQuery(_))
-            ));
-        }
-
-        #[tokio::test]
-        async fn test_materializes_on_the_streaming_context_without_sorted_table() {
-            let provider = provider(false, false);
-            let calls = provider.calls.clone();
-
-            let value = eval_sum_rate(provider, 30).await.unwrap();
-            let Value::Matrix(matrix) = value else {
-                panic!("expected a matrix, got {}", value.get_type());
-            };
-            assert_eq!(matrix.len(), 1, "sum() folds both series into one");
-            assert_eq!(matrix[0].samples.len(), 3, "one sample per evaluation step");
-            assert_eq!(
-                calls.load(Ordering::SeqCst),
-                1,
-                "the materializing fallback must reuse the context the streaming attempt created"
-            );
-        }
     }
 }

--- a/src/promql/src/engine/streaming.rs
+++ b/src/promql/src/engine/streaming.rs
@@ -1,0 +1,464 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The streaming entry for fused aggregations: attempts the ordered shard streams over the
+//! selector's contexts and falls back to the materializing fold on the same contexts.
+//!
+//! Reads `ctx`, `eval_ctx`, `label_selector`; writes `result_type` on success.
+
+use std::{sync::Arc, time::Duration};
+
+use config::meta::promql::value::*;
+use datafusion::error::Result;
+use futures::future::pending;
+use infra::errors::ErrorCodes;
+use promql_parser::{
+    label::Matchers,
+    parser::{LabelModifier, VectorSelector},
+};
+
+use super::{
+    Engine,
+    selector::{equal_matcher_filters, get_offset_modifier, named_selector, plain_selector},
+};
+use crate::{functions, fused, micros};
+
+impl Engine {
+    /// Streams the fused aggregation when the layout allows it, otherwise materializes on the
+    /// same contexts; `None` only when the query shape rules the streaming path out up front.
+    pub(super) async fn try_streaming_fused_agg(
+        &mut self,
+        vs: &VectorSelector,
+        range: Duration,
+        modifier: &Option<LabelModifier>,
+        func: Arc<dyn functions::RangeFunc>,
+        op: fused::FusedAggOp,
+    ) -> Result<Option<Value>> {
+        let query_ctx = &self.ctx.query_ctx;
+        // need_wal bails early: WAL would split series across contexts
+        if !config::get_config()
+            .search
+            .feature_metrics_streaming_agg_enabled
+            || query_ctx.query_exemplars
+            || query_ctx.query_data
+            || query_ctx.is_super_cluster
+            || query_ctx.need_wal
+            || matches!(modifier, Some(LabelModifier::Exclude(_)))
+        {
+            return Ok(None);
+        }
+        let selector = named_selector(plain_selector(vs, "MatrixSelector")?, "MatrixSelector")?;
+        let table_name = selector.name.clone().unwrap();
+        let timeout = query_ctx.timeout;
+
+        let offset = get_offset_modifier(selector.offset.clone());
+        let start = self.ctx.start - micros(range) - offset;
+        let end = self.ctx.end - offset;
+        let mut filters = equal_matcher_filters(&selector.matchers);
+        let mut label_selector = self.label_selector.clone();
+        label_selector.extend(self.ctx.label_selector.iter().cloned());
+
+        let ctxs = self
+            .ctx
+            .table_provider
+            .create_context(
+                &query_ctx.org_id,
+                &table_name,
+                (start, end),
+                selector.matchers.clone(),
+                label_selector,
+                &mut filters,
+            )
+            .await?;
+        // a second context would split series and evaluate rate windows on partial data
+        if let [(ctx, schema, scan_stats, keep_filters)] = ctxs.as_slice() {
+            let matchers = if *keep_filters {
+                selector.matchers.clone()
+            } else {
+                Matchers::empty()
+            };
+            let run = fused::stream::fused_agg(
+                ctx,
+                schema,
+                fused::stream::StreamingSelector {
+                    table_name: &table_name,
+                    matchers: &matchers,
+                    offset,
+                },
+                fused::stream::FusedShape {
+                    op,
+                    func: func.clone(),
+                    range,
+                },
+                modifier,
+                &self.eval_ctx,
+            );
+            if let Some(value) = self.run_cancellable(run, timeout).await? {
+                self.ctx.scan_stats.write().await.add(scan_stats);
+                if self.result_type.is_none() {
+                    self.result_type = Some("matrix".to_string());
+                }
+                return Ok(Some(value));
+            }
+        }
+
+        // the layout cannot stream: materialize on the contexts already created
+        let matrix = self
+            .eval_matrix_selector(&selector, range, Some(ctxs))
+            .await?;
+        let input = if matrix.is_empty() {
+            Value::None
+        } else {
+            Value::Matrix(matrix)
+        };
+        fused::matrix::fused_agg(modifier, input, func, op, &self.eval_ctx, timeout)
+            .await
+            .map(Some)
+    }
+
+    /// Runs the streaming fold under the query timeout and the host's cancel signal; dropping
+    /// the future aborts the shard folds.
+    async fn run_cancellable<T>(
+        &self,
+        run: impl Future<Output = Result<T>>,
+        timeout: u64,
+    ) -> Result<T> {
+        let trace_id = &self.ctx.query_ctx.trace_id;
+        let mut abort_receiver = self
+            .ctx
+            .table_provider
+            .register_cancellation(trace_id)
+            .await?;
+        tokio::pin!(run);
+        // a cancel or an expired budget wins over a fold that happens to be ready
+        tokio::select! {
+            biased;
+            _ = async {
+                match abort_receiver.as_mut() {
+                    Some(receiver) => {
+                        let _ = receiver.await;
+                    }
+                    None => pending::<()>().await,
+                }
+            } => {
+                log::info!("[trace_id {trace_id}] [PromQL] streaming fused agg canceled");
+                Err(ErrorCodes::SearchCancelQuery(
+                    "[PromQL] streaming fused agg canceled".to_string(),
+                )
+                .into())
+            }
+            _ = tokio::time::sleep(Duration::from_secs(timeout)) => {
+                log::error!("[trace_id {trace_id}] [PromQL] streaming fused agg timeout");
+                Err(ErrorCodes::SearchTimeout(
+                    "[PromQL] streaming fused agg timeout".to_string(),
+                )
+                .into())
+            }
+            ret = &mut run => ret,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use config::{
+        TIMESTAMP_COL_NAME,
+        meta::{
+            promql::{HASH_LABEL, HASH_SORTED_TABLE_SUFFIX, VALUE_LABEL},
+            search::ScanStats,
+        },
+    };
+    use datafusion::{
+        arrow::{
+            array::{Float64Array, Int64Array, RecordBatch, UInt64Array},
+            datatypes::{DataType, Field, Schema},
+        },
+        datasource::MemTable,
+        prelude::{SessionConfig, SessionContext, col},
+    };
+    use hashbrown::HashSet;
+    use tokio::sync::oneshot;
+
+    use super::*;
+    use crate::{engine::tests::*, exec::PromqlContext};
+
+    const SECOND: i64 = 1_000_000;
+    const BASE: i64 = 1_000 * SECOND;
+
+    /// Serves one hash-sorted context and can hand out an already-fired cancel signal.
+    struct StreamingProvider {
+        ctx: SessionContext,
+        calls: Arc<AtomicUsize>,
+        canceled: bool,
+        // a dropped sender reads as a cancel, so a live registration keeps it
+        cancel: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::TableProvider for StreamingProvider {
+        async fn create_context(
+            &self,
+            _org_id: &str,
+            _stream_name: &str,
+            _time_range: (i64, i64),
+            _matchers: Matchers,
+            _label_selector: HashSet<String>,
+            _filters: &mut [(String, Vec<String>)],
+        ) -> Result<Vec<(SessionContext, Arc<Schema>, ScanStats, bool)>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![(
+                self.ctx.clone(),
+                metrics_schema(),
+                ScanStats::default(),
+                true,
+            )])
+        }
+
+        async fn register_cancellation(
+            &self,
+            _trace_id: &str,
+        ) -> Result<Option<oneshot::Receiver<()>>> {
+            let (sender, receiver) = oneshot::channel();
+            if self.canceled {
+                let _ = sender.send(());
+            } else {
+                *self.cancel.lock().unwrap() = Some(sender);
+            }
+            Ok(Some(receiver))
+        }
+    }
+
+    fn metrics_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new(HASH_LABEL, DataType::UInt64, false),
+            Field::new(VALUE_LABEL, DataType::Float64, false),
+        ]))
+    }
+
+    /// Two counters sampled every 20 s; the hash-sorted table exists only when `streams`.
+    fn provider(streams: bool, canceled: bool) -> StreamingProvider {
+        let rows: Vec<(i64, u64, f64)> = [7u64, u64::MAX / 2]
+            .into_iter()
+            .flat_map(|hash| {
+                (0..10).map(move |step| (BASE + step * 20 * SECOND, hash, (step * 3) as f64))
+            })
+            .collect();
+        let batch = RecordBatch::try_new(
+            metrics_schema(),
+            vec![
+                Arc::new(Int64Array::from_iter_values(rows.iter().map(|row| row.0))),
+                Arc::new(UInt64Array::from_iter_values(rows.iter().map(|row| row.1))),
+                Arc::new(Float64Array::from_iter_values(rows.iter().map(|row| row.2))),
+            ],
+        )
+        .unwrap();
+        let table = || MemTable::try_new(metrics_schema(), vec![vec![batch.clone()]]).unwrap();
+        let mut config = SessionConfig::new().with_target_partitions(3);
+        config.options_mut().optimizer.prefer_existing_sort = true;
+        let ctx = SessionContext::new_with_config(config);
+        ctx.register_table("m", Arc::new(table())).unwrap();
+        if streams {
+            let sorted = table().with_sort_order(vec![vec![
+                col(HASH_LABEL).sort(true, false),
+                col(TIMESTAMP_COL_NAME).sort(true, false),
+            ]]);
+            ctx.register_table(format!("m{HASH_SORTED_TABLE_SUFFIX}"), Arc::new(sorted))
+                .unwrap();
+        }
+        StreamingProvider {
+            ctx,
+            calls: Default::default(),
+            canceled,
+            cancel: Default::default(),
+        }
+    }
+
+    /// Pins the flag on so a local env override cannot turn the streaming path off.
+    fn enable_streaming() {
+        static ENABLE: std::sync::Once = std::sync::Once::new();
+        ENABLE.call_once(|| {
+            unsafe { std::env::set_var("ZO_FEATURE_METRICS_STREAMING_AGG_ENABLED", "true") };
+            config::refresh_config().expect("config refresh");
+        });
+    }
+
+    fn engine(provider: StreamingProvider, timeout: u64) -> Engine {
+        enable_streaming();
+        let eval_ctx = EvalContext::new(
+            BASE + 60 * SECOND,
+            BASE + 180 * SECOND,
+            60 * SECOND,
+            "test_trace".into(),
+        );
+        let mut ctx = PromqlContext::new(
+            create_test_query_ctx("test_trace", "test_org", timeout),
+            provider,
+            vec![],
+        );
+        ctx.start = eval_ctx.start;
+        ctx.end = eval_ctx.end;
+        Engine::new("test_trace", Arc::new(ctx), eval_ctx)
+    }
+
+    async fn eval_query(provider: StreamingProvider, timeout: u64, query: &str) -> Result<Value> {
+        let mut engine = engine(provider, timeout);
+        let expr = promql_parser::parser::parse(query).unwrap();
+        engine.exec(&expr).await.map(|(value, _)| value)
+    }
+
+    async fn eval_sum_rate(provider: StreamingProvider, timeout: u64) -> Result<Value> {
+        eval_query(provider, timeout, "sum(rate(m[1m]))").await
+    }
+
+    /// The generic instant path: `eval_vector_selector` then the plain aggregation.
+    async fn generic_instant_agg(
+        provider: StreamingProvider,
+        selector: &str,
+        modifier: &Option<LabelModifier>,
+        agg: fn(&Option<LabelModifier>, Value, &EvalContext) -> Result<Value>,
+    ) -> Value {
+        let mut engine = engine(provider, 30);
+        let promql_parser::parser::Expr::VectorSelector(vs) =
+            promql_parser::parser::parse(selector).unwrap()
+        else {
+            panic!("{selector} is not a vector selector");
+        };
+        let data = engine.eval_vector_selector(&vs).await.unwrap();
+        let eval_ctx = engine.eval_ctx.clone();
+        agg(modifier, Value::Matrix(data), &eval_ctx).unwrap()
+    }
+
+    /// (sorted labels, (timestamp, value)) per series, sorted by labels.
+    type CanonicalSeries = (Vec<(String, String)>, Vec<(i64, f64)>);
+
+    fn canonical(value: Value) -> Vec<CanonicalSeries> {
+        let Value::Matrix(matrix) = value else {
+            panic!("expected a matrix, got {}", value.get_type());
+        };
+        let mut series: Vec<_> = matrix
+            .into_iter()
+            .map(|series| {
+                let mut labels: Vec<_> = series
+                    .labels
+                    .iter()
+                    .map(|label| (label.name.clone(), label.value.clone()))
+                    .collect();
+                labels.sort();
+                let samples = series
+                    .samples
+                    .iter()
+                    .map(|sample| (sample.timestamp, sample.value))
+                    .collect();
+                (labels, samples)
+            })
+            .collect();
+        series.sort_by(|a, b| a.0.cmp(&b.0));
+        series
+    }
+
+    fn assert_same_matrix(expected: Value, actual: Value, context: &str) {
+        let (expected, actual) = (canonical(expected), canonical(actual));
+        assert_eq!(expected.len(), actual.len(), "{context}: series count");
+        for (expected, actual) in expected.iter().zip(&actual) {
+            assert_eq!(expected.0, actual.0, "{context}: labels");
+            assert_eq!(expected.1.len(), actual.1.len(), "{context}: sample count");
+            for ((ts_e, v_e), (ts_a, v_a)) in expected.1.iter().zip(&actual.1) {
+                assert_eq!(ts_e, ts_a, "{context}: timestamp");
+                assert!(
+                    (v_e - v_a).abs() <= 1e-9,
+                    "{context}: {v_e} vs {v_a} at {ts_e}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_streaming_run_stops_on_cancel() {
+        let err = eval_sum_rate(provider(true, true), 30).await.unwrap_err();
+        assert!(matches!(
+            infra::errors::Error::from(err),
+            infra::errors::Error::ErrorCode(ErrorCodes::SearchCancelQuery(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_run_stops_on_timeout() {
+        let err = eval_sum_rate(provider(true, false), 0).await.unwrap_err();
+        assert!(matches!(
+            infra::errors::Error::from(err),
+            infra::errors::Error::ErrorCode(ErrorCodes::SearchTimeout(_))
+        ));
+    }
+
+    /// `agg(m)` streams as `agg(last_over_time(m[lookback]))` and must match the generic
+    /// instant path, both when it streams and when it materializes on the same context.
+    #[tokio::test]
+    async fn test_instant_agg_matches_generic_streaming_and_materialized() {
+        type Agg = fn(&Option<LabelModifier>, Value, &EvalContext) -> Result<Value>;
+        let cases: [(&str, &str, Agg); 4] = [
+            ("sum(m)", "m", crate::aggregations::sum),
+            ("count(m)", "m", crate::aggregations::count),
+            (
+                "avg(m offset 30s)",
+                "m offset 30s",
+                crate::aggregations::avg,
+            ),
+            (
+                "max(m offset 30s)",
+                "m offset 30s",
+                crate::aggregations::max,
+            ),
+        ];
+        for (query, selector, agg) in cases {
+            let expected = generic_instant_agg(provider(false, false), selector, &None, agg).await;
+            let streamed = eval_query(provider(true, false), 30, query).await.unwrap();
+            assert_same_matrix(expected.clone(), streamed, &format!("streamed {query}"));
+            let materialized = eval_query(provider(false, false), 30, query).await.unwrap();
+            assert_same_matrix(expected, materialized, &format!("materialized {query}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_instant_agg_takes_the_streaming_path() {
+        let err = eval_query(provider(true, true), 30, "sum(m)")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            infra::errors::Error::from(err),
+            infra::errors::Error::ErrorCode(ErrorCodes::SearchCancelQuery(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_materializes_on_the_streaming_context_without_sorted_table() {
+        let provider = provider(false, false);
+        let calls = provider.calls.clone();
+
+        let value = eval_sum_rate(provider, 30).await.unwrap();
+        let Value::Matrix(matrix) = value else {
+            panic!("expected a matrix, got {}", value.get_type());
+        };
+        assert_eq!(matrix.len(), 1, "sum() folds both series into one");
+        assert_eq!(matrix[0].samples.len(), 3, "one sample per evaluation step");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "the materializing fallback must reuse the context the streaming attempt created"
+        );
+    }
+}


### PR DESCRIPTION
Design at: https://github.com/openobserve/designs/blob/main/metrics/metrics-streaming-fused-aggregation.md

## What

`agg by(...)(instant_selector)` — `sum by(pod)(container_memory_usage_bytes)`, `count(m)`, `max by(path)(m offset 1m)` — now takes the streaming fused path.

An instant selector is exactly `last_over_time` over the lookback window: `eval_vector_selector` picks the last sample in the closed interval `[eval_ts - lookback_delta, eval_ts]` with the offset added to the sample timestamp, which is what the fold's window selection and `StreamSource` already do, and both keep `__name__` under `by(__name__)`. So `fused_agg_shape` recognizes a bare `VectorSelector` and hands the existing machinery `func = last_over_time`, `range = lookback_delta`. Shards, chain merge, fold and merge are unchanged.

- `FusedAggShape` carries the plain selector with an optional range (`None` = lookback) and an optional `range_arg`; `try_streaming_fused_agg` takes `(selector, range)` instead of a `MatrixSelector`.
- When an up-front gate rejects the instant shape it stays on the generic path (no range function to materialize). Once contexts exist and the layout cannot stream, it materializes on those contexts through `fused::matrix` with `last_over_time`, the same fallback the range shapes use.

Against the 731 PromQL queries in openobserve/dashboards this shape is 124 queries, taking streaming coverage from 17% to 35%.

## Benchmark

Same release+mimalloc binary, flag off (generic instant path) vs on, two interleaved rounds, medians of three runs, data-faker parquet set (~1.17M series folded into 1404 groups):

| query | off | on |
|---|---|---|
| `sum by(le,path)(bucket)` 1h | 4.80 s | 1.13 s |
| `sum by(le,path)(bucket)` 3h | 20.3 s | 2.40 s |
| `sum by(le,path)(bucket)` 6h | 61.2 s | 3.42 s |
| `count(bucket)` 3h | 12.1 s | 1.79 s |
| `sum by(le)(bucket{path="/api/service-1"})` 1h | 0.27 s | 0.24 s |
| `max by(path)(gauge)` 3h, 390 series | 9 ms | 12 ms |
| peak RSS | 17.3 GiB | 1.10 GiB |

63/63 streamed responses byte-identical to the generic path; 32/32 requests per round streamed with the flag on, 0 with it off.

## Tests

- `engine::aggregate`: shape recognition for range selectors, subquery arguments, instant selectors with matchers and offset, and non-fusable calls.
- `engine::selector::streaming_fused_agg`: `sum`/`count`/`avg offset`/`max offset` over the streaming path and over the materializing fallback both match `eval_vector_selector` + `aggregations::*`; a cancel test proves the instant shape goes through `run_cancellable`.
- Two-server end-to-end A/B (flag on vs off, identical data): 7 instant shapes including `count by(__name__)` and a regex matcher, all byte-identical, all streamed.

Note: with the flag on and hash-sorted files absent, an instant aggregation now goes through the fused materializing fold instead of the generic aggregation once the context exists. Fused-vs-generic parity for `last_over_time` across all eight aggregation ops was already covered in `fused::matrix` tests.
