### PR TITLE
fix(alerts): refuse condition columns that ingestion would rewrite

### DIFF
--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -683,6 +683,19 @@ impl ConditionList {
             ConditionList::EndCondition(_) => true,
         }
     }
+
+    /// Every column the tree references, in evaluation order, duplicates kept.
+    pub fn columns(&self) -> Vec<&str> {
+        match self {
+            ConditionList::OrNode { or } => or.iter().flat_map(ConditionList::columns).collect(),
+            ConditionList::AndNode { and } => and.iter().flat_map(ConditionList::columns).collect(),
+            ConditionList::NotNode { not } => not.columns(),
+            ConditionList::LegacyConditions(conditions) => {
+                conditions.iter().map(|c| c.column.as_str()).collect()
+            }
+            ConditionList::EndCondition(condition) => vec![condition.column.as_str()],
+        }
+    }
 }
 
 // Define a separate iterator struct for ConditionList
@@ -1008,6 +1021,15 @@ impl ConditionItem {
             } => logical_operator,
         }
     }
+
+    pub fn columns(&self) -> Vec<&str> {
+        match self {
+            ConditionItem::Condition(v) => vec![v.column.as_str()],
+            ConditionItem::Group { conditions, .. } => {
+                conditions.iter().flat_map(ConditionItem::columns).collect()
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
@@ -1031,6 +1053,13 @@ impl ConditionGroup {
     /// Checks if the condition group has conditions
     pub fn has_conditions(&self) -> bool {
         !self.conditions.is_empty()
+    }
+
+    pub fn columns(&self) -> Vec<&str> {
+        self.conditions
+            .iter()
+            .flat_map(ConditionItem::columns)
+            .collect()
     }
 
     /// Validates the condition group structure
@@ -1057,6 +1086,15 @@ pub enum AlertConditionParams {
     V1(ConditionList),
     /// v2 format: Linear ConditionGroup (version: 2)
     V2(ConditionGroup),
+}
+
+impl AlertConditionParams {
+    pub fn columns(&self) -> Vec<&str> {
+        match self {
+            AlertConditionParams::V1(conditions) => conditions.columns(),
+            AlertConditionParams::V2(group) => group.columns(),
+        }
+    }
 }
 
 impl MemorySize for AlertConditionParams {
@@ -2680,6 +2718,61 @@ mod test {
             })],
         };
         assert!(group.validate().is_ok());
+    }
+
+    #[test]
+    fn test_condition_list_columns_walks_every_node_kind() {
+        let condition = |column: &str| Condition {
+            column: column.to_string(),
+            operator: Operator::EqualTo,
+            value: serde_json::Value::String("x".to_string()),
+            ignore_case: false,
+        };
+        let tree = ConditionList::AndNode {
+            and: vec![
+                ConditionList::EndCondition(condition("a")),
+                ConditionList::NotNode {
+                    not: Box::new(ConditionList::OrNode {
+                        or: vec![
+                            ConditionList::EndCondition(condition("b")),
+                            ConditionList::LegacyConditions(vec![condition("c"), condition("a")]),
+                        ],
+                    }),
+                },
+            ],
+        };
+        assert_eq!(
+            AlertConditionParams::V1(tree).columns(),
+            vec!["a", "b", "c", "a"]
+        );
+    }
+
+    #[test]
+    fn test_condition_group_columns_walks_nested_groups() {
+        let condition = |column: &str| {
+            ConditionItem::Condition(ConditionItemCondition {
+                column: column.to_string(),
+                operator: Operator::EqualTo,
+                value: serde_json::Value::String("x".to_string()),
+                ignore_case: None,
+                logical_operator: LogicalOperator::And,
+            })
+        };
+        let group = ConditionGroup {
+            filter_type: "group".to_string(),
+            logical_operator: LogicalOperator::And,
+            conditions: vec![
+                condition("a"),
+                ConditionItem::Group {
+                    logical_operator: LogicalOperator::Or,
+                    conditions: vec![condition("b"), condition("c")],
+                },
+            ],
+        };
+        assert_eq!(
+            AlertConditionParams::V2(group).columns(),
+            vec!["a", "b", "c"]
+        );
     }
 
     #[test]

--- a/src/core/src/alerts/alert.rs
+++ b/src/core/src/alerts/alert.rs
@@ -37,7 +37,7 @@ use config::{
         stream::StreamType,
     },
     utils::{
-        base64,
+        base64, flatten,
         json::{Map, Value},
     },
 };
