### PR TITLE
fix(compactor): prevent data loss when storage checks skip files

### DIFF
--- a/src/compaction/src/merge/file.rs
+++ b/src/compaction/src/merge/file.rs
@@ -112,7 +112,7 @@ pub async fn merge_files(
     if !deleted_files.is_empty() {
         new_file_list.retain(|f| !deleted_files.contains(&f.key));
     }
-    if new_file_list.len() <= 1 && !merge_whole_batch {
+    if new_file_list.is_empty() || (new_file_list.len() == 1 && !merge_whole_batch) {
         return Ok((Vec::new(), retain_file_list));
     }
 
@@ -437,20 +437,13 @@ async fn cache_remote_files(files: &[FileKey]) -> Result<Vec<String>, anyhow::Er
             // must have been deleted by some external entity, and hence we
             // should remove the entry from file_list table.
             let file_name = match ret {
-                Ok(data_len) => {
-                    if data_len > 0 && data_len != file_size {
-                        log::warn!(
-                            "[COMPACT] download file {file_name} found size mismatch, expected: {file_size}, actual: {data_len}, will skip it",
-                        );
-                        // skip this file for compact
-                        Some(file_name)
-                    } else {
-                        None
-                    }
-                }
+                // The downloader validates files with mismatched sizes and corrects
+                // file_list. Keep them even if this batch still has the old size.
+                Ok(_) => None,
                 Err(e) => {
                     if e.to_string().to_lowercase().contains("not found")
                         || e.to_string().to_lowercase().contains("data size is zero")
+                        || e.to_string().to_lowercase().contains("is corrupted")
                     {
                         // delete file from file list
                         log::error!("[COMPACT] found invalid file: {file_name}, will delete it");

--- a/src/compaction/src/merge/stream.rs
+++ b/src/compaction/src/merge/stream.rs
@@ -234,6 +234,12 @@ pub async fn merge_by_stream(
                 }
                 check_guard.insert(batch_id);
 
+                // A storage check can leave too few files to merge. Keep the
+                // surviving source files when no replacement was produced.
+                if new_files.is_empty() {
+                    continue;
+                }
+
                 // delete small files keys & write big files keys, use transaction
                 let delete_file_list = batch_groups.get(batch_id).unwrap().files.as_slice();
                 let mut events = Vec::with_capacity(new_files.len() + delete_file_list.len());


### PR DESCRIPTION
## Summary

The compactor can retire valid source files that were skipped during storage checks, including the last surviving file when a batch produces no output. This can remove rows from the file list without a replacement file.

Keep successfully downloaded files in the merge when the downloader has validated and corrected a size mismatch. Filter corrupted files alongside missing and empty files, return early when storage checks empty a batch, and skip source-file retirement when no replacement was produced.

Fixes #14275

## Validation

- `cargo check -p compaction` passed.
- `rustfmt --check --edition 2024 src/compaction/src/merge/file.rs src/compaction/src/merge/stream.rs` passed.
- `git diff --check` passed.
- Object-storage end-to-end reproduction was not run.
