### PR TITLE
fix(slos): validate every required field in the SLO forms client-side

### DIFF
--- a/src/config/src/meta/slo/mod.rs
+++ b/src/config/src/meta/slo/mod.rs
@@ -368,6 +368,26 @@ pub enum SloValidationError {
     AlertSliSourceSilenceGated { silence_minutes: i64 },
 }
 
+impl SloValidationError {
+    /// A stable, short identifier for the source-alert rejections.
+    ///
+    /// The picker shows one chip per ineligible alert and the full sentence on
+    /// hover; the chip's wording is a UI decision and must not be parsed back
+    /// out of `Display`, which is prose and changes. `None` for the variants
+    /// that cannot reach the picker.
+    pub fn source_alert_code(&self) -> Option<&'static str> {
+        match self {
+            Self::AlertSliSourceNotScheduled => Some("not_scheduled"),
+            Self::AlertSliSourceIsGrouped => Some("grouped"),
+            Self::AlertSliSourceIneligible => Some("not_referenceable"),
+            Self::AlertSliSourceIsCron => Some("cron"),
+            Self::AlertSliSourceTooInfrequent { .. } => Some("too_infrequent"),
+            Self::AlertSliSourceSilenceGated { .. } => Some("silenced"),
+            _ => None,
+        }
+    }
+}
+
 impl std::fmt::Display for SloValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -2015,6 +2035,54 @@ mod tests {
         }
         assert_eq!(source_alert_ineligibility(&facts, SLICE_60_SECS), None);
         assert_eq!(validate_slo(&alert_def(), 99.9, Some(facts)), Ok(()));
+    }
+
+    /// Every rejection the picker can show must carry a code.
+    ///
+    /// The UI labels the row from the code and keeps the sentence for the
+    /// hover, so a variant that reaches the picker with `None` would render an
+    /// unlabelled chip — and parsing the sentence instead is what this exists
+    /// to prevent.
+    #[test]
+    fn every_source_alert_rejection_carries_a_code() {
+        let cases = [
+            SloValidationError::AlertSliSourceNotScheduled,
+            SloValidationError::AlertSliSourceIsGrouped,
+            SloValidationError::AlertSliSourceIneligible,
+            SloValidationError::AlertSliSourceIsCron,
+            SloValidationError::AlertSliSourceTooInfrequent {
+                frequency_secs: 3600,
+                slice_interval_secs: SLICE_300_SECS,
+            },
+            SloValidationError::AlertSliSourceSilenceGated {
+                silence_minutes: 30,
+            },
+        ];
+        let mut codes: Vec<&str> = cases
+            .iter()
+            .map(|e| {
+                e.source_alert_code()
+                    .unwrap_or_else(|| panic!("no code for {e:?}"))
+            })
+            .collect();
+        // Distinct, or two rejections would be labelled identically.
+        let before = codes.len();
+        codes.sort_unstable();
+        codes.dedup();
+        assert_eq!(
+            codes.len(),
+            before,
+            "duplicate source-alert codes: {codes:?}"
+        );
+    }
+
+    /// A rejection that cannot reach the picker has no chip to label.
+    #[test]
+    fn non_source_rejections_have_no_code() {
+        assert_eq!(
+            SloValidationError::TargetOutOfRange(100.0).source_alert_code(),
+            None
+        );
     }
 
     /// The picker and the save path must never disagree: whatever the helper

--- a/src/core/src/slo/service.rs
+++ b/src/core/src/slo/service.rs
@@ -431,6 +431,9 @@ pub struct SloEligibleAlert {
     pub eligible: bool,
     /// The validator's own message, verbatim — not a second wording of it.
     pub reason: Option<String>,
+    /// A stable identifier for `reason`, so the picker can label the row
+    /// without parsing the sentence. See `SloValidationError::source_alert_code`.
+    pub reason_code: Option<String>,
 }
 
 /// Reduce one alert to its picker row, or `None` if it cannot be referenced.
@@ -449,6 +452,10 @@ pub fn slo_eligibility(alert: &Alert) -> Option<SloEligibleAlert> {
         name: alert.name.clone(),
         frequency_secs: facts.frequency_secs,
         eligible: reason.is_none(),
+        reason_code: reason
+            .as_ref()
+            .and_then(|e| e.source_alert_code())
+            .map(str::to_string),
         reason: reason.map(|e| e.to_string()),
     })
 }

