### PR TITLE
fix(synthetics): bill from the frozen reservation, not the live pool balance

### DIFF
--- a/src/api/management/src/request/synthetics/mod.rs
+++ b/src/api/management/src/request/synthetics/mod.rs
@@ -1014,62 +1014,33 @@ fn record_step_usage_metrics(usage: &[config::meta::self_reporting::usage::Usage
     }
 }
 
-/// The org's one-time free step grant as it stands right now — SPEC §6.1, item
-/// 2.3. Handed to `job_api::ack`, which decides §4.2's free/billable split.
+/// Whether a free step grant gates this org at all — SPEC §6.1 / §7.3, item
+/// 2.3. Handed to `job_api::ack`, which reads the job row's frozen
+/// `steps_reserved` for §4.2's free/billable split.
 ///
-/// Ordering matters: the `customer_billings` read (the only way to spot an
-/// ExternalContract org, which §7.3 says to never pool-gate) is issued ONLY while
-/// the org still has grant left, so past that a request costs one counter read.
+/// It deliberately does NOT read the pool's balance. The balance answers "is
+/// there room now", and the ack needs "did THIS enqueue reserve": an org with a
+/// remainder too small for one run fails every reservation, so its balance never
+/// reaches zero and every run it makes as overage was billed as free.
 #[cfg(feature = "cloud")]
-async fn resolve_step_pool(org_id: &str) -> openobserve_synthetics::job_api::StepPoolViews {
-    // Both grants: this runs before `ack` reads the row that says which one the
-    // job spends from. Two in-memory counter reads, not two DB round trips.
-    let browser = openobserve_core::trial_quota::synthetics_steps_remaining(org_id, true);
-    let protocol = openobserve_core::trial_quota::synthetics_steps_remaining(org_id, false);
-    // Each grant decides for itself — summing would report an org whose browser
-    // pool is spent as still funded, and bill its browser steps as free.
-    //
-    // `> 0` first: a spent grant is billable whatever the plan says, so the
-    // `customer_billings` read is skipped once BOTH are gone.
-    let is_contract = (browser > 0 || protocol > 0)
-        && o2_enterprise::enterprise::cloud::ai_credits::resolve_ai_credit_exhaustion_policy(
-            org_id,
-        )
+async fn resolve_step_pool(org_id: &str) -> openobserve_synthetics::job_api::StepPoolGate {
+    use openobserve_synthetics::job_api::StepPoolGate;
+
+    // §7.3, E18/T36 — *"never pool-gate"* an ExternalContract org. §7.4 needs its
+    // acks billable so the NoOp provider advances a step-denominated true-up.
+    if o2_enterprise::enterprise::cloud::ai_credits::resolve_ai_credit_exhaustion_policy(org_id)
         .await
-        .requires_additional_credits();
-    openobserve_synthetics::job_api::StepPoolViews {
-        browser: step_pool_view(browser, is_contract),
-        protocol: step_pool_view(protocol, is_contract),
+        .requires_additional_credits()
+    {
+        return StepPoolGate::NotApplicable;
     }
-}
-
-/// SPEC §6.1 / §7.3 — the free/billable decision for one ack, as arithmetic.
-#[cfg(feature = "cloud")]
-fn step_pool_view(
-    remaining: u64,
-    is_contract: bool,
-) -> openobserve_synthetics::job_api::StepPoolView {
-    use openobserve_synthetics::job_api::StepPoolView;
-
-    if remaining == 0 {
-        // §7.3, E16/T31 — grant gone, so metered overage. A Free org never got
-        // here; its slot was skipped at the enqueue.
-        return StepPoolView::Spent;
-    }
-    if is_contract {
-        // §7.3, E18/T36 — *"never pool-gate"*. §7.4 needs the ack billable so
-        // the NoOp provider advances a step-denominated true-up.
-        return StepPoolView::NotApplicable;
-    }
-    StepPoolView::Funded
+    StepPoolGate::PoolGated
 }
 
 /// §8.1: a build without `cloud` has no pool, so every ack is `NotApplicable`.
 #[cfg(not(feature = "cloud"))]
-async fn resolve_step_pool(_org_id: &str) -> openobserve_synthetics::job_api::StepPoolViews {
-    openobserve_synthetics::job_api::StepPoolViews::uniform(
-        openobserve_synthetics::job_api::StepPoolView::NotApplicable,
-    )
+async fn resolve_step_pool(_org_id: &str) -> openobserve_synthetics::job_api::StepPoolGate {
+    openobserve_synthetics::job_api::StepPoolGate::NotApplicable
 }
 
 /// Applies the free-pool movement one ack owes — SPEC §6.3, item 2.3.
@@ -2056,26 +2027,36 @@ mod tests {
     }
 
     /// SPEC §6.1 / §7.3 — every grant state maps to exactly one answer, and the
-    /// wrong answer is invisible: `Funded` with the grant gone is free service;
-    /// `Spent`/`NotApplicable` with grant left invoices work §6.1 gave away.
+    /// wrong answer is invisible: `Funded` with nothing reserved is free
+    /// service; `Spent`/`NotApplicable` on a reserved run invoices work §6.1
+    /// gave away.
+    ///
+    /// The input is the job row's frozen reservation, NOT the pool's balance: a
+    /// grant holding a remainder smaller than one run reserves nothing and still
+    /// reads as "room left", which billed every such run free forever.
     #[cfg(feature = "cloud")]
     #[test]
     fn the_step_pool_view_is_spec_6_1_and_7_3() {
-        use openobserve_synthetics::job_api::StepPoolView;
+        use openobserve_synthetics::job_api::{StepPoolGate, StepPoolView};
 
-        use super::step_pool_view;
+        // The enqueue reserved, so the grant already paid for this run.
+        assert_eq!(StepPoolGate::PoolGated.view_for(1), StepPoolView::Funded);
+        assert_eq!(StepPoolGate::PoolGated.view_for(36), StepPoolView::Funded);
 
-        // The grant still has room.
-        assert_eq!(step_pool_view(1, false), StepPoolView::Funded);
-        assert_eq!(step_pool_view(10_000, false), StepPoolView::Funded);
+        // Reserved nothing ⇒ metered overage (E16/T31), whatever the pool's
+        // balance says now.
+        assert_eq!(StepPoolGate::PoolGated.view_for(0), StepPoolView::Spent);
+        assert_eq!(StepPoolGate::PoolGated.view_for(-1), StepPoolView::Spent);
 
-        // Spent ⇒ metered overage (E16/T31).
-        assert_eq!(step_pool_view(0, false), StepPoolView::Spent);
-
-        // A contract org with grant left is never pool-gated (E18/T36). It cannot
-        // be asked about a SPENT grant: `resolve_step_pool` short-circuits at
-        // `remaining == 0`, so `is_contract` is never computed there.
-        assert_eq!(step_pool_view(10_000, true), StepPoolView::NotApplicable);
+        // A contract org is never pool-gated (E18/T36), reservation or not.
+        assert_eq!(
+            StepPoolGate::NotApplicable.view_for(36),
+            StepPoolView::NotApplicable
+        );
+        assert_eq!(
+            StepPoolGate::NotApplicable.view_for(0),
+            StepPoolView::NotApplicable
+        );
     }
 
     /// No compiler checks that the two crates' directions map the right way

--- a/src/infra/src/table/entity/synthetics_jobs.rs
+++ b/src/infra/src/table/entity/synthetics_jobs.rs
@@ -31,6 +31,11 @@ pub struct Model {
     /// here rather than read live at ack: the ack clamps the probe's count at
     /// `steps_configured x (retries + 1)`, so an edit would reprice dispatched work.
     pub steps_configured: i32,
+    /// Steps the enqueue actually took out of the org's one-time grant — 0 when
+    /// gate 3's deduct was refused, when no pool gates this org, or on a private
+    /// venue. The ONLY record that the reservation happened, so the ack and the
+    /// reaper cannot disagree with the enqueue about it.
+    pub steps_reserved: i32,
     /// JSON blob of check metadata copied at enqueue time e.g. {"tags": ["prod"]}.
     pub metadata: String,
     /// JSON execution summaries written at ack time (no full step data — that's in the stream).
@@ -72,6 +77,7 @@ mod tests {
                     .to_string(),
             ),
             steps_configured: 14,
+            steps_reserved: 14,
             metadata: "{}".to_string(),
             result: None,
             started_at: None,
@@ -83,6 +89,7 @@ mod tests {
         assert_eq!(m.status, 0);
         assert_eq!(m.pool, "aws-browser");
         assert_eq!(m.steps_configured, 14);
+        assert_eq!(m.steps_reserved, 14);
         assert!(m.claimed_by.is_none());
     }
 }

--- a/src/infra/src/table/migration/m20260904_000001_add_steps_reserved_to_synthetics_jobs.rs
+++ b/src/infra/src/table/migration/m20260904_000001_add_steps_reserved_to_synthetics_jobs.rs
@@ -1,0 +1,109 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+use sea_orm_migration::prelude::*;
+
+/// New rows carry what the enqueue actually took: 0 whenever gate 3's deduct was
+/// refused, and the ack reads that as billable overage. Legacy rows are
+/// backfilled from `steps_configured` instead, so the handful of jobs in flight
+/// across the deploy stay free — the grant already paid for them, and billing
+/// them would charge a customer twice for the same steps.
+const NOT_RESERVED: i32 = 0;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+fn add_steps_reserved_statement() -> TableAlterStatement {
+    Table::alter()
+        .table(SyntheticsJobs::Table)
+        .add_column_if_not_exists(
+            ColumnDef::new(SyntheticsJobs::StepsReserved)
+                .integer()
+                .not_null()
+                .default(NOT_RESERVED),
+        )
+        .to_owned()
+}
+
+fn backfill_statement() -> UpdateStatement {
+    Query::update()
+        .table(SyntheticsJobs::Table)
+        .value(
+            SyntheticsJobs::StepsReserved,
+            Expr::col(SyntheticsJobs::StepsConfigured),
+        )
+        .and_where(Expr::col(SyntheticsJobs::StepsReserved).eq(NOT_RESERVED))
+        .to_owned()
+}
+
+fn drop_steps_reserved_statement() -> TableAlterStatement {
+    Table::alter()
+        .table(SyntheticsJobs::Table)
+        .drop_column(SyntheticsJobs::StepsReserved)
+        .to_owned()
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager.alter_table(add_steps_reserved_statement()).await?;
+        manager.exec_stmt(backfill_statement()).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager.alter_table(drop_steps_reserved_statement()).await
+    }
+}
+
+#[derive(DeriveIden)]
+enum SyntheticsJobs {
+    Table,
+    StepsConfigured,
+    StepsReserved,
+}
+
+#[cfg(test)]
+mod tests {
+    use collapse::*;
+
+    use super::*;
+
+    #[test]
+    fn postgres() {
+        collapsed_eq!(
+            &add_steps_reserved_statement().to_string(PostgresQueryBuilder),
+            r#"ALTER TABLE "synthetics_jobs" ADD COLUMN IF NOT EXISTS "steps_reserved" integer NOT NULL DEFAULT 0"#
+        );
+        collapsed_eq!(
+            &backfill_statement().to_string(PostgresQueryBuilder),
+            r#"UPDATE "synthetics_jobs" SET "steps_reserved" = "steps_configured" WHERE "steps_reserved" = 0"#
+        );
+    }
+
+    #[test]
+    fn mysql() {
+        collapsed_eq!(
+            &add_steps_reserved_statement().to_string(MysqlQueryBuilder),
+            r#"ALTER TABLE `synthetics_jobs` ADD COLUMN IF NOT EXISTS `steps_reserved` int NOT NULL DEFAULT 0"#
+        );
+    }
+
+    #[test]
+    fn sqlite() {
+        collapsed_eq!(
+            &add_steps_reserved_statement().to_string(SqliteQueryBuilder),
+            r#"ALTER TABLE "synthetics_jobs" ADD COLUMN "steps_reserved" integer NOT NULL DEFAULT 0"#
+        );
+    }
+}

--- a/src/infra/src/table/migration/mod.rs
+++ b/src/infra/src/table/migration/mod.rs
@@ -174,6 +174,7 @@ mod m20260825_000001_add_alert_pending_period_col;
 mod m20260825_000001_add_steps_configured_to_synthetics_jobs;
 mod m20260825_000001_create_status_page_custom_domains;
 mod m20260827_000001_drop_table_action_scripts;
+mod m20260904_000001_add_steps_reserved_to_synthetics_jobs;
 
 #[cfg(test)]
 pub(crate) async fn create_scheduled_jobs_for_test(
@@ -429,6 +430,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260825_000001_add_steps_configured_to_synthetics_jobs::Migration),
             Box::new(m20260825_000001_add_alert_pending_period_col::Migration),
             Box::new(m20260827_000001_drop_table_action_scripts::Migration),
+            Box::new(m20260904_000001_add_steps_reserved_to_synthetics_jobs::Migration),
             Box::new(m20260822_000001_create_status_pages_tables::Migration),
             Box::new(m20260825_000001_create_status_page_custom_domains::Migration),
         ]

--- a/src/infra/src/table/synthetics_jobs.rs
+++ b/src/infra/src/table/synthetics_jobs.rs
@@ -49,6 +49,11 @@ pub struct EnqueueParams<'a> {
     /// onto the row: the ack clamps the probe's count at `steps_configured x
     /// (retries + 1)`, so a live read would let an in-flight edit reprice work.
     pub steps_configured: i32,
+    /// What gate 3 actually deducted from the org's one-time grant, or 0 when it
+    /// deducted nothing — a refused deduct, an ungated org, a private venue.
+    /// Frozen because nothing else records it: the ack reads it to bill the run
+    /// free or as overage, and the reaper to size a refund.
+    pub steps_reserved: i32,
     /// Serialized `JobMetadata` — check-level context copied at enqueue time.
     pub metadata: &'a str,
 }
