### PR TITLE
refactor(promql): split the fused fold by DataFusion operator; keep approx_distinct off AggregateTopkExec

### DIFF
--- a/src/promql/src/engine/streaming.rs
+++ b/src/promql/src/engine/streaming.rs
@@ -139,7 +139,7 @@ impl Engine {
                 .await?
                 {
                     None => Ok(None),
-                    Some(sources) => fused::project(sources, eval).await.map(Some),
+                    Some(sources) => fused::eval_range(sources, eval).await.map(Some),
                 }
             };
             if let Some((series, scanned)) = self

--- a/src/promql/src/engine/streaming.rs
+++ b/src/promql/src/engine/streaming.rs
@@ -139,7 +139,7 @@ impl Engine {
                 .await?
                 {
                     None => Ok(None),
-                    Some(sources) => fused::map_sources(sources, eval).await.map(Some),
+                    Some(sources) => fused::project(sources, eval).await.map(Some),
                 }
             };
             if let Some((series, scanned)) = self

--- a/src/promql/src/fused/aggregate.rs
+++ b/src/promql/src/fused/aggregate.rs
@@ -13,81 +13,26 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! The single fused fold: every series stream folds its series into per-group
-//! accumulators, and the sources merge in order at the end. The
-//! producers only decide how series arrive; the aggregation lives here once.
+//! The fused aggregate: every partition folds its series into per-group accumulators (partial),
+//! and the partitions merge in order at the end (final). The streams only decide how series
+//! arrive; the aggregation lives here once.
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use config::meta::promql::value::{
-    CounterSeries, EvalContext, ExtrapolationKind, Labels, RangeValue, Sample, TimeWindow, Value,
-};
-use datafusion::error::{DataFusionError, Result};
+use config::meta::promql::value::{Labels, RangeValue, Value};
+use datafusion::error::Result;
 use hashbrown::{HashMap, hash_map::Entry};
-use tokio::task::JoinSet;
 
