### PR TITLE
fix(metrics): prefetch .midx sidecars into the file cache and gate the selection cache

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1554,6 +1554,18 @@ pub struct Search {
     )]
     pub feature_metrics_streaming_agg_enabled: bool,
     #[env_config(
+        name = "ZO_METRICS_INDEX_SELECTION_CACHE_ENABLED",
+        default = false,
+        help = "Cache the row ranges a PromQL query selected from each `.midx` metrics index, keyed by file and matchers, so a repeated query skips decoding and evaluating the index."
+    )]
+    pub metrics_index_selection_cache_enabled: bool,
+    #[env_config(
+        name = "ZO_METRICS_INDEX_SELECTION_CACHE_MAX_SIZE",
+        default = 256,
+        help = "Maximum memory size in MB of the metrics index selection cache."
+    )]
+    pub metrics_index_selection_cache_max_size: usize,
+    #[env_config(
         name = "ZO_FEATURE_DYNAMIC_PUSHDOWN_FILTER_ENABLED",
         default = true,
         help = "Enable dynamic pushdown filter"

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -1926,6 +1926,59 @@ pub static TANTIVY_RESULT_CACHE_HITS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// metrics for metrics index selection cache
+pub static METRICS_INDEX_SELECTION_CACHE_MEMORY_USAGE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "metrics_index_selection_cache_memory_usage",
+            "Total memory usage (bytes) of metrics index selection cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+pub static METRICS_INDEX_SELECTION_CACHE_GC_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "metrics_index_selection_cache_gc_total",
+            "Total number of GC of metrics index selection cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+pub static METRICS_INDEX_SELECTION_CACHE_REQUESTS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "metrics_index_selection_cache_requests_total",
+            "Total number of search of metrics index selection cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+pub static METRICS_INDEX_SELECTION_CACHE_HITS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "metrics_index_selection_cache_hits_total",
+            "Total number of hit of metrics index selection cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
 pub static QUERY_AGGREGATION_CACHE_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
@@ -2947,6 +3000,22 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(TANTIVY_RESULT_CACHE_HITS_TOTAL.clone()))
         .expect("Metric registered");
 
+    // metrics for metrics index selection cache
+    registry
+        .register(Box::new(METRICS_INDEX_SELECTION_CACHE_MEMORY_USAGE.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(METRICS_INDEX_SELECTION_CACHE_GC_TOTAL.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(
+            METRICS_INDEX_SELECTION_CACHE_REQUESTS_TOTAL.clone(),
+        ))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(METRICS_INDEX_SELECTION_CACHE_HITS_TOTAL.clone()))
+        .expect("Metric registered");
+
     // metrics for generic bytes cache
     registry
         .register(Box::new(BYTES_CACHE_MEMORY_SIZE.clone()))
@@ -3548,6 +3617,10 @@ mod tests {
         let _ = TANTIVY_RESULT_CACHE_GC_TOTAL.clone();
         let _ = TANTIVY_RESULT_CACHE_REQUESTS_TOTAL.clone();
         let _ = TANTIVY_RESULT_CACHE_HITS_TOTAL.clone();
+        let _ = METRICS_INDEX_SELECTION_CACHE_MEMORY_USAGE.clone();
+        let _ = METRICS_INDEX_SELECTION_CACHE_GC_TOTAL.clone();
+        let _ = METRICS_INDEX_SELECTION_CACHE_REQUESTS_TOTAL.clone();
+        let _ = METRICS_INDEX_SELECTION_CACHE_HITS_TOTAL.clone();
         let _ = BYTES_CACHE_MEMORY_SIZE.clone();
         let _ = BYTES_CACHE_ENTRY_COUNT.clone();
         let _ = BYTES_CACHE_GC_TIME.clone();

--- a/src/infra/src/cache/file_data/mod.rs
+++ b/src/infra/src/cache/file_data/mod.rs
@@ -53,6 +53,7 @@ enum FileType {
     Parquet,
     Ttv,
     Vortex,
+    Midx,
 }
 
 impl CacheStrategy {
@@ -230,6 +231,21 @@ async fn validate_file(bytes: &[u8], ftype: FileType) -> Result<(), anyhow::Erro
                 return Err(anyhow::anyhow!("vortex magic bytes mismatch"));
             }
         }
+        FileType::Midx => {
+            // Arrow IPC file: 8-byte leading magic, footer, i32 footer length, 6-byte magic
+            const ARROW_MAGIC: &[u8; 6] = b"ARROW1";
+            if bytes.len() < 18 {
+                return Err(anyhow::anyhow!("invalid metrics index file"));
+            }
+            if &bytes[..6] != ARROW_MAGIC || &bytes[bytes.len() - 6..] != ARROW_MAGIC {
+                return Err(anyhow::anyhow!("arrow ipc magic bytes mismatch"));
+            }
+            let footer_len =
+                i32::from_le_bytes(bytes[bytes.len() - 10..bytes.len() - 6].try_into().unwrap());
+            if footer_len < 0 || 8 + footer_len as usize + 10 > bytes.len() {
+                return Err(anyhow::anyhow!("arrow ipc footer size mismatch"));
+            }
+        }
     }
     Ok(())
 }
