### PR TITLE
fix(search): strip the account prefix when looking up segment ids [v0.40.0]

### DIFF
--- a/src/service/search/datafusion/storage/file_list.rs
+++ b/src/service/search/datafusion/storage/file_list.rs
@@ -94,7 +94,43 @@ pub fn clear(trace_id: &str) {
 
 pub fn get_segment_ids(file_key: &str) -> Option<Arc<BitVec>> {
     let (trace_id, filename) = file_key.split_once("/$$/")?;
+    // `set` keys segment data by the bare `file.key`; strip the account prefix
+    let filename = filename
+        .split_once("/::/")
+        .map_or(filename, |(_, filename)| filename);
     let r = SEGMENTS.read();
     let data = r.get(trace_id)?;
     data.get(filename).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_segment_ids_strips_account_prefix() {
+        let trace_id = "trace_segment_ids_account";
+        let bits = Arc::new(BitVec::from_iter([true, false, true]));
+        let file_key = "files/default/logs/a/1.parquet";
+        let mut file = FileKey::new(
+            0,
+            "acc1".to_string(),
+            file_key.to_string(),
+            Default::default(),
+            false,
+        );
+        file.segment_ids = Some(bits.clone());
+        set(trace_id, "schema", vec![file]).await;
+
+        let location = get(&format!("{trace_id}/schema=schema")).unwrap()[0]
+            .location
+            .to_string();
+        assert!(location.contains("/acc1/::/"));
+        assert_eq!(get_segment_ids(&location).as_deref(), Some(&*bits));
+        assert_eq!(
+            get_segment_ids(&format!("{trace_id}/schema=schema/$$/{file_key}")).as_deref(),
+            Some(&*bits)
+        );
+        clear(trace_id);
+    }
 }


### PR DESCRIPTION
Backport of the lookup fix that landed on main in #13866 (\`get_scan_selection\`).

## Problem

\`file_list::set\` writes the object location as \`{trace}/schema=X/$$/{account}/::/{file.key}\` when the file has a non-empty account, but keys the segment-id map by the bare \`file.key\`. \`get_segment_ids\` receives that location from DataFusion, splits on \`/$$/\` and looks up \`{account}/::/{file.key}\`, which never matches.

On multi-account storage every lookup returns \`None\`, so \`generate_access_plan\` bails out and the tantivy row selection is discarded: the query still returns correct results but scans the whole parquet file instead of the selected rows.

## Fix

Strip the \`{account}/::/\` prefix before the map lookup, the same way main does. Adds a unit test that registers a file with an account and checks the lookup works with both the full location and the bare key.