### PR TITLE
fix(search): accept scalar inputs in string UDFs

### DIFF
--- a/src/search/src/datafusion/udf/regexp_matches_udf.rs
+++ b/src/search/src/datafusion/udf/regexp_matches_udf.rs
@@ -150,7 +150,7 @@ pub fn regexp_matches<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
     let is_scalar_pattern = regex.len() == 1;
 
     // Precompile the regex if it's scalar
-    let scalar_regex = if is_scalar_pattern {
+    let scalar_regex = if is_scalar_pattern && !regex.is_null(0) {
         Some(
             Regex::new(regex.value(0))
                 .map_err(|e| DataFusionError::Execution(format!("Invalid regex pattern: {e}")))?,
@@ -162,7 +162,7 @@ pub fn regexp_matches<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
     let mut list_builder = ListBuilder::new(GenericStringBuilder::<T>::new());
 
     for i in 0..values.len() {
-        if values.is_null(i) || (!is_scalar_pattern && regex.is_null(i)) {
+        if values.is_null(i) || regex.is_null(if is_scalar_pattern { 0 } else { i }) {
             // Append NULL for this row
             list_builder.append(false);
             continue;
@@ -462,5 +462,42 @@ mod tests {
         ];
 
         assert_batches_eq!(expected, &results);
+    }
+
+    #[tokio::test]
+    async fn test_regexp_matches_null_scalar_pattern() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(REGEX_MATCHES_UDF.clone());
+        let sql = "SELECT re_matches('gateway', CAST(NULL AS VARCHAR)) IS NULL AS missing";
+        let expected = [
+            "+---------+",
+            "| missing |",
+            "+---------+",
+            "| true    |",
+            "+---------+",
+        ];
+        let result = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        assert_batches_eq!(expected, &result);
+        // A one-row batch takes the scalar-pattern path, two rows take the array path.
+        for rows in [1, 2] {
+            let schema = Arc::new(Schema::new(vec![Field::new("job", DataType::Utf8, true)]));
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(StringArray::from(vec!["gateway"; rows]))],
+            )
+            .unwrap();
+            ctx.register_table(
+                "t",
+                Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap()),
+            )
+            .unwrap();
+            let sql = "SELECT re_matches(job, CAST(NULL AS VARCHAR)) IS NULL AS missing FROM t";
+            let result = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+            let mut expected = vec!["+---------+", "| missing |", "+---------+"];
+            expected.extend(std::iter::repeat_n("| true    |", rows));
+            expected.push("+---------+");
+            assert_batches_eq!(expected, &result);
+            ctx.deregister_table("t").unwrap();
+        }
     }
 }

--- a/src/search/src/datafusion/udf/regexp_udf.rs
+++ b/src/search/src/datafusion/udf/regexp_udf.rs
@@ -293,7 +293,8 @@ impl ScalarUDFImpl for RegxpMatchToFields {
                 ColumnarValue::Array(arr) => Some(arr.len()),
             });
 
-        let inferred_length = len.unwrap_or(0);
+        // All-scalar input still carries one row to match.
+        let inferred_length = len.unwrap_or(1);
         let args_array = args
             .args
             .iter()
@@ -547,5 +548,22 @@ mod tests {
     fn test_regex_pattern_to_fields_empty_pattern_errors() {
         let result = regex_pattern_to_fields("", &DataType::Utf8);
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_regexp_match_to_fields_scalar_input() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(REGEXP_MATCH_TO_FIELDS_UDF.clone());
+        let sql =
+            "select regexp_match_to_fields('gateway', '(?P<head>gate)(?P<tail>way)') as fields";
+        let expected = [
+            "+-------------------------+",
+            "| fields                  |",
+            "+-------------------------+",
+            "| {head: gate, tail: way} |",
+            "+-------------------------+",
+        ];
+        let result = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        assert_batches_eq!(expected, &result);
     }
 }

--- a/src/search/src/datafusion/udf/str_match_udf.rs
+++ b/src/search/src/datafusion/udf/str_match_udf.rs
@@ -120,15 +120,8 @@ fn str_match_impl(args: &[ColumnarValue], case_insensitive: bool) -> Result<Colu
         ));
     }
 
