### PR TITLE
fix: bound JavaScript function execution time to prevent HTTP worker starvation

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2201,7 +2201,8 @@ pub struct Limit {
     pub disk_free: usize,
     #[env_config(name = "ZO_PAYLOAD_LIMIT", default = 209715200)]
     pub req_payload_limit: usize,
-    #[env_config(name = "ZO_JS_FUNCTION_MAX_EXECUTION_TIME_SECS", default = 5)] // 0 = no limit
+    #[env_config(name = "ZO_JS_FUNCTION_MAX_EXECUTION_TIME_SECS", default = 5)]
+    // 0 falls back to default
     pub js_function_max_execution_time_secs: u64,
     #[env_config(name = "ZO_MAX_FILE_RETENTION_TIME", default = 600)] // seconds
     pub max_file_retention_time: u64,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2201,6 +2201,8 @@ pub struct Limit {
     pub disk_free: usize,
     #[env_config(name = "ZO_PAYLOAD_LIMIT", default = 209715200)]
     pub req_payload_limit: usize,
+    #[env_config(name = "ZO_JS_FUNCTION_MAX_EXECUTION_TIME_SECS", default = 5)] // 0 = no limit
+    pub js_function_max_execution_time_secs: u64,
     #[env_config(name = "ZO_MAX_FILE_RETENTION_TIME", default = 600)] // seconds
     pub max_file_retention_time: u64,
     // MB, per log file size limit on disk

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -245,16 +245,20 @@ async fn test_run_js_function(
     function: String,
     events: Vec<Value>,
 ) -> Result<HttpResponse, anyhow::Error> {
-    // Check if function uses #ResultArray# marker
-    let apply_over_array = RESULT_ARRAY.is_match(&function);
+    let org_id = org_id.to_string();
+    // Synchronous QuickJS evaluation must run off the HTTP worker thread so it cannot starve the
+    // pool.
+    match tokio::task::spawn_blocking(move || run_js_test(&org_id, &function, events)).await? {
+        Ok(results) => Ok(MetaHttpResponse::json(TestVRLResponse { results })),
+        Err(e) => Ok(MetaHttpResponse::bad_request(e)),
+    }
+}
 
-    // Compile the JS function
-    let js_config = match transform::js::compile_js_function(&function, org_id) {
-        Ok(config) => config,
-        Err(e) => {
-            return Ok(MetaHttpResponse::bad_request(e));
-        }
-    };
+fn run_js_test(org_id: &str, function: &str, events: Vec<Value>) -> Result<Vec<VRLResult>, String> {
+    let apply_over_array = RESULT_ARRAY.is_match(function);
+
+    let js_config =
+        transform::js::compile_js_function(function, org_id).map_err(|e| e.to_string())?;
 
     let mut transformed_events = vec![];
 
@@ -304,11 +308,7 @@ async fn test_run_js_function(
         }
     }
 
-    let results = TestVRLResponse {
-        results: transformed_events,
-    };
-
-    Ok(MetaHttpResponse::json(results))
+    Ok(transformed_events)
 }
 
 #[tracing::instrument(skip(func))]

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::io::Error;
+use std::{io::Error, time::Instant};
 
 use axum::{
     Json, http,
@@ -290,8 +290,17 @@ fn run_js_test(org_id: &str, function: &str, events: Vec<Value>) -> Result<Vec<V
             transformed_events.push(VRLResult::new("", transform));
         }
     } else {
+        // Bound the whole request so a big batch can't tie up a thread for N x the per-eval limit.
+        let deadline = Instant::now() + transform::js::exec_timeout();
         // Normal mode: apply function to each event
         for event in events {
+            if Instant::now() >= deadline {
+                transformed_events.push(VRLResult::new(
+                    "Test aborted: exceeded the execution time limit",
+                    event,
+                ));
+                continue;
+            }
             let (ret_val, err) =
                 transform::js::apply_js_fn(&js_config, event.clone(), org_id, &[String::new()]);
 

--- a/src/transform/src/js.rs
+++ b/src/transform/src/js.rs
@@ -65,6 +65,9 @@ thread_local! {
     });
 }
 