--- a/tests/ui-testing/ci-matrix/ci_matrix.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix.json
@@ -142,7 +142,7 @@
   },
   {
     "testfolder": "Dashboards-Tables",
-    "_comment": "Owns the pagination and pivot-table specs (previously their own single-spec shards) \u2014 keep them here.",
+    "_comment": "Owns the pagination and pivot-table specs (previously their own single-spec shards) — keep them here.",
     "actual_folder": "Dashboards",
     "browser": "chrome",
     "run_files": [
@@ -298,7 +298,7 @@
     ]
   },
   {
-    "_comment": "Own shard because isSelectStarForTable() only exists when the server runs with ZO_QUICK_MODE_ENABLED=true. That flag is read once at process start, so it cannot vary between tests sharing a backend \u2014 each shard gets its own OpenObserve process. Every other shard omits quick_mode_enabled and keeps the default (false).",
+    "_comment": "Own shard because isSelectStarForTable() only exists when the server runs with ZO_QUICK_MODE_ENABLED=true. That flag is read once at process start, so it cannot vary between tests sharing a backend — each shard gets its own OpenObserve process. Every other shard omits quick_mode_enabled and keeps the default (false).",
     "testfolder": "Logs-SelectStar",
     "actual_folder": "Logs",
     "browser": "chrome",
@@ -386,7 +386,7 @@
   },
   {
     "testfolder": "RUM-Token",
-    "_comment": "rum-token.spec.js RESETS the org RUM token; running it beside the dataflow specs (workers run files in parallel) would 401 their in-flight SDK beacons. Own shard = own isolated instance \u2014 do NOT merge back into RUM.",
+    "_comment": "rum-token.spec.js RESETS the org RUM token; running it beside the dataflow specs (workers run files in parallel) would 401 their in-flight SDK beacons. Own shard = own isolated instance — do NOT merge back into RUM.",
     "actual_folder": "RUM",
     "browser": "chrome",
     "run_files": [
@@ -425,7 +425,7 @@
   },
   {
     "testfolder": "SLO",
-    "_comment": "SLO lifecycle, form validation and the alert SLI type. No backfill dependency, so these run in parallel \u2014 but pinned to 3 workers: at 5 the concurrent SLO/alert/destination writes trip SQLite's 'database is locked' on the single-node meta store. The REST contract is covered by pytest in tests/api-testing/tests/slos/.",
+    "_comment": "SLO lifecycle, form validation and the alert SLI type. No backfill dependency, so these run in parallel — but pinned to 3 workers: at 5 the concurrent SLO/alert/destination writes trip SQLite's 'database is locked' on the single-node meta store. The REST contract is covered by pytest in tests/api-testing/tests/slos/.",
     "actual_folder": "SLO",
     "browser": "chrome",
     "ingest_allowed_upto": "240",
@@ -433,6 +433,7 @@
     "run_files": [
       "slo-crud.spec.js",
       "slo-form-validation.spec.js",
+      "slo-required-fields.spec.js",
       "slo-alert-sli.spec.js"
     ],
     "disabled": []

--- a/tests/ui-testing/pages/sloPages/sloAlertsPage.js
+++ b/tests/ui-testing/pages/sloPages/sloAlertsPage.js
@@ -55,6 +55,16 @@ export class SloAlertsPage {
   presetCard(key) { return `[data-test="slos-sloalertcondition-preset-${key}"]`; }
   kindOption(value) { return `[data-test="slos-sloalertcondition-kind-${value}"]`; }
 
+  // ------------------------------------------------------------- element getters
+
+  getListItemByName(name) {
+    return this.page.locator(this.locators.list).getByText(name, { exact: false });
+  }
+
+  getListRowsByName(name) {
+    return this.page.locator(`${this.locators.list} li`).filter({ hasText: name });
+  }
+
   // ------------------------------------------------------------------- actions
 
   async clickAdd() {

--- a/tests/ui-testing/pages/sloPages/sloAlertsPage.js
+++ b/tests/ui-testing/pages/sloPages/sloAlertsPage.js
@@ -37,7 +37,7 @@ export class SloAlertsPage {
       silence: '[data-test="slo-alert-form-silence"]',
       submit: '[data-test="slo-alert-form-submit"]',
       cancel: '[data-test="slo-alert-form-cancel"]',
-      formError: '[data-test="slo-alert-form-error"]',
+      formError: '[data-test="o-toast-message"]',
 
       // Condition
       conditionCritical: '[data-test="slos-sloalertcondition-critical"]',
@@ -130,6 +130,9 @@ export class SloAlertsPage {
   async setDescription(text) { await this.fillInput(this.locators.description, text); }
   async setFrequency(mins) { await this.fillInput(this.locators.frequency, mins); }
   async setSilence(mins) { await this.fillInput(this.locators.silence, mins); }
+  async setCritical(value) { await this.fillInput(this.locators.conditionCritical, value); }
+  async setLongWindowHours(hours) { await this.fillInput(this.locators.conditionLong, hours); }
+  async setShortWindowMinutes(mins) { await this.fillInput(this.locators.conditionShort, mins); }
 
   async selectKind(kind) {
     const item = this.page.locator(this.kindOption(kind));
@@ -292,7 +295,7 @@ export class SloAlertsPage {
   /**
    * The NAME field's inline error.
    *
-   * A blank name never produces the `slo-alert-form-error` banner: `submit()`
+   * A blank name never produces a save toast: `submit()`
    * does `if (nameError.value) return;` before any request, so the only signal
    * is the OInput's own `-error` node. Asserting the banner here would demand
    * behaviour the form does not have.
@@ -303,11 +306,44 @@ export class SloAlertsPage {
     if (pattern) await expect(err).toContainText(pattern);
   }
 
-  /** The banner shown for a SERVER rejection (saveError). */
+  /** The toast raised for a refused save — the same surface the alert form uses. */
   async expectFormError(pattern = null) {
-    const err = this.page.locator(this.locators.formError);
+    const toasts = this.page.locator(this.locators.formError);
+    await expect(toasts.first()).toBeVisible({ timeout: 20000 });
+    if (pattern) await expect(toasts.filter({ hasText: pattern })).not.toHaveCount(0);
+  }
+
+  /** A field carries its own inline validation message. */
+  async expectFieldError(fieldSelector, pattern = null) {
+    const err = this.page.locator(`${fieldSelector} [data-test$="-error"]`).first();
     await expect(err).toBeVisible({ timeout: 20000 });
     if (pattern) await expect(err).toContainText(pattern);
+  }
+
+  async expectNoFieldError(fieldSelector) {
+    await expect(
+      this.page.locator(`${fieldSelector} [data-test$="-error"]`),
+    ).toHaveCount(0);
+  }
+
+  /**
+   * The form refused to submit at all.
+   *
+   * Counts alert writes while submitting: the check has to STOP the request,
+   * not decorate the field once the server has answered.
+   */
+  async submitExpectingClientRejection() {
+    let posted = 0;
+    const count = (req) => {
+      if (/\/alerts/.test(req.url()) && ['POST', 'PUT'].includes(req.method())) posted += 1;
+    };
+    this.page.on('request', count);
+    await this.page.locator(this.locators.submit).click();
+    await this.page.waitForTimeout(1500);
+    this.page.off('request', count);
+
+    await this.expectFormStillOpen();
+    expect(posted, 'an invalid alert must not reach the server').toBe(0);
   }
 
   async expectPresetActive(key) {

--- a/tests/ui-testing/pages/sloPages/sloFormPage.js
+++ b/tests/ui-testing/pages/sloPages/sloFormPage.js
@@ -35,7 +35,9 @@ export class SloFormPage {
       sliceNote: '[data-test="slos-addslo-slice-note"]',
       groupBy: '[data-test="slos-addslo-group-by"]',
       save: '[data-test="slos-addslo-save"]',
-      error: '[data-test="slos-addslo-error"]',
+      // Save errors are toasts, the same surface the alert form uses — the
+      // page-level banner pushed the whole form down to say one sentence.
+      error: '[data-test="o-toast-message"]',
       regenWarning: '[data-test="slos-addslo-regen-warning"]',
 
       // Count SLI
@@ -460,9 +462,54 @@ export class SloFormPage {
   // -------------------------------------------------------------- assertions
 
   async expectError(pattern) {
-    const err = this.page.locator(this.locators.error);
+    // Several toasts can be on screen at once (a stale success, say), so the
+    // assertion is over the set rather than over the first one.
+    const toasts = this.page.locator(this.locators.error);
+    await expect(toasts.first()).toBeVisible({ timeout: 15000 });
+    if (pattern) await expect(toasts.filter({ hasText: pattern })).not.toHaveCount(0);
+  }
+
+  /**
+   * A field is flagged with its own inline validation message.
+   *
+   * OInput/OSelect render the message at `<field>-error`; SloExpressionField
+   * (the Monaco wrapper) now does the same, so one helper covers every field.
+   */
+  async expectFieldError(fieldSelector, pattern = null) {
+    const err = this.page.locator(`${fieldSelector} [data-test$="-error"]`).first();
     await expect(err).toBeVisible({ timeout: 15000 });
     if (pattern) await expect(err).toContainText(pattern);
+  }
+
+  /** No inline error on this field. */
+  async expectNoFieldError(fieldSelector) {
+    await expect(
+      this.page.locator(`${fieldSelector} [data-test$="-error"]`),
+    ).toHaveCount(0);
+  }
+
+  /**
+   * The form refused to submit at all.
+   *
+   * Counts requests to /slos while saving: client-side validation must stop the
+   * request, not merely decorate the field after the server rejects it. This is
+   * the assertion that would have caught the original defect.
+   */
+  async saveExpectingClientRejection() {
+    let posted = 0;
+    const count = (req) => {
+      if (/\/slos(\?|$)/.test(req.url()) && ['POST', 'PUT'].includes(req.method())) posted += 1;
+    };
+    this.page.on('request', count);
+    await this.page.locator(this.locators.save).click();
+    await this.page.waitForTimeout(1500);
+    this.page.off('request', count);
+
+    await expect(
+      this.page.locator(this.locators.title),
+      'an invalid form must stay open',
+    ).toBeVisible();
+    expect(posted, 'an invalid form must not reach the server').toBe(0);
   }
 
   async expectRegenWarningVisible() {
@@ -490,6 +537,13 @@ export class SloFormPage {
   }
 
   /** The 1-minute slice is pinned off for grouped SLOs (D30, form + API). */
+  /** The slice bar reports its selection through OToggleGroupItem's data-state. */
+  async expectSliceSelected(secs) {
+    await expect(
+      this.page.locator(`[data-test="slos-addslo-slice-${secs}"]`),
+    ).toHaveAttribute('data-state', 'on', { timeout: 10000 });
+  }
+
   async expectSliceOptionDisabled(secs) {
     const item = this.page.locator(`[data-test="slos-addslo-slice-${secs}"]`);
     await expect(item).toBeDisabled({ timeout: 10000 });
@@ -632,6 +686,56 @@ export class SloFormPage {
       disabled !== null || ariaDisabled === 'true',
       'an ineligible source must be offered but not selectable',
     ).toBe(true);
+    await this.page.keyboard.press('Escape');
+  }
+
+  /**
+   * An ineligible option is ONE line: the alert name, a chip naming the rule it
+   * failed, and the full sentence only on hover.
+   *
+   * The row's height is the assertion that matters — the reason is a paragraph,
+   * and rendering it inline is what made a twenty-alert picker unusable. A
+   * `title` carrying the sentence proves nothing was lost in the process.
+   */
+  async expectAlertSourceOptionReason(alertId, alertName) {
+    await openOSelectDropdown(this.page, this.page.locator(this.locators.alertSource));
+    const search = this.page.locator('[data-test="slos-addslo-alert-source-search"]');
+    if (await search.count() > 0) {
+      await search.fill(alertName);
+      await this.page.waitForTimeout(400);
+    }
+    const option = this.page
+      .locator(`[data-test="slos-addslo-alert-source-option"][data-test-value="${alertId}"]`)
+      .first();
+    await option.waitFor({ state: 'visible', timeout: 15000 });
+
+    // `data-test-label` mirrors the option's `label` exactly, so this fails the
+    // moment the reason is concatenated back into it.
+    await expect(
+      option, 'the option label must be the alert name alone',
+    ).toHaveAttribute('data-test-label', alertName);
+
+    // The chip is short; the sentence is the tooltip behind it.
+    const chip = option.locator('span[title]').first();
+    await expect(chip, 'an ineligible option must say which rule it failed').toBeVisible();
+
+    // The chip MUST be hoverable. A disabled row sets `pointer-events-none`, so
+    // the one element carrying the explanation was unreachable — the tooltip
+    // existed in the DOM and could never be shown. Hovering is the assertion;
+    // `toBeVisible` above would pass either way.
+    await chip.hover({ timeout: 5000 });
+    expect(
+      (await chip.innerText()).length,
+      'the chip is a label, not the explanation',
+    ).toBeLessThan(30);
+    await expect(chip).toHaveAttribute(
+      'title', /silence|cadence|cron|grouped|real-?time|slice/i,
+    );
+
+    // One line. Two would mean the paragraph is back in the row.
+    const box = await option.boundingBox();
+    expect(box.height, 'an option row must stay a single line').toBeLessThan(40);
+
     await this.page.keyboard.press('Escape');
   }
 

--- a/tests/ui-testing/pages/sloPages/sloFormPage.js
+++ b/tests/ui-testing/pages/sloPages/sloFormPage.js
@@ -234,10 +234,30 @@ export class SloFormPage {
   }
 
   /** Toggle-group items report their state; clicking blind can silently no-op. */
+  /**
+   * Click an OToggleGroupItem and confirm it took.
+   *
+   * The explicit `scrollIntoViewIfNeeded` is load-bearing. "Visible" only means
+   * the element has a box, not that it is in the viewport, and the form grows
+   * and shrinks as branches mount — a language flip right after typing into
+   * Monaco (which scrolls on focus) put the toggle off-screen often enough to
+   * fail the shard while passing in isolation. Playwright's own auto-scroll
+   * loses that race when a scroll is still settling, so we scroll first and
+   * retry once rather than assuming the layout has stopped moving.
+   */
   async selectToggle(selector) {
     const item = this.page.locator(selector);
     await item.waitFor({ state: 'visible', timeout: 15000 });
-    await item.click();
+    for (const attempt of [1, 2]) {
+      try {
+        await item.scrollIntoViewIfNeeded({ timeout: 5000 });
+        await item.click({ timeout: 10000 });
+        break;
+      } catch (error) {
+        if (attempt === 2) throw error;
+        await this.page.waitForTimeout(300);
+      }
+    }
     await expect(item).toHaveAttribute('data-state', 'on', { timeout: 10000 });
   }
 

--- a/tests/ui-testing/playwright-tests/SLO/slo-alert-sli.spec.js
+++ b/tests/ui-testing/playwright-tests/SLO/slo-alert-sli.spec.js
@@ -158,7 +158,12 @@ test.describe('SLO alert SLI', { tag: ['@slo', '@sloAlertSli', '@all'] }, () => 
 
   /**
    * An ineligible source is LISTED but not selectable, with the server's reason
-   * folded into its label.
+   * on its own line UNDER the alert name.
+   *
+   * The reason is a paragraph. Folded into the label it produced one truncated
+   * line per row in which the name was the first thing cut, so the list could
+   * not be scanned at all — hence the assertion below that the name is the
+   * label and the reason is the sub-label, not one run-on string.
    *
    * A silence-gated alert is used because it violates exactly one clause, so a
    * failure here points at that clause rather than at any of the other five.
@@ -221,6 +226,7 @@ test.describe('SLO alert SLI', { tag: ['@slo', '@sloAlertSli', '@all'] }, () => 
     await pm.sloFormPage.gotoNew(ORG);
     await pm.sloFormPage.selectSliType('alert');
     await pm.sloFormPage.expectAlertSourceOptionDisabled(gatedId, name);
+    await pm.sloFormPage.expectAlertSourceOptionReason(gatedId, name);
   });
 
   /**

--- a/tests/ui-testing/playwright-tests/SLO/slo-alerts.spec.js
+++ b/tests/ui-testing/playwright-tests/SLO/slo-alerts.spec.js
@@ -178,10 +178,10 @@ test.describe('SLO burn-rate alerts', { tag: ['@slo', '@sloAlerts', '@all'] }, (
   /**
    * A blank name is refused BEFORE any request, and says so on the field.
    *
-   * `submit()` returns early on `nameError` without setting `saveError`, so the
-   * error banner never appears — the inline field error is the whole of the
-   * feedback. The form must also stay open rather than closing on a no-op,
-   * which would look like success.
+   * The name is the one field marked without a submit first — it is prefilled
+   * from the condition, so an empty one is a deliberate deletion rather than a
+   * form nobody has filled in yet. The form must also stay open rather than
+   * closing on a no-op, which would look like success.
    */
   test('submitting without a name is refused with an inline field error', {
     tag: ['@P1', '@validation'],
@@ -288,21 +288,26 @@ test.describe('SLO burn-rate alerts', { tag: ['@slo', '@sloAlerts', '@all'] }, (
 
   /**
    * A destination is mandatory: an alert nobody hears about is not an alert.
-   * The server says so, and the form must surface that rather than appearing
-   * to succeed.
+   *
+   * This used to reach the server, which answered "Alert destination or
+   * workflows is required" in a banner attached to nothing on screen. The
+   * reason now lands on the field, and the banner only says that SOMETHING is
+   * highlighted — so both are asserted, at their new homes.
    */
   test('submitting without a destination is refused with the reason', {
     tag: ['@P1', '@validation', '@negative'],
-  }, async () => {
+  }, async ({ page }) => {
     const name = uniqueName(`${PREFIX}_nodest`);
     await pm.sloAlertsPage.clickAdd();
     await pm.sloAlertsPage.setName(name);
     await pm.sloAlertsPage.applyPreset('fast');
     // No destination selected.
-    await pm.sloAlertsPage.submit();
+    await pm.sloAlertsPage.submitExpectingClientRejection();
 
-    await pm.sloAlertsPage.expectFormError(/destination|workflow/i);
-    await pm.sloAlertsPage.expectFormStillOpen();
+    await expect(
+      page.locator('[data-test="alert-settings-destinations-error"]'),
+    ).toContainText(/at least one destination or workflow/i);
+    await pm.sloAlertsPage.expectFormError(/highlighted fields/i);
   });
 
   /** Cancel must not create anything. */

--- a/tests/ui-testing/playwright-tests/SLO/slo-form-validation.spec.js
+++ b/tests/ui-testing/playwright-tests/SLO/slo-form-validation.spec.js
@@ -3,15 +3,16 @@
  *
  * Plan: docs/test_generator/features/slos-test-plan.md
  *
- * The form performs NO client-side validation: there is no zod schema and the
- * Save button carries only `:loading`, never `:disabled`. Every rejection
- * therefore comes from the server, and `save()` renders
- * `e.response.data.message` **verbatim** into `slos-addslo-error`.
+ * Rejection reaches the user through two distinct paths, and this spec covers
+ * both because a regression in either is invisible in the other.
  *
- * That makes this spec the join between the API contract and what a user
- * actually sees. `slo-api-validation.spec.js` proves the server rejects the
- * input; these tests prove the reason reaches the screen instead of being
- * flattened into a generic "save failed".
+ *   1. CLIENT — `save()` runs the field computeds first and returns without
+ *      issuing a request, marking the offending field inline. Asserting "no
+ *      request was sent" is the load-bearing half: a check that merely decorates
+ *      the field after a 422 looks identical on screen.
+ *   2. SERVER — anything the form cannot know (a duplicate name, a malformed
+ *      predicate) still comes back and is rendered verbatim into
+ *      an error toast, the same surface the alert form uses.
  *
  * The exact messages are asserted deliberately — they are user-facing copy, and
  * the backend's budget/target rejections carry arithmetic the user needs.
@@ -66,7 +67,7 @@ test.describe('SLO form validation', { tag: ['@slo', '@sloForm', '@all'] }, () =
 
   // ------------------------------------------------- server errors reach the UI
 
-  test('an empty name surfaces the server’s name constraint in the form', {
+  test('an empty name is blocked at the field before any request', {
     tag: ['@P0', '@validation'],
   }, async () => {
     await pm.sloFormPage.gotoNew(ORG);
@@ -76,12 +77,15 @@ test.describe('SLO form validation', { tag: ['@slo', '@sloForm', '@all'] }, () =
     await pm.sloFormPage.setExpression(
       pm.sloFormPage.locators.goodExpr, 'status_code < 500',
     );
-    await pm.sloFormPage.save();
+    await pm.sloFormPage.saveExpectingClientRejection();
 
-    await pm.sloFormPage.expectError(/name must be non empty/i);
+    await pm.sloFormPage.expectFieldError(pm.sloFormPage.locators.name, /name is required/i);
+    // Only the empty field is marked — a blanket "everything is red" is not
+    // guidance, and would hide which field actually needs attention.
+    await pm.sloFormPage.expectNoFieldError(pm.sloFormPage.locators.stream);
   });
 
-  test('an out-of-range target surfaces the reason, not a generic failure', {
+  test('an out-of-range target is marked on the target field', {
     tag: ['@P0', '@validation'],
   }, async ({}, testInfo) => {
     await pm.sloFormPage.gotoNew(ORG);
@@ -91,10 +95,12 @@ test.describe('SLO form validation', { tag: ['@slo', '@sloForm', '@all'] }, () =
       goodExpr: 'status_code < 500',
       target: 150,
     });
-    await pm.sloFormPage.save();
+    await pm.sloFormPage.saveExpectingClientRejection();
 
-    // The server explains WHY 100 is excluded; that explanation must survive.
-    await pm.sloFormPage.expectError(/greater than 0 and strictly below 100/i);
+    // The message must still explain WHY 100 is excluded, not just "invalid".
+    await pm.sloFormPage.expectFieldError(
+      pm.sloFormPage.locators.target, /greater than 0 and below 100/i,
+    );
   });
 
   test('a duplicate name surfaces the conflict', {
@@ -113,23 +119,18 @@ test.describe('SLO form validation', { tag: ['@slo', '@sloForm', '@all'] }, () =
   });
 
   /**
-   * FINDING — a blank "good when" produces an unusable error message.
+   * REGRESSION GUARD — a blank "good when" used to produce an unusable message.
    *
-   * The API has a clear message for an empty predicate
-   * ("good_expr must be exactly one boolean expression", HTTP 400), but the form
-   * never reaches it: `wireConfig()` runs the field through `pruned()`, which
-   * DROPS empty strings, so the request omits `good_expr` entirely and fails
-   * deserialization with HTTP 422. `save()` then finds no `response.data.message`
-   * on that body and falls back to `e.message` — so the user is told
-   * "Request failed with status code 422" about a field they left blank.
+   * `wireConfig()` runs the field through `pruned()`, which DROPS empty strings,
+   * so the request omitted `good_expr` entirely and failed deserialization with
+   * HTTP 422. That body carries no `message`, so the user was told "Request
+   * failed with status code 422" about a field they had left blank.
    *
-   * This pins the CURRENT behaviour (an error is shown; the form stays open and
-   * nothing is created) rather than asserting the friendly message the app does
-   * not produce. If the form gains a required-field check, or `pruned()` stops
-   * swallowing this one, the assertion below should be tightened to the 400 text.
-   * Reported in docs/test_generator/audit-reports/slos-audit-2026-08-15.md.
+   * The fix is the client check, so the assertion is that no request is made at
+   * all: leaving `pruned()` as it is but re-allowing the submit would restore
+   * the original 422 verbatim.
    */
-  test('a blank good expression is rejected and the form stays open', {
+  test('a blank good expression is blocked at the field, not at the server', {
     tag: ['@P1', '@validation'],
   }, async ({}, testInfo) => {
     const name = uniqueName(workerPrefix(testInfo));
@@ -138,10 +139,9 @@ test.describe('SLO form validation', { tag: ['@slo', '@sloForm', '@all'] }, () =
     await pm.sloFormPage.selectSliType('count');
     await pm.sloFormPage.selectStream(stream);
     // good_expr deliberately left empty: "" is a malformed predicate, not "all rows".
-    await pm.sloFormPage.save();
+    await pm.sloFormPage.saveExpectingClientRejection();
 
-    // An error IS surfaced — that much the user gets.
-    await pm.sloFormPage.expectError();
+    await pm.sloFormPage.expectFieldError(pm.sloFormPage.locators.goodExpr, /required/i);
     // And nothing was created behind it.
     await pm.sloListPage.goto(ORG);
     await pm.sloListPage.expectRowAbsent(name);
@@ -162,8 +162,8 @@ test.describe('SLO form validation', { tag: ['@slo', '@sloForm', '@all'] }, () =
     await pm.sloFormPage.fillCountSlo({
       name, stream, goodExpr: 'status_code < 500', target: 150,
     });
-    await pm.sloFormPage.save();
-    await pm.sloFormPage.expectError(/strictly below 100/i);
+    await pm.sloFormPage.saveExpectingClientRejection();
+    await pm.sloFormPage.expectFieldError(pm.sloFormPage.locators.target);
 
     // Fix the one bad field and retry. Waiting for the navigation is what
     // proves the create completed rather than merely being dispatched.
@@ -384,9 +384,9 @@ test.describe('SLO form validation', { tag: ['@slo', '@sloForm', '@all'] }, () =
     await pm.sloFormPage.setName(name);
     await pm.sloFormPage.selectSliType('count');
     // No stream picked at all.
-    await pm.sloFormPage.save();
+    await pm.sloFormPage.saveExpectingClientRejection();
 
-    await pm.sloFormPage.expectError();
+    await pm.sloFormPage.expectFieldError(pm.sloFormPage.locators.stream, /stream/i);
     await pm.sloListPage.goto(ORG);
     await pm.sloListPage.expectRowAbsent(name);
   });
@@ -425,9 +425,10 @@ test.describe('SLO form validation', { tag: ['@slo', '@sloForm', '@all'] }, () =
     await pm.sloFormPage.setExpression(
       pm.sloFormPage.locators.goodExpr, 'status_code < 500',
     );
-    await pm.sloFormPage.save();
+    await pm.sloFormPage.saveExpectingClientRejection();
 
-    await pm.sloFormPage.expectError(/less than 256 characters/i);
+    // The client bound must match the server's, which is inclusive at 256.
+    await pm.sloFormPage.expectFieldError(pm.sloFormPage.locators.name, /256/);
   });
 
   /**
@@ -461,8 +462,10 @@ test.describe('SLO form validation', { tag: ['@slo', '@sloForm', '@all'] }, () =
       goodExpr: 'status_code < 500',
       target: 100,
     });
-    await pm.sloFormPage.save();
-    await pm.sloFormPage.expectError(/strictly below 100/i);
+    await pm.sloFormPage.saveExpectingClientRejection();
+    await pm.sloFormPage.expectFieldError(
+      pm.sloFormPage.locators.target, /greater than 0 and below 100/i,
+    );
   });
 
   test('a fractional target just inside the range is accepted', {

--- a/tests/ui-testing/playwright-tests/SLO/slo-required-fields.spec.js
+++ b/tests/ui-testing/playwright-tests/SLO/slo-required-fields.spec.js
@@ -1,0 +1,538 @@
+/**
+ * SLO forms — required-field validation, client side
+ *
+ * Plan: docs/test_generator/features/slos-test-plan.md
+ *
+ * A companion to `slo-form-validation.spec.js`, which covers the messages the
+ * SERVER produces. This spec covers the checks the form makes on its own, and
+ * it exists because those checks were absent: every required field reached the
+ * API empty, and the user was shown "Request failed with status code 422" —
+ * a message naming no field at all.
+ *
+ * Two properties are asserted for every field, and both matter:
+ *
+ *   - the message lands ON THE FIELD (`<field>-error`), not only in the page
+ *     banner, so the user is told where to look; and
+ *   - NO request is issued (`saveExpectingClientRejection`). Without that, a
+ *     check that merely re-labels the server's 422 passes identically.
+ *
+ * Coverage is per SLI SHAPE rather than per field, because the required set is
+ * a function of `sli_type` × query language: a PromQL count needs two queries
+ * and no stream, while a PromQL time-slice needs the stream after all. Each
+ * shape gets its own test so a regression names the shape it broke.
+ */
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+const {
+  seedMinimalStream,
+  seedSloMetric,
+  seedNotificationDestination,
+  createSloViaApi,
+  countDefinition,
+  deleteSlosByPrefix,
+  deleteFixturesByPrefix,
+  uniqueName,
+} = require('../utils/slo-seed.js');
+
+const PREFIX = 'e2e_slo_req';
+const ORG = process.env['ORGNAME'];
+const workerPrefix = (testInfo) => `${PREFIX}_w${testInfo.workerIndex}`;
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('SLO required fields', { tag: ['@slo', '@sloForm', '@all'] }, () => {
+  let pm;
+  const shared = {};
+
+  test.beforeAll(async ({ browser }, testInfo) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    shared.stream = uniqueName(`${workerPrefix(testInfo)}_stream`);
+    shared.metric = uniqueName(`${workerPrefix(testInfo)}_metric`);
+    await seedMinimalStream(page, shared.stream, { records: 50 });
+    // The PromQL toggles are `v-if="isMetricsStream"`, so a metrics stream is
+    // the only way to reach the PromQL required set at all.
+    await seedSloMetric(page, shared.metric, { minutes: 30 });
+    await context.close();
+  });
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await pm.sloFormPage.gotoNew(ORG);
+  });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await deleteSlosByPrefix(page, `${workerPrefix(testInfo)}_`).catch(() => {});
+    await deleteFixturesByPrefix(page, `${workerPrefix(testInfo)}_`).catch(() => {});
+    await context.close();
+  });
+
+  // ------------------------------------------------------ nothing filled in
+
+  /**
+   * The empty-form case, which is what a user hits by clicking Save to find out
+   * what is needed. Every required field for the default shape must be marked
+   * at once — marking only the first would make this a guessing game, one save
+   * per field.
+   */
+  test('an untouched form marks every required field at once', {
+    tag: ['@P0', '@validation'],
+  }, async () => {
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.expectFieldError(f.name, /name is required/i);
+    await pm.sloFormPage.expectFieldError(f.stream, /stream is required/i);
+    await pm.sloFormPage.expectFieldError(f.goodExpr, /required/i);
+  });
+
+  /**
+   * The toast is the "something is wrong" cue for a field scrolled out of view;
+   * the field markers are the detail. Both are needed — a toast alone repeats
+   * the old, useless experience, and a marker alone is invisible from the
+   * bottom of a long form.
+   */
+  test('a blocked save also raises the error toast', {
+    tag: ['@P1', '@validation'],
+  }, async () => {
+    await pm.sloFormPage.saveExpectingClientRejection();
+    await pm.sloFormPage.expectError(/highlighted fields/i);
+  });
+
+  /**
+   * Errors must not appear before the user has done anything.
+   *
+   * A form that is red on arrival trains people to ignore the colour, which
+   * costs the marker its only job. Hence the `attemptedSave` gate.
+   */
+  test('a freshly opened form shows no errors', {
+    tag: ['@P0', '@validation'],
+  }, async ({ page }) => {
+    await expect(
+      page.locator('[data-test^="slos-addslo-"][data-test$="-error"]'),
+      'a form nobody has submitted must not be pre-marked',
+    ).toHaveCount(0);
+  });
+
+  /** Correcting the field clears its marker without another save attempt. */
+  test('filling a marked field clears its error', {
+    tag: ['@P0', '@validation'],
+  }, async ({}, testInfo) => {
+    await pm.sloFormPage.saveExpectingClientRejection();
+    await pm.sloFormPage.expectFieldError(pm.sloFormPage.locators.name);
+
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.expectNoFieldError(pm.sloFormPage.locators.name);
+    // The others are still outstanding — clearing one must not clear the rest.
+    await pm.sloFormPage.expectFieldError(pm.sloFormPage.locators.stream);
+  });
+
+  // --------------------------------------------------------- count SLI, SQL
+
+  test('a SQL count SLO requires stream type, stream and the good expression', {
+    tag: ['@P0', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('count');
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.stream, /stream is required/i);
+    await pm.sloFormPage.expectFieldError(f.goodExpr, /required/i);
+    // The name was supplied, so it must NOT be marked.
+    await pm.sloFormPage.expectNoFieldError(f.name);
+  });
+
+  test('a SQL count SLO with a stream still requires the good expression', {
+    tag: ['@P1', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('count');
+    await pm.sloFormPage.selectStream(shared.stream);
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.goodExpr, /required/i);
+    await pm.sloFormPage.expectNoFieldError(f.stream);
+  });
+
+  // ------------------------------------------------------ count SLI, PromQL
+
+  /**
+   * `CountSource::PromQl` is exactly two expressions, and the stream is NOT part
+   * of it — so requiring the stream here would block a legitimate definition.
+   * Both halves are asserted for that reason.
+   */
+  test('a PromQL count SLO requires both queries and not the stream', {
+    tag: ['@P0', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('count');
+    await pm.sloFormPage.selectStreamType('metrics');
+    await pm.sloFormPage.selectCountLanguage('prom_ql');
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.promqlGood, /good query is required/i);
+    await pm.sloFormPage.expectFieldError(f.promqlTotal, /total query is required/i);
+    await pm.sloFormPage.expectNoFieldError(f.stream);
+  });
+
+  test('a PromQL count SLO with only the good query still requires the total', {
+    tag: ['@P1', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('count');
+    await pm.sloFormPage.selectStreamType('metrics');
+    await pm.sloFormPage.selectCountLanguage('prom_ql');
+    await pm.sloFormPage.setExpression(f.promqlGood, `sum(${shared.metric})`);
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.promqlTotal, /total query is required/i);
+    await pm.sloFormPage.expectNoFieldError(f.promqlGood);
+  });
+
+  // ---------------------------------------------------- time-slice SLI, SQL
+
+  /**
+   * The comparator is deliberately absent from this list: switching to
+   * `time_slice` seeds it with "<", so it is never blank through the UI. The
+   * schema still carries the rule for a stored SLO that has none — asserting it
+   * here would only pin the default.
+   */
+  test('a time-slice SLO requires stream, aggregate and threshold', {
+    tag: ['@P0', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('time_slice');
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.timesliceStream, /stream is required/i);
+    await pm.sloFormPage.expectFieldError(f.aggregate, /aggregate expression is required/i);
+    await pm.sloFormPage.expectFieldError(f.threshold, /threshold is required/i);
+    // Seeded, so it must NOT be marked.
+    await pm.sloFormPage.expectNoFieldError(f.comparator);
+  });
+
+  /**
+   * Zero is a legitimate threshold — "error count < 1" is an ordinary slice
+   * rule — so a falsy-value check here would reject a valid SLO. Pinned because
+   * `if (!threshold)` is the natural mistake.
+   */
+  test('a threshold of zero is accepted, not treated as missing', {
+    tag: ['@P1', '@edge', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    const name = uniqueName(workerPrefix(testInfo));
+    await pm.sloFormPage.setName(name);
+    await pm.sloFormPage.selectSliType('time_slice');
+    await pm.sloFormPage.selectTimeSliceStream(shared.stream);
+    await pm.sloFormPage.setExpression(f.aggregate, 'count(*)');
+    await pm.sloFormPage.selectComparator('<');
+    await pm.sloFormPage.setThreshold(0);
+    // Saving is the assertion: a `!threshold` check would block this outright.
+    await pm.sloFormPage.saveExpectingSuccess();
+
+    await pm.sloListPage.goto(ORG);
+    await pm.sloListPage.expectRowVisible(name);
+  });
+
+  // ------------------------------------------------- time-slice SLI, PromQL
+
+  /**
+   * A PromQL time-slice keeps the stream, unlike a PromQL count — the aggregate
+   * is evaluated against a named metrics stream. Asserting the stream marker
+   * here is what stops the two PromQL shapes being collapsed into one rule.
+   */
+  test('a PromQL time-slice SLO still requires the stream', {
+    tag: ['@P1', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('time_slice');
+    await pm.sloFormPage.selectTimeSliceStreamType('metrics');
+    await pm.sloFormPage.selectTimeSliceLanguage('prom_ql');
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.timesliceStream, /stream is required/i);
+    await pm.sloFormPage.expectFieldError(f.aggregate, /required/i);
+  });
+
+  // ----------------------------------------------------------- alert SLI
+
+  test('an alert-based SLO requires a source alert', {
+    tag: ['@P0', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('alert');
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.alertSource, /source alert is required/i);
+    // An alert SLI carries no stream or expression, so nothing else may be marked.
+    await pm.sloFormPage.expectNoFieldError(f.name);
+  });
+
+  // -------------------------------------------------------------- objective
+
+  test('a blank target is marked on the target field', {
+    tag: ['@P0', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('count');
+    await pm.sloFormPage.selectStream(shared.stream);
+    await pm.sloFormPage.setExpression(f.goodExpr, 'status_code < 500');
+    await pm.sloFormPage.setTarget('');
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.target, /target is required/i);
+  });
+
+  /**
+   * The server stores the target to 3 decimals. A 4th is silently truncated,
+   * which changes the error budget without saying so — worth refusing.
+   */
+  test('a target with too many decimals is refused', {
+    tag: ['@P2', '@validation', '@edge'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('count');
+    await pm.sloFormPage.selectStream(shared.stream);
+    await pm.sloFormPage.setExpression(f.goodExpr, 'status_code < 500');
+    await pm.sloFormPage.setTarget(99.99999);
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.target, /3 decimal/i);
+  });
+
+  /** A target of 0 has no error budget at all, the same as 100. */
+  test('a target of zero is refused at the lower boundary', {
+    tag: ['@P2', '@validation', '@edge'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('count');
+    await pm.sloFormPage.selectStream(shared.stream);
+    await pm.sloFormPage.setExpression(f.goodExpr, 'status_code < 500');
+    await pm.sloFormPage.setTarget(0);
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(f.target, /greater than 0 and below 100/i);
+  });
+
+  // --------------------------------------------------------------- grouping
+
+  /**
+   * D30: a grouped SLO must be on the 5-minute grid.
+   *
+   * The form does not wait for a save to say so — picking a group-by snaps the
+   * slice to 5 minutes and DISABLES the 1-minute option, so the rejected pair
+   * cannot be assembled at all. That is the behaviour worth pinning; the schema
+   * still carries the rule for a stored SLO that predates it, which is why
+   * `AddSlo.schema.spec.ts` asserts the rejection directly.
+   */
+  test('grouping snaps the slice to 5 minutes and locks the 1-minute option', {
+    tag: ['@P1', '@validation'],
+  }, async ({}, testInfo) => {
+    const f = pm.sloFormPage.locators;
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('count');
+    await pm.sloFormPage.selectStream(shared.stream);
+    await pm.sloFormPage.setExpression(f.goodExpr, 'status_code < 500');
+    await pm.sloFormPage.setTarget(99);
+    await pm.sloFormPage.selectSlice(60);
+    await pm.sloFormPage.selectGroupBy('service');
+
+    await pm.sloFormPage.expectSliceSelected(300);
+    await pm.sloFormPage.expectSliceOptionDisabled(60);
+  });
+
+  /** An alert-based SLI cannot be grouped at all, so the control is locked. */
+  test('the group-by control is disabled for an alert-based SLI', {
+    tag: ['@P1', '@validation'],
+  }, async ({ page }, testInfo) => {
+    await pm.sloFormPage.setName(uniqueName(workerPrefix(testInfo)));
+    await pm.sloFormPage.selectSliType('alert');
+
+    await expect(
+      page.locator('[data-test="slos-addslo-group-by-locked"]'),
+      'the reason grouping is unavailable must be stated',
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  // -------------------------------------------------- the edit form as well
+
+  /**
+   * Edit shares the component with create, but hydration writes over the form
+   * AFTER mount — so a check keyed to mount would not survive the round trip.
+   * Emptying a hydrated field must still be refused.
+   */
+  test('clearing a required field on the edit form is refused', {
+    tag: ['@P1', '@validation'],
+  }, async ({ page }, testInfo) => {
+    const name = uniqueName(workerPrefix(testInfo));
+    const created = await createSloViaApi(
+      page, countDefinition({ name, stream: shared.stream }),
+    );
+
+    await pm.sloFormPage.gotoEdit(ORG, created.id);
+    await pm.sloFormPage.setName('');
+    await pm.sloFormPage.saveExpectingClientRejection();
+
+    await pm.sloFormPage.expectFieldError(pm.sloFormPage.locators.name, /name is required/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+test.describe('SLO alert required fields', { tag: ['@slo', '@sloAlerts', '@all'] }, () => {
+  let pm;
+  const shared = {};
+
+  test.beforeAll(async ({ browser }, testInfo) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const prefix = `${workerPrefix(testInfo)}_alert`;
+    shared.stream = uniqueName(`${prefix}_stream`);
+    await seedMinimalStream(page, shared.stream, { records: 50 });
+    shared.destination = await seedNotificationDestination(page, prefix);
+    const slo = await createSloViaApi(
+      page,
+      countDefinition({ name: uniqueName(prefix), stream: shared.stream }),
+    );
+    shared.sloId = slo.id;
+    await context.close();
+  });
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await pm.sloDetailPage.goto(ORG, shared.sloId);
+    await pm.sloDetailPage.openTab('alerts');
+    await pm.sloAlertsPage.clickAdd();
+  });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await deleteSlosByPrefix(page, `${workerPrefix(testInfo)}_`).catch(() => {});
+    await deleteFixturesByPrefix(page, `${workerPrefix(testInfo)}_`).catch(() => {});
+    await context.close();
+  });
+
+  /**
+   * A missing destination used to reach the server, which answered "Alert
+   * destination or workflows is required" in a banner attached to nothing.
+   * The field is where that belongs.
+   */
+  test('a missing destination is marked on the destinations field', {
+    tag: ['@P0', '@validation'],
+  }, async ({ page }) => {
+    await pm.sloAlertsPage.setName(uniqueName(`${PREFIX}_nodest`));
+    await pm.sloAlertsPage.applyPreset('fast');
+    await pm.sloAlertsPage.submitExpectingClientRejection();
+
+    // The field's own error node, shared with the generic alert form.
+    await expect(
+      page.locator('[data-test="alert-settings-destinations-error"]'),
+      'the destinations field must carry the reason',
+    ).toContainText(/at least one destination or workflow/i);
+  });
+
+  test('a blank frequency is marked on the frequency field', {
+    tag: ['@P1', '@validation'],
+  }, async ({ page }) => {
+    await pm.sloAlertsPage.setName(uniqueName(`${PREFIX}_nofreq`));
+    await pm.sloAlertsPage.applyPreset('fast');
+    await pm.sloAlertsPage.selectDestination(shared.destination);
+    await pm.sloAlertsPage.setFrequency('');
+    await pm.sloAlertsPage.submitExpectingClientRejection();
+
+    await pm.sloAlertsPage.expectFieldError(
+      pm.sloAlertsPage.locators.frequency, /frequency is required/i,
+    );
+  });
+
+  /**
+   * Zero silence means "re-notify every evaluation", which is a real choice —
+   * so it must be accepted while a NEGATIVE value is refused. The pair is the
+   * point: a single `> 0` check would pass one and fail the other.
+   */
+  test('a negative silence period is refused and zero is not', {
+    tag: ['@P1', '@validation', '@edge'],
+  }, async ({ page }) => {
+    await pm.sloAlertsPage.setName(uniqueName(`${PREFIX}_silence`));
+    await pm.sloAlertsPage.applyPreset('fast');
+    await pm.sloAlertsPage.selectDestination(shared.destination);
+    await pm.sloAlertsPage.setSilence(-5);
+    await pm.sloAlertsPage.submitExpectingClientRejection();
+    await pm.sloAlertsPage.expectFieldError(
+      pm.sloAlertsPage.locators.silence, /cannot be negative/i,
+    );
+
+    await pm.sloAlertsPage.setSilence(0);
+    await pm.sloAlertsPage.expectNoFieldError(pm.sloAlertsPage.locators.silence);
+  });
+
+  /**
+   * A burn-rate rule compares a fast window against a slow one. Inverted
+   * windows are not a burn-rate rule at all, and the backend rejects them — the
+   * form says so at the short-window field, which is the one to change.
+   */
+  test('a short window longer than the long window is refused', {
+    tag: ['@P1', '@validation', '@edge'],
+  }, async ({ page }) => {
+    await pm.sloAlertsPage.setName(uniqueName(`${PREFIX}_windows`));
+    await pm.sloAlertsPage.applyPreset('fast');
+    await pm.sloAlertsPage.selectDestination(shared.destination);
+    // The preset is 1h long / 5m short; 120 minutes inverts it.
+    await pm.sloAlertsPage.setShortWindowMinutes(120);
+    await pm.sloAlertsPage.submitExpectingClientRejection();
+
+    await pm.sloAlertsPage.expectFieldError(
+      pm.sloAlertsPage.locators.conditionShort, /shorter than the long window/i,
+    );
+  });
+
+  test('a non-positive burn-rate threshold is refused', {
+    tag: ['@P1', '@validation'],
+  }, async ({ page }) => {
+    await pm.sloAlertsPage.setName(uniqueName(`${PREFIX}_burn`));
+    await pm.sloAlertsPage.applyPreset('fast');
+    await pm.sloAlertsPage.selectDestination(shared.destination);
+    await pm.sloAlertsPage.setCritical(0);
+    await pm.sloAlertsPage.submitExpectingClientRejection();
+
+    await pm.sloAlertsPage.expectFieldError(
+      pm.sloAlertsPage.locators.conditionCritical, /greater than 0/i,
+    );
+  });
+
+  /**
+   * An error-budget alert deliberately NULLS both windows, so a blanket
+   * "windows are required" rule would make the whole kind unsubmittable. This
+   * is the test that catches that.
+   */
+  test('an error-budget alert saves without any windows', {
+    tag: ['@P0', '@validation'],
+  }, async ({ page }) => {
+    const name = uniqueName(`${PREFIX}_budget`);
+    await pm.sloAlertsPage.setName(name);
+    await pm.sloAlertsPage.selectKind('error_budget');
+    await pm.sloAlertsPage.selectDestination(shared.destination);
+    await pm.sloAlertsPage.submit();
+
+    await expect(pm.sloAlertsPage.getListItemByName(name)).toHaveCount(1, { timeout: 20000 });
+  });
+});

--- a/web/src/components/slos/SloAlertCondition.vue
+++ b/web/src/components/slos/SloAlertCondition.vue
@@ -117,6 +117,8 @@
             type="number"
             step="0.1"
             width="xs"
+            :error="!!errors?.critical"
+            :error-message="errors?.critical || undefined"
             data-test="slos-sloalertcondition-critical"
           />
           <span>{{ t("slos.alert.inBothWindows") }}</span>
@@ -127,6 +129,8 @@
             suffix="h"
             :label="t('slos.alert.long')"
             label-position="inside"
+            :error="!!errors?.long"
+            :error-message="errors?.long || undefined"
             data-test="slos-sloalertcondition-long"
           />
           <OInput
@@ -136,6 +140,8 @@
             suffix="min"
             :label="t('slos.alert.short')"
             label-position="inside"
+            :error="!!errors?.short"
+            :error-message="errors?.short || undefined"
             data-test="slos-sloalertcondition-short"
           />
         </div>
@@ -152,6 +158,7 @@
             step="0.1"
             width="xs"
             :placeholder="t('slos.alert.none')"
+            data-test="slos-sloalertcondition-warning"
           />
           <span class="text-compact text-text-secondary">
             {{ t("slos.alert.warningShares") }}
@@ -172,8 +179,22 @@
         <span class="text-negative font-medium">{{ t("slos.alert.criticalIf") }}</span>
         <div class="flex flex-wrap items-center gap-2">
           <span>{{ t("slos.alert.budgetConsumed") }}</span>
-          <OSelect v-model="model.operator" :options="operatorOptions" width="xs" />
-          <OInput v-model.number="model.critical" type="number" step="1" width="xs" suffix="%" />
+          <OSelect
+            v-model="model.operator"
+            :options="operatorOptions"
+            width="xs"
+            data-test="slos-sloalertcondition-operator"
+          />
+          <OInput
+            v-model.number="model.critical"
+            type="number"
+            step="1"
+            width="xs"
+            suffix="%"
+            :error="!!errors?.critical"
+            :error-message="errors?.critical || undefined"
+            data-test="slos-sloalertcondition-critical"
+          />
         </div>
         <span class="text-warning font-medium">{{ t("slos.alert.warningIf") }}</span>
         <div class="flex flex-wrap items-center gap-2">
@@ -186,6 +207,7 @@
             width="xs"
             suffix="%"
             :placeholder="t('slos.alert.none')"
+            data-test="slos-sloalertcondition-warning"
           />
         </div>
       </div>
@@ -223,7 +245,11 @@ const model = defineModel<any>({ required: true });
  *
  *  On the SLO page the SLO is CONTEXT, not a choice: it comes from the page,
  *  the selector is not rendered, and the list is never fetched. */
-const props = defineProps<{ slo?: Slo | null }>();
+const props = defineProps<{
+  slo?: Slo | null;
+  /** Per-field messages from the parent form, empty until a submit is attempted. */
+  errors?: { critical?: I18nText; long?: I18nText; short?: I18nText };
+}>();
 
 const { t } = useI18nTyped();
 const store = useStore();

--- a/web/src/components/slos/SloAlertForm.schema.spec.ts
+++ b/web/src/components/slos/SloAlertForm.schema.spec.ts
@@ -1,0 +1,146 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, expect, it } from "vitest";
+
+import { makeSloAlertSchema } from "./SloAlertForm.schema";
+
+const t = ((key: string) => key) as any;
+const schema = makeSloAlertSchema(t);
+
+const paths = (form: unknown): string[] => {
+  const result = schema.safeParse(form);
+  return result.success ? [] : result.error.issues.map((i) => i.path.join("."));
+};
+
+const burnRate = (over: Record<string, unknown> = {}) => ({
+  name: "checkout-burn-fast",
+  frequencyMinutes: 5,
+  silenceMinutes: 10,
+  destinations: ["email"],
+  workflows: [],
+  condition: {
+    kind: "burn_rate",
+    operator: ">",
+    critical: 14.4,
+    long_window_secs: 3600,
+    short_window_secs: 300,
+  },
+  ...over,
+});
+
+describe("SloAlertForm.schema — identity and delivery", () => {
+  it("accepts a complete burn-rate alert", () => {
+    expect(paths(burnRate())).toEqual([]);
+  });
+
+  it("requires a name", () => {
+    expect(paths(burnRate({ name: "" }))).toContain("name");
+  });
+
+  it("rejects the characters the generic alert form rejects", () => {
+    expect(paths(burnRate({ name: "bad name" }))).toContain("name");
+    expect(paths(burnRate({ name: "bad/name" }))).toContain("name");
+  });
+
+  // Either channel satisfies the server, so this is a rule about the PAIR.
+  it("requires a destination or a workflow, not both", () => {
+    expect(paths(burnRate({ destinations: [], workflows: [] }))).toContain("destinations");
+    expect(paths(burnRate({ destinations: [], workflows: ["wf"] }))).toEqual([]);
+  });
+});
+
+describe("SloAlertForm.schema — cadence", () => {
+  it("requires a frequency of at least a minute", () => {
+    expect(paths(burnRate({ frequencyMinutes: "" }))).toContain("frequencyMinutes");
+    expect(paths(burnRate({ frequencyMinutes: 0 }))).toContain("frequencyMinutes");
+  });
+
+  // Zero silence means "re-notify every evaluation", which is a real choice —
+  // so a single `> 0` rule would wrongly reject it.
+  it("accepts a silence of zero but not a negative one", () => {
+    expect(paths(burnRate({ silenceMinutes: 0 }))).toEqual([]);
+    expect(paths(burnRate({ silenceMinutes: -1 }))).toContain("silenceMinutes");
+    expect(paths(burnRate({ silenceMinutes: "" }))).toContain("silenceMinutes");
+  });
+});
+
+describe("SloAlertForm.schema — burn-rate condition", () => {
+  it("requires a positive threshold", () => {
+    expect(paths(burnRate({ condition: { kind: "burn_rate", critical: 0 } }))).toContain(
+      "condition.critical",
+    );
+  });
+
+  it("requires both windows", () => {
+    const flagged = paths(burnRate({ condition: { kind: "burn_rate", critical: 14.4 } }));
+    expect(flagged).toEqual(
+      expect.arrayContaining(["condition.long_window_secs", "condition.short_window_secs"]),
+    );
+  });
+
+  it("refuses a short window that is not shorter than the long one", () => {
+    const equal = burnRate({
+      condition: {
+        kind: "burn_rate",
+        critical: 14.4,
+        long_window_secs: 3600,
+        short_window_secs: 3600,
+      },
+    });
+    expect(paths(equal)).toContain("condition.short_window_secs");
+  });
+});
+
+describe("SloAlertForm.schema — error-budget condition", () => {
+  const budget = (over: Record<string, unknown> = {}) =>
+    burnRate({
+      condition: {
+        kind: "error_budget",
+        operator: ">",
+        critical: 75,
+        long_window_secs: null,
+        short_window_secs: null,
+        ...over,
+      },
+    });
+
+  // The kind watcher NULLS both windows on purpose, so a blanket "windows are
+  // required" rule would make this kind unsubmittable.
+  it("accepts null windows", () => {
+    expect(paths(budget())).toEqual([]);
+  });
+
+  it("caps the consumed budget at 100%", () => {
+    expect(paths(budget({ critical: 101 }))).toContain("condition.critical");
+    expect(paths(budget({ critical: 100 }))).toEqual([]);
+  });
+
+  // A burn MULTIPLE above 100 is ordinary, so the cap must not leak.
+  it("does not cap a burn-rate threshold at 100", () => {
+    expect(
+      paths(
+        burnRate({
+          condition: {
+            kind: "burn_rate",
+            critical: 200,
+            long_window_secs: 3600,
+            short_window_secs: 300,
+          },
+        }),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/web/src/components/slos/SloAlertForm.schema.ts
+++ b/web/src/components/slos/SloAlertForm.schema.ts
@@ -1,0 +1,114 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Burn-rate / error-budget alert schema, arranged like AddSlo.schema.ts and the
+// generic alert schemas: one `superRefine`, path-keyed issues, i18n messages.
+//
+// `kind` is the discriminator and it changes the required set outright: an
+// error-budget alert deliberately NULLS both windows (see the kind watcher in
+// SloAlertCondition), so a blanket "windows are required" rule would make that
+// whole kind unsubmittable.
+
+import { z } from "zod";
+
+import type { I18nText } from "@/types/i18n";
+import { ALERT_NAME_UNSUPPORTED_CHARS } from "@/components/alerts/AddAlert.schema";
+
+export type Translator = (_key: string, _named?: Record<string, unknown>) => I18nText;
+
+const isBlank = (v: unknown): boolean =>
+  v === undefined || v === null || (typeof v === "string" && v.trim() === "");
+
+export const makeSloAlertSchema = (t: Translator) =>
+  z
+    .looseObject({
+      name: z.string().optional(),
+      frequencyMinutes: z.unknown().optional(),
+      silenceMinutes: z.unknown().optional(),
+      destinations: z.array(z.string()).optional(),
+      workflows: z.array(z.string()).optional(),
+      condition: z.looseObject({}).optional(),
+    })
+    .superRefine((val: any, ctx) => {
+      const add = (path: (string | number)[], message: I18nText) =>
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path, message });
+
+      // The same name rule the generic alert form applies — these are ordinary
+      // alerts once saved, and a name this form accepts but that one rejects
+      // would be a trap.
+      if (isBlank(val.name)) {
+        add(["name"], t("alerts.nameRequired"));
+      } else if (
+        ALERT_NAME_UNSUPPORTED_CHARS.test(String(val.name)) ||
+        String(val.name).includes("/")
+      ) {
+        // "/" is rejected server-side too but is not in the shared regex, so it
+        // is checked alongside it rather than by widening a regex other forms use.
+        add(["name"], t("alerts.validation.nameUnsupportedChars"));
+      }
+
+      if (isBlank(val.frequencyMinutes)) {
+        add(["frequencyMinutes"], t("slos.validation.frequencyRequired"));
+      } else if (
+        !Number.isFinite(Number(val.frequencyMinutes)) ||
+        Number(val.frequencyMinutes) < 1
+      ) {
+        add(["frequencyMinutes"], t("slos.validation.frequencyPositive"));
+      }
+
+      // Zero silence means "re-notify every evaluation", a real choice — so the
+      // blank must be told apart from 0 rather than tested for truthiness.
+      if (isBlank(val.silenceMinutes)) {
+        add(["silenceMinutes"], t("slos.validation.silenceRequired"));
+      } else if (!Number.isFinite(Number(val.silenceMinutes)) || Number(val.silenceMinutes) < 0) {
+        add(["silenceMinutes"], t("slos.validation.silenceNonNegative"));
+      }
+
+      // Either channel satisfies the server, so this is a rule about the PAIR.
+      if ((val.destinations?.length ?? 0) === 0 && (val.workflows?.length ?? 0) === 0) {
+        add(["destinations"], t("slos.validation.targetsRequired"));
+      }
+
+      const c = val.condition ?? {};
+      const isBurnRate = c.kind === "burn_rate";
+
+      if (isBlank(c.critical)) {
+        add(["condition", "critical"], t("slos.validation.criticalRequired"));
+      } else {
+        const critical = Number(c.critical);
+        if (!Number.isFinite(critical) || critical <= 0) {
+          add(["condition", "critical"], t("slos.validation.criticalPositive"));
+        } else if (!isBurnRate && critical > 100) {
+          add(["condition", "critical"], t("slos.validation.budgetRange"));
+        }
+      }
+
+      if (!isBurnRate) return;
+
+      const long = Number(c.long_window_secs);
+      const short = Number(c.short_window_secs);
+      if (!Number.isFinite(long) || long <= 0) {
+        add(["condition", "long_window_secs"], t("slos.validation.longWindowRequired"));
+      }
+      if (!Number.isFinite(short) || short <= 0) {
+        add(["condition", "short_window_secs"], t("slos.validation.shortWindowRequired"));
+      } else if (Number.isFinite(long) && long > 0 && short >= long) {
+        // A burn-rate rule compares a fast signal against a slow one; inverted
+        // or equal windows are not a burn-rate rule at all.
+        add(["condition", "short_window_secs"], t("slos.validation.shortInsideLong"));
+      }
+    });
+
+export type SloAlertForm = z.infer<ReturnType<typeof makeSloAlertSchema>>;

--- a/web/src/components/slos/SloAlertForm.spec.ts
+++ b/web/src/components/slos/SloAlertForm.spec.ts
@@ -19,6 +19,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import i18n from "@/locales";
 import store from "@/test/unit/helpers/store";
 import SloAlertForm from "./SloAlertForm.vue";
+import AlertDestinationsField from "@/components/alerts/AlertDestinationsField.vue";
 
 const createSpy = vi.fn().mockResolvedValue({ data: { code: 200 } });
 const updateSpy = vi.fn().mockResolvedValue({ data: { code: 200 } });
@@ -60,6 +61,22 @@ const mountForm = async (props: Record<string, any> = {}) => {
   return wrapper;
 };
 
+/**
+ * Mount a form that is actually submittable.
+ *
+ * A new alert form has no destination and no threshold — `critical` starts null
+ * on purpose so the suggested cards are a choice rather than a default. The
+ * schema refuses both, so a test about the PAYLOAD has to satisfy them first or
+ * it only re-tests the required-field rules.
+ */
+const mountSubmittable = async (props: Record<string, any> = {}) => {
+  const wrapper = await mountForm(props);
+  await wrapper.find('[data-test="slos-sloalertcondition-preset-fast"]').trigger("click");
+  wrapper.findComponent(AlertDestinationsField).vm.$emit("update:destinations", ["dest1"]);
+  await flushPromises();
+  return wrapper;
+};
+
 describe("SloAlertForm", () => {
   beforeEach(() => {
     createSpy.mockClear();
@@ -93,7 +110,7 @@ describe("SloAlertForm", () => {
   });
 
   it("creates through the API with an SLO-shaped payload", async () => {
-    const wrapper = await mountForm();
+    const wrapper = await mountSubmittable();
     await wrapper.find('[data-test="slo-alert-form-submit"]').trigger("click");
     await flushPromises();
 
@@ -109,7 +126,7 @@ describe("SloAlertForm", () => {
   });
 
   it("emits saved so the page can refresh its list", async () => {
-    const wrapper = await mountForm();
+    const wrapper = await mountSubmittable();
     await wrapper.find('[data-test="slo-alert-form-submit"]').trigger("click");
     await flushPromises();
     expect(wrapper.emitted("saved")).toBeTruthy();

--- a/web/src/components/slos/SloAlertForm.vue
+++ b/web/src/components/slos/SloAlertForm.vue
@@ -42,7 +42,7 @@
     </div>
 
     <!-- The SLO is context, not a field: it comes from the page. -->
-    <SloAlertCondition v-model="form.condition" :slo="slo" />
+    <SloAlertCondition v-model="form.condition" :slo="slo" :errors="conditionFieldErrors" />
 
     <!-- Sized to their content (`width="sm"`, minutes suffix) rather than a
          half-panel column each: a two-digit interval in a 60rem input reads as
@@ -55,6 +55,8 @@
         suffix="min"
         :label="t('alerts.frequency')"
         required
+        :error="!!fieldError('frequencyMinutes')"
+        :error-message="fieldError('frequencyMinutes') || undefined"
         data-test="slo-alert-form-frequency"
       />
       <OInput
@@ -64,6 +66,8 @@
         suffix="min"
         :label="t('alerts.silence')"
         required
+        :error="!!fieldError('silenceMinutes')"
+        :error-message="fieldError('silenceMinutes') || undefined"
         data-test="slo-alert-form-silence"
       />
     </div>
@@ -74,13 +78,10 @@
       v-model:destinations="form.destinations"
       v-model:workflows="form.workflows"
       :destination-options="destinationOptions"
+      :error="fieldError('destinations') || undefined"
       data-test="slo-alert-form-targets"
       @refresh="loadDestinations"
     />
-
-    <OBanner v-if="saveError" variant="error" data-test="slo-alert-form-error">
-      {{ saveError }}
-    </OBanner>
 
     <div class="flex justify-end gap-2">
       <OButton
@@ -102,17 +103,18 @@
 import { computed, onMounted, reactive, ref, watch } from "vue";
 import { useStore } from "vuex";
 
-import { raw, useI18nTyped } from "@/types/i18n";
+import { raw, useI18nTyped, type I18nText } from "@/types/i18n";
+import { makeSloAlertSchema } from "./SloAlertForm.schema";
+import { scrollToFirstError } from "@/lib/forms/Form/scrollToFirstError";
 
-import OBanner from "@/lib/feedback/Banner/OBanner.vue";
 import OButton from "@/lib/core/Button/OButton.vue";
+import { toast } from "@/lib/feedback/Toast/useToast";
 import OInput from "@/lib/forms/Input/OInput.vue";
 import AlertDestinationsField from "@/components/alerts/AlertDestinationsField.vue";
 import SloAlertCondition from "@/components/slos/SloAlertCondition.vue";
 import alertsService from "@/services/alerts";
 import destinationService from "@/services/alert_destination";
 import type { Slo } from "@/ts/interfaces/slo";
-import { ALERT_NAME_UNSUPPORTED_CHARS } from "@/components/alerts/AddAlert.schema";
 import { buildSloAlertPayload, deriveSloAlertName } from "@/utils/alerts/sloAlertPayload";
 
 const props = defineProps<{ slo: Slo; alertId?: string | null }>();
@@ -128,7 +130,6 @@ const store = useStore();
 
 const org = computed(() => store.state.selectedOrganization?.identifier);
 const saving = ref(false);
-const saveError = ref("");
 const destinationOptions = ref<string[]>([]);
 
 /** The stored alert when editing. Held so the PUT can carry every field this
@@ -164,16 +165,7 @@ const form = reactive({
 //
 // `alerts.nameRequired` is the key the generic alert form already uses; there
 // is no `alerts.validation.nameRequired`, and a missing key renders as the key.
-const nameError = computed(() => {
-  if (!form.name.trim()) return t("alerts.nameRequired");
-  // Whitespace and "/" are both rejected server-side, and the first check runs
-  // before anything else — so a natural-language name never reaches save.
-  if (ALERT_NAME_UNSUPPORTED_CHARS.test(form.name) || form.name.includes("/")) {
-    return t("alerts.validation.nameUnsupportedChars");
-  }
-  return raw("");
-});
-
+// The rule itself lives in SloAlertForm.schema.ts.
 /** Keep the suggested name in step with the condition until the user types
  *  their own. Two alerts on one SLO are told apart by name, so a blank or
  *  duplicated default is the failure mode worth designing out. */
@@ -196,9 +188,72 @@ watch(
   },
 );
 
+/// Only the name was checked before, so a missing destination reached the server
+/// and came back as a banner reading "Alert destination or workflows is
+/// required" — accurate, but attached to nothing the user can see is wrong.
+/// These name the field instead.
+///
+/// Shown only after a submit attempt: unlike the name, which is prefilled from
+/// the condition, these start empty on every new alert and would otherwise paint
+/// the form red before anyone has typed.
+const attemptedSubmit = ref(false);
+
+/** The "no message" value. Branded so it is assignable to `error-message`. */
+const NO_ERROR = raw("");
+
+/// Rules live in `SloAlertForm.schema.ts`, the arrangement the generic alert
+/// forms use — see the note at the top of that file for why `kind` changes the
+/// required set rather than merely relaxing it.
+const validation = computed(() =>
+  makeSloAlertSchema(t).safeParse({
+    name: form.name,
+    frequencyMinutes: form.frequencyMinutes,
+    silenceMinutes: form.silenceMinutes,
+    destinations: form.destinations,
+    workflows: form.workflows,
+    condition: form.condition,
+  }),
+);
+
+const validationIssues = computed<Record<string, I18nText>>(() => {
+  const result = validation.value;
+  if (result.success) return {};
+  const out: Record<string, I18nText> = {};
+  for (const issue of result.error.issues) {
+    const key = issue.path.join(".");
+    if (!(key in out)) out[key] = issue.message as I18nText;
+  }
+  return out;
+});
+
+/// Submit-then-change, the timing `useOForm` configures everywhere else: these
+/// fields start empty on every new alert and would otherwise paint the form red
+/// before anyone has typed. The name is the exception — it is prefilled from the
+/// condition, so it is marked as soon as it is emptied.
+const fieldError = (path: string): I18nText =>
+  attemptedSubmit.value ? (validationIssues.value[path] ?? NO_ERROR) : NO_ERROR;
+
+const nameError = computed(() => validationIssues.value["name"] ?? NO_ERROR);
+
+/// Handed to SloAlertCondition so its inputs render their own inline markers,
+/// rather than the form reporting a condition problem far from the input.
+const conditionFieldErrors = computed(() => ({
+  critical: fieldError("condition.critical"),
+  long: fieldError("condition.long_window_secs"),
+  short: fieldError("condition.short_window_secs"),
+}));
+
 const submit = async () => {
-  saveError.value = "";
-  if (nameError.value) return;
+  attemptedSubmit.value = true;
+
+  // Refuse to send a knowingly-invalid alert. Previously only the name was
+  // checked, and it returned SILENTLY — no banner, no field marker — so a
+  // rejected name looked exactly like nothing happening.
+  if (!validation.value.success) {
+    await scrollToFirstError();
+    toast({ variant: "error", message: t("alerts.messages.fixHighlightedFields") });
+    return;
+  }
 
   saving.value = true;
   try {
@@ -210,7 +265,10 @@ const submit = async () => {
     }
     emit("saved");
   } catch (e: any) {
-    saveError.value = e?.response?.data?.message || t("alerts.saveFailed");
+    toast({
+      variant: "error",
+      message: e?.response?.data?.message || t("alerts.saveFailed"),
+    });
   } finally {
     saving.value = false;
   }

--- a/web/src/components/slos/SloExpressionField.vue
+++ b/web/src/components/slos/SloExpressionField.vue
@@ -30,7 +30,7 @@
   reach the payload as one.
 -->
 <template>
-  <div :data-test="dataTest">
+  <div :data-test="dataTest" :data-error="errorMessage ? 'true' : undefined">
     <label class="text-text-secondary mb-1 block text-xs">
       {{ label }}<span v-if="required" class="text-text-body"> *</span>
     </label>
@@ -53,7 +53,9 @@
          that grey. -->
     <div
       class="rounded-default border-input-border bg-input-bg h-[2.125rem] overflow-hidden border [&_.monaco-editor]:bg-transparent [&_.monaco-editor_.margin]:bg-transparent [&_.monaco-editor-background]:bg-transparent"
-      :class="focused ? 'border-input-border-focus' : ''"
+      :class="[
+        errorMessage ? 'border-input-border-error' : focused ? 'border-input-border-focus' : '',
+      ]"
     >
       <!-- Keyed by language: monaco reads `language` ONCE, when it is created —
            it registers the grammar and the completion providers there and
@@ -76,7 +78,15 @@
         @blur="focused = false"
       />
     </div>
-    <p v-if="hint" class="text-text-secondary mt-1 text-xs">{{ hint }}</p>
+    <p
+      v-if="errorMessage"
+      class="text-input-error-text mt-1 text-xs"
+      role="alert"
+      :data-test="dataTest ? `${dataTest}-error` : undefined"
+    >
+      {{ errorMessage }}
+    </p>
+    <p v-else-if="hint" class="text-text-secondary mt-1 text-xs">{{ hint }}</p>
   </div>
 </template>
 
@@ -104,6 +114,9 @@ const props = withDefaults(
     suggestions?: unknown[] | null;
     /** Field-value lookup, awaited by the completion provider. */
     fieldValueResolver?: ((field: string) => Promise<string[]>) | null;
+    /** Validation message. Present means invalid: the border turns and the
+     *  message replaces the hint, matching how OInput reports an error. */
+    errorMessage?: string | null;
     dataTest?: string;
   }>(),
   {
@@ -112,6 +125,7 @@ const props = withDefaults(
     keywords: () => [],
     suggestions: null,
     fieldValueResolver: null,
+    errorMessage: null,
   },
 );
 

--- a/web/src/lib/forms/Select/OSelect.vue
+++ b/web/src/lib/forms/Select/OSelect.vue
@@ -1561,8 +1561,19 @@ const fieldWidthClass = computed(() => {
                                 >
                                 <span
                                   v-if="filteredOptions[vRow.index].badge"
-                                  class="rounded-default text-status-positive border-status-positive shrink-0 border border-solid"
+                                  class="rounded-default shrink-0 border border-solid"
                                   :class="[
+                                    // A badge on a row that cannot be chosen is
+                                    // naming a limitation, so it must not read
+                                    // as the positive marker it is elsewhere.
+                                    // `pointer-events-auto` is what makes its
+                                    // tooltip reachable at all: a disabled row
+                                    // sets `pointer-events-none`, so the badge
+                                    // explaining WHY the row is disabled was the
+                                    // one thing on it that could never be hovered.
+                                    filteredOptions[vRow.index].disabled
+                                      ? 'text-text-secondary border-border-default pointer-events-auto'
+                                      : 'text-status-positive border-status-positive',
                                     filteredOptions[vRow.index].badgeTitle
                                       ? 'cursor-help'
                                       : undefined,

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -15365,7 +15365,6 @@
       "reservation": "Reservation",
       "sliType": "SLI type",
       "owner": "Owner",
-      "folder": "Folder",
       "streamPlaceholder": "Select a stream"
     },
     "empty": {
@@ -15395,7 +15394,24 @@
       "sourceHint": "Uptime is the fraction of measured time this alert was not firing. Time it did not evaluate — paused, silenced, or failing — is unmeasured, and never counted as uptime.",
       "loadFailed": "Could not load the eligible alerts",
       "noneEligible": "No alert in this organization can be used as a source yet.",
-      "ineligibleOption": "{name} — {reason}",
+      "ineligible": {
+        "notScheduled": "Not scheduled",
+        "grouped": "Grouped",
+        "notReferenceable": "Not usable",
+        "cron": "Cron schedule",
+        "tooInfrequent": "Runs too rarely",
+        "silenced": "Has silence",
+        "other": "Not eligible",
+        "why": {
+          "notScheduled": "Real-time alerts don't keep the run history an SLO needs. Use a scheduled alert instead.",
+          "grouped": "This alert is split by group, and a run doesn't record which groups it checked. Remove its group-by to use it here.",
+          "notReferenceable": "SLO and composite alerts can't be sources. Pick a plain scheduled alert.",
+          "cron": "This alert runs on a cron schedule, so its checks aren't evenly spaced and uptime can't be worked out. Change it to a fixed interval.",
+          "tooInfrequent": "This alert runs every {frequency}. It needs to run at least every {slice} so no time goes unchecked.",
+          "silenced": "After firing, this alert stops checking for a while — and that gap always lands on a bad patch, which would flatter the SLO. Set its silence period to 0."
+        },
+        "noFixedInterval": "no fixed interval"
+      },
       "groupingLocked": "An alert-based SLI cannot be grouped: the availability ledger records one run per alert, not per group, so there is no per-group coverage to stand on.",
       "sourceLink": "Source alert",
       "preview": {
@@ -15503,6 +15519,42 @@
       "editTargetMissing": "That alert is no longer on this SLO.",
       "describeBurn": "Burn rate > {critical} over {long} and {short}",
       "describeBudget": "Error budget consumed > {critical}%"
+    },
+    "validation": {
+      "nameRequired": "SLO name is required",
+      "nameTooLong": "SLO name must be 256 characters or fewer",
+      "targetRequired": "Target is required",
+      "targetRange": "Target must be greater than 0 and below 100",
+      "targetPrecision": "Target supports at most 3 decimal places",
+      "streamTypeRequired": "Stream type is required",
+      "streamRequired": "Stream is required",
+      "goodExprRequired": "\"Good when\" is required",
+      "promqlGoodRequired": "Good query is required",
+      "promqlTotalRequired": "Total query is required",
+      "aggregateRequired": "Aggregate expression is required",
+      "comparatorRequired": "Comparator is required",
+      "thresholdRequired": "Threshold is required",
+      "thresholdNumber": "Threshold must be a number",
+      "alertSourceRequired": "Source alert is required",
+      "groupedSlice": "Grouped SLOs must use a 5-minute slice",
+      "alertCannotGroup": "An alert-based SLI cannot be grouped",
+      "frequencyRequired": "Frequency is required",
+      "frequencyPositive": "Frequency must be at least 1 minute",
+      "silenceRequired": "Silence period is required",
+      "silenceNonNegative": "Silence period cannot be negative",
+      "targetsRequired": "Select at least one destination or workflow",
+      "criticalRequired": "Threshold is required",
+      "criticalPositive": "Threshold must be greater than 0",
+      "budgetRange": "Budget consumed must be 100% or less",
+      "longWindowRequired": "Long window is required",
+      "shortWindowRequired": "Short window is required",
+      "shortInsideLong": "Short window must be shorter than the long window"
+    },
+    "duration": {
+      "seconds": "{count} second | {count} seconds",
+      "minutes": "{count} minute | {count} minutes",
+      "hours": "{count} hour | {count} hours",
+      "days": "{count} day | {count} days"
     }
   },
   "promql": {

--- a/web/src/ts/interfaces/slo.ts
+++ b/web/src/ts/interfaces/slo.ts
@@ -57,6 +57,9 @@ export interface SloEligibleAlert {
   eligible: boolean;
   /** The server's own rejection message, verbatim. */
   reason: string | null;
+  /** A stable id for `reason` — the picker labels the row from this, never by
+   *  matching on the sentence. */
+  reason_code: string | null;
 }
 
 /** What an alert SLI would have measured over a window. */

--- a/web/src/views/slos/AddSlo.schema.spec.ts
+++ b/web/src/views/slos/AddSlo.schema.spec.ts
@@ -1,0 +1,221 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// The required SET is a function of SLI type × query language, so the tests are
+// arranged by SHAPE. Each asserts the paths that MUST be flagged and, just as
+// importantly, the ones that must not: a rule leaking across shapes blocks a
+// legitimate definition, which is the more expensive failure of the two.
+
+import { describe, expect, it } from "vitest";
+
+import { makeAddSloSchema, type SloFormMeta } from "./AddSlo.schema";
+
+const t = ((key: string) => key) as any;
+
+const meta = (over: Partial<SloFormMeta> = {}): SloFormMeta => ({
+  isPromqlCount: false,
+  isPromqlTimeSlice: false,
+  isGrouped: false,
+  ...over,
+});
+
+/** The paths flagged for one form value, as dotted strings. */
+const paths = (form: unknown, m: SloFormMeta = meta()): string[] => {
+  const result = makeAddSloSchema(t, m).safeParse(form);
+  return result.success ? [] : result.error.issues.map((i) => i.path.join("."));
+};
+
+const countSql = (over: Record<string, unknown> = {}) => ({
+  name: "checkout-availability",
+  sli_type: "count",
+  target: 99.9,
+  slice_interval_secs: 60,
+  config: { stream_type: "logs", stream: "default", good_expr: "status < 500" },
+  ...over,
+});
+
+describe("AddSlo.schema — identity and objective", () => {
+  it("accepts a complete SQL count definition", () => {
+    expect(paths(countSql())).toEqual([]);
+  });
+
+  it("requires a name", () => {
+    expect(paths(countSql({ name: "" }))).toContain("name");
+  });
+
+  it("treats a whitespace-only name as blank", () => {
+    expect(paths(countSql({ name: "   " }))).toContain("name");
+  });
+
+  it("accepts a name at the server's inclusive 256 bound and rejects 257", () => {
+    expect(paths(countSql({ name: "z".repeat(256) }))).toEqual([]);
+    expect(paths(countSql({ name: "z".repeat(257) }))).toContain("name");
+  });
+
+  it("requires a target", () => {
+    expect(paths(countSql({ target: "" }))).toContain("target");
+  });
+
+  it("rejects both open boundaries of the target range", () => {
+    expect(paths(countSql({ target: 0 }))).toContain("target");
+    expect(paths(countSql({ target: 100 }))).toContain("target");
+  });
+
+  it("accepts a target just inside the range", () => {
+    expect(paths(countSql({ target: 99.999 }))).toEqual([]);
+  });
+
+  it("rejects a target beyond 3 decimal places", () => {
+    expect(paths(countSql({ target: 99.9999 }))).toContain("target");
+  });
+
+  // `Number("") === 0`, so a rule that coerced first could not tell an empty
+  // target from a deliberate zero — and the two get different messages.
+  it("distinguishes a blank target from a zero one", () => {
+    const blank = makeAddSloSchema(t, meta()).safeParse(countSql({ target: "" }));
+    const zero = makeAddSloSchema(t, meta()).safeParse(countSql({ target: 0 }));
+    expect((blank as any).error.issues[0].message).not.toBe((zero as any).error.issues[0].message);
+  });
+});
+
+describe("AddSlo.schema — count SLI", () => {
+  it("requires stream, stream type and the good expression in SQL", () => {
+    const flagged = paths({ name: "x", sli_type: "count", target: 99, config: {} });
+    expect(flagged).toEqual(
+      expect.arrayContaining(["config.stream_type", "config.stream", "config.good_expr"]),
+    );
+  });
+
+  // The PromQL count is the one shape carrying no stream; requiring it here
+  // would block a definition the server accepts.
+  it("requires both queries and NOT the stream in PromQL", () => {
+    const flagged = paths(
+      { name: "x", sli_type: "count", target: 99, config: {} },
+      meta({ isPromqlCount: true }),
+    );
+    expect(flagged).toEqual(expect.arrayContaining(["config.good", "config.total"]));
+    expect(flagged).not.toContain("config.stream");
+    expect(flagged).not.toContain("config.good_expr");
+  });
+
+  it("accepts a complete PromQL count", () => {
+    const flagged = paths(
+      {
+        name: "x",
+        sli_type: "count",
+        target: 99,
+        config: { good: "sum(ok)", total: "sum(all)" },
+      },
+      meta({ isPromqlCount: true }),
+    );
+    expect(flagged).toEqual([]);
+  });
+});
+
+describe("AddSlo.schema — time-slice SLI", () => {
+  const base = { name: "x", sli_type: "time_slice", target: 99, config: {} };
+
+  it("requires stream, aggregate, comparator and threshold", () => {
+    expect(paths(base)).toEqual(
+      expect.arrayContaining([
+        "config.stream",
+        "config.query",
+        "config.comparator",
+        "config.threshold",
+      ]),
+    );
+  });
+
+  // "errors < 1" is an ordinary slice rule, so a truthiness test here would
+  // reject a valid SLO.
+  it("accepts a threshold of zero", () => {
+    const flagged = paths({
+      ...base,
+      config: {
+        stream_type: "logs",
+        stream: "default",
+        query: "count(*)",
+        comparator: "<",
+        threshold: 0,
+      },
+    });
+    expect(flagged).toEqual([]);
+  });
+
+  it("rejects a non-numeric threshold", () => {
+    const flagged = paths({
+      ...base,
+      config: {
+        stream_type: "logs",
+        stream: "default",
+        query: "count(*)",
+        comparator: "<",
+        threshold: "abc",
+      },
+    });
+    expect(flagged).toContain("config.threshold");
+  });
+
+  // Unlike the PromQL count, a PromQL time-slice is evaluated against a named
+  // metrics stream — so the stream stays required.
+  it("still requires the stream in PromQL", () => {
+    expect(paths(base, meta({ isPromqlTimeSlice: true }))).toContain("config.stream");
+  });
+});
+
+describe("AddSlo.schema — alert SLI", () => {
+  it("requires a source alert and nothing stream-shaped", () => {
+    const flagged = paths({ name: "x", sli_type: "alert", target: 99, config: {} });
+    expect(flagged).toEqual(["config.alert_id"]);
+  });
+
+  it("accepts a chosen source", () => {
+    expect(
+      paths({ name: "x", sli_type: "alert", target: 99, config: { alert_id: "abc" } }),
+    ).toEqual([]);
+  });
+
+  // The availability ledger records one run per alert, not per group, so there
+  // is no per-group coverage to stand on.
+  it("refuses grouping outright", () => {
+    const flagged = paths(
+      {
+        name: "x",
+        sli_type: "alert",
+        target: 99,
+        slice_interval_secs: 300,
+        config: { alert_id: "abc" },
+      },
+      meta({ isGrouped: true }),
+    );
+    expect(flagged).toContain("group_by");
+  });
+});
+
+describe("AddSlo.schema — grouping (D30)", () => {
+  it("refuses a grouped SLO on a 1-minute slice", () => {
+    expect(paths(countSql({ slice_interval_secs: 60 }), meta({ isGrouped: true }))).toContain(
+      "group_by",
+    );
+  });
+
+  it("accepts a grouped SLO on the 5-minute grid", () => {
+    expect(paths(countSql({ slice_interval_secs: 300 }), meta({ isGrouped: true }))).toEqual([]);
+  });
+
+  it("leaves an ungrouped SLO on a 1-minute slice alone", () => {
+    expect(paths(countSql({ slice_interval_secs: 60 }))).toEqual([]);
+  });
+});

--- a/web/src/views/slos/AddSlo.schema.ts
+++ b/web/src/views/slos/AddSlo.schema.ts
@@ -1,0 +1,177 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// SLO definition schema — the rules AddSlo enforces before it will POST.
+//
+// Same shape as the alert schemas (AddAlert.schema.ts and its step children): a
+// permissive `looseObject` with every rule in one `superRefine`, each issue
+// carrying the field PATH so the form can put the message on the offending
+// control. Messages are i18n keys resolved through the injected `t`, so this
+// file holds no copy.
+//
+// The required SET is a function of `sli_type` × query language, not a fixed
+// list — a PromQL count needs two expressions and NO stream, while a PromQL
+// time-slice still needs the stream. The discriminators are `_meta`, computed by
+// the form and passed in, because the language toggles live in component state
+// rather than in the payload.
+//
+// The API stays the authority. These rules exist because it was previously the
+// ONLY authority: an omitted required field failed deserialization with HTTP
+// 422, a body carrying no `message`, so the user was shown "Request failed with
+// status code 422" naming no field at all.
+
+import { z } from "zod";
+
+import type { I18nText } from "@/types/i18n";
+
+export type Translator = (_key: string, _named?: Record<string, unknown>) => I18nText;
+
+/** What the form knows and the payload does not. */
+export interface SloFormMeta {
+  /** A count SLI written in PromQL: two expressions, no stream. */
+  isPromqlCount: boolean;
+  /** A time-slice SLI written in PromQL. Keeps the stream, unlike the above. */
+  isPromqlTimeSlice: boolean;
+  /** Whether any group-by field is selected. */
+  isGrouped: boolean;
+}
+
+/** The server's inclusive bound: 257 characters is the first rejection. */
+export const SLO_NAME_MAX = 256;
+
+/** Targets sit strictly inside (0, 100) — a 100% target has a zero error
+ *  budget, which makes every burn rate either 0 or infinite. */
+export const TARGET_MIN_EXCLUSIVE = 0;
+export const TARGET_MAX_EXCLUSIVE = 100;
+
+/** Stored to 3 decimals; a 4th is silently truncated, changing the budget. */
+export const TARGET_DECIMALS = 3;
+
+/** D30: a grouped SLO is pinned to the 5-minute grid. */
+export const GROUPED_SLICE_SECS = 300;
+
+/** Blank in the sense the API's validator uses: whitespace does not count. */
+const isBlank = (v: unknown): boolean =>
+  v === undefined || v === null || (typeof v === "string" && v.trim() === "");
+
+/**
+ * Build the SLO form schema for one `_meta` snapshot.
+ *
+ * Rebuilt whenever the discriminators change (the form does this in a computed),
+ * because the required set changes with them.
+ */
+export const makeAddSloSchema = (t: Translator, meta: SloFormMeta) =>
+  z
+    .looseObject({
+      name: z.string().optional(),
+      description: z.string().optional(),
+      sli_type: z.string().optional(),
+      target: z.unknown().optional(),
+      slice_interval_secs: z.number().optional(),
+      config: z.looseObject({}).optional(),
+    })
+    .superRefine((val: any, ctx) => {
+      const add = (path: (string | number)[], message: I18nText) =>
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path, message });
+
+      const config = val.config ?? {};
+      const sliType = val.sli_type;
+
+      // ── identity ──────────────────────────────────────────────────────────
+      if (isBlank(val.name)) {
+        add(["name"], t("slos.validation.nameRequired"));
+      } else if (String(val.name).length > SLO_NAME_MAX) {
+        add(["name"], t("slos.validation.nameTooLong"));
+      }
+
+      // ── objective ─────────────────────────────────────────────────────────
+      // Checked on the RAW value, never coerced: `Number("") === 0`, so a
+      // coerced blank would be indistinguishable from a deliberate 0 — and 0
+      // has its own, different message.
+      if (isBlank(val.target)) {
+        add(["target"], t("slos.validation.targetRequired"));
+      } else {
+        const target = Number(val.target);
+        if (!Number.isFinite(target)) {
+          add(["target"], t("slos.validation.targetRequired"));
+        } else if (target <= TARGET_MIN_EXCLUSIVE || target >= TARGET_MAX_EXCLUSIVE) {
+          add(["target"], t("slos.validation.targetRange"));
+        } else if (Math.round(target * 10 ** TARGET_DECIMALS) / 10 ** TARGET_DECIMALS !== target) {
+          add(["target"], t("slos.validation.targetPrecision"));
+        }
+      }
+
+      // ── the SLI itself ────────────────────────────────────────────────────
+      // A stream is required by count-SQL and by BOTH time-slice languages; a
+      // PromQL count is the one shape that carries none.
+      const needsStream = (sliType === "count" && !meta.isPromqlCount) || sliType === "time_slice";
+      if (needsStream) {
+        if (isBlank(config.stream_type)) {
+          add(["config", "stream_type"], t("slos.validation.streamTypeRequired"));
+        }
+        if (isBlank(config.stream)) {
+          add(["config", "stream"], t("slos.validation.streamRequired"));
+        }
+      }
+
+      if (sliType === "count") {
+        if (meta.isPromqlCount) {
+          // `CountSource::PromQl` is exactly two expressions and BOTH are needed.
+          if (isBlank(config.good)) {
+            add(["config", "good"], t("slos.validation.promqlGoodRequired"));
+          }
+          if (isBlank(config.total)) {
+            add(["config", "total"], t("slos.validation.promqlTotalRequired"));
+          }
+        } else if (isBlank(config.good_expr)) {
+          // Left blank, `wireConfig`'s `pruned()` DROPS the key rather than
+          // sending "", so the server never sees the field it would explain.
+          add(["config", "good_expr"], t("slos.validation.goodExprRequired"));
+        }
+      }
+
+      if (sliType === "time_slice") {
+        if (isBlank(config.query)) {
+          add(["config", "query"], t("slos.validation.aggregateRequired"));
+        }
+        if (isBlank(config.comparator)) {
+          add(["config", "comparator"], t("slos.validation.comparatorRequired"));
+        }
+        // Zero and negatives are legitimate thresholds ("errors < 1"), so this
+        // must tell a blank apart from a 0 rather than testing truthiness.
+        if (isBlank(config.threshold)) {
+          add(["config", "threshold"], t("slos.validation.thresholdRequired"));
+        } else if (!Number.isFinite(Number(config.threshold))) {
+          add(["config", "threshold"], t("slos.validation.thresholdNumber"));
+        }
+      }
+
+      if (sliType === "alert" && isBlank(config.alert_id)) {
+        add(["config", "alert_id"], t("slos.validation.alertSourceRequired"));
+      }
+
+      // ── grouping ──────────────────────────────────────────────────────────
+      // Both are the SLO's own fields, so the form can answer them without
+      // asking the server.
+      if (meta.isGrouped) {
+        if (sliType === "alert") {
+          add(["group_by"], t("slos.validation.alertCannotGroup"));
+        } else if (val.slice_interval_secs !== GROUPED_SLICE_SECS) {
+          add(["group_by"], t("slos.validation.groupedSlice"));
+        }
+      }
+    });
+
+export type AddSloForm = z.infer<ReturnType<typeof makeAddSloSchema>>;

--- a/web/src/views/slos/AddSlo.vue
+++ b/web/src/views/slos/AddSlo.vue
@@ -48,10 +48,6 @@
       </OButton>
     </template>
 
-    <OBanner v-if="error" variant="error" class="mb-3" data-test="slos-addslo-error">
-      {{ error }}
-    </OBanner>
-
     <!-- A regeneration is not a normal edit: it discards every measurement
          taken under the old definition. Warned before saving, not after. -->
     <OBanner
@@ -82,13 +78,16 @@
           <!-- One row: folder, name, tags — in that order. The folder column
                is fixed-width so the name (the field people actually type in)
                takes the slack; tags get their own share. Wraps to a column on
-               narrow screens rather than crushing three controls. -->
-          <div class="grid grid-cols-1 items-end gap-3 md:grid-cols-[14rem_1fr_1fr]">
+               narrow screens rather than crushing three controls.
+               `items-start`, not `items-end`: OTagInput is taller than an
+               OInput, and bottom-aligning the cells lifted its label clear of
+               the other two so the row read as three unrelated fields. -->
+          <div class="grid grid-cols-1 items-start gap-3 md:grid-cols-[14rem_1fr_1fr]">
             <div>
-              <label class="text-text-secondary mb-1 block text-xs">
-                {{ t("slos.field.folder") }}
-              </label>
-              <!-- type="alerts": SLOs live in alert folders (there is no SLO
+              <!-- No label here: SelectFolderDropDown renders its own, and a
+                   second one above it left this column a row taller than the
+                   two beside it.
+                   type="alerts": SLOs live in alert folders (there is no SLO
                    folder type), so this offers the same folders the Alerts
                    page does. -->
               <SelectFolderDropDown
@@ -100,6 +99,8 @@
             <OInput
               v-model="form.name"
               :label="t('slos.field.name')"
+              :error="!!fieldError('name')"
+              :error-message="fieldError('name') || undefined"
               :placeholder="t('slos.field.namePlaceholder')"
               required
               data-test="slos-addslo-name"
@@ -157,6 +158,8 @@
                 :label="t('slos.field.streamType')"
                 :options="streamTypeOptions"
                 :searchable="false"
+                :error="!!fieldError('config.stream_type')"
+                :error-message="fieldError('config.stream_type') || undefined"
                 data-test="slos-addslo-stream-type"
                 @update:model-value="onStreamTypeChange"
               />
@@ -168,6 +171,8 @@
                 :disabled="!form.config.stream_type"
                 :placeholder="t('slos.field.streamPlaceholder')"
                 required
+                :error="!!fieldError('config.stream')"
+                :error-message="fieldError('config.stream') || undefined"
                 data-test="slos-addslo-stream"
               />
             </div>
@@ -209,6 +214,7 @@
                 language="prom_ql"
                 required
                 class="mt-3"
+                :error-message="fieldError('config.good') || undefined"
                 data-test="slos-addslo-promql-good"
               />
               <SloExpressionField
@@ -219,6 +225,7 @@
                 language="prom_ql"
                 required
                 class="mt-3"
+                :error-message="fieldError('config.total') || undefined"
                 data-test="slos-addslo-promql-total"
               />
               <!-- The evaluator samples at slice ends, so a range selector that
@@ -250,6 +257,7 @@
                 :field-value-resolver="resolveFieldValues"
                 required
                 class="mt-3"
+                :error-message="fieldError('config.good_expr') || undefined"
                 data-test="slos-addslo-good-expr"
               />
             </template>
@@ -262,6 +270,8 @@
                 :label="t('slos.field.streamType')"
                 :options="streamTypeOptions"
                 :searchable="false"
+                :error="!!fieldError('config.stream_type')"
+                :error-message="fieldError('config.stream_type') || undefined"
                 data-test="slos-addslo-timeslice-stream-type"
                 @update:model-value="onStreamTypeChange"
               />
@@ -273,6 +283,8 @@
                 :disabled="!form.config.stream_type"
                 :placeholder="t('slos.field.streamPlaceholder')"
                 required
+                :error="!!fieldError('config.stream')"
+                :error-message="fieldError('config.stream') || undefined"
                 data-test="slos-addslo-timeslice-stream"
               />
             </div>
@@ -312,6 +324,7 @@
               :field-value-resolver="resolveFieldValues"
               class="mt-3"
               required
+              :error-message="fieldError('config.query') || undefined"
               data-test="slos-addslo-aggregate"
             />
             <!-- Prometheus keeps answering for a metric that stopped being
@@ -329,12 +342,16 @@
                 v-model="form.config.comparator"
                 :label="t('slos.field.comparator')"
                 :options="comparatorOptions"
+                :error="!!fieldError('config.comparator')"
+                :error-message="fieldError('config.comparator') || undefined"
                 data-test="slos-addslo-comparator"
               />
               <OInput
                 v-model.number="form.config.threshold"
                 :label="t('slos.field.threshold')"
                 type="number"
+                :error="!!fieldError('config.threshold')"
+                :error-message="fieldError('config.threshold') || undefined"
                 data-test="slos-addslo-threshold"
               />
             </div>
@@ -368,6 +385,8 @@
               :placeholder="t('slos.alertSli.sourcePlaceholder')"
               required
               class="mt-3"
+              :error="!!fieldError('config.alert_id')"
+              :error-message="fieldError('config.alert_id') || undefined"
               data-test="slos-addslo-alert-source"
               @update:model-value="onAlertSourceChange"
             />
@@ -402,6 +421,8 @@
               step="0.001"
               suffix="%"
               required
+              :error="!!fieldError('target')"
+              :error-message="fieldError('target') || undefined"
               data-test="slos-addslo-target"
             />
             <div class="text-compact text-text-secondary flex items-end pb-2">
@@ -470,6 +491,8 @@
             multiple
             :disabled="isAlertSli"
             :placeholder="t('slos.field.groupByPlaceholder')"
+            :error="!!fieldError('group_by')"
+            :error-message="fieldError('group_by') || undefined"
             data-test="slos-addslo-group-by"
           />
           <p
@@ -572,7 +595,9 @@
 
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from "vue";
-import { raw, useI18nTyped, type I18nText } from "@/types/i18n";
+import { raw, useI18nTyped, type I18nKey, type I18nText } from "@/types/i18n";
+import { makeAddSloSchema } from "./AddSlo.schema";
+import { scrollToFirstError } from "@/lib/forms/Form/scrollToFirstError";
 import { useRoute, useRouter } from "vue-router";
 import { useStore } from "vuex";
 
@@ -606,7 +631,6 @@ const router = useRouter();
 const store = useStore();
 
 const saving = ref(false);
-const error = ref<string | null>(null);
 const original = ref<string>("");
 
 const sloId = computed(() => String(route.params.slo_id || ""));
@@ -942,13 +966,79 @@ const alertSourceError = ref<string | null>(null);
 
 const hasEligibleAlert = computed(() => alertSources.value.some((a) => a.eligible));
 
+// The reason is a PARAGRAPH, and every row that carries one costs three lines
+// — at twenty alerts the list stops being a list. So the row states WHICH rule
+// it failed as a chip and keeps the sentence for the hover, which is the same
+// trade the panel field list makes with its type badges.
+//
+// Keyed off `reason_code`, never off the sentence: the copy is the validator's
+// and is free to change.
+/// The picker judges every alert against the COARSEST slice there is, because
+/// no SLO exists yet to supply a narrower grid — same constant the server uses.
+const SLICE_CEILING_SECS = 300;
+
+const INELIGIBILITY_CODES = [
+  "not_scheduled",
+  "grouped",
+  "not_referenceable",
+  "cron",
+  "too_infrequent",
+  "silenced",
+] as const;
+
+/** `snake_case` code -> the `camelCase` half of its two locale keys. */
+const INELIGIBILITY_KEYS: Record<string, string> = Object.fromEntries(
+  INELIGIBILITY_CODES.map((code) => [
+    code,
+    code.replace(/_(.)/g, (_, c: string) => c.toUpperCase()),
+  ]),
+);
+
+/** A cadence in the units a person would say it in, not always minutes. */
+function formatDuration(secs: number): string {
+  if (secs <= 0) return t("slos.alertSli.ineligible.noFixedInterval");
+  // The third argument is the plural INDEX — vue-i18n picks the branch of a
+  // `one | many` message from it, not from the named `count`.
+  const plural = (key: string, count: number) => t(key, { count }, count);
+  if (secs % 86400 === 0) return plural("slos.duration.days", secs / 86400);
+  if (secs % 3600 === 0) return plural("slos.duration.hours", secs / 3600);
+  if (secs % 60 === 0) return plural("slos.duration.minutes", secs / 60);
+  return plural("slos.duration.seconds", secs);
+}
+
+/// What to change, in the reader's words.
+///
+/// The server's own sentence explains the measurement theory — why an
+/// unmeasured gap biases an SLI upward — which is the right level for an API
+/// error and the wrong one for someone picking an alert from a list. These say
+/// what is wrong and what to do about it instead; the original stays on the
+/// API for anyone debugging.
+function ineligibilityReason(a: SloEligibleAlert): string | undefined {
+  const key = INELIGIBILITY_KEYS[a.reason_code ?? ""];
+  // No key means a rule this build has not been taught. The server's sentence
+  // is denser than we would like but it is accurate, so it beats saying nothing.
+  if (!key) return a.reason ?? undefined;
+  return t(`slos.alertSli.ineligible.why.${key}`, {
+    frequency: formatDuration(a.frequency_secs),
+    slice: formatDuration(SLICE_CEILING_SECS),
+  });
+}
+
 const alertSourceOptions = computed(() =>
   alertSources.value.map((a) => ({
     value: a.alert_id,
-    label: a.eligible
-      ? raw(a.name)
-      : t("slos.alertSli.ineligibleOption", { name: a.name, reason: a.reason ?? "" }),
+    label: raw(a.name),
     disabled: !a.eligible,
+    // An unrecognised code still gets a chip — an ineligible row with no
+    // marker reads as a rendering bug rather than as a rule.
+    badge: a.eligible
+      ? undefined
+      : t(
+          (INELIGIBILITY_KEYS[a.reason_code ?? ""]
+            ? `slos.alertSli.ineligible.${INELIGIBILITY_KEYS[a.reason_code ?? ""]}`
+            : "slos.alertSli.ineligible.other") as I18nKey,
+        ),
+    badgeTitle: a.eligible ? undefined : ineligibilityReason(a),
   })),
 );
 
@@ -1172,8 +1262,71 @@ function payload() {
   };
 }
 
+/// Per-field validation, mirroring what the API enforces.
+///
+/// The form previously had NONE: `required` on OSelect renders an asterisk and
+/// nothing else, Save was never disabled, and every rejection came back from the
+/// server. For a missing field that server answer is a deserialization 422 whose
+/// body carries no `message`, so `save()` fell through to axios's own string and
+/// the user was told "Request failed with status code 422" about a field they
+/// left blank — with nothing marking which field.
+///
+/// These checks pre-empt the server rather than replace it: the API remains the
+/// authority, and anything it rejects still surfaces as an error toast.
+/// What they add is naming the field, at the field.
+const attemptedSave = ref(false);
+
+/// The rules live in `AddSlo.schema.ts` — same arrangement as the alert forms,
+/// where the zod schema is a sibling file the component composes. Keeping them
+/// out of here is what makes them unit-testable per SLI shape without mounting
+/// a 1,200-line form.
+const validation = computed(() =>
+  makeAddSloSchema(t, {
+    isPromqlCount: isPromqlCount.value,
+    isPromqlTimeSlice: isPromqlTimeSlice.value,
+    isGrouped: isGrouped.value,
+  }).safeParse({ ...form, group_by: groupByList.value }),
+);
+
+/// Issues keyed by their dotted path, so a field asks for its own message.
+const validationIssues = computed<Record<string, I18nText>>(() => {
+  const result = validation.value;
+  if (result.success) return {};
+  const out: Record<string, I18nText> = {};
+  for (const issue of result.error.issues) {
+    const key = issue.path.join(".");
+    // First issue wins: the rules are ordered from "missing" to "malformed",
+    // and telling someone their blank field is not a number helps nobody.
+    if (!(key in out)) out[key] = issue.message as I18nText;
+  }
+  return out;
+});
+
+/** The "no message" value. Branded so it is assignable to `error-message`. */
+const NO_ERROR = raw("");
+
+/** Errors are shown only AFTER a save attempt.
+ *
+ *  This is `revalidateLogic({ mode: "submit", modeAfterSubmission: "change" })`,
+ *  the timing `useOForm` configures for every other form in the product: a
+ *  brand-new form is empty by definition, so surfacing every "required" on
+ *  mount would paint the page red before the user has typed anything. */
+const fieldError = (path: string): I18nText =>
+  attemptedSave.value ? (validationIssues.value[path] ?? NO_ERROR) : NO_ERROR;
+
 async function save() {
-  error.value = null;
+  // Block the request outright. Sending a knowingly-invalid definition just to
+  // read the server's rejection is what produced "Request failed with status
+  // code 422" with no indication of which field was at fault.
+  attemptedSave.value = true;
+  if (!validation.value.success) {
+    // On a form this long the offending field is usually scrolled out of view,
+    // so a banner alone still leaves the user hunting for it.
+    await scrollToFirstError();
+    toast({ variant: "error", message: t("alerts.messages.fixHighlightedFields") });
+    return;
+  }
+
   saving.value = true;
   try {
     if (isEdit.value) {
@@ -1186,7 +1339,10 @@ async function save() {
   } catch (e: any) {
     // The backend's budget rejection carries its arithmetic (§6b.4d); show it
     // verbatim rather than replacing it with a generic message.
-    error.value = e?.response?.data?.message || e?.message || t("slos.saveFailed");
+    toast({
+      variant: "error",
+      message: e?.response?.data?.message || e?.message || t("slos.saveFailed"),
+    });
   } finally {
     saving.value = false;
   }

--- a/web/src/views/slos/AddSloAlertSli.spec.ts
+++ b/web/src/views/slos/AddSloAlertSli.spec.ts
@@ -64,6 +64,7 @@ const row = (over: Partial<EligibleRow> = {}): EligibleRow => ({
   frequency_secs: 60,
   eligible: true,
   reason: null,
+  reason_code: null,
   ...over,
 });
 
@@ -76,6 +77,7 @@ const ELIGIBLE = [
     frequency_secs: 604800,
     eligible: false,
     reason: "a cron-scheduled alert cannot be an SLI source",
+    reason_code: "cron",
   }),
   row({
     alert_id: "alert-silenced",
@@ -83,6 +85,7 @@ const ELIGIBLE = [
     frequency_secs: 60,
     eligible: false,
     reason: "set the source's silence to 0 or give it a warning threshold",
+    reason_code: "silenced",
   }),
   // Scheduled, ungrouped and not cron — refused purely on cadence, because
   // 300 is the coarsest supported slice.
@@ -92,6 +95,7 @@ const ELIGIBLE = [
     frequency_secs: 600,
     eligible: false,
     reason: "an alert-based SLI needs a source that evaluates at least once per slice",
+    reason_code: "too_infrequent",
   }),
 ];
 
@@ -196,24 +200,74 @@ describe("AddSlo — alert SLI", () => {
 
   // Without this the picker offers alerts the server will reject, and the user
   // learns why only on save.
-  it("disables the ineligible alerts and shows why", async () => {
+  //
+  // The reason is a PARAGRAPH. In the label it truncated the name; under it, it
+  // cost three lines per row and a twenty-alert org got an unreadable list. So
+  // the row keeps one line: the name, a chip naming the rule it failed, and the
+  // sentence on hover.
+  //
+  // The chip comes from `reason_code`, never from the sentence — the copy is the
+  // validator's and is free to change.
+  it("disables the ineligible alerts and names the rule on a chip", async () => {
     const wrapper = await mountForm();
     await selectAlertType(wrapper);
     const options = byTest(wrapper, OSelect, "slos-addslo-alert-source").props("options") as {
       value: string;
       label: string;
+      badge?: string;
+      badgeTitle?: string;
       disabled?: boolean;
     }[];
 
-    expect(options.find((o) => o.value === "alert-fast")?.disabled).toBeFalsy();
+    const eligible = options.find((o) => o.value === "alert-fast");
+    expect(eligible?.disabled).toBeFalsy();
+    // An eligible alert has nothing to explain, so it carries no chip.
+    expect(eligible?.badge).toBeUndefined();
+    expect(eligible?.badgeTitle).toBeUndefined();
 
     const cron = options.find((o) => o.value === "alert-cron");
     expect(cron?.disabled).toBe(true);
-    expect(cron?.label).toContain("cron");
+    // The name is the whole label, so the list stays scannable.
+    expect(cron?.label).toBe("weekly report");
+    expect(cron?.badge).toBe("Cron schedule");
+    // The hover says what to CHANGE. The server's own sentence explains the
+    // measurement theory behind the rule, which is the right level for an API
+    // error and the wrong one for someone picking from a list.
+    expect(cron?.badgeTitle).toContain("Change it to a fixed interval");
 
     const silenced = options.find((o) => o.value === "alert-silenced");
     expect(silenced?.disabled).toBe(true);
-    expect(silenced?.label).toContain("silence to 0");
+    expect(silenced?.badge).toBe("Has silence");
+    expect(silenced?.badgeTitle).toContain("Set its silence period to 0");
+  });
+
+  // A code the frontend does not know about must still mark the row: an
+  // ineligible option with no chip reads as a rendering bug, not as a rule.
+  it("falls back to a generic chip for an unrecognised reason", async () => {
+    vi.mocked(sloService.eligibleAlerts).mockResolvedValueOnce({
+      data: {
+        list: [
+          row({
+            alert_id: "alert-future",
+            name: "future rule",
+            eligible: false,
+            reason: "something the UI has not been taught yet",
+            reason_code: "a_rule_added_later",
+          }),
+        ],
+      },
+    } as any);
+
+    const wrapper = await mountForm();
+    await selectAlertType(wrapper);
+    const options = byTest(wrapper, OSelect, "slos-addslo-alert-source").props("options") as {
+      value: string;
+      badge?: string;
+      badgeTitle?: string;
+    }[];
+    const future = options.find((o) => o.value === "alert-future");
+    expect(future?.badge).toBe("Not eligible");
+    expect(future?.badgeTitle).toBe("something the UI has not been taught yet");
   });
 
   // A source evaluating slower than 300s cannot be used at all — 300 is the
@@ -224,11 +278,17 @@ describe("AddSlo — alert SLI", () => {
     const options = byTest(wrapper, OSelect, "slos-addslo-alert-source").props("options") as {
       value: string;
       label: string;
+      badge?: string;
+      badgeTitle?: string;
       disabled?: boolean;
     }[];
     const slow = options.find((o) => o.value === "alert-slow");
     expect(slow?.disabled).toBe(true);
-    expect(slow?.label).toContain("once per slice");
+    expect(slow?.badge).toBe("Runs too rarely");
+    // The cadence is named in the units a person would say it in, and the
+    // requirement is stated as a number they can act on.
+    expect(slow?.badgeTitle).toContain("runs every 10 minutes");
+    expect(slow?.badgeTitle).toContain("at least every 5 minutes");
   });
 
   it("defaults the slice to 60 for a one-minute source", async () => {
@@ -288,6 +348,10 @@ describe("AddSlo — alert SLI", () => {
     const wrapper = await mountForm();
     await selectAlertType(wrapper);
     await pickSource(wrapper, "alert-fast");
+    // The name is required and this test is about the config, so supplying one
+    // is setup — without it the save is refused and nothing reaches the spy.
+    await wrapper.find('[data-test="slos-addslo-name-field"]').setValue("payload-fixture");
+    await flushPromises();
     await wrapper.find('[data-test="slos-addslo-save"]').trigger("click");
     await flushPromises();
 
@@ -313,6 +377,22 @@ describe("AddSlo — time-slice SLI", () => {
   it("sends the query language required by the API", async () => {
     const wrapper = await mountForm();
     await wrapper.find('[data-test="slos-addslo-sli-type-time_slice"]').trigger("click");
+    // A time slice needs a name, a stream, an aggregate and a threshold before
+    // the form will submit at all; the subject here is only what the payload
+    // then DECLARES as its language.
+    await wrapper.find('[data-test="slos-addslo-name-field"]').setValue("payload-fixture");
+    await wrapper.find('[data-test="slos-addslo-threshold-field"]').setValue("1");
+    byTest(wrapper, OSelect, "slos-addslo-timeslice-stream").vm.$emit(
+      "update:modelValue",
+      "fixture_stream",
+    );
+    // SloExpressionField is auto-stubbed here, so it is found by its declared
+    // `dataTest` PROP rather than by an attribute.
+    wrapper
+      .findAllComponents({ name: "SloExpressionField" })
+      .find((c) => c.props("dataTest") === "slos-addslo-aggregate")!
+      .vm.$emit("update:modelValue", "avg(took)");
+    await flushPromises();
     await wrapper.find('[data-test="slos-addslo-save"]').trigger("click");
     await flushPromises();
 

--- a/web/src/views/slos/AddSloCountPromql.spec.ts
+++ b/web/src/views/slos/AddSloCountPromql.spec.ts
@@ -163,8 +163,40 @@ const setField = async (w: Form, test: string, value: string) => {
   await flushPromises();
 };
 
+/**
+ * Save, seeding the required fields a test has not set.
+ *
+ * These tests are about the PAYLOAD, not about identity or the objective — but
+ * the form refuses to submit while a required field is blank, so supplying one
+ * is setup rather than subject. Left out, every assertion below would fail as
+ * "no request was made" instead of naming what it actually checks.
+ */
 const save = async (w: Form) => {
+  await seedRequired(w);
   await w.find('[data-test="slos-addslo-save"]').trigger("click");
+  await flushPromises();
+};
+
+/** Fill any required field the test left empty, and only those. */
+const seedRequired = async (w: Form) => {
+  const name = w.find('[data-test="slos-addslo-name-field"]');
+  if (!(name.element as HTMLInputElement).value) await name.setValue("payload-fixture");
+
+  // Only rendered on the time-slice branch, and only that branch requires it.
+  const threshold = w.find('[data-test="slos-addslo-threshold-field"]');
+  if (threshold.exists() && !(threshold.element as HTMLInputElement).value) {
+    await threshold.setValue("1");
+  }
+
+  // Exactly one of these is mounted, and a PromQL count mounts neither.
+  for (const test of ["slos-addslo-stream", "slos-addslo-timeslice-stream"]) {
+    const picker = w
+      .findAllComponents(OSelect)
+      .find((c) => String(c.vm.$attrs["data-test"]) === test);
+    if (picker && !picker.props("modelValue")) {
+      picker.vm.$emit("update:modelValue", "fixture_stream");
+    }
+  }
   await flushPromises();
 };
 
@@ -226,15 +258,17 @@ describe("AddSlo — count PromQL", () => {
 
     // `CountSource` has no `deny_unknown_fields`, so a spare key is ignored —
     // but a MISSING one is a deserialization failure (axum `Json` -> 422), and
-    // 422 says nothing a user can act on. Sent empty, the same mistake comes
-    // back as the validator's own `EmptyExpression`.
-    it("always sends both keys, even when an expression is still empty", async () => {
+    // 422 says nothing a user can act on. The form now stops the half-filled
+    // pair before it becomes that 422, which is the only reason `pruned()`
+    // dropping the empty key is no longer a problem — so the guard is that no
+    // request is made at all.
+    it("refuses a half-filled pair rather than sending one key", async () => {
       const w = await mountForm();
       await setSelect(w, "slos-addslo-stream-type", "metrics");
       await setField(w, "slos-addslo-promql-good", GOOD);
       await save(w);
 
-      expect(savedSource().query).toEqual({ good: GOOD, total: "" });
+      expect(vi.mocked(sloService.create)).not.toHaveBeenCalled();
     });
 
     // The other half of the rule, and the one with existing SLOs behind it:

--- a/web/src/views/slos/AddSloMetricsLanguage.spec.ts
+++ b/web/src/views/slos/AddSloMetricsLanguage.spec.ts
@@ -189,8 +189,40 @@ const activeLanguage = (w: Form, branch: "count" | "timeslice") =>
       w.find(`[data-test="slos-addslo-${branch}-language-${l}"]`).attributes("data-state") === "on",
   );
 
+/**
+ * Save, seeding the required fields a test has not set.
+ *
+ * These tests are about the PAYLOAD, not about identity or the objective — but
+ * the form refuses to submit while a required field is blank, so supplying one
+ * is setup rather than subject. Left out, every assertion below would fail as
+ * "no request was made" instead of naming what it actually checks.
+ */
 const save = async (w: Form) => {
+  await seedRequired(w);
   await w.find('[data-test="slos-addslo-save"]').trigger("click");
+  await flushPromises();
+};
+
+/** Fill any required field the test left empty, and only those. */
+const seedRequired = async (w: Form) => {
+  const name = w.find('[data-test="slos-addslo-name-field"]');
+  if (!(name.element as HTMLInputElement).value) await name.setValue("payload-fixture");
+
+  // Only rendered on the time-slice branch, and only that branch requires it.
+  const threshold = w.find('[data-test="slos-addslo-threshold-field"]');
+  if (threshold.exists() && !(threshold.element as HTMLInputElement).value) {
+    await threshold.setValue("1");
+  }
+
+  // Exactly one of these is mounted, and a PromQL count mounts neither.
+  for (const test of ["slos-addslo-stream", "slos-addslo-timeslice-stream"]) {
+    const picker = w
+      .findAllComponents(OSelect)
+      .find((c) => String(c.vm.$attrs["data-test"]) === test);
+    if (picker && !picker.props("modelValue")) {
+      picker.vm.$emit("update:modelValue", "fixture_stream");
+    }
+  }
   await flushPromises();
 };
 
@@ -373,6 +405,9 @@ describe("AddSlo — SQL or PromQL over a metrics stream", () => {
         // Required by the variant and seeded by the form, so it is part of the
         // shape even when the dropdown was never opened.
         comparator: "<",
+        // Required too, and supplied by `seedRequired` — a time slice with no
+        // threshold has no rule to apply.
+        threshold: 1,
       });
     });
 

--- a/web/src/views/slos/AddSloTimeSlicePromql.spec.ts
+++ b/web/src/views/slos/AddSloTimeSlicePromql.spec.ts
@@ -163,8 +163,40 @@ const setField = async (w: Form, test: string, value: string) => {
   await flushPromises();
 };
 
+/**
+ * Save, seeding the required fields a test has not set.
+ *
+ * These tests are about the PAYLOAD, not about identity or the objective — but
+ * the form refuses to submit while a required field is blank, so supplying one
+ * is setup rather than subject. Left out, every assertion below would fail as
+ * "no request was made" instead of naming what it actually checks.
+ */
 const save = async (w: Form) => {
+  await seedRequired(w);
   await w.find('[data-test="slos-addslo-save"]').trigger("click");
+  await flushPromises();
+};
+
+/** Fill any required field the test left empty, and only those. */
+const seedRequired = async (w: Form) => {
+  const name = w.find('[data-test="slos-addslo-name-field"]');
+  if (!(name.element as HTMLInputElement).value) await name.setValue("payload-fixture");
+
+  // Only rendered on the time-slice branch, and only that branch requires it.
+  const threshold = w.find('[data-test="slos-addslo-threshold-field"]');
+  if (threshold.exists() && !(threshold.element as HTMLInputElement).value) {
+    await threshold.setValue("1");
+  }
+
+  // Exactly one of these is mounted, and a PromQL count mounts neither.
+  for (const test of ["slos-addslo-stream", "slos-addslo-timeslice-stream"]) {
+    const picker = w
+      .findAllComponents(OSelect)
+      .find((c) => String(c.vm.$attrs["data-test"]) === test);
+    if (picker && !picker.props("modelValue")) {
+      picker.vm.$emit("update:modelValue", "fixture_stream");
+    }
+  }
   await flushPromises();
 };
 


### PR DESCRIPTION
Backport of #14276 to `branch-v1.0.0`. Squashed into one commit; the main-branch PR carries it split across four, with the full rationale.

Related: #14267 (no validation, unclear error), and the picker complaints from the same thread.

## What

The SLO create form had no client-side validation at all — no schema, and a Save button that was never `:disabled`. Every required field reached the API empty. For the fields `wireConfig`'s `pruned()` drops (an empty `good_expr`, for one), the request omitted the key entirely and failed deserialization with an HTTP 422 whose body carries no `message`, so `save()` fell through to axios's own string: **"Request failed with status code 422"**, about a field the user had left blank, with nothing on screen marking which one.

Rules now live in `AddSlo.schema.ts` and `SloAlertForm.schema.ts` — the same arrangement the alert forms use (a zod `superRefine`, path-keyed issues, i18n messages), on the same submit-then-change timing `useOForm` configures elsewhere. Each issue renders at its own field, a refused save toasts through the same surface the alert form uses, and the first offender is scrolled into view.

The required set is a function of SLI type × query language, not a fixed list — a PromQL count needs two expressions and no stream, while a PromQL time-slice still needs the stream — so the schema is built per shape and tested per shape.

## The source-alert picker

Ineligible alerts are listed rather than filtered out, which is right — "your alert is not in the list" is not an explanation. But the reason is a *paragraph*, and it was concatenated into the option label, so each row truncated at the alert's own name.

Rows are one line now: the name, a chip naming the rule it failed (`Cron schedule`, `Has silence`, `Runs too rarely`), and a plain-language "what to change" on hover — "Set its silence period to 0", "Change it to a fixed interval". The chip is keyed off a new `reason_code` on the eligibility response, **the one backend change here** (~20 lines), because `Display` is prose and matching on it would break silently the next time the copy is edited.

Also drops the duplicate "Folder" label above the folder picker, which had left that column a row taller than the two beside it, and top-aligns the row so folder / name / tags read as one set.

## Nothing is refused that the API would accept

Every client rule mirrors a backend one — `TargetOutOfRange`, `TargetTooPrecise`, `ThresholdNotFinite`, `GroupedRequiresCoarseSlice`, `ErrorBudgetOutOfRange`, `ShortWindowExceedsLong`. The rules the client cannot know (`BurnRateAboveMax`, source eligibility, duplicate names) still come back from the server exactly as before. Values a truthiness check would wrongly reject are covered explicitly: a time-slice threshold of `0`, a silence of `0`, and an error-budget alert whose windows are deliberately `null`.

## Tests

| | |
|---|---|
| `AddSlo.schema.spec.ts` | 22 |
| `SloAlertForm.schema.spec.ts` | 12 |
| `slo-required-fields.spec.js` | 24 |
| `source_alert_code` (Rust) | 2 |

The Playwright tests assert two things per field: the message lands on the field, **and** no request is issued — the second is load-bearing, since a check that only decorates the field after the server's 422 looks identical on screen.

## Verification on this branch

Patch applied to `branch-v1.0.0` with no conflicts. 371/371 SLO + OSelect unit tests, `vue-tsc` clean, `cargo check` clean, and `cargo test -p config` green including the two new code tests.