### PR TITLE
fix: render streaming aggregation results as they arrive (#14303)

### DIFF
--- a/tests/ui-testing/ci-matrix/ci_matrix_regression.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix_regression.json
@@ -9,7 +9,8 @@
       "logs-9754.spec.js",
       "logs-9044-7354.spec.js",
       "logs-multistream-matchall-pagination.spec.js",
-      "logs-14283.spec.js"
+      "logs-14283.spec.js",
+      "logs-14303-streaming-render.spec.js"
     ],
     "disabled": []
   },

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -502,7 +502,7 @@ export class LogsPage {
         this.resultsSkeleton = '[data-test="logs-search-result-logs-table"] [data-test="o2-table-skeleton-body"]';
         this.resultsLoadingBanner = '[data-test="logs-search-result-logs-table"] [data-test="o2-table-loading-banner"]';
         this.noResultsFoundText = '[data-test="logs-search-no-events-found-text"]';
-        this.resultsProgressBar = '[data-test="logs-search-result-progress"] [data-test="loading-progress"]';
+        this.resultsProgressBar = '[data-test="logs-results-progress"]';
         this.tableRowExpandMenu = '[data-test^="o2-table-expand-"]';
         this.logDetailsIncludeExcludeBtn = '[data-test="log-details-include-exclude-field-btn"]';
         this.timestampCells = '[data-test="o2-table-cell-_timestamp"]';

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -501,6 +501,7 @@ export class LogsPage {
         this.logsSearchResultTableRows = '[data-test="logs-search-result-logs-table"] tbody tr[data-test^="o2-table-row-"]';
         this.resultsSkeleton = '[data-test="logs-search-result-logs-table"] [data-test="o2-table-skeleton-body"]';
         this.resultsLoadingBanner = '[data-test="logs-search-result-logs-table"] [data-test="o2-table-loading-banner"]';
+        this.noResultsFoundText = '[data-test="logs-search-no-events-found-text"]';
         this.resultsProgressBar = '[data-test="logs-search-result-progress"] [data-test="loading-progress"]';
         this.tableRowExpandMenu = '[data-test^="o2-table-expand-"]';
         this.logDetailsIncludeExcludeBtn = '[data-test="log-details-include-exclude-field-btn"]';

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -501,6 +501,7 @@ export class LogsPage {
         this.logsSearchResultTableRows = '[data-test="logs-search-result-logs-table"] tbody tr[data-test^="o2-table-row-"]';
         this.resultsSkeleton = '[data-test="logs-search-result-logs-table"] [data-test="o2-table-skeleton-body"]';
         this.resultsLoadingBanner = '[data-test="logs-search-result-logs-table"] [data-test="o2-table-loading-banner"]';
+        this.resultsProgressBar = '[data-test="logs-search-result-progress"] [data-test="loading-progress"]';
         this.tableRowExpandMenu = '[data-test^="o2-table-expand-"]';
         this.logDetailsIncludeExcludeBtn = '[data-test="log-details-include-exclude-field-btn"]';
         this.timestampCells = '[data-test="o2-table-cell-_timestamp"]';
@@ -10770,6 +10771,13 @@ export class LogsPage {
         await expect(this.page.locator(this.resultsSkeleton)).toHaveCount(0);
         await expect(this.page.locator(this.resultsLoadingBanner)).toHaveCount(0);
         testLogger.info('Results grid settled with rows, no skeleton or loading banner');
+    }
+
+    /** Assert the results progress bar has faded out once the search settled. */
+    async expectResultsProgressBarFadedOut() {
+        // The bar stays mounted to run its own fade, so absence is opacity-0, not detachment.
+        await expect(this.page.locator(this.resultsProgressBar)).toHaveClass(/opacity-0/);
+        testLogger.info('Results progress bar faded out after the search settled');
     }
 
     // ============================================================================

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -499,6 +499,8 @@ export class LogsPage {
 
         // ===== V0.40 REGRESSION TEST LOCATORS =====
         this.logsSearchResultTableRows = '[data-test="logs-search-result-logs-table"] tbody tr[data-test^="o2-table-row-"]';
+        this.resultsSkeleton = '[data-test="logs-search-result-logs-table"] [data-test="o2-table-skeleton-body"]';
+        this.resultsLoadingBanner = '[data-test="logs-search-result-logs-table"] [data-test="o2-table-loading-banner"]';
         this.tableRowExpandMenu = '[data-test^="o2-table-expand-"]';
         this.logDetailsIncludeExcludeBtn = '[data-test="log-details-include-exclude-field-btn"]';
         this.timestampCells = '[data-test="o2-table-cell-_timestamp"]';
@@ -10760,6 +10762,14 @@ export class LogsPage {
     async expectLogsTableVisible() {
         await expect(this.page.locator(this.logsSearchResultLogsTable)).toBeVisible({ timeout: 30000 });
         testLogger.info('Logs table is visible');
+    }
+
+    /** Assert the settled results grid shows real rows, not the skeleton or a banner. */
+    async expectResultsGridSettledWithRows() {
+        await expect(this.page.locator(this.logsSearchResultTableRows).first()).toBeVisible({ timeout: 30000 });
+        await expect(this.page.locator(this.resultsSkeleton)).toHaveCount(0);
+        await expect(this.page.locator(this.resultsLoadingBanner)).toHaveCount(0);
+        testLogger.info('Results grid settled with rows, no skeleton or loading banner');
     }
 
     // ============================================================================

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
@@ -50,8 +50,9 @@ test.describe("Logs Streaming Render Regression", () => {
     await pm.logsPage.runQueryAndWaitForResults();
 
     await pm.logsPage.expectResultsGridSettledWithRows();
+    await pm.logsPage.expectResultsProgressBarFadedOut();
 
-    testLogger.info('✓ PASSED: aggregate query settles with rows, no skeleton or banner');
+    testLogger.info('✓ PASSED: aggregate query settles with rows, no skeleton, banner or progress bar');
   });
 
   test("plain non-aggregate logs query is unchanged @bug-14303 @P1 @streamingAggs @regression @logsRegression", async ({ page }) => {

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
@@ -3,8 +3,9 @@
  *
  * Collateral-damage guard for #14303: the results grid stayed hidden behind the
  * skeleton for the whole duration of a streaming-aggs query. The regression itself
- * is caught by the unit tests (SearchResult.spec.ts / OTable.spec.ts) — see
- * docs/issue-14303-implementation-spec.md §1.8.1. These cases assert the settled
+ * is caught by the unit tests (SearchResult.spec.ts / OTable.spec.ts); this suite
+ * can only assert settled state, because no route.fulfill body leaves a stream open
+ * long enough to observe the mid-stream render. These cases assert the settled
  * states adjacent to the fix still resolve correctly against a real backend.
  */
 

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
@@ -38,6 +38,9 @@ test.describe("Logs Streaming Render Regression", () => {
     await page.waitForTimeout(1000);
     await pm.logsPage.clickDateTimeButton();
     await pm.logsPage.clickRelative1HourOrFallback();
+    // sqlMode's watcher rewrites the editor asynchronously, so it must settle here, before any test writes its query
+    await pm.logsPage.enableSqlModeIfNeeded();
+    await page.waitForTimeout(2000);
 
     testLogger.info('Logs streaming render regression test setup completed');
   });
@@ -45,11 +48,8 @@ test.describe("Logs Streaming Render Regression", () => {
   test("aggregate query resolves to settled rows with no skeleton or banner left behind @bug-14303 @P1 @streamingAggs @regression @logsRegression", async ({ page }) => {
     testLogger.info('Test: streaming_aggs query settles the results grid (Bug #14303)');
 
-    // sqlMode's watcher asynchronously rewrites the editor, so it must land before we write the query
-    await pm.logsPage.enableSqlModeIfNeeded();
-    await page.waitForTimeout(500);
     await pm.logsPage.clearAndFillQueryEditor('SELECT kubernetes_pod_name, count(*) as total FROM "e2e_automate" GROUP BY kubernetes_pod_name');
-    await page.waitForTimeout(500);
+    await pm.logsPage.expectQueryEditorContainsText('GROUP BY kubernetes_pod_name');
     await pm.logsPage.runQueryAndWaitForResults();
 
     await pm.logsPage.expectResultsGridSettledWithRows();
@@ -67,11 +67,8 @@ test.describe("Logs Streaming Render Regression", () => {
     testLogger.info('Test: non-aggregate query still settles the results grid (Bug #14303)');
 
     const plainQuery = 'SELECT * FROM "e2e_automate"';
-    // sqlMode's watcher asynchronously rewrites the editor, so it must land before we write the query
-    await pm.logsPage.enableSqlModeIfNeeded();
-    await page.waitForTimeout(500);
     await pm.logsPage.clearAndFillQueryEditor(plainQuery);
-    await page.waitForTimeout(500);
+    await pm.logsPage.expectQueryEditorContainsText(plainQuery);
     await pm.logsPage.runQueryAndWaitForResults();
 
     await pm.logsPage.expectResultsGridSettledWithRows();
@@ -83,11 +80,8 @@ test.describe("Logs Streaming Render Regression", () => {
   test("zero-row query still shows the no-events empty state @bug-14303 @P1 @streamingAggs @regression @logsRegression", async ({ page }) => {
     testLogger.info('Test: empty result set still renders the no-events state (Bug #14303)');
 
-    // sqlMode's watcher asynchronously rewrites the editor, so it must land before we write the query
-    await pm.logsPage.enableSqlModeIfNeeded();
-    await page.waitForTimeout(500);
     await pm.logsPage.clearAndFillQueryEditor('SELECT * FROM "e2e_automate" WHERE kubernetes_pod_name = \'nonexistent_pod_14303_regression\'');
-    await page.waitForTimeout(500);
+    await pm.logsPage.expectQueryEditorContainsText('nonexistent_pod_14303_regression');
     await pm.logsPage.runQueryAndWaitForResults();
 
     await expect(page.locator(pm.logsPage.noResultsFoundText), 'No-events empty state must render for a zero-row result').toBeVisible();

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
@@ -45,12 +45,20 @@ test.describe("Logs Streaming Render Regression", () => {
   test("aggregate query resolves to settled rows with no skeleton or banner left behind @bug-14303 @P1 @streamingAggs @regression @logsRegression", async ({ page }) => {
     testLogger.info('Test: streaming_aggs query settles the results grid (Bug #14303)');
 
+    // sqlMode's watcher asynchronously rewrites the editor, so it must land before we write the query
     await pm.logsPage.enableSqlModeIfNeeded();
-    await pm.logsPage.setQueryEditorContent('SELECT kubernetes_pod_name, count(*) as total FROM "e2e_automate" GROUP BY kubernetes_pod_name');
+    await page.waitForTimeout(500);
+    await pm.logsPage.clearAndFillQueryEditor('SELECT kubernetes_pod_name, count(*) as total FROM "e2e_automate" GROUP BY kubernetes_pod_name');
+    await page.waitForTimeout(500);
     await pm.logsPage.runQueryAndWaitForResults();
 
     await pm.logsPage.expectResultsGridSettledWithRows();
     await pm.logsPage.expectResultsProgressBarFadedOut();
+
+    // guards against a silently un-applied query: the raw stream fills a full 50-row page, the GROUP BY does not
+    const aggregateRowCount = await page.locator(pm.logsPage.logsSearchResultTableRows).count();
+    expect(aggregateRowCount, 'grid must show the aggregate result, not a full page of raw stream rows').toBeGreaterThan(0);
+    expect(aggregateRowCount, 'grid must show the aggregate result, not a full page of raw stream rows').toBeLessThan(50);
 
     testLogger.info('✓ PASSED: aggregate query settles with rows, no skeleton, banner or progress bar');
   });
@@ -58,9 +66,16 @@ test.describe("Logs Streaming Render Regression", () => {
   test("plain non-aggregate logs query is unchanged @bug-14303 @P1 @streamingAggs @regression @logsRegression", async ({ page }) => {
     testLogger.info('Test: non-aggregate query still settles the results grid (Bug #14303)');
 
+    const plainQuery = 'SELECT * FROM "e2e_automate"';
+    // sqlMode's watcher asynchronously rewrites the editor, so it must land before we write the query
+    await pm.logsPage.enableSqlModeIfNeeded();
+    await page.waitForTimeout(500);
+    await pm.logsPage.clearAndFillQueryEditor(plainQuery);
+    await page.waitForTimeout(500);
     await pm.logsPage.runQueryAndWaitForResults();
 
     await pm.logsPage.expectResultsGridSettledWithRows();
+    await pm.logsPage.expectQueryEditorContainsText(plainQuery);
 
     testLogger.info('✓ PASSED: non-aggregate query unaffected by the streaming-aggs fix');
   });
@@ -68,8 +83,11 @@ test.describe("Logs Streaming Render Regression", () => {
   test("zero-row query still shows the no-events empty state @bug-14303 @P1 @streamingAggs @regression @logsRegression", async ({ page }) => {
     testLogger.info('Test: empty result set still renders the no-events state (Bug #14303)');
 
+    // sqlMode's watcher asynchronously rewrites the editor, so it must land before we write the query
     await pm.logsPage.enableSqlModeIfNeeded();
-    await pm.logsPage.setQueryEditorContent('SELECT * FROM "e2e_automate" WHERE kubernetes_pod_name = \'nonexistent_pod_14303_regression\'');
+    await page.waitForTimeout(500);
+    await pm.logsPage.clearAndFillQueryEditor('SELECT * FROM "e2e_automate" WHERE kubernetes_pod_name = \'nonexistent_pod_14303_regression\'');
+    await page.waitForTimeout(500);
     await pm.logsPage.runQueryAndWaitForResults();
 
     await expect(page.locator(pm.logsPage.noResultsFoundText), 'No-events empty state must render for a zero-row result').toBeVisible();

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
@@ -1,0 +1,80 @@
+/**
+ * Logs Streaming Render Regression Tests
+ *
+ * Collateral-damage guard for #14303: the results grid stayed hidden behind the
+ * skeleton for the whole duration of a streaming-aggs query. The regression itself
+ * is caught by the unit tests (SearchResult.spec.ts / OTable.spec.ts) — see
+ * docs/issue-14303-implementation-spec.md §1.8.1. These cases assert the settled
+ * states adjacent to the fix still resolve correctly against a real backend.
+ */
+
+const { test, expect, navigateToBase } = require('../../utils/enhanced-baseFixtures.js');
+const testLogger = require('../../utils/test-logger.js');
+const PageManager = require('../../../pages/page-manager.js');
+const logData = require("../../../fixtures/log.json");
+const { ingestTestData, sendRequest, getHeaders, getIngestionUrl, waitForFieldValueSearchable } = require('../../utils/data-ingestion.js');
+const { getOrgIdentifier, isCloudEnvironment } = require('../../utils/cloud-auth.js');
+
+test.describe("Logs Streaming Render Regression", () => {
+  test.describe.configure({ mode: 'parallel' });
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    // Attempt data ingestion but don't fail test if it errors (global setup already ingested data)
+    try {
+      await ingestTestData(page);
+    } catch (error) {
+      testLogger.warn(`Data ingestion skipped (may already exist from global setup): ${error.message}`);
+    }
+
+    await page.goto(`${logData.logsUrl}?org_identifier=${getOrgIdentifier() || 'default'}`);
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await pm.logsPage.selectStream('e2e_automate');
+    await page.waitForTimeout(1000);
+    await pm.logsPage.clickDateTimeButton();
+    await pm.logsPage.clickRelative1HourOrFallback();
+
+    testLogger.info('Logs streaming render regression test setup completed');
+  });
+
+  test("aggregate query resolves to settled rows with no skeleton or banner left behind @bug-14303 @P1 @streamingAggs @regression @logsRegression", async ({ page }) => {
+    testLogger.info('Test: streaming_aggs query settles the results grid (Bug #14303)');
+
+    await pm.logsPage.enableSqlModeIfNeeded();
+    await pm.logsPage.setQueryEditorContent('SELECT kubernetes_pod_name, count(*) as total FROM "e2e_automate" GROUP BY kubernetes_pod_name');
+    await pm.logsPage.runQueryAndWaitForResults();
+
+    await pm.logsPage.expectResultsGridSettledWithRows();
+
+    testLogger.info('✓ PASSED: aggregate query settles with rows, no skeleton or banner');
+  });
+
+  test("plain non-aggregate logs query is unchanged @bug-14303 @P1 @streamingAggs @regression @logsRegression", async ({ page }) => {
+    testLogger.info('Test: non-aggregate query still settles the results grid (Bug #14303)');
+
+    await pm.logsPage.runQueryAndWaitForResults();
+
+    await pm.logsPage.expectResultsGridSettledWithRows();
+
+    testLogger.info('✓ PASSED: non-aggregate query unaffected by the streaming-aggs fix');
+  });
+
+  test("zero-row query still shows the no-events empty state @bug-14303 @P1 @streamingAggs @regression @logsRegression", async ({ page }) => {
+    testLogger.info('Test: empty result set still renders the no-events state (Bug #14303)');
+
+    await pm.logsPage.enableSqlModeIfNeeded();
+    await pm.logsPage.setQueryEditorContent('SELECT * FROM "e2e_automate" WHERE kubernetes_pod_name = \'nonexistent_pod_14303_regression\'');
+    await pm.logsPage.runQueryAndWaitForResults();
+
+    const noResultsVisible = await pm.logsPage.isNoResultsMessageVisible();
+    expect(noResultsVisible, 'No-events empty state must render for a zero-row result').toBeTruthy();
+    await expect(page.locator(pm.logsPage.resultsSkeleton)).toHaveCount(0);
+
+    testLogger.info('✓ PASSED: zero-row query still shows the no-events empty state');
+  });
+});

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14303-streaming-render.spec.js
@@ -72,8 +72,7 @@ test.describe("Logs Streaming Render Regression", () => {
     await pm.logsPage.setQueryEditorContent('SELECT * FROM "e2e_automate" WHERE kubernetes_pod_name = \'nonexistent_pod_14303_regression\'');
     await pm.logsPage.runQueryAndWaitForResults();
 
-    const noResultsVisible = await pm.logsPage.isNoResultsMessageVisible();
-    expect(noResultsVisible, 'No-events empty state must render for a zero-row result').toBeTruthy();
+    await expect(page.locator(pm.logsPage.noResultsFoundText), 'No-events empty state must render for a zero-row result').toBeVisible();
     await expect(page.locator(pm.logsPage.resultsSkeleton)).toHaveCount(0);
 
     testLogger.info('✓ PASSED: zero-row query still shows the no-events empty state');

--- a/web/src/components/common/LoadingProgress.vue
+++ b/web/src/components/common/LoadingProgress.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    data-test="loading-progress"
     class="absolute top-0 left-0 z-999 w-full transition-opacity duration-500 ease-out"
     :class="{
       'opacity-0': !loading && !isFadingOut,

--- a/web/src/components/common/LoadingProgress.vue
+++ b/web/src/components/common/LoadingProgress.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    data-test="loading-progress"
     class="absolute top-0 left-0 z-999 w-full transition-opacity duration-500 ease-out"
     :class="{
       'opacity-0': !loading && !isFadingOut,

--- a/web/src/lib/core/Table/OTable.spec.ts
+++ b/web/src/lib/core/Table/OTable.spec.ts
@@ -1568,6 +1568,18 @@ describe("OTable", () => {
       expect(wrapper.findAll('[data-test="o2-table-loading-banner"]').length).toBe(0);
       expect(wrapper.find('[data-test="o2-table-streaming-bar"]').exists()).toBe(true);
     });
+
+    it("renders the default banner while streaming when no loading-banner slot is supplied", () => {
+      // Pairs with the empty-slot case: together they pin the opt-out as a contract.
+      wrapper = mount(OTable, {
+        props: {
+          data: makeRows(5),
+          columns: makeColumns(),
+          streaming: true,
+        },
+      });
+      expect(wrapper.find('[data-test="o2-table-loading-banner"]').exists()).toBe(true);
+    });
   });
 
   // ── Scoped Bottom Slot ─────────────────────────────────────

--- a/web/src/lib/core/Table/OTable.spec.ts
+++ b/web/src/lib/core/Table/OTable.spec.ts
@@ -1552,6 +1552,22 @@ describe("OTable", () => {
       });
       expect(wrapper.find('[data-test="custom-loading-banner"]').exists()).toBe(true);
     });
+
+    it("suppresses the default banner for an empty loading-banner slot but keeps the streaming bar", () => {
+      // An empty slot still counts as "provided" — consumers can opt out of the default banner entirely.
+      wrapper = mount(OTable, {
+        props: {
+          data: makeRows(5),
+          columns: makeColumns(),
+          streaming: true,
+        },
+        slots: {
+          "loading-banner": "",
+        },
+      });
+      expect(wrapper.findAll('[data-test="o2-table-loading-banner"]').length).toBe(0);
+      expect(wrapper.find('[data-test="o2-table-streaming-bar"]').exists()).toBe(true);
+    });
   });
 
   // ── Scoped Bottom Slot ─────────────────────────────────────

--- a/web/src/plugins/logs/SearchResult.spec.ts
+++ b/web/src/plugins/logs/SearchResult.spec.ts
@@ -50,6 +50,15 @@ vi.mock("@/lib/core/Table/OTable.vue", () => ({
   },
 }));
 
+// Named stub so both progress bars on the page can be told apart by their props.
+vi.mock("@/components/common/LoadingProgress.vue", () => ({
+  default: {
+    name: "LoadingProgress",
+    props: ["loading", "loadingProgressPercentage"],
+    template: '<div data-test="loading-progress-stub" />',
+  },
+}));
+
 describe("SearchResult Component", () => {
   let wrapper: any;
 
@@ -984,6 +993,47 @@ describe("SearchResult Component", () => {
     it("passes a loading-banner slot so OTable suppresses its default banner", async () => {
       await setState(true, hits(3));
       expect(wrapper.find('[data-test="otable-stub-has-loading-banner-slot"]').exists()).toBe(true);
+    });
+  });
+  describe("results progress bar (#14303)", () => {
+    const progressBars = () => wrapper.findAllComponents({ name: "LoadingProgress" });
+    const barsLoading = () => progressBars().filter((bar: any) => bar.props("loading") === true);
+
+    const setProgress = async (loading: boolean, percentage: number | undefined) => {
+      wrapper.vm.searchObj.loading = loading;
+      wrapper.vm.searchObj.loadingProgressPercentage = percentage;
+      wrapper.vm.searchObj.loadingHistogram = false;
+      wrapper.vm.searchObj.loadingHistogramProgressPercentage = 0;
+      await wrapper.vm.$nextTick();
+      await flushPromises();
+    };
+
+    it("binds the streaming results percentage to its own progress bar", async () => {
+      await setProgress(true, 42);
+      expect(barsLoading()).toHaveLength(1);
+      expect(barsLoading()[0].props("loadingProgressPercentage")).toBe(42);
+    });
+
+    it("falls back to 0 when no progress has been reported yet", async () => {
+      await setProgress(true, undefined);
+      expect(barsLoading()).toHaveLength(1);
+      expect(barsLoading()[0].props("loadingProgressPercentage")).toBe(0);
+    });
+
+    it("stays mounted with loading=false so it can run its own fade-out", async () => {
+      await setProgress(false, 37);
+      const settled = progressBars().filter(
+        (bar: any) => bar.props("loadingProgressPercentage") === 37,
+      );
+      expect(settled).toHaveLength(1);
+      expect(settled[0].props("loading")).toBe(false);
+    });
+
+    it("does not let the histogram bar stand in for the results bar", async () => {
+      await setProgress(true, 42);
+      expect(barsLoading()).toHaveLength(1);
+      expect(barsLoading()[0].props("loadingProgressPercentage")).toBe(42);
+      expect(wrapper.vm.searchObj.loadingHistogram).toBe(false);
     });
   });
 });

--- a/web/src/plugins/logs/SearchResult.spec.ts
+++ b/web/src/plugins/logs/SearchResult.spec.ts
@@ -36,6 +36,20 @@ const oDrawerStub = {
   emits: ["update:open", "close"],
 };
 
+// Named stub so props and the presence of a `loading-banner` slot are observable.
+vi.mock("@/lib/core/Table/OTable.vue", () => ({
+  // defineAsyncComponent unwraps `.default` only for a module-shaped result.
+  __esModule: true,
+  default: {
+    name: "OTable",
+    props: ["columns", "data", "loading", "streaming", "wrap", "rowKey", "virtualScroll"],
+    template:
+      '<div data-test="otable-stub">' +
+      '<div v-if="$slots[\'loading-banner\']" data-test="otable-stub-has-loading-banner-slot" />' +
+      "</div>",
+  },
+}));
+
 describe("SearchResult Component", () => {
   let wrapper: any;
 
@@ -81,7 +95,6 @@ describe("SearchResult Component", () => {
           DetailTable: true,
           ChartRenderer: true,
           SanitizedHtmlRenderer: true,
-          OTable: true,
           CellActions: true,
           O2AIContextAddBtn: true,
           PatternDetailsDialog: true,
@@ -902,6 +915,75 @@ describe("SearchResult Component", () => {
       await flushPromises();
 
       expect(wrapper.vm.searchObj.meta.showDetailTab).toBe(false);
+    });
+  });
+  describe("streaming results grid (#14303)", () => {
+    const hits = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({ _timestamp: i, log: `line-${i}` }));
+
+    const setState = async (loading: boolean, rows: any[]) => {
+      wrapper.vm.searchObj.loading = loading;
+      wrapper.vm.searchObj.data.queryResults = { hits: rows };
+      await wrapper.vm.$nextTick();
+      await flushPromises();
+    };
+
+    const table = () => wrapper.findComponent({ name: "OTable" });
+
+    it("shows the skeleton on first paint: loading with no rows", async () => {
+      await setState(true, []);
+      expect(table().props("loading")).toBe(true);
+      expect(table().props("streaming")).toBe(false);
+    });
+
+    it("switches to streaming once rows exist while still loading", async () => {
+      await setState(true, hits(3));
+      expect(table().props("loading")).toBe(false);
+      expect(table().props("streaming")).toBe(true);
+    });
+
+    it("is neither loading nor streaming once the search settles with rows", async () => {
+      await setState(false, hits(3));
+      expect(table().props("loading")).toBe(false);
+      expect(table().props("streaming")).toBe(false);
+    });
+
+    it("is neither loading nor streaming when the search settles with no rows", async () => {
+      await setState(false, []);
+      expect(table().props("loading")).toBe(false);
+      expect(table().props("streaming")).toBe(false);
+    });
+
+    it("tracks the latest hits array across successive replacements", async () => {
+      await setState(true, hits(2));
+      expect(table().props("data").length).toBe(2);
+      await setState(true, hits(5));
+      expect(table().props("data").length).toBe(5);
+      await setState(true, hits(9));
+      expect(table().props("data").length).toBe(9);
+    });
+
+    it("never remounts the grid across successive replacements", async () => {
+      await setState(true, hits(2));
+      const uid = table().vm.$.uid;
+      await setState(true, hits(5));
+      expect(table().vm.$.uid).toBe(uid);
+      await setState(true, hits(9));
+      expect(table().vm.$.uid).toBe(uid);
+      await setState(false, hits(9));
+      expect(table().vm.$.uid).toBe(uid);
+    });
+
+    it("returns streaming to false when the hits are emptied mid-search", async () => {
+      await setState(true, hits(3));
+      expect(table().props("streaming")).toBe(true);
+      await setState(true, []);
+      expect(table().props("streaming")).toBe(false);
+    });
+
+    it("passes a loading-banner slot so OTable suppresses its default banner", async () => {
+      await setState(true, hits(3));
+      expect(wrapper.find('[data-test="otable-stub-has-loading-banner-slot"]').exists()).toBe(true);
     });
   });
 });

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -2297,6 +2297,7 @@ export default defineComponent({
       );
     };
     // `immediate` so a mount with results already present still highlights them.
+    // `clearCache: true` is load-bearing: updateGridColumns() reassigns the columns on every streaming chunk, and this is the only path that drops the previous partition's highlighted HTML for a reused row index.
     watch(
       () => getColumns.value,
       () => reprocessLogsHighlight(true),

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -265,6 +265,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </div>
 
+      <!-- Outside scrollContainerRef so the results progress bar can't scroll away. -->
+      <div class="relative" data-test="logs-search-result-progress">
+        <LoadingProgress
+          :loading="searchObj.loading"
+          :loadingProgressPercentage="searchObj.loadingProgressPercentage || 0"
+        />
+      </div>
+
       <!-- Combined scroll: histogram + logs/patterns scroll together vertically.
         The histogram is pinned along the X axis only (see histogramPinStyle), so
         scrolling the wide results table sideways can't drag the chart with it. -->

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -266,8 +266,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
 
       <!-- Outside scrollContainerRef so the results progress bar can't scroll away. -->
-      <div class="relative" data-test="logs-search-result-progress">
+      <div class="relative">
         <LoadingProgress
+          data-test="logs-results-progress"
           :loading="searchObj.loading"
           :loadingProgressPercentage="searchObj.loadingProgressPercentage || 0"
         />

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -489,7 +489,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   :columns="getColumns || []"
                   :data="searchObj.data.queryResults?.hits || []"
                   :wrap="searchObj.meta.toggleSourceWrap"
-                  :loading="searchObj.loading"
+                  :loading="isResultsSkeleton"
+                  :streaming="isResultsStreaming"
                   :row-key="logsRowKey"
                   :row-height="20"
                   virtual-scroll
@@ -524,6 +525,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   @row-click="openLogDetailsByRow"
                   @update:expandedIds="onExpandedLogIdsChange"
                 >
+                  <!-- Empty slot opts out of OTable's default banner, which would shift the grid on every partition. -->
+                  <template #loading-banner />
+
                   <!-- FTS-highlighted cell content; falls back to the plain value. -->
                   <template
                     v-for="col in getColumns || []"
@@ -1961,6 +1965,11 @@ export default defineComponent({
       return ((searchObj.data?.resultGrid?.columns as any[]) ?? []).filter((col: any) => !!col.id);
     });
 
+    const hasResultRows = computed(() => (searchObj.data.queryResults?.hits?.length ?? 0) > 0);
+    // First paint has nothing to show, so the skeleton is right; once rows exist we switch to `streaming` so partial results stay on screen.
+    const isResultsSkeleton = computed(() => searchObj.loading && !hasResultRows.value);
+    const isResultsStreaming = computed(() => searchObj.loading && hasResultRows.value);
+
     const getPartitionPaginations = computed(() => {
       return searchObj.data.queryResults?.partitionDetail?.paginations || [];
     });
@@ -2413,6 +2422,9 @@ export default defineComponent({
       getTableWidth,
       scrollTableToTop,
       getColumns,
+      hasResultRows,
+      isResultsSkeleton,
+      isResultsStreaming,
       reorderSelectedFields,
       getPaginations,
       refreshPagination,


### PR DESCRIPTION
Fixes #14303.

## The problem

When the backend answers an aggregate query with `streaming_aggs`, it streams ~85 progressively refined result sets over the life of the query. `searchObj.loading` stays `true` for that whole time, and the results grid bound `:loading` straight to it — so `OTable`'s skeleton covered the grid for the entire query (~90s in the reported case) and the user saw nothing until the very end.

Regressed in #13451, when the grid moved from the bespoke `TenstackTable` to the shared `OTable`. The old table gated its skeleton on `loading && rows.length === 0` and rendered a progress bar; both were dropped in the move. `OTable` already ships the replacement mechanism (`streaming`), so this restores the behaviour rather than inventing a new pattern.

## What changed

Two independent parts, in commit order, so they can be reverted separately.

**1. Keep rows on screen while results stream in** — `web/src/plugins/logs/SearchResult.vue`

Splits the single loading flag in two: `isResultsSkeleton` (loading, no rows yet) drives `:loading`, and `isResultsStreaming` (loading, rows exist) drives `:streaming`. The skeleton now shows only on first paint; once rows exist they stay on screen and update in place as each partition lands.

`OTable` renders a "Loading…" banner whenever `streaming` is true with rows present. On a virtual-scrolled grid that appears and disappears on every search and shifts the layout, so it is suppressed via the supported escape hatch — passing an empty `#loading-banner` slot. No new prop, no `v-if` added to `OTable`; other consumers keep the default.

**2. Restore the results progress bar** — `SearchResult.vue`, `web/src/components/common/LoadingProgress.vue`

`searchObj.loadingProgressPercentage` is written on every progress event but no template read it after #13451. This puts a `LoadingProgress` back above the results, mirroring the histogram's existing usage, and gives the component a stable `data-test` hook. It sits outside the scroll container so it cannot scroll away with the rows.

Two further streaming-aggs bugs found during this work — chunked hits being dropped, and `total` being summed instead of replaced across partitions — are **not in this PR**. They are independent of the render regression and older than #13451, so they live on their own branch (`fix-14303-streaming-aggs-accumulation`) to keep a rendering fix and a totals fix from being confused for one another in a bisect.

## Verification

- **705 unit tests pass** across the touched suites; `format:check` clean; lint unchanged from the pre-existing baseline.
- **The unit tests were proven to be a real regression guard**: reverting only the template bindings turns cases 1/2/3/4/7/8 red.
- **Verified by hand against a live cluster**, running the issue's query over a 3-week window: first rows at 0.9s instead of at the end, seven progressively refined result sets visibly rendered, skeleton only before the first rows and never over them, no loading banner, progress bar 0 → 100% then faded, settled count correct. A plain non-aggregate query and a zero-row query both still behave as before, with the empty state resolving correctly.

## The Playwright spec

The spec added here asserts settled state only — no `route.fulfill` body leaves a
stream open long enough to observe the mid-stream render, so the regression guard
itself lives in the unit tests. These cases cover the collateral damage: the
aggregate query settling with rows and no skeleton or banner, a plain query
unchanged, and a zero-row query still reaching the no-events state.

An earlier revision of this PR had all three cases passing vacuously — the editor
displayed each query while the page kept running its default one, so the aggregate
case never touched the streaming-aggs path. Fixed in `test(e2e): run the queries
under test` and `test(e2e): settle SQL mode before writing each query`: SQL mode
now settles in `beforeEach` before any test writes, every fill is followed by an
`expectQueryEditorContainsText` assertion that the query actually landed, and the
aggregate case additionally asserts a row count below 50 — the raw stream fills a
full page, the `GROUP BY` does not, so a silently un-applied query now fails.

Note that `ci_matrix_regression.json` feeds `playwright_bugfix_regression.yml`,
which runs on a schedule and on manual dispatch, not on pull requests — this
registration does not affect PR CI either way.

## Notes for reviewers

- `logsRowKey`, `logsRowIndex` and `expandedLogIds` are deliberately untouched. Under streaming aggs the hits array is replaced each partition, but in virtual mode `OTable` keys rendered rows off the virtualizer index, so rows update in place — which is the effect we want.
- The highlighter cache stays fresh mid-stream only because `updateGridColumns` reassigns `resultGrid.columns` on every chunk, firing the `getColumns` watcher with `clearCache: true`. That is load-bearing and non-obvious, so it now carries a comment — memoizing that array would silently freeze the grid on the first partition's values.
- No enterprise-gated code is touched, so a green local check is meaningful here. No `src/` change; backend already streams correctly.

