### PR TITLE
feat(logs): allow pinning Quick Mode to the search toolbar

### DIFF
--- a/web/src/components/dashboards/viewPanel/ViewPanel.spec.ts
+++ b/web/src/components/dashboards/viewPanel/ViewPanel.spec.ts
@@ -94,6 +94,7 @@ vi.mock("@/composables/useStreamingSearch", () => ({
 // Mock additional utilities that may cause import issues
 vi.mock("@/utils/zincutils", () => ({
   useLocalWrapContent: vi.fn(() => null),
+  useLocalQuickModePin: vi.fn(() => "true"),
 }));
 vi.mock("@/utils/query/sqlUtils", () => ({}));
 vi.mock("@/utils/query/search", () => ({}));

--- a/web/src/locales/languages/de.json
+++ b/web/src/locales/languages/de.json
@@ -384,7 +384,9 @@
     "patternNavNext": "Weiter",
     "patternWildcardSampleValues": "Beispielwerte",
     "wildcardSampleValues": "Beispielwerte",
-    "patternZScore": "Z-Score: {zScore} (durchschnittliche Häufigkeit: {avgFrequency})"
+    "patternZScore": "Z-Score: {zScore} (durchschnittliche Häufigkeit: {avgFrequency})",
+    "pinToToolbar": "An Werkzeugleiste anheften",
+    "unpinFromToolbar": "Von der Werkzeugleiste lösen"
   },
   "menu": {
     "home": "Startseite",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -197,6 +197,8 @@
     "sqlModeLabel": "SQL Mode",
     "nlpModeLabel": "Natural Language Mode",
     "quickModeLabel": "Quick Mode",
+    "pinToToolbar": "Pin to toolbar",
+    "unpinFromToolbar": "Unpin from toolbar",
     "toggleFunctionLabel": "Function",
     "labelWrap": "Wrap Content",
     "messageWrapContent": "Wrap Table Content",

--- a/web/src/locales/languages/es.json
+++ b/web/src/locales/languages/es.json
@@ -384,7 +384,9 @@
     "patternNavNext": "Próxima",
     "patternWildcardSampleValues": "Valores de muestra",
     "wildcardSampleValues": "Valores de muestra",
-    "patternZScore": "Puntuación Z: {zScore} (frecuencia promedio: {AvgFrequency})"
+    "patternZScore": "Puntuación Z: {zScore} (frecuencia promedio: {AvgFrequency})",
+    "pinToToolbar": "Fijar a la barra de herramientas",
+    "unpinFromToolbar": "Desanclar de la barra de herramientas"
   },
   "menu": {
     "home": "Inicio",

--- a/web/src/locales/languages/fr.json
+++ b/web/src/locales/languages/fr.json
@@ -384,7 +384,9 @@
     "patternNavNext": "Suivant",
     "patternWildcardSampleValues": "Exemples de valeurs",
     "wildcardSampleValues": "Exemples de valeurs",
-    "patternZScore": "Score Z : {zScore} (fréquence moyenne : {AVGFrequency})"
+    "patternZScore": "Score Z : {zScore} (fréquence moyenne : {AVGFrequency})",
+    "pinToToolbar": "Ajouter à la barre d'outils",
+    "unpinFromToolbar": "Détacher de la barre d'outils"
   },
   "menu": {
     "home": "Accueil",

--- a/web/src/locales/languages/it.json
+++ b/web/src/locales/languages/it.json
@@ -384,7 +384,9 @@
     "patternWildcardSampleValues": "Valori di esempio",
     "wildcardSampleValues": "Valori di esempio",
     "patternZScore": "Z-score: {zScore} (frequenza media: {avgFrequency})",
-    "createAlertFromPattern": "Crea un avviso da questo modello"
+    "createAlertFromPattern": "Crea un avviso da questo modello",
+    "pinToToolbar": "Aggiungi alla barra degli strumenti",
+    "unpinFromToolbar": "Sblocca dalla barra degli strumenti"
   },
   "menu": {
     "home": "Home",

--- a/web/src/locales/languages/ja.json
+++ b/web/src/locales/languages/ja.json
@@ -384,7 +384,9 @@
     "patternNavNext": "[次へ]",
     "patternWildcardSampleValues": "サンプル値",
     "wildcardSampleValues": "サンプル値",
-    "patternZScore": "Z スコア:{スコア} (平均周波数:{平均周波数})"
+    "patternZScore": "Z スコア:{スコア} (平均周波数:{平均周波数})",
+    "pinToToolbar": "ツールバーに固定",
+    "unpinFromToolbar": "ツールバーからピン留め解除"
   },
   "menu": {
     "home": "ホーム",

--- a/web/src/locales/languages/ko.json
+++ b/web/src/locales/languages/ko.json
@@ -384,7 +384,9 @@
     "patternWildcardSampleValues": "샘플 값",
     "wildcardSampleValues": "샘플 값",
     "patternZScore": "Z-점수: {z점수} (평균 주파수: {평균 주파수})",
-    "createAlertFromPattern": "이 패턴으로 알림 생성"
+    "createAlertFromPattern": "이 패턴으로 알림 생성",
+    "pinToToolbar": "도구 모음에 고정",
+    "unpinFromToolbar": "도구 모음에서 고정 해제"
   },
   "menu": {
     "home": "홈",

--- a/web/src/locales/languages/nl.json
+++ b/web/src/locales/languages/nl.json
@@ -384,7 +384,9 @@
     "patternWildcardSampleValues": "Voorbeeldwaarden",
     "wildcardSampleValues": "Voorbeeldwaarden",
     "patternZScore": "Z-score: {zScore} (gemiddelde frequentie: {avgFrequency})",
-    "createAlertFromPattern": "Creëer een waarschuwing op basis van dit patroon"
+    "createAlertFromPattern": "Creëer een waarschuwing op basis van dit patroon",
+    "pinToToolbar": "Aan de werkbalk vastmaken",
+    "unpinFromToolbar": "Van de werkbalk loskoppelen"
   },
   "menu": {
     "home": "Home",

--- a/web/src/locales/languages/pt.json
+++ b/web/src/locales/languages/pt.json
@@ -384,7 +384,9 @@
     "patternNavNext": "Próximo",
     "patternWildcardSampleValues": "Valores da amostra",
     "wildcardSampleValues": "Valores da amostra",
-    "patternZScore": "Pontuação Z: {zScore} (frequência média: {avgFrequency})"
+    "patternZScore": "Pontuação Z: {zScore} (frequência média: {avgFrequency})",
+    "pinToToolbar": "Fixar na barra de ferramentas",
+    "unpinFromToolbar": "Desfixar da barra de ferramentas"
   },
   "menu": {
     "home": "Início",

--- a/web/src/locales/languages/tr.json
+++ b/web/src/locales/languages/tr.json
@@ -384,7 +384,9 @@
     "patternWildcardSampleValues": "Örnek değerler",
     "wildcardSampleValues": "Örnek değerler",
     "patternZScore": "Z puanı: {zScore} (ortalama frekans: {avgFrequency})",
-    "createAlertFromPattern": "Bu modelden uyarı oluştur"
+    "createAlertFromPattern": "Bu modelden uyarı oluştur",
+    "pinToToolbar": "Araç çubuğuna sabitleyin",
+    "unpinFromToolbar": "Araç çubuğundan sabitlemeyi kaldırın"
   },
   "menu": {
     "home": "Ana Sayfa",

--- a/web/src/locales/languages/zh.json
+++ b/web/src/locales/languages/zh.json
@@ -384,7 +384,9 @@
     "patternNavNext": "下一步",
     "patternWildcardSampleValues": "样本值",
     "wildcardSampleValues": "样本值",
-    "patternZScore": "Z 分数：{zScore}（平均频率：{avgFrequency}）"
+    "patternZScore": "Z 分数：{zScore}（平均频率：{avgFrequency}）",
+    "pinToToolbar": "固定到工具栏",
+    "unpinFromToolbar": "从工具栏中取消固定"
   },
   "menu": {
     "home": "主页",

--- a/web/src/plugins/logs/FunctionSelector.spec.ts
+++ b/web/src/plugins/logs/FunctionSelector.spec.ts
@@ -37,6 +37,7 @@ vi.mock("@/composables/useLogs", () => ({
 vi.mock("@/utils/zincutils", () => ({
   getImageURL: vi.fn((path: string) => `http://localhost:8080/${path}`),
   useLocalWrapContent: vi.fn(() => false),
+  useLocalQuickModePin: vi.fn(() => "true"),
 }));
 
 installQuasar();

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -157,6 +157,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </q-tooltip>
           </q-toggle>
         </div>
+        <div
+          v-if="!shouldMoveSqlToggleToMenu && searchObj.meta.quickModePinned"
+          class="toolbar-toggle-container element-box-shadow"
+        >
+          <q-toggle
+            data-test="logs-search-bar-quick-mode-pinned-toggle-btn"
+            v-model="searchObj.meta.quickMode"
+            class="o2-toggle-button-xs"
+            size="xs"
+            flat
+            :class="
+              store.state.theme === 'dark'
+                ? 'o2-toggle-button-xs-dark'
+                : 'o2-toggle-button-xs-light'
+            "
+            @update:model-value="handleQuickModePinnedUpdate"
+          >
+            <img :src="quickModeIcon" alt="Quick Mode" class="toolbar-icon" />
+            <q-tooltip>
+              {{ t("search.quickModeLabel") }}
+            </q-tooltip>
+          </q-toggle>
+        </div>
         <q-btn-group
           v-if="!shouldMoveSavedViewToMenu"
           class="q-ml-xs q-pa-none element-box-shadow el-border"
@@ -566,6 +589,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     </div>
                     {{ t("search.quickModeLabel") }}
                   </q-item-label>
+                </q-item-section>
+                <q-item-section side>
+                  <q-btn
+                    data-test="logs-search-bar-quick-mode-pin-btn"
+                    flat
+                    round
+                    dense
+                    size="xs"
+                    icon="push_pin"
+                    :color="
+                      searchObj.meta.quickModePinned ? 'primary' : 'grey-6'
+                    "
+                    @click.stop="toggleQuickModePin"
+                  >
+                    <q-tooltip>
+                      {{
+                        searchObj.meta.quickModePinned
+                          ? t("search.unpinFromToolbar")
+                          : t("search.pinToToolbar")
+                      }}
+                    </q-tooltip>
+                  </q-btn>
                 </q-item-section>
               </q-item>
 
@@ -2309,6 +2354,7 @@ import {
   getImageURL,
   useLocalInterestingFields,
   useLocalSavedView,
+  useLocalQuickModePin,
   queryIndexSplit,
   timestampToTimezoneDate,
   b64EncodeUnicode,
@@ -4734,6 +4780,15 @@ export default defineComponent({
       emit("handleQuickModeChange");
     };
 
+    const toggleQuickModePin = () => {
+      searchObj.meta.quickModePinned = !searchObj.meta.quickModePinned;
+      useLocalQuickModePin(String(searchObj.meta.quickModePinned));
+    };
+
+    const handleQuickModePinnedUpdate = () => {
+      emit("handleQuickModeChange");
+    };
+
     const handleHistogramMode = () => {};
 
     const handleRunQueryFn = (clear_cache = false) => {
@@ -5320,6 +5375,8 @@ export default defineComponent({
       config,
       handleRegionsSelection,
       handleQuickMode,
+      toggleQuickModePin,
+      handleQuickModePinnedUpdate,
       handleHistogramMode,
       regionFilterMethod,
       regionFilterRef,

--- a/web/src/utils/logs/constants.ts
+++ b/web/src/utils/logs/constants.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { useLocalWrapContent } from "@/utils/zincutils";
+import { useLocalWrapContent, useLocalQuickModePin } from "@/utils/zincutils";
 import { TimePeriodUnit } from "@/ts/interfaces";
 
 /**
@@ -124,6 +124,7 @@ export const DEFAULT_LOGS_CONFIG = {
     sqlModeManualTrigger: false,
     nlpMode: false,
     quickMode: false,
+    quickModePinned: useLocalQuickModePin() === "true",
     queryEditorPlaceholderFlag: true,
     functionEditorPlaceholderFlag: true,
     resultGrid: {

--- a/web/src/utils/logs/constants.ts
+++ b/web/src/utils/logs/constants.ts
@@ -124,7 +124,7 @@ export const DEFAULT_LOGS_CONFIG = {
     sqlModeManualTrigger: false,
     nlpMode: false,
     quickMode: false,
-    quickModePinned: useLocalQuickModePin() === "true",
+    quickModePinned: useLocalQuickModePin() !== "false",
     queryEditorPlaceholderFlag: true,
     functionEditorPlaceholderFlag: true,
     resultGrid: {

--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -354,6 +354,15 @@ export const useLocalWrapContent = (val = "", isDelete = false) => {
   return wrapcontent.value;
 };
 
+export const useLocalQuickModePin = (val = "", isDelete = false) => {
+  const quickModePinned: any = useLocalStorage(
+    "logsQuickModePinned",
+    val,
+    isDelete,
+  );
+  return quickModePinned.value;
+};
+
 export const deleteSessionStorageVal = (key: string) => {
   try {
     return sessionStorage.removeItem(key);


### PR DESCRIPTION
Quick Mode currently lives only inside the search bar's "more" menu. Add a pin toggle on that menu item so users can pin it to appear as a standalone toggle next to the SQL Mode button, persisted in localStorage across sessions.