### PR TITLE
chore(cli): support -s stream key for reset -c stream-stats

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -51,7 +51,7 @@ fn create_cli_app() -> Command {
                 .about("reset openobserve data")
                 .arg(arg!("component", 'c', "component", "reset data of the component: root, user, alert, dashboard, function, stream-stats, file-list-jobs, index-updated-at", true))
                 .arg(arg!("time", 't', "time", "timestamp in microseconds, used by file-list-jobs (default: 0) and index-updated-at (default: stream min data date)"))
-                .arg(arg!("stream", 's', "stream", "stream key org/stream_type/stream_name, used by file-list-jobs and index-updated-at (default: all streams)")),
+                .arg(arg!("stream", 's', "stream", "stream key org/stream_type/stream_name, used by stream-stats, file-list-jobs and index-updated-at (default: all streams)")),
             Command::new("import")
                 .about("import openobserve data").args(dataArgs()),
             Command::new("export")
@@ -281,16 +281,20 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                     db::functions::reset().await?;
                 }
                 "stream-stats" => {
-                    // reset stream stats update offset
-                    db::compact::stats::set_offset(0, None).await?;
-                    // reset stream stats table data
-                    infra_file_list::reset_stream_stats().await?;
-                    // load stream list
-                    db::schema::cache().await?;
-                    // update stats from file list
-                    compaction::stats::update_stats_from_file_list()
-                        .await
-                        .expect("file list remote calculate stats failed");
+                    if let Some(stream) = command.get_one::<String>("stream") {
+                        super::stream::reset_stream_stats(stream).await?;
+                    } else {
+                        // reset stream stats update offset
+                        db::compact::stats::set_offset(0, None).await?;
+                        // reset stream stats table data
+                        infra_file_list::reset_stream_stats().await?;
+                        // load stream list
+                        db::schema::cache().await?;
+                        // update stats from file list
+                        compaction::stats::update_stats_from_file_list()
+                            .await
+                            .expect("file list remote calculate stats failed");
+                    }
                 }
                 "file-list-jobs" => {
                     let time = command

--- a/src/cli/basic/stream.rs
+++ b/src/cli/basic/stream.rs
@@ -14,7 +14,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use chrono::{DateTime, Utc};
-use config::{meta::stream::StreamType, utils::json};
+use config::{
+    meta::stream::{StreamStats, StreamType},
+    utils::json,
+};
 use db;
 use infra::schema::unwrap_stream_settings;
 
@@ -38,16 +41,11 @@ pub async fn reset_index_updated_at(stream: &str, time: Option<i64>) -> Result<(
         }
         all
     } else {
-        let parts = stream.splitn(3, '/').collect::<Vec<&str>>();
-        if parts.len() != 3 {
-            return Err(anyhow::anyhow!(
-                "invalid stream [{stream}], expected format: org/stream_type/stream_name"
-            ));
-        }
+        let [org_id, stream_type, stream_name] = split_stream_key(stream)?;
         vec![(
-            parts[0].to_string(),
-            StreamType::from(parts[1]),
-            parts[2].to_string(),
+            org_id.to_string(),
+            StreamType::from(stream_type),
+            stream_name.to_string(),
         )]
     };
 
@@ -83,6 +81,42 @@ pub async fn reset_index_updated_at(stream: &str, time: Option<i64>) -> Result<(
     Ok(())
 }
 
