### PR TITLE
docs: fix web/AGENTS.md's CLAUDE.md link to the repo root

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent guidance for `web/`
 
-See [CLAUDE.md](CLAUDE.md) for the conventions (stack, "build from the O2 component library in
+See [CLAUDE.md](../CLAUDE.md) for the conventions (stack, "build from the O2 component library in
 `web/src/lib`", the
 `ui-architect` and `eslint-error-handling` skills, ratchet rules, and commands). This file is a
 thin pointer so non-Claude tools (Cursor, etc.) that read `AGENTS.md` pick up the same source.


### PR DESCRIPTION
`web/AGENTS.md` links `[CLAUDE.md](CLAUDE.md)` — resolved relative to `web/` it 404s; the file lives at the repo root. Link now uses `../CLAUDE.md`.