@@ -83,6 +88,8 @@ pub struct LeasedRow {
     /// Steps frozen at enqueue (1 for protocol checks). The ack's clamp ceiling
     /// comes from THIS, never the current check — see `EnqueueParams`.
     pub steps_configured: i32,
+    /// What the enqueue reserved from the grant, frozen — see `EnqueueParams`.
+    pub steps_reserved: i32,
     pub metadata: String,
 }
 
@@ -104,6 +111,9 @@ pub struct DeadLetteredRow {
     /// Steps frozen at enqueue — what the reservation was computed from. See
     /// `scheduled_ts` for why the reaper needs it.
     pub steps_configured: i32,
+    /// What the enqueue took out of the grant for this job, frozen — the number
+    /// the reaper gives back, and 0 when it took nothing.
+    pub steps_reserved: i32,
     /// Engine+device combos frozen onto this job (`None` for protocol checks) —
     /// the other half of `configured x combos`.
     pub browser_devices: Option<String>,
@@ -166,8 +176,8 @@ pub async fn enqueue<C: ConnectionTrait>(
         INSERT INTO synthetics_jobs
             (id, synthetics_id, synthetics_name, org_id, location, pool,
              scheduled_ts, valid_until, status, dispatch_attempts, run_id, browser_devices,
-             steps_configured, metadata)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 0, 0, $9, $10, $11, $12)
+             steps_configured, steps_reserved, metadata)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 0, 0, $9, $10, $11, $12, $13)
         ON CONFLICT (synthetics_id, location, scheduled_ts) DO NOTHING
     "#;
 
@@ -188,6 +198,7 @@ pub async fn enqueue<C: ConnectionTrait>(
                 .map(Value::from)
                 .unwrap_or(Value::from(None::<String>)),
             Value::from(p.steps_configured),
+            Value::from(p.steps_reserved),
             Value::from(p.metadata),
         ],
     ))
