### PR TITLE
test: cover builder saved views applied on the build tab [v0.80.0]

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -6351,6 +6351,26 @@ export class LogsPage {
     }
 
     /**
+     * Expect the Build tab to be the selected tab.
+     * The toggle carries the "selected" class only while logsVisualizeToggle === 'build',
+     * and BuildQueryPage is v-if'd on the same condition, so both are checked.
+     */
+    async expectBuildTabSelected(timeout = 15000) {
+        await expect(this.page.locator(this.buildToggle)).toHaveClass(/selected/, { timeout });
+        await expect(this.page.locator('.build-query-page')).toBeVisible({ timeout });
+        testLogger.info('Build tab is the selected tab');
+    }
+
+    /**
+     * Expect the Logs tab to be the selected tab (BuildQueryPage unmounted).
+     */
+    async expectLogsTabSelected(timeout = 15000) {
+        await expect(this.page.locator(this.logsToggle)).toHaveClass(/selected/, { timeout });
+        await expect(this.page.locator('.build-query-page')).toHaveCount(0, { timeout });
+        testLogger.info('Logs tab is the selected tab');
+    }
+
+    /**
      * Expect Builder mode (Auto mode) to be active
      */
     async expectBuilderModeActive(timeout = 15000) {
@@ -6488,10 +6508,12 @@ export class LogsPage {
      * @param {string} chartId - The chart type ID (e.g., 'bar', 'line', 'metric', 'table')
      */
     async selectChartType(chartId) {
-        // Use .first() to handle multiple matching elements (e.g., from cached panels)
-        const chartItem = this.page.locator(this.chartTypeItem(chartId)).first();
+        // The Build and Visualize tabs each mount a PanelEditor, so the chart list is in
+        // the DOM twice; the cached one is zero-size and .first() would resolve to it.
+        const chartItem = this.page.locator(this.chartTypeItem(chartId)).locator('visible=true').first();
 
-        // Click the chart item (tests should check visibility before calling this)
+        await chartItem.waitFor({ state: 'visible', timeout: 15000 });
+        await chartItem.scrollIntoViewIfNeeded();
         await chartItem.click();
         await this.page.waitForTimeout(500);
         testLogger.info(`Selected chart type: ${chartId}`);
@@ -6502,8 +6524,8 @@ export class LogsPage {
      * @param {string} chartId - The chart type ID
      */
     async expectChartTypeVisible(chartId) {
-        const chartItem = this.page.locator(this.chartTypeItem(chartId)).first();
-        await expect(chartItem).toBeVisible();
+        const chartItem = this.page.locator(this.chartTypeItem(chartId)).locator('visible=true').first();
+        await expect(chartItem).toBeVisible({ timeout: 15000 });
         testLogger.info(`Chart type "${chartId}" is visible`);
     }
 

--- a/tests/ui-testing/pages/reportsPages/reportFoldersPage.js
+++ b/tests/ui-testing/pages/reportsPages/reportFoldersPage.js
@@ -56,6 +56,15 @@ export class ReportFoldersPage {
     return this.page.locator(`${this.folderTabsContainer} [role="tab"]`).filter({ hasText: folderName });
   }
 
+  // Several dialogs can sit in the DOM at once, so a bare .q-dialog__backdrop locator
+  // matches more than one element and waitFor throws a strict-mode violation. Count the
+  // visible ones instead: a leftover backdrop swallows every click on the page beneath.
+  async waitForNoDialogBackdrop(timeout = 10000) {
+    await expect(
+      this.page.locator('.q-dialog__backdrop').locator('visible=true')
+    ).toHaveCount(0, { timeout });
+  }
+
   async navigateToReports() {
     await this.page.goto(
       `${process.env["ZO_BASE_URL"]}/web/reports?org_identifier=${process.env["ORGNAME"]}`,
@@ -96,8 +105,7 @@ export class ReportFoldersPage {
     await this.clickSaveFolder();
     // Wait for the dialog to close after save
     await this.page.locator(this.folderDialog).waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
-    // Also wait for the Quasar backdrop to fade — otherwise it can intercept the next click.
-    await this.page.locator('.q-dialog__backdrop').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    await this.waitForNoDialogBackdrop();
   }
 
   async expectFolderTabVisible(folderName) {
@@ -109,6 +117,7 @@ export class ReportFoldersPage {
   }
 
   async clickFolderTab(folderName) {
+    await this.waitForNoDialogBackdrop();
     await this.getTabByName(folderName).click();
     await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
   }
@@ -185,14 +194,13 @@ export class ReportFoldersPage {
   async clickMove() {
     await this.page.locator(this.moveSubmitBtn).click();
     await this.page.locator(this.moveDialogHeader).waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {});
-    // Wait for Quasar dialog backdrop close animation before interacting with the page
-    await this.page.locator('.q-dialog__backdrop').waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+    await this.waitForNoDialogBackdrop();
   }
 
   async cancelMove() {
     await this.page.locator(this.moveCancelBtn).first().click();
     await this.page.locator(this.moveDialogHeader).waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
-    await this.page.locator('.q-dialog__backdrop').waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+    await this.waitForNoDialogBackdrop();
   }
 
   async expectDefaultFolderExists() {
@@ -226,10 +234,11 @@ export class ReportFoldersPage {
     await this.page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
   }
 
-  async expectReportVisibleInTable(reportName) {
+  async expectReportVisibleInTable(reportName, timeout = 20000) {
+    await this.page.locator(this.reportTable).waitFor({ state: 'visible', timeout }).catch(() => {});
     await expect(
       this.page.locator(`[data-test="report-list-${reportName}-pause-start-report"]`)
-    ).toBeVisible({ timeout: 10000 });
+    ).toBeVisible({ timeout });
   }
 
   async expectReportNotVisibleInTable(reportName) {

--- a/tests/ui-testing/playwright-tests/RegressionSet/logs-regression-bugs.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/logs-regression-bugs.spec.js
@@ -9,6 +9,7 @@
  * - Quick mode query removed when selecting interesting field
  * - Pagination not showing with histogram and SQL disabled
  * - Error message should identify problematic field
+ * - #14228: Builder saved view not applied when already on the Build tab
  */
 
 const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
@@ -17,6 +18,61 @@ const PageManager = require('../../pages/page-manager.js');
 const logData = require("../../fixtures/log.json");
 const { ingestTestData, sendRequest, getHeaders, getIngestionUrl } = require('../utils/data-ingestion.js');
 const { getOrgIdentifier, isCloudEnvironment } = require('../utils/cloud-auth.js');
+
+// Auto-derives to a bar chart with X+Y populated, so a saved chart type of "line"
+// is provably restored config rather than config re-derived from this query.
+const BUILDER_QUERY =
+  'SELECT histogram(_timestamp) as "x_axis_1", count(*) as "y_axis_1" FROM "e2e_automate" GROUP BY x_axis_1';
+
+/**
+ * Build a chart on the Build tab and save it as a saved view.
+ * The view must be saved while the Build tab is open — SearchBar only persists
+ * buildData when logsVisualizeToggle === 'build'.
+ */
+async function createBuilderSavedView(pm, page, viewName, chartType) {
+  await pm.logsPage.enableSqlModeIfNeeded();
+  await pm.logsPage.setQueryEditorContent(BUILDER_QUERY);
+  await pm.logsPage.runQueryAndWaitForResults();
+
+  await pm.logsPage.clickBuildToggle();
+  await pm.logsPage.waitForBuildTabLoaded();
+
+  await pm.logsPage.selectChartType(chartType);
+  await pm.logsPage.verifyChartTypeSelected(chartType);
+
+  await pm.logsPage.clickSavedViewsExpand();
+  await page.waitForTimeout(500);
+  await pm.logsPage.clickSaveViewButton();
+  await page.waitForTimeout(500);
+  await pm.logsPage.fillSavedViewName(viewName);
+  await page.waitForTimeout(500);
+  await pm.logsPage.clickSavedViewDialogSave();
+  await page.waitForTimeout(2000);
+  testLogger.info(`Builder saved view created: ${viewName} (chart type ${chartType})`);
+}
+
+async function applySavedViewByName(pm, page, viewName) {
+  await pm.logsPage.clickSavedViewsExpand();
+  await page.waitForTimeout(500);
+  await pm.logsPage.clickSavedViewSearchInput();
+  await pm.logsPage.fillSavedViewSearchInput(viewName);
+  await page.waitForTimeout(1000);
+  await pm.logsPage.waitForSavedViewText(viewName);
+  await pm.logsPage.clickSavedViewByText(viewName);
+  await page.waitForTimeout(3000);
+  testLogger.info(`Applied saved view: ${viewName}`);
+}
+
+async function deleteSavedViewQuietly(pm, page, viewName) {
+  try {
+    await pm.logsPage.clickDeleteSavedViewButton(viewName).catch(() => {});
+    await page.waitForTimeout(500);
+    await pm.logsPage.clickConfirmButton().catch(() => {});
+    testLogger.info(`Cleaned up saved view: ${viewName}`);
+  } catch (cleanupError) {
+    testLogger.debug(`Saved view cleanup skipped: ${viewName}`);
+  }
+}
 
 test.describe("Logs Regression Bug Fixes", () => {
   // Changed from serial to parallel - tests are independent (each gets own page/PM in beforeEach)
@@ -849,6 +905,132 @@ test.describe("Logs Regression Bug Fixes", () => {
     }
 
     testLogger.info('✓ PASSED: VRL saved views test completed (Bug #9690)');
+  });
+
+  // ==========================================================================
+  // Bug #14228: Builder saved view does not apply when already on the Build tab
+  // https://github.com/openobserve/openobserve/issues/14228
+  // ==========================================================================
+  test("should apply a builder saved view while already on the build tab @bug-14228 @P1 @savedViews @queryBuilder @regression", async ({ page }) => {
+    testLogger.info('Test: Builder saved view applies without a tab toggle (Bug #14228)');
+    test.setTimeout(180000);
+
+    // The "streamslog" prefix lets CI saved-view cleanup reap any leak.
+    const savedViewName = `streamslog_build_14228_${Date.now()}`;
+
+    try {
+      await page.goto(`${logData.logsUrl}?org_identifier=${getOrgIdentifier() || 'default'}`);
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      await pm.logsPage.selectStream('e2e_automate');
+      await page.waitForTimeout(1000);
+
+      await createBuilderSavedView(pm, page, savedViewName, 'line');
+
+      // Diverge the live builder from the saved view. Without this the assertion
+      // would pass even unfixed, since the builder would already show "line".
+      await pm.logsPage.selectChartType('area');
+      await pm.logsPage.verifyChartTypeSelected('area');
+      await pm.logsPage.expectBuildTabSelected();
+      testLogger.info('Builder diverged to area chart before applying the saved view');
+
+      await applySavedViewByName(pm, page, savedViewName);
+
+      // No tab toggle happened, so BuildQueryPage never remounts — the watcher on
+      // searchObj.meta.savedBuildConfig is the only thing that can apply the view.
+      await pm.logsPage.expectBuildTabSelected();
+      await pm.logsPage.verifyChartTypeSelected('line');
+      await pm.logsPage.verifyChartTypeSelected('area', false);
+      testLogger.info('✓ PRIMARY CHECK PASSED: builder re-initialized to the saved chart type');
+
+      const xCount = await pm.logsPage.expectXAxisHasItems();
+      const yCount = await pm.logsPage.expectYAxisHasItems();
+      expect(xCount, 'Bug #14228: X-axis must stay populated after applying the view').toBeGreaterThan(0);
+      expect(yCount, 'Bug #14228: Y-axis must stay populated after applying the view').toBeGreaterThan(0);
+
+    } finally {
+      await deleteSavedViewQuietly(pm, page, savedViewName);
+    }
+
+    testLogger.info('✓ PASSED: Builder saved view applied in place (Bug #14228)');
+  });
+
+  test("should still apply a builder saved view when toggling in from the logs tab @bug-14228 @P1 @savedViews @queryBuilder @regression", async ({ page }) => {
+    testLogger.info('Test: Toggle-in path still applies builder saved views (Bug #14228 no-regression)');
+    test.setTimeout(180000);
+
+    const savedViewName = `streamslog_build_14228_toggle_${Date.now()}`;
+
+    try {
+      await page.goto(`${logData.logsUrl}?org_identifier=${getOrgIdentifier() || 'default'}`);
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      await pm.logsPage.selectStream('e2e_automate');
+      await page.waitForTimeout(1000);
+
+      await createBuilderSavedView(pm, page, savedViewName, 'line');
+
+      await pm.logsPage.clickLogsToggle();
+      await pm.logsPage.expectLogsTabSelected();
+      testLogger.info('Switched back to the Logs tab');
+
+      await applySavedViewByName(pm, page, savedViewName);
+
+      // Here the view flips the toggle to build and BuildQueryPage mounts, so
+      // onMounted applies the config. The watcher must not undo or double-apply it.
+      await pm.logsPage.expectBuildTabSelected();
+      await pm.logsPage.verifyChartTypeSelected('line');
+      testLogger.info('✓ CHECK PASSED: toggle-in path still restores the saved chart type');
+
+    } finally {
+      await deleteSavedViewQuietly(pm, page, savedViewName);
+    }
+
+    testLogger.info('✓ PASSED: Toggle-in path unaffected (Bug #14228)');
+  });
+
+  test("should not re-initialize the builder when applying a non-builder saved view @bug-14228 @P2 @savedViews @queryBuilder @regression", async ({ page }) => {
+    testLogger.info('Test: Non-builder saved views do not trigger builder re-init (Bug #14228)');
+    test.setTimeout(180000);
+
+    const savedViewName = `streamslog_logs_14228_${Date.now()}`;
+
+    try {
+      await page.goto(`${logData.logsUrl}?org_identifier=${getOrgIdentifier() || 'default'}`);
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      await pm.logsPage.selectStream('e2e_automate');
+      await page.waitForTimeout(1000);
+
+      // Saved from the Logs tab, so the view carries no buildData.
+      await pm.logsPage.clickRefreshButton();
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      await page.waitForTimeout(2000);
+
+      await pm.logsPage.clickSavedViewsExpand();
+      await page.waitForTimeout(500);
+      await pm.logsPage.clickSaveViewButton();
+      await page.waitForTimeout(500);
+      await pm.logsPage.fillSavedViewName(savedViewName);
+      await page.waitForTimeout(500);
+      await pm.logsPage.clickSavedViewDialogSave();
+      await page.waitForTimeout(2000);
+      testLogger.info(`Logs-tab saved view created: ${savedViewName}`);
+
+      await pm.logsPage.clickBuildToggle();
+      await pm.logsPage.waitForBuildTabLoaded();
+      await pm.logsPage.expectBuildTabSelected();
+
+      await applySavedViewByName(pm, page, savedViewName);
+
+      // buildData is null, so the watcher's guard must skip it and the view's own
+      // logs toggle must win.
+      await pm.logsPage.expectLogsTabSelected();
+      await pm.logsPage.expectLogsTableVisible();
+      testLogger.info('✓ CHECK PASSED: non-builder view applied with no builder re-init');
+
+    } finally {
+      await deleteSavedViewQuietly(pm, page, savedViewName);
+    }
+
+    testLogger.info('✓ PASSED: Non-builder saved view handled correctly (Bug #14228)');
   });
 
   test.afterEach(async () => {

--- a/tests/ui-testing/playwright-tests/Reports/reportFolders.spec.js
+++ b/tests/ui-testing/playwright-tests/Reports/reportFolders.spec.js
@@ -71,6 +71,9 @@ test.describe("Report Folders", () => {
 
     // Refresh the page so the reports table picks up the newly created report
     await pm.reportFoldersPage.navigateToReports();
+    // The page can restore a previously selected folder tab, so pin the folder the
+    // report was created in rather than trusting whatever tab happens to be active.
+    await pm.reportFoldersPage.clickFolderTab('default');
     await pm.reportFoldersPage.expectReportVisibleInTable(REPORT_A);
 
     testLogger.info('Test report visible in default folder');
@@ -89,20 +92,26 @@ test.describe("Report Folders", () => {
 
     testLogger.info(`Moving report "${REPORT_A}" to folder "${FOLDER_B}"`);
 
-    // Open move dialog and move to destination folder
-    await pm.reportFoldersPage.openMoveDialog(REPORT_A);
-    await pm.reportFoldersPage.selectMoveDestination(FOLDER_B);
-    await pm.reportFoldersPage.expectMoveButtonEnabled();
-    await pm.reportFoldersPage.clickMove();
+    try {
+      // Open move dialog and move to destination folder
+      await pm.reportFoldersPage.openMoveDialog(REPORT_A);
+      await pm.reportFoldersPage.selectMoveDestination(FOLDER_B);
+      await pm.reportFoldersPage.expectMoveButtonEnabled();
+      await pm.reportFoldersPage.clickMove();
 
-    // Verify report is now in destination folder
-    await pm.reportFoldersPage.clickFolderTab(FOLDER_B);
-    await pm.reportFoldersPage.expectReportVisibleInTable(REPORT_A);
-
-    // Move it back to default
-    await pm.reportFoldersPage.openMoveDialog(REPORT_A);
-    await pm.reportFoldersPage.selectMoveDestination('default');
-    await pm.reportFoldersPage.clickMove();
+      // Verify report is now in destination folder
+      await pm.reportFoldersPage.clickFolderTab(FOLDER_B);
+      await pm.reportFoldersPage.expectReportVisibleInTable(REPORT_A);
+    } finally {
+      // Later tests expect REPORT_A in default; restore it even if the move above failed
+      // partway, so one failure here does not cascade into the rest of the serial group.
+      await pm.reportFoldersPage.openMoveDialog(REPORT_A)
+        .then(async () => {
+          await pm.reportFoldersPage.selectMoveDestination('default');
+          await pm.reportFoldersPage.clickMove();
+        })
+        .catch(() => testLogger.warn('Could not restore REPORT_A to the default folder'));
+    }
 
     testLogger.info('Report moved to another folder and back successfully');
   });


### PR DESCRIPTION
Regression coverage for #14228, fixed on this branch by #14230.

## The bug

Applying a Builder saved view while **already on the Build tab** left the builder showing its previous state. `BuildQueryPage` is `v-if`'d on `logsVisualizeToggle == 'build'`, so it only mounts when toggling *into* the tab, and `searchObj.meta.savedBuildConfig` was consumed exactly once in `onMounted`. With no toggle there is no remount, so the config was set and never read. #14230 adds a watcher on `savedBuildConfig` that re-runs `initializeFromQuery()`.

## Tests

Three tests added to `RegressionSet/logs-regression-bugs.spec.js`, tagged `@bug-14228`:

| Test | Covers |
|---|---|
| applies while already on the build tab | the bug itself |
| still applies when toggling in from the logs tab | the mount path, unchanged behaviour |
| non-builder saved view does not re-init the builder | the `if (config)` guard |

The first test saves a view with a `line` chart, then deliberately switches the live builder to `area` before applying the view. That divergence is what makes the test meaningful - without it the builder would already show `line` and the assertion would pass against unfixed code.

The spec is already in the `RegressionSet` CI matrix entry, so no workflow change is needed.

## Validation

Run against a v0.80.13 build at commit `863cb969b7` - the commit immediately before the fix, and the exact build reported in #14228:

- **`should apply a builder saved view while already on the build tab` -> FAILED**, on the chart-type assertion: `line` not selected after applying the view, having first confirmed the Build tab stayed selected. This is #14228 reproducing.
- **The other two -> PASSED**, as expected for paths that already worked.

Not yet verified: the first test passing against fixed code. No environment available at the time of writing carried the fix, so the green half is blocked on deployment rather than on the tests. Worth re-running once one picks up #14230.

## Page-object fix

`LogsPage.selectChartType` and `expectChartTypeVisible` now filter for the visible element instead of using `.first()`. The Build and Visualize tabs each mount a `PanelEditor`, so the chart list appears in the DOM twice (40 items for 20 chart types) and the zero-size cached copy sorts first - `.first()` resolved to an unclickable element. `verifyChartTypeSelected` already documented and guarded this hazard; these two had not. Neither method had any existing caller, so no other spec changes behaviour.

`expectBuildTabSelected` / `expectLogsTabSelected` were also added. The existing `expectBuildTabActive` only asserts the toggle is *visible*, which is true on every tab, so it cannot show which tab is selected.

---

## Also: deflake `Reports/reportFolders.spec.js`

Unrelated to the above, but these were failing in this PR's own CI run and share one root cause.

`createFolder`, `clickMove` and `cancelMove` each waited on a bare `.q-dialog__backdrop` locator. Once a second dialog is in the DOM that matches multiple elements, so `waitFor` throws a strict-mode violation - which the trailing `.catch(() => {})` swallowed. The wait silently did nothing, the leftover backdrop intercepted the next click, and `clickFolderTab` timed out after 45s.

Replaced with `waitForNoDialogBackdrop()`, which counts *visible* backdrops and does not swallow errors, and called it in `clickFolderTab` where the interception actually surfaced.

`P2: Move button disabled when source equals destination` was collateral damage, not an independent failure: the move test died *after* `clickMove()` had succeeded, stranding the report in folder B, so the later test could not find it in `default`. The move test now restores the report in a `finally` block so one failure no longer cascades through the serial group.

Also waits for the report table before asserting a row, and pins the `default` folder tab before checking the API-created report, since the page can restore a previously selected tab.

Verified: the full 12-test `reportFolders` spec passes against a v0.80.13 build. A single green run is not proof the flake is gone, but the strict-mode bug it fixes is deterministic and was guaranteed to fire whenever two dialogs coexisted.
