### PR TITLE
fix: typos in Rust comments and doc comments

### DIFF
--- a/src/api/management/src/request/users/mod.rs
+++ b/src/api/management/src/request/users/mod.rs
@@ -572,7 +572,7 @@ pub async fn authentication(
         .collect::<Vec<_>>()
         .join("&");
 
-    // Until decoding the token or body, we can not know the the user_email
+    // Until decoding the token or body, we can not know the user_email
     #[cfg(feature = "enterprise")]
     let mut audit_message = AuditMessage {
         user_email: "".to_string(),

--- a/src/config/src/utils/async_walkdir/error.rs
+++ b/src/config/src/utils/async_walkdir/error.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 pub struct Error(#[from] InnerError);
 
 impl Error {
-    /// Returns the path where the error occured if it applies,
+    /// Returns the path where the error occurred if it applies,
     /// for instance during IO operations.
     pub fn path(&self) -> Option<&Path> {
         let InnerError::Io { ref path, .. } = self.0;
@@ -52,9 +52,9 @@ impl From<Error> for io::Error {
 #[derive(Debug, Error)]
 pub enum InnerError {
     #[error("IO error at '{path}': {source}")]
-    /// A error produced during an IO operation.
+    /// An error produced during an IO operation.
     Io {
-        /// The path in the directory tree where the IO error occured.
+        /// The path in the directory tree where the IO error occurred.
         path: PathBuf,
         /// The IO error.
         source: io::Error,

--- a/src/core/src/alerts/scheduler/handlers.rs
+++ b/src/core/src/alerts/scheduler/handlers.rs
@@ -2234,7 +2234,7 @@ async fn handle_alert_triggers(
                     }
                     #[allow(clippy::collapsible_match)]
                     (Some(RunOutcome::Pending), Some(last)) => {
-                        // last state was pending, so check if the the pending state exists for more
+                        // last state was pending, so check if the pending state exists for more
                         // than pending seconds or not.
                         if now - last < alert.pending_period_sec.saturating_mul(1_000_000) {
                             trigger_data_stream.status = RunOutcome::Pending;

--- a/src/infra/src/table/search_job/search_jobs.rs
+++ b/src/infra/src/table/search_job/search_jobs.rs
@@ -395,7 +395,7 @@ pub async fn delete_by_org(org_id: &str) -> Result<(), errors::Error> {
 // 6. commit the transaction
 // NOTE: this function can ensure,
 // 1. for finished job, it reset all partition job's status, result_path, error_message
-// 2. for failed job, it reset faild job and all pending job's status, result_path, error_message
+// 2. for failed job, it reset failed job and all pending job's status, result_path, error_message
 pub async fn retry_search_job(
     job_id: &str,
     new_trace_id: &str,


### PR DESCRIPTION
Six comment/doc-comment typos across four files:

- `alerts/scheduler/handlers.rs` + `api/management/src/request/users/mod.rs`: "**the the** pending/user_email"
- `config/src/utils/async_walkdir/error.rs`: "**occured**" ×2 → "occurred"; "**A** error produced" → "An error"
- `infra/src/table/search_job/search_jobs.rs`: "**faild** job" → "failed job"

Comments/doc comments only — no behavior change, so the unit-test coverage gate is unaffected.