### PR TITLE
perf(promql): cut the search groups at the WAL floor so the head streams

### DIFF
--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -163,6 +163,13 @@ impl Engine {
                     (Value::Float(left), Value::Matrix(right)) => {
                         binaries::vector_scalar_bin_op(expr, right, left, true).await?
                     }
+                    // a set operator keeps the other side when one side has no series at all
+                    (Value::None, Value::Matrix(right)) if expr.op.is_set_operator() => {
+                        binaries::vector_bin_op(expr, vec![], right)?
+                    }
+                    (Value::Matrix(left), Value::None) if expr.op.is_set_operator() => {
+                        binaries::vector_bin_op(expr, left, vec![])?
+                    }
                     (Value::None, Value::None) => Value::None,
                     _ => {
                         log::debug!(
@@ -635,6 +642,45 @@ pub(crate) mod tests {
         } else {
             panic!("Expected Value::Float");
         }
+    }
+
+    #[tokio::test]
+    async fn test_set_operators_keep_the_other_side_when_one_is_empty() {
+        let trace_id = "test_trace";
+        let query_ctx = create_test_query_ctx(trace_id, "test_org", 30);
+        // three steps, so the vector side is not folded into a scalar
+        let eval_ctx = EvalContext::new(
+            1640995200000000i64,
+            1640995320000000i64,
+            60000000i64,
+            trace_id.to_string(),
+        );
+        let eval = |query: &str| {
+            let ctx = Arc::new(PromqlContext::new(
+                query_ctx.clone(),
+                SimpleMockProvider,
+                vec![],
+            ));
+            let expr = promql_parser::parser::parse(query).unwrap();
+            let eval_ctx = eval_ctx.clone();
+            async move { Engine::new(trace_id, ctx, eval_ctx).exec_expr(&expr).await }
+        };
+
+        // `up` has no data on the mock provider, so the fallback vector must come through
+        let Value::Matrix(series) = eval("up or vector(0)").await.unwrap() else {
+            panic!("`or` with an empty left side must return the right side");
+        };
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0].samples.len(), 3);
+        assert!(series[0].samples.iter().all(|s| s.value == 0.0));
+
+        let Value::Matrix(series) = eval("vector(0) unless up").await.unwrap() else {
+            panic!("`unless` with an empty right side must return the left side");
+        };
+        assert_eq!(series.len(), 1);
+
+        let value = eval("vector(0) and up").await.unwrap();
+        assert!(matches!(value, Value::Matrix(series) if series.is_empty()));
     }
 
     #[tokio::test]

--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -137,8 +137,13 @@ impl Engine {
                 // This is a very special case, as we treat the float also a
                 // `Value::Matrix(vec![element])` therefore, better convert it
                 // back to its representation.
+                // a set operator needs a vector on both sides, so its right side is never folded
                 let rhs = match rhs {
-                    Value::Matrix(m) if m.len() == 1 && m[0].samples.len() == 1 => {
+                    Value::Matrix(m)
+                        if !expr.op.is_set_operator()
+                            && m.len() == 1
+                            && m[0].samples.len() == 1 =>
+                    {
                         Value::Float(m[0].samples[0].value)
                     }
                     _ => rhs,
@@ -681,6 +686,14 @@ pub(crate) mod tests {
 
         let value = eval("vector(0) and up").await.unwrap();
         assert!(matches!(value, Value::Matrix(series) if series.is_empty()));
+
+        // a right side filtered down to one sample must stay a vector for the set operator
+        let sparse = r#"vector(0) or label_replace(timestamp(vector(1)) >= 1640995320, "source", "sparse", "", "")"#;
+        let Value::Matrix(series) = eval(sparse).await.unwrap() else {
+            panic!("`or` must keep a single-sample right side");
+        };
+        assert_eq!(series.len(), 2);
+        assert_eq!(series.iter().map(|s| s.samples.len()).sum::<usize>(), 4);
     }
 
     #[tokio::test]

--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -134,20 +134,8 @@ impl Engine {
                 let return_bool = expr.return_bool();
                 let op = expr.op.is_comparison_operator();
 
-                // This is a very special case, as we treat the float also a
-                // `Value::Matrix(vec![element])` therefore, better convert it
-                // back to its representation.
-                // only a scalar-typed right side folds; a one-sample vector still matches by labels
-                let rhs = match rhs {
-                    Value::Matrix(m)
-                        if expr.rhs.value_type() == ValueType::Scalar
-                            && m.len() == 1
-                            && m[0].samples.len() == 1 =>
-                    {
-                        Value::Float(m[0].samples[0].value)
-                    }
-                    _ => rhs,
-                };
+                let lhs = scalar_operand(lhs, &expr.lhs);
+                let rhs = scalar_operand(rhs, &expr.rhs);
                 match (lhs, rhs) {
                     (Value::Float(left), Value::Float(right)) => {
                         let value = binaries::scalar_binary_operations(
@@ -237,6 +225,21 @@ impl Engine {
                 )));
             }
         })
+    }
+}
+
+/// Folds a scalar-typed operand evaluated as a one-sample series back into a scalar.
+fn scalar_operand(value: Value, expr: &PromExpr) -> Value {
+    // a one-sample vector is not a scalar: it keeps its labels for matching
+    match value {
+        Value::Matrix(m)
+            if expr.value_type() == ValueType::Scalar
+                && m.len() == 1
+                && m[0].samples.len() == 1 =>
+        {
+            Value::Float(m[0].samples[0].value)
+        }
+        other => other,
     }
 }
 
@@ -695,8 +698,18 @@ pub(crate) mod tests {
         assert_eq!(series.iter().map(|s| s.samples.len()).sum::<usize>(), 4);
     }
 
+    fn single_value(value: Value) -> f64 {
+        match value {
+            Value::Float(f) => f,
+            Value::Matrix(series) if series.len() == 1 && series[0].samples.len() == 1 => {
+                series[0].samples[0].value
+            }
+            other => panic!("expected one value, got {:?}", other.get_type()),
+        }
+    }
+
     #[tokio::test]
