### PR TITLE
perf(search): download small files in full before the search instead of range-reading them

### DIFF
--- a/src/api/grpc/src/handler/grpc/request/event.rs
+++ b/src/api/grpc/src/handler/grpc/request/event.rs
@@ -64,9 +64,6 @@ impl Event for Eventer {
 
             // Collect files to download
             for item in put_items.iter() {
-                if !infra::cache::file_downloader::should_download(item.meta.records) {
-                    continue;
-                }
                 // files with data older than the cache max age should not be
                 // cached, e.g. merged files from compaction of old partitions
                 if infra::cache::file_downloader::exceeds_cache_max_age(

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2270,8 +2270,12 @@ pub struct Limit {
     pub query_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_THREAD_NUM", default = 0)]
     pub file_download_thread_num: usize,
-    #[env_config(name = "ZO_FILE_DOWNLOAD_MIN_RECORDS", default = 100)]
-    pub file_download_min_records: i64,
+    #[env_config(
+        name = "ZO_FILE_DOWNLOAD_SYNC_MAX_SIZE",
+        default = 1,
+        help = "Files up to this size in MB are downloaded into the cache before a search reads them instead of being range-read from object storage, 0 disables"
+    )]
+    pub file_download_sync_max_size: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_THREAD_NUM", default = 0)]
     pub file_download_priority_queue_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_WINDOW_SECS", default = 3600)]
@@ -3638,6 +3642,7 @@ fn check_common_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     } else {
         cfg.limit.max_file_size_in_memory *= 1024 * 1024;
     }
+    cfg.limit.file_download_sync_max_size *= 1024 * 1024;
 
     // check for metrics limit
     if cfg.limit.metrics_max_points_per_series == 0 {

--- a/src/infra/src/cache/file_data/mod.rs
+++ b/src/infra/src/cache/file_data/mod.rs
@@ -393,6 +393,10 @@ pub async fn get_opts(
     })
 }
 
+pub async fn exist(file: &str) -> bool {
+    memory::exist(file).await || disk::exist(file).await
+}
+
 pub async fn get_size(account: &str, file: &str) -> object_store::Result<usize> {
     get_size_opts(account, file, true).await
 }

--- a/src/infra/src/cache/file_downloader.rs
+++ b/src/infra/src/cache/file_downloader.rs
@@ -335,7 +335,7 @@ async fn download_file(
     ret
 }
 