@@ -180,6 +180,11 @@ pub enum AlertError {
 
     #[error("Stream {stream_name} not found")]
     StreamNotFound { stream_name: String },
+
+    #[error(
+        "Condition column `{column}` can never match: ingestion stores that field as `{stored_as}`"
+    )]
+    ConditionColumnNeverStored { column: String, stored_as: String },
 
     /// Feature 5 (SA-3 … SA-19). Rendered from the inner error, which names
     /// its own bound so the 400 is actionable.
@@ -387,6 +392,32 @@ fn validate_multi_alert_config(alert: &Alert) -> Result<(), AlertError> {
         return Err(AlertError::InvalidMultiAlert(
             config::meta::alerts::grouping::MultiAlertError::NotificationGroupingUnsupported,
         ));
+    }
+    Ok(())
+}
+
+/// Refuse a Custom condition on a column ingestion could never store under
+/// that name: `flatten::format_key` rewrites every ingested field name, so the
+/// alert would fail (scheduled) or stay silent (realtime) on every evaluation.
+// Sync like `validate_multi_alert_config`, so `result_large_err` needs the same allow.
+#[allow(clippy::result_large_err)]
+fn validate_condition_columns(alert: &Alert) -> Result<(), AlertError> {
+    let Some(conditions) = alert.query_condition.conditions.as_ref() else {
+        return Ok(());
+    };
+    for column in conditions.columns() {
+        // Empty is the draft-workflow placeholder `evaluate` treats as always true.
+        if column.is_empty() {
+            continue;
+        }
+        let mut stored_as = column.to_owned();
+        flatten::format_key(&mut stored_as);
+        if stored_as != column {
+            return Err(AlertError::ConditionColumnNeverStored {
+                column: column.to_owned(),
+                stored_as,
+            });
+        }
     }
     Ok(())
 }
@@ -842,6 +873,7 @@ async fn prepare_alert(
         {
             return Err(AlertError::PromqlMissingQuery);
         }
+        QueryType::Custom => validate_condition_columns(alert)?,
         _ => {}
     }
 
@@ -5601,6 +5633,96 @@ mod tests {
         assert_eq!(arr[1]["user"], "Bob");
     }
 
