### PR TITLE
feat: backport Tantivy footer cache [v0.40]

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1582,6 +1582,12 @@ pub struct Limit {
     )]
     pub inverted_index_result_cache_max_entry_size: usize,
     #[env_config(
+        name = "ZO_INVERTED_INDEX_FOOTER_CACHE_MAX_SIZE",
+        default = 0, // MB, default is 5% of total memory, clamped to 100-1024 MB
+        help = "Maximum memory size in MB for the Tantivy and Puffin footer cache. Higher values allow caching more file footers but increase memory usage."
+    )]
+    pub inverted_index_footer_cache_max_size: usize,
+    #[env_config(
         name = "ZO_INVERTED_INDEX_SKIP_THRESHOLD",
         default = 35,
         help = "If the inverted index returns row_id more than this threshold(%), it will skip the inverted index."
@@ -2842,6 +2848,14 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
     if cfg.limit.query_default_limit == 0 {
         cfg.limit.query_default_limit = 1000;
+    }
+
+    if cfg.limit.inverted_index_footer_cache_max_size == 0 {
+        cfg.limit.inverted_index_footer_cache_max_size =
+            ((cfg.limit.mem_total as f64 / SIZE_IN_MB * 0.05) as usize).clamp(100, 1024)
+                * (SIZE_IN_MB as usize);
+    } else {
+        cfg.limit.inverted_index_footer_cache_max_size *= SIZE_IN_MB as usize;
     }
     Ok(())
 }

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -1394,6 +1394,88 @@ pub static QUERY_AGGREGATION_CACHE_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// metrics for generic bytes cache
+pub static BYTES_CACHE_MEMORY_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "bytes_cache_memory_size",
+            "Total memory size (bytes) of a bytes cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["tag"],
+    )
+    .expect("Metric created")
+});
+
+pub static BYTES_CACHE_ENTRY_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "bytes_cache_entry_count",
+            "Number of entries in a bytes cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["tag"],
+    )
+    .expect("Metric created")
+});
+
+pub static BYTES_CACHE_GC_TIME: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
+            "bytes_cache_gc_time",
+            "Time spent per GC run for a bytes cache",
+        )
+        .namespace(NAMESPACE)
+        .buckets(vec![
+            0.2, 0.5, 1.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0,
+        ])
+        .const_labels(create_const_labels()),
+        &["tag"],
+    )
+    .expect("Metric created")
+});
+
+pub static BYTES_CACHE_GC_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "bytes_cache_gc_count",
+            "Total number of GC runs of a bytes cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["tag"],
+    )
+    .expect("Metric created")
+});
+
+pub static BYTES_CACHE_HITS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "bytes_cache_hits_total",
+            "Total number of hits of a bytes cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["tag"],
+    )
+    .expect("Metric created")
+});
+
+pub static BYTES_CACHE_MISS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "bytes_cache_miss_total",
+            "Total number of misses of a bytes cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["tag"],
+    )
+    .expect("Metric created")
+});
+
 // Tokio runtime metrics - consolidated into fewer metrics with different labels
 pub static TOKIO_RUNTIME_TASKS: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
