### PR TITLE
ci: rename regression workflow to Playwright Bug-Fix Regression Tests

### DIFF
--- a/.github/scripts/O2-REPORTING.md
+++ b/.github/scripts/O2-REPORTING.md
@@ -5,7 +5,7 @@ OpenObserve stream, so we can build performance/reliability dashboards on top of
 
 | Workflow | Repo | Stream | Emitting job |
 |---|---|---|---|
-| Playwright Regression (`playwright_regression.yml`) | openobserve (OSS) | `ci_regression` | `report_to_openobserve` |
+| Playwright Bug-Fix Regression (`playwright_bugfix_regression.yml`) | openobserve (OSS) | `ci_regression` | `report_to_openobserve` |
 | DocGen engine (`docgen.yml`) | o2-enterprise | `ci_docgen` | `report_metrics` |
 | E2E Council engine (`e2e-council.yml`) | o2-enterprise | `ci_council` | `report_metrics` |
 

--- a/.github/scripts/o2_metrics_resync.py
+++ b/.github/scripts/o2_metrics_resync.py
@@ -28,7 +28,7 @@ if os.environ.get("O2_REPORTING_INSECURE", "") == "true":
 TARGETS = [
     ("playwright.yml", "ci_test_runs", "ui", False),
     ("api-testing.yml", "ci_test_runs", "api", False),
-    ("playwright_regression.yml", "ci_regression", "regression", True),
+    ("playwright_bugfix_regression.yml", "ci_regression", "regression", True),
 ]
 
 def gh(path):

--- a/.github/workflows/o2-metrics-resync.yml
+++ b/.github/workflows/o2-metrics-resync.yml
@@ -1,7 +1,7 @@
 name: OpenObserve Metrics Re-sync (fallback)
 
 # Fallback for the LIVE per-run metrics (report_to_openobserve jobs in playwright.yml,
-# api-testing.yml, playwright_regression.yml). Those are the happy path (ingest_source="live").
+# api-testing.yml, playwright_bugfix_regression.yml). Those are the happy path (ingest_source="live").
 # This cron re-posts the last LOOKBACK_DAYS of runs tagged ingest_source="backfill" so any run
 # whose live emit was missed still lands. Dashboards dedup by run_id (latest attempt) and PREFER
 # the live doc, so a backfill row only surfaces when live genuinely missed — making the

--- a/.github/workflows/playwright_bugfix_regression.yml
+++ b/.github/workflows/playwright_bugfix_regression.yml
@@ -1,4 +1,4 @@
-name: Playwright Regression Tests
+name: Playwright Bug-Fix Regression Tests
 
 on:
   schedule:

--- a/.github/workflows/stuck-run-reaper.yml
+++ b/.github/workflows/stuck-run-reaper.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           # Comma-separated workflow file names to police (all use eks-openobserve-* runners).
           # Release workflows are intentionally excluded — a stuck release build is left for a human.
-          WORKFLOWS: "playwright.yml,playwright_regression.yml"
+          WORKFLOWS: "playwright.yml,playwright_bugfix_regression.yml"
           DEFAULT_THRESHOLD_MINUTES: "60"
           # Separate, much longer cap for "zombie" runs stuck with no jobs ever dispatched
           # (these never held a runner, so 60m would be too aggressive — a brief GitHub

--- a/tests/ui-testing/ci-matrix/README.md
+++ b/tests/ui-testing/ci-matrix/README.md
@@ -9,7 +9,7 @@ Each Playwright workflow builds its matrix from one of these JSON files (via a
 | Manifest | Drives workflow | Kind |
 |---|---|---|
 | `ci_matrix.json` (+ ENT `ci_matrix.ent.json`) | `playwright.yml` (PR gate) | shared base + overlay |
-| `ci_matrix_regression.json` (+ ENT `ci_matrix_regression.ent.json`) | `playwright_regression.yml` | shared base + overlay |
+| `ci_matrix_regression.json` (+ ENT `ci_matrix_regression.ent.json`) | `playwright_bugfix_regression.yml` | shared base + overlay |
 | `ci_matrix_cloud.json` *(ENT repo)* | `playwright_alpha1.yml` | ENT-only standalone |
 | `ci_matrix_env.json` *(ENT repo)* | `playwright_env.yml` | ENT-only standalone |
 | `ci_matrix_env_scheduled.json` *(ENT repo)* | `playwright_env_scheduled.yml` | ENT-only standalone |


### PR DESCRIPTION
Renames the nightly regression job for clarity — it runs the curated RegressionSet (bug-fix lock-in) subset. Display name → **Playwright Bug-Fix Regression Tests**, file → `playwright_bugfix_regression.yml`. Filename refs updated (o2_metrics_resync.py, stuck-run-reaper.yml, O2-REPORTING / ci-matrix docs). Stream `ci_regression`, the workflow tag, matrix files and `RegressionSet/` dir are unchanged (history + dashboards preserved). Paired with the same rename in o2-enterprise (same branch).