### PR TITLE
chore: assign third-party PRs to Ashish instead of hengfeiyang

### DIFF
--- a/.github/workflows/auto-assign-metadata.yml
+++ b/.github/workflows/auto-assign-metadata.yml
@@ -233,7 +233,7 @@ jobs:
             && echo "Assigned simranquirky to stranger issue #$NUMBER" \
             || echo "::warning::Could not assign to stranger issue #$NUMBER"
 
-      # ── Stranger: assign PR to hengfeiyang + label as community (label skips bots) ──
+      # ── Stranger: assign PR to Ashish + label as community (label skips bots) ──
       - name: Assign and label stranger PR
         if: github.event_name == 'pull_request_target' && steps.classify.outputs.category == 'stranger'
         env:
@@ -242,8 +242,8 @@ jobs:
           NUMBER: ${{ github.event.pull_request.number }}
           USER_TYPE: ${{ github.event.pull_request.user.type }}
         run: |
-          gh pr edit "$NUMBER" --add-assignee "hengfeiyang" \
-            && echo "Assigned hengfeiyang to stranger PR #$NUMBER" \
+          gh pr edit "$NUMBER" --add-assignee "oasisk" \
+            && echo "Assigned oasisk to stranger PR #$NUMBER" \
             || echo "::warning::Could not assign to stranger PR #$NUMBER"
           if [ "$USER_TYPE" != "Bot" ]; then
             gh pr edit "$NUMBER" --add-label "community" \


### PR DESCRIPTION
## What

In `auto-assign-metadata.yml`, stranger (non-org-member) PRs are now assigned to `oasisk` (Ashish Kolhe) instead of `hengfeiyang`.

## Why

All community PRs were landing on `hengfeiyang`. Moving the assignment so community PR triage sits with a single dedicated owner.

## Notes for reviewers

- Only the **PR** branch changed. Stranger **issues** still assign to `simranquirky` (unchanged).
- `playwright_bugfix_regression.yml`'s `NOTIFY` list is a separate regression-failure notification and was intentionally left alone.
- This only affects PRs opened/updated from now on — existing PRs already assigned to `hengfeiyang` are not reassigned by this workflow.