### PR TITLE
perf(traces): cut the org trace time-range fan-out to what it needs

### DIFF
--- a/src/api/search/src/traces/time_index/mod.rs
+++ b/src/api/search/src/traces/time_index/mod.rs
@@ -62,14 +62,8 @@ const EXPAND_WINDOW: i64 = DAY_MICROS;
 const SESSION_EXPAND_WINDOW: i64 = 7 * DAY_MICROS;
 const MAX_LOOKUP_KEYS: usize = 100;
 const LOOKUP_CONCURRENCY: usize = 8;
-/// How many remembered streams the first lookup stage scans; a stale guess
-/// costs one extra stage, so a short list beats a broad first pass.
 const AFFINITY_STREAMS: usize = 2;
 
-/// Per `(org, kind)` memory of the streams that last answered a lookup, so the
-/// common case — a batch of ids that all live in one stream — settles in the
-/// first stage instead of fanning out over every trace stream. Entries are
-/// hints, never answers, and are bounded by the org count times the two kinds.
 static STREAM_AFFINITY: Lazy<RwHashMap<String, Vec<String>>> = Lazy::new(Default::default);
 
 /// What the lookup key identifies. The timer algorithm is shared; the kind
@@ -242,8 +236,6 @@ struct LookupOutcome {
     timed_out: bool,
 }
 
-/// One stream's slot in the request's fan-out: everything else the scan needs
-/// is built once and read through `run`.
 struct ScanParams<'a> {
     run: &'a LookupRun<'a>,
     stream_index: usize,
@@ -255,8 +247,7 @@ impl ScanParams<'_> {
     }
 }
 
-/// Shared state for one request's fan-out: the key-derived tables are built
-/// once, and `resolved` carries the cross-stream pruning across stages.
+/// `resolved` carries the cross-stream pruning across stages.
 struct LookupRun<'a> {
     org_id: &'a str,
     streams: &'a [String],
@@ -300,16 +291,13 @@ impl<'a> LookupRun<'a> {
         }
     }
 
-    /// True once every key has been seen by some stream, which is what lets a
-    /// later stage be skipped entirely.
     fn all_resolved(&self) -> bool {
         self.resolved
             .iter()
             .all(|flag| flag.load(Ordering::Relaxed))
     }
 