+/// Recompute a stream's `stream_stats` rows from `file_list`; never touches the compactor offset.
+pub async fn reset_stream_stats(stream: &str) -> Result<(), anyhow::Error> {
+    let (org_id, stream_type, stream_name) = parse_stream_stats_key(stream)?;
+    if !infra::schema::exists(org_id, stream_type, stream_name).await {
+        return Err(anyhow::anyhow!(
+            "stream not found: {org_id}/{stream_type}/{stream_name}"
+        ));
+    }
+
+    // Summarise what was written; a read-back would go through CLIENT_RO and can lag the primary
+    let mut stats = StreamStats::default();
+    for (date_range, is_recent) in compaction::stats::stats_date_ranges() {
+        let range_stats = compaction::stats::update_stats_from_file_list_for_stream(
+            org_id,
+            stream_type,
+            stream_name,
+            date_range,
+            is_recent,
+        )
+        .await?;
+        stats.merge(&range_stats);
+    }
+    println!(
+        "reset stream stats for {org_id}/{stream_type}/{stream_name}: file_num={}, doc_num={}, storage_size={}, compressed_size={}, index_size={}, doc_time_min={}, doc_time_max={}",
+        stats.file_num,
+        stats.doc_num,
+        stats.storage_size,
+        stats.compressed_size,
+        stats.index_size,
+        stats.doc_time_min,
+        stats.doc_time_max
+    );
+
+    Ok(())
+}
+
 /// Resolve a stream's earliest data date from file_list and convert it to a
 /// microseconds timestamp. Returns `None` when the stream has no data.
 async fn min_date_micros(
@@ -99,4 +133,97 @@ async fn min_date_micros(
         .with_timezone(&Utc)
         .timestamp_micros();
     Ok(Some(ts))
+}
+
+fn split_stream_key(stream: &str) -> Result<[&str; 3], anyhow::Error> {
+    let parts = stream.splitn(3, '/').collect::<Vec<&str>>();
+    if parts.len() != 3 {
+        return Err(anyhow::anyhow!(
+            "invalid stream [{stream}], expected format: org/stream_type/stream_name"
+        ));
+    }
+    Ok([parts[0], parts[1], parts[2]])
+}
+
+fn parse_stream_stats_key(stream: &str) -> Result<(&str, StreamType, &str), anyhow::Error> {
+    let parts = split_stream_key(stream)?;
+    if parts.iter().any(|p| p.is_empty()) {
+        return Err(anyhow::anyhow!(
+            "invalid stream [{stream}], expected format: org/stream_type/stream_name"
+        ));
+    }
+    let [org_id, type_name, stream_name] = parts;
+    let stream_type = StreamType::from(type_name);
+    // `From<&str>` maps unknown names to the default type, so the fallback has to be detected here
+    if stream_type == StreamType::default()
+        && !type_name.eq_ignore_ascii_case(StreamType::default().as_str())
+    {
+        return Err(anyhow::anyhow!(
+            "unknown stream_type [{type_name}] in stream [{stream}]"
+        ));
+    }
+    if matches!(stream_type, StreamType::Index | StreamType::Filelist) {
+        return Err(anyhow::anyhow!(
+            "stream_type [{stream_type}] has no stream stats"
+        ));
+    }
+    Ok((org_id, stream_type, stream_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_stream_stats_key_valid() {
+        let (org_id, stream_type, stream_name) =
+            parse_stream_stats_key("default/logs/app").unwrap();
+        assert_eq!(org_id, "default");
+        assert_eq!(stream_type, StreamType::Logs);
+        assert_eq!(stream_name, "app");
+    }
+
+    #[test]
+    fn test_parse_stream_stats_key_maps_known_types() {
+        for (name, expected) in [
+            ("logs", StreamType::Logs),
+            ("metrics", StreamType::Metrics),
+            ("traces", StreamType::Traces),
+        ] {
+            let key = format!("org/{name}/s1");
+            let (_, stream_type, _) = parse_stream_stats_key(&key).unwrap();
+            assert_eq!(stream_type, expected, "{key}");
+        }
+    }
+
+    #[test]
+    fn test_parse_stream_stats_key_rejects_two_parts() {
+        let err = parse_stream_stats_key("org/logs").unwrap_err().to_string();
+        assert!(err.contains("expected format"), "{err}");
+    }
+
+    #[test]
+    fn test_parse_stream_stats_key_rejects_empty_segment() {
+        for key in ["/logs/s1", "org//s1", "org/logs/"] {
+            let err = parse_stream_stats_key(key).unwrap_err().to_string();
+            assert!(err.contains("expected format"), "{key}: {err}");
+        }
+    }
+
+    #[test]
+    fn test_parse_stream_stats_key_rejects_unknown_type() {
+        let err = parse_stream_stats_key("org/bogus/s1")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown stream_type [bogus]"), "{err}");
+    }
+
+    #[test]
+    fn test_parse_stream_stats_key_rejects_index_and_file_list() {
+        for name in ["index", "file_list"] {
+            let key = format!("org/{name}/s1");
+            let err = parse_stream_stats_key(&key).unwrap_err().to_string();
+            assert!(err.contains("has no stream stats"), "{key}: {err}");
+        }
+    }
 }

--- a/src/compaction/src/stats.rs
+++ b/src/compaction/src/stats.rs
@@ -18,7 +18,7 @@ use std::{collections::HashSet, time::Duration};
 use config::{
     cluster::LOCAL_NODE,
     get_config,
-    meta::stream::StreamType,
+    meta::stream::{StreamStats, StreamType},
     metrics,
     utils::time::{HourFormat, day_micros, get_ymdh_from_micros, now_micros},
 };
@@ -78,11 +78,7 @@ pub async fn update_stats_from_file_list() -> Result<(), anyhow::Error> {
         HashSet::new()
     };
 
-    let yesterday_boundary = get_yesterday_boundary();
-    let new_data_range = (yesterday_boundary.clone(), "".to_string());
-    let old_data_range = ("".to_string(), yesterday_boundary.clone());
-
-    let iter = [(new_data_range, true), (old_data_range, false)];
+    let iter = stats_date_ranges();
 
     let grouped = db::schema::list_all_streams_grouped().await;
     let mut total_streams = 0;
@@ -137,13 +133,14 @@ pub async fn update_stats_from_file_list() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Returns the stats it wrote so callers need not read `stream_stats` back through a replica.
 pub async fn update_stats_from_file_list_for_stream(
     org_id: &str,
     stream_type: StreamType,
     stream_name: &str,
     date_range: (String, String),
     is_recent: bool,
-) -> Result<(), anyhow::Error> {
+) -> Result<StreamStats, anyhow::Error> {
     let mut stats =
         infra_file_list::stats_by_date_range(org_id, stream_type, stream_name, date_range.clone())
             .await?;
@@ -162,7 +159,7 @@ pub async fn update_stats_from_file_list_for_stream(
     }
     infra_file_list::set_stream_stats(org_id, stream_type, stream_name, &stats, is_recent).await?;
 
-    Ok(())
+    Ok(stats)
 }
 
 async fn update_stats_lock_node() -> Result<Option<i64>, anyhow::Error> {
@@ -234,6 +231,15 @@ async fn update_stream_stats_with_retry(
         tokio::time::sleep(delay).await;
         attempt += 1;
     }
+}
+
+/// Recent and historical scan ranges as `((start, end), is_recent)`; an empty bound is open-ended.
+pub fn stats_date_ranges() -> [((String, String), bool); 2] {
+    let yesterday_boundary = get_yesterday_boundary();
+    [
+        ((yesterday_boundary.clone(), String::new()), true),
+        ((String::new(), yesterday_boundary), false),
+    ]
 }
 
 /// Get yesterday's boundary date (yesterday 00:00:00 in YYYY/MM/DD/00)
@@ -324,6 +330,16 @@ mod tests {
 
         // Should handle empty range gracefully (may return error or empty stats)
         let _ = result; // Test structure - actual behavior depends on implementation
+    }
+
+    #[test]
+    fn test_stats_date_ranges() {
+        let [(recent_range, recent), (old_range, old)] = stats_date_ranges();
+        let boundary = get_yesterday_boundary();
+        assert!(recent);
+        assert_eq!(recent_range, (boundary.clone(), String::new()));
+        assert!(!old);
+        assert_eq!(old_range, (String::new(), boundary));
     }
 
     #[test]


### PR DESCRIPTION
## What

`reset -c stream-stats` gains an optional `-s org/stream_type/stream_name`, the same flag `file-list-jobs` and `index-updated-at` already take.

```
./openobserve reset -c stream-stats -s default/logs/app
```

With `-s`, the CLI recomputes the `stream_stats` rows (recent and historical) of that one stream from `file_list` via the existing `compaction::stats::update_stats_from_file_list_for_stream`, then prints the values it wrote. Without `-s` the command behaves exactly as before.

## Why

The global reset zeroes every stream's stats, clears `/compact/stream_stats/offset` and rescans all streams. On a large cluster that is far too heavy when only one stream's stats are wrong.

## Design notes for reviewers

- **The single-stream path does not touch `/compact/stream_stats/offset`.** That key is the compactor's node lock, its no-op short-circuit (`last >= MAX(file_list.updated_at)`), and its same-day incremental scope. Clearing it would make the running compactor rescan every stream on its next tick. The global reset clears it only to get past those guards so the inline rescan actually runs.
- **No zeroing.** `set_stream_stats` is a full-row upsert on `(stream, is_recent)` and `stats_by_date_range` returns zeros for a range with no files, so recomputing both ranges overwrites both rows. No `infra::file_list` trait or backend changes.
- **Validation.** The key must have three non-empty parts; an unrecognised `stream_type` is rejected instead of silently falling back to the default type; `index` and `file_list` are rejected (the compactor scan skips them too); the stream must exist per `infra::schema::exists`.
- **Summary line.** `update_stats_from_file_list_for_stream` now returns the `StreamStats` it upserted; the CLI merges recent and historical and prints that. It does not read back through the read-only pool, so a lagging `ZO_META_POSTGRES_RO_DSN` replica cannot make the command print stale or all-zero values.
- **Shared boundary.** `compaction::stats::stats_date_ranges()` defines the recent/historical split once; the compactor loop and the CLI both use it.
- **Known residual, accepted.** The recompute is a scan followed by an upsert, not a transaction. If a new file for the same stream lands in that gap while a compactor tick also recomputes it, the CLI can overwrite the newer value with one that is one file behind. The next `file_list` change for that stream makes the compactor recompute it, and rerunning the command also fixes it. The same pattern already exists between retention and the compactor.
- Not run against a live metastore in this PR; the DB paths were verified by reading the sqlite and postgres backends. No enterprise code touched and o2-enterprise has no caller of the changed function.

## Tests

- `stats::tests::test_stats_date_ranges`
- `cli::basic::stream::tests::test_parse_stream_stats_key_*` (valid key, known types, two parts, empty segment, unknown type, index/file_list)
- `cargo fmt --all -- --check`, CI clippy command (`-D warnings` plus the structural lints), `cargo test -p compaction stats`, `cargo test -p openobserve --lib cli::basic` all pass.