@@ -2037,6 +2119,26 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(TANTIVY_RESULT_CACHE_HITS_TOTAL.clone()))
+        .expect("Metric registered");
+
+    // metrics for generic bytes cache
+    registry
+        .register(Box::new(BYTES_CACHE_MEMORY_SIZE.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(BYTES_CACHE_ENTRY_COUNT.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(BYTES_CACHE_GC_TIME.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(BYTES_CACHE_GC_COUNT.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(BYTES_CACHE_HITS_TOTAL.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(BYTES_CACHE_MISS_TOTAL.clone()))
         .expect("Metric registered");
 
     // tokio runtime metrics

--- a/src/infra/src/cache/bytes_cache.rs
+++ b/src/infra/src/cache/bytes_cache.rs
@@ -1,0 +1,211 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    collections::VecDeque,
+    sync::atomic::{AtomicI64, Ordering},
+    time::Instant,
+};
+
+use bytes::Bytes;
+use config::{RwHashMap, metrics};
+
+// NOTE: for this cache, if you insert a key that already exists,
+// it will drop the second key and value
+pub struct BytesCache {
+    tag: String,
+    readers: RwHashMap<String, Bytes>,
+    cacher: parking_lot::Mutex<VecDeque<String>>,
+    max_bytes: usize,
+    current_memory: AtomicI64,
+}
+
+impl BytesCache {
+    pub fn new(max_bytes: usize, tag: String) -> Self {
+        Self {
+            tag,
+            readers: RwHashMap::default(),
+            cacher: parking_lot::Mutex::new(VecDeque::new()),
+            max_bytes,
+            current_memory: AtomicI64::new(0),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<Bytes> {
+        match self.readers.get(key) {
+            Some(r) => {
+                metrics::BYTES_CACHE_HITS_TOTAL
+                    .with_label_values(&[&self.tag])
+                    .inc();
+                Some(r.clone())
+            }
+            None => {
+                metrics::BYTES_CACHE_MISS_TOTAL
+                    .with_label_values(&[&self.tag])
+                    .inc();
+                None
+            }
+        }
+    }
+
+    pub fn put(&self, key: String, value: Bytes) {
+        let value_len = (value.len() + key.len() * 2) as i64;
+
+        {
+            let mut w = self.cacher.lock();
+            // NOTE: if key already exists, drop the second key and value
+            if self.readers.contains_key(&key) {
+                return;
+            }
+            w.push_back(key.clone());
+            self.readers.insert(key, value);
+
+            self.current_memory.fetch_add(value_len, Ordering::Relaxed);
+            metrics::BYTES_CACHE_ENTRY_COUNT
+                .with_label_values(&[&self.tag])
+                .inc();
+            metrics::BYTES_CACHE_MEMORY_SIZE
+                .with_label_values(&[&self.tag])
+                .add(value_len);
+        }
+
+        // GC: evict oldest entries if over memory limit
+        if self.current_memory.load(Ordering::Relaxed) > self.max_bytes as i64 {
+            self.evict();
+        }
+    }
+
+    fn evict(&self) {
+        let start = Instant::now();
+        let mut w = self.cacher.lock();
+        loop {
+            if self.current_memory.load(Ordering::Relaxed) <= self.max_bytes as i64 || w.is_empty()
+            {
+                break;
+            }
+            let batch = (w.len() / 20).max(1);
+            let mut removed_total = 0i64;
+            let mut removed_count = 0i64;
+            for k in w.drain(0..batch) {
+                if let Some((_, removed)) = self.readers.remove(&k) {
+                    removed_total += (removed.len() + k.len() * 2) as i64;
+                    removed_count += 1;
+                }
+            }
+            self.current_memory
+                .fetch_sub(removed_total, Ordering::Relaxed);
+            metrics::BYTES_CACHE_MEMORY_SIZE
+                .with_label_values(&[&self.tag])
+                .sub(removed_total);
+            metrics::BYTES_CACHE_ENTRY_COUNT
+                .with_label_values(&[&self.tag])
+                .sub(removed_count);
+        }
+        metrics::BYTES_CACHE_GC_COUNT
+            .with_label_values(&[&self.tag])
+            .inc();
+        let elapsed = start.elapsed().as_millis() as f64;
+        metrics::BYTES_CACHE_GC_TIME
+            .with_label_values(&[&self.tag])
+            .observe(elapsed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_max_size_limit_evicts_oldest_entries() {
+        let cache = BytesCache::new(100, "test".to_string());
+
+        // Insert entries that exceed the max_bytes limit
+        // Each key is 5 chars, value is 90 bytes -> memory = 90 + 5*2 = 100
+        cache.put("key-1".to_string(), Bytes::from(vec![0u8; 90]));
+        // Total: 100, right at the limit — no eviction
+        assert!(cache.get("key-1").is_some());
+
+        // This pushes memory over the limit -> should evict key-1
+        cache.put("key-2".to_string(), Bytes::from(vec![1u8; 90]));
+        // key-1 should be evicted (oldest), key-2 should remain
+        assert!(
+            cache.get("key-1").is_none(),
+            "oldest entry should be evicted"
+        );
+        assert!(cache.get("key-2").is_some(), "newest entry should remain");
+    }
+
+    #[test]
+    fn test_max_size_limit_memory_stays_below_limit() {
+        let cache = BytesCache::new(200, "test".to_string());
+
+        // Insert many small entries until memory exceeds the limit
+        for i in 0..100 {
+            cache.put(format!("key-{i}"), Bytes::from(vec![0u8; 50]));
+        }
+
+        // After eviction, current memory should be <= max_bytes
+        let mem = cache.current_memory.load(Ordering::Relaxed);
+        assert!(mem <= 200, "memory {mem} should not exceed max_bytes 200");
+    }
+
+    #[test]
+    fn test_duplicate_key_does_not_increase_memory() {
+        let cache = BytesCache::new(500, "test".to_string());
+
+        cache.put("dup".to_string(), Bytes::from(vec![0u8; 100]));
+        let mem_after_first = cache.current_memory.load(Ordering::Relaxed);
+
+        // Inserting the same key again should be a no-op
+        cache.put("dup".to_string(), Bytes::from(vec![0u8; 100]));
+        let mem_after_second = cache.current_memory.load(Ordering::Relaxed);
+
+        assert_eq!(
+            mem_after_first, mem_after_second,
+            "duplicate key should not increase memory"
+        );
+    }
+
+    #[test]
+    fn test_eviction_stops_when_below_limit() {
+        let cache = BytesCache::new(300, "test".to_string());
+
+        // Insert enough entries to trigger eviction
+        for i in 0..10 {
+            cache.put(format!("k{i}"), Bytes::from(vec![0u8; 100]));
+        }
+
+        let remaining = cache.current_memory.load(Ordering::Relaxed);
+        assert!(
+            remaining <= 300,
+            "eviction should bring memory {remaining} within limit 300"
+        );
+
+        // The newest entries should still be present
+        assert!(cache.get("k9").is_some(), "newest entry should survive");
+    }
+
+    #[test]
+    fn test_zero_max_bytes_evicts_all() {
+        let cache = BytesCache::new(0, "test".to_string());
+
+        cache.put("key".to_string(), Bytes::from(vec![0u8; 10]));
+        assert!(
+            cache.get("key").is_none(),
+            "entry should be evicted immediately"
+        );
+        assert_eq!(cache.current_memory.load(Ordering::Relaxed), 0);
+    }
+}

--- a/src/infra/src/cache/mod.rs
+++ b/src/infra/src/cache/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+pub mod bytes_cache;
 pub mod file_data;
 pub mod meta;
 pub mod stats;

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -775,7 +775,7 @@ async fn search_tantivy_index(
         )
         .await?,
     );
-    let footer_cache = FooterCache::from_directory(puffin_dir.clone()).await?;
+    let footer_cache = FooterCache::from_directory(puffin_dir.clone(), &ttv_file_name).await?;
     let cache_dir = CachingDirectory::new_with_cacher(puffin_dir, Arc::new(footer_cache));
     let reader_directory: Box<dyn Directory> = Box::new(cache_dir);
 

--- a/src/service/tantivy/puffin/reader.rs
+++ b/src/service/tantivy/puffin/reader.rs
@@ -16,9 +16,10 @@
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow, ensure};
-use bytes::Buf;
+use bytes::Bytes;
 
 use super::*;
+use crate::service::tantivy::puffin_directory::footer_cache::FOOTER_DATA_CACHE;
 
 #[derive(Debug)]
 pub struct PuffinBytesReader {
@@ -119,7 +120,36 @@ impl PuffinFooterBytesReader {
 
 impl PuffinFooterBytesReader {
     async fn parse(mut self) -> Result<PuffinMeta> {
-        // read footer
+        // the location is unique key for the footer cache
+        let cache_key = format!("puffin_footer_{}", self.source.location);
+
+        let payload = match FOOTER_DATA_CACHE.get(&cache_key) {
+            Some(cached) => {
+                // Combined cache: first FOOTER_SIZE bytes = footer tail, rest = payload
+                let footer = cached.slice(0..FOOTER_SIZE as usize);
+                let payload = cached.slice(FOOTER_SIZE as usize..);
+                self.parse_footer_metadata(&footer)?;
+                payload
+            }
+            None => {
+                let footer = self.read_footer_metadata().await?;
+                let payload = self.read_payload().await?;
+                let mut combined = Vec::with_capacity(footer.len() + payload.len());
+                combined.extend_from_slice(&footer);
+                combined.extend_from_slice(&payload);
+                FOOTER_DATA_CACHE.put(cache_key, Bytes::from(combined));
+                payload
+            }
+        };
+
+        self.metadata = Some(self.parse_payload(&payload.slice(MAGIC_SIZE as usize..))?);
+        self.validate_payload()?;
+
+        Ok(self.metadata.unwrap())
+    }
+
+    /// Read the footer tail and populate flags + payload_size. Returns the raw footer bytes.
+    async fn read_footer_metadata(&mut self) -> Result<Bytes> {
         if self.source.size < FOOTER_SIZE {
             return Err(anyhow!(
                 "Unexpected footer size: expected size {} vs actual size {}",
@@ -134,34 +164,32 @@ impl PuffinFooterBytesReader {
         )
         .await?;
 
+        self.parse_footer_metadata(&footer)?;
+        Ok(footer)
+    }
+
+    /// Parse footer metadata from in-memory bytes. Sets flags and payload_size on self.
+    fn parse_footer_metadata(&mut self, footer: &[u8]) -> Result<()> {
         // check the footer magic
         ensure!(
-            footer
-                .slice((FOOTER_SIZE - MAGIC_SIZE) as usize..FOOTER_SIZE as usize)
-                .to_vec()
-                == MAGIC,
+            footer[(FOOTER_SIZE - MAGIC_SIZE) as usize..FOOTER_SIZE as usize].to_vec() == MAGIC,
             anyhow!("Footer MAGIC mismatch")
         );
 
         // check the flags
         let mut flags = [0u8; 4];
-        footer
-            .slice(
-                (FOOTER_SIZE - MAGIC_SIZE - FLAGS_SIZE) as usize
-                    ..(FOOTER_SIZE - MAGIC_SIZE) as usize,
-            )
-            .copy_to_slice(&mut flags);
+        flags.copy_from_slice(
+            &footer[(FOOTER_SIZE - MAGIC_SIZE - FLAGS_SIZE) as usize
+                ..(FOOTER_SIZE - MAGIC_SIZE) as usize],
+        );
         self.flags = PuffinFooterFlags::from_bits(u32::from_le_bytes(flags))
             .ok_or_else(|| anyhow!("Error parsing Puffin flags from bytes"))?;
 
         // check the payload size
         let mut payload_size = [0u8; 4];
-        footer
-            .slice(0..FOOTER_PAYLOAD_SIZE_SIZE as usize)
-            .copy_to_slice(&mut payload_size);
+        payload_size.copy_from_slice(&footer[0..FOOTER_PAYLOAD_SIZE_SIZE as usize]);
         self.payload_size = i32::from_le_bytes(payload_size) as u64;
 
-        // read the payload
         if self.source.size < FOOTER_SIZE + self.payload_size {
             return Err(anyhow!(
                 "Unexpected payload size: expected size {} vs actual size {}",
@@ -169,24 +197,29 @@ impl PuffinFooterBytesReader {
                 self.source.size
             ));
         }
-        let payload = infra::cache::storage::get_range(
+
+        Ok(())
+    }
+
+    /// Read the payload region from storage. Requires self.payload_size to be set first.
+    async fn read_payload(&self) -> Result<Bytes> {
+        match infra::cache::storage::get_range(
             &self.account,
             &self.source.location,
             (self.source.size - FOOTER_SIZE - self.payload_size - MAGIC_SIZE)
                 ..(self.source.size - FOOTER_SIZE),
         )
-        .await?;
-
-        // check the footer magic
-        ensure!(
-            payload.slice(0..MAGIC_SIZE as usize).to_vec() == MAGIC,
-            anyhow!("Footer MAGIC mismatch")
-        );
-
-        self.metadata = Some(self.parse_payload(&payload.slice(MAGIC_SIZE as usize..))?);
-        self.validate_payload()?;
-
-        Ok(self.metadata.unwrap())
+        .await
+        {
+            Ok(payload) => {
+                ensure!(
+                    payload.slice(0..MAGIC_SIZE as usize).to_vec() == MAGIC,
+                    anyhow!("Footer MAGIC mismatch")
+                );
+                Ok(payload)
+            }
+            Err(e) => Err(anyhow!("Error reading footer payload: {e}")),
+        }
     }
 
     fn parse_payload(&self, bytes: &[u8]) -> Result<PuffinMeta> {
@@ -241,6 +274,36 @@ mod tests {
             e_tag: None,
             version: None,
         }
+    }
+
+    #[tokio::test]
+    async fn test_puffin_footer_cache_hit_without_storage() {
+        let metadata = PuffinMeta {
+            blobs: vec![],
+            properties: HashMap::new(),
+        };
+        let payload = serde_json::to_vec(&metadata).unwrap();
+        let mut source = create_mock_object_meta(0);
+        source.location = Path::from("test/cached-puffin-footer");
+        source.size = MAGIC_SIZE * 2 + payload.len() as u64 + FOOTER_SIZE;
+        let mut cached = Vec::new();
+        cached.extend_from_slice(&(payload.len() as i32).to_le_bytes());
+        cached.extend_from_slice(&PuffinFooterFlags::DEFAULT.bits().to_le_bytes());
+        cached.extend_from_slice(&MAGIC);
+        cached.extend_from_slice(&MAGIC);
+        cached.extend_from_slice(&payload);
+        FOOTER_DATA_CACHE.put(
+            format!("puffin_footer_{}", source.location),
+            Bytes::from(cached),
+        );
+
+        // No object exists at this path; parsing must use the cached footer and payload.
+        let parsed = PuffinFooterBytesReader::new("test".to_string(), Arc::new(source))
+            .parse()
+            .await
+            .unwrap();
+        assert!(parsed.blobs.is_empty());
+        assert!(parsed.properties.is_empty());
     }
 
     #[test]

--- a/src/service/tantivy/puffin_directory/footer_cache.rs
+++ b/src/service/tantivy/puffin_directory/footer_cache.rs
@@ -17,16 +17,24 @@ use std::{
     collections::HashMap,
     ops::Range,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 use byteorder::ByteOrder;
 use bytes::Bytes;
+use infra::cache::bytes_cache::BytesCache;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tantivy::{Directory, ReloadPolicy, directory::OwnedBytes};
 
 use super::{EMPTY_FILE_EXT, FOOTER_CACHE, caching_directory::CachingDirectory};
+
+pub(crate) static FOOTER_DATA_CACHE: LazyLock<BytesCache> = LazyLock::new(|| {
+    let max_size = config::get_config()
+        .limit
+        .inverted_index_footer_cache_max_size;
+    BytesCache::new(max_size, "tantivy_footer_cache".to_string())
+});
 
 const FOOTER_CACHE_VERSION: u32 = 1;
 const FOOTER_VERSION_LEN: usize = 4;
@@ -156,10 +164,20 @@ impl FooterCache {
         })
     }
 
-    pub(crate) async fn from_directory(source: Arc<dyn Directory>) -> tantivy::Result<Self> {
+    pub(crate) async fn from_directory(
+        source: Arc<dyn Directory>,
+        cache_key: &str,
+    ) -> tantivy::Result<Self> {
+        if let Some(cached) = FOOTER_DATA_CACHE.get(cache_key) {
+            return Self::from_bytes(OwnedBytes::new(cached.to_vec()));
+        }
         let path = std::path::Path::new(FOOTER_CACHE);
         let file = source.get_file_handle(path)?;
         let data = file.read_bytes_async(0..file.len()).await?;
+        FOOTER_DATA_CACHE.put(
+            cache_key.to_string(),
+            Bytes::copy_from_slice(data.as_slice()),
+        );
         Self::from_bytes(data)
     }
 }
@@ -616,10 +634,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_footer_cache_reuses_bytes_across_directories() {
+        let source = Arc::new(RamDirectory::create());
+        let cache = FooterCache::new();
+        let path = PathBuf::from("cached.term");
+        cache.put_slice(path.clone(), 0..5, OwnedBytes::new(b"hello".to_vec()));
+        source
+            .atomic_write(Path::new(FOOTER_CACHE), &cache.to_bytes().unwrap())
+            .unwrap();
+
+        let key = "test_footer_cache_reuses_bytes_across_directories";
+        FooterCache::from_directory(source, key).await.unwrap();
+        // An empty directory can only succeed when the bytes are reused from memory.
+        let empty = Arc::new(RamDirectory::create());
+        let cached = FooterCache::from_directory(empty.clone(), key)
+            .await
+            .unwrap();
+        assert_eq!(cached.get_slice(&path, 1..4).unwrap().as_slice(), b"ell");
+        assert!(
+            FooterCache::from_directory(empty, "test_other_footer_file")
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
     async fn test_footer_cache_from_directory_nonexistent() {
         let ram_directory = Arc::new(RamDirectory::create());
 
-        let result = FooterCache::from_directory(ram_directory).await;
+        let result = FooterCache::from_directory(ram_directory, "test_nonexistent").await;
         assert!(result.is_err());
     }
 
@@ -639,7 +682,7 @@ mod tests {
             .atomic_write(std::path::Path::new(FOOTER_CACHE), &cache_bytes)
             .unwrap();
 
-        let result = FooterCache::from_directory(ram_directory).await;
+        let result = FooterCache::from_directory(ram_directory, "test_success").await;
         assert!(result.is_ok());
 
         let loaded_cache = result.unwrap();


### PR DESCRIPTION
Repeated searches on v0.40.0 reload Tantivy footer-cache bytes and Puffin footer metadata from storage. Backport the footer memory cache from #11895 and the configuration naming fix so subsequent reads reuse these bytes across queries.

- Add a bounded FIFO bytes cache with memory, entry, hit/miss and eviction metrics. Keep insertion accounting under the writer lock so eviction cannot race with accounting.
- Cache Tantivy footer bytes by index filename and Puffin footer tail/payload under a separate key prefix, adapting the implementation to v0.40.0's `src/service/tantivy` layout.
- Add `ZO_INVERTED_INDEX_FOOTER_CACHE_MAX_SIZE` in MB; zero uses 5% of total memory, clamped to 100–1024 MB. The existing index format is unchanged.
- Keep unrelated search refactors and parallel warm-up changes from the original commit out of this backport.

Validation:
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo test -p infra cache::bytes_cache --lib --locked` — 5 passed.
- `cargo test --lib service::tantivy:: --locked` — 165 passed, including new cross-directory reuse/key isolation and Puffin cache-hit tests.
- `cargo test --bin openobserve service::tantivy:: --locked` — binary compiled successfully; no matching tests (the tests above run in the library target).
