### PR TITLE
fix: don't parse the WHERE predicate for table cell drilldown

### DIFF
--- a/web/src/composables/dashboard/usePanelDrilldown.spec.ts
+++ b/web/src/composables/dashboard/usePanelDrilldown.spec.ts
@@ -237,6 +237,24 @@ describe("usePanelDrilldown", () => {
     expect(api.drilldownAllColumns.value).toBe(false);
   });
 
+  it("still resolves drillable columns when the WHERE clause is deeply nested", async () => {
+    // Regression: astify() is exponential in WHERE nesting, so a builder-generated
+    // predicate like this used to block the main thread for minutes on mount.
+    let where = `"c0" = 'v0'`;
+    for (let i = 1; i < 22; i++) where = `(${where} AND "c${i}" = 'v${i}')`;
+    const deps = makeTableDeps(
+      `select service, count(*) as cnt from logs where ${where} group by service`,
+    );
+
+    const started = Date.now();
+    const api = usePanelDrilldown(deps as any);
+    await flush(() => api.drilldownColumnAliases.value.length > 0);
+
+    expect(api.drilldownColumnAliases.value).toContain("service");
+    expect(api.drilldownColumnAliases.value).not.toContain("cnt");
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+
   it("treats SELECT * / dynamic-columns tables as all-columns drillable", async () => {
     const deps = makeTableDeps("select * from logs");
     const api = usePanelDrilldown(deps as any);

--- a/web/src/composables/dashboard/usePanelDrilldown.ts
+++ b/web/src/composables/dashboard/usePanelDrilldown.ts
@@ -23,6 +23,11 @@ import searchService from "@/services/search";
 import { isCrossLinkingEnabledForStream } from "@/utils/crossLinking";
 import { isSafeNavigableUrl } from "@/utils/safeUrl";
 import { extractFields } from "@/utils/query/sqlUtils";
+import {
+  maxParenDepth,
+  SQL_PARSE_MAX_DEPTH,
+  stripWherePredicate,
+} from "@/utils/query/sqlComplexity";
 
 export function usePanelDrilldown({
   panelSchema,
@@ -297,9 +302,13 @@ export function usePanelDrilldown({
       const streamType = query?.fields?.stream_type;
       if (!executedQuery || !streamName) return;
 
+      // astify() is exponential in WHERE nesting; only SELECT/FROM are read below.
+      const parseTarget = stripWherePredicate(executedQuery);
+      if (maxParenDepth(parseTarget) > SQL_PARSE_MAX_DEPTH) return;
+
       let parsed: any;
       try {
-        parsed = parser.astify(executedQuery);
+        parsed = parser.astify(parseTarget);
       } catch {
         return;
       }

--- a/web/src/utils/query/sqlComplexity.spec.ts
+++ b/web/src/utils/query/sqlComplexity.spec.ts
@@ -1,0 +1,127 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, it, expect } from "vitest";
+import { maxParenDepth, stripWherePredicate, SQL_PARSE_MAX_DEPTH } from "./sqlComplexity";
+
+describe("maxParenDepth", () => {
+  it("counts the deepest nesting, not the total number of parens", () => {
+    expect(maxParenDepth("(a) (b) (c)")).toBe(1);
+    expect(maxParenDepth("((( a )))")).toBe(3);
+  });
+
+  it("returns 0 when there are no parens", () => {
+    expect(maxParenDepth("SELECT a FROM t")).toBe(0);
+  });
+});
+
+describe("stripWherePredicate", () => {
+  it("replaces the predicate and keeps everything around it", () => {
+    expect(stripWherePredicate(`SELECT a FROM "t" WHERE x = 1`)).toBe(
+      `SELECT a FROM "t" WHERE 1 = 1 `,
+    );
+  });
+
+  it("stops at each clause that can follow a WHERE", () => {
+    for (const tail of [
+      "GROUP BY a",
+      "ORDER BY a",
+      "LIMIT 10",
+      "OFFSET 5",
+      "HAVING COUNT(*) > 1",
+      "WINDOW w AS ()",
+    ]) {
+      expect(stripWherePredicate(`SELECT a FROM "t" WHERE x = 1 ${tail}`)).toBe(
+        `SELECT a FROM "t" WHERE 1 = 1 ${tail}`,
+      );
+    }
+  });
+
+  it("leaves a statement without a WHERE untouched", () => {
+    const sql = `SELECT a FROM "t" GROUP BY a ORDER BY a`;
+    expect(stripWherePredicate(sql)).toBe(sql);
+  });
+
+  it("ignores WHERE inside a string literal", () => {
+    const sql = `SELECT a FROM "t" WHERE msg = 'WHERE x = 1'`;
+    expect(stripWherePredicate(sql)).toBe(`SELECT a FROM "t" WHERE 1 = 1 `);
+  });
+
+  it("does not treat a doubled quote as the end of a literal", () => {
+    const sql = `SELECT a FROM "t" WHERE msg = 'it''s here' AND b = 2`;
+    expect(stripWherePredicate(sql)).toBe(`SELECT a FROM "t" WHERE 1 = 1 `);
+  });
+
+  it("ignores WHERE used as a quoted identifier", () => {
+    const sql = `SELECT "where" FROM "t" ORDER BY "where"`;
+    expect(stripWherePredicate(sql)).toBe(sql);
+  });
+
+  it("does not match identifiers that merely start with where", () => {
+    const sql = `SELECT where_clause FROM "t" ORDER BY where_clause`;
+    expect(stripWherePredicate(sql)).toBe(sql);
+  });
+
+  it("ignores WHERE inside a subquery and strips only the outer one", () => {
+    const sql = `SELECT a FROM (SELECT a FROM "t" WHERE inner_col = 1) s WHERE outer_col = 2`;
+    expect(stripWherePredicate(sql)).toBe(
+      `SELECT a FROM (SELECT a FROM "t" WHERE inner_col = 1) s WHERE 1 = 1 `,
+    );
+  });
+
+  it("strips the predicate of each branch of a UNION", () => {
+    const sql = `SELECT a FROM "t" WHERE x = 1 UNION SELECT a FROM "u" WHERE y = 2`;
+    expect(stripWherePredicate(sql)).toBe(
+      `SELECT a FROM "t" WHERE 1 = 1 UNION SELECT a FROM "u" WHERE 1 = 1 `,
+    );
+  });
+
+  it("ignores WHERE inside line and block comments", () => {
+    expect(stripWherePredicate(`SELECT a FROM "t" -- WHERE x = 1\nORDER BY a`)).toBe(
+      `SELECT a FROM "t" -- WHERE x = 1\nORDER BY a`,
+    );
+    expect(stripWherePredicate(`SELECT a FROM "t" /* WHERE x = 1 */ ORDER BY a`)).toBe(
+      `SELECT a FROM "t" /* WHERE x = 1 */ ORDER BY a`,
+    );
+  });
+
+  it("handles empty and non-string input", () => {
+    expect(stripWherePredicate("")).toBe("");
+    expect(stripWherePredicate(undefined as any)).toBe(undefined);
+  });
+
+  it("collapses the nesting that makes the parser exponential", () => {
+    // The shape the dashboard query builder emits: one paren layer per condition.
+    let where = `"c0" = 'v0'`;
+    for (let i = 1; i < 22; i++) where = `(${where} AND "c${i}" = 'v${i}')`;
+    const sql = `SELECT COUNT(*) AS c FROM "t" WHERE ${where}`;
+
+    expect(maxParenDepth(sql)).toBeGreaterThan(SQL_PARSE_MAX_DEPTH);
+    expect(maxParenDepth(stripWherePredicate(sql))).toBeLessThanOrEqual(SQL_PARSE_MAX_DEPTH);
+  });
+
+  it("keeps the SELECT list intact so field extraction is unaffected", () => {
+    const sql =
+      `SELECT AVG("d") AS oo_average, approx_percentile_cont("d", 0.95) AS oo_p95 ` +
+      `FROM "s" WHERE ((("a" = 1 AND "b" = 2) AND "c" = 3)) GROUP BY "e"`;
+    const stripped = stripWherePredicate(sql);
+
+    expect(stripped).toContain(`AVG("d") AS oo_average`);
+    expect(stripped).toContain(`approx_percentile_cont("d", 0.95) AS oo_p95`);
+    expect(stripped).toContain(`FROM "s"`);
+    expect(stripped).toContain(`GROUP BY "e"`);
+    expect(stripped).not.toContain(`"a" = 1`);
+  });
+});

--- a/web/src/utils/query/sqlComplexity.ts
+++ b/web/src/utils/query/sqlComplexity.ts
@@ -22,6 +22,19 @@
 // server-side, only these optional client-side UX features are lost.
 export const SQL_PARSE_MAX_DEPTH = 12;
 
+// Top-level keywords that can follow a WHERE predicate and end it.
+const WHERE_TERMINATORS = new Set([
+  "GROUP",
+  "ORDER",
+  "LIMIT",
+  "OFFSET",
+  "HAVING",
+  "WINDOW",
+  "UNION",
+  "INTERSECT",
+  "EXCEPT",
+]);
+
 export const maxParenDepth = (text: string): number => {
   let depth = 0;
   let max = 0;
@@ -34,4 +47,90 @@ export const maxParenDepth = (text: string): number => {
     }
   }
   return max;
+};
+
+/**
+ * Replaces every top-level WHERE predicate with `1 = 1` so callers that read only the
+ * SELECT list or FROM aliases can parse without paying the predicate's nesting cost.
+ */
+export const stripWherePredicate = (sql: string): string => {
+  if (!sql || typeof sql !== "string") return sql;
+
+  const ranges: Array<[number, number]> = [];
+  const n = sql.length;
+  let depth = 0;
+  let whereStart = -1;
+  let i = 0;
+
+  while (i < n) {
+    const ch = sql[i];
+
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      i++;
+      while (i < n) {
+        if (sql[i] === quote) {
+          // A doubled quote is an escaped quote, not the end of the literal.
+          if (sql[i + 1] === quote) i += 2;
+          else {
+            i++;
+            break;
+          }
+        } else i++;
+      }
+      continue;
+    }
+
+    if (ch === "-" && sql[i + 1] === "-") {
+      while (i < n && sql[i] !== "\n") i++;
+      continue;
+    }
+
+    if (ch === "/" && sql[i + 1] === "*") {
+      i += 2;
+      while (i < n && !(sql[i] === "*" && sql[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+
+    if (ch === "(") {
+      depth++;
+      i++;
+      continue;
+    }
+
+    if (ch === ")") {
+      depth--;
+      i++;
+      continue;
+    }
+
+    if (/[A-Za-z_]/.test(ch)) {
+      let j = i;
+      while (j < n && /[A-Za-z0-9_$]/.test(sql[j])) j++;
+      if (depth === 0) {
+        const word = sql.slice(i, j).toUpperCase();
+        if (word === "WHERE" && whereStart === -1) whereStart = j;
+        else if (whereStart !== -1 && WHERE_TERMINATORS.has(word)) {
+          ranges.push([whereStart, i]);
+          whereStart = -1;
+        }
+      }
+      i = j;
+      continue;
+    }
+
+    i++;
+  }
+
+  if (whereStart !== -1) ranges.push([whereStart, n]);
+  if (!ranges.length) return sql;
+
+  let out = "";
+  let prev = 0;
+  for (const [start, end] of ranges) {
+    out += sql.slice(prev, start) + " 1 = 1 ";
+    prev = end;
+  }
+  return out + sql.slice(prev);
 };


### PR DESCRIPTION
## Problem

A customer dashboard with 26 table panels freezes the browser for minutes on load, until the tab dies. **No search request is ever sent** — it hangs before any query runs.

Every table panel calls `parser.astify()` on mount, to work out which columns get an "Explore in Logs" icon. That parser is exponential in `WHERE`-clause paren nesting (~2× per level), and our query builder wraps every added condition in another paren layer. These predicates nest 16–27 deep. The worst single panel takes **8.9 minutes** to parse.

The kicker: `computeCellDrilldownFields` only reads `ast.type`, `ast.from` and `ast.columns`. **It never touches `ast.where`** — so all of that time is spent parsing a clause we throw away.

## Fix

We already have a guard for this hazard (`maxParenDepth > SQL_PARSE_MAX_DEPTH → skip parsing`), used in 8+ places. `usePanelDrilldown.ts` was just missed.

New `stripWherePredicate()` in `sqlComplexity.ts` swaps every top-level `WHERE` predicate for `1 = 1` before parsing (quote-, comment- and depth-aware, so a `WHERE` in a string, identifier, comment or subquery is safe):

```ts
// astify() is exponential in WHERE nesting; only SELECT/FROM are read below.
const parseTarget = stripWherePredicate(executedQuery);
if (maxParenDepth(parseTarget) > SQL_PARSE_MAX_DEPTH) return;
```

**Why not just add the guard?** Every one of these panels is past depth 12, so the guard alone would fix the hang by turning drilldown *off* for all of them. Stripping takes them from depth 27 to 1, so the guard never fires and the feature keeps working.

Only the string handed to the parser changes; drilldown entries still store the original query.

## Result

Across all 26 table panels: **696.3s → 17ms**, with **0/26** differences in the AST fields this code actually reads.

## Tests

15 new tests for the stripper, plus a regression test in the drilldown suite. Verified it fails without the fix (18,210ms) and passes with it. Type-check, ESLint, Prettier clean.
