### PR TITLE
fix: dashboard report overlap issue v1

### DIFF
--- a/web/src/components/dashboards/panels/ChartRenderer.vue
+++ b/web/src/components/dashboards/panels/ChartRenderer.vue
@@ -203,9 +203,19 @@ export default defineComponent({
         await nextTick();
         await nextTick();
         chart?.resize();
+        applySvgPrintViewBox();
       } catch (e) {
         console.error("Error during resizing", e);
       }
+    };
+
+    // print-only: viewBox lets print CSS scale the SVG to the narrower page instead of clipping it (ECharts' SVG renderer omits it)
+    const applySvgPrintViewBox = () => {
+      if (!store.state.printMode || props.renderType !== "svg") return;
+      const svg = chartRef.value?.querySelector("svg");
+      const w = Number(svg?.getAttribute("width"));
+      const h = Number(svg?.getAttribute("height"));
+      if (svg && w > 0 && h > 0) svg.setAttribute("viewBox", `0 0 ${w} ${h}`);
     };
 
     // currently hovered series state
@@ -491,6 +501,8 @@ export default defineComponent({
         key: "dataZoomSelect",
         dataZoomSelectActive: true,
       });
+
+      applySvgPrintViewBox();
     };
 
     // dispatch tooltip action for all charts
@@ -767,6 +779,7 @@ export default defineComponent({
         try {
           await nextTick();
           chart?.resize();
+          applySvgPrintViewBox();
         } catch (e) {
           console.error("Error while resizing", e);
         }

--- a/web/src/views/Dashboards/RenderDashboardCharts.vue
+++ b/web/src/views/Dashboards/RenderDashboardCharts.vue
@@ -1880,11 +1880,8 @@ export default defineComponent({
     break-inside: avoid;
   }
 
-  /* Overflow must stay visible here: `hidden` clips each panel to its
-   * grid-cell rectangle which, paired with print pagination, prevents
-   * browsers from honouring panel heights. */
   .displayDiv :deep(.grid-stack-item-content) {
-    overflow: visible !important;
+    overflow: hidden !important;
   }
 }
 


### PR DESCRIPTION
1. chart overlap issue
<img width="893" height="483" alt="image" src="https://github.com/user-attachments/assets/cfd5e1e6-2a18-4976-be5c-f3bd975b584a" />

2. multiple metric chart issue with report
<img width="998" height="401" alt="image" src="https://github.com/user-attachments/assets/3f0d39b0-b0ef-4b40-83e0-d9604c4f70de" />

on print:
<img width="591" height="369" alt="image" src="https://github.com/user-attachments/assets/e8c1c04d-a4cc-4791-b714-7438d39f5754" />