@@ -299,7 +315,8 @@ async fn download_from_storage(
                 // so we check if the footer is valid. If it is, then the db entry is invalid
                 // and we reset it. If footer is invalid, the store has a corrupted file
                 // so we mark it as deleted, and return error.
-                // data files (parquet/vortex) are tracked in file_list, ttv index files are not
+                // data files (parquet/vortex) are tracked in file_list, ttv/midx index files are
+                // not
                 let is_data_file = file.ends_with(".parquet") || file.ends_with(".vortex");
                 let valid_parquet = file.ends_with(".parquet")
                     && validate_file(&data_bytes, FileType::Parquet).await.is_ok();
@@ -307,7 +324,9 @@ async fn download_from_storage(
                     && validate_file(&data_bytes, FileType::Vortex).await.is_ok();
                 let valid_ttv = file.ends_with(".ttv")
                     && validate_file(&data_bytes, FileType::Ttv).await.is_ok();
-                if valid_parquet || valid_vortex || valid_ttv {
+                let valid_midx = file.ends_with(".midx")
+                    && validate_file(&data_bytes, FileType::Midx).await.is_ok();
+                if valid_parquet || valid_vortex || valid_ttv || valid_midx {
                     log::warn!(
                         "download file {file} found size mismatch, remote : {expected_blob_size}, db: {size}, correcting db as valid file",
                     );
@@ -508,6 +527,46 @@ fn get_file_time(file: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn validate_midx_checks_arrow_ipc_magic_and_footer() {
+        use arrow::{
+            array::{RecordBatch, UInt32Array},
+            datatypes::{DataType, Field, Schema},
+            ipc::writer::FileWriter,
+        };
+        let schema = std::sync::Arc::new(Schema::new(vec![Field::new(
+            "__oo_midx_row_count",
+            DataType::UInt32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![std::sync::Arc::new(UInt32Array::from(vec![3, 2]))],
+        )
+        .unwrap();
+        let mut writer = FileWriter::try_new(Vec::new(), &schema).unwrap();
+        writer.write(&batch).unwrap();
+        let bytes = writer.into_inner().unwrap();
+
+        assert!(validate_file(&bytes, FileType::Midx).await.is_ok());
+        // truncated: trailing magic gone
+        assert!(
+            validate_file(&bytes[..bytes.len() - 3], FileType::Midx)
+                .await
+                .is_err()
+        );
+        // footer length claims more bytes than the file has
+        let mut oversized = bytes.clone();
+        let len = oversized.len();
+        oversized[len - 10..len - 6].copy_from_slice(&i32::MAX.to_le_bytes());
+        assert!(validate_file(&oversized, FileType::Midx).await.is_err());
+        assert!(
+            validate_file(b"not an arrow file", FileType::Midx)
+                .await
+                .is_err()
+        );
+    }
 
     #[test]
     fn test_file_data_lru_cache_miss() {

--- a/src/metrics_index/src/cache.rs
+++ b/src/metrics_index/src/cache.rs
@@ -18,7 +18,7 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
-use config::get_config;
+use config::{get_config, metrics};
 use hashlink::LruCache;
 
 pub(super) static METRICS_INDEX_SELECTION_CACHE: LazyLock<Mutex<MetricsIndexSelectionCache>> =
@@ -57,18 +57,29 @@ impl MetricsIndexSelectionCache {
             return;
         }
         if let Some(previous) = self.entries.insert(key.clone(), selection) {
-            self.memory_size = self
-                .memory_size
-                .saturating_sub(Self::entry_size(&key, &previous.0));
+            self.release(Self::entry_size(&key, &previous.0));
         }
         self.memory_size += size;
+        metrics::METRICS_INDEX_SELECTION_CACHE_MEMORY_USAGE
+            .with_label_values::<&str>(&[])
+            .add(size as i64);
+        if self.memory_size > max_bytes {
+            metrics::METRICS_INDEX_SELECTION_CACHE_GC_TOTAL
+                .with_label_values::<&str>(&[])
+                .inc();
+        }
         while self.memory_size > max_bytes {
             let Some((key, evicted)) = self.entries.remove_lru() else {
                 break;
             };
-            self.memory_size = self
-                .memory_size
-                .saturating_sub(Self::entry_size(&key, &evicted.0));
+            self.release(Self::entry_size(&key, &evicted.0));
         }
+    }
+
+    fn release(&mut self, size: usize) {
+        self.memory_size = self.memory_size.saturating_sub(size);
+        metrics::METRICS_INDEX_SELECTION_CACHE_MEMORY_USAGE
+            .with_label_values::<&str>(&[])
+            .sub(size as i64);
     }
 }

--- a/src/metrics_index/src/cache.rs
+++ b/src/metrics_index/src/cache.rs
@@ -24,8 +24,11 @@ use hashlink::LruCache;
 pub(super) static METRICS_INDEX_SELECTION_CACHE: LazyLock<Mutex<MetricsIndexSelectionCache>> =
     LazyLock::new(|| Mutex::new(MetricsIndexSelectionCache::default()));
 
+/// Selected physical row ranges of one sidecar plus the parquet row-group size they map onto.
+pub(super) type CachedSelection = (Arc<Vec<Range<usize>>>, u32);
+
 pub(super) struct MetricsIndexSelectionCache {
-    entries: LruCache<String, Arc<Vec<Range<usize>>>>,
+    entries: LruCache<String, CachedSelection>,
     memory_size: usize,
 }
 
@@ -43,20 +46,20 @@ impl MetricsIndexSelectionCache {
         key.len() + std::mem::size_of::<Vec<Range<usize>>>() + std::mem::size_of_val(ranges)
     }
 
-    pub(super) fn get(&mut self, key: &str) -> Option<Arc<Vec<Range<usize>>>> {
+    pub(super) fn get(&mut self, key: &str) -> Option<CachedSelection> {
         self.entries.get(key).cloned()
     }
 
-    pub(super) fn insert(&mut self, key: String, ranges: Arc<Vec<Range<usize>>>) {
+    pub(super) fn insert(&mut self, key: String, selection: CachedSelection) {
         let max_bytes = get_config().search.metrics_index_selection_cache_max_size * 1024 * 1024;
-        let size = Self::entry_size(&key, &ranges);
+        let size = Self::entry_size(&key, &selection.0);
         if size > max_bytes {
             return;
         }
-        if let Some(previous) = self.entries.insert(key.clone(), ranges) {
+        if let Some(previous) = self.entries.insert(key.clone(), selection) {
             self.memory_size = self
                 .memory_size
-                .saturating_sub(Self::entry_size(&key, &previous));
+                .saturating_sub(Self::entry_size(&key, &previous.0));
         }
         self.memory_size += size;
         while self.memory_size > max_bytes {
@@ -65,7 +68,7 @@ impl MetricsIndexSelectionCache {
             };
             self.memory_size = self
                 .memory_size
-                .saturating_sub(Self::entry_size(&key, &evicted));
+                .saturating_sub(Self::entry_size(&key, &evicted.0));
         }
     }
 }

--- a/src/metrics_index/src/cache.rs
+++ b/src/metrics_index/src/cache.rs
@@ -18,10 +18,8 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
+use config::get_config;
 use hashlink::LruCache;
-
-/// Process-wide upper bound for cached physical row-range selections.
-const METRICS_INDEX_SELECTION_CACHE_MAX_BYTES: usize = 256 * 1024 * 1024;
 
 pub(super) static METRICS_INDEX_SELECTION_CACHE: LazyLock<Mutex<MetricsIndexSelectionCache>> =
     LazyLock::new(|| Mutex::new(MetricsIndexSelectionCache::default()));
@@ -50,8 +48,9 @@ impl MetricsIndexSelectionCache {
     }
 
     pub(super) fn insert(&mut self, key: String, ranges: Arc<Vec<Range<usize>>>) {
+        let max_bytes = get_config().search.metrics_index_selection_cache_max_size * 1024 * 1024;
         let size = Self::entry_size(&key, &ranges);
-        if size > METRICS_INDEX_SELECTION_CACHE_MAX_BYTES {
+        if size > max_bytes {
             return;
         }
         if let Some(previous) = self.entries.insert(key.clone(), ranges) {
@@ -60,7 +59,7 @@ impl MetricsIndexSelectionCache {
                 .saturating_sub(Self::entry_size(&key, &previous));
         }
         self.memory_size += size;
-        while self.memory_size > METRICS_INDEX_SELECTION_CACHE_MAX_BYTES {
+        while self.memory_size > max_bytes {
             let Some((key, evicted)) = self.entries.remove_lru() else {
                 break;
             };

--- a/src/metrics_index/src/layout.rs
+++ b/src/metrics_index/src/layout.rs
@@ -27,6 +27,12 @@ use config::{
 };
 
 pub const METRICS_INDEX_ROW_COUNT: &str = "__oo_midx_row_count";
+/// Format version a writer stamps into the `.midx` schema; readers reject newer ones.
+pub const METRICS_INDEX_VERSION: u32 = 1;
+pub const METRICS_INDEX_VERSION_KEY: &str = "o2:midx_version";
+pub const METRICS_INDEX_PARENT_RECORDS_KEY: &str = "o2:parent_records";
+pub const METRICS_INDEX_ROW_GROUP_SIZE_KEY: &str = "o2:row_group_size";
+pub const METRICS_INDEX_EXCLUDED_LABELS_KEY: &str = "o2:excluded_labels";
 
 /// [`metrics_index_enabled`] narrowed to one stream: the layout also
 /// needs a `__hash__` column of type `UInt64` (remote-write / OTLP metrics).
@@ -41,10 +47,7 @@ pub fn metrics_index_stream(stream_type: StreamType, schema: &Schema) -> bool {
 /// (`ZO_METRICS_INDEX_ENABLED`): metrics files ordered by
 /// `(__hash__, _timestamp)`, so readers must not assume a `_timestamp` order.
 pub fn metrics_index_enabled(stream_type: StreamType) -> bool {
-    if stream_type != StreamType::Metrics {
-        return false;
-    }
-    get_config().compact.metrics_index_enabled
+    stream_type == StreamType::Metrics && get_config().compact.metrics_index_enabled
 }
 
 /// Metrics-specific physical layout encoded in a file-name prefix so readers

--- a/src/metrics_index/src/layout.rs
+++ b/src/metrics_index/src/layout.rs
@@ -30,8 +30,11 @@ pub const METRICS_INDEX_ROW_COUNT: &str = "__oo_midx_row_count";
 /// Format version a writer stamps into the `.midx` schema; readers reject newer ones.
 pub const METRICS_INDEX_VERSION: u32 = 1;
 pub const METRICS_INDEX_VERSION_KEY: &str = "o2:midx_version";
+/// Row count of the data file the sidecar was written for; readers refuse a mismatch.
 pub const METRICS_INDEX_PARENT_RECORDS_KEY: &str = "o2:parent_records";
+/// Parquet only; absent for Vortex data files, whose access plan needs no row groups.
 pub const METRICS_INDEX_ROW_GROUP_SIZE_KEY: &str = "o2:row_group_size";
+/// Comma-joined `METRICS_HASH_EXCLUDED_LABELS` at write time; informational, readers ignore it.
 pub const METRICS_INDEX_EXCLUDED_LABELS_KEY: &str = "o2:excluded_labels";
 
 /// [`metrics_index_enabled`] narrowed to one stream: the layout also

--- a/src/metrics_index/src/lib.rs
+++ b/src/metrics_index/src/lib.rs
@@ -44,7 +44,7 @@ mod tests {
     use promql_parser::label::{MatchOp, Matcher, Matchers};
 
     use super::{
-        METRICS_INDEX_ROW_COUNT,
+        METRICS_INDEX_ROW_COUNT, MetricsIndexWriter, layout,
         pruner::{
             create_physical_filter, metrics_index_labels, residual_matchers_covered,
             selection_cache_key, sidecar_covers_labels,
@@ -121,6 +121,8 @@ mod tests {
         let data = MetricsIndexData {
             schema: Arc::clone(&schema),
             batches: vec![batch],
+            parent_records: None,
+            row_group_size: None,
         };
         let matchers = Matchers::new(vec![Matcher::new(MatchOp::Equal, "path", "a")]);
         let filter = create_physical_filter(&schema, &matchers).unwrap();
@@ -148,6 +150,60 @@ mod tests {
             evaluate_metrics_index(&data, filter.as_deref(), 8).unwrap(),
             vec![Range { start: 2, end: 4 }]
         );
+    }
+
+    #[test]
+    fn reader_enforces_the_recorded_parent_and_version() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("__hash__", DataType::UInt64, false),
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new("path", DataType::Utf8View, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::UInt64Array::from(vec![1, 1, 2])),
+                Arc::new(arrow::array::Int64Array::from(vec![10, 20, 10])),
+                Arc::new(StringViewArray::from(vec!["a", "a", "b"])),
+            ],
+        )
+        .unwrap();
+        let mut writer = MetricsIndexWriter::try_new(&schema).unwrap();
+        writer.write(&batch).unwrap();
+        let bytes = writer.finish(3, Some(2)).unwrap();
+
+        let data =
+            decode_metrics_index("parent", Bytes::from(bytes), &["path".to_string()]).unwrap();
+        assert_eq!(data.parent_records, Some(3));
+        assert_eq!(data.row_group_size, Some(2));
+        assert_eq!(
+            evaluate_metrics_index(&data, None, 3).unwrap(),
+            vec![Range { start: 0, end: 3 }]
+        );
+        // file_list says 4 rows: the index was written for another file
+        let mismatch = evaluate_metrics_index(&data, None, 4).unwrap_err();
+        assert!(mismatch.to_string().contains("written for 3 rows"));
+
+        // a newer format version is refused before anything is decoded
+        let newer_schema = Arc::new(Schema::new_with_metadata(
+            vec![Field::new(METRICS_INDEX_ROW_COUNT, DataType::UInt32, false)],
+            std::collections::HashMap::from([(
+                layout::METRICS_INDEX_VERSION_KEY.to_string(),
+                (layout::METRICS_INDEX_VERSION + 1).to_string(),
+            )]),
+        ));
+        let newer = RecordBatch::try_new(
+            Arc::clone(&newer_schema),
+            vec![Arc::new(UInt32Array::from(vec![3]))],
+        )
+        .unwrap();
+        let mut ipc = ArrowFileWriter::try_new(Vec::new(), &newer_schema).unwrap();
+        ipc.write(&newer).unwrap();
+        let newer_bytes = Bytes::from(ipc.into_inner().unwrap());
+        let Err(error) = decode_metrics_index("newer", newer_bytes, &[]) else {
+            panic!("a newer metrics index version was decoded");
+        };
+        assert!(error.to_string().contains("this build reads up to 1"));
     }
 
     #[test]

--- a/src/metrics_index/src/lib.rs
+++ b/src/metrics_index/src/lib.rs
@@ -204,6 +204,15 @@ mod tests {
             panic!("a newer metrics index version was decoded");
         };
         assert!(error.to_string().contains("this build reads up to 1"));
+
+        // a zero row group size would make the parquet access plan divide by zero
+        let mut writer = MetricsIndexWriter::try_new(&schema).unwrap();
+        writer.write(&batch).unwrap();
+        let zero_bytes = Bytes::from(writer.finish(3, Some(0)).unwrap());
+        let Err(error) = decode_metrics_index("zero", zero_bytes, &[]) else {
+            panic!("a zero row group size was decoded");
+        };
+        assert!(error.to_string().contains("row group size of 0"));
     }
 
     #[test]

--- a/src/metrics_index/src/pruner.rs
+++ b/src/metrics_index/src/pruner.rs
@@ -25,6 +25,7 @@ use config::{
         promql::is_metrics_hash_excluded_label,
         stream::{FileKey, FileSelection},
     },
+    metrics,
 };
 use datafusion::{
     common::{DFSchema, DataFusionError, Result},
@@ -119,7 +120,13 @@ pub async fn search(
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         for (data_path, (account, sidecar_path, cache_key, expected_rows)) in index_files {
+            metrics::METRICS_INDEX_SELECTION_CACHE_REQUESTS_TOTAL
+                .with_label_values::<&str>(&[])
+                .inc();
             if let Some((ranges, row_group_size)) = cache.get(&cache_key) {
+                metrics::METRICS_INDEX_SELECTION_CACHE_HITS_TOTAL
+                    .with_label_values::<&str>(&[])
+                    .inc();
                 // only complete selections are cached, so a hit implies exactness
                 evaluated.push((data_path, ranges, true, row_group_size));
             } else {

--- a/src/metrics_index/src/pruner.rs
+++ b/src/metrics_index/src/pruner.rs
@@ -20,7 +20,7 @@ use std::{
 
 use arrow::datatypes::Schema;
 use config::{
-    PARQUET_MAX_ROW_GROUP_SIZE,
+    PARQUET_MAX_ROW_GROUP_SIZE, get_config,
     meta::{
         promql::is_metrics_hash_excluded_label,
         stream::{FileKey, FileSelection},
@@ -111,9 +111,10 @@ pub async fn search(
     let other_files = files.len() - index_files.len();
 
     let start = std::time::Instant::now();
+    let selection_cache_enabled = get_config().search.metrics_index_selection_cache_enabled;
     let mut evaluated = Vec::with_capacity(index_files.len());
     let mut misses = Vec::new();
-    {
+    if selection_cache_enabled {
         let mut cache = METRICS_INDEX_SELECTION_CACHE
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -125,6 +126,12 @@ pub async fn search(
                 misses.push((data_path, account, sidecar_path, cache_key, expected_rows));
             }
         }
+    } else {
+        misses.extend(index_files.into_iter().map(
+            |(data_path, (account, sidecar_path, cache_key, expected_rows))| {
+                (data_path, account, sidecar_path, cache_key, expected_rows)
+            },
+        ));
     }
     let cache_hits = evaluated.len();
     let concurrency = target_partitions.max(1).saturating_mul(2).min(64);
@@ -162,7 +169,7 @@ pub async fn search(
     while let Some((data_path, result)) = evaluations.next().await {
         match result {
             Ok((cache_key, ranges, complete)) => {
-                if complete {
+                if complete && selection_cache_enabled {
                     METRICS_INDEX_SELECTION_CACHE
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/src/metrics_index/src/pruner.rs
+++ b/src/metrics_index/src/pruner.rs
@@ -71,6 +71,7 @@ pub async fn search(
     // Keep the complete matcher set in the key. A short hash collision could
     // otherwise reuse physical row ranges selected by a different query.
     let filter_key = format!("{matchers:?}");
+    let selection_cache_enabled = get_config().search.metrics_index_selection_cache_enabled;
     let mut index_files = BTreeMap::new();
     for file in files.iter() {
         // only indexed metrics files own a sidecar; other layouts stay as they are
@@ -92,13 +93,17 @@ pub async fn search(
             );
             continue;
         };
-        let cache_key = selection_cache_key(
-            &file.account,
-            &sidecar_path,
-            expected_rows,
-            &matcher_labels,
-            &filter_key,
-        );
+        let cache_key = if selection_cache_enabled {
+            selection_cache_key(
+                &file.account,
+                &sidecar_path,
+                expected_rows,
+                &matcher_labels,
+                &filter_key,
+            )
+        } else {
+            String::new()
+        };
         index_files.entry(file.key.clone()).or_insert((
             file.account.clone(),
             sidecar_path,
@@ -112,7 +117,6 @@ pub async fn search(
     let other_files = files.len() - index_files.len();
 
     let start = std::time::Instant::now();
-    let selection_cache_enabled = get_config().search.metrics_index_selection_cache_enabled;
     let mut evaluated = Vec::with_capacity(index_files.len());
     let mut misses = Vec::new();
     if selection_cache_enabled {

--- a/src/metrics_index/src/pruner.rs
+++ b/src/metrics_index/src/pruner.rs
@@ -119,9 +119,9 @@ pub async fn search(
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         for (data_path, (account, sidecar_path, cache_key, expected_rows)) in index_files {
-            if let Some(ranges) = cache.get(&cache_key) {
+            if let Some((ranges, row_group_size)) = cache.get(&cache_key) {
                 // only complete selections are cached, so a hit implies exactness
-                evaluated.push((data_path, ranges, true));
+                evaluated.push((data_path, ranges, true, row_group_size));
             } else {
                 misses.push((data_path, account, sidecar_path, cache_key, expected_rows));
             }
@@ -147,10 +147,14 @@ pub async fn search(
                             .await?;
                     tokio::task::spawn_blocking(move || {
                         let complete = sidecar_covers_labels(data.schema.as_ref(), &labels);
+                        // indexes without the key predate it: written with the fixed size
+                        let row_group_size = data
+                            .row_group_size
+                            .unwrap_or(PARQUET_MAX_ROW_GROUP_SIZE as u32);
                         let physical_filter =
                             create_physical_filter(data.schema.as_ref(), &matchers)?;
                         evaluate_metrics_index(&data, physical_filter.as_deref(), expected_rows)
-                            .map(|ranges| (cache_key, Arc::new(ranges), complete))
+                            .map(|ranges| (cache_key, Arc::new(ranges), complete, row_group_size))
                     })
                     .await
                     .map_err(|error| DataFusionError::External(Box::new(error)))?
@@ -168,14 +172,14 @@ pub async fn search(
     let mut failed_files = 0usize;
     while let Some((data_path, result)) = evaluations.next().await {
         match result {
-            Ok((cache_key, ranges, complete)) => {
+            Ok((cache_key, ranges, complete, row_group_size)) => {
                 if complete && selection_cache_enabled {
                     METRICS_INDEX_SELECTION_CACHE
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner())
-                        .insert(cache_key, Arc::clone(&ranges));
+                        .insert(cache_key, (Arc::clone(&ranges), row_group_size));
                 }
-                evaluated.push((data_path, ranges, complete));
+                evaluated.push((data_path, ranges, complete, row_group_size));
             }
             Err(error) => {
                 failed_files += 1;
@@ -189,11 +193,11 @@ pub async fn search(
 
     let selected_files = evaluated
         .iter()
-        .filter(|(_, ranges, _)| !ranges.is_empty())
+        .filter(|(_, ranges, ..)| !ranges.is_empty())
         .count();
     let selected_ranges = evaluated
         .iter()
-        .map(|(_, ranges, _)| ranges.len())
+        .map(|(_, ranges, ..)| ranges.len())
         .sum::<usize>();
     let indexed_file_count = evaluated.len() + failed_files;
     // An empty selection drops its file, so an incomplete matcher set cannot
@@ -203,23 +207,20 @@ pub async fn search(
         && residual_matchers_covered(table_schema, &matchers, &matcher_labels)
         && evaluated
             .iter()
-            .all(|(_, ranges, complete)| *complete || ranges.is_empty());
+            .all(|(_, ranges, complete, _)| *complete || ranges.is_empty());
     let mut selections = evaluated
         .into_iter()
-        .map(|(data_path, ranges, _)| (data_path, ranges))
+        .map(|(data_path, ranges, _, row_group_size)| (data_path, (ranges, row_group_size)))
         .collect::<HashMap<_, _>>();
     files.retain_mut(|file| {
-        let Some(ranges) = selections.remove(&file.key) else {
+        let Some((ranges, row_group_size)) = selections.remove(&file.key) else {
             // not indexed metrics: untouched, the caller decides how to scan it
             return true;
         };
         if ranges.is_empty() {
             return false;
         }
-        file.with_selection(
-            FileSelection::RowRanges(ranges),
-            Some(PARQUET_MAX_ROW_GROUP_SIZE as u32),
-        );
+        file.with_selection(FileSelection::RowRanges(ranges), Some(row_group_size));
         true
     });
 

--- a/src/metrics_index/src/reader.rs
+++ b/src/metrics_index/src/reader.rs
@@ -78,6 +78,12 @@ pub(super) fn decode_metrics_index(
     }
     let parent_records = parse_metadata(metadata, METRICS_INDEX_PARENT_RECORDS_KEY, path)?;
     let row_group_size = parse_metadata(metadata, METRICS_INDEX_ROW_GROUP_SIZE_KEY, path)?;
+    // the access plan divides by it; a corrupt 0 must fail here, not panic there
+    if row_group_size == Some(0) {
+        return Err(DataFusionError::Execution(format!(
+            "metrics index {path} has a row group size of 0"
+        )));
+    }
     let mut projection = vec![file_schema.index_of(METRICS_INDEX_ROW_COUNT)?];
     for label in labels {
         match file_schema.index_of(label) {

--- a/src/metrics_index/src/reader.rs
+++ b/src/metrics_index/src/reader.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{io::Cursor, ops::Range, sync::Arc};
+use std::{collections::HashMap, io::Cursor, ops::Range, sync::Arc};
 
 use arrow::{
     array::{Array, BooleanArray, RecordBatch, UInt32Array},
@@ -25,11 +25,18 @@ use datafusion::{
     physical_plan::PhysicalExpr,
 };
 
-use crate::layout::METRICS_INDEX_ROW_COUNT;
+use crate::layout::{
+    METRICS_INDEX_PARENT_RECORDS_KEY, METRICS_INDEX_ROW_COUNT, METRICS_INDEX_ROW_GROUP_SIZE_KEY,
+    METRICS_INDEX_VERSION, METRICS_INDEX_VERSION_KEY,
+};
 
 pub(super) struct MetricsIndexData {
     pub(super) schema: SchemaRef,
     pub(super) batches: Vec<RecordBatch>,
+    /// Rows of the data file this index was written for, absent in v1 files without metadata.
+    pub(super) parent_records: Option<usize>,
+    /// Parquet row-group size of the data file, absent for Vortex and older indexes.
+    pub(super) row_group_size: Option<u32>,
 }
 
 pub(super) async fn load_metrics_index_file(
@@ -61,6 +68,16 @@ pub(super) fn decode_metrics_index(
     let file_schema = ArrowFileReaderBuilder::new()
         .build(Cursor::new(bytes.clone()))?
         .schema();
+    let metadata = file_schema.metadata();
+    if let Some(version) = parse_metadata::<u32>(metadata, METRICS_INDEX_VERSION_KEY, path)?
+        && version > METRICS_INDEX_VERSION
+    {
+        return Err(DataFusionError::Execution(format!(
+            "metrics index {path} has version {version}, this build reads up to {METRICS_INDEX_VERSION}"
+        )));
+    }
+    let parent_records = parse_metadata(metadata, METRICS_INDEX_PARENT_RECORDS_KEY, path)?;
+    let row_group_size = parse_metadata(metadata, METRICS_INDEX_ROW_GROUP_SIZE_KEY, path)?;
     let mut projection = vec![file_schema.index_of(METRICS_INDEX_ROW_COUNT)?];
     for label in labels {
         match file_schema.index_of(label) {
@@ -79,7 +96,29 @@ pub(super) fn decode_metrics_index(
         .first()
         .map(RecordBatch::schema)
         .unwrap_or(reader_schema);
-    Ok(MetricsIndexData { schema, batches })
+    Ok(MetricsIndexData {
+        schema,
+        batches,
+        parent_records,
+        row_group_size,
+    })
+}
+
+fn parse_metadata<T: std::str::FromStr>(
+    metadata: &HashMap<String, String>,
+    key: &str,
+    path: &str,
+) -> Result<Option<T>> {
+    metadata
+        .get(key)
+        .map(|value| {
+            value.parse::<T>().map_err(|_| {
+                DataFusionError::Execution(format!(
+                    "metrics index {path} has an invalid {key}: {value}"
+                ))
+            })
+        })
+        .transpose()
 }
 
 /// Evaluate `filter` over the run rows and collect the selected physical row
@@ -90,6 +129,13 @@ pub(super) fn evaluate_metrics_index(
     filter: Option<&dyn PhysicalExpr>,
     expected_rows: usize,
 ) -> Result<Vec<Range<usize>>> {
+    if let Some(parent_records) = data.parent_records
+        && parent_records != expected_rows
+    {
+        return Err(DataFusionError::Execution(format!(
+            "metrics-index was written for {parent_records} rows, but the parent file contains {expected_rows} records"
+        )));
+    }
     let count_index = data.schema.index_of(METRICS_INDEX_ROW_COUNT)?;
     let mut ranges: Vec<Range<usize>> = Vec::new();
     let mut next_row: usize = 0;

--- a/src/metrics_index/src/writer.rs
+++ b/src/metrics_index/src/writer.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use arrow::{
     array::{Array, ArrayRef as ArrowArrayRef, RecordBatch, UInt32Array, UInt64Array},
@@ -24,10 +24,15 @@ use arrow::{
         writer::{FileWriter as ArrowFileWriter, IpcWriteOptions},
     },
 };
-use config::meta::promql::{HASH_LABEL, is_metrics_hash_excluded_label};
+use config::meta::promql::{
+    HASH_LABEL, METRICS_HASH_EXCLUDED_LABELS, is_metrics_hash_excluded_label,
+};
 use datafusion::error::{DataFusionError, Result};
 
-use crate::layout::METRICS_INDEX_ROW_COUNT;
+use crate::layout::{
+    METRICS_INDEX_EXCLUDED_LABELS_KEY, METRICS_INDEX_PARENT_RECORDS_KEY, METRICS_INDEX_ROW_COUNT,
+    METRICS_INDEX_ROW_GROUP_SIZE_KEY, METRICS_INDEX_VERSION, METRICS_INDEX_VERSION_KEY,
+};
 
 /// Writer for an indexed metrics file's `.midx` metrics index. Every row
 /// describes one contiguous metrics series run in the data file: its row count plus the
@@ -127,12 +132,37 @@ impl MetricsIndexWriter {
         Ok(())
     }
 
-    pub fn finish(self) -> Result<Vec<u8>> {
+    /// Encode the index for a data file of `parent_records` rows and the given parquet row-group
+    /// size (`None` for Vortex).
+    pub fn finish(self, parent_records: i64, row_group_size: Option<usize>) -> Result<Vec<u8>> {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            METRICS_INDEX_VERSION_KEY.to_string(),
+            METRICS_INDEX_VERSION.to_string(),
+        );
+        metadata.insert(
+            METRICS_INDEX_PARENT_RECORDS_KEY.to_string(),
+            parent_records.to_string(),
+        );
+        if let Some(row_group_size) = row_group_size {
+            metadata.insert(
+                METRICS_INDEX_ROW_GROUP_SIZE_KEY.to_string(),
+                row_group_size.to_string(),
+            );
+        }
+        metadata.insert(
+            METRICS_INDEX_EXCLUDED_LABELS_KEY.to_string(),
+            METRICS_HASH_EXCLUDED_LABELS.join(","),
+        );
+        let schema = Arc::new(Schema::new_with_metadata(
+            self.schema.fields().clone(),
+            metadata,
+        ));
         let batch = concat_batches(&self.schema, &self.pending_batches)?;
+        let batch = RecordBatch::try_new(Arc::clone(&schema), batch.columns().to_vec())?;
         let options =
             IpcWriteOptions::default().try_with_compression(Some(CompressionType::ZSTD))?;
-        let mut writer =
-            ArrowFileWriter::try_new_with_options(Vec::new(), batch.schema_ref(), options)?;
+        let mut writer = ArrowFileWriter::try_new_with_options(Vec::new(), &schema, options)?;
         writer.write(&batch)?;
         Ok(writer.into_inner()?)
     }
@@ -187,7 +217,16 @@ mod tests {
         writer.write(&batch1).unwrap();
         writer.write(&batch2).unwrap();
 
-        let bytes = writer.finish().unwrap();
+        let bytes = writer.finish(5, Some(4)).unwrap();
+        let metadata = FileReader::try_new(Cursor::new(bytes.clone()), None)
+            .unwrap()
+            .schema()
+            .metadata()
+            .clone();
+        assert_eq!(metadata[METRICS_INDEX_VERSION_KEY], "1");
+        assert_eq!(metadata[METRICS_INDEX_PARENT_RECORDS_KEY], "5");
+        assert_eq!(metadata[METRICS_INDEX_ROW_GROUP_SIZE_KEY], "4");
+        assert!(metadata[METRICS_INDEX_EXCLUDED_LABELS_KEY].contains("trace_id"));
         let batches = FileReader::try_new(Cursor::new(bytes), None)
             .unwrap()
             .collect::<std::result::Result<Vec<_>, _>>()

--- a/src/promql_service/src/search/grpc/storage.rs
+++ b/src/promql_service/src/search/grpc/storage.rs
@@ -266,7 +266,7 @@ async fn cache_metrics_index_files(trace_id: &str, org_id: &str, files: &[FileKe
         trace_id,
         &sidecars
             .iter()
-            .map(|(f, path)| (f.id, &f.account, path, 0, f.meta.max_ts, f.meta.records))
+            .map(|(f, path)| (f.id, &f.account, path, 0, f.meta.max_ts))
             .collect_vec(),
         &mut sidecar_stats,
         "midx",

--- a/src/promql_service/src/search/grpc/storage.rs
+++ b/src/promql_service/src/search/grpc/storage.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use config::{
     get_config,
     meta::{
-        search::{Session as SearchSession, StorageType},
+        search::{ScanStats, Session as SearchSession, StorageType},
         stream::{FileKey, PartitionTimeLevel, StreamParams, StreamPartition, StreamType},
     },
     metrics::{self, QUERY_PARQUET_CACHE_RATIO_NODE},
@@ -191,6 +191,8 @@ pub(crate) async fn create_context(
 
     let schema = Arc::new(schema.to_owned().with_metadata(Default::default()));
 
+    cache_metrics_index_files(trace_id, org_id, &files).await;
+
     // Prune indexed metrics files through their `.midx` metrics indexes: matching
     // physical rows are attached to each FileKey before the metrics table is
     // built. Files of any other layout (legacy or not yet finalized hours) are
@@ -246,6 +248,44 @@ pub(crate) async fn create_context(
 
     // keep_filters=false only when the pruner proved its selections exact
     Ok(Some((ctx, schema, scan_stats, keep_filters)))
+}
+
+/// Prefetch the `.midx` sidecars like the Tantivy path prefetches `.ttv` files:
+/// misses download in the background, this query reads them from storage.
+async fn cache_metrics_index_files(trace_id: &str, org_id: &str, files: &[FileKey]) {
+    let sidecars = files
+        .iter()
+        .filter_map(|f| MetricsFileLayout::metrics_index_path(&f.key).map(|path| (f, path)))
+        .collect_vec();
+    if sidecars.is_empty() {
+        return;
+    }
+    let start = std::time::Instant::now();
+    // sidecar sizes are not tracked in file_list; 0 lets the downloader skip the size check
+    let mut sidecar_stats = ScanStats::default();
+    let (cache_type, cache_hits, cache_misses) = cache_files(
+        trace_id,
+        &sidecars
+            .iter()
+            .map(|(f, path)| (f.id, &f.account, path, 0, f.meta.max_ts, f.meta.records))
+            .collect_vec(),
+        &mut sidecar_stats,
+        "midx",
+    )
+    .await;
+    metrics::QUERY_DISK_CACHE_HIT_COUNT
+        .with_label_values(&[org_id, &StreamType::Metrics.to_string(), "midx"])
+        .inc_by(cache_hits);
+    metrics::QUERY_DISK_CACHE_MISS_COUNT
+        .with_label_values(&[org_id, &StreamType::Metrics.to_string(), "midx"])
+        .inc_by(cache_misses);
+    log::info!(
+        "[trace_id {trace_id}] promql->search->storage: metrics index files {}, memory cached {}, disk cached {}, downloading others into {cache_type:?} in background, took: {} ms",
+        sidecars.len(),
+        sidecar_stats.querier_memory_cached_files,
+        sidecar_stats.querier_disk_cached_files,
+        start.elapsed().as_millis()
+    );
 }
 
 #[tracing::instrument(name = "promql:search:grpc:storage:get_file_list", skip(trace_id))]

--- a/src/search/src/datafusion/merge/metrics.rs
+++ b/src/search/src/datafusion/merge/metrics.rs
@@ -20,7 +20,8 @@ use arrow::{
     compute::{max, min},
 };
 use config::{
-    FileFormat, TIMESTAMP_COL_NAME, meta::stream::FileMeta, utils::parquet::new_parquet_writer,
+    FileFormat, PARQUET_MAX_ROW_GROUP_SIZE, TIMESTAMP_COL_NAME, meta::stream::FileMeta,
+    utils::parquet::new_parquet_writer,
 };
 use datafusion::{
     arrow::datatypes::Schema,
@@ -204,14 +205,20 @@ struct IndexedMetricsFileState {
     metrics_index: MetricsIndexWriter,
     file_meta: FileMeta,
     timestamp_index: usize,
+    row_group_size: Option<usize>,
 }
 
 impl IndexedMetricsFileState {
-    fn try_new(schema: &Arc<Schema>, timestamp_index: usize) -> Result<Self> {
+    fn try_new(
+        schema: &Arc<Schema>,
+        timestamp_index: usize,
+        row_group_size: Option<usize>,
+    ) -> Result<Self> {
         Ok(Self {
             metrics_index: MetricsIndexWriter::try_new(schema)?,
             file_meta: FileMeta::default(),
             timestamp_index,
+            row_group_size,
         })
     }
 
@@ -246,13 +253,17 @@ impl IndexedMetricsFileState {
         let Self {
             metrics_index,
             mut file_meta,
+            row_group_size,
             ..
         } = self;
 
         // below the target so an indexed file never advertises >= max_file_size
         file_meta.original_size =
             proportional_original_size(source_meta, file_meta.records).min(max_file_size - 1);
-        Ok((metrics_index.finish()?, file_meta))
+        Ok((
+            metrics_index.finish(file_meta.records, row_group_size)?,
+            file_meta,
+        ))
     }
 }
 
@@ -274,7 +285,11 @@ impl ActiveIndexedParquetWriter {
         Ok(Self {
             writer,
             data_path,
-            state: IndexedMetricsFileState::try_new(schema, timestamp_index)?,
+            state: IndexedMetricsFileState::try_new(
+                schema,
+                timestamp_index,
+                Some(PARQUET_MAX_ROW_GROUP_SIZE),
+            )?,
         })
     }
 
@@ -313,7 +328,7 @@ impl ActiveIndexedVortexWriter {
         Ok(Self {
             writer: write_options.writer(file, dtype),
             data_path,
-            state: IndexedMetricsFileState::try_new(schema, timestamp_index)?,
+            state: IndexedMetricsFileState::try_new(schema, timestamp_index, None)?,
         })
     }
 

--- a/src/search/src/file_cache.rs
+++ b/src/search/src/file_cache.rs
@@ -49,7 +49,7 @@ pub async fn cache_files(
             cache_misses += 1;
         }
 
-        let stream_type = if file_type == "index" {
+        let stream_type = if file_type == "index" || file_type == "midx" {
             config::meta::stream::StreamType::Index
         } else if file.contains("/logs/") {
             config::meta::stream::StreamType::Logs


### PR DESCRIPTION
## Problem

With `ZO_METRICS_INDEX_ENABLED` on, PromQL queries never cached the `.midx` metrics indexes. The reader went through `file_data::get`, which only consults the memory/disk cache and reads object storage on every miss without populating anything, and the data-file prefetch (`cache_files`) did not include the sidecars. Every selection-cache miss (new matcher text, another querier node, an eviction) re-downloaded and re-decoded every sidecar in the window from object storage.

## Change

- **Prefetch the sidecars like Tantivy prefetches `.ttv`.** Before `metrics_index::search`, the PromQL storage path hands the `.midx` keys of the indexed files to the same `cache_files` the Tantivy path uses. Misses are queued for background download into the configured cache (memory when `ZO_MEMORY_CACHE_ENABLED`, else disk), with the downloader's dedup, max-age and min-records rules; the current query reads misses from storage exactly as `.ttv` does. Hit/miss counts go to `QUERY_DISK_CACHE_HIT_COUNT` / `QUERY_DISK_CACHE_MISS_COUNT` with the file type `midx`, and the `midx` type joins `index` for the `FILE_ACCESS_TIME` stream label. Sidecar sizes are not tracked in file_list, so the downloader gets 0 and skips the size check.
- **Selection cache behind a switch.** The process-wide cache of evaluated row ranges is now gated by `ZO_METRICS_INDEX_SELECTION_CACHE_ENABLED` (default `false`); its bound moves from a hard-coded 256 MiB to `ZO_METRICS_INDEX_SELECTION_CACHE_MAX_SIZE` (MB, default 256). Off, the pruner neither looks up nor inserts, and the `LazyLock` is never initialised.


- **`.midx` carries version and parent metadata.** The sidecar was a bare Arrow IPC file: only the file-name prefix said which format it was, and its only link to the data file was the run-count tiling check after a full decode. The writer now stamps the IPC schema metadata with `o2:midx_version`, `o2:parent_records`, `o2:row_group_size` (parquet only) and `o2:excluded_labels`. The reader refuses newer versions, rejects a sidecar whose recorded row count disagrees with file_list before evaluating it, refuses a zero row-group size (it would divide the access plan by zero) so that file is scanned in full, and builds the parquet access plan from the recorded row-group size instead of the hard-coded 131072; sidecars without metadata keep the previous behaviour. `validate_file` gains a `.midx` branch checking the Arrow IPC magic at both ends and the footer length, mirroring the puffin check for `.ttv`.

- **Selection cache metrics.** `zo_metrics_index_selection_cache_{requests_total,hits_total,memory_usage,gc_total}`, mirroring the tantivy result cache counters, so the switch can be judged from Prometheus. Requests and hits are counted only when the switch is on; `gc_total` counts inserts that triggered LRU eviction.

## Verification

- `cargo fmt --all --check` clean; CI clippy command clean on `metrics_index`, `search`, `infra`, `promql-service`, `config` (workspace run clean before the metadata commit).
- `cargo test -p metrics_index` (12, including the new parent/version enforcement test), `search` merge::metrics and file_cache, `promql-service` grpc, and the new `infra` `validate_midx` test pass; `config` and `metrics_index` clippy clean after the metrics commit.
- Not exercised end to end. After enabling the layout, the pruner log line `metrics index files N, memory cached X, disk cached Y` should show all sidecars cached on the second query of a window, and `zo_query_disk_cache_hit_count{file_type="midx"}` should grow.

## Notes

- No enterprise change: the o2-enterprise tree has no reference to the metrics index; root `Cargo.toml` untouched.