+    // ── Condition columns as `prepare_alert` checks them ───────────────────
+    // Same scope caveat as the per-group rules above: these pin the rule
+    // through the production function, not that `prepare_alert` calls it.
+
+    use super::validate_condition_columns;
+
+    /// A Custom alert whose v1 condition list names the given columns.
+    fn custom_alert_on(columns: &[&str]) -> Alert {
+        let mut alert = Alert::default();
+        alert.query_condition.query_type = config::meta::alerts::QueryType::Custom;
+        alert.query_condition.conditions = Some(config::meta::alerts::AlertConditionParams::V1(
+            config::meta::alerts::ConditionList::LegacyConditions(
+                columns
+                    .iter()
+                    .map(|column| config::meta::alerts::Condition {
+                        column: column.to_string(),
+                        operator: config::meta::alerts::Operator::EqualTo,
+                        value: json!("4624"),
+                        ignore_case: false,
+                    })
+                    .collect(),
+            ),
+        ));
+        alert
+    }
+
+    #[test]
+    fn test_condition_columns_ingestion_keeps_as_written_pass() {
+        let alert = custom_alert_on(&["eventid", "k8s_pod_name", "_timestamp"]);
+        assert!(validate_condition_columns(&alert).is_ok());
+    }
+
+    #[test]
+    fn test_condition_columns_absent_pass() {
+        assert!(validate_condition_columns(&Alert::default()).is_ok());
+    }
+
+    /// The spelling from openobserve#14131: QRadar sends `EventID`, ingestion
+    /// stores `eventid`, and the alert never matched a single row.
+    #[test]
+    fn test_condition_column_ingestion_would_rewrite_is_rejected_with_the_stored_name() {
+        let err =
+            validate_condition_columns(&custom_alert_on(&["eventid", "EventID"])).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                AlertError::ConditionColumnNeverStored { column, stored_as }
+                    if column.as_str() == "EventID" && stored_as.as_str() == "eventid"
+            ),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_condition_column_in_a_nested_v2_group_is_checked() {
+        let condition = |column: &str| {
+            config::meta::alerts::ConditionItem::Condition(
+                config::meta::alerts::ConditionItemCondition {
+                    column: column.to_string(),
+                    operator: config::meta::alerts::Operator::EqualTo,
+                    value: json!("x"),
+                    ignore_case: None,
+                    logical_operator: config::meta::alerts::LogicalOperator::And,
+                },
+            )
+        };
+        let mut alert = Alert::default();
+        alert.query_condition.conditions = Some(config::meta::alerts::AlertConditionParams::V2(
+            config::meta::alerts::ConditionGroup {
+                filter_type: "group".to_string(),
+                logical_operator: config::meta::alerts::LogicalOperator::And,
+                conditions: vec![
+                    condition("level"),
+                    config::meta::alerts::ConditionItem::Group {
+                        logical_operator: config::meta::alerts::LogicalOperator::Or,
+                        conditions: vec![condition("trace.id")],
+                    },
+                ],
+            },
+        ));
+        let err = validate_condition_columns(&alert).unwrap_err();
+        assert!(err.to_string().contains("`trace_id`"), "got: {err}");
+    }
+
+    /// Empty is the draft-workflow placeholder, which `evaluate` accepts.
+    #[test]
+    fn test_empty_condition_column_is_not_rejected_here() {
+        assert!(validate_condition_columns(&custom_alert_on(&[""])).is_ok());
+    }
+
     // ── update_cron_expression ──────────────────────────────────────────────
 
     #[test]
@@ -5966,6 +6088,15 @@ mod tests {
             stream_name: "my_stream".to_string(),
         };
         assert_eq!(e.to_string(), "Stream my_stream not found");