-    /// Scans one slice of the candidate streams concurrently. The bool reports
-    /// whether any of them lacked index coverage.
+    /// The bool reports whether any scanned stream lacked index coverage.
     async fn scan(&self, stage: Range<usize>) -> Result<(Vec<LookupOutcome>, bool)> {
         let scans = futures::stream::iter(stage.map(move |stream_index| async move {
             scan_stream(&ScanParams {
@@ -770,12 +758,7 @@ async fn query_inner(
     Ok(Some(SessionTimeIndexResult { range, traces }))
 }
 
-/// Two-stage fan-out under one shared deadline: the remembered streams first,
-/// the rest only when a key is still unseen. A trace or session id lives in
-/// exactly one stream, so a key seen by one stream's scan is skipped by the
-/// others. Skipping the second stage is safe because it only happens when
-/// every key was found, leaving no `not_found` for the unscanned streams to
-/// qualify. The bool reports whether any scanned stream lacked index coverage.
+/// Skipping the second stage is safe: it only happens when every key was found.
 async fn run_staged_lookups(
     run: &LookupRun<'_>,
     stage_one: usize,
@@ -789,10 +772,7 @@ async fn run_staged_lookups(
     Ok((outcomes, coverage_missing))
 }
 
-/// The org fan-out end to end: order the candidates by affinity, scan them in
-/// stages, then drop what the caller may not see. The steps are ordered — the
-/// affinity must not learn a stream the caller was denied — so they stay
-/// together rather than in the handler.
+/// Step order matters: the affinity must not learn a stream the caller was denied.
 async fn run_org_lookups(
     org_id: &str,
     user_id: &str,
@@ -817,7 +797,6 @@ async fn run_org_lookups(
     ))
 }
 
-/// The distinct streams that answered for at least one key.
 fn answering_streams(outcomes: &[LookupOutcome]) -> Vec<usize> {
     let mut answered = Vec::new();
     for outcome in outcomes {
@@ -828,8 +807,7 @@ fn answering_streams(outcomes: &[LookupOutcome]) -> Vec<usize> {
     answered
 }
 
-/// Moves the streams that last answered for this org to the front and returns
-/// how many of them the first stage should scan.
+/// Returns how many of the reordered prefix the first stage should scan.
 fn order_by_affinity(org_id: &str, kind: TimeIndexKind, streams: &mut [String]) -> usize {
     let Some(remembered) = STREAM_AFFINITY.get(&affinity_key(org_id, kind)) else {
         return 0;
@@ -844,8 +822,6 @@ fn order_by_affinity(org_id: &str, kind: TimeIndexKind, streams: &mut [String]) 
     front
 }
 
-/// Records the streams that answered, most recent first, so the next lookup
-/// for this org starts with them.
 fn remember_streams(
     org_id: &str,
     kind: TimeIndexKind,
@@ -872,10 +848,7 @@ fn affinity_key(org_id: &str, kind: TimeIndexKind) -> String {
     format!("{org_id}/{}", kind.label())
 }
 
-/// Permission is checked only on the streams that answered — one check in the
-/// common case instead of one per org trace stream. A denied stream's outcomes
-/// are dropped and reported as missing coverage, so the response neither
-/// returns its range nor names it.
+/// A denied stream is reported as missing coverage, never named or ranged.
 async fn drop_unpermitted(
     org_id: &str,
     user_id: &str,
@@ -1296,11 +1269,7 @@ async fn index_stream_exists(org_id: &str, stream_name: &str) -> bool {
     .await
 }
 
-/// Trace streams of the org that carry a time index, optionally narrowed to
-/// `filter`. The bool reports whether any candidate stream had to be skipped
-/// (partial coverage). Both listings are served by the schema cache, so this
-/// costs no per-stream round trip; permission is checked later, on the streams
-/// that answer.
+/// The bool reports whether any candidate was skipped for lacking an index.
 async fn resolve_org_streams(org_id: &str, filter: &[String]) -> Result<(Vec<String>, bool)> {
     if !get_config().common.trace_time_index_enabled {
         return Ok((Vec::new(), true));

--- a/src/api/search/src/traces/time_index/mod.rs
+++ b/src/api/search/src/traces/time_index/mod.rs
@@ -17,7 +17,11 @@ mod scan;
 
 use std::{
     collections::HashSet,
-    sync::atomic::{AtomicBool, Ordering},
+    ops::Range,
+    sync::{
+        LazyLock as Lazy,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 
@@ -28,7 +32,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use config::{
-    get_config,
+    RwHashMap, get_config,
     meta::{
         search::{Query, Request, RequestEncoding, SearchEventType},
         stream::StreamType,
@@ -58,6 +62,15 @@ const EXPAND_WINDOW: i64 = DAY_MICROS;
 const SESSION_EXPAND_WINDOW: i64 = 7 * DAY_MICROS;
 const MAX_LOOKUP_KEYS: usize = 100;
 const LOOKUP_CONCURRENCY: usize = 8;
+/// How many remembered streams the first lookup stage scans; a stale guess
+/// costs one extra stage, so a short list beats a broad first pass.
+const AFFINITY_STREAMS: usize = 2;
+
+/// Per `(org, kind)` memory of the streams that last answered a lookup, so the
+/// common case — a batch of ids that all live in one stream — settles in the
+/// first stage instead of fanning out over every trace stream. Entries are
+/// hints, never answers, and are bounded by the org count times the two kinds.
+static STREAM_AFFINITY: Lazy<RwHashMap<String, Vec<String>>> = Lazy::new(Default::default);
 
 /// What the lookup key identifies. The timer algorithm is shared; the kind
 /// selects the index column and the completeness assumption (expand window):
@@ -229,20 +242,95 @@ struct LookupOutcome {
     timed_out: bool,
 }
 
-/// Inputs for one stream's batch scan over all keys. The key-derived fields
-/// are built once per request and shared by every stream's scan.
+/// One stream's slot in the request's fan-out: everything else the scan needs
+/// is built once and read through `run`.
 struct ScanParams<'a> {
-    org_id: &'a str,
+    run: &'a LookupRun<'a>,
     stream_index: usize,
-    stream_name: &'a str,
+}
+
+impl ScanParams<'_> {
+    fn stream_name(&self) -> &str {
+        &self.run.streams[self.stream_index]
+    }
+}
+
+/// Shared state for one request's fan-out: the key-derived tables are built
+/// once, and `resolved` carries the cross-stream pruning across stages.
+struct LookupRun<'a> {
+    org_id: &'a str,
+    streams: &'a [String],
     kind: TimeIndexKind,
     keys: &'a [String],
-    key_indexes: &'a HashMap<&'a str, usize>,
-    key_uuid_ts: &'a [Option<i64>],
+    key_indexes: HashMap<&'a str, usize>,
+    key_uuid_ts: Vec<Option<i64>>,
     hint_ts: Option<i64>,
     bounds: Option<TraceTimeRange>,
     deadline: Instant,
-    resolved: &'a [AtomicBool],
+    resolved: Vec<AtomicBool>,
+}
+
+impl<'a> LookupRun<'a> {
+    fn new(
+        org_id: &'a str,
+        streams: &'a [String],
+        kind: TimeIndexKind,
+        keys: &'a [String],
+        hint_ts: Option<i64>,
+        bounds: Option<TraceTimeRange>,
+    ) -> Self {
+        Self {
+            org_id,
+            streams,
+            kind,
+            keys,
+            key_indexes: keys
+                .iter()
+                .enumerate()
+                .map(|(index, key)| (key.as_str(), index))
+                .collect(),
+            key_uuid_ts: keys
+                .iter()
+                .map(|key| config::ider::get_start_time_from_trace_id(key))
+                .collect(),
+            hint_ts,
+            bounds,
+            deadline: default_deadline(),
+            resolved: (0..keys.len()).map(|_| AtomicBool::new(false)).collect(),
+        }
+    }
+
+    /// True once every key has been seen by some stream, which is what lets a
+    /// later stage be skipped entirely.
+    fn all_resolved(&self) -> bool {
+        self.resolved
+            .iter()
+            .all(|flag| flag.load(Ordering::Relaxed))
+    }
+
+    /// Scans one slice of the candidate streams concurrently. The bool reports
+    /// whether any of them lacked index coverage.
+    async fn scan(&self, stage: Range<usize>) -> Result<(Vec<LookupOutcome>, bool)> {
+        let scans = futures::stream::iter(stage.map(move |stream_index| async move {
+            scan_stream(&ScanParams {
+                run: self,
+                stream_index,
+            })
+            .await
+        }))
+        .buffer_unordered(LOOKUP_CONCURRENCY)
+        .try_collect::<Vec<Option<Vec<LookupOutcome>>>>()
+        .await?;
+        let mut coverage_missing = false;
+        let mut outcomes = Vec::new();
+        for scan in scans {
+            match scan {
+                Some(scan) => outcomes.extend(scan),
+                None => coverage_missing = true,
+            }
+        }
+        Ok((outcomes, coverage_missing))
+    }
 }
 
 /// One window's worth of index rows: the merged overall range drives the
@@ -401,10 +489,10 @@ async fn query_batch_window(
     if start_time >= end_time || active.is_empty() {
         return Ok(Some(Vec::new()));
     }
-    let column = params.kind.column();
+    let column = params.run.kind.column();
     let predicate = key_in_predicate(
         column,
-        active.iter().map(|&index| params.keys[index].as_str()),
+        active.iter().map(|&index| params.run.keys[index].as_str()),
     );
     let sql = format!(
         "SELECT {}, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts FROM {} WHERE {predicate} GROUP BY {}",
@@ -412,8 +500,14 @@ async fn query_batch_window(
         quote_identifier(index_stream),
         quote_identifier(column),
     );
-    let Some(hits) =
-        search_index_window(params.org_id, sql, start_time, end_time, params.deadline).await?
+    let Some(hits) = search_index_window(
+        params.run.org_id,
+        sql,
+        start_time,
+        end_time,
+        params.run.deadline,
+    )
+    .await?
     else {
         return Ok(None);
     };
@@ -422,7 +516,7 @@ async fn query_batch_window(
         let Some((key, range)) = parse_hit_range(hit, column) else {
             continue;
         };
-        if let Some(&index) = params.key_indexes.get(key.as_str()) {
+        if let Some(&index) = params.run.key_indexes.get(key.as_str()) {
             rows.push((index, range));
         }
     }
@@ -676,63 +770,137 @@ async fn query_inner(
     Ok(Some(SessionTimeIndexResult { range, traces }))
 }
 
-/// Runs one batch scan per stream under one shared deadline. A trace or
-/// session id lives in exactly one stream, so a key seen by one stream's scan
-/// is skipped by the others. The bool reports whether any stream lacked index
-/// coverage.
-async fn run_lookups(
+/// Two-stage fan-out under one shared deadline: the remembered streams first,
+/// the rest only when a key is still unseen. A trace or session id lives in
+/// exactly one stream, so a key seen by one stream's scan is skipped by the
+/// others. Skipping the second stage is safe because it only happens when
+/// every key was found, leaving no `not_found` for the unscanned streams to
+/// qualify. The bool reports whether any scanned stream lacked index coverage.
+async fn run_staged_lookups(
+    run: &LookupRun<'_>,
+    stage_one: usize,
+) -> Result<(Vec<LookupOutcome>, bool)> {
+    let (mut outcomes, mut coverage_missing) = run.scan(0..stage_one).await?;
+    if !run.all_resolved() {
+        let (rest, missing) = run.scan(stage_one..run.streams.len()).await?;
+        outcomes.extend(rest);
+        coverage_missing |= missing;
+    }
+    Ok((outcomes, coverage_missing))
+}
+
+/// The org fan-out end to end: order the candidates by affinity, scan them in
+/// stages, then drop what the caller may not see. The steps are ordered — the
+/// affinity must not learn a stream the caller was denied — so they stay
+/// together rather than in the handler.
+async fn run_org_lookups(
     org_id: &str,
-    streams: &[String],
-    kind: TimeIndexKind,
-    keys: &[String],
-    hint_ts: Option<i64>,
-    bounds: Option<TraceTimeRange>,
+    user_id: &str,
+    streams: &mut [String],
+    request: &LookupRequest,
 ) -> Result<(Vec<TimeRangeResult>, bool)> {
-    let deadline = default_deadline();
-    let resolved: Vec<AtomicBool> = (0..keys.len()).map(|_| AtomicBool::new(false)).collect();
-    let resolved = &resolved;
-    let key_indexes: HashMap<&str, usize> = keys
-        .iter()
-        .enumerate()
-        .map(|(index, key)| (key.as_str(), index))
-        .collect();
-    let key_indexes = &key_indexes;
-    let key_uuid_ts: Vec<Option<i64>> = keys
-        .iter()
-        .map(|key| config::ider::get_start_time_from_trace_id(key))
-        .collect();
-    let key_uuid_ts = &key_uuid_ts;
-    let scans = futures::stream::iter((0..streams.len()).map(|stream_index| async move {
-        scan_stream(&ScanParams {
-            org_id,
-            stream_index,
-            stream_name: &streams[stream_index],
-            kind,
-            keys,
-            key_indexes,
-            key_uuid_ts,
-            hint_ts,
-            bounds,
-            deadline,
-            resolved,
-        })
-        .await
-    }))
-    .buffer_unordered(LOOKUP_CONCURRENCY)
-    .try_collect::<Vec<Option<Vec<LookupOutcome>>>>()
-    .await?;
-    let mut coverage_missing = false;
-    let mut outcomes = Vec::new();
-    for scan in scans {
-        match scan {
-            Some(scan) => outcomes.extend(scan),
-            None => coverage_missing = true,
+    let stage_one = order_by_affinity(org_id, request.kind, streams);
+    let run = LookupRun::new(
+        org_id,
+        streams,
+        request.kind,
+        &request.keys,
+        request.hint_ts,
+        request.bounds,
+    );
+    let (outcomes, coverage_missing) = run_staged_lookups(&run, stage_one).await?;
+    let (outcomes, denied) = drop_unpermitted(org_id, user_id, streams, outcomes).await;
+    remember_streams(org_id, request.kind, streams, &outcomes);
+    Ok((
+        aggregate_outcomes(streams, request.kind, &request.keys, outcomes),
+        coverage_missing || denied,
+    ))
+}
+
+/// The distinct streams that answered for at least one key.
+fn answering_streams(outcomes: &[LookupOutcome]) -> Vec<usize> {
+    let mut answered = Vec::new();
+    for outcome in outcomes {
+        if outcome.range.is_some() && !answered.contains(&outcome.stream_index) {
+            answered.push(outcome.stream_index);
         }
     }
-    Ok((
-        aggregate_outcomes(streams, kind, keys, outcomes),
-        coverage_missing,
+    answered
+}
+
+/// Moves the streams that last answered for this org to the front and returns
+/// how many of them the first stage should scan.
+fn order_by_affinity(org_id: &str, kind: TimeIndexKind, streams: &mut [String]) -> usize {
+    let Some(remembered) = STREAM_AFFINITY.get(&affinity_key(org_id, kind)) else {
+        return 0;
+    };
+    let mut front = 0;
+    for name in remembered.iter() {
+        if let Some(offset) = streams[front..].iter().position(|stream| stream == name) {
+            streams.swap(front, front + offset);
+            front += 1;
+        }
+    }
+    front
+}
+
+/// Records the streams that answered, most recent first, so the next lookup
+/// for this org starts with them.
+fn remember_streams(
+    org_id: &str,
+    kind: TimeIndexKind,
+    streams: &[String],
+    outcomes: &[LookupOutcome],
+) {
+    let hits = answering_streams(outcomes);
+    if hits.is_empty() {
+        return;
+    }
+    let mut remembered = STREAM_AFFINITY
+        .entry(affinity_key(org_id, kind))
+        .or_default();
+    let names: Vec<String> = hits
+        .into_iter()
+        .map(|index| streams[index].clone())
+        .collect();
+    remembered.retain(|stream| !names.contains(stream));
+    remembered.splice(..0, names);
+    remembered.truncate(AFFINITY_STREAMS);
+}
+
+fn affinity_key(org_id: &str, kind: TimeIndexKind) -> String {
+    format!("{org_id}/{}", kind.label())
+}
+
+/// Permission is checked only on the streams that answered — one check in the
+/// common case instead of one per org trace stream. A denied stream's outcomes
+/// are dropped and reported as missing coverage, so the response neither
+/// returns its range nor names it.
+async fn drop_unpermitted(
+    org_id: &str,
+    user_id: &str,
+    streams: &[String],
+    outcomes: Vec<LookupOutcome>,
+) -> (Vec<LookupOutcome>, bool) {
+    let denied: Vec<usize> = futures::stream::iter(answering_streams(&outcomes).into_iter().map(
+        |index| async move {
+            super::check_stream_permissions(org_id, &streams[index], user_id)
+                .await
+                .map(|_| index)
+        },
     ))
+    .buffered(LOOKUP_CONCURRENCY)
+    .filter_map(|denied| async move { denied })
+    .collect()
+    .await;
+    if denied.is_empty() {
+        return (outcomes, false);
+    }
+    let kept = outcomes
+        .into_iter()
+        .filter(|outcome| !denied.contains(&outcome.stream_index))
+        .collect();
+    (kept, true)
 }
 
 /// Drives one stream's [`BatchScanner`]: asks it for windows, runs them, and
@@ -743,7 +911,7 @@ async fn scan_stream(params: &ScanParams<'_>) -> Result<Option<Vec<LookupOutcome
     let result = scan_stream_inner(params).await;
     if result.is_err() {
         config::metrics::TRACE_TIME_INDEX_OPERATIONS
-            .with_label_values(&[params.org_id, params.kind.operation(), "error"])
+            .with_label_values(&[params.run.org_id, params.run.kind.operation(), "error"])
             .inc();
     }
     result
@@ -751,37 +919,27 @@ async fn scan_stream(params: &ScanParams<'_>) -> Result<Option<Vec<LookupOutcome
 
 async fn scan_stream_inner(params: &ScanParams<'_>) -> Result<Option<Vec<LookupOutcome>>> {
     let started = std::time::Instant::now();
-    let kind = params.kind;
-    let floor = session_uuid_floor(kind, params.key_uuid_ts);
-    let Some(bounds) = resolve_scan_bounds(
-        params.org_id,
-        params.stream_name,
-        kind,
-        params.bounds,
-        floor,
-    )
-    .await?
+    let run = params.run;
+    let kind = run.kind;
+    let floor = session_uuid_floor(kind, &run.key_uuid_ts);
+    let Some(bounds) =
+        resolve_scan_bounds(run.org_id, params.stream_name(), kind, run.bounds, floor).await?
     else {
         return Ok(None);
     };
-    let index_stream = get_trace_time_index_stream_name(params.stream_name);
-    let mut scanner = BatchScanner::new(
-        kind,
-        params.keys.len(),
-        bounds,
-        params.hint_ts,
-        params.key_uuid_ts,
-    );
+    let index_stream = get_trace_time_index_stream_name(params.stream_name());
+    let mut scanner =
+        BatchScanner::new(kind, run.keys.len(), bounds, run.hint_ts, &run.key_uuid_ts);
     let mut windows = 0u64;
     loop {
-        if params
+        if run
             .deadline
             .saturating_duration_since(Instant::now())
             .is_zero()
         {
             break;
         }
-        for (key, flag) in params.resolved.iter().enumerate() {
+        for (key, flag) in run.resolved.iter().enumerate() {
             if flag.load(Ordering::Relaxed) {
                 scanner.skip_key(key);
             }
@@ -796,7 +954,7 @@ async fn scan_stream_inner(params: &ScanParams<'_>) -> Result<Option<Vec<LookupO
             break;
         };
         for key in scanner.ingest(rows) {
-            params.resolved[key].store(true, Ordering::Relaxed);
+            run.resolved[key].store(true, Ordering::Relaxed);
         }
     }
     let outcomes = collect_scan_outcomes(params.stream_index, scanner.finish());
@@ -875,8 +1033,8 @@ fn record_scan_metrics(
     outcomes: &[LookupOutcome],
     elapsed: std::time::Duration,
 ) {
-    let org_id = params.org_id;
-    let kind = params.kind;
+    let org_id = params.run.org_id;
+    let kind = params.run.kind;
     // Same per-key accounting the per-key path emits: hit/miss verdicts, plus
     // a timeout marker whenever the scan gave up on that key. Scan duration
     // has no per-lookup status, so only the log line carries it.
@@ -903,9 +1061,9 @@ fn record_scan_metrics(
         .observe(windows as f64);
     log::info!(
         "[trace_time_index] batch scan org_id={org_id:?} stream={:?} kind={} keys={} windows={windows} hits={hits} misses={} timeouts={timeouts} took={} ms",
-        params.stream_name,
+        params.stream_name(),
         kind.label(),
-        params.keys.len(),
+        params.run.keys.len(),
         outcomes.len() as u64 - hits,
         elapsed.as_millis(),
     );
@@ -1138,38 +1296,30 @@ async fn index_stream_exists(org_id: &str, stream_name: &str) -> bool {
     .await
 }
 
-/// Trace streams of the org the caller may search and that have a time index,
-/// optionally narrowed to `filter`. The bool reports whether any candidate
-/// stream had to be skipped (partial coverage).
-async fn resolve_org_streams(
-    org_id: &str,
-    user_id: &str,
-    filter: &[String],
-) -> Result<(Vec<String>, bool)> {
+/// Trace streams of the org that carry a time index, optionally narrowed to
+/// `filter`. The bool reports whether any candidate stream had to be skipped
+/// (partial coverage). Both listings are served by the schema cache, so this
+/// costs no per-stream round trip; permission is checked later, on the streams
+/// that answer.
+async fn resolve_org_streams(org_id: &str, filter: &[String]) -> Result<(Vec<String>, bool)> {
     if !get_config().common.trace_time_index_enabled {
         return Ok((Vec::new(), true));
     }
     let stream_list = db::schema::list(org_id, Some(StreamType::Traces), false)
         .await
         .map_err(|e| Error::Message(format!("list trace streams: {e}")))?;
-    let candidates = stream_list
-        .into_iter()
-        .map(|stream| stream.stream_name)
-        .filter(|name| filter.is_empty() || filter.contains(name));
-    let checks = futures::stream::iter(candidates.map(|name| async move {
-        let searchable = super::check_stream_permissions(org_id, &name, user_id)
+    let indexes: HashSet<String> =
+        db::schema::list_streams_from_cache(org_id, StreamType::Metadata)
             .await
-            .is_none()
-            && index_stream_exists(org_id, &name).await;
-        (name, searchable)
-    }))
-    .buffered(LOOKUP_CONCURRENCY)
-    .collect::<Vec<_>>()
-    .await;
+            .into_iter()
+            .collect();
     let mut streams = Vec::new();
     let mut partial = false;
-    for (name, searchable) in checks {
-        if searchable {
+    for name in stream_list.into_iter().map(|stream| stream.stream_name) {
+        if !filter.is_empty() && !filter.contains(&name) {
+            continue;
+        }
+        if indexes.contains(&get_trace_time_index_stream_name(&name)) {
             streams.push(name);
         } else {
             partial = true;
@@ -1221,16 +1371,19 @@ pub async fn get_trace_time_range(
     };
     let request_trace_id = get_or_create_trace_id(&headers, &tracing::Span::none());
     let streams = std::slice::from_ref(&stream_name);
-    let (results, coverage_missing) = match run_lookups(
-        &org_id,
-        streams,
-        request.kind,
-        &request.keys,
-        request.hint_ts,
-        request.bounds,
-    )
-    .await
-    {
+    // Scoped so the run's borrow of `stream_name` ends before the response moves it.
+    let lookup = {
+        let run = LookupRun::new(
+            &org_id,
+            streams,
+            request.kind,
+            &request.keys,
+            request.hint_ts,
+            request.bounds,
+        );
+        run_staged_lookups(&run, streams.len()).await
+    };
+    let (outcomes, coverage_missing) = match lookup {
         Ok(outcome) => outcome,
         Err(e) => {
             log::error!(
@@ -1239,6 +1392,7 @@ pub async fn get_trace_time_range(
             return MetaHttpResponse::internal_error("Failed to query trace time index");
         }
     };
+    let results = aggregate_outcomes(streams, request.kind, &request.keys, outcomes);
     let single = (request.keys.len() == 1).then(|| results.first()).flatten();
     let (trace_id, session_id, range) = match single {
         Some(single) => (
@@ -1304,13 +1458,7 @@ pub async fn get_org_trace_time_range(
     };
     let request_trace_id = get_or_create_trace_id(&headers, &tracing::Span::none());
     let stream_filter = parse_id_list(params.get("streams"));
-    let (streams, partial_streams) = match resolve_org_streams(
-        &org_id,
-        &user_email.user_id,
-        &stream_filter,
-    )
-    .await
-    {
+    let (mut streams, partial_streams) = match resolve_org_streams(&org_id, &stream_filter).await {
         Ok(resolved) => resolved,
         Err(e) => {
             log::error!(
@@ -1319,24 +1467,16 @@ pub async fn get_org_trace_time_range(
             return MetaHttpResponse::internal_error("Failed to query trace time index");
         }
     };
-    let (results, coverage_missing) = match run_lookups(
-        &org_id,
-        &streams,
-        request.kind,
-        &request.keys,
-        request.hint_ts,
-        request.bounds,
-    )
-    .await
-    {
-        Ok(outcome) => outcome,
-        Err(e) => {
-            log::error!(
-                "[trace_id {request_trace_id}] trace time index query failed for {org_id}: {e}"
-            );
-            return MetaHttpResponse::internal_error("Failed to query trace time index");
-        }
-    };
+    let (results, coverage_missing) =
+        match run_org_lookups(&org_id, &user_email.user_id, &mut streams, &request).await {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                log::error!(
+                    "[trace_id {request_trace_id}] trace time index query failed for {org_id}: {e}"
+                );
+                return MetaHttpResponse::internal_error("Failed to query trace time index");
+            }
+        };
     Json(OrgTraceTimeRangeResponse {
         results,
         searched_range: effective_searched_range(request.kind, request.bounds).await,
@@ -1616,5 +1756,93 @@ mod tests {
         );
         assert_eq!(union_ranges(Some(caller), None), Some(caller));
         assert_eq!(union_ranges(None, None), None);
+    }
+
+    fn outcome(stream_index: usize) -> LookupOutcome {
+        LookupOutcome {
+            key_index: 0,
+            stream_index,
+            range: Some(TraceTimeRange {
+                start_time: 1,
+                end_time: 2,
+            }),
+            timed_out: false,
+        }
+    }
+
+    #[test]
+    fn affinity_is_empty_until_a_stream_answers() {
+        let mut streams = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(
+            order_by_affinity("unseen-org", TimeIndexKind::Trace, &mut streams),
+            0
+        );
+        assert_eq!(streams, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn affinity_moves_the_answering_stream_to_the_front() {
+        let org = "affinity-front-org";
+        let streams = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        remember_streams(org, TimeIndexKind::Trace, &streams, &[outcome(2)]);
+        let mut next = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(order_by_affinity(org, TimeIndexKind::Trace, &mut next), 1);
+        assert_eq!(next[0], "c");
+    }
+
+    #[test]
+    fn affinity_is_capped_and_most_recent_first() {
+        let org = "affinity-cap-org";
+        let streams = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        for index in 0..streams.len() {
+            remember_streams(org, TimeIndexKind::Trace, &streams, &[outcome(index)]);
+        }
+        let mut next = streams.clone();
+        assert_eq!(
+            order_by_affinity(org, TimeIndexKind::Trace, &mut next),
+            AFFINITY_STREAMS
+        );
+        assert_eq!(next[0], "c");
+        assert_eq!(next[1], "b");
+    }
+
+    #[test]
+    fn affinity_skips_streams_that_are_no_longer_candidates() {
+        let org = "affinity-gone-org";
+        let streams = vec!["a".to_string(), "gone".to_string()];
+        remember_streams(org, TimeIndexKind::Trace, &streams, &[outcome(1)]);
+        let mut next = vec!["a".to_string()];
+        assert_eq!(order_by_affinity(org, TimeIndexKind::Trace, &mut next), 0);
+        assert_eq!(next, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn affinity_is_kept_per_kind() {
+        let org = "affinity-kind-org";
+        let streams = vec!["a".to_string(), "b".to_string()];
+        remember_streams(org, TimeIndexKind::Trace, &streams, &[outcome(1)]);
+        let mut next = streams.clone();
+        assert_eq!(order_by_affinity(org, TimeIndexKind::Session, &mut next), 0);
+        assert_eq!(order_by_affinity(org, TimeIndexKind::Trace, &mut next), 1);
+        assert_eq!(next[0], "b");
+    }
+
+    #[test]
+    fn a_missing_stream_is_not_remembered() {
+        let org = "affinity-miss-org";
+        let streams = vec!["a".to_string()];
+        remember_streams(
+            org,
+            TimeIndexKind::Trace,
+            &streams,
+            &[LookupOutcome {
+                key_index: 0,
+                stream_index: 0,
+                range: None,
+                timed_out: false,
+            }],
+        );
+        let mut next = streams.clone();
+        assert_eq!(order_by_affinity(org, TimeIndexKind::Trace, &mut next), 0);
     }
 }


### PR DESCRIPTION
## Why

A colleague reported `GET /api/{org}/traces/time_range` taking 1.71s for one trace id and 9s for ~40. Reproduced and measured against a live 25-stream org (11 of them carrying a time index), on one connection so network is a flat ~0.20s:

| variant | n | min | p50 | max |
|---|---|---|---|---|
| 1 id, org-wide | 8 | 2.72s | 4.52s | 10.99s |
| 40 ids, org-wide | 8 | 3.01s | 5.46s | 9.80s |
| 1 id, `streams=default` | 8 | 0.36s | 0.70s | 8.36s |
| 40 ids, `streams=default` | 8 | 0.38s | 0.73s | 13.09s |

The id count is not the driver — the batch scan already resolves 40 keys in the same windows as 1. Two things were:

1. **Stream resolution, ~72% of the server time.** `resolve_org_streams` did one OpenFGA check plus one `schema::exists` probe per org trace stream. Isolating it with a filter that triggers no index scan shows it is linear at ~0.10s per stream *despite* `buffered(8)` — 0 candidates 0.19s, 1 → 0.31s, 4 → 0.54s, 8 → 0.91s, 14 → 1.70s. The existence probe also hits the metadata DB on every request for streams that have no index, because `get_cache` deliberately never caches an empty schema.
2. **Tail amplification.** Each of the ~22 internal searches (11 streams × 2 windows) has p50 ~40–170ms but stalls 1.5–4.5s roughly a quarter of the time — on a 69-doc/5-file index stream scanning zero records, `search_took` was 4417ms with `file_list_took=4` and `wait_in_queue=11`. Taking the max over 22 of those makes a multi-second response near-certain. (That tail is cluster-wide, not specific to this endpoint — a `count(*)` over one minute of a logs stream shows the same shape — and is not addressed here.)

## What changed

**Resolution and permission.** Candidate streams now come from the schema cache with no per-stream round trip. Permission moved to the streams that actually answered, so a lookup costs one check instead of one per org stream. A denied stream's outcomes are dropped and the response reports missing coverage — it neither returns that stream's range nor names it, so the existing "don't leak stream existence" property holds.

**Two-stage fan-out.** A per-`(org, kind)` memory of the streams that last answered is scanned first; the rest only when a key is still unseen. Skipping the second stage happens only when every key was found, so no `not_found` is left for the unscanned streams to qualify. The memory is a hint — a stale guess costs one extra stage, never a wrong answer — and it is written after the permission filter so it can never learn a stream the caller was denied.

Expected, decomposed from the measurements above (1 trace id, org-wide, excluding network):

| | before | affinity hit | affinity miss |
|---|---|---|---|
| permission / stream resolution | 2.4s | ~0 | ~0 |
| index scans | 0.7s | ~0.25s (1–2 streams) | ~1.4s (11 streams) |
| permission on the hit stream | — | ~0.1s | ~0.1s |
| **total** | **~3.1s** | **~0.35s** | **~1.5s** |

The first request after a process start takes the miss column, then converges.

## For the reviewer

- **The security trade is deliberate.** Index streams the caller cannot read are now scanned before permission is known — their compute is spent on the caller's behalf, and a denied stream is observable through `partial_coverage` and latency. What is *not* observable is the stream's name or the range. The alternative considered was `list_objects_for_user` as a one-round-trip prefilter (the shape used elsewhere in the codebase); it was passed over because the lazy check gets the same 25→1 reduction without changing the response contract, but it remains the cleaner option if we want candidates authorized up front.
- **Known cost on the not-found path.** The two stages share one deadline and run strictly serially, so for a key that is genuinely absent (where stage one cannot prune) the scan time roughly doubles versus the old single wave. Giving stage one its own sub-deadline was rejected: cutting it short turns a definitive `not_found` into `timeout`, which loses the proof-of-absence the frontend relies on to skip its expensive `_search_multi_stream` probe.
- **`infra::schema::exists` is still broken for negatives** — `get_cache` never caches an empty schema, so every "this stream has no index" answer is a fresh DB round trip, for this endpoint's remaining per-scan call and five other callers. Fixing it needs invalidation on stream creation, so it is left for a separate change.
- **Collapsing the fan-out into one `UNION ALL` query was measured, not assumed**: an 11-way union over the index streams ran at p50 1.72s against ~1.4s for the current 11-stream fan-out — planning overhead eats the win.
- No `#[cfg(feature = "enterprise")]` code changed; the enterprise-gated `check_stream_permissions` is the same helper called from a different place, so no paired o2-enterprise PR is needed.

## Testing

`cargo fmt --all`, the CI clippy command (`--workspace --all-targets` with the three structural lints, `-D warnings`) and `cargo test -p openobserve-api-search --lib traces::time_index` all pass — 37 tests, including 6 new ones pinning the affinity ordering, its cap, per-kind isolation, and that a miss is never remembered.