### PR TITLE
fix: update free tier ingestion from 200 GB/day to 50 GB/day in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Deploy in High Availability mode with clustering for mission-critical workloads 
 | Aspect | OpenObserve | Datadog |
 | --- | --- | --- |
 | Deployment | Self-hosted or Cloud | SaaS only |
-| Pricing model | Per-GB (free up to 200 GB/day) | Per-host + per-GB |
+| Pricing model | Per-GB (free up to 50 GB/day) | Per-host + per-GB |
 | Open source | Yes (AGPL-3.0) | No |
 | OpenTelemetry | Native OTLP | Supported |
 | Query language | SQL + PromQL | Proprietary |


### PR DESCRIPTION
## Summary
The Datadog comparison table in the README still said the OpenObserve free tier was "free up to 200 GB/day," while the Quick Start and Enterprise pricing sections elsewhere in the same file already say 50 GB/day. This fixes the leftover inconsistency.

## Change
- `README.md`: "Per-GB (free up to 200 GB/day)" → "Per-GB (free up to 50 GB/day)" in the OpenObserve vs Datadog comparison table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)