### PR TITLE
fix: builder tab saved views apply issue

### DIFF
--- a/web/src/plugins/logs/BuildQueryPage.vue
+++ b/web/src/plugins/logs/BuildQueryPage.vue
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch, defineAsyncComponent, provide, defineExpose } from "vue";
+import { ref, onMounted, watch, defineAsyncComponent, provide } from "vue";
 import { useRouter } from "vue-router";
 import { useI18nTyped } from "@/types/i18n";
 import useDashboardPanelData from "@/composables/dashboard/useDashboardPanel";

--- a/web/src/plugins/logs/BuildQueryPage.vue
+++ b/web/src/plugins/logs/BuildQueryPage.vue
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, defineAsyncComponent, provide } from "vue";
+import { ref, onMounted, watch, defineAsyncComponent, provide, defineExpose } from "vue";
 import { useRouter } from "vue-router";
 import { useI18nTyped } from "@/types/i18n";
 import useDashboardPanelData from "@/composables/dashboard/useDashboardPanel";
@@ -478,6 +478,19 @@ const addPanelToDashboard = () => {
 // ============================================================================
 // Watchers
 // ============================================================================
+
+// Applying a saved view while already on the build tab does not remount this
+// component, so onMounted never re-reads savedBuildConfig. Re-initialize here so
+// the applied view is reflected. initializeFromQuery consumes and nulls it, so a
+// fresh non-null value always signals a newly applied saved view.
+watch(
+  () => searchObj.meta.savedBuildConfig,
+  (config) => {
+    if (config) {
+      initializeFromQuery();
+    }
+  },
+);
 
 // NOTE: URL sync for build mode fields is handled by explicit actions (runQuery, apply)
 // rather than a deep watcher. A deep watcher here would call router.push on every


### PR DESCRIPTION
- #14228

## Fix: Builder-tab saved views not applied when already on the Builder tab

### Problem

When applying a **Builder** saved view, the behavior was inconsistent depending on which tab the user was currently on:

- ✅ **On a different tab** (e.g. SQL/Custom): applying a Builder saved view toggled over to the Builder tab and applied correctly.
- ❌ **Already on the Builder tab**: applying a Builder saved view did **not** reflect in the tab — the builder kept showing the previously-open state.

This stems from our design behavior: we always (re)apply the builder state when we *toggle* into the Builder tab. So when the user is already on Builder and applies a Builder saved view, there's no toggle, and the view is never applied.

### Root cause

`BuildQueryPage` is rendered with `v-if="logsVisualizeToggle == 'build'"`, so it only mounts when toggling *into* the Builder tab. The saved-view config (`searchObj.meta.savedBuildConfig`) is consumed exactly once, inside `onMounted → initializeFromQuery`.

- Applying from another tab flips the toggle to `build` → the component mounts → `onMounted` reads and applies the config.
- Applying while already on `build` doesn't change the toggle → no remount → `savedBuildConfig` is set but never read.

### Fix

Added a watcher in `BuildQueryPage.vue` on `searchObj.meta.savedBuildConfig`. When a fresh (non-null) config appears, it re-runs `initializeFromQuery()` so the applied view is reflected in place — regardless of whether the component just mounted.

```js
watch(
  () => searchObj.meta.savedBuildConfig,
  (config) => {
    if (config) {
      initializeFromQuery();
    }
  },
);
```

`initializeFromQuery` consumes and nulls the config, so a fresh non-null value always signals a newly applied saved view. This is safe in both paths:

- **Already on Builder:** the null→value transition fires the watcher → view applies in place.
- **Toggle-in (unchanged behavior):** the config is set before mount, so the non-immediate watcher never fires for it; `onMounted` consumes it, and the resulting null transition is a guarded no-op — no double initialization.
- **Non-builder saved views:** `buildData` is null → skipped by the `if (config)` guard.

### Testing

- On the Builder tab, apply a Builder saved view → fields/chart now update in place. ✅
- From SQL/Custom tab, apply a Builder saved view → still toggles to Builder and applies (no regression). ✅
- Apply a non-Builder saved view → no spurious builder re-init. ✅