-    // 1. cast both arguments to be aligned with the signature
-    let ColumnarValue::Array(haystack) = &args[0] else {
-        return Err(DataFusionError::SQL(
-            Box::new(ParserError::ParserError(
-                "Invalid argument types[haystack] to str_match function".to_string(),
-            )),
-            None,
-        ));
-    };
+    // Parquet pushdown replaces constant or missing columns with scalars.
+    let haystack = args[0].clone().into_array(1)?;
     let haystack = as_string_array(&haystack)?;
     let ColumnarValue::Scalar(needle) = &args[1] else {
         return Err(DataFusionError::SQL(
@@ -192,6 +185,8 @@ fn str_match_impl(args: &[ColumnarValue], case_insensitive: bool) -> Result<Colu
 
 #[cfg(test)]
 mod tests {
+    use std::fs::File;
+
     use arrow::array::StringArray;
     use datafusion::{
         arrow::{
@@ -200,10 +195,12 @@ mod tests {
             record_batch::RecordBatch,
         },
         datasource::MemTable,
-        prelude::SessionContext,
+        prelude::{ParquetReadOptions, SessionConfig, SessionContext},
     };
+    use parquet::arrow::ArrowWriter;
 
     use super::*;
+    use crate::datafusion::exec::register_builtin_udfs;
 
     #[test]
     fn test_str_match_udf_name() {
@@ -335,6 +332,119 @@ mod tests {
             assert!(out.value(0));
         } else {
             panic!("expected array result");
+        }
+    }
+
+    fn context(pushdown: bool) -> SessionContext {
+        let config = SessionConfig::new()
+            .set_bool("datafusion.execution.parquet.pushdown_filters", pushdown);
+        let ctx = SessionContext::new_with_config(config);
+        register_builtin_udfs(&ctx);
+        ctx
+    }
+
+    async fn booleans(ctx: &SessionContext, sql: &str) -> Vec<Option<bool>> {
+        ctx.sql(sql)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap()
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .unwrap()
+                    .iter()
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_str_match_scalar_haystack() {
+        let ctx = context(true);
+        for name in [
+            "str_match",
+            "str_match_ignore_case",
+            "match_field",
+            "match_field_ignore_case",
+        ] {
+            for (haystack, needle, expected) in [
+                ("'gateway'", "'gate'", Some(true)),
+                ("'other'", "'gate'", Some(false)),
+                ("'gateway'", "''", Some(true)),
+                ("''", "'gateway'", Some(false)),
+                ("CAST(NULL AS VARCHAR)", "'gateway'", None),
+            ] {
+                let sql = format!("SELECT {name}({haystack}, {needle})");
+                assert_eq!(booleans(&ctx, &sql).await, vec![expected], "{sql}");
+            }
+            let expected = name.contains("ignore_case");
+            let sql = format!("SELECT {name}('Gateway', 'GATEWAY')");
+            assert_eq!(booleans(&ctx, &sql).await, vec![Some(expected)], "{sql}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parquet_pushdown_constant_null_and_missing_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("level", DataType::Utf8, true),
+            Field::new("job", DataType::Utf8, true),
+        ]));
+        for (case, jobs, expected) in [
+            ("constant", Some(vec![Some("gateway"), Some("gateway")]), 2),
+            ("mixed", Some(vec![Some("gateway"), Some("other")]), 1),
+            ("nullable", Some(vec![Some("gateway"), None]), 1),
+            ("null", Some(vec![None, None]), 0),
+            ("missing", None, 0),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("data.parquet");
+            let mut columns: Vec<ArrayRef> =
+                vec![Arc::new(StringArray::from(vec!["info", "error"]))];
+            let file_schema = if let Some(jobs) = jobs {
+                columns.push(Arc::new(StringArray::from(jobs)));
+                schema.clone()
+            } else {
+                Arc::new(Schema::new(vec![schema.field(0).clone()]))
+            };
+            let batch = RecordBatch::try_new(file_schema.clone(), columns).unwrap();
+            let mut writer =
+                ArrowWriter::try_new(File::create(&path).unwrap(), file_schema, None).unwrap();
+            writer.write(&batch).unwrap();
+            writer.close().unwrap();
+            for pushdown in [false, true] {
+                let ctx = context(pushdown);
+                ctx.register_parquet(
+                    "gateway",
+                    path.to_str().unwrap(),
+                    ParquetReadOptions::default().schema(&schema),
+                )
+                .await
+                .unwrap();
+                for predicate in [
+                    "str_match(job, 'gateway')",
+                    "str_match_ignore_case(job, 'GATEWAY')",
+                    "match_field(job, 'gateway')",
+                    "match_field_ignore_case(job, 'GATEWAY')",
+                    "re_match(job, '^gateway$')",
+                    "re_not_match(job, '^other$')",
+                    "array_length(re_matches(job, '(gateway)')) > 0",
+                ] {
+                    let sql = format!("SELECT level FROM gateway WHERE {predicate} GROUP BY level");
+                    let batches = ctx
+                        .sql(&sql)
+                        .await
+                        .unwrap()
+                        .collect()
+                        .await
+                        .unwrap_or_else(|err| panic!("{case}, pushdown={pushdown}, {sql}: {err}"));
+                    let count: usize = batches.iter().map(|batch| batch.num_rows()).sum();
+                    assert_eq!(count, expected, "{case}, pushdown={pushdown}, {sql}");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Parquet filter pushdown replaces constant or missing columns with scalar values. `str_match(job, 'gateway')` rejected a scalar haystack, so queries such as `SELECT level FROM gateway WHERE str_match(job, 'gateway') GROUP BY level` failed only with pushdown enabled. Convert the haystack with `into_array(1)` and keep every other behaviour unchanged; DataFusion folds the one-row result back to a scalar. This also covers `str_match_ignore_case`, `match_field` and `match_field_ignore_case`.

Two smaller scalar-input fixes in the same area: `regexp_match_to_fields` inferred zero rows for all-scalar input and panicked on `.value(0)`, so it now infers one row; `re_matches` treated a NULL scalar pattern as an empty regex in one-row batches, so it now returns NULL for that pattern regardless of batch size. Quote stripping, field nullability, error semantics and the wire format of `regexp_match_to_fields` are untouched.

Regression coverage: scalar and NULL haystacks for the four `str_match` names, a scalar `regexp_match_to_fields` call, NULL scalar patterns for `re_matches` across batch sizes, and real Parquet files with constant, mixed, nullable, all-NULL or missing columns queried with filter pushdown both disabled and enabled.

Validation:
- `cargo test -p search --lib datafusion::udf`: 145 passed.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy -p search --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings`: passed.
