### PR TITLE
fix: Importing a dashboard JSON fails validation

### DIFF
--- a/web/src/utils/dashboard/panelValidation.spec.ts
+++ b/web/src/utils/dashboard/panelValidation.spec.ts
@@ -158,6 +158,19 @@ describe("panelValidation", () => {
       expect(errors).toEqual([]);
     });
 
+    it("accepts a numeric layout.i of 0", () => {
+      const tabs = [
+        {
+          ...validDashboard.tabs[0],
+          panels: [
+            { ...validDashboard.tabs[0].panels[0], layout: { i: 0, x: 0, y: 0, w: 12, h: 6 } },
+          ],
+        },
+      ];
+      const errors = validateDashboardJson(gt, { ...validDashboard, tabs });
+      expect(errors).toEqual([]);
+    });
+
     it("returns error for null dashboard", () => {
       const errors = validateDashboardJson(gt, null);
       expect(errors).toContain("Dashboard JSON is empty or invalid");

--- a/web/src/utils/dashboard/panelValidation.ts
+++ b/web/src/utils/dashboard/panelValidation.ts
@@ -1119,7 +1119,8 @@ export const validateDashboardJson = (t: TranslateFn, dashboardJson: any): strin
       }
 
       // Check layout i value uniqueness within the tab
-      if (!panel?.layout || !panel?.layout?.i) {
+      // `i` is a grid index, so 0 is a valid value — only null/undefined is missing.
+      if (!panel?.layout || panel?.layout?.i == null) {
         errors.push(t("dashboard.utils.panelMissingLayoutI", { id: panel?.id }));
       } else {
         const tabLayoutValues = layoutIValues.get(tab?.tabId);


### PR DESCRIPTION
## Problem

Importing a dashboard JSON fails validation with:

```
Dashboard 1: Panel panel_0 is missing a layout.i value
```

even though the panel has a valid `"layout": { "i": 0, ... }`. Any dashboard whose first panel carries grid index `0` cannot be imported.

## Root cause

`validateDashboardJson` in `utils/dashboard/panelValidation.ts` checked presence with a truthiness test:

```ts
if (!panel?.layout || !panel?.layout?.i) {
```

`i` is a numeric grid index, so `0` is a legitimate value — and `!0` is `true`, so the validator reported it as missing.

## Fix

Check for absence, not falsiness:

```ts
if (!panel?.layout || panel?.layout?.i == null) {
```

Only `null`/`undefined` count as missing. The duplicate-`i` check below it already stringifies the value, so `0` flows through it unchanged.

## Verification

- New unit test: a panel with `layout.i = 0` validates with no errors.
- Existing "missing layout.i" and "duplicate layout.i" cases still pass.
- `vitest` (`panelValidation.spec.ts`, 32/32), `eslint`, `prettier` clean.

Found while reproducing a dashboard-open freeze with a customer's exported dashboard (whose panels are indexed from `0`); the freeze itself is fixed separately.