@@ -204,7 +215,7 @@ pub async fn get_by_id<C: ConnectionTrait>(
     let sql = r#"
         SELECT id, synthetics_id, synthetics_name, org_id, location, pool,
                scheduled_ts, valid_until, dispatch_attempts, run_id, browser_devices,
-               steps_configured, metadata
+               steps_configured, steps_reserved, metadata
         FROM synthetics_jobs
         WHERE id = $1
     "#;
@@ -232,6 +243,7 @@ pub async fn get_by_id<C: ConnectionTrait>(
                 run_id: row.try_get("", "run_id")?,
                 browser_devices: row.try_get("", "browser_devices")?,
                 steps_configured: row.try_get("", "steps_configured")?,
+                steps_reserved: row.try_get("", "steps_reserved")?,
                 metadata: row.try_get("", "metadata").unwrap_or_default(),
             })
         })
@@ -380,6 +392,7 @@ pub async fn lease_batch<C: ConnectionTrait>(
             run_id: m.run_id,
             browser_devices: m.browser_devices,
             steps_configured: m.steps_configured,
+            steps_reserved: m.steps_reserved,
             metadata: m.metadata,
         })
         .collect())
@@ -565,7 +578,8 @@ pub async fn dead_letter_expired<C: ConnectionTrait>(
     // the CAS can require the row not to have moved under us.
     let select_sql = r#"
         SELECT id, synthetics_id, synthetics_name, org_id, location, scheduled_ts,
-               steps_configured, browser_devices, dispatch_attempts, run_id, metadata, status
+               steps_configured, steps_reserved, browser_devices, dispatch_attempts, run_id,
+               metadata, status
         FROM synthetics_jobs
         WHERE (status = 1 AND lease_expires_at < $1 AND (dispatch_attempts >= $2 OR valid_until < $1))
            OR (status = 0 AND valid_until < $1)
@@ -608,6 +622,7 @@ pub async fn dead_letter_expired<C: ConnectionTrait>(
                     // if reached, `enqueue_reservation` floors it at 1 — the
                     // refund is short, never inverted.
                     steps_configured: row.try_get("", "steps_configured").unwrap_or_default(),
+                    steps_reserved: row.try_get("", "steps_reserved").unwrap_or_default(),
                     browser_devices: row.try_get("", "browser_devices").unwrap_or_default(),
                     dispatch_attempts,
                     run_id: row.try_get("", "run_id").ok()?,
@@ -965,6 +980,7 @@ mod tests {
                 r#"[{"execution_id":"3Fze001XX","engine":"chromium","device":"desktop"}]"#,
             ),
             steps_configured: 14,
+            steps_reserved: 28,
             metadata: r#"{"tags":["prod","checkout"]}"#,
         };
         assert_eq!(p.synthetics_id, "mon-1");
@@ -972,6 +988,7 @@ mod tests {
         assert_eq!(p.run_id, "3Fzn001XXXXXXXXXXXXXXXX");
         assert!(p.browser_devices.is_some());
         assert_eq!(p.steps_configured, 14);
+        assert_eq!(p.steps_reserved, 28);
     }
 
     #[test]
@@ -989,6 +1006,7 @@ mod tests {
             run_id: "3Fzn001XXXXXXXXXXXXXXXX".to_string(),
             browser_devices: None,
             steps_configured: 1,
+            steps_reserved: 1,
             metadata: "{}".to_string(),
         };
         assert_eq!(row.id, "2MNfNTxePfZ1pnY5gKVLkwsVRXv");
@@ -1040,6 +1058,7 @@ mod tests {
                 r#"[{"execution_id":"3Fze001XX","engine":"chromium","device":"desktop"}]"#,
             ),
             steps_configured,
+            steps_reserved: steps_configured,
             metadata: r#"{"tags":["prod"],"synthetic_type":"browser"}"#,
         }
     }

--- a/src/infra/src/table/trial_quota_usage.rs
+++ b/src/infra/src/table/trial_quota_usage.rs
@@ -15,13 +15,31 @@
 
 use sea_orm::{
     ColumnTrait, EntityTrait, QueryFilter, QuerySelect, TransactionTrait,
-    sea_query::{Expr, Func, OnConflict},
+    sea_query::{Expr, ExprTrait, Func, OnConflict, SimpleExpr},
 };
 
 use crate::{
     db::{get_orm_client_ro, get_orm_client_rw},
     table::entity::trial_quota_usage,
 };
+
+/// `usage_count + delta`, floored at zero.
+///
+/// The in-memory counter is a `u64` that saturates, the column is a signed
+/// `bigint` that does not: a refund of steps the deduct never took drove the row
+/// NEGATIVE, and `fold_db_records` then read it as zero on the next restart —
+/// handing the org back a one-time grant it had already spent. Both sides must
+/// clamp the same way or the two answers diverge with nothing to reconcile them.
+fn floored_count(delta: i64) -> SimpleExpr {
+    let bumped = || {
+        Expr::col((
+            trial_quota_usage::Entity,
+            trial_quota_usage::Column::UsageCount,
+        ))
+        .add(delta)
+    };
+    Expr::case(bumped().lt(0), 0).finally(bumped()).into()
+}
 
 /// Batch increment quota records by delta. Each tuple is (org_id, feature, delta).
 /// Upserts: if the row exists, adds delta to usage_count; otherwise inserts with
@@ -52,14 +70,7 @@ pub async fn batch_increment(records: Vec<(String, String, i64)>) -> Result<(), 
                     trial_quota_usage::Column::OrgId,
                     trial_quota_usage::Column::Feature,
                 ])
-                .value(
-                    trial_quota_usage::Column::UsageCount,
-                    Expr::col((
-                        trial_quota_usage::Entity,
-                        trial_quota_usage::Column::UsageCount,
-                    ))
-                    .add(delta),
-                )
+                .value(trial_quota_usage::Column::UsageCount, floored_count(delta))
                 .value(trial_quota_usage::Column::UpdatedAt, Expr::value(now))
                 .to_owned(),
             )

--- a/src/jobs/src/job/mod.rs
+++ b/src/jobs/src/job/mod.rs
@@ -322,7 +322,6 @@ fn synthetics_step_pool() -> Option<openobserve_synthetics::pool::StepPoolHooks>
     Some(openobserve_synthetics::pool::StepPoolHooks {
         try_deduct: openobserve_core::trial_quota::synthetics_steps_try_deduct,
         refund: openobserve_core::trial_quota::synthetics_steps_refund,
-        remaining: openobserve_core::trial_quota::synthetics_steps_remaining,
         dead_letter_refund: openobserve_core::trial_quota::synthetics_steps_dead_letter_refund,
     })
 }
