### PR TITLE
fix: Fix/logs stream selector issues

### DIFF
--- a/tests/ui-testing/playwright-tests/Logs/streamsExploreLogsTypePersistence.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/streamsExploreLogsTypePersistence.spec.js
@@ -1,0 +1,89 @@
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+const { ensureMetricsIngested } = require('../utils/shared-metrics-setup.js');
+const { getOrgIdentifier } = require('../utils/cloud-auth.js');
+
+// Metric name is seeded by ensureMetricsIngested() / metrics-ingestion.js and is
+// guaranteed to exist as a "metrics" type stream (see metrics.spec.js).
+const METRIC_STREAM = 'cpu_usage';
+
+// ===========================================================================
+// Repro: Streams page "explore" (search icon) on a metrics stream → Logs page
+// → "switch back to logs" → navigate to Home → back to Logs + hard refresh.
+//
+// Bug: after the refresh, stream_type shows "logs" (switch-back persisted
+// correctly) but the stream dropdown still shows the metrics stream name —
+// an inconsistent logs-type-with-metrics-stream-name state.
+//
+// Root cause: IndexList.vue's onStreamTypeChange('logs') clears
+// selectedStream and calls saveLogsStream(orgId, []) to wipe the persisted
+// logs stream, but streamPersist.ts's saveLogsStream() no-ops on an empty
+// array, so the stale metrics stream name is never cleared from
+// oo_selected_stream_logs_{orgId}. Separately, the selectedStream watcher in
+// Index.vue wrote into that same logs-only bucket without checking that
+// streamType was actually "logs", letting the metrics stream name leak in
+// there in the first place.
+// ===========================================================================
+
+test.describe('Streams explore → Logs stream-type persistence', () => {
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await ensureMetricsIngested();
+  });
+
+  test('should not retain the metrics stream name after switching back to logs, leaving Home and reloading', {
+    tag: ['@streams-logs-persistence', '@all', '@logs', '@streams', '@P0']
+  }, async ({ page }) => {
+    // 1. Streams page: filter to the Metrics tab and open the metric via the
+    //    action column's search/explore icon.
+    await pm.streamsPage.navigateToStreamExplorer();
+    await page.locator('[data-test="log-stream-table"] [data-otoggle-value="metrics"]').click();
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await pm.streamsPage.searchStream(METRIC_STREAM);
+    await pm.streamsPage.verifyStreamNameVisibility(METRIC_STREAM);
+    await pm.streamsPage.exploreStream();
+
+    // 2. Landed on Logs with stream_type=metrics and the metric pre-selected.
+    await expect(page).toHaveURL(/stream_type=metrics/);
+    await pm.logsPage.expectStreamSelectorContainsText(METRIC_STREAM);
+
+    // 3. Click "switch back to logs" beside the stream dropdown.
+    const backToLogsBtn = page.locator('[data-test="log-search-index-list-back-to-logs-btn"]');
+    await expect(backToLogsBtn).toBeVisible();
+    await backToLogsBtn.click();
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await expect(backToLogsBtn).not.toBeVisible();
+
+    // 4. Go to Home.
+    await navigateToBase(page);
+
+    // 5. Back to Logs, then hard refresh.
+    await pm.logsPage.clickMenuLinkLogsItem();
+    await page.reload();
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+
+    // Bug repro assertions: stream type must genuinely be "logs" (back-to-logs
+    // button hidden) AND the stream dropdown must NOT still show the metrics
+    // stream name left over from before the switch-back.
+    await expect(backToLogsBtn).not.toBeVisible();
+    await expect(page.locator('[data-test="log-search-index-list-select-stream-trigger"]'))
+      .not.toContainText(METRIC_STREAM);
+
+    // Confirm at the persistence layer too: the logs-type localStorage bucket
+    // must not carry the metrics stream name across the reload.
+    const persistedLogsStream = await page.evaluate(
+      (orgId) => localStorage.getItem(`oo_selected_stream_logs_${orgId}`),
+      getOrgIdentifier(),
+    );
+    if (persistedLogsStream) {
+      expect(JSON.parse(persistedLogsStream)).not.toContain(METRIC_STREAM);
+    }
+
+    testLogger.info('Logs stream type/name stayed consistent after switch-back + reload');
+  });
+});

--- a/web/src/lib/core/EmptyState/OEmptyState.vue
+++ b/web/src/lib/core/EmptyState/OEmptyState.vue
@@ -50,10 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     />
 
     <div
-      :class="[
-        'relative flex w-full min-w-0 flex-col items-center text-center',
-        sizeClass.stack,
-      ]"
+      :class="['relative flex w-full min-w-0 flex-col items-center text-center', sizeClass.stack]"
     >
       <!-- illustration (hero/block) — preset/illustration prop or slot -->
       <div v-if="hasIllustration" class="shrink-0">