+
+        let e = AlertError::ConditionColumnNeverStored {
+            column: "EventID".to_string(),
+            stored_as: "eventid".to_string(),
+        };
+        assert_eq!(
+            e.to_string(),
+            "Condition column `EventID` can never match: ingestion stores that field as `eventid`"
+        );
 
         let e = AlertError::AlertTemplateNotFound {
             template: "default_tpl".to_string(),

--- a/src/core/src/http.rs
+++ b/src/core/src/http.rs
@@ -91,6 +91,7 @@ impl From<AlertError> for Response {
             | AlertError::AlertIdMissing
             | AlertError::PendingPeriodOnRealtimeAlert
             | AlertError::NegativePendingPeriod
+            | AlertError::ConditionColumnNeverStored { .. }
             | AlertError::MultiAlertGroupingError(_) => MetaHttpResponse::bad_request(value),
             // S-16 PR 4. A conflict, not a bad request: the alert being sent is
             // fine on its own terms — it is the SLOs that already exist and


### PR DESCRIPTION
## Summary

An alert whose Custom condition names a column with a capital letter, a dot, a dash or any other character ingestion rewrites is accepted by the API and saved, and then never matches anything. Found while reproducing https://github.com/openobserve/openobserve/discussions/14131, where the reporter's alerts show `Last Triggered At: Never` with an empty history.

### What happens

Every field name goes through `flatten::format_key` at ingestion (`src/config/src/utils/flatten.rs`): uppercase is lowercased and anything outside `[a-z0-9_]` becomes `_`, on every path (JSON, bulk, HEC, Loki, OTLP, and again after a pipeline). A record ingested as `{"EventID": "4624"}` is stored under `eventid`. `prepare_alert` loads the stream schema and checks that the stream exists, but never looks at the columns the condition names, so a condition on `EventID` is saved as is.

From there the two alert types fail differently, measured on v1.0.0-rc2 with two alerts on `EventID` next to two identical ones on `eventid`:

| alert | `last_triggered_at` | history (`_meta/triggers`) | container log |
|---|---|---|---|
| realtime on `EventID` | `0` | no rows | nothing |
| scheduled on `EventID` | advances | one `status=error` row per run: `Error building SQL on stream qradar: Column EventID not found` | one `evaluation failed` line per run |
| realtime on `eventid` | advances | `firing` rows | `Evaluating trigger for alert` |
| scheduled on `eventid` | advances | `firing` rows | normal |

The realtime case is the costly one: `Condition::evaluate` (`src/core/src/alerts/mod.rs`) returns `false` when `row.get(&self.column)` is `None`, so nothing is logged or written anywhere and the alert is indistinguishable from "no matching traffic yet". The UI normally offers the column from the stream schema, so this mostly reaches people through the API and through names typed as they appear in the source system (Windows event logs, QRadar, camelCase JSON).

### Why this shape

The check runs the condition column through `format_key` itself and rejects it if the result differs, naming the stored form: `Condition column `EventID` can never match: ingestion stores that field as `eventid``, as a 400. Reusing `format_key` keeps the rule identical to ingestion by construction, and a name it would rewrite can never exist in a stream, so this cannot reject a column that a future record could still create. A well formed column that is simply absent from the schema is deliberately left alone, since alerts are routinely created before the first record with that field arrives.

It follows the existing write time rules in `prepare_alert` (`RealtimeMissingCustomQuery`, `SqlContainsSelectStar`, the aggregation threshold check whose comment states the principle: caught at write time rather than failing every evaluation). Empty columns are skipped, since `evaluate` treats them as the draft workflow placeholder. Both condition formats are walked: the v1 `ConditionList` tree (`or`/`and`/`not`, legacy lists) and the v2 `ConditionGroup` with nested groups, through a `columns()` accessor added next to `has_conditions()`.

### Tests

`config`: `columns()` over a nested v1 tree and a nested v2 group. `openobserve-core`: the rule accepts columns ingestion keeps, rejects `EventID` with `stored_as = "eventid"`, finds `trace.id` inside a nested v2 group, skips empty columns and alerts without conditions, plus the `Display` string. Same caveat as the neighbouring per-group rule tests: they pin the rule through the production function, not that `prepare_alert` calls it, since `prepare_alert` reaches the global ORM clients.

### Verification

Same six `POST /api/v2/default/alerts` requests against a v1.0.0-rc2 container and against a debug build of this branch, after ingesting `{"EventID": "4624", "Trace.ID": "t1"}` (stored as `eventid`, `trace_id`):

| condition column | rc2 | this branch |
|---|---|---|
| v1 realtime `eventid` | 200 | 200 |
| v1 realtime `EventID` | 200 | 400 `Condition column `EventID` can never match: ingestion stores that field as `eventid`` |
| v1 scheduled `EventID` | 200 | 400, same message |
| v1 scheduled `k8s_pod_name` | 200 | 200 |
| v2 nested group `trace.id` | 200 | 400 `... ingestion stores that field as `trace_id`` |
| v2 nested group `trace_id` | 200 | 200 |

`cargo fmt --all` and the CI clippy command from `CLAUDE.md` (`cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings`) are clean on `nightly-2026-05-20`. No enterprise gated code is touched.
