### PR TITLE
fix(slos): surface real API error messages on the SLO form

### DIFF
--- a/web/src/views/slos/AddSlo.vue
+++ b/web/src/views/slos/AddSlo.vue
@@ -366,6 +366,8 @@
               :options="alertSourceOptions"
               :loading="isFetchingAlertSources"
               :placeholder="t('slos.alertSli.sourcePlaceholder')"
+              :error="!!alertSourceError"
+              :error-message="alertSourceError || undefined"
               required
               class="mt-3"
               data-test="slos-addslo-alert-source"
@@ -375,15 +377,7 @@
               {{ t("slos.alertSli.sourceHint") }}
             </p>
             <OBanner
-              v-if="alertSourceError"
-              variant="error"
-              class="mt-3"
-              data-test="slos-addslo-alert-source-error"
-            >
-              {{ alertSourceError }}
-            </OBanner>
-            <OBanner
-              v-else-if="!isFetchingAlertSources && !hasEligibleAlert"
+              v-if="!isFetchingAlertSources && !hasEligibleAlert && !alertSourceError"
               variant="info"
               class="mt-3"
               data-test="slos-addslo-alert-source-empty"
@@ -938,7 +932,7 @@ watch(isGrouped, (grouped) => {
 // the server's own reason attached rather than being filtered away.
 const alertSources = ref<SloEligibleAlert[]>([]);
 const isFetchingAlertSources = ref(false);
-const alertSourceError = ref<string | null>(null);
+const alertSourceError = ref<I18nText | null>(null);
 
 const hasEligibleAlert = computed(() => alertSources.value.some((a) => a.eligible));
 
@@ -959,9 +953,9 @@ async function loadAlertSources() {
   try {
     const res = await sloService.eligibleAlerts(org.value);
     alertSources.value = res.data?.list ?? [];
-  } catch {
+  } catch (e: any) {
     alertSources.value = [];
-    alertSourceError.value = t("slos.alertSli.loadFailed");
+    alertSourceError.value = raw(e?.response?.data?.message) || t("slos.alertSli.loadFailed");
   } finally {
     isFetchingAlertSources.value = false;
   }
@@ -1185,8 +1179,15 @@ async function save() {
     router.push(backTarget.value);
   } catch (e: any) {
     // The backend's budget rejection carries its arithmetic (§6b.4d); show it
-    // verbatim rather than replacing it with a generic message.
-    error.value = e?.response?.data?.message || e?.message || t("slos.saveFailed");
+    // verbatim rather than replacing it with a generic message. A rejected
+    // JSON body (missing/mistyped field) comes back as a plain-text response,
+    // not `{message}`, so that shape has to be read directly too.
+    const body = e?.response?.data;
+    error.value =
+      body?.message ||
+      (typeof body === "string" && body.trim()) ||
+      e?.message ||
+      t("slos.saveFailed");
   } finally {
     saving.value = false;
   }

--- a/web/src/views/slos/AddSloAlertSli.spec.ts
+++ b/web/src/views/slos/AddSloAlertSli.spec.ts
@@ -117,10 +117,11 @@ function byTest(wrapper: VueWrapper, component: Component, test: string) {
   return hit;
 }
 
-async function mountForm() {
+async function mountForm(setup?: () => void) {
   vi.mocked(sloService.eligibleAlerts).mockResolvedValue({
     data: { list: ELIGIBLE },
   } as never);
+  setup?.();
 
   const wrapper = mount(AddSlo, {
     attachTo: node,
@@ -302,6 +303,55 @@ describe("AddSlo — alert SLI", () => {
     expect(body.config).toEqual({ alert_id: "alert-fast" });
     expect(body.group_by).toBeNull();
     expect(body.slice_interval_secs).toBe(60);
+  });
+});
+
+describe("AddSlo — alert source load failure", () => {
+  beforeEach(() => {
+    vi.mocked(sloService.eligibleAlerts).mockClear();
+  });
+
+  // The picker itself carries the error now (:error / :error-message on
+  // OSelect), not a sibling OBanner — so the failure has to surface through
+  // the select's own error slot.
+  it("surfaces the server's message on the source picker", async () => {
+    const wrapper = await mountForm(() => {
+      vi.mocked(sloService.eligibleAlerts).mockRejectedValue({
+        response: { data: { message: "org has no alerts configured" } },
+      });
+    });
+    await selectAlertType(wrapper);
+
+    const select = byTest(wrapper, OSelect, "slos-addslo-alert-source");
+    expect(select.props("error")).toBe(true);
+    expect(select.props("errorMessage")).toBe("org has no alerts configured");
+    expect(wrapper.text()).toContain("org has no alerts configured");
+  });
+
+  // No server message at all (network failure, 500 with no body) falls back
+  // to the generic copy rather than showing "undefined" or an empty banner.
+  it("falls back to the generic message when the server gives no reason", async () => {
+    const wrapper = await mountForm(() => {
+      vi.mocked(sloService.eligibleAlerts).mockRejectedValue(new Error("network down"));
+    });
+    await selectAlertType(wrapper);
+
+    const select = byTest(wrapper, OSelect, "slos-addslo-alert-source");
+    expect(select.props("error")).toBe(true);
+    expect(select.props("errorMessage")).toBe(i18n.global.t("slos.alertSli.loadFailed"));
+  });
+
+  // Without the `!alertSourceError` guard, the "no eligible alerts" info
+  // banner and the picker's error would show side by side.
+  it("hides the empty-state banner while a load error is showing", async () => {
+    const wrapper = await mountForm(() => {
+      vi.mocked(sloService.eligibleAlerts).mockRejectedValue({
+        response: { data: { message: "boom" } },
+      });
+    });
+    await selectAlertType(wrapper);
+
+    expect(wrapper.find('[data-test="slos-addslo-alert-source-empty"]').exists()).toBe(false);
   });
 });
 


### PR DESCRIPTION
The "Source alert" load failure discarded the real error and always showed a generic string; it now reads e.response.data.message and shows it as a small error under the picker itself, matching how other field errors render. The top-level save error also fell back to axios's generic "Request failed with status code N" whenever the backend returned a plain-text body (e.g. a 422 JSON-deserialize rejection) instead of {message}; that body is now read directly too.

Fixes #14267, #14269