-    async fn test_only_a_scalar_typed_right_side_folds_into_a_scalar() {
+    async fn test_scalar_typed_operands_fold_on_either_side() {
         // a one-sample vector keeps label matching: the sum exists at that one step only
         let series = matrix(
             eval_on_empty("vector(1) + (timestamp(vector(1)) >= 1640995320)", 3)
@@ -707,14 +720,18 @@ pub(crate) mod tests {
         assert_eq!(series[0].samples.len(), 1);
         assert_eq!(series[0].samples[0].value, 1640995321.0);
 
-        // a scalar-typed right side still applies to every step
-        let series = matrix(
-            eval_on_empty("vector(1) + scalar(vector(2))", 1)
-                .await
-                .unwrap(),
-        );
-        assert_eq!(series.len(), 1);
-        assert_eq!(series[0].samples[0].value, 3.0);
+        // a scalar-typed side folds whichever side it is on, even against a labelled vector
+        let labelled = r#"label_replace(vector(2), "job", "x", "", "")"#;
+        for query in [
+            "vector(1) + scalar(vector(2))".to_string(),
+            format!("scalar(vector(1)) + {labelled}"),
+            format!("sum(scalar(vector(1)) + {labelled})"),
+            format!("{labelled} + scalar(vector(1))"),
+            "scalar(vector(1)) + scalar(vector(2))".to_string(),
+        ] {
+            let value = eval_on_empty(&query, 1).await.unwrap();
+            assert_eq!(single_value(value), 3.0, "{query}");
+        }
     }
 
     #[tokio::test]

--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -134,8 +134,8 @@ impl Engine {
                 let return_bool = expr.return_bool();
                 let op = expr.op.is_comparison_operator();
 
-                let lhs = scalar_operand(lhs, &expr.lhs);
-                let rhs = scalar_operand(rhs, &expr.rhs);
+                let lhs = scalar_operand(lhs, &expr.lhs, &self.eval_ctx);
+                let rhs = scalar_operand(rhs, &expr.rhs, &self.eval_ctx);
                 match (lhs, rhs) {
                     (Value::Float(left), Value::Float(right)) => {
                         let value = binaries::scalar_binary_operations(
@@ -228,12 +228,13 @@ impl Engine {
     }
 }
 
-/// Folds a scalar-typed operand evaluated as a one-sample series back into a scalar.
-fn scalar_operand(value: Value, expr: &PromExpr) -> Value {
+/// Folds a scalar-typed instant operand back into a scalar without broadcasting range samples.
+fn scalar_operand(value: Value, expr: &PromExpr, eval_ctx: &EvalContext) -> Value {
     // a one-sample vector is not a scalar: it keeps its labels for matching
     match value {
         Value::Matrix(m)
-            if expr.value_type() == ValueType::Scalar
+            if eval_ctx.is_instant()
+                && expr.value_type() == ValueType::Scalar
                 && m.len() == 1
                 && m[0].samples.len() == 1 =>
         {
@@ -732,6 +733,67 @@ pub(crate) mod tests {
             let value = eval_on_empty(&query, 1).await.unwrap();
             assert_eq!(single_value(value), 3.0, "{query}");
         }
+    }
+
+    #[tokio::test]
+    async fn test_sparse_scalar_operands_preserve_timestamps() {
+        for (filter, timestamp) in [
+            ("== 1640995200", 1640995200000000),
+            (">= 1640995320", 1640995320000000),
+        ] {
+            let sparse = format!("scalar(timestamp(vector(1)) {filter})");
+            for query in [
+                format!("{sparse} + vector(1)"),
+                format!("vector(1) + {sparse}"),
+            ] {
+                let series = matrix(eval_on_empty(&query, 3).await.unwrap());
+                assert_eq!(series.len(), 1, "{query}");
+                assert_eq!(series[0].samples.len(), 1, "{query}");
+                assert_eq!(series[0].samples[0].timestamp, timestamp, "{query}");
+                assert_eq!(
+                    series[0].samples[0].value,
+                    timestamp as f64 / 1_000_000.0 + 1.0,
+                    "{query}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_constant_operands_preserve_range_steps() {
+        for query in [
+            "vector(2) + 1",
+            "1 + vector(2)",
+            "scalar(vector(1)) + vector(2)",
+            "vector(2) + scalar(vector(1))",
+        ] {
+            let series = matrix(eval_on_empty(query, 3).await.unwrap());
+            assert_eq!(series.len(), 1, "{query}");
+            let samples = &series[0].samples;
+            assert_eq!(samples.len(), 3, "{query}");
+            for (index, sample) in samples.iter().enumerate() {
+                assert_eq!(
+                    sample.timestamp,
+                    1640995200000000 + index as i64 * 60000000,
+                    "{query}"
+                );
+                assert_eq!(sample.value, 3.0, "{query}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_scalar_operand_keeps_single_step_range_timestamp() {
+        let eval_ctx = EvalContext::new(1_000_000, 1_500_000, 1_000_000, "test".into());
+        assert_eq!(eval_ctx.timestamps(), vec![1_000_000]);
+        let expr = promql_parser::parser::parse("scalar(vector(1))").unwrap();
+        let value = Value::Matrix(vec![RangeValue {
+            samples: vec![Sample::new(1_000_000, 1.0)],
+            ..Default::default()
+        }]);
+        let series = matrix(scalar_operand(value, &expr, &eval_ctx));
+        assert_eq!(series[0].samples[0].timestamp, 1_000_000);
+        assert_eq!(series[0].samples[0].value, 1.0);
     }
 
     #[tokio::test]

--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -26,7 +26,7 @@ use datafusion::error::{DataFusionError, Result};
 use hashbrown::HashSet;
 use promql_parser::parser::{
     AggregateExpr, Call, Expr as PromExpr, MatrixSelector, NumberLiteral, ParenExpr, StringLiteral,
-    UnaryExpr,
+    UnaryExpr, value::ValueType,
 };
 
 use crate::{binaries, exec::PromqlContext, promql::label_usage::labels_dropped_at_root};
@@ -137,10 +137,10 @@ impl Engine {
                 // This is a very special case, as we treat the float also a
                 // `Value::Matrix(vec![element])` therefore, better convert it
                 // back to its representation.
-                // a set operator needs a vector on both sides, so its right side is never folded
+                // only a scalar-typed right side folds; a one-sample vector still matches by labels
                 let rhs = match rhs {
                     Value::Matrix(m)
-                        if !expr.op.is_set_operator()
+                        if expr.rhs.value_type() == ValueType::Scalar
                             && m.len() == 1
                             && m[0].samples.len() == 1 =>
                     {
@@ -649,51 +649,72 @@ pub(crate) mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_set_operators_keep_the_other_side_when_one_is_empty() {
+    /// Evaluates `query` on the empty mock provider over `steps` one-minute steps.
+    async fn eval_on_empty(query: &str, steps: i64) -> Result<Value> {
         let trace_id = "test_trace";
-        let query_ctx = create_test_query_ctx(trace_id, "test_org", 30);
-        // three steps, so the vector side is not folded into a scalar
+        let ctx = Arc::new(PromqlContext::new(
+            create_test_query_ctx(trace_id, "test_org", 30),
+            SimpleMockProvider,
+            vec![],
+        ));
+        let start = 1640995200000000i64;
         let eval_ctx = EvalContext::new(
-            1640995200000000i64,
-            1640995320000000i64,
-            60000000i64,
+            start,
+            start + (steps - 1) * 60000000,
+            60000000,
             trace_id.to_string(),
         );
-        let eval = |query: &str| {
-            let ctx = Arc::new(PromqlContext::new(
-                query_ctx.clone(),
-                SimpleMockProvider,
-                vec![],
-            ));
-            let expr = promql_parser::parser::parse(query).unwrap();
-            let eval_ctx = eval_ctx.clone();
-            async move { Engine::new(trace_id, ctx, eval_ctx).exec_expr(&expr).await }
-        };
+        let expr = promql_parser::parser::parse(query).unwrap();
+        Engine::new(trace_id, ctx, eval_ctx).exec_expr(&expr).await
+    }
 
+    fn matrix(value: Value) -> Vec<RangeValue> {
+        match value {
+            Value::Matrix(series) => series,
+            other => panic!("expected a matrix, got {:?}", other.get_type()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_set_operators_keep_the_other_side_when_one_is_empty() {
         // `up` has no data on the mock provider, so the fallback vector must come through
-        let Value::Matrix(series) = eval("up or vector(0)").await.unwrap() else {
-            panic!("`or` with an empty left side must return the right side");
-        };
+        for steps in [1, 3] {
+            let series = matrix(eval_on_empty("up or vector(0)", steps).await.unwrap());
+            assert_eq!(series.len(), 1, "{steps} steps");
+            assert_eq!(series[0].samples.len(), steps as usize);
+            assert!(series[0].samples.iter().all(|s| s.value == 0.0));
+        }
+        let series = matrix(eval_on_empty("vector(0) unless up", 3).await.unwrap());
         assert_eq!(series.len(), 1);
-        assert_eq!(series[0].samples.len(), 3);
-        assert!(series[0].samples.iter().all(|s| s.value == 0.0));
-
-        let Value::Matrix(series) = eval("vector(0) unless up").await.unwrap() else {
-            panic!("`unless` with an empty right side must return the left side");
-        };
-        assert_eq!(series.len(), 1);
-
-        let value = eval("vector(0) and up").await.unwrap();
-        assert!(matches!(value, Value::Matrix(series) if series.is_empty()));
+        assert!(matrix(eval_on_empty("vector(0) and up", 3).await.unwrap()).is_empty());
 
         // a right side filtered down to one sample must stay a vector for the set operator
         let sparse = r#"vector(0) or label_replace(timestamp(vector(1)) >= 1640995320, "source", "sparse", "", "")"#;
-        let Value::Matrix(series) = eval(sparse).await.unwrap() else {
-            panic!("`or` must keep a single-sample right side");
-        };
+        let series = matrix(eval_on_empty(sparse, 3).await.unwrap());
         assert_eq!(series.len(), 2);
         assert_eq!(series.iter().map(|s| s.samples.len()).sum::<usize>(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_only_a_scalar_typed_right_side_folds_into_a_scalar() {
+        // a one-sample vector keeps label matching: the sum exists at that one step only
+        let series = matrix(
+            eval_on_empty("vector(1) + (timestamp(vector(1)) >= 1640995320)", 3)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0].samples.len(), 1);
+        assert_eq!(series[0].samples[0].value, 1640995321.0);
+
+        // a scalar-typed right side still applies to every step
+        let series = matrix(
+            eval_on_empty("vector(1) + scalar(vector(2))", 1)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0].samples[0].value, 3.0);
     }
 
     #[tokio::test]

--- a/src/promql/src/promql/mod.rs
+++ b/src/promql/src/promql/mod.rs
@@ -17,3 +17,4 @@ pub(crate) mod label_usage;
 pub mod name_visitor;
 pub(crate) mod rewrite;
 pub(crate) mod selector_visitor;
+pub mod selector_window;

--- a/src/promql/src/promql/selector_window.rs
+++ b/src/promql/src/promql/selector_window.rs
@@ -1,0 +1,84 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::time::Duration;
+
+use promql_parser::parser::{Expr, Offset};
+
+use crate::DEFAULT_LOOKBACK;
+
+/// How far before an evaluation timestamp the query reads: the widest selector range or
+/// lookback plus its positive offset, with subqueries nesting their inner window.
+pub fn max_selector_window(expr: &Expr) -> Duration {
+    match expr {
+        Expr::VectorSelector(vs) => DEFAULT_LOOKBACK + positive_offset(&vs.offset),
+        Expr::MatrixSelector(ms) => ms.range + positive_offset(&ms.vs.offset),
+        Expr::Subquery(sq) => {
+            max_selector_window(&sq.expr) + sq.range + positive_offset(&sq.offset)
+        }
+        Expr::Aggregate(agg) => {
+            let param = agg
+                .param
+                .as_deref()
+                .map_or(Duration::ZERO, max_selector_window);
+            max_selector_window(&agg.expr).max(param)
+        }
+        Expr::Unary(unary) => max_selector_window(&unary.expr),
+        Expr::Paren(paren) => max_selector_window(&paren.expr),
+        Expr::Binary(binary) => {
+            max_selector_window(&binary.lhs).max(max_selector_window(&binary.rhs))
+        }
+        Expr::Call(call) => call
+            .args
+            .args
+            .iter()
+            .map(|arg| max_selector_window(arg))
+            .max()
+            .unwrap_or(Duration::ZERO),
+        Expr::NumberLiteral(_) | Expr::StringLiteral(_) | Expr::Extension(_) => Duration::ZERO,
+    }
+}
+
+fn positive_offset(offset: &Option<Offset>) -> Duration {
+    match offset {
+        Some(Offset::Pos(offset)) => *offset,
+        _ => Duration::ZERO,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use promql_parser::parser;
+
+    use super::*;
+
+    fn window(query: &str) -> Duration {
+        max_selector_window(&parser::parse(query).unwrap())
+    }
+
+    #[test]
+    fn test_max_selector_window() {
+        let minutes = |m: u64| Duration::from_secs(60 * m);
+        assert_eq!(window("up"), minutes(5));
+        assert_eq!(window("up offset 10m"), minutes(15));
+        assert_eq!(window("up offset -10m"), minutes(5));
+        assert_eq!(window("rate(x[1m])"), minutes(1));
+        assert_eq!(window("rate(x[1h] offset 30m)"), minutes(90));
+        assert_eq!(window("sum(rate(a[5m])) / sum(rate(b[1h]))"), minutes(60));
+        assert_eq!(window("topk(3, rate(a[15m]))"), minutes(15));
+        assert_eq!(window("max_over_time(rate(a[5m])[1h:1m])"), minutes(65));
+        assert_eq!(window("1 + 2"), Duration::ZERO);
+    }
+}

--- a/src/promql/src/promql/selector_window.rs
+++ b/src/promql/src/promql/selector_window.rs
@@ -19,42 +19,77 @@ use promql_parser::parser::{Expr, Offset};
 
 use crate::DEFAULT_LOOKBACK;
 
-/// How far before an evaluation timestamp the query reads: the widest selector range or
-/// lookback plus its positive offset, with subqueries nesting their inner window.
-pub fn max_selector_window(expr: &Expr) -> Duration {
+/// What a query reads around each evaluation timestamp.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SelectorWindow {
+    /// The farthest read before the timestamp: widest range or lookback plus positive offset.
+    pub back: Duration,
+    /// The farthest read after the timestamp: the largest negative offset.
+    pub ahead: Duration,
+    /// A subquery evaluates its inner expression inside the evaluated range only.
+    pub subquery: bool,
+}
+
+impl SelectorWindow {
+    fn merge(self, other: Self) -> Self {
+        Self {
+            back: self.back.max(other.back),
+            ahead: self.ahead.max(other.ahead),
+            subquery: self.subquery || other.subquery,
+        }
+    }
+}
+
+pub fn selector_window(expr: &Expr) -> SelectorWindow {
     match expr {
-        Expr::VectorSelector(vs) => DEFAULT_LOOKBACK + positive_offset(&vs.offset),
-        Expr::MatrixSelector(ms) => ms.range + positive_offset(&ms.vs.offset),
+        Expr::VectorSelector(vs) => offset_window(DEFAULT_LOOKBACK, &vs.offset),
+        Expr::MatrixSelector(ms) => offset_window(ms.range, &ms.vs.offset),
         Expr::Subquery(sq) => {
-            max_selector_window(&sq.expr) + sq.range + positive_offset(&sq.offset)
+            let inner = selector_window(&sq.expr);
+            let own = offset_window(sq.range, &sq.offset);
+            SelectorWindow {
+                back: inner.back + own.back,
+                ahead: inner.ahead + own.ahead,
+                subquery: true,
+            }
         }
         Expr::Aggregate(agg) => {
             let param = agg
                 .param
                 .as_deref()
-                .map_or(Duration::ZERO, max_selector_window);
-            max_selector_window(&agg.expr).max(param)
+                .map_or_else(Default::default, selector_window);
+            selector_window(&agg.expr).merge(param)
         }
-        Expr::Unary(unary) => max_selector_window(&unary.expr),
-        Expr::Paren(paren) => max_selector_window(&paren.expr),
-        Expr::Binary(binary) => {
-            max_selector_window(&binary.lhs).max(max_selector_window(&binary.rhs))
-        }
+        Expr::Unary(unary) => selector_window(&unary.expr),
+        Expr::Paren(paren) => selector_window(&paren.expr),
+        Expr::Binary(binary) => selector_window(&binary.lhs).merge(selector_window(&binary.rhs)),
         Expr::Call(call) => call
             .args
             .args
             .iter()
-            .map(|arg| max_selector_window(arg))
-            .max()
-            .unwrap_or(Duration::ZERO),
-        Expr::NumberLiteral(_) | Expr::StringLiteral(_) | Expr::Extension(_) => Duration::ZERO,
+            .map(|arg| selector_window(arg))
+            .fold(SelectorWindow::default(), SelectorWindow::merge),
+        Expr::NumberLiteral(_) | Expr::StringLiteral(_) | Expr::Extension(_) => {
+            SelectorWindow::default()
+        }
     }
 }
 
-fn positive_offset(offset: &Option<Offset>) -> Duration {
+fn offset_window(range: Duration, offset: &Option<Offset>) -> SelectorWindow {
     match offset {
-        Some(Offset::Pos(offset)) => *offset,
-        _ => Duration::ZERO,
+        Some(Offset::Pos(offset)) => SelectorWindow {
+            back: range + *offset,
+            ..Default::default()
+        },
+        Some(Offset::Neg(offset)) => SelectorWindow {
+            back: range,
+            ahead: *offset,
+            ..Default::default()
+        },
+        None => SelectorWindow {
+            back: range,
+            ..Default::default()
+        },
     }
 }
 
@@ -64,21 +99,72 @@ mod tests {
 
     use super::*;
 
-    fn window(query: &str) -> Duration {
-        max_selector_window(&parser::parse(query).unwrap())
+    fn window(query: &str) -> SelectorWindow {
+        selector_window(&parser::parse(query).unwrap())
+    }
+
+    fn minutes(m: u64) -> Duration {
+        Duration::from_secs(60 * m)
+    }
+
+    fn plain(back: Duration) -> SelectorWindow {
+        SelectorWindow {
+            back,
+            ..Default::default()
+        }
     }
 
     #[test]
-    fn test_max_selector_window() {
-        let minutes = |m: u64| Duration::from_secs(60 * m);
-        assert_eq!(window("up"), minutes(5));
-        assert_eq!(window("up offset 10m"), minutes(15));
-        assert_eq!(window("up offset -10m"), minutes(5));
-        assert_eq!(window("rate(x[1m])"), minutes(1));
-        assert_eq!(window("rate(x[1h] offset 30m)"), minutes(90));
-        assert_eq!(window("sum(rate(a[5m])) / sum(rate(b[1h]))"), minutes(60));
-        assert_eq!(window("topk(3, rate(a[15m]))"), minutes(15));
-        assert_eq!(window("max_over_time(rate(a[5m])[1h:1m])"), minutes(65));
-        assert_eq!(window("1 + 2"), Duration::ZERO);
+    fn test_selector_window() {
+        assert_eq!(window("up"), plain(minutes(5)));
+        assert_eq!(window("up offset 10m"), plain(minutes(15)));
+        assert_eq!(window("rate(x[1m])"), plain(minutes(1)));
+        assert_eq!(window("rate(x[1h] offset 30m)"), plain(minutes(90)));
+        assert_eq!(
+            window("sum(rate(a[5m])) / sum(rate(b[1h]))"),
+            plain(minutes(60))
+        );
+        assert_eq!(window("topk(3, rate(a[15m]))"), plain(minutes(15)));
+        assert_eq!(window("1 + 2"), SelectorWindow::default());
+    }
+
+    #[test]
+    fn test_selector_window_reads_ahead_on_negative_offsets() {
+        assert_eq!(
+            window("up offset -10m"),
+            SelectorWindow {
+                back: minutes(5),
+                ahead: minutes(10),
+                subquery: false
+            }
+        );
+        assert_eq!(
+            window("rate(a[5m] offset -3m) + rate(b[1h] offset 2m)"),
+            SelectorWindow {
+                back: minutes(62),
+                ahead: minutes(3),
+                subquery: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_selector_window_flags_subqueries() {
+        assert_eq!(
+            window("max_over_time(rate(a[5m])[1h:1m])"),
+            SelectorWindow {
+                back: minutes(65),
+                ahead: Duration::ZERO,
+                subquery: true
+            }
+        );
+        assert_eq!(
+            window("sum(a) + max_over_time(b[1h:1m] offset -5m)"),
+            SelectorWindow {
+                back: minutes(65),
+                ahead: minutes(5),
+                subquery: true
+            }
+        );
     }
 }

--- a/src/promql/src/promql/selector_window.rs
+++ b/src/promql/src/promql/selector_window.rs
@@ -17,14 +17,10 @@ use std::time::Duration;
 
 use promql_parser::parser::{Expr, Offset};
 
-use crate::DEFAULT_LOOKBACK;
-
-/// What a query reads around each evaluation timestamp.
+/// What a query reads beyond its evaluation range.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SelectorWindow {
-    /// The farthest read before the timestamp: widest range or lookback plus positive offset.
-    pub back: Duration,
-    /// The farthest read after the timestamp: the largest negative offset.
+    /// The farthest read after an evaluation timestamp: the largest negative offset.
     pub ahead: Duration,
     /// A subquery evaluates its inner expression inside the evaluated range only.
     pub subquery: bool,
@@ -33,7 +29,6 @@ pub struct SelectorWindow {
 impl SelectorWindow {
     fn merge(self, other: Self) -> Self {
         Self {
-            back: self.back.max(other.back),
             ahead: self.ahead.max(other.ahead),
             subquery: self.subquery || other.subquery,
         }
@@ -42,17 +37,18 @@ impl SelectorWindow {
 
 pub fn selector_window(expr: &Expr) -> SelectorWindow {
     match expr {
-        Expr::VectorSelector(vs) => offset_window(DEFAULT_LOOKBACK, &vs.offset),
-        Expr::MatrixSelector(ms) => offset_window(ms.range, &ms.vs.offset),
-        Expr::Subquery(sq) => {
-            let inner = selector_window(&sq.expr);
-            let own = offset_window(sq.range, &sq.offset);
-            SelectorWindow {
-                back: inner.back + own.back,
-                ahead: inner.ahead + own.ahead,
-                subquery: true,
-            }
-        }
+        Expr::VectorSelector(vs) => SelectorWindow {
+            ahead: negative_offset(&vs.offset),
+            subquery: false,
+        },
+        Expr::MatrixSelector(ms) => SelectorWindow {
+            ahead: negative_offset(&ms.vs.offset),
+            subquery: false,
+        },
+        Expr::Subquery(sq) => SelectorWindow {
+            ahead: selector_window(&sq.expr).ahead + negative_offset(&sq.offset),
+            subquery: true,
+        },
         Expr::Aggregate(agg) => {
             let param = agg
                 .param
@@ -75,21 +71,10 @@ pub fn selector_window(expr: &Expr) -> SelectorWindow {
     }
 }
 
-fn offset_window(range: Duration, offset: &Option<Offset>) -> SelectorWindow {
+fn negative_offset(offset: &Option<Offset>) -> Duration {
     match offset {
-        Some(Offset::Pos(offset)) => SelectorWindow {
-            back: range + *offset,
-            ..Default::default()
-        },
-        Some(Offset::Neg(offset)) => SelectorWindow {
-            back: range,
-            ahead: *offset,
-            ..Default::default()
-        },
-        None => SelectorWindow {
-            back: range,
-            ..Default::default()
-        },
+        Some(Offset::Neg(offset)) => *offset,
+        _ => Duration::ZERO,
     }
 }
 
@@ -107,41 +92,23 @@ mod tests {
         Duration::from_secs(60 * m)
     }
 
-    fn plain(back: Duration) -> SelectorWindow {
-        SelectorWindow {
-            back,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_selector_window() {
-        assert_eq!(window("up"), plain(minutes(5)));
-        assert_eq!(window("up offset 10m"), plain(minutes(15)));
-        assert_eq!(window("rate(x[1m])"), plain(minutes(1)));
-        assert_eq!(window("rate(x[1h] offset 30m)"), plain(minutes(90)));
-        assert_eq!(
-            window("sum(rate(a[5m])) / sum(rate(b[1h]))"),
-            plain(minutes(60))
-        );
-        assert_eq!(window("topk(3, rate(a[15m]))"), plain(minutes(15)));
-        assert_eq!(window("1 + 2"), SelectorWindow::default());
-    }
-
     #[test]
     fn test_selector_window_reads_ahead_on_negative_offsets() {
+        let none = SelectorWindow::default();
+        assert_eq!(window("up"), none);
+        assert_eq!(window("rate(x[1h] offset 30m)"), none);
+        assert_eq!(window("sum(rate(a[5m])) / sum(rate(b[1h]))"), none);
+        assert_eq!(window("1 + 2"), none);
         assert_eq!(
             window("up offset -10m"),
             SelectorWindow {
-                back: minutes(5),
                 ahead: minutes(10),
                 subquery: false
             }
         );
         assert_eq!(
-            window("rate(a[5m] offset -3m) + rate(b[1h] offset 2m)"),
+            window("topk(3, rate(a[5m] offset -3m)) + rate(b[1h] offset 2m)"),
             SelectorWindow {
-                back: minutes(62),
                 ahead: minutes(3),
                 subquery: false
             }
@@ -153,7 +120,6 @@ mod tests {
         assert_eq!(
             window("max_over_time(rate(a[5m])[1h:1m])"),
             SelectorWindow {
-                back: minutes(65),
                 ahead: Duration::ZERO,
                 subquery: true
             }
@@ -161,7 +127,6 @@ mod tests {
         assert_eq!(
             window("sum(a) + max_over_time(b[1h:1m] offset -5m)"),
             SelectorWindow {
-                back: minutes(65),
                 ahead: minutes(5),
                 subquery: true
             }

--- a/src/promql_service/src/search/grpc/mod.rs
+++ b/src/promql_service/src/search/grpc/mod.rs
@@ -30,7 +30,6 @@ use config::{
 use datafusion::{arrow::datatypes::Schema, error::DataFusionError, prelude::SessionContext};
 use hashbrown::HashSet;
 use infra::errors::Result;
-use metrics_index::MetricsFileLayout;
 use promql::{
     DEFAULT_LOOKBACK, TableProvider,
     exec::PromqlContext,
@@ -51,10 +50,8 @@ type Context = (SessionContext, Arc<Schema>, ScanStats, bool);
 struct GroupPlan {
     /// The heaviest stream's files, oldest `max_ts` first.
     files: Vec<FileKey>,
-    /// What the query reads around each evaluation timestamp.
+    /// What the query reads beyond its evaluation range.
     window: SelectorWindow,
-    /// The newest legacy file's `max_ts`, only when hash-ordered files exist alongside it.
-    legacy_max_ts: Option<i64>,
 }
 
 struct StorageProvider {
@@ -165,18 +162,20 @@ pub async fn search(
 
         // 2. generate search group with max records stream
         let start_ts = std::time::Instant::now();
-        // cuts pay off only where the engine streams; a subquery's inner expression is per-group
-        let cuts = if cfg.search.feature_metrics_streaming_agg_enabled
+        // the cut pays off only where the engine streams; a subquery's inner expression is
+        // per-group
+        let cut = if cfg.search.feature_metrics_streaming_agg_enabled
             && !query.query_exemplars
             && !req.is_super_cluster
             && !plan.window.subquery
         {
-            search_group_cuts(start, end, step, &plan, wal_floor())
+            wal_cut(start, end, step, micros(plan.window.ahead), wal_floor())
         } else {
-            Vec::new()
+            None
         };
         let memory_limit = cfg.memory_cache.datafusion_max_size; // bytes
-        let group = match generate_search_groups(memory_limit, &plan, start, end, step, &cuts).await
+        let group = match generate_search_groups(memory_limit, plan.files, start, end, step, cut)
+            .await
         {
             Ok(v) => v,
             Err(e) => {
@@ -188,7 +187,7 @@ pub async fn search(
         };
         if group.len() > 1 {
             log::info!(
-                "[trace_id {trace_id}] promql->search->grpc: get groups {group:?}, cuts {cuts:?}"
+                "[trace_id {trace_id}] promql->search->grpc: get groups {group:?}, wal cut {cut:?}"
             );
         }
         log::info!(
@@ -433,27 +432,17 @@ async fn get_max_file_list(
     // 2. get max records stream
     let mut file_list = Vec::new();
     let mut max_records = 0;
-    let mut legacy_max_ts = None;
-    let mut hash_ordered = false;
     for stream_name in metrics_name {
-        // the read-back window loads with the first group, so its files count too
         let stream_file_list = search_service::file_list::query(
             trace_id,
             org_id,
             StreamType::Metrics,
             &stream_name,
             PartitionTimeLevel::default(),
-            start - micros(window.back),
+            start,
             end,
         )
         .await?;
-        for file in &stream_file_list {
-            if MetricsFileLayout::is_hash_ordered(&file.key) {
-                hash_ordered = true;
-            } else {
-                legacy_max_ts = legacy_max_ts.max(Some(file.meta.max_ts));
-            }
-        }
         let stream_records = stream_file_list.iter().map(|f| f.meta.records).sum::<i64>();
         if stream_records > max_records {
             max_records = stream_records;
@@ -464,7 +453,6 @@ async fn get_max_file_list(
     Ok(GroupPlan {
         files: file_list,
         window,
-        legacy_max_ts: legacy_max_ts.filter(|_| hash_ordered),
     })
 }
 
@@ -474,69 +462,39 @@ fn wal_floor() -> i64 {
     now_micros() - second_micros(retention * 3)
 }
 
-/// Group boundaries after which every group streams from hash-ordered files alone.
-fn search_group_cuts(
-    start: i64,
-    end: i64,
-    step: i64,
-    plan: &GroupPlan,
-    wal_floor: i64,
-) -> Vec<i64> {
-    // a group starting at the cut reads back `window` and must still miss the newest legacy file
-    let layout_cut = plan
-        .legacy_max_ts
-        .map(|ts| ts + micros(plan.window.back) + step);
+/// The grid-aligned cut before the WAL floor, `None` when the range does not straddle it.
+fn wal_cut(start: i64, end: i64, step: i64, ahead: i64, wal_floor: i64) -> Option<i64> {
     // a group ending before the cut still reads `ahead` past its end, which must stay off the WAL
-    let wal_cut = wal_floor - micros(plan.window.ahead);
-    let mut cuts: Vec<i64> = layout_cut
-        .into_iter()
-        .chain([wal_cut])
-        .filter(|&cut| cut > start && cut <= end)
-        // groups evaluate on the query's own grid
-        .map(|cut| start + (cut - start + step - 1) / step * step)
-        .collect();
-    cuts.sort_unstable();
-    // a lone point evaluates as an instant vector the leader cannot merge: every piece keeps two
-    let mut kept = Vec::new();
-    let mut piece_start = start;
-    for cut in cuts {
-        if cut >= piece_start + 2 * step && cut + step <= end {
-            kept.push(cut);
-            piece_start = cut;
-        }
+    let cut = wal_floor - ahead;
+    if cut <= start || cut > end {
+        return None;
     }
-    kept
+    // groups evaluate on the query's own grid
+    let cut = start + (cut - start + step - 1) / step * step;
+    // a lone point evaluates as an instant vector the leader cannot merge: both pieces keep two
+    (cut >= start + 2 * step && cut + step <= end).then_some(cut)
 }
 
-/// Sizes the groups by memory within each piece between two cuts, so no group straddles a cut.
+/// Sizes the groups by memory on each side of the cut, so no group straddles it.
 async fn generate_search_groups(
     memory_limit: usize,
-    plan: &GroupPlan,
+    files: Vec<FileKey>,
     start: i64,
     end: i64,
     step: i64,
-    cuts: &[i64],
+    cut: Option<i64>,
 ) -> Result<Vec<(i64, i64)>> {
-    if cuts.is_empty() {
-        return generate_search_group(memory_limit, plan.files.clone(), start, end, step).await;
-    }
-    let mut groups = Vec::new();
-    let mut piece_start = start;
-    for piece_end in cuts.iter().map(|cut| cut - step).chain([end]) {
-        let files = plan
-            .files
-            .iter()
-            .filter(|f| {
-                f.meta.min_ts <= piece_end
-                    && f.meta.max_ts >= piece_start - micros(plan.window.back)
-            })
-            .cloned()
-            .collect();
-        groups.extend(
-            generate_search_group(memory_limit, files, piece_start, piece_end, step).await?,
-        );
-        piece_start = piece_end + step;
-    }
+    let Some(cut) = cut else {
+        return generate_search_group(memory_limit, files, start, end, step).await;
+    };
+    let head = files
+        .iter()
+        .filter(|f| f.meta.min_ts <= cut - step)
+        .cloned()
+        .collect();
+    let tail = files.into_iter().filter(|f| f.meta.max_ts >= cut).collect();
+    let mut groups = generate_search_group(memory_limit, head, start, cut - step, step).await?;
+    groups.extend(generate_search_group(memory_limit, tail, cut, end, step).await?);
     Ok(groups)
 }
 
@@ -759,63 +717,26 @@ mod tests {
         }
     }
 
-    fn plan(files: Vec<FileKey>, back: u64, legacy_max_ts: Option<i64>) -> GroupPlan {
-        GroupPlan {
-            files,
-            window: SelectorWindow {
-                back: Duration::from_micros(back),
-                ..Default::default()
-            },
-            legacy_max_ts,
-        }
-    }
-
     #[test]
-    fn test_search_group_cuts_land_on_the_query_grid() {
-        let mixed = plan(vec![], 300, Some(1000));
-        // the layout cut 1000 + 300 + 30 rounds up to 1350, the WAL floor 2000 to 2010
-        assert_eq!(
-            search_group_cuts(0, 3000, 30, &mixed, 2000),
-            vec![1350, 2010]
-        );
-        // an off-grid start keeps its own grid
-        assert_eq!(
-            search_group_cuts(5, 3000, 30, &mixed, 2000),
-            vec![1355, 2015]
-        );
-        // cuts outside (start, end] are dropped
-        assert_eq!(
-            search_group_cuts(1400, 3000, 30, &mixed, 4000),
-            Vec::<i64>::new()
-        );
-        // every piece keeps at least two points: no cut on `end`, none one step after `start`
-        assert_eq!(search_group_cuts(0, 2010, 30, &mixed, 2000), vec![1350]);
-        assert_eq!(search_group_cuts(0, 2005, 30, &mixed, 2000), vec![1350]);
-        let hash_only = plan(vec![], 300, None);
-        assert_eq!(search_group_cuts(0, 3000, 30, &hash_only, 2970), vec![2970]);
-        assert_eq!(
-            search_group_cuts(0, 3000, 30, &hash_only, 2980),
-            Vec::<i64>::new()
-        );
-        let at_start = plan(vec![], 0, Some(0));
-        assert_eq!(
-            search_group_cuts(0, 3000, 30, &at_start, 4000),
-            Vec::<i64>::new()
-        );
-        // no legacy files: only the WAL floor
-        assert_eq!(search_group_cuts(0, 3000, 30, &hash_only, 2000), vec![2010]);
-        // coinciding or adjacent cuts collapse into the first
-        let adjacent = plan(vec![], 300, Some(1670));
-        assert_eq!(search_group_cuts(0, 3000, 30, &adjacent, 2000), vec![2010]);
-        assert_eq!(search_group_cuts(0, 3000, 30, &mixed, 1360), vec![1350]);
-        // a negative offset reads past the group end, so the WAL cut moves that far earlier
-        let mut ahead = plan(vec![], 300, None);
-        ahead.window.ahead = Duration::from_micros(100);
-        assert_eq!(search_group_cuts(0, 3000, 30, &ahead, 2000), vec![1920]);
+    fn test_wal_cut_lands_on_the_query_grid() {
+        // the floor rounds up to the query's own grid
+        assert_eq!(wal_cut(0, 3000, 30, 0, 2000), Some(2010));
+        assert_eq!(wal_cut(5, 3000, 30, 0, 2000), Some(2015));
+        // a floor outside (start, end] leaves one group
+        assert_eq!(wal_cut(1400, 3000, 30, 0, 1000), None);
+        assert_eq!(wal_cut(0, 3000, 30, 0, 4000), None);
+        // both pieces keep at least two points
+        assert_eq!(wal_cut(0, 2010, 30, 0, 2000), None);
+        assert_eq!(wal_cut(0, 3000, 30, 0, 2970), Some(2970));
+        assert_eq!(wal_cut(0, 3000, 30, 0, 2980), None);
+        assert_eq!(wal_cut(0, 3000, 30, 0, 30), None);
+        assert_eq!(wal_cut(0, 3000, 30, 0, 31), Some(60));
+        // a negative offset reads past the group end, so the cut moves that far earlier
+        assert_eq!(wal_cut(0, 3000, 30, 100, 2000), Some(1920));
     }
 
     #[tokio::test]
-    async fn test_generate_search_groups_never_straddle_a_cut() {
+    async fn test_generate_search_groups_never_straddle_the_cut() {
         let files = vec![
             file(0, 100, 100),
             file(100, 200, 100),
@@ -823,27 +744,26 @@ mod tests {
             file(300, 400, 100),
             file(400, 430, 30),
         ];
-        let plan = plan(files, 0, None);
-        // no cuts: the memory sizing alone
+        // no cut: the memory sizing alone
         assert_eq!(
-            generate_search_groups(100, &plan, 0, 430, 5, &[])
+            generate_search_groups(100, files.clone(), 0, 430, 5, None)
                 .await
                 .unwrap(),
             vec![(0, 200), (205, 300), (305, 400), (405, 430)]
         );
-        // each piece is sized on its own and the piece after a cut starts exactly at it
+        // each side is sized on its own and the tail starts exactly at the cut
         assert_eq!(
-            generate_search_groups(100, &plan, 0, 430, 5, &[300])
+            generate_search_groups(100, files.clone(), 0, 430, 5, Some(300))
                 .await
                 .unwrap(),
             vec![(0, 200), (205, 295), (300, 400), (405, 430)]
         );
-        // the last piece is a two-point group of its own
+        // the tail may be a two-point group of its own
         assert_eq!(
-            generate_search_groups(100_000, &plan, 0, 430, 10, &[200, 420])
+            generate_search_groups(100_000, files, 0, 430, 10, Some(420))
                 .await
                 .unwrap(),
-            vec![(0, 190), (200, 410), (420, 430)]
+            vec![(0, 410), (420, 430)]
         );
     }
 }

--- a/src/promql_service/src/search/grpc/mod.rs
+++ b/src/promql_service/src/search/grpc/mod.rs
@@ -34,7 +34,10 @@ use promql::{
     DEFAULT_LOOKBACK, TableProvider,
     exec::PromqlContext,
     micros,
-    promql::{name_visitor, selector_window::SelectorWindow},
+    promql::{
+        name_visitor,
+        selector_window::{SelectorWindow, selector_window},
+    },
 };
 use promql_parser::{label::Matchers, parser};
 use proto::cluster_rpc;
@@ -162,14 +165,14 @@ pub async fn search(
 
         // 2. generate search group with max records stream
         let start_ts = std::time::Instant::now();
-        // the cut pays off only where the engine streams; a subquery's inner expression is
-        // per-group
+        let wal_floor = wal_floor();
+        // no cut without streaming, and none around a subquery, whose inner expression is per-group
         let cut = if cfg.search.feature_metrics_streaming_agg_enabled
             && !query.query_exemplars
             && !req.is_super_cluster
             && !plan.window.subquery
         {
-            wal_cut(start, end, step, micros(plan.window.ahead), wal_floor())
+            wal_cut(start, end, step, micros(plan.window.ahead), wal_floor)
         } else {
             None
         };
@@ -198,7 +201,7 @@ pub async fn search(
         // 3. search each group
         for (start, end) in group {
             let mut req = req.clone();
-            req.need_wal = end + micros(plan.window.ahead) >= wal_floor();
+            req.need_wal = end + micros(plan.window.ahead) >= wal_floor;
             req.query.as_mut().unwrap().start = start;
             req.query.as_mut().unwrap().end = end;
             let resp = search_inner(&req).await?;
@@ -319,9 +322,10 @@ pub async fn data(
     );
 
     // 3. search each group
+    let wal_floor = wal_floor();
     for (start, end) in group {
         let mut req = req.clone();
-        req.need_wal = end + micros(plan.window.ahead) >= wal_floor();
+        req.need_wal = end + micros(plan.window.ahead) >= wal_floor;
         req.query.as_mut().unwrap().start = start;
         req.query.as_mut().unwrap().end = end;
         let resp = search_inner(&req).await?;
@@ -427,7 +431,7 @@ async fn get_max_file_list(
     let mut visitor = name_visitor::MetricNameVisitor::default();
     promql_parser::util::walk_expr(&mut visitor, &ast).unwrap();
     let metrics_name = visitor.into_names();
-    let window = promql::promql::selector_window::selector_window(&ast);
+    let window = selector_window(&ast);
 
     // 2. get max records stream
     let mut file_list = Vec::new();

--- a/src/promql_service/src/search/grpc/mod.rs
+++ b/src/promql_service/src/search/grpc/mod.rs
@@ -35,7 +35,7 @@ use promql::{
     DEFAULT_LOOKBACK, TableProvider,
     exec::PromqlContext,
     micros,
-    promql::{name_visitor, selector_window},
+    promql::{name_visitor, selector_window::SelectorWindow},
 };
 use promql_parser::{label::Matchers, parser};
 use proto::cluster_rpc;
@@ -51,8 +51,8 @@ type Context = (SessionContext, Arc<Schema>, ScanStats, bool);
 struct GroupPlan {
     /// The heaviest stream's files, oldest `max_ts` first.
     files: Vec<FileKey>,
-    /// How far before its start the query reads.
-    window: i64,
+    /// What the query reads around each evaluation timestamp.
+    window: SelectorWindow,
     /// The newest legacy file's `max_ts`, only when hash-ordered files exist alongside it.
     legacy_max_ts: Option<i64>,
 }
@@ -165,10 +165,11 @@ pub async fn search(
 
         // 2. generate search group with max records stream
         let start_ts = std::time::Instant::now();
-        // cuts only pay off where the engine can stream
+        // cuts pay off only where the engine streams; a subquery's inner expression is per-group
         let cuts = if cfg.search.feature_metrics_streaming_agg_enabled
             && !query.query_exemplars
             && !req.is_super_cluster
+            && !plan.window.subquery
         {
             search_group_cuts(start, end, step, &plan, wal_floor())
         } else {
@@ -198,7 +199,7 @@ pub async fn search(
         // 3. search each group
         for (start, end) in group {
             let mut req = req.clone();
-            req.need_wal = end >= wal_floor();
+            req.need_wal = end + micros(plan.window.ahead) >= wal_floor();
             req.query.as_mut().unwrap().start = start;
             req.query.as_mut().unwrap().end = end;
             let resp = search_inner(&req).await?;
@@ -321,7 +322,7 @@ pub async fn data(
     // 3. search each group
     for (start, end) in group {
         let mut req = req.clone();
-        req.need_wal = end >= wal_floor();
+        req.need_wal = end + micros(plan.window.ahead) >= wal_floor();
         req.query.as_mut().unwrap().start = start;
         req.query.as_mut().unwrap().end = end;
         let resp = search_inner(&req).await?;
@@ -427,7 +428,7 @@ async fn get_max_file_list(
     let mut visitor = name_visitor::MetricNameVisitor::default();
     promql_parser::util::walk_expr(&mut visitor, &ast).unwrap();
     let metrics_name = visitor.into_names();
-    let window = micros(selector_window::max_selector_window(&ast));
+    let window = promql::promql::selector_window::selector_window(&ast);
 
     // 2. get max records stream
     let mut file_list = Vec::new();
@@ -442,7 +443,7 @@ async fn get_max_file_list(
             StreamType::Metrics,
             &stream_name,
             PartitionTimeLevel::default(),
-            start - window,
+            start - micros(window.back),
             end,
         )
         .await?;
@@ -482,10 +483,14 @@ fn search_group_cuts(
     wal_floor: i64,
 ) -> Vec<i64> {
     // a group starting at the cut reads back `window` and must still miss the newest legacy file
-    let layout_cut = plan.legacy_max_ts.map(|ts| ts + plan.window + step);
+    let layout_cut = plan
+        .legacy_max_ts
+        .map(|ts| ts + micros(plan.window.back) + step);
+    // a group ending before the cut still reads `ahead` past its end, which must stay off the WAL
+    let wal_cut = wal_floor - micros(plan.window.ahead);
     let mut cuts: Vec<i64> = layout_cut
         .into_iter()
-        .chain([wal_floor])
+        .chain([wal_cut])
         .filter(|&cut| cut > start && cut <= end)
         // groups evaluate on the query's own grid
         .map(|cut| start + (cut - start + step - 1) / step * step)
@@ -521,7 +526,10 @@ async fn generate_search_groups(
         let files = plan
             .files
             .iter()
-            .filter(|f| f.meta.min_ts <= piece_end && f.meta.max_ts >= piece_start - plan.window)
+            .filter(|f| {
+                f.meta.min_ts <= piece_end
+                    && f.meta.max_ts >= piece_start - micros(plan.window.back)
+            })
             .cloned()
             .collect();
         groups.extend(
@@ -751,10 +759,13 @@ mod tests {
         }
     }
 
-    fn plan(files: Vec<FileKey>, window: i64, legacy_max_ts: Option<i64>) -> GroupPlan {
+    fn plan(files: Vec<FileKey>, back: u64, legacy_max_ts: Option<i64>) -> GroupPlan {
         GroupPlan {
             files,
-            window,
+            window: SelectorWindow {
+                back: Duration::from_micros(back),
+                ..Default::default()
+            },
             legacy_max_ts,
         }
     }
@@ -797,6 +808,10 @@ mod tests {
         let adjacent = plan(vec![], 300, Some(1670));
         assert_eq!(search_group_cuts(0, 3000, 30, &adjacent, 2000), vec![2010]);
         assert_eq!(search_group_cuts(0, 3000, 30, &mixed, 1360), vec![1350]);
+        // a negative offset reads past the group end, so the WAL cut moves that far earlier
+        let mut ahead = plan(vec![], 300, None);
+        ahead.window.ahead = Duration::from_micros(100);
+        assert_eq!(search_group_cuts(0, 3000, 30, &ahead, 2000), vec![1920]);
     }
 
     #[tokio::test]

--- a/src/promql_service/src/search/grpc/mod.rs
+++ b/src/promql_service/src/search/grpc/mod.rs
@@ -464,11 +464,18 @@ fn search_group_cuts(
         .filter(|&cut| cut > start && cut <= end)
         // groups evaluate on the query's own grid
         .map(|cut| start + (cut - start + step - 1) / step * step)
-        .filter(|&cut| cut <= end)
         .collect();
     cuts.sort_unstable();
-    cuts.dedup();
-    cuts
+    // a lone point evaluates as an instant vector the leader cannot merge: every piece keeps two
+    let mut kept = Vec::new();
+    let mut piece_start = start;
+    for cut in cuts {
+        if cut >= piece_start + 2 * step && cut + step <= end {
+            kept.push(cut);
+            piece_start = cut;
+        }
+    }
+    kept
 }
 
 /// Sizes the groups by memory within each piece between two cuts, so no group straddles a cut.
@@ -486,21 +493,15 @@ async fn generate_search_groups(
     let mut groups = Vec::new();
     let mut piece_start = start;
     for piece_end in cuts.iter().map(|cut| cut - step).chain([end]) {
-        if piece_start == piece_end {
-            groups.push((piece_start, piece_end));
-        } else {
-            let files = plan
-                .files
-                .iter()
-                .filter(|f| {
-                    f.meta.min_ts <= piece_end && f.meta.max_ts >= piece_start - plan.window
-                })
-                .cloned()
-                .collect();
-            groups.extend(
-                generate_search_group(memory_limit, files, piece_start, piece_end, step).await?,
-            );
-        }
+        let files = plan
+            .files
+            .iter()
+            .filter(|f| f.meta.min_ts <= piece_end && f.meta.max_ts >= piece_start - plan.window)
+            .cloned()
+            .collect();
+        groups.extend(
+            generate_search_group(memory_limit, files, piece_start, piece_end, step).await?,
+        );
         piece_start = piece_end + step;
     }
     Ok(groups)
@@ -746,22 +747,31 @@ mod tests {
             search_group_cuts(5, 3000, 30, &mixed, 2000),
             vec![1355, 2015]
         );
-        // cuts outside (start, end] are dropped, a cut on `end` stays
+        // cuts outside (start, end] are dropped
         assert_eq!(
             search_group_cuts(1400, 3000, 30, &mixed, 4000),
             Vec::<i64>::new()
         );
-        assert_eq!(
-            search_group_cuts(0, 2010, 30, &mixed, 2000),
-            vec![1350, 2010]
-        );
+        // every piece keeps at least two points: no cut on `end`, none one step after `start`
+        assert_eq!(search_group_cuts(0, 2010, 30, &mixed, 2000), vec![1350]);
         assert_eq!(search_group_cuts(0, 2005, 30, &mixed, 2000), vec![1350]);
-        // no legacy files: only the WAL floor
         let hash_only = plan(vec![], 300, None);
+        assert_eq!(search_group_cuts(0, 3000, 30, &hash_only, 2970), vec![2970]);
+        assert_eq!(
+            search_group_cuts(0, 3000, 30, &hash_only, 2980),
+            Vec::<i64>::new()
+        );
+        let at_start = plan(vec![], 0, Some(0));
+        assert_eq!(
+            search_group_cuts(0, 3000, 30, &at_start, 4000),
+            Vec::<i64>::new()
+        );
+        // no legacy files: only the WAL floor
         assert_eq!(search_group_cuts(0, 3000, 30, &hash_only, 2000), vec![2010]);
-        // coinciding cuts collapse
+        // coinciding or adjacent cuts collapse into the first
         let adjacent = plan(vec![], 300, Some(1670));
         assert_eq!(search_group_cuts(0, 3000, 30, &adjacent, 2000), vec![2010]);
+        assert_eq!(search_group_cuts(0, 3000, 30, &mixed, 1360), vec![1350]);
     }
 
     #[tokio::test]
@@ -788,12 +798,12 @@ mod tests {
                 .unwrap(),
             vec![(0, 200), (205, 295), (300, 400), (405, 430)]
         );
-        // a cut on `end` leaves a single-point group
+        // the last piece is a two-point group of its own
         assert_eq!(
-            generate_search_groups(100_000, &plan, 0, 430, 10, &[200, 430])
+            generate_search_groups(100_000, &plan, 0, 430, 10, &[200, 420])
                 .await
                 .unwrap(),
-            vec![(0, 190), (200, 420), (430, 430)]
+            vec![(0, 190), (200, 410), (420, 430)]
         );
     }
 }

--- a/src/promql_service/src/search/grpc/mod.rs
+++ b/src/promql_service/src/search/grpc/mod.rs
@@ -30,7 +30,13 @@ use config::{
 use datafusion::{arrow::datatypes::Schema, error::DataFusionError, prelude::SessionContext};
 use hashbrown::HashSet;
 use infra::errors::Result;
-use promql::{DEFAULT_LOOKBACK, TableProvider, exec::PromqlContext, promql::name_visitor};
+use metrics_index::MetricsFileLayout;
+use promql::{
+    DEFAULT_LOOKBACK, TableProvider,
+    exec::PromqlContext,
+    micros,
+    promql::{name_visitor, selector_window},
+};
 use promql_parser::{label::Matchers, parser};
 use proto::cluster_rpc;
 use rayon::slice::ParallelSliceMut;
@@ -40,6 +46,16 @@ mod storage;
 mod wal;
 
 type Context = (SessionContext, Arc<Schema>, ScanStats, bool);
+
+/// What a range query's groups are planned from.
+struct GroupPlan {
+    /// The heaviest stream's files, oldest `max_ts` first.
+    files: Vec<FileKey>,
+    /// How far before its start the query reads.
+    window: i64,
+    /// The newest legacy file's `max_ts`, only when hash-ordered files exist alongside it.
+    legacy_max_ts: Option<i64>,
+}
 
 struct StorageProvider {
     trace_id: String,
@@ -123,55 +139,22 @@ pub async fn search(
 
     let start = query.start;
     let end = query.end;
-    let step = query.step;
     let trace_id = req.job.as_ref().unwrap().trace_id.to_string();
-    let org_id = &req.org_id;
 
     let mut results = Vec::new();
     if start == end {
         results.push(search_inner(req).await?);
     } else {
-        // 1. get max records stream
-        let start_ts = std::time::Instant::now();
-        let file_list = match get_max_file_list(&trace_id, org_id, &query.query, start, end).await {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!(
-                    "[trace_id {trace_id}] promql->search->grpc: get max records stream error: {e}"
-                );
-                return Err(e);
-            }
-        };
-        log::info!(
-            "[trace_id {trace_id}] promql->search->grpc: get max records stream, took: {} ms",
-            start_ts.elapsed().as_millis()
-        );
+        // cuts only pay off where the engine can stream
+        let with_cuts = cfg.search.feature_metrics_streaming_agg_enabled
+            && !query.query_exemplars
+            && !req.is_super_cluster;
+        let group = search_groups(req, with_cuts, "search").await?;
 
-        // 2. generate search group with max records stream
-        let start_ts = std::time::Instant::now();
-        let memory_limit = cfg.memory_cache.datafusion_max_size; // bytes
-        let group = match generate_search_group(memory_limit, file_list, start, end, step).await {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!(
-                    "[trace_id {trace_id}] promql->search->grpc: generate search group error: {e}"
-                );
-                return Err(e);
-            }
-        };
-        if group.len() > 1 {
-            log::info!("[trace_id {trace_id}] promql->search->grpc: get groups {group:?}");
-        }
-        log::info!(
-            "[trace_id {trace_id}] promql->search->grpc: generate search group, took: {} ms",
-            start_ts.elapsed().as_millis()
-        );
-
-        // 3. search each group
+        // search each group
         for (start, end) in group {
             let mut req = req.clone();
-            req.need_wal =
-                end >= now_micros() - second_micros(cfg.limit.max_file_retention_time as i64 * 3);
+            req.need_wal = end >= wal_floor();
             req.query.as_mut().unwrap().start = start;
             req.query.as_mut().unwrap().end = end;
             let resp = search_inner(&req).await?;
@@ -205,14 +188,11 @@ pub async fn data(
     req: &cluster_rpc::MetricsQueryRequest,
     tx: mpsc::Sender<Result<cluster_rpc::MetricsQueryResponse, tonic::Status>>,
 ) -> Result<()> {
-    let cfg = config::get_config();
     let query = req.query.as_ref().unwrap();
 
     let start = query.start;
     let end = query.end;
-    let step = query.step;
     let trace_id = req.job.as_ref().unwrap().trace_id.to_string();
-    let org_id = &req.org_id;
 
     let (data_tx, mut data_rx) = mpsc::channel::<(value::Value, String, ScanStats, i64)>(2);
     let data_trace_id = trace_id.clone();
@@ -256,46 +236,12 @@ pub async fn data(
         );
         return Ok(());
     }
-    // 1. get max records stream
-    let file_list = match get_max_file_list(&trace_id, org_id, &query.query, start, end).await {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!(
-                "[trace_id {trace_id}] promql->data->grpc: get max records stream error: {e}"
-            );
-            return Err(e);
-        }
-    };
-    log::info!(
-        "[trace_id {trace_id}] promql->data->grpc: get max records stream, took: {} ms",
-        start_ts.elapsed().as_millis()
-    );
+    let group = search_groups(req, false, "data").await?;
 
-    // 2. generate search group with max records stream
-    let start_ts = std::time::Instant::now();
-    let memory_limit = cfg.memory_cache.datafusion_max_size; // bytes
-    let group = match generate_search_group(memory_limit, file_list, start, end, step).await {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!(
-                "[trace_id {trace_id}] promql->data->grpc: generate search group error: {e}"
-            );
-            return Err(e);
-        }
-    };
-    if group.len() > 1 {
-        log::info!("[trace_id {trace_id}] promql->data->grpc: get groups {group:?}");
-    }
-    log::info!(
-        "[trace_id {trace_id}] promql->data->grpc: generate data group, took: {} ms",
-        start_ts.elapsed().as_millis()
-    );
-
-    // 3. search each group
+    // search each group
     for (start, end) in group {
         let mut req = req.clone();
-        req.need_wal =
-            end >= now_micros() - second_micros(cfg.limit.max_file_retention_time as i64 * 3);
+        req.need_wal = end >= wal_floor();
         req.query.as_mut().unwrap().start = start;
         req.query.as_mut().unwrap().end = end;
         let resp = search_inner(&req).await?;
@@ -389,33 +335,99 @@ pub async fn search_inner(
     Ok((value, result_type, scan_stats, took))
 }
 
-async fn get_max_file_list(
+/// Plans a range query's groups: split at the streaming cuts when asked, then sized by memory.
+async fn search_groups(
+    req: &cluster_rpc::MetricsQueryRequest,
+    with_cuts: bool,
+    tag: &str,
+) -> Result<Vec<(i64, i64)>> {
+    let trace_id = req.job.as_ref().unwrap().trace_id.as_str();
+    let query = req.query.as_ref().unwrap();
+    let (start, end, step) = (query.start, query.end, query.step);
+
+    // 1. get max records stream
+    let start_ts = std::time::Instant::now();
+    let plan = match group_plan(trace_id, &req.org_id, &query.query, start, end).await {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!(
+                "[trace_id {trace_id}] promql->{tag}->grpc: get max records stream error: {e}"
+            );
+            return Err(e);
+        }
+    };
+    log::info!(
+        "[trace_id {trace_id}] promql->{tag}->grpc: get max records stream, took: {} ms",
+        start_ts.elapsed().as_millis()
+    );
+
+    // 2. generate search group with max records stream
+    let start_ts = std::time::Instant::now();
+    let cuts = if with_cuts {
+        search_group_cuts(start, end, step, &plan, wal_floor())
+    } else {
+        Vec::new()
+    };
+    let memory_limit = config::get_config().memory_cache.datafusion_max_size; // bytes
+    let groups = match generate_search_groups(memory_limit, &plan, start, end, step, &cuts).await {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!(
+                "[trace_id {trace_id}] promql->{tag}->grpc: generate search group error: {e}"
+            );
+            return Err(e);
+        }
+    };
+    if groups.len() > 1 {
+        log::info!(
+            "[trace_id {trace_id}] promql->{tag}->grpc: get groups {groups:?}, cuts {cuts:?}"
+        );
+    }
+    log::info!(
+        "[trace_id {trace_id}] promql->{tag}->grpc: generate search group, took: {} ms",
+        start_ts.elapsed().as_millis()
+    );
+    Ok(groups)
+}
+
+async fn group_plan(
     trace_id: &str,
     org_id: &str,
     query: &str,
     start: i64,
     end: i64,
-) -> Result<Vec<FileKey>> {
+) -> Result<GroupPlan> {
     // 1. get metrics name
     let ast = parser::parse(query).map_err(DataFusionError::Execution)?;
     let mut visitor = name_visitor::MetricNameVisitor::default();
     promql_parser::util::walk_expr(&mut visitor, &ast).unwrap();
     let metrics_name = visitor.into_names();
+    let window = micros(selector_window::max_selector_window(&ast));
 
     // 2. get max records stream
     let mut file_list = Vec::new();
     let mut max_records = 0;
+    let mut legacy_max_ts = None;
+    let mut hash_ordered = false;
     for stream_name in metrics_name {
+        // the read-back window loads with the first group, so its files count too
         let stream_file_list = search_service::file_list::query(
             trace_id,
             org_id,
             StreamType::Metrics,
             &stream_name,
             PartitionTimeLevel::default(),
-            start,
+            start - window,
             end,
         )
         .await?;
+        for file in &stream_file_list {
+            if MetricsFileLayout::is_hash_ordered(&file.key) {
+                hash_ordered = true;
+            } else {
+                legacy_max_ts = legacy_max_ts.max(Some(file.meta.max_ts));
+            }
+        }
         let stream_records = stream_file_list.iter().map(|f| f.meta.records).sum::<i64>();
         if stream_records > max_records {
             max_records = stream_records;
@@ -423,7 +435,75 @@ async fn get_max_file_list(
         }
     }
     file_list.par_sort_unstable_by(|a, b| a.meta.max_ts.cmp(&b.meta.max_ts));
-    Ok(file_list)
+    Ok(GroupPlan {
+        files: file_list,
+        window,
+        legacy_max_ts: legacy_max_ts.filter(|_| hash_ordered),
+    })
+}
+
+/// The time from which a group must also read the WAL.
+fn wal_floor() -> i64 {
+    let retention = config::get_config().limit.max_file_retention_time as i64;
+    now_micros() - second_micros(retention * 3)
+}
+
+/// Group boundaries after which every group streams from hash-ordered files alone.
+fn search_group_cuts(
+    start: i64,
+    end: i64,
+    step: i64,
+    plan: &GroupPlan,
+    wal_floor: i64,
+) -> Vec<i64> {
+    // a group starting at the cut reads back `window` and must still miss the newest legacy file
+    let layout_cut = plan.legacy_max_ts.map(|ts| ts + plan.window + step);
+    let mut cuts: Vec<i64> = layout_cut
+        .into_iter()
+        .chain([wal_floor])
+        .filter(|&cut| cut > start && cut <= end)
+        // groups evaluate on the query's own grid
+        .map(|cut| start + (cut - start + step - 1) / step * step)
+        .filter(|&cut| cut <= end)
+        .collect();
+    cuts.sort_unstable();
+    cuts.dedup();
+    cuts
+}
+
+/// Sizes the groups by memory within each piece between two cuts, so no group straddles a cut.
+async fn generate_search_groups(
+    memory_limit: usize,
+    plan: &GroupPlan,
+    start: i64,
+    end: i64,
+    step: i64,
+    cuts: &[i64],
+) -> Result<Vec<(i64, i64)>> {
+    if cuts.is_empty() {
+        return generate_search_group(memory_limit, plan.files.clone(), start, end, step).await;
+    }
+    let mut groups = Vec::new();
+    let mut piece_start = start;
+    for piece_end in cuts.iter().map(|cut| cut - step).chain([end]) {
+        if piece_start == piece_end {
+            groups.push((piece_start, piece_end));
+        } else {
+            let files = plan
+                .files
+                .iter()
+                .filter(|f| {
+                    f.meta.min_ts <= piece_end && f.meta.max_ts >= piece_start - plan.window
+                })
+                .cloned()
+                .collect();
+            groups.extend(
+                generate_search_group(memory_limit, files, piece_start, piece_end, step).await?,
+            );
+        }
+        piece_start = piece_end + step;
+    }
+    Ok(groups)
 }
 
 /// generate search group
@@ -631,5 +711,89 @@ mod tests {
         let expected = vec![(0, 200), (210, 300), (310, 430)];
         assert!(resp.is_ok());
         assert_eq!(resp.unwrap(), expected);
+    }
+
+    fn file(min_ts: i64, max_ts: i64, records: i64) -> FileKey {
+        FileKey {
+            meta: FileMeta {
+                records,
+                min_ts,
+                max_ts,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn plan(files: Vec<FileKey>, window: i64, legacy_max_ts: Option<i64>) -> GroupPlan {
+        GroupPlan {
+            files,
+            window,
+            legacy_max_ts,
+        }
+    }
+
+    #[test]
+    fn test_search_group_cuts_land_on_the_query_grid() {
+        let mixed = plan(vec![], 300, Some(1000));
+        // the layout cut 1000 + 300 + 30 rounds up to 1350, the WAL floor 2000 to 2010
+        assert_eq!(
+            search_group_cuts(0, 3000, 30, &mixed, 2000),
+            vec![1350, 2010]
+        );
+        // an off-grid start keeps its own grid
+        assert_eq!(
+            search_group_cuts(5, 3000, 30, &mixed, 2000),
+            vec![1355, 2015]
+        );
+        // cuts outside (start, end] are dropped, a cut on `end` stays
+        assert_eq!(
+            search_group_cuts(1400, 3000, 30, &mixed, 4000),
+            Vec::<i64>::new()
+        );
+        assert_eq!(
+            search_group_cuts(0, 2010, 30, &mixed, 2000),
+            vec![1350, 2010]
+        );
+        assert_eq!(search_group_cuts(0, 2005, 30, &mixed, 2000), vec![1350]);
+        // no legacy files: only the WAL floor
+        let hash_only = plan(vec![], 300, None);
+        assert_eq!(search_group_cuts(0, 3000, 30, &hash_only, 2000), vec![2010]);
+        // coinciding cuts collapse
+        let adjacent = plan(vec![], 300, Some(1670));
+        assert_eq!(search_group_cuts(0, 3000, 30, &adjacent, 2000), vec![2010]);
+    }
+
+    #[tokio::test]
+    async fn test_generate_search_groups_never_straddle_a_cut() {
+        let files = vec![
+            file(0, 100, 100),
+            file(100, 200, 100),
+            file(200, 300, 100),
+            file(300, 400, 100),
+            file(400, 430, 30),
+        ];
+        let plan = plan(files, 0, None);
+        // no cuts: the memory sizing alone
+        assert_eq!(
+            generate_search_groups(100, &plan, 0, 430, 5, &[])
+                .await
+                .unwrap(),
+            vec![(0, 200), (205, 300), (305, 400), (405, 430)]
+        );
+        // each piece is sized on its own and the piece after a cut starts exactly at it
+        assert_eq!(
+            generate_search_groups(100, &plan, 0, 430, 5, &[300])
+                .await
+                .unwrap(),
+            vec![(0, 200), (205, 295), (300, 400), (405, 430)]
+        );
+        // a cut on `end` leaves a single-point group
+        assert_eq!(
+            generate_search_groups(100_000, &plan, 0, 430, 10, &[200, 430])
+                .await
+                .unwrap(),
+            vec![(0, 190), (200, 420), (430, 430)]
+        );
     }
 }

--- a/src/promql_service/src/search/grpc/mod.rs
+++ b/src/promql_service/src/search/grpc/mod.rs
@@ -139,19 +139,63 @@ pub async fn search(
 
     let start = query.start;
     let end = query.end;
+    let step = query.step;
     let trace_id = req.job.as_ref().unwrap().trace_id.to_string();
+    let org_id = &req.org_id;
 
     let mut results = Vec::new();
     if start == end {
         results.push(search_inner(req).await?);
     } else {
-        // cuts only pay off where the engine can stream
-        let with_cuts = cfg.search.feature_metrics_streaming_agg_enabled
-            && !query.query_exemplars
-            && !req.is_super_cluster;
-        let group = search_groups(req, with_cuts, "search").await?;
+        // 1. get max records stream
+        let start_ts = std::time::Instant::now();
+        let plan = match get_max_file_list(&trace_id, org_id, &query.query, start, end).await {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!(
+                    "[trace_id {trace_id}] promql->search->grpc: get max records stream error: {e}"
+                );
+                return Err(e);
+            }
+        };
+        log::info!(
+            "[trace_id {trace_id}] promql->search->grpc: get max records stream, took: {} ms",
+            start_ts.elapsed().as_millis()
+        );
 
-        // search each group
+        // 2. generate search group with max records stream
+        let start_ts = std::time::Instant::now();
+        // cuts only pay off where the engine can stream
+        let cuts = if cfg.search.feature_metrics_streaming_agg_enabled
+            && !query.query_exemplars
+            && !req.is_super_cluster
+        {
+            search_group_cuts(start, end, step, &plan, wal_floor())
+        } else {
+            Vec::new()
+        };
+        let memory_limit = cfg.memory_cache.datafusion_max_size; // bytes
+        let group = match generate_search_groups(memory_limit, &plan, start, end, step, &cuts).await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!(
+                    "[trace_id {trace_id}] promql->search->grpc: generate search group error: {e}"
+                );
+                return Err(e);
+            }
+        };
+        if group.len() > 1 {
+            log::info!(
+                "[trace_id {trace_id}] promql->search->grpc: get groups {group:?}, cuts {cuts:?}"
+            );
+        }
+        log::info!(
+            "[trace_id {trace_id}] promql->search->grpc: generate search group, took: {} ms",
+            start_ts.elapsed().as_millis()
+        );
+
+        // 3. search each group
         for (start, end) in group {
             let mut req = req.clone();
             req.need_wal = end >= wal_floor();
@@ -188,11 +232,14 @@ pub async fn data(
     req: &cluster_rpc::MetricsQueryRequest,
     tx: mpsc::Sender<Result<cluster_rpc::MetricsQueryResponse, tonic::Status>>,
 ) -> Result<()> {
+    let cfg = config::get_config();
     let query = req.query.as_ref().unwrap();
 
     let start = query.start;
     let end = query.end;
+    let step = query.step;
     let trace_id = req.job.as_ref().unwrap().trace_id.to_string();
+    let org_id = &req.org_id;
 
     let (data_tx, mut data_rx) = mpsc::channel::<(value::Value, String, ScanStats, i64)>(2);
     let data_trace_id = trace_id.clone();
@@ -236,9 +283,42 @@ pub async fn data(
         );
         return Ok(());
     }
-    let group = search_groups(req, false, "data").await?;
+    // 1. get max records stream
+    let plan = match get_max_file_list(&trace_id, org_id, &query.query, start, end).await {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!(
+                "[trace_id {trace_id}] promql->data->grpc: get max records stream error: {e}"
+            );
+            return Err(e);
+        }
+    };
+    log::info!(
+        "[trace_id {trace_id}] promql->data->grpc: get max records stream, took: {} ms",
+        start_ts.elapsed().as_millis()
+    );
 
-    // search each group
+    // 2. generate search group with max records stream
+    let start_ts = std::time::Instant::now();
+    let memory_limit = cfg.memory_cache.datafusion_max_size; // bytes
+    let group = match generate_search_group(memory_limit, plan.files, start, end, step).await {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!(
+                "[trace_id {trace_id}] promql->data->grpc: generate search group error: {e}"
+            );
+            return Err(e);
+        }
+    };
+    if group.len() > 1 {
+        log::info!("[trace_id {trace_id}] promql->data->grpc: get groups {group:?}");
+    }
+    log::info!(
+        "[trace_id {trace_id}] promql->data->grpc: generate data group, took: {} ms",
+        start_ts.elapsed().as_millis()
+    );
+
+    // 3. search each group
     for (start, end) in group {
         let mut req = req.clone();
         req.need_wal = end >= wal_floor();
@@ -335,62 +415,7 @@ pub async fn search_inner(
     Ok((value, result_type, scan_stats, took))
 }
 
-/// Plans a range query's groups: split at the streaming cuts when asked, then sized by memory.
-async fn search_groups(
-    req: &cluster_rpc::MetricsQueryRequest,
-    with_cuts: bool,
-    tag: &str,
-) -> Result<Vec<(i64, i64)>> {
-    let trace_id = req.job.as_ref().unwrap().trace_id.as_str();
-    let query = req.query.as_ref().unwrap();
-    let (start, end, step) = (query.start, query.end, query.step);
-
-    // 1. get max records stream
-    let start_ts = std::time::Instant::now();
-    let plan = match group_plan(trace_id, &req.org_id, &query.query, start, end).await {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!(
-                "[trace_id {trace_id}] promql->{tag}->grpc: get max records stream error: {e}"
-            );
-            return Err(e);
-        }
-    };
-    log::info!(
-        "[trace_id {trace_id}] promql->{tag}->grpc: get max records stream, took: {} ms",
-        start_ts.elapsed().as_millis()
-    );
-
-    // 2. generate search group with max records stream
-    let start_ts = std::time::Instant::now();
-    let cuts = if with_cuts {
-        search_group_cuts(start, end, step, &plan, wal_floor())
-    } else {
-        Vec::new()
-    };
-    let memory_limit = config::get_config().memory_cache.datafusion_max_size; // bytes
-    let groups = match generate_search_groups(memory_limit, &plan, start, end, step, &cuts).await {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!(
-                "[trace_id {trace_id}] promql->{tag}->grpc: generate search group error: {e}"
-            );
-            return Err(e);
-        }
-    };
-    if groups.len() > 1 {
-        log::info!(
-            "[trace_id {trace_id}] promql->{tag}->grpc: get groups {groups:?}, cuts {cuts:?}"
-        );
-    }
-    log::info!(
-        "[trace_id {trace_id}] promql->{tag}->grpc: generate search group, took: {} ms",
-        start_ts.elapsed().as_millis()
-    );
-    Ok(groups)
-}
-
-async fn group_plan(
+async fn get_max_file_list(
     trace_id: &str,
     org_id: &str,
     query: &str,


### PR DESCRIPTION
## What

The node-side PromQL range search already splits a query into time groups (sized by predicted memory) and runs each group as an independent query. A group whose end is within `3 × ZO_MAX_FILE_RETENTION_TIME` of now must read the WAL, which the streaming path does not support, so a dashboard query ending at `now` materialized as a whole (the UI's HTTP2 partitions only lose their last partition; Grafana or a direct `query_range` call lost the whole range).

This PR adds one more group boundary at that WAL floor: the head group streams, only the tail (30 minutes by default) reads the WAL and materializes. The cut lands on the query's own step grid, is only planned when streaming is enabled (and not for exemplar or super-cluster queries), and the memory-based sizing still runs on each side of it. The raw-samples `data` path is unchanged apart from the shared `need_wal` rule below.

## Boundary rules

- **Negative offsets.** A group ending at `t` reads up to `t + ahead` (`selector_window` collects the largest negative offset), so the cut is placed at `wal_floor - ahead`, and every group's `need_wal` (the memory-sized groups included, which had the same gap before) is now `end + ahead >= wal_floor`.
- **Subqueries.** The engine evaluates a subquery's inner expression over the group's own range only and never back-fills the points before the group start, so any group boundary changes the result at the boundary. That is a pre-existing engine limitation (the leader's per-node partitions and the memory-sized groups already hit it); this PR does not plan a cut for an expression containing a subquery.
- **Set operators with an empty side.** The engine turned `None or vector` (and `vector unless None`) into an empty matrix, so a fallback like `x or vector(0)` lost its samples on any group where `x` had no series at all. A pre-existing gap that any group boundary exposed; the binary evaluator now hands an empty side to the set operator, which keeps the other side (`or`, `unless`) or returns empty (`and`), for instant and range evaluation alike.
- **One-sample operands.** The evaluator folded any right side of one series with one sample into a scalar, which bypassed label matching for arithmetic and comparisons and sent set operators down the vector-scalar path; a group boundary can leave a filtered right side with a single sample. Both operands now fold only when their static type is scalar (`scalar()`, `time()`, literals and their arithmetic, via `Expr::value_type`), on whichever side they stand; a one-sample vector keeps vector semantics. Visible consequence for instant queries: `sum by(pod)(x) / count(x)` used to broadcast the right side as a scalar and now needs `on()`/`group_left` like Prometheus, matching what OpenObserve already returned for the same query as a range query. Untouched, pre-existing: `scalar(x)` over a range (one sample per step) still goes through label matching instead of a per-step broadcast.
- **Single-point groups.** A group with `start == end` is evaluated as an instant query and its sample would be dropped by the leader's matrix merge, so both sides of the cut keep at least two steps.

## Verification

- Unit tests: cut placement on the query grid, a floor outside the range, the two-step minimum on both sides, the cut moved by `ahead`, no group straddles the cut, `selector_window` over negative offsets, aggregations, binary expressions and subqueries, set operators with an empty side (instant and range), a one-sample vector right side under `or` and `+`, and scalar-typed operands folding on either side (`scalar(x) + labelled`, `labelled + scalar(x)`, `sum(scalar + labelled)`, `scalar + scalar`). `cargo test -p promql -p promql-service` green, clippy with the CI flags clean.

## TODO: mixed layout after `ZO_METRICS_INDEX_ENABLED` is flipped

The hours written before the flip stay in the legacy layout for good, and the storage context streams only when *all* files of a group are hash-ordered, so any query whose window crosses the flip materializes as a whole until the legacy hours age out of retention. The same cut mechanism fixes it: cut at `newest legacy max_ts + the query's read-back window + step`, so the groups after it load hash-ordered files only. An earlier revision of this PR carried that cut and validated it end to end (faker dataset with hour 03 renamed to legacy file names: responses byte-identical to the pure dataset, the group after the cut streamed 4/4); it was dropped here to keep this PR to the WAL floor and will follow separately.
