### PR TITLE
perf(promql): stream a bare instant selector as last_over_time over the lookback

### DIFF
--- a/src/promql/src/engine/aggregate.rs
+++ b/src/promql/src/engine/aggregate.rs
@@ -50,8 +50,7 @@ impl Engine {
         // fused shapes fold the range function into the aggregation; others stay generic
         if let Some(shape) = fused_agg_shape(op, expr) {
             if let Some((selector, range)) = shape.selector {
-                let range =
-                    range.unwrap_or_else(|| Duration::from_micros(self.ctx.lookback_delta as u64));
+                let range = range.unwrap_or_else(|| self.ctx.lookback());
                 if let Some(value) = self
                     .try_streaming_fused_agg(
                         selector,
@@ -183,7 +182,7 @@ fn fused_agg_shape<'a>(op: &token::TokenType, expr: &'a PromExpr) -> Option<Fuse
         // name, which is exactly last_over_time
         PromExpr::VectorSelector(selector) => Some(FusedAggShape {
             op: agg_op,
-            func: Arc::from(functions::fusable_range_func("last_over_time")?),
+            func: functions::instant_lookback_func(),
             range_arg: None,
             selector: Some((selector, None)),
         }),

--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -201,10 +201,12 @@ impl Engine {
             PromExpr::NumberLiteral(NumberLiteral { val }) => Value::Float(*val),
             PromExpr::StringLiteral(StringLiteral { val }) => Value::String(val.clone()),
             PromExpr::VectorSelector(vs) => {
-                let vs = selector::plain_selector(vs, "VectorSelector")?;
-                let data = match self.try_streaming_instant_selector(&vs).await? {
+                let data = match self.try_streaming_instant_selector(vs).await? {
                     Some(data) => data,
-                    None => self.eval_vector_selector(&vs, None).await?,
+                    None => {
+                        let vs = selector::plain_selector(vs, "VectorSelector")?;
+                        self.eval_vector_selector(&vs, None).await?
+                    }
                 };
                 if data.is_empty() {
                     Value::None

--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -202,7 +202,10 @@ impl Engine {
             PromExpr::StringLiteral(StringLiteral { val }) => Value::String(val.clone()),
             PromExpr::VectorSelector(vs) => {
                 let vs = selector::plain_selector(vs, "VectorSelector")?;
-                let data = self.eval_vector_selector(&vs).await?;
+                let data = match self.try_streaming_instant_selector(&vs).await? {
+                    Some(data) => data,
+                    None => self.eval_vector_selector(&vs, None).await?,
+                };
                 if data.is_empty() {
                     Value::None
                 } else {

--- a/src/promql/src/engine/selector.rs
+++ b/src/promql/src/engine/selector.rs
@@ -54,6 +54,7 @@ impl Engine {
     pub(super) async fn eval_vector_selector(
         &mut self,
         selector: &VectorSelector,
+        ctxs: Option<SelectorContexts>,
     ) -> Result<Vec<RangeValue>> {
         if self.result_type.is_none() {
             self.result_type = Some("vector".to_string());
@@ -61,7 +62,7 @@ impl Engine {
 
         let selector = named_selector(selector.clone(), "VectorSelector")?;
 
-        let data = self.selector_load_data_owned(&selector, None, None).await?;
+        let data = self.selector_load_data_owned(&selector, None, ctxs).await?;
 
         let metrics_cache = match data.get_range_values() {
             Some(v) => v,
@@ -688,7 +689,7 @@ mod tests {
             at: None,
         };
 
-        engine.eval_vector_selector(&selector).await.unwrap();
+        engine.eval_vector_selector(&selector, None).await.unwrap();
 
         let matchers = captured.lock().unwrap().take().unwrap();
         assert!(matchers.matchers.iter().all(|m| m.name != NAME_LABEL));
@@ -726,7 +727,7 @@ mod tests {
             at: None,
         };
 
-        let result = engine.eval_vector_selector(&selector).await;
+        let result = engine.eval_vector_selector(&selector, None).await;
         assert!(result.is_ok());
         let values = result.unwrap();
         assert_eq!(values.len(), 0); // Mock provider returns empty data
@@ -762,7 +763,7 @@ mod tests {
             at: None,
         };
 
-        let result = engine.eval_vector_selector(&selector).await;
+        let result = engine.eval_vector_selector(&selector, None).await;
         assert!(result.is_ok());
         let values = result.unwrap();
         assert_eq!(values.len(), 0); // Mock provider returns empty data
@@ -798,7 +799,7 @@ mod tests {
             at: None,
         };
 
-        let result = engine.eval_vector_selector(&selector).await;
+        let result = engine.eval_vector_selector(&selector, None).await;
         assert!(result.is_ok());
         let values = result.unwrap();
         assert_eq!(values.len(), 0); // Mock provider returns empty data
@@ -871,7 +872,7 @@ mod tests {
             at: None,
         };
 
-        let result = engine.eval_vector_selector(&selector).await;
+        let result = engine.eval_vector_selector(&selector, None).await;
 
         assert!(result.is_err(), "expected an error, not a panic");
         assert!(

--- a/src/promql/src/engine/streaming.rs
+++ b/src/promql/src/engine/streaming.rs
@@ -13,8 +13,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! The streaming entry for fused aggregations: attempts the ordered partition streams over the
-//! selector's contexts and falls back to the materializing fold on the same contexts.
+//! The streaming entries for fused aggregations, bare range functions and instant selectors:
+//! each attempts the ordered partition streams over the selector's contexts and falls back to
+//! the materializing evaluation on the same contexts.
 //!
 //! Reads `ctx`, `eval_ctx`, `label_selector`; writes `result_type` on success.
 
@@ -119,43 +120,15 @@ impl Engine {
         let Some(scan) = self.selector_scan(vs, range).await? else {
             return Ok(None);
         };
-        if let [(ctx, schema, scan_stats, _)] = scan.ctxs.as_slice() {
-            let label_cols = if self.skip_labels {
-                vec![]
-            } else {
-                series_label_columns(schema, &scan.label_selector, func.name())
-            };
-            let selector = scan.streaming_selector();
-            let eval = Arc::new(fused::RangeExpr::new(func.clone(), range, &self.eval_ctx));
-            let run = async {
-                match MergeSeriesStream::execute_partitioned(
-                    ctx,
-                    schema,
-                    &selector,
-                    label_cols,
-                    micros(range),
-                    &self.eval_ctx,
-                )
-                .await?
-                {
-                    None => Ok(None),
-                    Some(sources) => fused::eval_range(sources, eval).await.map(Some),
-                }
-            };
-            if let Some((series, scanned)) = self
-                .run_cancellable(run, self.ctx.query_ctx.timeout)
-                .await?
-            {
-                self.ctx.scan_stats.write().await.add(scan_stats);
-                if self.result_type.is_none() {
-                    self.result_type = Some("matrix".to_string());
-                }
-                // the generic path evaluates an empty selector to None, not to an empty matrix
-                return Ok(Some(match scanned {
-                    0 => Value::None,
-                    _ => Value::Matrix(series),
-                }));
+        if let Some((series, scanned)) = self.stream_range_func(&scan, func.clone(), range).await? {
+            if self.result_type.is_none() {
+                self.result_type = Some("matrix".to_string());
             }
+            // the generic path evaluates an empty selector to None, not to an empty matrix
+            return Ok(Some(match scanned {
+                0 => Value::None,
+                _ => Value::Matrix(series),
+            }));
         }
 
         // the layout cannot stream: evaluate the generic function on the contexts already created
@@ -168,6 +141,84 @@ impl Engine {
             Value::Matrix(matrix)
         };
         functions::eval_range(input, func, &self.eval_ctx).map(Some)
+    }
+
+    /// Streams an instant selector as `last_over_time` over the lookback window, and otherwise
+    /// selects on the same contexts; `None` only when the query shape rules the streaming path
+    /// out up front.
+    pub(super) async fn try_streaming_instant_selector(
+        &mut self,
+        vs: &VectorSelector,
+    ) -> Result<Option<Vec<RangeValue>>> {
+        let lookback = Duration::from_micros(self.ctx.lookback_delta as u64);
+        let Some(scan) = self.selector_scan(vs, lookback).await? else {
+            return Ok(None);
+        };
+        if self.result_type.is_none() {
+            self.result_type = Some("vector".to_string());
+        }
+        let func: Arc<dyn functions::RangeFunc> =
+            Arc::from(functions::fusable_range_func("last_over_time").expect("a range function"));
+        if let Some((series, _)) = self.stream_range_func(&scan, func, lookback).await? {
+            // an instant vector carries no window: the lookback is the query's, not the selector's
+            let series = series
+                .into_iter()
+                .map(|series| RangeValue {
+                    time_window: None,
+                    ..series
+                })
+                .collect();
+            return Ok(Some(series));
+        }
+
+        // the layout cannot stream: select on the contexts already created
+        self.eval_vector_selector(&scan.selector, Some(scan.ctxs))
+            .await
+            .map(Some)
+    }
+
+    /// Runs the range function over the ordered partition streams of the scan's single context;
+    /// `None` when the layout cannot stream.
+    async fn stream_range_func(
+        &self,
+        scan: &SelectorScan,
+        func: Arc<dyn functions::RangeFunc>,
+        range: Duration,
+    ) -> Result<Option<(Vec<RangeValue>, usize)>> {
+        // a second context would split series and evaluate windows on partial data
+        let [(ctx, schema, scan_stats, _)] = scan.ctxs.as_slice() else {
+            return Ok(None);
+        };
+        let label_cols = if self.skip_labels {
+            vec![]
+        } else {
+            series_label_columns(schema, &scan.label_selector, func.name())
+        };
+        let selector = scan.streaming_selector();
+        let eval = Arc::new(fused::RangeExpr::new(func, range, &self.eval_ctx));
+        let run = async {
+            match MergeSeriesStream::execute_partitioned(
+                ctx,
+                schema,
+                &selector,
+                label_cols,
+                micros(range),
+                &self.eval_ctx,
+            )
+            .await?
+            {
+                None => Ok(None),
+                Some(sources) => fused::eval_range(sources, eval).await.map(Some),
+            }
+        };
+        let Some(result) = self
+            .run_cancellable(run, self.ctx.query_ctx.timeout)
+            .await?
+        else {
+            return Ok(None);
+        };
+        self.ctx.scan_stats.write().await.add(scan_stats);
+        Ok(Some(result))
     }
 
     /// Normalizes the selector and creates its contexts; `None` when a query-level gate rules
@@ -284,7 +335,7 @@ mod tests {
     use config::{
         TIMESTAMP_COL_NAME,
         meta::{
-            promql::{HASH_LABEL, HASH_SORTED_TABLE_SUFFIX, VALUE_LABEL},
+            promql::{HASH_LABEL, HASH_SORTED_TABLE_SUFFIX, NAME_LABEL, VALUE_LABEL},
             search::ScanStats,
         },
     };
@@ -354,6 +405,7 @@ mod tests {
             Field::new(HASH_LABEL, DataType::UInt64, false),
             Field::new(VALUE_LABEL, DataType::Float64, false),
             Field::new("instance", DataType::Utf8, true),
+            Field::new(NAME_LABEL, DataType::Utf8, true),
         ]))
     }
 
@@ -374,6 +426,7 @@ mod tests {
                 Arc::new(StringArray::from_iter_values(
                     rows.iter().map(|row| if row.1 == 7 { "a" } else { "b" }),
                 )),
+                Arc::new(StringArray::from_iter_values(rows.iter().map(|_| "m"))),
             ],
         )
         .unwrap();
@@ -425,10 +478,31 @@ mod tests {
         Engine::new("test_trace", Arc::new(ctx), eval_ctx)
     }
 
-    async fn eval_query(provider: StreamingProvider, timeout: u64, query: &str) -> Result<Value> {
+    async fn exec_query(
+        provider: StreamingProvider,
+        timeout: u64,
+        query: &str,
+    ) -> Result<(Value, Option<String>)> {
         let mut engine = engine(provider, timeout);
         let expr = promql_parser::parser::parse(query).unwrap();
-        engine.exec(&expr).await.map(|(value, _)| value)
+        engine.exec(&expr).await
+    }
+
+    async fn eval_query(provider: StreamingProvider, timeout: u64, query: &str) -> Result<Value> {
+        exec_query(provider, timeout, query)
+            .await
+            .map(|(value, _)| value)
+    }
+
+    /// The generic instant path on its own: `eval_vector_selector` over the plain table.
+    async fn generic_instant_selector(provider: StreamingProvider, selector: &str) -> Value {
+        let mut engine = engine(provider, 30);
+        let promql_parser::parser::Expr::VectorSelector(vs) =
+            promql_parser::parser::parse(selector).unwrap()
+        else {
+            panic!("{selector} is not a vector selector");
+        };
+        Value::Matrix(engine.eval_vector_selector(&vs, None).await.unwrap())
     }
 
     async fn eval_sum_rate(provider: StreamingProvider, timeout: u64) -> Result<Value> {
@@ -448,7 +522,7 @@ mod tests {
         else {
             panic!("{selector} is not a vector selector");
         };
-        let data = engine.eval_vector_selector(&vs).await.unwrap();
+        let data = engine.eval_vector_selector(&vs, None).await.unwrap();
         let eval_ctx = engine.eval_ctx.clone();
         agg(modifier, Value::Matrix(data), &eval_ctx).unwrap()
     }
@@ -624,6 +698,85 @@ mod tests {
             infra::errors::Error::from(err),
             infra::errors::Error::ErrorCode(ErrorCodes::SearchCancelQuery(_))
         ));
+    }
+
+    /// A bare instant selector streams as `last_over_time(m[lookback])` and must match the
+    /// generic instant path, both when it streams and when it selects on the same context.
+    #[tokio::test]
+    async fn test_instant_selector_matches_generic_streaming_and_materialized() {
+        for selector in ["m", "m offset 30s", "m{instance=\"a\"}"] {
+            let expected = generic_instant_selector(provider(false, false), selector).await;
+            let (streamed, result_type) = exec_query(provider(true, false), 30, selector)
+                .await
+                .unwrap();
+            assert_eq!(
+                result_type.as_deref(),
+                Some("vector"),
+                "streamed {selector}"
+            );
+            let Value::Matrix(matrix) = &streamed else {
+                panic!("expected a matrix, got {}", streamed.get_type());
+            };
+            assert!(
+                matrix.iter().all(|series| series.time_window.is_none()),
+                "streamed {selector}: an instant vector carries no window"
+            );
+            assert_same_matrix(expected.clone(), streamed, &format!("streamed {selector}"));
+            let (materialized, result_type) = exec_query(provider(false, false), 30, selector)
+                .await
+                .unwrap();
+            assert_eq!(
+                result_type.as_deref(),
+                Some("vector"),
+                "materialized {selector}"
+            );
+            assert_same_matrix(expected, materialized, &format!("materialized {selector}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_instant_selector_keeps_the_metric_name() {
+        let value = eval_query(provider(true, false), 30, "m").await.unwrap();
+        let mut labels: Vec<Vec<(String, String)>> = canonical(value)
+            .into_iter()
+            .map(|(labels, _)| labels)
+            .collect();
+        labels.sort();
+        let name = (NAME_LABEL.to_string(), "m".to_string());
+        assert_eq!(
+            labels,
+            vec![
+                vec![name.clone(), ("instance".to_string(), "a".to_string())],
+                vec![name, ("instance".to_string(), "b".to_string())],
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_instant_selector_takes_the_streaming_path() {
+        let err = eval_query(provider(true, true), 30, "m").await.unwrap_err();
+        assert!(matches!(
+            infra::errors::Error::from(err),
+            infra::errors::Error::ErrorCode(ErrorCodes::SearchCancelQuery(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_instant_selector_selects_on_the_streaming_context_without_sorted_table() {
+        let provider = provider(false, false);
+        let calls = provider.calls.clone();
+
+        let value = eval_query(provider, 30, "m").await.unwrap();
+        let Value::Matrix(matrix) = value else {
+            panic!("expected a matrix, got {}", value.get_type());
+        };
+        assert_eq!(matrix.len(), 2, "one series per instance");
+        assert!(matrix.iter().all(|series| series.samples.len() == 3));
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "the selecting fallback must reuse the context the streaming attempt created"
+        );
     }
 
     #[tokio::test]

--- a/src/promql/src/engine/streaming.rs
+++ b/src/promql/src/engine/streaming.rs
@@ -13,8 +13,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Streaming entries (agg, range func, instant selector); each falls back on the same contexts.
-
 use std::{sync::Arc, time::Duration};
 
 use config::meta::promql::value::*;
@@ -139,7 +137,6 @@ impl Engine {
         functions::eval_range(input, func, &self.eval_ctx).map(Some)
     }
 
-    /// Streams `last_over_time(m[lookback])` or selects on the same contexts; `None` when gated.
     pub(super) async fn try_streaming_instant_selector(
         &mut self,
         vs: &VectorSelector,
@@ -171,7 +168,6 @@ impl Engine {
             .map(Some)
     }
 
-    /// Streams the range function over the single context; `None` when the layout cannot stream.
     async fn stream_range_func(
         &self,
         scan: &SelectorScan,
@@ -693,7 +689,6 @@ mod tests {
         ));
     }
 
-    /// `m` streams as `last_over_time(m[lookback])` and must match the generic path either way.
     #[tokio::test]
     async fn test_instant_selector_matches_generic_streaming_and_materialized() {
         for selector in ["m", "m offset 30s", "m{instance=\"a\"}"] {

--- a/src/promql/src/engine/streaming.rs
+++ b/src/promql/src/engine/streaming.rs
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! The streaming entries for fused aggregations, bare range functions and instant selectors:
-//! each attempts the ordered partition streams over the selector's contexts and falls back to
-//! the materializing evaluation on the same contexts.
-//!
-//! Reads `ctx`, `eval_ctx`, `label_selector`; writes `result_type` on success.
+//! Streaming entries (agg, range func, instant selector); each falls back on the same contexts.
 
 use std::{sync::Arc, time::Duration};
 
@@ -143,9 +139,7 @@ impl Engine {
         functions::eval_range(input, func, &self.eval_ctx).map(Some)
     }
 
-    /// Streams an instant selector as `last_over_time` over the lookback window, and otherwise
-    /// selects on the same contexts; `None` only when the query shape rules the streaming path
-    /// out up front.
+    /// Streams `last_over_time(m[lookback])` or selects on the same contexts; `None` when gated.
     pub(super) async fn try_streaming_instant_selector(
         &mut self,
         vs: &VectorSelector,
@@ -177,8 +171,7 @@ impl Engine {
             .map(Some)
     }
 
-    /// Runs the range function over the ordered partition streams of the scan's single context;
-    /// `None` when the layout cannot stream.
+    /// Streams the range function over the single context; `None` when the layout cannot stream.
     async fn stream_range_func(
         &self,
         scan: &SelectorScan,
@@ -700,8 +693,7 @@ mod tests {
         ));
     }
 
-    /// A bare instant selector streams as `last_over_time(m[lookback])` and must match the
-    /// generic instant path, both when it streams and when it selects on the same context.
+    /// `m` streams as `last_over_time(m[lookback])` and must match the generic path either way.
     #[tokio::test]
     async fn test_instant_selector_matches_generic_streaming_and_materialized() {
         for selector in ["m", "m offset 30s", "m{instance=\"a\"}"] {

--- a/src/promql/src/engine/streaming.rs
+++ b/src/promql/src/engine/streaming.rs
@@ -16,7 +16,7 @@
 use std::{sync::Arc, time::Duration};
 
 use config::meta::promql::value::*;
-use datafusion::error::Result;
+use datafusion::{arrow::datatypes::Schema, error::Result, prelude::SessionContext};
 use futures::future::pending;
 use infra::errors::ErrorCodes;
 use promql_parser::{
@@ -61,31 +61,32 @@ impl Engine {
         if matches!(modifier, Some(LabelModifier::Exclude(_))) {
             return Ok(None);
         }
-        let Some(scan) = self.selector_scan(vs, range).await? else {
+        let Some(scan) = self.selector_scan(vs, range, "MatrixSelector").await? else {
             return Ok(None);
         };
         let timeout = self.ctx.query_ctx.timeout;
-        // a second context would split series and evaluate rate windows on partial data
-        if let [(ctx, schema, scan_stats, _)] = scan.ctxs.as_slice() {
-            let run = fused::stream::fused_agg(
-                ctx,
-                schema,
-                scan.streaming_selector(),
-                fused::stream::FusedShape {
-                    op,
-                    func: func.clone(),
-                    range,
-                },
-                modifier,
-                &self.eval_ctx,
-            );
-            if let Some(value) = self.run_cancellable(run, timeout).await? {
-                self.ctx.scan_stats.write().await.add(scan_stats);
-                if self.result_type.is_none() {
-                    self.result_type = Some("matrix".to_string());
-                }
-                return Ok(Some(value));
+        let shape = fused::stream::FusedShape {
+            op,
+            func: func.clone(),
+            range,
+        };
+        let streamed = self
+            .stream_scan_guarded(&scan, |ctx, schema| {
+                fused::stream::fused_agg(
+                    ctx,
+                    schema,
+                    scan.streaming_selector(),
+                    shape,
+                    modifier,
+                    &self.eval_ctx,
+                )
+            })
+            .await?;
+        if let Some(value) = streamed {
+            if self.result_type.is_none() {
+                self.result_type = Some("matrix".to_string());
             }
+            return Ok(Some(value));
         }
 
         // the layout cannot stream: materialize on the contexts already created
@@ -111,7 +112,7 @@ impl Engine {
         range: Duration,
         func: Arc<dyn functions::RangeFunc>,
     ) -> Result<Option<Value>> {
-        let Some(scan) = self.selector_scan(vs, range).await? else {
+        let Some(scan) = self.selector_scan(vs, range, "MatrixSelector").await? else {
             return Ok(None);
         };
         if let Some((series, scanned)) = self.stream_range_func(&scan, func.clone(), range).await? {
@@ -141,24 +142,19 @@ impl Engine {
         &mut self,
         vs: &VectorSelector,
     ) -> Result<Option<Vec<RangeValue>>> {
-        let lookback = Duration::from_micros(self.ctx.lookback_delta as u64);
-        let Some(scan) = self.selector_scan(vs, lookback).await? else {
+        let lookback = self.ctx.lookback();
+        let Some(scan) = self.selector_scan(vs, lookback, "VectorSelector").await? else {
             return Ok(None);
         };
-        if self.result_type.is_none() {
-            self.result_type = Some("vector".to_string());
-        }
-        let func: Arc<dyn functions::RangeFunc> =
-            Arc::from(functions::fusable_range_func("last_over_time").expect("a range function"));
-        if let Some((series, _)) = self.stream_range_func(&scan, func, lookback).await? {
+        let func = functions::instant_lookback_func();
+        if let Some((mut series, _)) = self.stream_range_func(&scan, func, lookback).await? {
+            if self.result_type.is_none() {
+                self.result_type = Some("vector".to_string());
+            }
             // an instant vector carries no window: the lookback is the query's, not the selector's
-            let series = series
-                .into_iter()
-                .map(|series| RangeValue {
-                    time_window: None,
-                    ..series
-                })
-                .collect();
+            series
+                .iter_mut()
+                .for_each(|series| series.time_window = None);
             return Ok(Some(series));
         }
 
@@ -174,22 +170,17 @@ impl Engine {
         func: Arc<dyn functions::RangeFunc>,
         range: Duration,
     ) -> Result<Option<(Vec<RangeValue>, usize)>> {
-        // a second context would split series and evaluate windows on partial data
-        let [(ctx, schema, scan_stats, _)] = scan.ctxs.as_slice() else {
-            return Ok(None);
-        };
-        let label_cols = if self.skip_labels {
-            vec![]
-        } else {
-            series_label_columns(schema, &scan.label_selector, func.name())
-        };
-        let selector = scan.streaming_selector();
-        let eval = Arc::new(fused::RangeExpr::new(func, range, &self.eval_ctx));
-        let run = async {
+        self.stream_scan_guarded(scan, |ctx, schema| async move {
+            let label_cols = if self.skip_labels {
+                vec![]
+            } else {
+                series_label_columns(schema, &scan.label_selector, func.name())
+            };
+            let eval = Arc::new(fused::RangeExpr::new(func, range, &self.eval_ctx));
             match MergeSeriesStream::execute_partitioned(
                 ctx,
                 schema,
-                &selector,
+                &scan.streaming_selector(),
                 label_cols,
                 micros(range),
                 &self.eval_ctx,
@@ -199,11 +190,58 @@ impl Engine {
                 None => Ok(None),
                 Some(sources) => fused::eval_range(sources, eval).await.map(Some),
             }
+        })
+        .await
+    }
+
+    /// Runs `run` on the scan's single context under timeout and cancel, then accounts its stats.
+    async fn stream_scan_guarded<'s, T, Fut>(
+        &'s self,
+        scan: &'s SelectorScan,
+        run: impl FnOnce(&'s SessionContext, &'s Schema) -> Fut,
+    ) -> Result<Option<T>>
+    where
+        Fut: Future<Output = Result<Option<T>>>,
+    {
+        // a second context would split series and evaluate windows on partial data
+        let [(ctx, schema, scan_stats, _)] = scan.ctxs.as_slice() else {
+            return Ok(None);
         };
-        let Some(result) = self
-            .run_cancellable(run, self.ctx.query_ctx.timeout)
-            .await?
-        else {
+        let trace_id = &self.ctx.query_ctx.trace_id;
+        let mut abort_receiver = self
+            .ctx
+            .table_provider
+            .register_cancellation(trace_id)
+            .await?;
+        let run = run(ctx, schema);
+        tokio::pin!(run);
+        // a cancel or an expired budget wins over a fold that happens to be ready and aborts it
+        let result = tokio::select! {
+            biased;
+            _ = async {
+                match abort_receiver.as_mut() {
+                    Some(receiver) => {
+                        let _ = receiver.await;
+                    }
+                    None => pending::<()>().await,
+                }
+            } => {
+                log::info!("[trace_id {trace_id}] [PromQL] streaming query canceled");
+                Err(ErrorCodes::SearchCancelQuery(
+                    "[PromQL] streaming query canceled".to_string(),
+                )
+                .into())
+            }
+            _ = tokio::time::sleep(Duration::from_secs(self.ctx.query_ctx.timeout)) => {
+                log::error!("[trace_id {trace_id}] [PromQL] streaming query timeout");
+                Err(ErrorCodes::SearchTimeout(
+                    "[PromQL] streaming query timeout".to_string(),
+                )
+                .into())
+            }
+            ret = &mut run => ret,
+        };
+        let Some(result) = result? else {
             return Ok(None);
         };
         self.ctx.scan_stats.write().await.add(scan_stats);
@@ -216,6 +254,7 @@ impl Engine {
         &mut self,
         vs: &VectorSelector,
         range: Duration,
+        kind: &str,
     ) -> Result<Option<SelectorScan>> {
         let query_ctx = &self.ctx.query_ctx;
         // need_wal bails early: WAL would split series across contexts
@@ -229,7 +268,7 @@ impl Engine {
         {
             return Ok(None);
         }
-        let selector = named_selector(plain_selector(vs, "MatrixSelector")?, "MatrixSelector")?;
+        let selector = named_selector(plain_selector(vs, kind)?, kind)?;
         let table_name = selector.name.clone().unwrap();
 
         let offset = get_offset_modifier(selector.offset.clone());
@@ -262,48 +301,6 @@ impl Engine {
             label_selector,
             ctxs,
         }))
-    }
-
-    /// Runs the streaming fold under the query timeout and the host's cancel signal; dropping
-    /// the future aborts the partition folds.
-    async fn run_cancellable<T>(
-        &self,
-        run: impl Future<Output = Result<T>>,
-        timeout: u64,
-    ) -> Result<T> {
-        let trace_id = &self.ctx.query_ctx.trace_id;
-        let mut abort_receiver = self
-            .ctx
-            .table_provider
-            .register_cancellation(trace_id)
-            .await?;
-        tokio::pin!(run);
-        // a cancel or an expired budget wins over a fold that happens to be ready
-        tokio::select! {
-            biased;
-            _ = async {
-                match abort_receiver.as_mut() {
-                    Some(receiver) => {
-                        let _ = receiver.await;
-                    }
-                    None => pending::<()>().await,
-                }
-            } => {
-                log::info!("[trace_id {trace_id}] [PromQL] streaming fused agg canceled");
-                Err(ErrorCodes::SearchCancelQuery(
-                    "[PromQL] streaming fused agg canceled".to_string(),
-                )
-                .into())
-            }
-            _ = tokio::time::sleep(Duration::from_secs(timeout)) => {
-                log::error!("[trace_id {trace_id}] [PromQL] streaming fused agg timeout");
-                Err(ErrorCodes::SearchTimeout(
-                    "[PromQL] streaming fused agg timeout".to_string(),
-                )
-                .into())
-            }
-            ret = &mut run => ret,
-        }
     }
 }
 
@@ -450,13 +447,19 @@ mod tests {
     }
 
     fn engine(provider: StreamingProvider, timeout: u64) -> Engine {
+        engine_at(provider, timeout, BASE + 60 * SECOND, 60 * SECOND, None)
+    }
+
+    /// Steps from `start` to `BASE + 180 s`; `lookback` overrides the 5 min default.
+    fn engine_at(
+        provider: StreamingProvider,
+        timeout: u64,
+        start: i64,
+        step: i64,
+        lookback: Option<i64>,
+    ) -> Engine {
         enable_streaming();
-        let eval_ctx = EvalContext::new(
-            BASE + 60 * SECOND,
-            BASE + 180 * SECOND,
-            60 * SECOND,
-            "test_trace".into(),
-        );
+        let eval_ctx = EvalContext::new(start, BASE + 180 * SECOND, step, "test_trace".into());
         let mut ctx = PromqlContext::new(
             create_test_query_ctx("test_trace", "test_org", timeout),
             provider,
@@ -464,6 +467,9 @@ mod tests {
         );
         ctx.start = eval_ctx.start;
         ctx.end = eval_ctx.end;
+        if let Some(lookback) = lookback {
+            ctx.lookback_delta = lookback;
+        }
         Engine::new("test_trace", Arc::new(ctx), eval_ctx)
     }
 
@@ -485,7 +491,10 @@ mod tests {
 
     /// The generic instant path on its own: `eval_vector_selector` over the plain table.
     async fn generic_instant_selector(provider: StreamingProvider, selector: &str) -> Value {
-        let mut engine = engine(provider, 30);
+        generic_instant_selector_on(engine(provider, 30), selector).await
+    }
+
+    async fn generic_instant_selector_on(mut engine: Engine, selector: &str) -> Value {
         let promql_parser::parser::Expr::VectorSelector(vs) =
             promql_parser::parser::parse(selector).unwrap()
         else {
@@ -736,6 +745,50 @@ mod tests {
                 vec![name.clone(), ("instance".to_string(), "a".to_string())],
                 vec![name, ("instance".to_string(), "b".to_string())],
             ]
+        );
+    }
+
+    /// With a 10 s lookback over 20 s samples the steps hit the lower bound, miss, then the upper.
+    #[tokio::test]
+    async fn test_instant_selector_window_bounds_match_generic() {
+        let (start, step, lookback) = (BASE + 70 * SECOND, 45 * SECOND, Some(10 * SECOND));
+        for selector in ["m", "m offset -20s", "m{instance=\"a\"}"] {
+            let generic = engine_at(provider(false, false), 30, start, step, lookback);
+            let expected = generic_instant_selector_on(generic, selector).await;
+            let mut streaming = engine_at(provider(true, false), 30, start, step, lookback);
+            let expr = promql_parser::parser::parse(selector).unwrap();
+            let (streamed, _) = streaming.exec(&expr).await.unwrap();
+            assert_same_matrix(expected, streamed, selector);
+        }
+        let mut streaming = engine_at(provider(true, false), 30, start, step, lookback);
+        let expr = promql_parser::parser::parse("m{instance=\"a\"}").unwrap();
+        let (value, _) = streaming.exec(&expr).await.unwrap();
+        let series = canonical(value);
+        assert_eq!(series.len(), 1);
+        assert_eq!(
+            series[0].1,
+            vec![(BASE + 70 * SECOND, 9.0), (BASE + 160 * SECOND, 24.0)],
+            "the sample at 60 s is on the lower bound of [60 s, 70 s], 115 s sees none, 160 s is its own"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_instant_selector_with_no_matching_series_is_none() {
+        let value = eval_query(provider(true, false), 30, "m{instance=\"zzz\"}")
+            .await
+            .unwrap();
+        assert!(matches!(value, Value::None), "got {}", value.get_type());
+    }
+
+    #[tokio::test]
+    async fn test_instant_selector_without_a_metric_name_names_the_vector_selector() {
+        let err = eval_query(provider(true, false), 30, "{instance=\"a\"}")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("VectorSelector: metric name is required"),
+            "{err}"
         );
     }
 

--- a/src/promql/src/exec.rs
+++ b/src/promql/src/exec.rs
@@ -65,6 +65,10 @@ impl PromqlContext {
         }
     }
 
+    pub fn lookback(&self) -> Duration {
+        Duration::from_micros(self.lookback_delta as u64)
+    }
+
     #[tracing::instrument(name = "promql:engine:exec", skip_all)]
     pub async fn exec(
         &mut self,

--- a/src/promql/src/functions/mod.rs
+++ b/src/promql/src/functions/mod.rs
@@ -260,6 +260,11 @@ pub(crate) fn fusable_range_func(name: &str) -> Option<Box<dyn RangeFunc>> {
     name.parse::<Func>().ok()?.range_func()
 }
 
+/// The range function a bare instant selector streams as; it keeps the metric name.
+pub(crate) fn instant_lookback_func() -> std::sync::Arc<dyn RangeFunc> {
+    std::sync::Arc::new(last_over_time::LastOverTimeFunc::new())
+}
+
 pub(crate) fn eval_range<F>(data: Value, func: F, eval_ctx: &EvalContext) -> Result<Value>
 where
     F: RangeFunc,


### PR DESCRIPTION
## What

A bare instant selector (`m`, `m{path="x"}`, and every `histogram_quantile(0.9, m)`, `topk(5, m)`, `a / b` built on one) went through `eval_vector_selector`: load every sample of the window, sort each series, then pick the last sample in the lookback per step. `agg(m)` already streams as `agg(last_over_time(m[lookback]))` (#14198) and a bare `rate(m[r])` streams series by series (#14294); this PR gives the bare instant selector the same path.

`exec_expr`'s `VectorSelector` branch now calls `try_streaming_instant_selector`, which opens the selector over the lookback window and runs `last_over_time` through the same `MergeSeriesStream` + `fused::eval_range` pipeline as a bare range function. The window bounds match the instant path (`[t - lookback, t]`, both inclusive), `last_over_time` keeps the metric name, the output timestamps are the evaluation steps, and the result carries no `time_window` and reports `result_type` `vector`, so nothing downstream can tell the two apart.

When the layout cannot stream (no hash-ordered files, a second context, super-cluster, exemplars), the selector runs the existing `eval_vector_selector` on the contexts the streaming attempt already created; `eval_vector_selector` takes an `Option<SelectorContexts>` for that, like `eval_matrix_selector`.

The streaming part of `try_streaming_range_func` moved into `stream_range_func` so both entries share it.

## Shape coverage

Of the 813 PromQL queries in the `openobserve/dashboards` repository, 303 are a single bare instant selector (optionally wrapped in a function or arithmetic); with this PR every query shape except the one subquery has a streaming path. The bare instant selector is the light shape, so the gain is pipeline (no full-window sort and materialization per series), not peak memory: the output is one sample per series per step either way.

## Benchmark

Release build (`--features mimalloc`), local single node over the faker dataset (`codelab_api_request_duration_seconds_bucket`, 1.17M bucket series per hour), 15 s step, one fresh process per (binary, query): run 1 gives the cold wall time and the peak RSS, run 2 the warm wall time. A = main `fa538c5790`, B = this branch. `ZO_METRICS_MAX_SERIES_RESPONSE=100000` so the `histogram_quantile` result is not truncated.

Hash-ordered files (the streaming path engages on B, `streaming last_over_time() started` in the log):

| query | series | A cold / warm | B cold / warm | peak RSS A → B | response |
|---|---|---|---|---|---|
| `m{path="/api/service-1"}` 1h | 20280 | 3.19 s / 2.95 s | 3.13 s / 3.02 s | 0.91 → 1.00 GiB | identical |
| `m{path="/api/service-1"}` 3h | 20280 | 7.00 s / 6.76 s | 7.23 s / 6.94 s | 1.61 → 1.67 GiB | identical |
| `histogram_quantile(0.9, m{path=…})` 3h | 780 | 1.03 s / 0.61 s | 0.89 s / 0.75 s | 0.76 → 0.95 GiB | identical |
| `histogram_quantile(0.9, m)` 1h | 45124 | 9.20 s / 8.28 s | 8.68 s / 8.07 s | 9.05 → 6.06 GiB | identical |
| `topk(5, m)` 1h | 51 | 4.41 s / 3.77 s | 3.77 s / 3.42 s | 8.50 → 5.73 GiB | identical |
| `m` at one instant (1.17M series) | first 100000 | 7.64 s / 7.24 s | 7.25 s / 7.18 s | 3.10 → 3.23 GiB | values identical on the 8520 series both truncations share; the two paths emit series in a different order, so the first 100000 differ |

Legacy-layout files (the mixed-layout dataset from #14307, hour 03 only: the streaming attempt creates the contexts, finds no hash-ordered table, and `eval_vector_selector` runs on the same contexts; `streaming … started` absent from B's log):

| query | series | A cold / warm | B cold / warm | peak RSS A → B | response |
|---|---|---|---|---|---|
| `m{path="/api/service-1"}` 1h | 20280 | 2.97 s / 2.25 s | 2.75 s / 2.22 s | 0.70 → 0.70 GiB | identical |
| `histogram_quantile(0.9, m)` 1h | 44854 | 8.04 s / 7.88 s | 8.21 s / 7.53 s | 8.98 → 9.75 GiB | identical |
| same, second run | 44854 | 8.83 s / 9.33 s | 8.22 s / 7.70 s | 9.03 → 9.27 GiB | identical |

Wall time is within noise on the small queries and 5–15% lower on the 1.17M-series ones; peak RSS drops by a third where a function consumes the vector (`histogram_quantile`, `topk`) because the per-series sample vectors are never materialized, and stays level on the fallback (the 9 GiB readings move by up to 0.7 GiB between runs of the same binary). The full `m` over 1h (1.17M series × 241 steps) fails on both binaries with the 4 GiB decompression limit at the gRPC boundary, so it is not in the table.

## Tests

- Parity: `m`, `m offset 30s`, `m{instance="a"}` streamed vs materialized vs `eval_vector_selector` (labels including `__name__`, timestamps, values), `result_type` `vector` on both paths, no `time_window` on the streamed vector.
- The streaming path engages (a fired cancel signal surfaces as `SearchCancelQuery` for `m`); the fallback reuses the streaming attempt's context (one `create_context` call).
- `cargo test -p promql`: 415 passed. CI clippy command: clean.
