### PR TITLE
fix(logs): retain the query re-applied from Search History

### DIFF
--- a/tests/ui-testing/ci-matrix/ci_matrix_regression.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix_regression.json
@@ -8,7 +8,8 @@
       "logs-bugs.spec.js",
       "logs-9754.spec.js",
       "logs-9044-7354.spec.js",
-      "logs-multistream-matchall-pagination.spec.js"
+      "logs-multistream-matchall-pagination.spec.js",
+      "logs-14283.spec.js"
     ],
     "disabled": []
   },

--- a/tests/ui-testing/pages/logsPages/searchHistoryPage.js
+++ b/tests/ui-testing/pages/logsPages/searchHistoryPage.js
@@ -45,7 +45,7 @@ export class SearchHistoryPage {
   /**
    * Usage rows are published asynchronously, so refresh until the query shows up.
    */
-  async waitForQueryRow(sqlFragment, { attempts = 20, intervalMs = 5000 } = {}) {
+  async waitForQueryRow(sqlFragment, { attempts = 12, intervalMs = 5000 } = {}) {
     const row = this.rowContaining(sqlFragment);
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
@@ -57,7 +57,10 @@ export class SearchHistoryPage {
       await this.page.waitForTimeout(intervalMs);
     }
 
-    throw new Error(`Search History never listed a query containing "${sqlFragment}"`);
+    throw new Error(
+      `Search History never listed a query containing "${sqlFragment}" after ${attempts} refreshes — ` +
+        'usage reporting is most likely disabled or not publishing on this environment.',
+    );
   }
 
   /** Expands the row for the given query and re-applies it on the logs page. */

--- a/tests/ui-testing/pages/logsPages/searchHistoryPage.js
+++ b/tests/ui-testing/pages/logsPages/searchHistoryPage.js
@@ -1,0 +1,77 @@
+// searchHistoryPage.js
+const testLogger = require('../../playwright-tests/utils/test-logger.js');
+
+/**
+ * Page Object Model for the standalone Search History page (/web/logs/search-history).
+ *
+ * Search History is backed by usage reporting, so rows only appear once the usage
+ * batch has been published — every read here polls the refresh button rather than
+ * assuming the row is present on first paint.
+ */
+export class SearchHistoryPage {
+  constructor(page) {
+    this.page = page;
+
+    this.searchHistoryPath = '/web/logs/search-history';
+
+    // ===== ENTRY POINT (SearchBar.vue) =====
+    this.utilitiesMenuBtn = '[data-test="logs-search-bar-utilities-menu-btn"]';
+    this.searchHistoryItemBtn = '[data-test="search-history-item-btn"]';
+
+    // ===== SEARCH HISTORY PAGE (SearchHistory.vue) =====
+    this.refreshHistoryBtn = '[data-test="search-history-get-history-btn"]';
+    this.goToLogsBtn = '[data-test="search-history-go-to-logs-btn"]';
+    this.colorizedSql = '[data-test="search-history-sql-colorized"]';
+  }
+
+  /** Opens Search History through the logs search-bar menu, as a user would. */
+  async openFromLogs() {
+    await this.page.locator(this.utilitiesMenuBtn).click();
+    await this.page.locator(this.searchHistoryItemBtn).click();
+    await this.page.waitForURL(/\/logs\/search-history/, { timeout: 30000 });
+    await this.page.locator(this.refreshHistoryBtn).waitFor({ state: 'visible', timeout: 30000 });
+    testLogger.info('Search History page opened');
+  }
+
+  rowContaining(sqlFragment) {
+    return this.page.locator('tr').filter({ hasText: sqlFragment }).first();
+  }
+
+  /**
+   * Usage rows are published asynchronously, so refresh until the query shows up.
+   */
+  async waitForQueryRow(sqlFragment, { attempts = 20, intervalMs = 5000 } = {}) {
+    const row = this.rowContaining(sqlFragment);
+
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      if (await row.count()) {
+        testLogger.info(`Search History row found on attempt ${attempt}`, { sqlFragment });
+        return row;
+      }
+      await this.page.locator(this.refreshHistoryBtn).click();
+      await this.page.waitForTimeout(intervalMs);
+    }
+
+    throw new Error(`Search History never listed a query containing "${sqlFragment}"`);
+  }
+
+  /** Expands the row for the given query and re-applies it on the logs page. */
+  async reApplyQuery(sqlFragment) {
+    const row = await this.waitForQueryRow(sqlFragment);
+
+    // The table expands on row click (expand-on-row-click), which reveals Go to Logs.
+    await row.click();
+    const goToLogs = this.page.locator(this.goToLogsBtn).first();
+    await goToLogs.waitFor({ state: 'visible', timeout: 15000 });
+
+    const reAppliedSql = (await this.page.locator(this.colorizedSql).first().innerText()).trim();
+
+    await goToLogs.click();
+    await this.page.waitForURL(/\/logs(\?|$)/, { timeout: 30000 });
+    testLogger.info('Re-applied query from Search History', { reAppliedSql });
+
+    return reAppliedSql;
+  }
+}
+
+export default SearchHistoryPage;

--- a/tests/ui-testing/pages/logsPages/searchHistoryPage.js
+++ b/tests/ui-testing/pages/logsPages/searchHistoryPage.js
@@ -15,10 +15,12 @@ export class SearchHistoryPage {
     this.searchHistoryPath = '/web/logs/search-history';
 
     // ===== ENTRY POINT (SearchBar.vue) =====
-    this.utilitiesMenuBtn = '[data-test="logs-search-bar-utilities-menu-btn"]';
+    // Search History lives in the more-options (hamburger) menu, not the "More" utilities one.
+    this.moreOptionsMenuBtn = '[data-test="logs-search-bar-more-options-btn"]';
     this.searchHistoryItemBtn = '[data-test="search-history-item-btn"]';
 
     // ===== SEARCH HISTORY PAGE (SearchHistory.vue) =====
+    this.tableRow = '[data-test^="o2-table-row-"]';
     this.refreshHistoryBtn = '[data-test="search-history-get-history-btn"]';
     this.goToLogsBtn = '[data-test="search-history-go-to-logs-btn"]';
     this.colorizedSql = '[data-test="search-history-sql-colorized"]';
@@ -26,15 +28,18 @@ export class SearchHistoryPage {
 
   /** Opens Search History through the logs search-bar menu, as a user would. */
   async openFromLogs() {
-    await this.page.locator(this.utilitiesMenuBtn).click();
-    await this.page.locator(this.searchHistoryItemBtn).click();
+    await this.page.locator(this.moreOptionsMenuBtn).click();
+    const historyItem = this.page.locator(this.searchHistoryItemBtn);
+    await historyItem.waitFor({ state: 'visible', timeout: 15000 });
+    await historyItem.click();
     await this.page.waitForURL(/\/logs\/search-history/, { timeout: 30000 });
     await this.page.locator(this.refreshHistoryBtn).waitFor({ state: 'visible', timeout: 30000 });
     testLogger.info('Search History page opened');
   }
 
   rowContaining(sqlFragment) {
-    return this.page.locator('tr').filter({ hasText: sqlFragment }).first();
+    // Body rows only — the expansion panel is a separate <tr> carrying the same text.
+    return this.page.locator(this.tableRow).filter({ hasText: sqlFragment }).first();
   }
 
   /**

--- a/tests/ui-testing/pages/page-manager.js
+++ b/tests/ui-testing/pages/page-manager.js
@@ -104,6 +104,7 @@ const WorkflowsPage = require("./workflowsPages/workflowsPage.js");
 
 // ===== LOGS, REPORTS, STREAMS, PIPELINES ADDITIONAL PAGE OBJECTS =====
 import { LogsQueryPage } from "./logsPages/logsQueryPage.js";
+import { SearchHistoryPage } from "./logsPages/searchHistoryPage.js";
 import UnflattenedPage from "./logsPages/unflattened.js";
 
 // ===== SDR (SENSITIVE DATA REDACTION) PAGE OBJECTS =====
@@ -178,6 +179,7 @@ class PageManager {
 
     // ===== SANITY SPEC ADDITIONAL PAGE OBJECTS =====
     this.logsPage = new LogsPage(page);
+    this.searchHistoryPage = new SearchHistoryPage(page);
     this.streamsPage = new StreamsPage(page);
     this.alertTemplatesPage = new AlertTemplatesPage(page);
     this.alertDestinationsPage = new AlertDestinationsPage(page);

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
@@ -56,7 +56,12 @@ test.describe('Regression: Search History re-apply retains the query (#14283)', 
     const reAppliedSql = await pm.searchHistoryPage.reApplyQuery(EARLIER_MARKER);
     expect(reAppliedSql).toContain(EARLIER_MARKER);
 
-    const editorText = await pm.logsPage.getQueryEditorTextWhenReady(EARLIER_MARKER, 30000);
+    // Fall back to a plain read so a miss reports the query the editor actually held
+    // (the stale one) rather than an opaque poll timeout.
+    const editorText = await pm.logsPage
+      .getQueryEditorTextWhenReady(EARLIER_MARKER, 30000)
+      .catch(() => pm.logsPage.getQueryEditorText());
+    testLogger.info('Editor content after re-apply', { editorText });
 
     expect(editorText).toContain(EARLIER_MARKER);
     // The stale cached query must not win over the one carried in the URL.

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
@@ -78,7 +78,10 @@ test.describe('Regression: Search History re-apply retains the query (#14283)', 
     const encodedQuery = url.searchParams.get('query');
     expect(encodedQuery).toBeTruthy();
 
-    const decoded = Buffer.from(encodedQuery, 'base64').toString('utf-8');
+    // b64EncodeUnicode emits URL-safe base64 (+ - / _ = .); undo that rather than
+    // relying on Node's decoder being lenient about the alphabet.
+    const standardBase64 = encodedQuery.replace(/-/g, '+').replace(/_/g, '/').replace(/\./g, '=');
+    const decoded = Buffer.from(standardBase64, 'base64').toString('utf-8');
     expect(decoded).toContain(EARLIER_MARKER);
     expect(url.searchParams.get('sql_mode')).toBe('true');
   });

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
@@ -1,0 +1,72 @@
+const { test, expect, navigateToBase } = require('../../utils/enhanced-baseFixtures.js');
+const PageManager = require('../../../pages/page-manager.js');
+const testLogger = require('../../utils/test-logger.js');
+const logData = require('../../../fixtures/log.json');
+
+// https://github.com/openobserve/openobserve/issues/14283
+//
+// Search History became a standalone route in #13512, so re-applying a query from it
+// remounts the logs page. The mount path used to restore the cached searchObj from Vuex
+// on top of the query carried in the URL, and the re-applied query was silently dropped.
+// The regression only shows up when the logs page has already been used in the session —
+// that is what puts the stale query in the cache — hence the two searches in beforeEach.
+test.describe('Regression: Search History re-apply retains the query (#14283)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  const EARLIER_QUERY = `SELECT * FROM "e2e_automate" WHERE code = '200'`;
+  const LATEST_QUERY = `SELECT * FROM "e2e_automate" WHERE code = '404'`;
+
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+
+    await page.goto(`${logData.logsUrl}?org_identifier=${process.env['ORGNAME']}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(2000);
+
+    await pm.logsPage.selectIndexStream('e2e_automate');
+    await page.waitForTimeout(1000);
+
+    for (const query of [EARLIER_QUERY, LATEST_QUERY]) {
+      await pm.logsPage.typeQuery(query);
+      await page.waitForTimeout(500);
+      await pm.logsPage.selectRunQuery();
+      await pm.logsPage.waitForResultsLoaded();
+    }
+
+    testLogger.info('Two searches run; the logs cache now holds the later query');
+  });
+
+  test('Re-applying an earlier query from Search History loads it into the editor', {
+    tag: ['@regression', '@logs', '@searchHistory', '@P0'],
+  }, async ({ page }) => {
+    await pm.searchHistoryPage.openFromLogs();
+
+    const reAppliedSql = await pm.searchHistoryPage.reApplyQuery(`code = '200'`);
+    expect(reAppliedSql).toContain(`code = '200'`);
+
+    const editorText = await pm.logsPage.getQueryEditorTextWhenReady(`code = '200'`, 30000);
+
+    expect(editorText).toContain(`code = '200'`);
+    // The stale cached query must not win over the one carried in the URL.
+    expect(editorText).not.toContain(`code = '404'`);
+  });
+
+  test('Re-applied query is carried in the logs URL', {
+    tag: ['@regression', '@logs', '@searchHistory', '@P1'],
+  }, async ({ page }) => {
+    await pm.searchHistoryPage.openFromLogs();
+    await pm.searchHistoryPage.reApplyQuery(`code = '200'`);
+
+    const url = new URL(page.url());
+    const encodedQuery = url.searchParams.get('query');
+    expect(encodedQuery).toBeTruthy();
+
+    const decoded = Buffer.from(encodedQuery, 'base64').toString('utf-8');
+    expect(decoded).toContain(`code = '200'`);
+    expect(url.searchParams.get('sql_mode')).toBe('true');
+  });
+});

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
@@ -13,10 +13,13 @@ const logData = require('../../../fixtures/log.json');
 test.describe('Regression: Search History re-apply retains the query (#14283)', () => {
   test.describe.configure({ mode: 'serial' });
 
-  const EARLIER_QUERY = `SELECT * FROM "e2e_automate" WHERE code = '200'`;
-  const LATEST_QUERY = `SELECT * FROM "e2e_automate" WHERE code = '404'`;
-  const EARLIER_MARKER = `'200'`;
-  const LATEST_MARKER = `'404'`;
+  // The predicates are always true on purpose: the two searches only need to be
+  // textually distinct and both return rows. A filter that matches nothing leaves the
+  // results grid unrendered, and waitForResultsLoaded() never sees its pagination.
+  const EARLIER_QUERY = `SELECT * FROM "e2e_automate" WHERE 200 = 200`;
+  const LATEST_QUERY = `SELECT * FROM "e2e_automate" WHERE 404 = 404`;
+  const EARLIER_MARKER = '200';
+  const LATEST_MARKER = '404';
 
   let pm;
 
@@ -49,6 +52,7 @@ test.describe('Regression: Search History re-apply retains the query (#14283)', 
 
     // Match on the literal alone: the SQL recorded in usage may differ in spacing
     // from what was typed, but 200 vs 404 is what discriminates the two queries.
+    // Both markers are compared against editor/URL text only, never against log rows.
     const reAppliedSql = await pm.searchHistoryPage.reApplyQuery(EARLIER_MARKER);
     expect(reAppliedSql).toContain(EARLIER_MARKER);
 

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
@@ -15,6 +15,8 @@ test.describe('Regression: Search History re-apply retains the query (#14283)', 
 
   const EARLIER_QUERY = `SELECT * FROM "e2e_automate" WHERE code = '200'`;
   const LATEST_QUERY = `SELECT * FROM "e2e_automate" WHERE code = '404'`;
+  const EARLIER_MARKER = `'200'`;
+  const LATEST_MARKER = `'404'`;
 
   let pm;
 
@@ -45,28 +47,30 @@ test.describe('Regression: Search History re-apply retains the query (#14283)', 
   }, async ({ page }) => {
     await pm.searchHistoryPage.openFromLogs();
 
-    const reAppliedSql = await pm.searchHistoryPage.reApplyQuery(`code = '200'`);
-    expect(reAppliedSql).toContain(`code = '200'`);
+    // Match on the literal alone: the SQL recorded in usage may differ in spacing
+    // from what was typed, but 200 vs 404 is what discriminates the two queries.
+    const reAppliedSql = await pm.searchHistoryPage.reApplyQuery(EARLIER_MARKER);
+    expect(reAppliedSql).toContain(EARLIER_MARKER);
 
-    const editorText = await pm.logsPage.getQueryEditorTextWhenReady(`code = '200'`, 30000);
+    const editorText = await pm.logsPage.getQueryEditorTextWhenReady(EARLIER_MARKER, 30000);
 
-    expect(editorText).toContain(`code = '200'`);
+    expect(editorText).toContain(EARLIER_MARKER);
     // The stale cached query must not win over the one carried in the URL.
-    expect(editorText).not.toContain(`code = '404'`);
+    expect(editorText).not.toContain(LATEST_MARKER);
   });
 
   test('Re-applied query is carried in the logs URL', {
     tag: ['@regression', '@logs', '@searchHistory', '@P1'],
   }, async ({ page }) => {
     await pm.searchHistoryPage.openFromLogs();
-    await pm.searchHistoryPage.reApplyQuery(`code = '200'`);
+    await pm.searchHistoryPage.reApplyQuery(EARLIER_MARKER);
 
     const url = new URL(page.url());
     const encodedQuery = url.searchParams.get('query');
     expect(encodedQuery).toBeTruthy();
 
     const decoded = Buffer.from(encodedQuery, 'base64').toString('utf-8');
-    expect(decoded).toContain(`code = '200'`);
+    expect(decoded).toContain(EARLIER_MARKER);
     expect(url.searchParams.get('sql_mode')).toBe('true');
   });
 });

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -883,16 +883,12 @@ export default defineComponent({
       return searchObj.meta.logsVisualizeToggle === "logs";
     }
 
-    // Arrivals that carry the whole search in the URL. Search History and the AI chat only
-    // re-apply the query into the editor; the scheduler also runs it.
+    // Search History and the AI chat only re-apply the query; the scheduler also runs it.
     const RE_APPLY_QUERY_TYPES = ["search_history_re_apply", "ai_chat_query"];
     const URL_DRIVEN_QUERY_TYPES = [...RE_APPLY_QUERY_TYPES, "search_scheduler"];
 
     const isRouteChanged = () => {
-      // Search History / Scheduler are standalone routes and /logs is not kept alive, so this
-      // is a fresh mount and the query.type watchers below never see the initial value. Unless
-      // the cached state is dropped, initialLogsState() restores the previous searchObj over
-      // the query carried in the URL and the re-applied query is silently lost (#14283).
+      // Not kept alive: this fresh mount never fires the type watchers, so the cached searchObj would bury the URL query (#14283).
       if (URL_DRIVEN_QUERY_TYPES.includes(router.currentRoute.value.query.type)) {
         store.dispatch("logs/setIsInitialized", false);
         return;
@@ -925,7 +921,7 @@ export default defineComponent({
     // Setup logic for the logs tab
     async function setupLogsTab() {
       try {
-        // restoreUrlQueryParams() strips `type` off the route, so read it before that runs.
+        // restoreUrlQueryParams() deletes a search_history_re_apply `type` off the route, so read it first.
         const arrivalType = router.currentRoute.value.query.type;
         isRouteChanged();
         if (!store.state.logs.isInitialized) {
@@ -1131,8 +1127,7 @@ export default defineComponent({
       loadLogsData();
     }
 
-    // Mirrors loadLogsData() minus getQueryData(): a re-applied query is loaded into the
-    // editor for the user to run, never run on their behalf.
+    // loadLogsData() minus getQueryData(): a re-applied query is loaded for the user to run, not run for them.
     async function applyReAppliedQuery() {
       searchObj.meta.searchApplied = false;
       await getStreamList();

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -883,7 +883,21 @@ export default defineComponent({
       return searchObj.meta.logsVisualizeToggle === "logs";
     }
 
+    // Arrivals that carry the whole search in the URL. Search History and the AI chat only
+    // re-apply the query into the editor; the scheduler also runs it.
+    const RE_APPLY_QUERY_TYPES = ["search_history_re_apply", "ai_chat_query"];
+    const URL_DRIVEN_QUERY_TYPES = [...RE_APPLY_QUERY_TYPES, "search_scheduler"];
+
     const isRouteChanged = () => {
+      // Search History / Scheduler are standalone routes and /logs is not kept alive, so this
+      // is a fresh mount and the query.type watchers below never see the initial value. Unless
+      // the cached state is dropped, initialLogsState() restores the previous searchObj over
+      // the query carried in the URL and the re-applied query is silently lost (#14283).
+      if (URL_DRIVEN_QUERY_TYPES.includes(router.currentRoute.value.query.type)) {
+        store.dispatch("logs/setIsInitialized", false);
+        return;
+      }
+
       if (
         !Object.hasOwn(router.currentRoute.value.query, "stream") ||
         !Object.hasOwn(router.currentRoute.value.query, "org_identifier")
@@ -911,6 +925,8 @@ export default defineComponent({
     // Setup logic for the logs tab
     async function setupLogsTab() {
       try {
+        // restoreUrlQueryParams() strips `type` off the route, so read it before that runs.
+        const arrivalType = router.currentRoute.value.query.type;
         isRouteChanged();
         if (!store.state.logs.isInitialized) {
           searchObj.organizationIdentifier = store.state.selectedOrganization.identifier;
@@ -970,8 +986,12 @@ export default defineComponent({
           }
 
           if (isLogsTab()) {
-            searchObj.loading = true;
-            loadLogsData();
+            if (RE_APPLY_QUERY_TYPES.includes(arrivalType)) {
+              await applyReAppliedQuery();
+            } else {
+              searchObj.loading = true;
+              loadLogsData();
+            }
           } else if (searchObj.meta.logsVisualizeToggle === "patterns") {
             await loadPatternsData();
             await extractPatternsForCurrentQuery();
@@ -1109,6 +1129,17 @@ export default defineComponent({
       resetStreamData();
       await restoreUrlQueryParams(dashboardPanelData);
       loadLogsData();
+    }
+
+    // Mirrors loadLogsData() minus getQueryData(): a re-applied query is loaded into the
+    // editor for the user to run, never run on their behalf.
+    async function applyReAppliedQuery() {
+      searchObj.meta.searchApplied = false;
+      await getStreamList();
+      await getFunctions();
+      await extractFields();
+      refreshData();
+      searchObj.loading = false;
     }
 
     // Helper function for handling the stream explorer


### PR DESCRIPTION
Fixes #14283

## The bug

Clicking a query in Search History and going to Logs does not carry the query over — the logs page keeps whatever was last searched.

Reproduces only after the logs page has already been used in the session, which is what puts the stale query in the cache.

## When it broke

Commit 232b38351d ("fix: search history routes change", #13512), merged 4 Aug 2026. First shipped in **v0.92.0-rc3** (last clean tag: v0.92.0-rc1) and present in every release since, including v1.0.0-rc2.

That PR moved Search History from an `?action=history` overlay rendered inside the logs page to a standalone `/logs/search-history` route, and removed the overlay block from `Index.vue` without moving the restore logic that depended on it.

## Root cause

The re-apply path is still written for a page that never unmounts.

`SearchHistory.goToLogs()` pushes `/logs?...&type=search_history_re_apply`, and the only code reading that is a **watcher** in `Index.vue`. Three things combine:

1. **The logs page is no longer alive on arrival.** `meta.keepAlive: true` on the logs route is dead metadata — there is no `<keep-alive>` wrapping the `router-view` in `MainLayout.vue`. So leaving `/logs` genuinely unmounts `Index.vue`, and `onActivated` never fires either.
2. **The watcher is not `immediate`**, so on the fresh mount it never sees the initial `type` value. The whole restore path is dead code on this route.
3. **The mount-time restore is gated shut.** `setupLogsTab()` only calls `restoreUrlQueryParams()` inside `if (!store.state.logs.isInitialized)`. That flag is set true on the first logs visit and never cleared on unmount, so the `else` branch runs `initialLogsState()`, which deep-clones the previous `searchObj` back out of Vuex over the query the URL carried.

`isRouteChanged()` was the only thing clearing the flag, and only when the **stream or org differed** — re-applying a query on the same stream never did.

Every other page navigating into logs already clears the flag explicitly (`TraceDetails.vue`, `ServiceGraphNodeSidePanel.vue`, `usePanelDrilldown.ts`, `useTraces.ts` — the first of those spells this exact trap out in a comment). Search History and Search Scheduler don't, because as overlays they never had to.

## The fix

Three edits in `Index.vue`:

1. `isRouteChanged()` clears `logs/setIsInitialized` when the URL carries `search_history_re_apply`, `ai_chat_query`, or `search_scheduler` — the URL is authoritative, the cache must not win.
2. `setupLogsTab()` reads `query.type` into a local **before** `restoreUrlQueryParams()` runs, since that function deletes `type` off the route.
3. Re-apply arrivals run `getStreamList / getFunctions / extractFields / refreshData` instead of `loadLogsData()`, preserving the original author's deliberate choice not to auto-run a re-applied query. `search_scheduler` still auto-runs, matching its own watcher.

Search Scheduler (`type=search_scheduler`) was broken identically by the same PR and is fixed by the same change.

## Blast radius

`isRouteChanged()` has exactly one caller, `setupLogsTab()`, reached only from `onBeforeMount`. Navigations with no `type` (menu click, shared link, refresh) and `stream_explorer` / `trace_explorer` take byte-identical paths. AI chat firing from *within* logs still goes through the existing watcher — the page never remounts, so the new code is not reached.

One intentional behaviour change: reloading a `/logs?…&type=ai_chat_query` URL no longer auto-runs the query. That now matches what clicking through from the chat does.

## Tests

`tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js` — 2 tests, plus a new `searchHistoryPage.js` page object wired into `PageManager`.

The spec runs **two** searches in `beforeEach` (`code = '200'` then `code = '404'`) so the Vuex cache holds the wrong query — without that setup the bug cannot reproduce. It then re-applies the earlier one from Search History and asserts the editor shows `'200'` and not `'404'`.

Registered in `ci_matrix_regression.json` (the shared base manifest, so ENT picks it up automatically via `build-ci-matrix.js`).

## Verification status

- Verified: Playwright discovers both tests; `build-ci-matrix.js` emits the spec into the `Logs-Regression` shard; every selector traced to a real `data-test` in the Vue source; Prettier clean; `Index.spec.ts` passes unchanged against the fix.
- **Not verified: the new Playwright spec has never been executed against a running server** — not red on unfixed code, not green on fixed code. It needs an instance with usage reporting enabled, since Search History is backed by usage data.

The spec is currently only in the nightly regression matrix, not the PR gate (`ci_matrix.json`).
