### PR TITLE
ci: run bug-fix regression twice daily at 11 PM & 5 AM IST

### DIFF
--- a/.github/workflows/playwright_bugfix_regression.yml
+++ b/.github/workflows/playwright_bugfix_regression.yml
@@ -2,8 +2,9 @@ name: Playwright Bug-Fix Regression Tests
 
 on:
   schedule:
-    # Once a day, after the previous day's merges and before either team starts (08:00 Beijing, 05:30 IST).
-    - cron: '0 0 * * *'
+    # Twice a day, bracketing the IST workday: 11:00 PM IST (17:30 UTC) and 5:00 AM IST (23:30 UTC).
+    - cron: '30 17 * * *'  # 11:00 PM IST
+    - cron: '30 23 * * *'  # 5:00 AM IST
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Schedules the Playwright Bug-Fix Regression workflow to run **twice a day**, bracketing the IST workday: **11:00 PM IST** (`30 17 * * *` = 17:30 UTC) and **5:00 AM IST** (`30 23 * * *` = 23:30 UTC). Replaces the single 05:30 IST cron; `workflow_dispatch` kept. Paired with the same change in o2-enterprise (same branch).