### PR TITLE
perf(promql): bounded-heap topk and parallel instant selection

### DIFF
--- a/src/promql/src/aggregations/bottomk.rs
+++ b/src/promql/src/aggregations/bottomk.rs
@@ -15,7 +15,6 @@
 
 use config::meta::promql::value::{EvalContext, RangeValue, Value};
 use datafusion::error::{DataFusionError, Result};
-use hashbrown::HashSet;
 use promql_parser::parser::LabelModifier;
 use rayon::prelude::*;
 
@@ -51,7 +50,7 @@ pub fn bottomk(
 
     // For bottomk, we select the bottom k series at each timestamp
     // We need to preserve the original series structure
-    let eval_timestamps: HashSet<i64> = eval_ctx.timestamps().iter().cloned().collect();
+    let eval_timestamps = eval_ctx.timestamps();
 
     // Group series by label modifier
     let grouped_series = super::group_series_by_labels(&matrix, modifier);

--- a/src/promql/src/aggregations/topk.rs
+++ b/src/promql/src/aggregations/topk.rs
@@ -13,12 +13,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::{cmp::Ordering, collections::BinaryHeap};
+
 use config::{
-    meta::promql::value::{EvalContext, RangeValue, Value},
+    meta::promql::value::{EvalContext, RangeValue, Value, signature},
     utils::sort::sort_float,
 };
 use datafusion::error::{DataFusionError, Result};
-use hashbrown::{HashMap, HashSet};
+use hashbrown::HashMap;
 use promql_parser::parser::LabelModifier;
 use rayon::prelude::*;
 
@@ -52,9 +54,7 @@ pub fn topk(
         eval_ctx.timestamps().len()
     );
 
-    // For topk, we select the top k series at each timestamp
-    // We need to preserve the original series structure
-    let eval_timestamps: HashSet<i64> = eval_ctx.timestamps().iter().cloned().collect();
+    let eval_timestamps = eval_ctx.timestamps();
 
     // Group series by label modifier
     let grouped_series = super::group_series_by_labels(&matrix, modifier);
@@ -82,84 +82,101 @@ pub fn topk(
     }
 }
 