@@ -1390,7 +1389,6 @@ mod tests {
         for hook in [
             "synthetics_steps_try_deduct",
             "synthetics_steps_refund",
-            "synthetics_steps_remaining",
             "synthetics_steps_dead_letter_refund",
         ] {
             assert_eq!(

--- a/src/synthetics/src/job_api.rs
+++ b/src/synthetics/src/job_api.rs
@@ -83,6 +83,11 @@ pub(crate) mod billing {
         /// FROZEN at enqueue. Per combo: the scheduler freezes
         /// `steps.len().max(1)` (`DueCheck::try_from`), not the fan-out product.
         pub steps_configured: i32,
+        /// FROZEN at enqueue: the steps gate 3 actually took out of the grant,
+        /// 0 when it took none. The reconcile gives back against THIS, never a
+        /// number recomputed from the definition — the two agree only while the
+        /// reservation succeeded.
+        pub steps_reserved: u32,
         /// FROZEN at enqueue — the engine+device combinations this one job runs
         /// sequentially. `None` for a protocol check.
         pub combos: Option<u32>,
@@ -315,6 +320,7 @@ pub(crate) mod billing {
             steps_defined: req.steps_defined,
             browser_ms: req.browser_ms,
             steps_configured: row.steps_configured,
+            steps_reserved: u32::try_from(row.steps_reserved).unwrap_or(0),
             combos: frozen_combos(row.browser_devices.as_deref()),
             retries: live_retries,
             now_us,
@@ -516,11 +522,10 @@ pub(crate) mod billing {
     /// input: an `error_source = "queue"` ack emits NOTHING **and** refunds the
     /// WHOLE reservation — no step ran, so none may be held against the grant.
     ///
-    /// Nothing records what the enqueue reserved, so "was this run pool-funded?"
-    /// is answered by the pool's state NOW. Both boundary cases are bounded by
-    /// one run and err towards leaving the pool alone: a grant exhausted between
-    /// enqueue and ack leaves an over-deduct unrefunded, and a limit raised
-    /// mid-run reconciles against a reservation that never happened.
+    /// "Was this run pool-funded?" is answered by `steps_reserved`, frozen by
+    /// the enqueue that deducted it, so a pool that moved between enqueue and
+    /// ack — exhausted by another check, or raised by an operator — cannot make
+    /// this ack reconcile against a reservation that never happened.
     pub(crate) fn pool_adjustment_for_ack(
         flags: BillingFlags,
         i: &BillingInputs<'_>,
@@ -541,7 +546,7 @@ pub(crate) mod billing {
             return None;
         }
 
-        let reserved = i.frozen_definition();
+        let reserved = i.steps_reserved;
 
         // The job never ran, so the whole reservation goes back. Checked BEFORE
         // `resolve_billable`: a queue-errored ack carries `steps_executed = 0`,
@@ -1095,33 +1100,36 @@ pub enum StepPoolView {
     Spent,
 }
 
-/// Both step grants as the caller resolved them. Two, because the caller cannot
-/// know a job's check type — that is frozen on the row `ack` itself reads — and
-/// browser and protocol draw on independent pools.
+/// Whether a pool gates this org's acks at all — the ONE thing the caller can
+/// answer and the job row cannot.
+///
+/// The free/billable split itself is NOT here: it is `steps_reserved`, frozen on
+/// the row by the enqueue that did or did not deduct. Asking the live pool
+/// instead billed a run as free whenever the grant still held a remainder too
+/// small to reserve — the reservation failed, the run went out as overage, and
+/// the ack called it funded anyway, forever, because a pool nothing deducts from
+/// never reaches zero.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct StepPoolViews {
-    pub browser: StepPoolView,
-    pub protocol: StepPoolView,
+pub enum StepPoolGate {
+    /// A one-time grant gates this org: the row's reservation decides.
+    PoolGated,
+    /// No pool is consulted — a build without `cloud`, a node with
+    /// `O2_SYNTHETICS_BILLING_ENABLED` off, or an **ExternalContract** org
+    /// (§7.3), whose acks must stay billable for the true-up.
+    ///
+    /// The default, so a build that never sets it bills rather than silently
+    /// consuming a grant it is not tracking.
+    #[default]
+    NotApplicable,
 }
 
-impl StepPoolViews {
-    /// Both sides the same — a build or node that consults no pool at all.
-    pub fn uniform(view: StepPoolView) -> Self {
-        Self {
-            browser: view,
-            protocol: view,
-        }
-    }
-
-    /// The grant this job spends from. `browser_devices` is written iff the check
-    /// is a browser check, and unlike the live `check_type` it cannot change under
-    /// an in-flight job.
-    #[cfg(feature = "cloud")]
-    fn for_job(&self, browser_devices: Option<&str>) -> StepPoolView {
-        if browser_devices.is_some() {
-            self.browser
-        } else {
-            self.protocol
+impl StepPoolGate {
+    /// How this ack bills, from the steps its enqueue actually reserved.
+    pub fn view_for(self, steps_reserved: i32) -> StepPoolView {
+        match self {
+            Self::NotApplicable => StepPoolView::NotApplicable,
+            Self::PoolGated if steps_reserved > 0 => StepPoolView::Funded,
+            Self::PoolGated => StepPoolView::Spent,
         }
     }
 }
@@ -1563,14 +1571,15 @@ fn stale_lease_response(
 /// notifications. Returns `run_complete = true` when all jobs in the run have
 /// acked.
 ///
-/// `pools` carries BOTH free step grants as the CALLER resolved them. Parameters
-/// rather than a global because a `OnceCell` installed from `init()` would be
-/// unset on the API nodes that serve acks; a required argument cannot be unset.
-/// Both, because only the row read below says which grant this job spends from.
+/// `gate` says only whether a pool gates this org. A parameter rather than a
+/// global because a `OnceCell` installed from `init()` would be unset on the API
+/// nodes that serve acks; a required argument cannot be unset. WHICH way the ack
+/// bills comes from the row's frozen `steps_reserved`, not from the pool's state
+/// now — see [`StepPoolGate`].
 pub async fn ack(
     req: AckRequest,
     token_org: &str,
-    pools: StepPoolViews,
+    gate: StepPoolGate,
 ) -> anyhow::Result<AckResponse> {
     let conn = get_orm_client_rw().await;
 
@@ -1733,9 +1742,9 @@ pub async fn ack(
         // number of super-cluster PUBLISHES, and this is a read.
         let sc = &ent.super_cluster;
         let region = (sc.enabled && !sc.region.is_empty()).then(|| sc.region.clone());
-        // The grant is chosen from the FROZEN row, so the reserve, the reconcile
-        // and this ack cannot disagree about which pool the job spends from.
-        let pool = pools.for_job(check.browser_devices.as_deref());
+        // Read from the FROZEN row, so the reserve, the reconcile and this ack
+        // cannot disagree about what the enqueue took.
+        let pool = gate.view_for(check.steps_reserved);
         let inputs =
             billing::inputs_from(&check, &req, synthetic.retries, venue, now_us, region, pool);
         // Built BEFORE `events_for_ack` consumes `inputs`. The two read the same
@@ -1758,8 +1767,8 @@ pub async fn ack(
     // `enterprise` would write usage rows onto every customer's own cluster.
     #[cfg(not(feature = "cloud"))]
     let (usage_events, pool_adjustment) = {
-        // `pools` is the caller's answer for grants this build does not have.
-        let _ = pools;
+        // `gate` is the caller's answer for a grant this build does not have.
+        let _ = gate;
         (Vec::new(), None)
     };
 
@@ -2108,6 +2117,10 @@ mod tests {
                 steps_defined: 0,
                 browser_ms: 0,
                 steps_configured: configured,
+                // The reservation gate 3 took for this run — `browser()` is the
+                // funded shape, and the tests that need a refused deduct set it
+                // to 0 themselves.
+                steps_reserved: super::enqueue_reservation(configured, Some(combos)),
                 combos: Some(combos),
                 retries,
                 now_us: NOW_US,
@@ -3409,6 +3422,7 @@ mod tests {
                 run_id: "run_1".to_string(),
                 browser_devices: Some("[]".to_string()),
                 steps_configured: 14,
+                steps_reserved: 14,
                 metadata: "{}".to_string(),
             }
         }

--- a/src/synthetics/src/pool.rs
+++ b/src/synthetics/src/pool.rs
@@ -39,15 +39,6 @@ pub struct StepPoolHooks {
     pub try_deduct: fn(org_id: &str, is_browser: bool, steps: u64) -> bool,
     /// Give `steps` back — the enqueue did not happen (E10/E11, T29).
     pub refund: fn(org_id: &str, is_browser: bool, steps: u64),
-    /// Steps left in the org's one-time grant — SPEC §6.1.
-    ///
-    /// Read by the REAPER, not the enqueue, to ask what neither side records:
-    /// *did* the enqueue reserve anything? Zero means the grant is spent, and
-    /// BOTH sides must read it the same way — the ack calls that state
-    /// [`crate::job_api::StepPoolView::Spent`] and does not reconcile, the
-    /// reaper does not refund. A job either acks or is reaped; it must not be
-    /// treated as funded by one path and unfunded by the other.
-    pub remaining: fn(org_id: &str, is_browser: bool) -> u64,
     /// Give back the reservation of a job that will NEVER ack — SPEC §6.3, E10.
     ///
     /// Idempotent, unlike [`Self::refund`]: applied at most once per

--- a/src/synthetics/src/reaper/mod.rs
+++ b/src/synthetics/src/reaper/mod.rs
@@ -276,65 +276,39 @@ enum DeadLetterRefund {
     /// The enqueue took nothing: unmetered node, private agent (§7.1 gate 2,
     /// E13), external contract (§7.3, E18), or a grant already spent (E16).
     NothingReserved,
-    /// The registry could not say whose hardware ran this job, so whether
-    /// anything was reserved is unknowable — see [`ReservationVerdict`].
-    VenueUnknown,
     Refunded(u64),
     /// This key had already been applied — not a failure, the grant has it back.
     AlreadyRefunded(u64),
 }
 
 /// Whether the ENQUEUE took anything out of the grant for a job that has now
-/// been dead-lettered, and how much — SPEC §7.1 gate 2 / §7.3, as pure
-/// arithmetic.
+/// been dead-lettered, and how much — SPEC §6.3, E10, item 2.3.
 ///
-/// Mirrors `scheduler::reserve_for_slot`, the only place a job is enqueued, and
-/// must keep mirroring it: the number refunded here has to be the number
-/// reserved there, computed the same way, or the grant drifts. The one input it
-/// cannot mirror is whether `try_deduct` succeeded — no column records it — so
-/// it reads the pool's state now, exactly as the ack does: `remaining == 0` is
-/// the ack's [`crate::job_api::StepPoolView::Spent`]. A job must not be treated
-/// as funded by one path and unfunded by the other.
+/// One column, read verbatim: `steps_reserved` is what
+/// `scheduler::reserve_for_slot` deducted, written by the same statement that
+/// enqueued the job. It replaces a mirror of that arithmetic that had to guess
+/// the one input it could not see — whether `try_deduct` succeeded — from the
+/// pool's balance now, which refunded `configured x combos` for jobs whose
+/// reservation had been REFUSED and drove `usage_count` negative.
 #[cfg(feature = "cloud")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReservationVerdict {
-    /// `configured x combos` came out of the grant and must go back.
+    /// This many steps came out of the grant and must go back.
     Reserved(u32),
     Nothing,
-    /// The registry could not answer. That failure is FLEET-WIDE, so refunding
-    /// on it would hand every free org steps back at once. Declining loses one
-    /// run's reservation, permanently under a one-time grant (§11 **F8**) —
-    /// hence the caller's `error` log (§9B.2 A5).
-    VenueUnknown,
 }
 
 #[cfg(feature = "cloud")]
 fn dead_letter_reservation(
     policy: crate::scheduler::PoolExhaustionPolicy,
-    venue: crate::job_api::billing::Venue,
-    remaining: u64,
-    steps_configured: i32,
-    combos: Option<u32>,
+    steps_reserved: i32,
 ) -> ReservationVerdict {
-    use crate::job_api::billing::Venue;
-
-    // §7.3 first, venue-independent: a contract org never attempts a reservation
-    // (E18/T36) and a spent grant means `try_deduct` failed at enqueue (E16/T31).
-    // Ahead of the registry, so an unreadable one is not a reported lost refund.
-    if !crate::scheduler::pool_reserves(policy) || remaining == 0 {
+    // A policy that never reserves cannot have reserved here either, whatever
+    // the column says (§7.3, E18/T36 — a contract org is never pool-gated).
+    if !crate::scheduler::pool_reserves(policy) || steps_reserved <= 0 {
         return ReservationVerdict::Nothing;
     }
-    match venue {
-        // §6.3's `configured x combos`, from the columns FROZEN on this job's
-        // row — never the live check, which may have been edited since (E5).
-        Venue::Public => ReservationVerdict::Reserved(crate::job_api::enqueue_reservation(
-            steps_configured,
-            combos,
-        )),
-        // §7.1 gate 2, E13/T17 — customer hardware: no deduct, so nothing back.
-        Venue::Private => ReservationVerdict::Nothing,
-        Venue::Unresolved => ReservationVerdict::VenueUnknown,
-    }
+    ReservationVerdict::Reserved(u32::try_from(steps_reserved).unwrap_or(u32::MAX))
 }
 
 /// The refund for one dead letter, with every read already done — SPEC §6.3,
@@ -356,8 +330,6 @@ fn refund_dead_letter_with(
         crate::pool::StepPoolHooks,
         crate::scheduler::PoolExhaustionPolicy,
     )>,
-    venue: crate::job_api::billing::Venue,
-    remaining: u64,
     row: &synthetics_jobs::DeadLetteredRow,
 ) -> DeadLetterRefund {
     // No pool on this node: an OSS build, `O2_SYNTHETICS_BILLING_ENABLED` off,
@@ -366,16 +338,9 @@ fn refund_dead_letter_with(
         return DeadLetterRefund::NothingReserved;
     };
 
-    let steps = match dead_letter_reservation(
-        policy,
-        venue,
-        remaining,
-        row.steps_configured,
-        crate::job_api::billing::frozen_combos(row.browser_devices.as_deref()),
-    ) {
+    let steps = match dead_letter_reservation(policy, row.steps_reserved) {
         ReservationVerdict::Reserved(steps) => u64::from(steps),
         ReservationVerdict::Nothing => return DeadLetterRefund::NothingReserved,
-        ReservationVerdict::VenueUnknown => return DeadLetterRefund::VenueUnknown,
     };
 
     // SPEC §6.3's MUST, and the SAME key the ack would have built: all four
@@ -400,30 +365,14 @@ fn refund_dead_letter_with(
 /// batch. See [`refund_dead_letter_with`] for the decision.
 #[cfg(feature = "cloud")]
 async fn refund_dead_letter(row: &synthetics_jobs::DeadLetteredRow) {
-    // Before the registry read, so an unmetered node — the default, since
-    // `O2_SYNTHETICS_BILLING_ENABLED` ships off — does no extra work here.
     let gate = crate::scheduler::resolve_pool_gate(&row.org_id).await;
-    let Some((hooks, _)) = gate else {
+    if gate.is_none() {
         return;
-    };
-    let venue = crate::job_api::billing::resolve_venue(&row.location).await;
-    let remaining = (hooks.remaining)(&row.org_id, row.browser_devices.is_some());
+    }
 
-    match refund_dead_letter_with(gate, venue, remaining, row) {
+    match refund_dead_letter_with(gate, row) {
         // The steady state for every paid, contract and private-venue job.
         DeadLetterRefund::NothingReserved => {}
-        DeadLetterRefund::VenueUnknown => {
-            // §9B.2 **A5** — an unappliable adjustment is an ERROR: under a
-            // one-time grant (§6.1) the loss is permanent and invisible.
-            tracing::error!(
-                synthetics_id = %row.synthetics_id,
-                org_id = %row.org_id,
-                job_id = %row.id,
-                location = %row.location,
-                "[synthetics reaper] dead letter: location is not in the registry, so its \
-                 free-pool reservation cannot be refunded — the grant keeps it permanently"
-            );
-        }
         DeadLetterRefund::Refunded(steps) => {
             tracing::info!(
                 synthetics_id = %row.synthetics_id,
@@ -549,7 +498,6 @@ mod pool_refund_tests {
         DeadLetterRefund, ReservationVerdict, dead_letter_reservation, refund_dead_letter_with,
     };
     use crate::{
-        job_api::billing::Venue,
         pool::StepPoolHooks,
         scheduler::{PoolExhaustionPolicy, PoolGate, reserve_for_slot},
     };
@@ -563,16 +511,15 @@ mod pool_refund_tests {
     static LAST_ORG: Mutex<String> = Mutex::new(String::new());
     static SEEN_KEYS: Mutex<Vec<String>> = Mutex::new(Vec::new());
     static POOL_ACCEPTS: AtomicBool = AtomicBool::new(true);
+    /// Gate 3 refusing — the state that made every later reservation fail while
+    /// the grant still reported a remainder.
+    static POOL_REFUSES_DEDUCT: AtomicBool = AtomicBool::new(false);
 
     fn fake_try_deduct(_org_id: &str, _is_browser: bool, _steps: u64) -> bool {
-        true
+        !POOL_REFUSES_DEDUCT.load(Ordering::Relaxed)
     }
 
     fn fake_refund(_org_id: &str, _is_browser: bool, _steps: u64) {}
-
-    fn fake_remaining(_org_id: &str, _is_browser: bool) -> u64 {
-        unreachable!("the pure decision takes `remaining` as data; the hook is only wiring")
-    }
 
     /// The real contract: apply at most once per key, report whether it moved.
     fn fake_dead_letter_refund(
@@ -599,7 +546,6 @@ mod pool_refund_tests {
     const FAKE: StepPoolHooks = StepPoolHooks {
         try_deduct: fake_try_deduct,
         refund: fake_refund,
-        remaining: fake_remaining,
         dead_letter_refund: fake_dead_letter_refund,
     };
 
@@ -608,6 +554,7 @@ mod pool_refund_tests {
         REFUNDED.store(0, Ordering::Relaxed);
         REFUND_CALLS.store(0, Ordering::Relaxed);
         POOL_ACCEPTS.store(true, Ordering::Relaxed);
+        POOL_REFUSES_DEDUCT.store(false, Ordering::Relaxed);
         LAST_KEY.lock().unwrap_or_else(|e| e.into_inner()).clear();
         LAST_ORG.lock().unwrap_or_else(|e| e.into_inner()).clear();
         SEEN_KEYS.lock().unwrap_or_else(|e| e.into_inner()).clear();
@@ -638,6 +585,7 @@ mod pool_refund_tests {
             location: "aws-us-east-1".to_string(),
             scheduled_ts: SLOT_TS,
             steps_configured: 14,
+            steps_reserved: 28,
             browser_devices: Some(TWO_COMBOS.to_string()),
             dispatch_attempts: 3,
             run_id: "3Fzn001XXXXXXXXXXXXXXXX".to_string(),
@@ -672,22 +620,16 @@ mod pool_refund_tests {
 
     /// **E10.** What a funded public slot reserved is what comes back.
     #[test]
-    fn a_reaped_job_gives_back_configured_times_combos() {
+    fn a_reaped_job_gives_back_what_the_enqueue_reserved() {
         assert_eq!(
-            dead_letter_reservation(
-                PoolExhaustionPolicy::SubscriptionRequired,
-                Venue::Public,
-                10_000,
-                14,
-                Some(2),
-            ),
+            dead_letter_reservation(PoolExhaustionPolicy::SubscriptionRequired, 28),
             ReservationVerdict::Reserved(28),
         );
     }
 
-    /// Not "28 == 28" twice: the enqueue's own `reserve_for_slot` runs over the
-    /// same inputs, so changing one formula and not the other fails here rather
-    /// than becoming a silent partial credit.
+    /// Not "28 == 28" twice: the enqueue's own `reserve_for_slot` produces the
+    /// number, and the reaper gives back the column it wrote, so a change to one
+    /// side fails here rather than becoming a silent partial credit.
     #[test]
     fn the_refund_is_the_same_number_the_enqueue_reserved() {
         let _guard = fake_pool();
@@ -709,10 +651,7 @@ mod pool_refund_tests {
             assert_eq!(
                 dead_letter_reservation(
                     PoolExhaustionPolicy::SubscriptionRequired,
-                    Venue::Public,
-                    10_000,
-                    steps_configured,
-                    combos,
+                    reserved as i32,
                 ),
                 ReservationVerdict::Reserved(reserved),
                 "the reaper must give back exactly what gate 3 took for \
@@ -721,84 +660,79 @@ mod pool_refund_tests {
         }
     }
 
-    /// **T17 / E13.** §7.1 gate 2 gives a private agent no deduct, so a refund
-    /// here would credit a grant the org never spent.
+    /// **T17 / E13.** §7.1 gate 2 gives a private agent no deduct, so its row
+    /// froze a zero reservation and a refund here would credit a grant the org
+    /// never spent.
     #[test]
     fn t17_a_private_venue_job_reserved_nothing_and_is_not_refunded() {
+        let _guard = fake_pool();
+        let (verdict, reserved) = reserve_for_slot(
+            gate(PoolExhaustionPolicy::SubscriptionRequired),
+            "acme",
+            14,
+            Some(2),
+            true,
+        );
+        assert_eq!(verdict, PoolGate::Run);
+        assert_eq!(reserved, 0);
         assert_eq!(
-            dead_letter_reservation(
-                PoolExhaustionPolicy::SubscriptionRequired,
-                Venue::Private,
-                10_000,
-                14,
-                Some(2),
-            ),
+            dead_letter_reservation(PoolExhaustionPolicy::SubscriptionRequired, reserved as i32),
             ReservationVerdict::Nothing,
         );
     }
 
     /// **T36 / E18.** A contract org is never pool-gated, so its enqueue never
-    /// reserved, whatever its grant looked like.
+    /// reserved — refused by the policy even if a row somehow carried a count.
     #[test]
     fn t36_a_contract_org_job_reserved_nothing_and_is_not_refunded() {
         assert_eq!(
-            dead_letter_reservation(
-                PoolExhaustionPolicy::AdditionalCreditsRequired,
-                Venue::Public,
-                10_000,
-                14,
-                Some(2),
-            ),
+            dead_letter_reservation(PoolExhaustionPolicy::AdditionalCreditsRequired, 28),
             ReservationVerdict::Nothing,
         );
     }
 
-    /// **T31 / E16.** A spent grant means `try_deduct` failed and the run went
-    /// out as metered overage holding nothing. The ack reads that state as
+    /// **T31 / E16.** An overage run's deduct was REFUSED, so its row froze 0
+    /// and the run went out holding nothing. The ack reads the same column as
     /// `StepPoolView::Spent` and does not reconcile; nor may the reaper refund.
     #[test]
     fn t31_an_overage_run_reserved_nothing_and_is_not_refunded() {
         assert_eq!(
-            dead_letter_reservation(
-                PoolExhaustionPolicy::MeteredOverage,
-                Venue::Public,
-                0,
-                14,
-                Some(2),
-            ),
+            dead_letter_reservation(PoolExhaustionPolicy::MeteredOverage, 0),
             ReservationVerdict::Nothing,
         );
     }
 
-    /// A registry that cannot answer is NOT a refund: the failure is fleet-wide,
-    /// so refunding on it would hand every free org steps back at once.
+    /// **The bug this column exists for.** A grant holding a remainder SMALLER
+    /// than one run reserves nothing and still reads as "room left". Sizing the
+    /// refund from the definition — as a mirror of the enqueue arithmetic had to
+    /// — gave back steps that were never taken, and drove `usage_count` below
+    /// zero, which the next restart read as a fresh grant.
     #[test]
-    fn an_unresolved_venue_is_not_refunded_and_is_reported() {
-        assert_eq!(
-            dead_letter_reservation(
-                PoolExhaustionPolicy::SubscriptionRequired,
-                Venue::Unresolved,
-                10_000,
-                14,
-                Some(2),
-            ),
-            ReservationVerdict::VenueUnknown,
+    fn a_run_the_grant_could_not_cover_is_not_refunded() {
+        let _guard = fake_pool();
+        POOL_REFUSES_DEDUCT.store(true, Ordering::Relaxed);
+        let (verdict, reserved) = reserve_for_slot(
+            gate(PoolExhaustionPolicy::MeteredOverage),
+            "acme",
+            14,
+            Some(2),
+            false,
         );
-    }
+        assert_eq!(
+            verdict,
+            PoolGate::RunAsOverage,
+            "an overage run still goes out"
+        );
+        assert_eq!(reserved, 0, "but it holds nothing");
 
-    /// …but §9B.2 **A5** pages on `VenueUnknown`, so an org that reserved
-    /// nothing anyway must not be reported as a lost refund.
-    #[test]
-    fn an_unresolved_venue_for_an_org_that_never_reserves_is_silent() {
-        for (policy, remaining) in [
-            (PoolExhaustionPolicy::AdditionalCreditsRequired, 10_000),
-            (PoolExhaustionPolicy::MeteredOverage, 0),
-        ] {
-            assert_eq!(
-                dead_letter_reservation(policy, Venue::Unresolved, remaining, 14, Some(2)),
-                ReservationVerdict::Nothing,
-            );
-        }
+        let mut row = dead_row(DeadLetterReason::Expired);
+        row.steps_reserved = reserved as i32;
+        assert_eq!(
+            refund_dead_letter_with(gate(PoolExhaustionPolicy::MeteredOverage), &row),
+            DeadLetterRefund::NothingReserved,
+        );
+        assert_eq!(REFUND_CALLS.load(Ordering::Relaxed), 0);
+        assert_eq!(REFUNDED.load(Ordering::Relaxed), 0);
     }
 
     /// All three reasons differ only in the message written to the results
@@ -809,12 +743,7 @@ mod pool_refund_tests {
             let _guard = fake_pool();
             let row = dead_row(reason);
             assert_eq!(
-                refund_dead_letter_with(
-                    gate(PoolExhaustionPolicy::SubscriptionRequired),
-                    Venue::Public,
-                    10_000,
-                    &row,
-                ),
+                refund_dead_letter_with(gate(PoolExhaustionPolicy::SubscriptionRequired), &row),
                 DeadLetterRefund::Refunded(28),
                 "{reason:?} terminates the job without an ack and must refund",
             );
@@ -834,12 +763,7 @@ mod pool_refund_tests {
     fn the_refund_key_is_the_key_the_ack_would_have_used() {
         let _guard = fake_pool();
         let row = dead_row(DeadLetterReason::Expired);
-        refund_dead_letter_with(
-            gate(PoolExhaustionPolicy::SubscriptionRequired),
-            Venue::Public,
-            10_000,
-            &row,
-        );
+        refund_dead_letter_with(gate(PoolExhaustionPolicy::SubscriptionRequired), &row);
         assert_eq!(
             last_key(),
             crate::job_api::adjustment_key("chk_1", "aws-us-east-1", SLOT_TS, &row.id),
@@ -848,12 +772,7 @@ mod pool_refund_tests {
         // a row scheduled for a different slot keys differently.
         let mut other = dead_row(DeadLetterReason::Expired);
         other.scheduled_ts = SLOT_TS + 300_000_000;
-        refund_dead_letter_with(
-            gate(PoolExhaustionPolicy::SubscriptionRequired),
-            Venue::Public,
-            10_000,
-            &other,
-        );
+        refund_dead_letter_with(gate(PoolExhaustionPolicy::SubscriptionRequired), &other);
         assert_ne!(
             last_key(),
             crate::job_api::adjustment_key("chk_1", "aws-us-east-1", SLOT_TS, &row.id)
@@ -868,15 +787,15 @@ mod pool_refund_tests {
         let row = dead_row(DeadLetterReason::AttemptsExhausted);
         let g = gate(PoolExhaustionPolicy::SubscriptionRequired);
         assert_eq!(
-            refund_dead_letter_with(g, Venue::Public, 10_000, &row),
+            refund_dead_letter_with(g, &row),
             DeadLetterRefund::Refunded(28),
         );
         assert_eq!(
-            refund_dead_letter_with(g, Venue::Public, 10_000, &row),
+            refund_dead_letter_with(g, &row),
             DeadLetterRefund::AlreadyRefunded(28),
         );
         assert_eq!(
-            refund_dead_letter_with(g, Venue::Public, 10_000, &row),
+            refund_dead_letter_with(g, &row),
             DeadLetterRefund::AlreadyRefunded(28),
         );
         assert_eq!(
@@ -891,7 +810,7 @@ mod pool_refund_tests {
         sibling.id = "2MNfNTxePfZ1pnY5gKVLkwsVRXw".to_string();
         sibling.location = "aws-eu-west-1".to_string();
         assert_eq!(
-            refund_dead_letter_with(g, Venue::Public, 10_000, &sibling),
+            refund_dead_letter_with(g, &sibling),
             DeadLetterRefund::Refunded(28),
         );
         assert_eq!(REFUNDED.load(Ordering::Relaxed), 56);
@@ -900,44 +819,23 @@ mod pool_refund_tests {
     /// The hook is not called at all, so it cannot burn an idempotency key.
     #[test]
     fn a_job_that_reserved_nothing_never_touches_the_pool() {
-        for (policy, venue, remaining) in [
-            (
-                PoolExhaustionPolicy::SubscriptionRequired,
-                Venue::Private,
-                10_000,
-            ),
-            (
-                PoolExhaustionPolicy::AdditionalCreditsRequired,
-                Venue::Public,
-                10_000,
-            ),
-            (PoolExhaustionPolicy::MeteredOverage, Venue::Public, 0),
+        for (policy, steps_reserved) in [
+            // A private agent (§7.1 gate 2) and a refused deduct (E16) both
+            // froze 0; a contract org is refused by the policy (E18).
+            (PoolExhaustionPolicy::SubscriptionRequired, 0),
+            (PoolExhaustionPolicy::MeteredOverage, 0),
+            (PoolExhaustionPolicy::AdditionalCreditsRequired, 28),
         ] {
             let _guard = fake_pool();
-            let row = dead_row(DeadLetterReason::Expired);
+            let mut row = dead_row(DeadLetterReason::Expired);
+            row.steps_reserved = steps_reserved;
             assert_eq!(
-                refund_dead_letter_with(gate(policy), venue, remaining, &row),
+                refund_dead_letter_with(gate(policy), &row),
                 DeadLetterRefund::NothingReserved,
             );
             assert_eq!(REFUND_CALLS.load(Ordering::Relaxed), 0);
             assert_eq!(REFUNDED.load(Ordering::Relaxed), 0);
         }
-    }
-
-    #[test]
-    fn an_unresolved_venue_reports_without_touching_the_pool() {
-        let _guard = fake_pool();
-        let row = dead_row(DeadLetterReason::NeverDispatched);
-        assert_eq!(
-            refund_dead_letter_with(
-                gate(PoolExhaustionPolicy::SubscriptionRequired),
-                Venue::Unresolved,
-                10_000,
-                &row,
-            ),
-            DeadLetterRefund::VenueUnknown,
-        );
-        assert_eq!(REFUND_CALLS.load(Ordering::Relaxed), 0);
     }
 
     /// FAIL OPEN. No pool resolved — an OSS build, the master switch off, or a
@@ -947,7 +845,7 @@ mod pool_refund_tests {
         let _guard = fake_pool();
         let row = dead_row(DeadLetterReason::Expired);
         assert_eq!(
-            refund_dead_letter_with(None, Venue::Public, 10_000, &row),
+            refund_dead_letter_with(None, &row),
             DeadLetterRefund::NothingReserved,
         );
         assert_eq!(REFUND_CALLS.load(Ordering::Relaxed), 0);
@@ -961,13 +859,9 @@ mod pool_refund_tests {
         let mut row = dead_row(DeadLetterReason::Expired);
         row.browser_devices = None;
         row.steps_configured = 1;
+        row.steps_reserved = 1;
         assert_eq!(
-            refund_dead_letter_with(
-                gate(PoolExhaustionPolicy::SubscriptionRequired),
-                Venue::Public,
-                10_000,
-                &row,
-            ),
+            refund_dead_letter_with(gate(PoolExhaustionPolicy::SubscriptionRequired), &row),
             DeadLetterRefund::Refunded(1),
         );
     }
@@ -981,12 +875,7 @@ mod pool_refund_tests {
         POOL_ACCEPTS.store(false, Ordering::Relaxed);
         let row = dead_row(DeadLetterReason::Expired);
         assert_eq!(
-            refund_dead_letter_with(
-                gate(PoolExhaustionPolicy::SubscriptionRequired),
-                Venue::Public,
-                10_000,
-                &row,
-            ),
+            refund_dead_letter_with(gate(PoolExhaustionPolicy::SubscriptionRequired), &row),
             DeadLetterRefund::AlreadyRefunded(28),
         );
         assert_eq!(REFUNDED.load(Ordering::Relaxed), 0);
@@ -995,42 +884,7 @@ mod pool_refund_tests {
         let mut next = dead_row(DeadLetterReason::Expired);
         next.id = "2MNfNTxePfZ1pnY5gKVLkwsVRXx".to_string();
         assert_eq!(
-            refund_dead_letter_with(
-                gate(PoolExhaustionPolicy::SubscriptionRequired),
-                Venue::Public,
-                10_000,
-                &next,
-            ),
-            DeadLetterRefund::Refunded(28),
-        );
-        assert_eq!(REFUNDED.load(Ordering::Relaxed), 28);
-    }
-
-    /// The registry read is the one input that can fail outright, and it fails
-    /// FLEET-WIDE: a database outage must not turn one lost refund into a batch.
-    #[test]
-    fn a_refund_that_cannot_be_worked_out_does_not_stop_the_batch() {
-        let _guard = fake_pool();
-        let unknown = dead_row(DeadLetterReason::Expired);
-        assert_eq!(
-            refund_dead_letter_with(
-                gate(PoolExhaustionPolicy::SubscriptionRequired),
-                Venue::Unresolved,
-                10_000,
-                &unknown,
-            ),
-            DeadLetterRefund::VenueUnknown,
-        );
-
-        let mut next = dead_row(DeadLetterReason::Expired);
-        next.id = "2MNfNTxePfZ1pnY5gKVLkwsVRXy".to_string();
-        assert_eq!(
-            refund_dead_letter_with(
-                gate(PoolExhaustionPolicy::SubscriptionRequired),
-                Venue::Public,
-                10_000,
-                &next,
-            ),
+            refund_dead_letter_with(gate(PoolExhaustionPolicy::SubscriptionRequired), &next),
             DeadLetterRefund::Refunded(28),
         );
         assert_eq!(REFUNDED.load(Ordering::Relaxed), 28);
@@ -1158,7 +1012,9 @@ mod pool_refund_tests {
         let whole = include_str!("mod.rs");
         let src = &whole[..whole.find("\n#[cfg(all(test,").unwrap()];
         assert_eq!(src.matches("(hooks.dead_letter_refund)(").count(), 1);
-        assert_eq!(src.matches("(hooks.remaining)(").count(), 1);
+        // And the size of that refund comes from the row, never from a pool read
+        // that would have to guess whether the enqueue reserved at all.
+        assert_eq!(src.matches("row.steps_reserved").count(), 1);
         // And the key is built once, from the row's own four columns.
         assert_eq!(src.matches("adjustment_key(").count(), 1);
         for field in [

--- a/src/synthetics/src/scheduler.rs
+++ b/src/synthetics/src/scheduler.rs
@@ -609,6 +609,11 @@ pub async fn run() {
                     // is `steps_configured x (retries + 1)`, and a journey edited
                     // mid-flight must not reprice dispatched work (§4.4.1, E5).
                     steps_configured: synthetic.steps_configured,
+                    // What gate 3 took, frozen with it: a refused deduct writes
+                    // 0, and the ack bills that run as overage instead of
+                    // re-deriving "was it funded?" from a pool that has moved
+                    // since (E16/T31).
+                    steps_reserved: i32::try_from(slot.reserved).unwrap_or(i32::MAX),
                     metadata: &metadata_json,
                 };
                 match synthetics_jobs::enqueue(db, p).await {
@@ -2389,12 +2394,8 @@ mod pool_gate_tests {
         REFUNDED.fetch_add(steps, Ordering::Relaxed);
     }
 
-    /// The enqueue path never reads these — they are the REAPER's (§6.3 / E10).
-    /// Unreachable, so a new dependency on them fails loudly, not quietly.
-    fn fake_remaining(_org_id: &str, _is_browser: bool) -> u64 {
-        unreachable!("gate 3 asks `try_deduct`, never the balance")
-    }
-
+    /// The enqueue path never reads this — it is the REAPER's (§6.3 / E10).
+    /// Unreachable, so a new dependency on it fails loudly, not quietly.
     fn fake_dead_letter_refund(_org_id: &str, _is_browser: bool, _steps: u64, _key: &str) -> bool {
         unreachable!("the keyed refund belongs to the reaper, not to the enqueue")
     }
@@ -2402,7 +2403,6 @@ mod pool_gate_tests {
     const FAKE: StepPoolHooks = StepPoolHooks {
         try_deduct: fake_try_deduct,
         refund: fake_refund,
-        remaining: fake_remaining,
         dead_letter_refund: fake_dead_letter_refund,
     };
 


### PR DESCRIPTION
## The bug

On alpha1 (org `3IrVEvq35bykArnKlYtQwtJJG2I`) synthetics browser steps never reach Stripe. 1152 executed browser steps in the usage stream, all as the non-billable `SyntheticsFreeBrowserSteps`; zero billable rows; the Stripe meter has no events for the customer.

The free/billable split was decided at ack time from the pool's balance (`resolve_step_pool` -> `remaining > 0`), not from whether the enqueue's reservation actually succeeded. Those two answers differ whenever the grant holds a remainder smaller than one run:

```
grant: limit 1, used 0  =>  remaining = 1
browser run costs 36 steps

ENQUEUE (scheduler)             ACK (api node)
try_deduct(36) -> REFUSED       remaining = 1 (> 0) -> Funded
reserved = 0                    -> SyntheticsFreeBrowserSteps (non-billable)
run dispatched as OVERAGE       -> Stripe never sees it
       |                                  ^
       +-- nothing deducted, remaining stays 1 forever --+
```

Self-locking: because the deduct always fails, `usage_count` never grows, `remaining` never reaches 0, and every run is billed free — permanently, for any org whose remaining grant is smaller than one run's step count.

The reaper mirrored the same guess (`reaper::dead_letter_reservation`, "the one input it cannot mirror is whether `try_deduct` succeeded"), so it refunded `configured x combos` for jobs that had reserved nothing. The in-memory counter saturates at 0, the DB column does not: `trial_quota_usage.usage_count` for that org sits at **-36**, and `fold_db_records` reads a negative as 0 on the next restart — handing the org back a one-time grant it had already spent.

## The fix

Record the reservation instead of re-deriving it.

- `synthetics_jobs.steps_reserved` (new column): what gate 3 actually deducted, 0 when it deducted nothing. Written by the same statement that enqueues the job.
- Ack: `StepPoolGate` (`PoolGated` / `NotApplicable`) says only whether a pool gates this org; the free/billable split comes from the row. The reconcile gives back `steps_reserved`, not a number recomputed from the frozen definition.
- Reaper: refunds `steps_reserved` verbatim. The venue lookup and the pool-balance read it used to guess with are gone, along with `ReservationVerdict::VenueUnknown` and the `remaining` pool hook.
- `trial_quota_usage.usage_count` is floored at 0 in SQL, so the column cannot diverge from the saturating in-memory counter again.

Legacy rows are backfilled from `steps_configured`: the handful of jobs in flight across the deploy stay free rather than being billed for steps the grant already paid for.

## Verification

OSS build: `cargo check --workspace --all-targets`, `cargo fmt --all` and the CI clippy command are clean; `openobserve-synthetics` lib tests 135 pass.

Enterprise-gated code WAS built and tested locally, by swapping in `Cargo.toml.openobserve` against an `o2-enterprise` worktree at `origin/main` (swap not committed):

- `openobserve-synthetics --features cloud`: 216 pass, 3 fail — `the_master_switch_off_emits_nothing`, `the_master_switch_off_moves_no_pool_at_all` and `both_flag_positions_are_supported_and_the_two_flags_are_independent`. All three fail identically on a clean `origin/main` in the same pairing: their `DARK` `BillingFlags` is now byte-identical to `LIVE`, so the assertions no longer test a switch. Pre-existing, untouched here.
- `infra --features cloud`: 1492 pass.
- `openobserve-core`, `openobserve-jobs`, `openobserve-api-management` under `--features cloud` could NOT be built locally: the `proto` crate fails in that pairing with `cannot find profiles in tonic`, and does so on a clean `origin/main` too. Their changes are small (one hook field removed, `resolve_step_pool` rewritten) and CI's paired build covers them.

New/updated tests:

- `a_run_the_grant_could_not_cover_is_not_refunded` reproduces the alpha1 state end to end: gate 3 refuses, the run is dispatched as overage, and the reaper refunds nothing.
- `the_refund_is_the_same_number_the_enqueue_reserved` now compares the reaper against `reserve_for_slot`'s own output rather than a re-derivation.
- `the_step_pool_view_is_spec_6_1_and_7_3` asserts the split off the frozen reservation, including `steps_reserved = 0` while the pool still reports a remainder.
- `t17_a_private_venue_job_reserved_nothing_and_is_not_refunded` drives the private-venue case through `reserve_for_slot` instead of asserting on a mirrored constant.

## Alpha1 cleanup after deploy

`trial_quota_usage` for that org needs its negative row corrected once, e.g. `UPDATE trial_quota_usage SET usage_count = 0 WHERE org_id = '...' AND feature = 'synthetics_browser_steps' AND usage_count < 0;` (the code change stops it recurring but does not repair the existing row).