-use super::{accumulator::FusedAccumulator, op::FusedAggOp};
-use crate::{
-    functions::{RangeFunc, advance_sample_window},
-    micros,
-    series_stream::SeriesStream,
+use super::{
+    accumulator::FusedAccumulator, collect_partitioned, op::FusedAggOp, range_expr::RangeExpr,
 };
+use crate::series_stream::SeriesStream;
 
 pub(super) type GroupAccs = HashMap<u64, GroupEntry>;
 
 pub(super) struct GroupEntry {
     labels: Labels,
     acc: FusedAccumulator,
-}
-
-/// How one series becomes per-step values: the range function, its window, and the slots.
-pub(crate) struct RangeExpr {
-    pub(crate) func: Arc<dyn RangeFunc>,
-    counter_kind: Option<ExtrapolationKind>,
-    pub(crate) range: Duration,
-    pub(crate) eval_ctx: EvalContext,
-    pub(crate) timestamps: Vec<i64>,
-}
-
-impl RangeExpr {
-    pub(crate) fn new(func: Arc<dyn RangeFunc>, range: Duration, eval_ctx: &EvalContext) -> Self {
-        Self {
-            counter_kind: func.counter_extrapolation(),
-            func,
-            range,
-            eval_ctx: eval_ctx.clone(),
-            timestamps: eval_ctx.timestamps(),
-        }
-    }
-
-    /// Evaluates the function over one series, handing each value to `emit` with its slot.
-    fn evaluate(&self, samples: &[Sample], mut emit: impl FnMut(usize, f64)) {
-        let range_micros = micros(self.range);
-        let mut start_index = 0;
-        let mut end_index = 0;
-        let counter =
-            CounterSeries::try_new(samples, self.counter_kind, &self.eval_ctx, range_micros);
-
-        for (slot, &eval_ts) in self.timestamps.iter().enumerate() {
-            let window_samples = advance_sample_window(
-                samples,
-                eval_ts - range_micros,
-                eval_ts,
-                &mut start_index,
-                &mut end_index,
-            );
-            if window_samples.is_empty() {
-                continue;
-            }
-            let value = match &counter {
-                Some(counter) => counter.extrapolate(start_index, end_index, eval_ts, self.range),
-                None => self.func.exec(window_samples, eval_ts, &self.range),
-            };
-            if let Some(value) = value {
-                emit(slot, value);
-            }
-        }
-    }
 }
 
 /// Aggregates every partition, partial then final; each source opens inside its own task, and
@@ -143,29 +88,6 @@ async fn aggregate_partial<S: SeriesStream>(
     Ok((groups, series_count))
 }
 
-/// Collects every partition in order; the first failure fails the whole, and dropping the set
-/// aborts the rest.
-async fn collect_partitioned<T, Fut>(parts: Vec<Fut>) -> Result<Vec<T>>
-where
-    T: Send + 'static,
-    Fut: Future<Output = Result<T>> + Send + 'static,
-{
-    let mut results: Vec<Option<T>> = parts.iter().map(|_| None).collect();
-    let mut tasks = JoinSet::new();
-    for (index, part) in parts.into_iter().enumerate() {
-        tasks.spawn(async move { (index, part.await) });
-    }
-    // sources finish in any order; the merge needs them in source order
-    while let Some(joined) = tasks.join_next().await {
-        let (index, part) = joined.map_err(|e| DataFusionError::Execution(e.to_string()))?;
-        results[index] = Some(part?);
-    }
-    Ok(results
-        .into_iter()
-        .map(|part| part.expect("every source joined"))
-        .collect())
-}
-
 /// The final aggregate: partial groups merged in partition order, groups without output dropped
 /// like the generic path.
 fn aggregate_final(folds: Vec<GroupAccs>, timestamps: &[i64]) -> Value {
@@ -205,69 +127,6 @@ fn aggregate_final(folds: Vec<GroupAccs>, timestamps: &[i64]) -> Value {
     }
 }
 
-/// Maps every source's series through the function and returns them whole, in source order;
-/// dropping the future aborts the sources.
-pub(crate) async fn map_sources<F, S>(
-    sources: Vec<F>,
-    eval: Arc<RangeExpr>,
-) -> Result<(Vec<RangeValue>, usize)>
-where
-    F: Future<Output = Result<S>> + Send + 'static,
-    S: SeriesStream + 'static,
-{
-    let start_time = std::time::Instant::now();
-    let func_name = eval.func.name();
-    let trace_id = eval.eval_ctx.trace_id.clone();
-    log::info!(
-        "[trace_id: {trace_id}] [PromQL Timing] streaming {func_name}() started with {} partitions",
-        sources.len(),
-    );
-    let parts = sources
-        .into_iter()
-        .map(|source| {
-            let eval = eval.clone();
-            async move { map_partition(source.await?, eval).await }
-        })
-        .collect();
-    let parts = collect_partitioned(parts).await?;
-    let series_count: usize = parts.iter().map(|(_, series)| series).sum();
-    let series: Vec<RangeValue> = parts.into_iter().flat_map(|(series, _)| series).collect();
-    log::info!(
-        "[trace_id: {trace_id}] [PromQL Timing] streaming {func_name}() execution took: {:?}, mapped {} of {series_count} series",
-        start_time.elapsed(),
-        series.len(),
-    );
-    Ok((series, series_count))
-}
-
-/// Maps one source's series; like the generic evaluator, a series with no value is dropped.
-async fn map_partition<S: SeriesStream>(
-    mut source: S,
-    eval: Arc<RangeExpr>,
-) -> Result<(Vec<RangeValue>, usize)> {
-    let mut series = Vec::new();
-    let mut series_count = 0;
-    while source.advance().await?.is_some() {
-        let labels = source.labels();
-        let samples = source.consume().await?;
-        let mut values = Vec::with_capacity(eval.timestamps.len());
-        eval.evaluate(samples, |slot, value| {
-            values.push(Sample::new(eval.timestamps[slot], value));
-        });
-        if !values.is_empty() {
-            series.push(RangeValue {
-                labels,
-                samples: values,
-                exemplars: None,
-                time_window: Some(TimeWindow::new(eval.range)),
-            });
-        }
-        series_count += 1;
-        tokio::task::consume_budget().await;
-    }
-    Ok((series, series_count))
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
@@ -278,10 +137,11 @@ mod tests {
         time::Duration,
     };
 
-    use config::meta::promql::value::{Labels, Sample};
+    use config::meta::promql::value::{EvalContext, Labels, Sample};
+    use datafusion::error::DataFusionError;
 
     use super::*;
-    use crate::functions;
+    use crate::functions::{self, RangeFunc};
 
     /// Errors on its first series.
     struct FailingStream;

--- a/src/promql/src/fused/eval_range.rs
+++ b/src/promql/src/fused/eval_range.rs
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! The fused projection: a bare range function whose output is the result, so every series
-//! maps to its own values and nothing folds.
+//! The streaming `eval_range`: the range function over every series, its output kept whole
+//! because it is the result.
 
 use std::sync::Arc;
 
@@ -24,9 +24,9 @@ use datafusion::error::Result;
 use super::{collect_partitioned, range_expr::RangeExpr};
 use crate::series_stream::SeriesStream;
 
-/// Projects every partition's series through the function and returns them whole, in partition
-/// order; dropping the future aborts the partitions.
-pub(crate) async fn project<F, S>(
+/// Evaluates the range function over every partition's series and returns them whole, in
+/// partition order; dropping the future aborts the partitions.
+pub(crate) async fn eval_range<F, S>(
     sources: Vec<F>,
     eval: Arc<RangeExpr>,
 ) -> Result<(Vec<RangeValue>, usize)>
@@ -45,23 +45,23 @@ where
         .into_iter()
         .map(|source| {
             let eval = eval.clone();
-            async move { project_partition(source.await?, eval).await }
+            async move { eval_range_partition(source.await?, eval).await }
         })
         .collect();
     let parts = collect_partitioned(parts).await?;
     let series_count: usize = parts.iter().map(|(_, series)| series).sum();
     let series: Vec<RangeValue> = parts.into_iter().flat_map(|(series, _)| series).collect();
     log::info!(
-        "[trace_id: {trace_id}] [PromQL Timing] streaming {func_name}() execution took: {:?}, mapped {} of {series_count} series",
+        "[trace_id: {trace_id}] [PromQL Timing] streaming {func_name}() execution took: {:?}, evaluated {} of {series_count} series",
         start_time.elapsed(),
         series.len(),
     );
     Ok((series, series_count))
 }
 
-/// Projects one partition's series; like the generic evaluator, a series with no value is
+/// Evaluates one partition's series; like the generic evaluator, a series with no value is
 /// dropped.
-async fn project_partition<S: SeriesStream>(
+async fn eval_range_partition<S: SeriesStream>(
     mut source: S,
     eval: Arc<RangeExpr>,
 ) -> Result<(Vec<RangeValue>, usize)> {

--- a/src/promql/src/fused/matrix.rs
+++ b/src/promql/src/fused/matrix.rs
@@ -24,10 +24,7 @@ use infra::errors::ErrorCodes;
 use promql_parser::parser::LabelModifier;
 use rayon::prelude::*;
 
-use super::{
-    fold::{RangeExpr, aggregate},
-    op::FusedAggOp,
-};
+use super::{aggregate::aggregate, op::FusedAggOp, range_expr::RangeExpr};
 use crate::{
     functions::{KEEP_METRIC_NAME_FUNC, RangeFunc},
     series_stream::matrix::matrix_streams,

--- a/src/promql/src/fused/mod.rs
+++ b/src/promql/src/fused/mod.rs
@@ -18,13 +18,41 @@
 //! evaluator's intermediate per-series materialization.
 
 mod accumulator;
-mod fold;
+mod aggregate;
 pub(crate) mod matrix;
 mod op;
+mod project;
+mod range_expr;
 pub(crate) mod stream;
 
-pub(crate) use fold::{RangeExpr, map_sources};
+use datafusion::error::{DataFusionError, Result};
 pub(crate) use op::FusedAggOp;
+pub(crate) use project::project;
+pub(crate) use range_expr::RangeExpr;
+use tokio::task::JoinSet;
+
+/// Collects every partition in order; the first failure fails the whole, and dropping the set
+/// aborts the rest.
+pub(super) async fn collect_partitioned<T, Fut>(parts: Vec<Fut>) -> Result<Vec<T>>
+where
+    T: Send + 'static,
+    Fut: Future<Output = Result<T>> + Send + 'static,
+{
+    let mut results: Vec<Option<T>> = parts.iter().map(|_| None).collect();
+    let mut tasks = JoinSet::new();
+    for (index, part) in parts.into_iter().enumerate() {
+        tasks.spawn(async move { (index, part.await) });
+    }
+    // sources finish in any order; the merge needs them in source order
+    while let Some(joined) = tasks.join_next().await {
+        let (index, part) = joined.map_err(|e| DataFusionError::Execution(e.to_string()))?;
+        results[index] = Some(part?);
+    }
+    Ok(results
+        .into_iter()
+        .map(|part| part.expect("every source joined"))
+        .collect())
+}
 
 #[cfg(test)]
 mod test_support {

--- a/src/promql/src/fused/mod.rs
+++ b/src/promql/src/fused/mod.rs
@@ -19,15 +19,15 @@
 
 mod accumulator;
 mod aggregate;
+mod eval_range;
 pub(crate) mod matrix;
 mod op;
-mod project;
 mod range_expr;
 pub(crate) mod stream;
 
 use datafusion::error::{DataFusionError, Result};
+pub(crate) use eval_range::eval_range;
 pub(crate) use op::FusedAggOp;
-pub(crate) use project::project;
 pub(crate) use range_expr::RangeExpr;
 use tokio::task::JoinSet;
 

--- a/src/promql/src/fused/project.rs
+++ b/src/promql/src/fused/project.rs
@@ -1,0 +1,89 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The fused projection: a bare range function whose output is the result, so every series
+//! maps to its own values and nothing folds.
+
+use std::sync::Arc;
+
+use config::meta::promql::value::{RangeValue, Sample, TimeWindow};
+use datafusion::error::Result;
+
+use super::{collect_partitioned, range_expr::RangeExpr};
+use crate::series_stream::SeriesStream;
+
+/// Projects every partition's series through the function and returns them whole, in partition
+/// order; dropping the future aborts the partitions.
+pub(crate) async fn project<F, S>(
+    sources: Vec<F>,
+    eval: Arc<RangeExpr>,
+) -> Result<(Vec<RangeValue>, usize)>
+where
+    F: Future<Output = Result<S>> + Send + 'static,
+    S: SeriesStream + 'static,
+{
+    let start_time = std::time::Instant::now();
+    let func_name = eval.func.name();
+    let trace_id = eval.eval_ctx.trace_id.clone();
+    log::info!(
+        "[trace_id: {trace_id}] [PromQL Timing] streaming {func_name}() started with {} partitions",
+        sources.len(),
+    );
+    let parts = sources
+        .into_iter()
+        .map(|source| {
+            let eval = eval.clone();
+            async move { project_partition(source.await?, eval).await }
+        })
+        .collect();
+    let parts = collect_partitioned(parts).await?;
+    let series_count: usize = parts.iter().map(|(_, series)| series).sum();
+    let series: Vec<RangeValue> = parts.into_iter().flat_map(|(series, _)| series).collect();
+    log::info!(
+        "[trace_id: {trace_id}] [PromQL Timing] streaming {func_name}() execution took: {:?}, mapped {} of {series_count} series",
+        start_time.elapsed(),
+        series.len(),
+    );
+    Ok((series, series_count))
+}
+
+/// Projects one partition's series; like the generic evaluator, a series with no value is
+/// dropped.
+async fn project_partition<S: SeriesStream>(
+    mut source: S,
+    eval: Arc<RangeExpr>,
+) -> Result<(Vec<RangeValue>, usize)> {
+    let mut series = Vec::new();
+    let mut series_count = 0;
+    while source.advance().await?.is_some() {
+        let labels = source.labels();
+        let samples = source.consume().await?;
+        let mut values = Vec::with_capacity(eval.timestamps.len());
+        eval.evaluate(samples, |slot, value| {
+            values.push(Sample::new(eval.timestamps[slot], value));
+        });
+        if !values.is_empty() {
+            series.push(RangeValue {
+                labels,
+                samples: values,
+                exemplars: None,
+                time_window: Some(TimeWindow::new(eval.range)),
+            });
+        }
+        series_count += 1;
+        tokio::task::consume_budget().await;
+    }
+    Ok((series, series_count))
+}

--- a/src/promql/src/fused/range_expr.rs
+++ b/src/promql/src/fused/range_expr.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //! The range function as a physical expression: one series in, one value per evaluation slot
-//! out, shared by the aggregate and the projection.
+//! out, shared by the aggregate and `eval_range`.
 
 use std::{sync::Arc, time::Duration};
 

--- a/src/promql/src/fused/range_expr.rs
+++ b/src/promql/src/fused/range_expr.rs
@@ -1,0 +1,76 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The range function as a physical expression: one series in, one value per evaluation slot
+//! out, shared by the aggregate and the projection.
+
+use std::{sync::Arc, time::Duration};
+
+use config::meta::promql::value::{CounterSeries, EvalContext, ExtrapolationKind, Sample};
+
+use crate::{
+    functions::{RangeFunc, advance_sample_window},
+    micros,
+};
+
+/// How one series becomes per-step values: the range function, its window, and the slots.
+pub(crate) struct RangeExpr {
+    pub(crate) func: Arc<dyn RangeFunc>,
+    counter_kind: Option<ExtrapolationKind>,
+    pub(crate) range: Duration,
+    pub(crate) eval_ctx: EvalContext,
+    pub(crate) timestamps: Vec<i64>,
+}
+
+impl RangeExpr {
+    pub(crate) fn new(func: Arc<dyn RangeFunc>, range: Duration, eval_ctx: &EvalContext) -> Self {
+        Self {
+            counter_kind: func.counter_extrapolation(),
+            func,
+            range,
+            eval_ctx: eval_ctx.clone(),
+            timestamps: eval_ctx.timestamps(),
+        }
+    }
+
+    /// Evaluates the function over one series, handing each value to `emit` with its slot.
+    pub(super) fn evaluate(&self, samples: &[Sample], mut emit: impl FnMut(usize, f64)) {
+        let range_micros = micros(self.range);
+        let mut start_index = 0;
+        let mut end_index = 0;
+        let counter =
+            CounterSeries::try_new(samples, self.counter_kind, &self.eval_ctx, range_micros);
+
+        for (slot, &eval_ts) in self.timestamps.iter().enumerate() {
+            let window_samples = advance_sample_window(
+                samples,
+                eval_ts - range_micros,
+                eval_ts,
+                &mut start_index,
+                &mut end_index,
+            );
+            if window_samples.is_empty() {
+                continue;
+            }
+            let value = match &counter {
+                Some(counter) => counter.extrapolate(start_index, end_index, eval_ts, self.range),
+                None => self.func.exec(window_samples, eval_ts, &self.range),
+            };
+            if let Some(value) = value {
+                emit(slot, value);
+            }
+        }
+    }
+}

--- a/src/promql/src/fused/stream.rs
+++ b/src/promql/src/fused/stream.rs
@@ -30,7 +30,7 @@ use config::{
 use datafusion::{arrow::datatypes::Schema, error::Result, prelude::SessionContext};
 use promql_parser::parser::LabelModifier;
 
-use super::fold::{RangeExpr, aggregate};
+use super::{aggregate::aggregate, range_expr::RangeExpr};
 use crate::{
     functions::{KEEP_METRIC_NAME_FUNC, RangeFunc},
     fused::FusedAggOp,
@@ -141,11 +141,7 @@ mod tests {
     use promql_parser::label::{Labels as ModifierLabels, Matchers};
 
     use super::{
-        super::{
-            fold::{RangeExpr, map_sources},
-            matrix,
-            test_support::*,
-        },
+        super::{matrix, project::project, range_expr::RangeExpr, test_support::*},
         *,
     };
     use crate::{functions, series_stream::merge::series_label_columns};
@@ -442,7 +438,7 @@ mod tests {
             .unwrap()
             .expect("the sorted table streams");
             let eval = Arc::new(RangeExpr::new(func, range, &eval_ctx));
-            let (actual, _) = map_sources(sources, eval).await.unwrap();
+            let (actual, _) = project(sources, eval).await.unwrap();
             assert_matrix_close(
                 canonical_matrix(expected),
                 canonical_matrix(Value::Matrix(actual)),

--- a/src/promql/src/fused/stream.rs
+++ b/src/promql/src/fused/stream.rs
@@ -141,7 +141,7 @@ mod tests {
     use promql_parser::label::{Labels as ModifierLabels, Matchers};
 
     use super::{
-        super::{matrix, project::project, range_expr::RangeExpr, test_support::*},
+        super::{eval_range::eval_range, matrix, range_expr::RangeExpr, test_support::*},
         *,
     };
     use crate::{functions, series_stream::merge::series_label_columns};
@@ -438,7 +438,7 @@ mod tests {
             .unwrap()
             .expect("the sorted table streams");
             let eval = Arc::new(RangeExpr::new(func, range, &eval_ctx));
-            let (actual, _) = project(sources, eval).await.unwrap();
+            let (actual, _) = eval_range(sources, eval).await.unwrap();
             assert_matrix_close(
                 canonical_matrix(expected),
                 canonical_matrix(Value::Matrix(actual)),

--- a/src/search/src/datafusion/optimizer/physical_optimizer/aggregate_topk.rs
+++ b/src/search/src/datafusion/optimizer/physical_optimizer/aggregate_topk.rs
@@ -73,9 +73,7 @@ impl PhysicalOptimizerRule for AggregateTopkRule {
         }
 
         if let Some(expr) = final_agg_plan.aggr_expr().first() {
-            if !["count", "avg", "min", "max", "sum", "approx_distinct"]
-                .contains(&expr.fun().name())
-            {
+            if !["count", "avg", "min", "max", "sum"].contains(&expr.fun().name()) {
                 return Ok(plan);
             }
             let expr_name = expr.name();
@@ -225,5 +223,69 @@ impl<'n> TreeNodeVisitor<'n> for SortLimitVisitor {
             }
         }
         Ok(TreeNodeRecursion::Continue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::{physical_plan::displayable, prelude::SessionConfig};
+
+    use super::*;
+    use crate::datafusion::table_provider::empty_table::NewEmptyTable;
+
+    /// Pins the flag on so a local env override cannot turn the rule off.
+    fn enable_topk() {
+        static ENABLE: std::sync::Once = std::sync::Once::new();
+        ENABLE.call_once(|| {
+            unsafe { std::env::set_var("ZO_AGGREGATION_TOPK_ENABLED", "true") };
+            config::refresh_config().expect("config refresh");
+        });
+    }
+
+    /// Whether the rule inserts `AggregateTopkExec` for `agg(v)` grouped by `name`, sorted
+    /// on the aggregate and limited.
+    async fn inserts_topk(agg: &str) -> bool {
+        enable_topk();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("v", DataType::Int64, false),
+        ]));
+        let ctx = datafusion::prelude::SessionContext::new_with_config(
+            SessionConfig::new().with_target_partitions(2),
+        );
+        ctx.register_table("t", Arc::new(NewEmptyTable::new("t", schema)))
+            .unwrap();
+        let sql =
+            format!("SELECT name, {agg}(v) AS x FROM t GROUP BY name ORDER BY x DESC LIMIT 10");
+        let plan = ctx
+            .sql(&sql)
+            .await
+            .unwrap()
+            .create_physical_plan()
+            .await
+            .unwrap();
+        let plan = AggregateTopkRule::new(10)
+            .optimize(plan, &ConfigOptions::default())
+            .unwrap();
+        displayable(plan.as_ref())
+            .indent(true)
+            .to_string()
+            .contains("AggregateTopkExec")
+    }
+
+    #[tokio::test]
+    async fn test_topk_keeps_the_supported_aggregates() {
+        for agg in ["count", "avg", "min", "max", "sum"] {
+            assert!(inserts_topk(agg).await, "{agg} must stay eligible");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_topk_skips_approx_distinct() {
+        assert!(
+            !inserts_topk("approx_distinct").await,
+            "approx_distinct must stay on the regular aggregation path"
+        );
     }
 }


### PR DESCRIPTION
Follows #14294 (merged). Closes #14282.

## Summary

Two things, both small:

**1. Split `fused/fold.rs` by DataFusion operator** (moves only). It held four things a DataFusion reader would look for in four places:

| before (`fused/fold.rs`) | after | DataFusion |
|---|---|---|
| `RangeExpr` + `evaluate` | `fused/range_expr.rs` | `PhysicalExpr` |
| `GroupAccs`, `GroupEntry`, `aggregate` / `aggregate_partial` / `aggregate_final` | `fused/aggregate.rs` | `AggregateExec` (Partial / Final) |
| `map_sources` / `map_partition` → **`eval_range`** / **`eval_range_partition`** | `fused/eval_range.rs` | none; it is the streaming twin of `functions::eval_range`, so it takes that name |
| `collect_partitioned` | `fused/mod.rs` | `physical_plan::collect_partitioned` |

The fail-fast test and its mock streams move with `aggregate_partial`. Verified as a pure move: a line-multiset diff of the old files against the new ones leaves only module docs, import regrouping, visibility markers, and the rename.

**2. `AggregateTopkRule` no longer rewrites `approx_distinct`** (#14282). The allowlist keeps `count`, `avg`, `min`, `max`, `sum`; a grouped `approx_distinct` with `ORDER BY … LIMIT` stays on the regular aggregation path and the SQL function itself is untouched.

## Tests

- `physical_optimizer/aggregate_topk.rs`: the rule inserts `AggregateTopkExec` for each supported aggregate and does not for `approx_distinct`, on a physical plan built from SQL over an empty table.
- 411 promql tests unchanged and passing; workspace clippy clean.