+/// Fallback when the configured limit is 0; every eval stays bounded (no unlimited option).
+const DEFAULT_JS_EXEC_TIMEOUT_SECS: u64 = 5;
+
 /// Compiled JS function configuration
 #[derive(Clone, Debug)]
 pub struct JSRuntimeConfig {
@@ -80,18 +83,18 @@ impl MemorySize for JSRuntimeConfig {
 
 /// Arms the thread-local eval deadline; clears it on drop (including early return/panic).
 struct JsDeadlineGuard {
-    deadline: Option<Instant>,
+    deadline: Instant,
 }
 
 impl JsDeadlineGuard {
-    fn new(timeout: Option<Duration>) -> Self {
-        let deadline = timeout.map(|t| Instant::now() + t);
-        JS_DEADLINE.with(|d| d.set(deadline));
+    fn new(timeout: Duration) -> Self {
+        let deadline = Instant::now() + timeout;
+        JS_DEADLINE.with(|d| d.set(Some(deadline)));
         Self { deadline }
     }
 
     fn expired(&self) -> bool {
-        self.deadline.is_some_and(|d| Instant::now() >= d)
+        Instant::now() >= self.deadline
     }
 }
 
@@ -110,13 +113,13 @@ pub fn init_js_runtime() -> Result<(), String> {
 /// Compile and validate a JS function
 /// Similar to compile_vrl_function but for JavaScript
 pub fn compile_js_function(func: &str, org_id: &str) -> Result<JSRuntimeConfig, std::io::Error> {
-    compile_js_function_inner(func, org_id, js_exec_timeout())
+    compile_js_function_inner(func, org_id, exec_timeout())
 }
 
 fn compile_js_function_inner(
     func: &str,
     _org_id: &str,
-    timeout: Option<Duration>,
+    timeout: Duration,
 ) -> Result<JSRuntimeConfig, std::io::Error> {
     // Basic validation: function must not be empty
     if func.trim().is_empty() {
@@ -249,11 +252,16 @@ fn strip_result_array_marker(func: &str) -> String {
     result
 }
 
-fn js_exec_timeout() -> Option<Duration> {
+/// Per-eval execution budget; a configured `0` falls back to the default rather than disabling it.
+pub fn exec_timeout() -> Duration {
     let secs = config::get_config()
         .limit
         .js_function_max_execution_time_secs;
-    (secs > 0).then(|| Duration::from_secs(secs))
+    Duration::from_secs(if secs == 0 {
+        DEFAULT_JS_EXEC_TIMEOUT_SECS
+    } else {
+        secs
+    })
 }
 
 /// Apply a JS function to transform data
@@ -339,7 +347,7 @@ pub fn apply_js_fn(
             );
 
             // Execute the function
-            let guard = JsDeadlineGuard::new(js_exec_timeout());
+            let guard = JsDeadlineGuard::new(exec_timeout());
             let eval_result = ctx.eval::<String, _>(exec_code);
             if guard.expired() {
                 let msg = "JavaScript function exceeded the execution time limit".to_string();
@@ -466,11 +474,8 @@ mod tests {
     fn test_compile_rejects_infinite_loop() {
         // Executing at compile time rejects an obvious infinite loop before it can be saved.
         let start = Instant::now();
-        let result = compile_js_function_inner(
-            "while (true) {}",
-            "test_org",
-            Some(Duration::from_millis(100)),
-        );
+        let result =
+            compile_js_function_inner("while (true) {}", "test_org", Duration::from_millis(100));
         let err = result.expect_err("infinite loop must be rejected at compile");
         assert!(
             err.to_string().contains("time limit"),
@@ -496,7 +501,7 @@ mod tests {
         ];
         for src in payloads {
             let start = Instant::now();
-            let _guard = JsDeadlineGuard::new(Some(Duration::from_millis(100)));
+            let _guard = JsDeadlineGuard::new(Duration::from_millis(100));
             let result: Result<String, _> = JS_CONTEXT.with(|ctx| ctx.with(|ctx| ctx.eval(src)));
             assert!(result.is_err(), "infinite loop must be interrupted: {src}");
             assert!(

--- a/src/transform/src/js.rs
+++ b/src/transform/src/js.rs
@@ -13,10 +13,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::{
+    cell::Cell,
+    time::{Duration, Instant},
+};
+
 use config::{meta::function::RESULT_ARRAY, stats::MemorySize, utils::json};
 use rquickjs::{Context, Runtime};
 
 thread_local! {
+    /// Deadline for the eval running on this thread; the interrupt handler aborts once it passes.
+    static JS_DEADLINE: Cell<Option<Instant>> = const { Cell::new(None) };
+
     /// Thread-local JS runtime - each thread gets its own runtime with security hardening
     /// This pattern matches the VRL runtime approach and ensures thread safety
     ///
@@ -35,6 +43,11 @@ thread_local! {
         // 512KB max stack - prevents stack overflow attacks and excessive recursion
         rt.set_max_stack_size(512 * 1024);
 
+        // A non-yielding function (e.g. `while(true){}`) would otherwise pin the thread forever.
+        rt.set_interrupt_handler(Some(Box::new(|| {
+            JS_DEADLINE.with(|d| d.get().is_some_and(|deadline| Instant::now() >= deadline))
+        })));
+
         rt
     };
 
@@ -47,7 +60,7 @@ thread_local! {
         // doesn't expose individual global registration. Instead, we rely on:
         // 1. Comprehensive pattern blocking (Phase 1)
         // 2. Memory/stack limits (Phase 2)
-        // 3. Execution timeout (100ms, enforced in pipeline/batch_execution.rs)
+        // 3. Execution deadline via the runtime interrupt handler (see JS_DEADLINE / JsDeadlineGuard)
         Context::full(rt).expect("Failed to create JS context")
     });
 }
@@ -65,6 +78,29 @@ impl MemorySize for JSRuntimeConfig {
     }
 }
 
+/// Arms the thread-local eval deadline; clears it on drop (including early return/panic).
+struct JsDeadlineGuard {
+    deadline: Option<Instant>,
+}
+
+impl JsDeadlineGuard {
+    fn new(timeout: Option<Duration>) -> Self {
+        let deadline = timeout.map(|t| Instant::now() + t);
+        JS_DEADLINE.with(|d| d.set(deadline));
+        Self { deadline }
+    }
+
+    fn expired(&self) -> bool {
+        self.deadline.is_some_and(|d| Instant::now() >= d)
+    }
+}
+
+impl Drop for JsDeadlineGuard {
+    fn drop(&mut self) {
+        JS_DEADLINE.with(|d| d.set(None));
+    }
+}
+
 /// Initialize a new JS runtime for the current thread
 /// This is called automatically via thread_local!, but can be used to verify runtime
 pub fn init_js_runtime() -> Result<(), String> {
@@ -73,7 +109,15 @@ pub fn init_js_runtime() -> Result<(), String> {
 
 /// Compile and validate a JS function
 /// Similar to compile_vrl_function but for JavaScript
-pub fn compile_js_function(func: &str, _org_id: &str) -> Result<JSRuntimeConfig, std::io::Error> {
+pub fn compile_js_function(func: &str, org_id: &str) -> Result<JSRuntimeConfig, std::io::Error> {
+    compile_js_function_inner(func, org_id, js_exec_timeout())
+}
+
+fn compile_js_function_inner(
+    func: &str,
+    _org_id: &str,
+    timeout: Option<Duration>,
+) -> Result<JSRuntimeConfig, std::io::Error> {
     // Basic validation: function must not be empty
     if func.trim().is_empty() {
         return Err(std::io::Error::other("JavaScript function cannot be empty"));
@@ -146,12 +190,9 @@ pub fn compile_js_function(func: &str, _org_id: &str) -> Result<JSRuntimeConfig,
     let var_name = if is_result_array { "rows" } else { "row" };
     let test_value = if is_result_array { "[]" } else { "{}" };
 
-    // Try to compile the function to check syntax
+    // Execute against empty input so an obvious infinite loop is rejected at save, not at runtime.
     JS_CONTEXT.with(|ctx| {
         ctx.with(|ctx| {
-            // Create a test wrapper that catches errors and returns error details as a string
-            // This way we can extract the actual error message from JavaScript
-            // Use 'rows' for #ResultArray# functions, 'row' for regular functions
             let test_code = format!(
                 r#"
                 (function() {{
@@ -160,25 +201,24 @@ pub fn compile_js_function(func: &str, _org_id: &str) -> Result<JSRuntimeConfig,
                         {}
                     }} catch(e) {{
                     }}
-                    // the syntax errors will be caught separately, but because we are
-                    // assigning the var_name as empty object, user's code will likely throw exception
-                    // through no fault of their own. So we ignore that.
                     return JSON.stringify({{ success: true }});
                 }})();
                 "#,
                 var_name, test_value, func_for_compilation
             );
 
+            let guard = JsDeadlineGuard::new(timeout);
+            let eval_result = ctx.eval::<String, _>(test_code);
+            if guard.expired() {
+                return Err(std::io::Error::other(
+                    "JavaScript function exceeded the execution time limit (possible infinite loop)",
+                ));
+            }
             // error here would mean there was some syntax error, which should be propagated
-            let _: String = ctx
-                .eval(test_code)
-                .map_err(|e| {
-                    std::io::Error::other(format!("JS compilation failed: {}", e))
-                })?;
-            // Extract parameter names (simple heuristic)
-            // TODO: Parse function signature properly
-            let params = vec!["row".to_string()];
+            let _: String = eval_result
+                .map_err(|e| std::io::Error::other(format!("JavaScript syntax error: {}", e)))?;
 
+            let params = vec!["row".to_string()];
             Ok(JSRuntimeConfig {
                 function: func.to_string(), // Store original with marker
                 params,
@@ -207,6 +247,13 @@ fn strip_result_array_marker(func: &str) -> String {
         .to_string();
 
     result
+}
+
+fn js_exec_timeout() -> Option<Duration> {
+    let secs = config::get_config()
+        .limit
+        .js_function_max_execution_time_secs;
+    (secs > 0).then(|| Duration::from_secs(secs))
 }
 
 /// Apply a JS function to transform data
@@ -292,7 +339,14 @@ pub fn apply_js_fn(
             );
 
             // Execute the function
-            match ctx.eval::<String, _>(exec_code) {
+            let guard = JsDeadlineGuard::new(js_exec_timeout());
+            let eval_result = ctx.eval::<String, _>(exec_code);
+            if guard.expired() {
+                let msg = "JavaScript function exceeded the execution time limit".to_string();
+                log::error!("{}/{:?} {}", org_id, stream_name, msg);
+                return (row, Some(msg));
+            }
+            match eval_result {
                 Ok(result_json) => {
                     // Parse the result to check if there was an error
                     match serde_json::from_str::<json::Value>(&result_json) {
@@ -409,6 +463,50 @@ mod tests {
     }
 
     #[test]
+    fn test_compile_rejects_infinite_loop() {
+        // Executing at compile time rejects an obvious infinite loop before it can be saved.
+        let start = Instant::now();
+        let result = compile_js_function_inner(
+            "while (true) {}",
+            "test_org",
+            Some(Duration::from_millis(100)),
+        );
+        let err = result.expect_err("infinite loop must be rejected at compile");
+        assert!(
+            err.to_string().contains("time limit"),
+            "error should mention the time limit, got: {err}"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "compile must fail fast, not hang"
+        );
+    }
+
+    #[test]
+    fn test_infinite_loops_are_interrupted() {
+        // The deadline is enforced at runtime, so interception is independent of how the loop is
+        // written; whitespace, comments and alternate loop forms all reach the same handler.
+        let payloads = [
+            "while (true) {}",
+            "while(true){}",
+            "while ( true ) { /* spin */ }",
+            "while (1) {}",
+            "for (;;) {}",
+            "do {} while (true);",
+        ];
+        for src in payloads {
+            let start = Instant::now();
+            let _guard = JsDeadlineGuard::new(Some(Duration::from_millis(100)));
+            let result: Result<String, _> = JS_CONTEXT.with(|ctx| ctx.with(|ctx| ctx.eval(src)));
+            assert!(result.is_err(), "infinite loop must be interrupted: {src}");
+            assert!(
+                start.elapsed() < Duration::from_secs(5),
+                "interrupt must fire near the deadline, not hang: {src}"
+            );
+        }
+    }
+
+    #[test]
     fn test_apply_js_fn_modify_field() {
         let func = r#"
             row.count = (row.count || 0) + 1;
@@ -512,8 +610,8 @@ rows.map(function(r) {
         println!("Captured error message: {}", err_msg);
         // The error message should contain information about the undefined variable
         assert!(
-            err_msg.contains("Exception") || err_msg.contains("compilation failed"),
-            "Error message should mention compilation failed, got: {}",
+            err_msg.contains("Exception") || err_msg.contains("syntax"),
+            "Error message should mention a syntax error, got: {}",
             err_msg
         );
         // Should NOT contain "(line: unknown, column: unknown)"


### PR DESCRIPTION
## Summary

The QuickJS runtime backing JavaScript transform functions set memory (10MB) and stack (512KB) limits but had **no execution-time bound**. A non-yielding function such as `while (true) {}` runs synchronously on a Tokio HTTP worker and never returns, pinning that worker until the process restarts. A handful of such requests (roughly one per worker) exhausts the finite HTTP worker pool and makes the service unavailable.

Ref: `GHSA-rx6v-8ppc-596m` (private, in triage).

## What changed

All JavaScript execution funnels through `src/transform/src/js.rs`, so the fix lives at the eval layer and every caller inherits it (the `/functions/test` endpoint, the ingestion pipeline, and JWT claim mapping).

- **Execution deadline via a QuickJS interrupt handler.** The thread-local runtime gets an interrupt handler that aborts evaluation once a per-eval deadline passes; the deadline is armed with an RAII guard (`JsDeadlineGuard`) around each `ctx.eval` site and cleared on drop (including early return/panic). A latching wall-clock deadline is form-independent — `while(true){}`, `for(;;){}`, `while(1){}`, whitespace/comment variants, etc. are all aborted, because the check is elapsed time, not source shape (detecting infinite loops statically is undecidable).
- **Reject obvious loops at save/validation time.** `compile_js_function` executes the function against empty input, so an unconditional infinite loop is caught and rejected at save with a clear `exceeded the execution time limit (possible infinite loop)` message — it never reaches a running pipeline (important: a per-record timeout in a realtime pipeline would be catastrophic). The runtime deadline backs this up for input-dependent loops that only manifest on real data.
- **New config knob** `ZO_JS_FUNCTION_MAX_EXECUTION_TIME_SECS` (default `5`, `0` = no limit).
- **Off the async workers:** the `/functions/test` handler now runs its evaluation on `spawn_blocking` so a burst of test requests cannot tie up the async HTTP worker pool.
- Corrected a stale comment that claimed a "100ms timeout enforced in pipeline/batch_execution.rs" — no such mechanism existed.

## Reviewer notes

- `spawn_blocking` is applied only to the interactive test endpoint, **not** the per-record ingestion path, on purpose: per-record `spawn_blocking` would add a thread hop per record and wreck throughput, and the deadline already bounds per-eval CPU there.
- `compile_js_function_inner(func, org, timeout)` is a thin internal seam so the reject-at-save behavior has a fast (100ms) regression test instead of waiting the full default.
- The change is not behind `#[cfg(feature = "enterprise")]`; the OSS default build fully exercises it.

## Testing

- `cargo test -p transform js::` — 39 passed (new `test_compile_rejects_infinite_loop`, `test_infinite_loops_are_interrupted` covering 6 equivalent loop forms, plus existing syntax/behavior tests). Full suite runs in ~0.6s (no hangs).
- `cargo fmt --all` clean.
- CI clippy gate `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` — exit 0, no lints.