-// For topk/bottomk, we keep the original series but only include timestamps
-// where they are in the top/bottom k
+/// A series' value at one evaluation slot; the heap keeps the k best and its top is the worst
+/// of them, so a better arrival pops it. Ties go to the lower label signature, which is stable
+/// across runs where the load order of the series is not.
+#[derive(PartialEq)]
+struct Ranked {
+    value: f64,
+    signature: u64,
+    idx: usize,
+    is_bottom: bool,
+}
+
+impl Eq for Ranked {}
+
+impl PartialOrd for Ranked {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Ranked {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // greater = worse: keep NaN below every number, as sort_float orders them
+        let by_value = if self.is_bottom {
+            sort_float(&self.value, &other.value)
+        } else {
+            sort_float(&other.value, &self.value)
+        };
+        by_value.then_with(|| self.signature.cmp(&other.signature))
+    }
+}
+
+/// For each evaluation timestamp keeps the top/bottom k series of the group in a bounded heap,
+/// so memory is `slots × k` instead of a copy of every sample; the output keeps each series
+/// with only the timestamps where it ranked.
 pub(super) fn select_topk_series(
     matrix: &[RangeValue],
     series_indices: &[usize],
     k: usize,
-    eval_timestamps: &HashSet<i64>,
+    eval_timestamps: &[i64],
     is_bottom: bool,
 ) -> Vec<RangeValue> {
     if series_indices.is_empty() || k == 0 {
         return Vec::new();
     }
 
-    // Pre-build timestamp index: timestamp -> Vec<(series_idx, value)>
-    let mut timestamp_index: HashMap<i64, Vec<(usize, f64)>> =
-        HashMap::with_capacity(eval_timestamps.len());
-
+    let mut heaps: Vec<BinaryHeap<Ranked>> = (0..eval_timestamps.len())
+        .map(|_| BinaryHeap::new())
+        .collect();
     for &idx in series_indices {
+        let signature = signature(&matrix[idx].labels);
         for sample in &matrix[idx].samples {
-            if eval_timestamps.contains(&sample.timestamp) {
-                timestamp_index
-                    .entry(sample.timestamp)
-                    .or_default()
-                    .push((idx, sample.value));
+            let Ok(slot) = eval_timestamps.binary_search(&sample.timestamp) else {
+                continue;
+            };
+            let entry = Ranked {
+                value: sample.value,
+                signature,
+                idx,
+                is_bottom,
+            };
+            let heap = &mut heaps[slot];
+            if heap.len() < k {
+                heap.push(entry);
+            } else if heap.peek().is_some_and(|worst| entry < *worst) {
+                heap.pop();
+                heap.push(entry);
             }
         }
     }
 
-    // Use partial sorting (select_nth_unstable) to find top-k efficiently
-    // This is O(N) average case instead of O(N log N) for full sort
-    let mut topk_per_timestamp: HashMap<i64, HashSet<usize>> =
-        HashMap::with_capacity(timestamp_index.len());
-
-    for (timestamp, mut values) in timestamp_index {
-        let len = values.len();
-
-        if len <= k {
-            // All values are in top-k
-            topk_per_timestamp.insert(timestamp, values.iter().map(|(idx, _)| *idx).collect());
-        } else {
-            // Use partial sorting to find top k elements
-            // select_nth_unstable is O(n) average, partitions around the k-th element
-            let k_index = k.saturating_sub(1);
-            values.select_nth_unstable_by(k_index, |(_, a), (_, b)| {
-                if is_bottom {
-                    sort_float(a, b)
-                } else {
-                    sort_float(b, a)
-                }
-            });
-
-            // Take the first k elements (now partitioned)
-            let topk_indices: HashSet<usize> = values[..k].iter().map(|(idx, _)| *idx).collect();
-            topk_per_timestamp.insert(timestamp, topk_indices);
+    // slots are visited in order, so every series' winning slots come out ascending
+    let mut winning_slots: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (slot, heap) in heaps.into_iter().enumerate() {
+        for entry in heap {
+            winning_slots.entry(entry.idx).or_default().push(slot);
         }
     }
 
-    // Build result efficiently by iterating through series once
-    // and checking which of their samples are in top-k
-    let mut result = Vec::with_capacity(series_indices.len().min(k * eval_timestamps.len()));
-
+    let mut result = Vec::with_capacity(winning_slots.len());
     for &series_idx in series_indices {
+        let Some(slots) = winning_slots.get(&series_idx) else {
+            continue;
+        };
         let series = &matrix[series_idx];
-
-        // Use with_capacity since we know samples won't exceed series.samples.len()
-        let mut filtered_samples =
-            Vec::with_capacity(series.samples.len().min(eval_timestamps.len()));
-
+        let mut slots = slots.iter().map(|&slot| eval_timestamps[slot]).peekable();
+        let mut filtered_samples = Vec::with_capacity(slots.len());
         for sample in &series.samples {
-            // O(1) lookup to check if this timestamp has top-k data
-            // and if this series is in the top k for that timestamp
-            if let Some(topk_indices) = topk_per_timestamp.get(&sample.timestamp)
-                && topk_indices.contains(&series_idx)
-            {
+            while slots.peek().is_some_and(|&ts| ts < sample.timestamp) {
+                slots.next();
+            }
+            if slots.peek() == Some(&sample.timestamp) {
                 filtered_samples.push(*sample);
+                slots.next();
             }
         }
-
         if !filtered_samples.is_empty() {
             result.push(RangeValue {
                 labels: series.labels.clone(),
@@ -316,9 +333,79 @@ mod tests {
             exemplars: None,
             time_window: None,
         }];
-        let eval_timestamps = HashSet::from([timestamp]);
-        let result = select_topk_series(&matrix, &[], 2, &eval_timestamps, false);
+        let result = select_topk_series(&matrix, &[], 2, &[timestamp], false);
         assert!(result.is_empty());
+    }
+
+    /// The bounded heaps pick exactly what a full per-slot sort by (value, signature) picks,
+    /// with NaN ranking below every number and ties going to the lower label signature.
+    #[test]
+    fn test_select_topk_bounded_heap_matches_full_ranking() {
+        let ts: Vec<i64> = (0..4).map(|i| 1_000 + i * 10).collect();
+        let series = |name: &str, values: [f64; 4]| RangeValue {
+            labels: vec![Arc::new(Label::new("s", name))],
+            samples: ts
+                .iter()
+                .zip(values)
+                .map(|(&t, v)| Sample::new(t, v))
+                .collect(),
+            exemplars: None,
+            time_window: None,
+        };
+        let matrix = vec![
+            series("a", [5.0, 1.0, f64::NAN, 2.0]),
+            series("b", [5.0, 2.0, 1.0, 2.0]),
+            series("c", [4.0, 3.0, 2.0, 2.0]),
+            series("d", [1.0, 4.0, 3.0, 9.0]),
+        ];
+        let name = |s: &RangeValue| s.labels[0].value.clone();
+        let full_sort = |is_bottom: bool| -> Vec<(String, Vec<i64>)> {
+            let mut picked: HashMap<String, Vec<i64>> = HashMap::new();
+            for &t in &ts {
+                let mut candidates: Vec<(f64, u64, String)> = matrix
+                    .iter()
+                    .filter_map(|s| {
+                        let sample = s.samples.iter().find(|x| x.timestamp == t)?;
+                        Some((sample.value, signature(&s.labels), name(s)))
+                    })
+                    .collect();
+                candidates.sort_by(|x, y| {
+                    let by_value = if is_bottom {
+                        sort_float(&x.0, &y.0)
+                    } else {
+                        sort_float(&y.0, &x.0)
+                    };
+                    by_value.then_with(|| x.1.cmp(&y.1))
+                });
+                for (_, _, n) in candidates.into_iter().take(2) {
+                    picked.entry(n).or_default().push(t);
+                }
+            }
+            let mut rows: Vec<_> = picked.into_iter().collect();
+            rows.sort();
+            rows
+        };
+        let heaps = |is_bottom: bool| -> Vec<(String, Vec<i64>)> {
+            let mut rows: Vec<_> = select_topk_series(&matrix, &[0, 1, 2, 3], 2, &ts, is_bottom)
+                .iter()
+                .map(|s| (name(s), s.samples.iter().map(|x| x.timestamp).collect()))
+                .collect();
+            rows.sort();
+            rows
+        };
+        assert_eq!(heaps(false), full_sort(false));
+        assert_eq!(heaps(true), full_sort(true));
+        // the NaN never wins a top slot and always wins a bottom slot it competes in
+        let a_top = &heaps(false)
+            .iter()
+            .find(|(n, _)| n == "a")
+            .map(|(_, t)| t.clone());
+        assert!(!a_top.as_ref().is_some_and(|t| t.contains(&1_020)));
+        let a_bottom = heaps(true)
+            .iter()
+            .find(|(n, _)| n == "a")
+            .map(|(_, t)| t.clone());
+        assert!(a_bottom.is_some_and(|t| t.contains(&1_020)));
     }
 
     #[test]
@@ -339,8 +426,7 @@ mod tests {
                 time_window: None,
             },
         ];
-        let eval_timestamps = HashSet::from([timestamp]);
-        let result = select_topk_series(&matrix, &[0, 1], 5, &eval_timestamps, false);
+        let result = select_topk_series(&matrix, &[0, 1], 5, &[timestamp], false);
         assert_eq!(result.len(), 2);
     }
 }

--- a/src/promql/src/engine/selector.rs
+++ b/src/promql/src/engine/selector.rs
@@ -73,15 +73,14 @@ impl Engine {
         // Get all evaluation timestamps from the context
         let eval_timestamps = self.eval_ctx.timestamps();
 
-        // For each metric, select appropriate samples at each evaluation timestamp
-        // TODO: make it parallel
-        let mut result = Vec::with_capacity(metrics_cache.len());
-        for metric in metrics_cache {
+        let lookback_delta = self.ctx.lookback_delta;
+        // every series selects independently, so fan the selection out
+        let result = metrics_cache.into_par_iter().filter_map(|metric| {
             let mut selected_samples = Vec::with_capacity(eval_timestamps.len());
 
             for &eval_ts in &eval_timestamps {
                 // Calculate lookback window for this evaluation timestamp
-                let start = eval_ts - self.ctx.lookback_delta;
+                let start = eval_ts - lookback_delta;
 
                 // Find the sample for this evaluation timestamp
                 // Binary search for the last sample before or at eval_ts (considering offset)
@@ -111,17 +110,15 @@ impl Engine {
             }
 
             // Only include metrics that have at least one sample
-            if !selected_samples.is_empty() {
-                result.push(RangeValue {
-                    labels: metric.labels,
-                    samples: selected_samples,
-                    exemplars: metric.exemplars,
-                    time_window: metric.time_window,
-                });
-            }
-        }
+            (!selected_samples.is_empty()).then_some(RangeValue {
+                labels: metric.labels,
+                samples: selected_samples,
+                exemplars: metric.exemplars,
+                time_window: metric.time_window,
+            })
+        });
 
-        Ok(result)
+        Ok(result.collect())
     }
 
     /// Range vector selector --- select a whole time range at each evaluation


### PR DESCRIPTION
## What

Two hot spots on the generic PromQL path, found while profiling the memory of `topk(5, rate(bucket[5m]))` and the latency of instant aggregations with streaming off.

**`topk` / `bottomk` keep a bounded heap per evaluation slot.** `select_topk_series` used to copy every sample of the group into a `timestamp_index: HashMap<ts, Vec<(idx, value)>>` and partial-sort each timestamp, so it held a second copy of the whole matrix before producing the output. It now keeps one `BinaryHeap` of capacity k per slot whose top is the worst kept entry; a better arrival pops it. Memory is `slots × k` entries instead of the matrix. Ties go to the lower label signature, which is stable across runs (the previous implementation, and series load order, are not), and NaN ranks below every number as `sort_float` already ordered it. The function takes the sorted evaluation timestamps and locates slots by binary search.

**`eval_vector_selector` selects in parallel.** The per-series lookback selection loop (marked `TODO: make it parallel`) becomes `into_par_iter().filter_map`; the selection logic is unchanged. On 1.17M series it was a 3.2 s single-threaded gap between the load and the aggregation.

## Benchmark

Same-round interleaved A/B, release + mimalloc, base = main binary vs this branch, streaming flag off on both so every query takes the generic path, RSS sampled per query with the topk queries first on a fresh process:

| query (1h unless noted, ~1.17M series) | base | new |
|---|---|---|
| `topk(5, rate(bucket[5m]))` | 7.82 s / 16.8 GiB | 3.74 s / 9.0 GiB |
| `bottomk(5, rate(bucket[5m]))` | 7.08 s / 17.1 GiB | 3.71 s / 9.7 GiB |
| `topk by(path)(3, rate(bucket[5m]))` | 2.95 s | 2.57 s |
| `sum by(le,path)(bucket)` 1h | 4.71 s | 1.84 s |
| `sum by(le,path)(bucket)` 3h | 12.5 s | 4.21 s |
| `sum by(le,path)(bucket)` 6h | 62.8 s | 43.1 s |
| control `sum by(le,path)(rate(bucket[5m]))` 3h | 4.76 s | 4.21 s |

The flag was off on purpose: the table measures the generic path only. With the default flag on, `sum by(le,path)(bucket)` already streams (#14198: 1.13 s / 2.40 s / 3.42 s at 1h/3h/6h, 1.1 GiB) and is untouched by this PR. The parallel selector matters for deployments that run with streaming off, for layouts that fall back, and for bare instant vector selectors such as `node_memory_bytes`, which never fuse and always go through `eval_vector_selector`. The topk change applies on either setting, since `topk` is not a fused aggregation.

All non-topk responses are byte-identical to the base binary (36/36). The topk responses differ from base only in tie order, which base resolves nondeterministically (its own two rounds disagree); the new binary's rounds are identical (9/9).

## Tests

- `select_topk_series` is checked against a full per-slot sort by (value, signature), including a NaN series that must never win a top slot and must win the bottom slot it competes in.
- Existing topk/bottomk and selector tests unchanged; `cargo fmt` and the CI clippy command are clean.