-// downloads one file for a waiting search, or waits for the task that is already downloading it
+// downloads one file whose in-flight mark the caller already holds, then clears the mark
 async fn download_file_sync(
     trace_id: &str,
     file_id: i64,
@@ -344,9 +344,6 @@ async fn download_file_sync(
     file_size: usize,
     cache_type: file_data::CacheType,
 ) -> bool {
-    if !processing_files::add(file_name) {
-        return wait_for_download(trace_id, file_name).await;
-    }
     let ret = download_file(
         0, trace_id, file_id, account, file_name, file_size, cache_type,
     )
@@ -638,16 +635,17 @@ pub async fn download_sync(
         if exceeds_cache_max_age(ts, cache_type) {
             continue;
         }
-        // files another task is already fetching are awaited later without holding a permit
-        if processing_files::is_processing(&file) {
-            in_flight.push(file);
-            continue;
-        }
         let permit = semaphore
             .clone()
             .acquire_owned()
             .await
             .expect("sync download semaphore is never closed");
+        // ownership is claimed under the permit; a file another task owns is awaited without one
+        if !processing_files::add(&file) {
+            drop(permit);
+            in_flight.push(file);
+            continue;
+        }
         let trace_id = trace_id.to_string();
         // spawned so a cancelled search still finishes the download and clears the in-flight mark
         tasks.push(tokio::spawn(async move {
@@ -731,6 +729,35 @@ mod tests {
             .await
             .expect("waiter should finish once the download is removed")
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_download_sync_waits_for_file_owned_by_another_task() {
+        let name = "test_download_sync_wait_file_333.parquet";
+        assert!(processing_files::add(name));
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            processing_files::remove(name);
+        });
+        let files = vec![(1, "default".to_string(), name.to_string(), 1024, 0)];
+        let cached = tokio::time::timeout(
+            Duration::from_secs(5),
+            super::download_sync("trace", files, file_data::CacheType::None, 1),
+        )
+        .await
+        .expect("download_sync should return once the other download finishes");
+        assert_eq!(cached, 0);
+        assert!(!processing_files::is_processing(name));
+    }
+
+    #[tokio::test]
+    async fn test_download_sync_clears_in_flight_mark() {
+        let name = "test_download_sync_owned_file_444.parquet";
+        let files = vec![(1, "default".to_string(), name.to_string(), 1024, 0)];
+        // CacheType::None makes download_file a no-op success, so no storage is touched
+        let cached = super::download_sync("trace", files, file_data::CacheType::None, 1).await;
+        assert_eq!(cached, 1);
+        assert!(!processing_files::is_processing(name));
     }
 
     #[test]

--- a/src/infra/src/cache/file_downloader.rs
+++ b/src/infra/src/cache/file_downloader.rs
@@ -16,6 +16,7 @@
 use std::{
     collections::VecDeque,
     sync::{Arc, LazyLock as Lazy},
+    time::Duration,
 };
 
 use config::{
@@ -38,26 +39,46 @@ use crate::{cache::file_data, cluster};
 
 /// (trace_id, file_id, account, file, size, cache_type)
 type FileInfo = (String, i64, String, String, usize, file_data::CacheType);
+/// (file_id, account, file, size, max_ts)
+pub type DownloadFile = (i64, String, String, i64, i64);
 
 mod processing_files {
-    use hashbrown::HashSet;
+    use hashbrown::HashMap;
     use parking_lot::RwLock;
+    use tokio::sync::Semaphore;
 
     use super::*;
 
-    static PROCESSING_FILES: Lazy<RwLock<HashSet<String>>> =
-        Lazy::new(|| RwLock::new(HashSet::new()));
+    // a closed zero-permit semaphore is a terminal done signal every waiter observes, unlike Notify
+    static PROCESSING_FILES: Lazy<RwLock<HashMap<String, Arc<Semaphore>>>> =
+        Lazy::new(|| RwLock::new(HashMap::new()));
 
     pub fn is_processing(file_name: &str) -> bool {
-        PROCESSING_FILES.read().contains(file_name)
+        PROCESSING_FILES.read().contains_key(file_name)
     }
 
-    pub fn add(file_name: &str) {
-        PROCESSING_FILES.write().insert(file_name.to_string());
+    /// Returns false when the file is already being downloaded by another task.
+    pub fn add(file_name: &str) -> bool {
+        let mut files = PROCESSING_FILES.write();
+        if files.contains_key(file_name) {
+            return false;
+        }
+        files.insert(file_name.to_string(), Arc::new(Semaphore::new(0)));
+        true
     }
 
     pub fn remove(file_name: &str) {
-        PROCESSING_FILES.write().remove(file_name);
+        if let Some(done) = PROCESSING_FILES.write().remove(file_name) {
+            done.close();
+        }
+    }
+
+    /// Waits until the in-flight download of the file has finished.
+    pub async fn wait(file_name: &str) {
+        let Some(done) = PROCESSING_FILES.read().get(file_name).cloned() else {
+            return;
+        };
+        let _ = done.acquire().await;
     }
 }
 
@@ -138,6 +159,8 @@ impl PriorityDownloadQueue {
 }
 
 const FILE_DOWNLOAD_QUEUE_SIZE: usize = 10000;
+// caps how long a search waits on another task's download before falling back to range reads
+const SYNC_DOWNLOAD_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 static FILE_DOWNLOAD_CHANNEL: Lazy<DownloadQueue> = Lazy::new(|| {
     let (tx, rx) = tokio::sync::mpsc::channel::<FileInfo>(FILE_DOWNLOAD_QUEUE_SIZE);
     DownloadQueue::new(tx, Arc::new(Mutex::new(rx)))
@@ -164,7 +187,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                         queued_files::remove(&file);
 
                         // check if the file is already being downloaded
-                        if processing_files::is_processing(&file) {
+                        if !processing_files::add(&file) {
                             log::warn!(
                                 "[trace_id {trace_id}] [thread {thread}] search->storage: file {file} is already being downloaded, will skip it"
                             );
@@ -174,9 +197,6 @@ pub async fn run() -> Result<(), anyhow::Error> {
                                 .dec();
                             continue;
                         }
-
-                        // add the file to processing set
-                        processing_files::add(&file);
 
                         // download the file
                         match download_file(
@@ -222,7 +242,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 queued_files::remove(&file);
 
                 // check if the file is already being downloaded
-                if processing_files::is_processing(&file) {
+                if !processing_files::add(&file) {
                     log::warn!(
                         "[trace_id {trace_id}] [thread {thread}] search->storage: file {file} is already being downloaded, will skip it"
                     );
@@ -231,9 +251,6 @@ pub async fn run() -> Result<(), anyhow::Error> {
                         .dec();
                     continue;
                 }
-
-                // add the file to processing set
-                processing_files::add(&file);
 
                 // download the file
                 match download_file(thread, &trace_id, id, &account, &file, file_size, cache).await
@@ -318,6 +335,48 @@ async fn download_file(
     ret
 }
 
+// downloads one file for a waiting search, or waits for the task that is already downloading it
+async fn download_file_sync(
+    trace_id: &str,
+    file_id: i64,
+    account: &str,
+    file_name: &str,
+    file_size: usize,
+    cache_type: file_data::CacheType,
+) -> bool {
+    if !processing_files::add(file_name) {
+        return wait_for_download(trace_id, file_name).await;
+    }
+    let ret = download_file(
+        0, trace_id, file_id, account, file_name, file_size, cache_type,
+    )
+    .await;
+    processing_files::remove(file_name);
+    ret.inspect_err(|e| {
+        log::warn!(
+            "[FILE_CACHE_DOWNLOAD:SYNC] [trace_id {trace_id}] download file {file_name} to cache {cache_type:?} err: {e}"
+        )
+    })
+    .is_ok()
+}
+
+// waits for another task's download of the file and reports whether it landed in the cache
+async fn wait_for_download(trace_id: &str, file_name: &str) -> bool {
+    if tokio::time::timeout(
+        SYNC_DOWNLOAD_WAIT_TIMEOUT,
+        processing_files::wait(file_name),
+    )
+    .await
+    .is_err()
+    {
+        log::warn!(
+            "[FILE_CACHE_DOWNLOAD:SYNC] [trace_id {trace_id}] waited {}s for file {file_name} downloaded by another task, giving up",
+            SYNC_DOWNLOAD_WAIT_TIMEOUT.as_secs()
+        );
+    }
+    file_data::exist(file_name).await
+}
+
 async fn download_file_with_consistent_hash(
     file_id: i64,
     account: &str,
@@ -362,11 +421,10 @@ async fn download_file_with_consistent_hash(
 }
 
 // download files from node and return download failed files
-// file: (account, file, size, ts)
 pub async fn download_from_node(
     addr: &str,
-    files: &[(i64, String, String, i64, i64)],
-) -> Result<Vec<(i64, String, String, i64, i64)>, anyhow::Error> {
+    files: &[DownloadFile],
+) -> Result<Vec<DownloadFile>, anyhow::Error> {
     let start = std::time::Instant::now();
     let cfg = get_config();
     log::debug!(
@@ -566,12 +624,51 @@ pub async fn queue_download(
     Ok(())
 }
 
-/// Returns true when the record count is unknown or the file contains enough
-/// records to be worth downloading into the cache.
-pub fn should_download(records: i64) -> bool {
-    // A zero value can mean the record count was not populated by an older
-    // gRPC sender. Treat it as unknown rather than as an undersized file.
-    records == 0 || records >= get_config().limit.file_download_min_records
+/// Downloads the files into the cache before returning and reports how many are cached afterwards.
+pub async fn download_sync(
+    trace_id: &str,
+    files: Vec<DownloadFile>,
+    cache_type: file_data::CacheType,
+    concurrency: usize,
+) -> usize {
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency.max(1)));
+    let mut tasks = Vec::with_capacity(files.len());
+    let mut in_flight = Vec::new();
+    for (id, account, file, size, ts) in files {
+        if exceeds_cache_max_age(ts, cache_type) {
+            continue;
+        }
+        // files another task is already fetching are awaited later without holding a permit
+        if processing_files::is_processing(&file) {
+            in_flight.push(file);
+            continue;
+        }
+        let permit = semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("sync download semaphore is never closed");
+        let trace_id = trace_id.to_string();
+        // spawned so a cancelled search still finishes the download and clears the in-flight mark
+        tasks.push(tokio::spawn(async move {
+            let _permit = permit;
+            download_file_sync(&trace_id, id, &account, &file, size as usize, cache_type).await
+        }));
+    }
+    let waited = in_flight
+        .iter()
+        .map(|file| wait_for_download(trace_id, file));
+    let mut cached = futures::future::join_all(waited)
+        .await
+        .into_iter()
+        .filter(|ok| *ok)
+        .count();
+    for task in tasks {
+        if task.await.unwrap_or(false) {
+            cached += 1;
+        }
+    }
+    cached
 }
 
 // if the file timestamp is in the past window, it should be prioritized
@@ -607,16 +704,33 @@ mod tests {
     use config::utils::time::{day_micros, hour_micros, now_micros};
 
     use super::{
-        FileInfo, PriorityDownloadQueue, exceeds_max_age, file_data, processing_files,
-        queued_files, should_download,
+        Duration, FileInfo, PriorityDownloadQueue, exceeds_max_age, file_data, processing_files,
+        queued_files,
     };
 
     #[test]
-    fn test_should_download() {
-        assert!(should_download(0));
-        assert!(!should_download(99));
-        assert!(should_download(100));
-        assert!(should_download(101));
+    fn test_add_rejects_in_flight_file() {
+        let name = "test_add_dup_file_dup111.parquet";
+        assert!(processing_files::add(name));
+        assert!(!processing_files::add(name));
+        processing_files::remove(name);
+        assert!(processing_files::add(name));
+        processing_files::remove(name);
+    }
+
+    #[tokio::test]
+    async fn test_wait_returns_when_download_finishes() {
+        let name = "test_wait_file_wait222.parquet";
+        processing_files::wait(name).await;
+        assert!(processing_files::add(name));
+        let waiter = tokio::spawn(async move { processing_files::wait(name).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!waiter.is_finished());
+        processing_files::remove(name);
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter should finish once the download is removed")
+            .unwrap();
     }
 
     #[test]

--- a/src/promql_service/src/search/grpc/storage.rs
+++ b/src/promql_service/src/search/grpc/storage.rs
@@ -138,7 +138,6 @@ pub(crate) async fn create_context(
                     &f.key,
                     f.meta.compressed_size,
                     f.meta.max_ts,
-                    f.meta.records,
                 )
             })
             .collect_vec(),

--- a/src/search/src/file_cache.rs
+++ b/src/search/src/file_cache.rs
@@ -28,7 +28,7 @@ pub fn calc_target_partitions(cpu_num: usize, query_thread_num: usize, cached_ra
 #[tracing::instrument(name = "service:search:grpc:storage:cache_files", skip_all)]
 pub async fn cache_files(
     trace_id: &str,
-    files: &[(i64, &String, &String, i64, i64, i64)],
+    files: &[(i64, &String, &String, i64, i64)],
     scan_stats: &mut ScanStats,
     file_type: &str,
 ) -> (file_data::CacheType, u64, u64) {
@@ -36,7 +36,7 @@ pub async fn cache_files(
     let (mut cache_hits, mut cache_misses) = (0, 0);
 
     let start = std::time::Instant::now();
-    for (_id, _account, file, _size, max_ts, _records) in files.iter() {
+    for (_id, _account, file, _size, max_ts) in files.iter() {
         if file_data::memory::exist(file).await {
             scan_stats.querier_memory_cached_files += 1;
             cached_files.insert(file);
@@ -98,41 +98,42 @@ pub async fn cache_files(
         return (file_data::CacheType::None, cache_hits, cache_misses);
     };
 
-    let trace_id = trace_id.to_string();
-    let files = files
+    let sync_max_size = cfg.limit.file_download_sync_max_size as i64;
+    let (small, large): (Vec<_>, Vec<_>) = files
         .iter()
-        .filter_map(|(id, account, file, size, ts, records)| {
-            if cached_files.contains(file) || !file_downloader::should_download(*records) {
-                None
-            } else {
-                Some((*id, account.to_string(), file.to_string(), *size, *ts))
-            }
+        .filter(|(_, _, file, ..)| !cached_files.contains(file))
+        .map(|(id, account, file, size, ts)| {
+            (*id, account.to_string(), file.to_string(), *size, *ts)
         })
-        .collect::<Vec<_>>();
-    let file_type = file_type.to_string();
-    tokio::spawn(async move {
-        let files_num = files.len();
-        for (id, account, file, size, ts) in files {
-            if let Err(e) = file_downloader::queue_download(
-                trace_id.clone(),
-                id,
-                account,
-                file.clone(),
-                size,
-                ts,
-                cache_type,
-            )
-            .await
-            {
-                log::error!(
-                    "[trace_id {trace_id}] error in queuing file {file} for background download: {e}"
-                );
+        .partition(|(.., size, _)| (1..=sync_max_size).contains(size));
+    if !large.is_empty() {
+        let trace_id = trace_id.to_string();
+        let file_type = file_type.to_string();
+        tokio::spawn(async move {
+            let files_num = large.len();
+            for (id, account, file, size, ts) in large {
+                if let Err(e) = file_downloader::queue_download(
+                    trace_id.clone(),
+                    id,
+                    account,
+                    file.clone(),
+                    size,
+                    ts,
+                    cache_type,
+                )
+                .await
+                {
+                    log::error!(
+                        "[trace_id {trace_id}] error in queuing file {file} for background download: {e}"
+                    );
+                }
             }
-        }
-        log::info!(
-            "[trace_id {trace_id}] search->storage: successfully enqueued {files_num} files of {file_type} for background download into {cache_type:?}",
-        );
-    });
+            log::info!(
+                "[trace_id {trace_id}] search->storage: successfully enqueued {files_num} files of {file_type} for background download into {cache_type:?}",
+            );
+        });
+    }
+    download_small_files(trace_id, small, cache_type, scan_stats, file_type).await;
 
     if scan_stats.querier_memory_cached_files + scan_stats.querier_disk_cached_files < files_num / 2
     {
@@ -140,6 +141,32 @@ pub async fn cache_files(
     } else {
         (cache_type, cache_hits, cache_misses)
     }
+}
+
+// one full GET per small file is cheaper than a cold range read, so fetch them before the search
+async fn download_small_files(
+    trace_id: &str,
+    files: Vec<file_downloader::DownloadFile>,
+    cache_type: file_data::CacheType,
+    scan_stats: &mut ScanStats,
+    file_type: &str,
+) {
+    if files.is_empty() {
+        return;
+    }
+    let start = std::time::Instant::now();
+    let total = files.len();
+    let concurrency = get_config().limit.query_thread_num;
+    let cached = file_downloader::download_sync(trace_id, files, cache_type, concurrency).await;
+    if cache_type == file_data::CacheType::Memory {
+        scan_stats.querier_memory_cached_files += cached as i64;
+    } else {
+        scan_stats.querier_disk_cached_files += cached as i64;
+    }
+    log::info!(
+        "[trace_id {trace_id}] search->storage: downloaded {cached} of {total} small files of {file_type} into {cache_type:?} before search, took: {} ms",
+        start.elapsed().as_millis()
+    );
 }
 
 #[cfg(test)]

--- a/src/search/src/tantivy/mod.rs
+++ b/src/search/src/tantivy/mod.rs
@@ -102,16 +102,7 @@ pub async fn tantivy_search(
         &query.trace_id,
         &index_file_names
             .iter()
-            .map(|(ttv_file, f)| {
-                (
-                    f.id,
-                    &f.account,
-                    ttv_file,
-                    f.meta.index_size,
-                    f.meta.max_ts,
-                    f.meta.records,
-                )
-            })
+            .map(|(ttv_file, f)| (f.id, &f.account, ttv_file, f.meta.index_size, f.meta.max_ts))
             .collect_vec(),
         &mut scan_stats,
         "index",

--- a/src/search_service/src/file_list_dump.rs
+++ b/src/search_service/src/file_list_dump.rs
@@ -196,7 +196,6 @@ pub async fn exec(
                     &f.key,
                     f.meta.compressed_size,
                     f.meta.max_ts,
-                    f.meta.records,
                 )
             })
             .collect_vec(),

--- a/src/search_service/src/grpc/storage.rs
+++ b/src/search_service/src/grpc/storage.rs
@@ -185,7 +185,6 @@ pub async fn search(
                     &f.key,
                     f.meta.compressed_size,
                     f.meta.max_ts,
-                    f.meta.records,
                 )
             })
             .collect_vec(),


### PR DESCRIPTION
## What

Files that miss the querier cache and are at or below `ZO_FILE_DOWNLOAD_SYNC_MAX_SIZE` (MB, default `1`, `0` disables) are now downloaded into the cache before the search runs, so DataFusion and tantivy read them locally. Larger files keep the existing background download queue, which is now enqueued before the sync phase instead of after it.

`ZO_FILE_DOWNLOAD_MIN_RECORDS` and `should_download` are removed. That threshold kept files under 100 records out of the cache entirely, which are exactly the files this change targets.

## Why

A cold read of a small parquet file through `CacheFS` costs four S3 GETs and about three times the file's bytes:

| Step | Requests | Bytes |
|---|---|---|
| table build `collect_stat` metadata fetch | 1 suffix GET | min(512KB, file size) |
| scan-time metadata fetch (no reader metadata cache, runtime env is per query) | 1 suffix GET | min(512KB, file size) |
| data pages | 1 GET | ~whole file |
| background full download | 1 GET | whole file |

One full GET per small file replaces all of that and warms the cache at the same time. `.ttv` index files had the same pattern (footer probe plus one range GET per blob). On S3 the latency of a full 1MB GET is about the same as a single range GET, so the search does not wait longer than it does today.

## How

- `search::file_cache::cache_files` (shared by the parquet, tantivy index and promql paths) partitions cache misses by size. Small files go through the new `file_downloader::download_sync`, bounded by `query_thread_num` concurrent downloads; successes are counted into `scan_stats` so `cached_ratio` and `target_partitions` reflect what the scan will actually read locally.
- Each download runs in its own spawned task so a cancelled search still finishes the download and clears the in-flight mark.
- A file another task is already downloading (background worker, another query) is awaited instead of downloaded twice, without holding a concurrency permit, with a 30s cap before falling back to the existing range read. The in-flight table now stores a zero-permit `Semaphore` per file; `remove` closes it, which is a terminal signal every waiter observes. `processing_files::add` returns `bool`, which also removes the check-then-insert race the workers had.
- Files the cache policy refuses (`max_age_days`, `skip_size`) keep the current range-read behaviour.

## Reviewer notes

- Design decisions: one env for the size threshold only, no cap on the number of files downloaded synchronously (a query over 10k small files downloads 10k files; anything skipped would be range-read anyway), and the min-records threshold is deleted rather than lowered.
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` passes; `config`, `infra` (`cache::file_downloader`) and `search` (`file_cache`) unit tests pass.
- The o2-enterprise repo has no references to `should_download`, `file_download_min_records` or `cache_files`.
- Follow-up: openobserve-docs needs an entry for `ZO_FILE_DOWNLOAD_SYNC_MAX_SIZE` and the removal of `ZO_FILE_DOWNLOAD_MIN_RECORDS`.
- Before/after can be measured with `STORAGE_READ_REQUESTS{method="get_opts",storage="remote"}` on the same set of queries.