--- a/web/src/lib/core/EmptyState/OEmptyState.vue
+++ b/web/src/lib/core/EmptyState/OEmptyState.vue
@@ -49,7 +49,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :style="dotGridStyle"
     />
 
-    <div :class="['relative flex flex-col items-center text-center', sizeClass.stack]">
+    <div
+      :class="[
+        'relative flex w-full min-w-0 flex-col items-center text-center',
+        sizeClass.stack,
+      ]"
+    >
       <!-- illustration (hero/block) — preset/illustration prop or slot -->
       <div v-if="hasIllustration" class="shrink-0">
         <slot name="illustration">

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1612,7 +1612,12 @@ export default defineComponent({
     watch(
       () => searchObj.data.stream.selectedStream,
       (streams: string[]) => {
-        if (store.state.zoConfig?.auto_query_enabled && Array.isArray(streams) && streams.length) {
+        if (
+          store.state.zoConfig?.auto_query_enabled &&
+          searchObj.data.stream.streamType === "logs" &&
+          Array.isArray(streams) &&
+          streams.length
+        ) {
           saveLogsStream(store.state.selectedOrganization.identifier, streams);
         }
       },

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -83,7 +83,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               class="w-full justify-start"
               @click="quickSelectStream(stream.value)"
             >
-              <span class="truncate">{{ stream.label }}</span>
+              <span class="min-w-0 flex-1 truncate">{{ stream.label }}</span>
+              <OTooltip :content="raw(stream.label)" side="right" align="center" />
             </OButton>
             <span
               v-if="streamList.length > quickPickStreams.length"

--- a/web/src/utils/streamPersist.ts
+++ b/web/src/utils/streamPersist.ts
@@ -8,8 +8,12 @@ const STORAGE_KEYS = {
 };
 
 export function saveLogsStream(orgId: string, streams: string[]): void {
-  if (!orgId || !streams.length) return;
-  localStorage.setItem(STORAGE_KEYS.logs(orgId), JSON.stringify(streams));
+  if (!orgId) return;
+  if (streams.length) {
+    localStorage.setItem(STORAGE_KEYS.logs(orgId), JSON.stringify(streams));
+  } else {
+    localStorage.removeItem(STORAGE_KEYS.logs(orgId));
+  }
 }
 
 export function restoreLogsStream(orgId: string): string[] {


### PR DESCRIPTION
Two related bugs in the Logs page's stream selector, found while reproducing a reported issue (Streams page → explore a metrics stream → switch back to logs → navigate away → reload):

**Stale stream persisted across reload:** exploring a metrics/traces stream from the Streams page and then clicking "switch back to logs" left the metrics stream name stuck in the logs-only localStorage bucket. Two bugs combined to cause this: saveLogsStream() silently no-op'd on an empty array (so the switch-back's attempt to clear it never took effect), and the selectedStream persistence watcher wrote into that bucket regardless of the currently active stream type. After leaving the Logs page and reloading, stream_type correctly showed logs, but the stream dropdown still showed the leftover metrics stream name.
**Long stream names overflow their container:** in the "Recently active streams" quick-pick list (shown when no stream is selected yet), OEmptyState's inner content wrapper had no explicit width, so under align-items:center it sized itself via shrink-to-fit — which can't shrink below an unbroken word's min-content width. A long stream name (e.g. zo_stream_stats_scan_duration_seconds_bucket) forced the whole block wider than its panel, hard-clipping at the panel edge instead of truncating with an ellipsis.

### Changes
web/src/utils/streamPersist.ts: saveLogsStream() now clears the localStorage key on an empty array instead of no-opping.
web/src/plugins/logs/Index.vue: the selectedStream persistence watcher now only writes into the logs bucket when streamType === "logs".
web/src/lib/core/EmptyState/OEmptyState.vue: give the inner content wrapper an explicit w-full min-w-0 so nested content is properly bounded instead of growing past its container.
web/src/plugins/logs/IndexList.vue: min-w-0 flex-1 on the quick-pick button's label span so it can actually truncate, plus a tooltip showing the full name on hover.

### Test plan
 Added tests/ui-testing/playwright-tests/Logs/streamsExploreLogsTypePersistence.spec.js, reproducing the exact repro steps (explore metrics stream → switch back to logs → Home → Logs + reload) and asserting stream type/name stay consistent, including a direct localStorage check.
 OEmptyState.spec.ts (28 tests) and IndexList.spec.ts (128 tests) pass unchanged.
 Verified the overflow fix against an isolated Playwright repro of the nested-flex structure (before/after screenshots) since OEmptyState is shared app-wide.
 Manual verification in a running instance (pending local server restart).