### PR TITLE
fix(search): run search job queries on background queriers [v0.40.0]

### DIFF
--- a/src/service/search_jobs.rs
+++ b/src/service/search_jobs.rs
@@ -218,7 +218,7 @@ async fn run_partition_job(
         stream_type,
         Some(job.user_id.clone()),
         &req,
-        Some(RoleGroup::Interactive),
+        Some(RoleGroup::Background),
     )
     .await;
     if let Err(e) = res {


### PR DESCRIPTION
Backport of #14180 (`0e557a11f9c7746c008031928bc473dfbd23b0cb`) to `branch-v0.40.0`.

## Problem

An external tool calling `search_job/<id>/result` gets an empty `hits` array for a time range that returns data from the logs UI. In a two-region super cluster the job's partition query is dispatched to a **normal (interactive) querier**, which becomes the query leader and then queries only the remote background cluster — never fanning out to its own region's queriers and ingesters.

## Cause

`run_partition_job` picks the query leader from the **interactive** querier pool, while every other background workload picks from the **background** pool. That contradicts this branch's own classification — `config/src/meta/cluster.rs:275` maps `SearchEventType::SearchJob → RoleGroup::Background`.

The interactive leader then loses the local region:

1. The leader recomputes its own role group from the request payload; `search_type` is `SearchEventType::SearchJob`, so `RoleGroup::from` yields **Background**.
2. `get_cluster_nodes` → `list_by_role_group(Background)` keeps only clusters labelled empty or `"background"`.
3. The local cluster's label comes from whichever node is asking — `get_local_cluster()` reads `common.node_role_group`.

On an interactive querier that label is `"interactive"`, so the local cluster fails its own Background filter and **excludes itself from the search**. Only the remote background cluster answers, the job stores zero hits, and the result endpoint serves them back.

Alerts and pipelines are unaffected because they land on a background node, whose local-cluster label matches.

## Fix

One line: dispatch the search-job partition query to the background pool.

`handle_search_partition` is deliberately left on `Interactive`. That node only plans the time-range split, and `search_partition` derives its own role group from `req.search_type` independently of the caller, so the plan is computed as Background either way.

## Backport note

The file lives at `src/service/search_jobs.rs` on this branch instead of `src/search_service/src/search_jobs.rs` on `main`, so `git cherry-pick` could not apply cleanly and the change was made by hand. The surrounding `grpc_search` call is identical to main's and the resulting diff matches the original commit exactly.

## Behaviour change worth noting

A deployment running interactive queriers but no background ones now fails search jobs with `no querier node online` instead of quietly returning nothing. That is the better failure mode, but it is a change.

## Testing

`cargo fmt --all -- --check` is clean. No local compile was run — `RoleGroup::Background` is confirmed present in `config/src/meta/cluster.rs:254` on this branch and is already passed to this same `grpc_search` argument position elsewhere, so the change is type-identical to existing code. Please confirm via CI.
