### PR TITLE
fix: reject reserved columns in delete_fields and update_fields_type

### DIFF
--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -1025,6 +1025,22 @@ async fn transform_stats(
     }
 }
 
+async fn find_reserved_field<'a>(
+    org_id: &str,
+    stream_name: &str,
+    stream_type: StreamType,
+    mut field_names: impl Iterator<Item = &'a str>,
+) -> Option<String> {
+    let settings = infra::schema::get_settings(org_id, stream_name, stream_type).await;
+    let reserved_columns = match settings.as_deref() {
+        Some(settings) => settings.uds_internal_columns(),
+        None => StreamSettings::default().uds_internal_columns(),
+    };
+    field_names
+        .find(|name| reserved_columns.iter().any(|r| r == name))
+        .map(String::from)
+}
+
 pub async fn delete_fields(
     org_id: &str,
     stream_name: &str,
@@ -1034,13 +1050,20 @@ pub async fn delete_fields(
     if fields.is_empty() {
         return Ok(());
     }
-    db::schema::delete_fields(
+    let stream_type = stream_type.unwrap_or_default();
+    if let Some(reserved) = find_reserved_field(
         org_id,
         stream_name,
-        stream_type.unwrap_or_default(),
-        fields.to_vec(),
+        stream_type,
+        fields.iter().map(String::as_str),
     )
-    .await?;
+    .await
+    {
+        return Err(anyhow::anyhow!(
+            "field [{reserved}] is reserved and cannot be deleted"
+        ));
+    }
+    db::schema::delete_fields(org_id, stream_name, stream_type, fields.to_vec()).await?;
     Ok(())
 }
 
@@ -1065,6 +1088,19 @@ pub async fn update_fields_type(
 ) -> Result<(), anyhow::Error> {
     if field_updates.is_empty() {
         return Ok(());
+    }
+    let stream_type = stream_type.unwrap_or_default();
+    if let Some(reserved) = find_reserved_field(
+        org_id,
+        stream_name,
+        stream_type,
+        field_updates.iter().map(|f| f.name.as_str()),
+    )
+    .await
+    {
+        return Err(anyhow::anyhow!(
+            "field [{reserved}] is reserved and cannot be updated"
+        ));
     }
 
     // Build HashMap of field_name -> (DataType, nullable)
@@ -1095,7 +1131,7 @@ pub async fn update_fields_type(
     schema::handle_diff_schema(
         org_id,
         stream_name,
-        stream_type.unwrap_or_default(),
+        stream_type,
         false,
         &new_schema,
         min_ts,
@@ -1319,6 +1355,77 @@ mod tests {
     async fn test_delete_fields_empty() {
         let result = delete_fields("org1", "stream1", Some(StreamType::Logs), &[]).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_fields_rejects_always_reserved_columns() {
+        // no persisted settings, so falls back to StreamSettings::default()
+        let reserved_fields = [
+            TIMESTAMP_COL_NAME.to_string(),
+            get_config().common.column_all.clone(),
+        ];
+        for reserved in reserved_fields {
+            let result = delete_fields(
+                "org1",
+                "stream1",
+                Some(StreamType::Logs),
+                std::slice::from_ref(&reserved),
+            )
+            .await;
+            assert!(result.is_err(), "expected {reserved} to be rejected");
+            let err = result.unwrap_err().to_string();
+            assert!(err.contains(&reserved), "reserved={reserved:?} err={err:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_fields_allows_uds_columns_when_feature_disabled() {
+        // _original is only reserved when store_original_data/index_original_data is set
+        let result = delete_fields(
+            "org1",
+            "stream1",
+            Some(StreamType::Logs),
+            &[config::ORIGINAL_DATA_COL_NAME.to_string()],
+        )
+        .await;
+        if let Err(e) = result {
+            assert!(
+                !e.to_string().contains("is reserved"),
+                "expected _original not to be rejected as reserved, got: {e}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_fields_rejects_reserved_among_others() {
+        let result = delete_fields(
+            "org1",
+            "stream1",
+            Some(StreamType::Logs),
+            &[
+                "a".to_string(),
+                TIMESTAMP_COL_NAME.to_string(),
+                "b".to_string(),
+            ],
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_update_fields_type_rejects_reserved_columns() {
+        let result = update_fields_type(
+            "org1",
+            "stream1",
+            Some(StreamType::Logs),
+            &[FieldUpdate {
+                name: TIMESTAMP_COL_NAME.to_string(),
+                data_type: "int64".to_string(),
+                nullable: None,
+            }],
+        )
+        .await;
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `PUT .../{org}/streams/{stream}/delete_fields` had no guard against deleting the reserved `_timestamp` column. Deleting it succeeded (200) and made all of the stream's existing data unqueryable (search returns 0 rows as a *success*) until the next ingest self-healed the schema.
- `PUT .../{org}/streams/{stream}/update_fields_type` had the same gap for retyping a reserved column.
- Both endpoints now reject reserved fields with a 400. The always-reserved set (`_timestamp`, `_all`) is rejected unconditionally; the conditionally-reserved set (`_original`, `_all_values`, `_o2_id`) is rejected only when the corresponding stream setting (`store_original_data`/`index_original_data`, `index_all_values`) is actually enabled — matching `StreamSettings::uds_internal_columns()`, the same model already used by stream-settings validation (FTS/index/bloom/partition-key checks in `src/schema/src/lib.rs`). This avoids a stream that never enabled those features from being permanently blocked from deleting/renaming a genuine user field that happens to share one of those names.

## Fixes
Fixes #14331

## Test plan
- [x] `cargo test -p stream --lib` — 29/29 pass, including new tests covering: always-reserved columns rejected, conditionally-reserved columns allowed when the feature is off, a reserved field mixed in with normal fields, and `update_fields_type` rejecting a reserved column.
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p stream -p openobserve-api-management --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` — clean

## Known follow-up (not in scope here)
The super-cluster replication receive path (`src/super_cluster_queue/src/schemas.rs`, `MessageType::SchemaDeleteFields`) calls `infra::schema::delete_fields` directly and does not go through this guard. That path only replicates a deletion already validated by the leader via `stream::delete_fields`, so it's lower risk, but it isn't independently guarded — worth a follow-up if defense-in-depth is wanted there too.