### PR TITLE
test: deflake GeneralTests nav + ingestion-token create race

### DIFF
--- a/tests/ui-testing/pages/dashboardPages/visualise.js
+++ b/tests/ui-testing/pages/dashboardPages/visualise.js
@@ -685,6 +685,16 @@ export default class LogsVisualise {
     // The Query Inspector item is v-if-gated on the panel's metaData, populated only after its query executes, so wait for the panel to render before opening the menu.
     await this.verifyChartRenders(this.page);
 
+    // The dashboard panel query can transiently return empty under CI load (WAL lag) though the data exists (it rendered in Visualize) — metaData gating the Query Inspector item only populates on a non-empty query, so refresh until the panel loads data.
+    const noData = this.page.locator('[data-test="no-data"]');
+    const refreshBtn = this.page.locator('[data-test="dashboard-refresh-btn"]');
+    await expect(async () => {
+      if (await noData.isVisible().catch(() => false)) {
+        await refreshBtn.click({ timeout: 5000 }).catch(() => {});
+        await expect(noData).toBeHidden({ timeout: 5000 });
+      }
+    }).toPass({ timeout: 30000, intervals: [1000, 2000, 3000] });
+
     const dropdown = this.getPanelDropdown(panelName);
     await dropdown.waitFor({ state: "visible", timeout: 20000 });
 

--- a/tests/ui-testing/pages/rumPages/rumPage.js
+++ b/tests/ui-testing/pages/rumPages/rumPage.js
@@ -39,7 +39,11 @@ export class RumPage {
     }
 
     async gotoRumPage() {
-        await this.rumPageMenu.click();
+        // The sidebar click can be swallowed by the nav flyout under load, so retry until the RUM route loads.
+        await expect(async () => {
+            await this.rumPageMenu.click();
+            await this.page.waitForURL('**/rum**', { timeout: 5000 });
+        }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
     }
 
     async rumPageDefaultOrg() {

--- a/tests/ui-testing/pages/tracesPages/tracesPage.js
+++ b/tests/ui-testing/pages/tracesPages/tracesPage.js
@@ -209,13 +209,19 @@ export class TracesPage {
   }
 
   async navigateToTraces() {
-    await this.tracesMenuItem.click();
     // Cloud: sidebar click may silently fail — verify URL and fallback to direct navigation
     if (isCloudEnvironment()) {
+      await this.tracesMenuItem.click();
       await this.page.waitForURL('**/traces**', { timeout: 5000 }).catch(async () => {
         await this.navigateToTracesUrl();
       });
+      return;
     }
+    // The sidebar click can be swallowed by the nav flyout under load, so retry until the traces route loads.
+    await expect(async () => {
+      await this.tracesMenuItem.click();
+      await this.page.waitForURL('**/traces**', { timeout: 5000 });
+    }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
   }
 
   async validateTracesPage() {

--- a/tests/ui-testing/playwright-tests/Alerts/dl-email-destinations.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/dl-email-destinations.spec.js
@@ -514,6 +514,8 @@ test.describe('Email destinations and distribution lists', () => {
     const destName = uniq('onemsg');
     const cleared = await sink.clear();
     test.skip(!cleared, 'needs a clearable sink to count messages exactly (use Mailpit)');
+    // The prior serial delivery test also mails ORG_USER; its async delivery can land after clear() and, since only one org recipient exists, cannot be told apart by address — so drain to stable-empty before sending.
+    await sink.waitUntilEmptyStable();
 
     await fillEmailForm(pm, destName, `${ORG_USER},${ORG_USER}`);
     await pm.alertDestinationsPage.clickTest();

--- a/tests/ui-testing/playwright-tests/GeneralTests/ingestionTokens.spec.js
+++ b/tests/ui-testing/playwright-tests/GeneralTests/ingestionTokens.spec.js
@@ -182,6 +182,9 @@ test.describe("Org-Level Ingestion Tokens", () => {
         await pageManager.ingestionTokensPage.fillTokenName(uniqueName);
         await pageManager.ingestionTokensPage.clickCreate();
 
+        // Gate on create success before reloading — reload cancels the in-flight POST if the token hasn't persisted yet.
+        await pageManager.ingestionTokensPage.verifySuccessMessage('Token created successfully.');
+
         // Reload page to dismiss all dialogs cleanly (avoids overlay race conditions)
         await page.reload();
         await pageManager.ingestionTokensPage.titleHeading.waitFor({ state: 'visible', timeout: 10000 });

--- a/tests/ui-testing/playwright-tests/utils/mail-sink.js
+++ b/tests/ui-testing/playwright-tests/utils/mail-sink.js
@@ -92,6 +92,25 @@ async function clear() {
   return false;
 }
 
+/** Drain to a stable-empty sink: a prior serial test's async SMTP delivery can land after clear(),
+ *  and with only one valid org recipient the count cannot be scoped by address, so wait until the
+ *  sink has stayed empty for `stableMs` (re-clearing any late arrival) before sending the next message. */
+async function waitUntilEmptyStable(stableMs = 3000, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  let emptySince = null;
+  while (Date.now() < deadline) {
+    if ((await count()) === 0) {
+      if (emptySince === null) emptySince = Date.now();
+      else if (Date.now() - emptySince >= stableMs) return true;
+    } else {
+      await clear();
+      emptySince = null;
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return false;
+}
+
 async function waitForCount(n, timeoutMs = 120000) {
   const deadline = Date.now() + timeoutMs;
   let last = 0;
@@ -143,4 +162,4 @@ async function latest() {
   return null;
 }
 
-module.exports = { available, unavailableReason, backend, list, count, clear, waitForCount, latest };
+module.exports = { available, unavailableReason, backend, list, count, clear, waitUntilEmptyStable, waitForCount, latest };


### PR DESCRIPTION
Deflake reappearing top-flaky UI tests, each root-caused from CI traces (method per #14025). Page-object/spec only, no product code, no validation weakened.

- **GeneralTests · Toggle token enable/disable** (board #1): `clickCreate()` was immediately followed by `page.reload()`, cancelling the in-flight `POST /ingestion-tokens` → token never persists → search finds no row → poll timeout. Fix: gate on the create success toast before reloading. Local 3/3.
- **GeneralTests · Traces / RUM Page default validation**: sidebar nav click swallowed by the nav flyout; URL was only verified on cloud, so OSS stayed on home and `toHaveURL(/traces|rum/)` failed after 30s. Fix: retry the click until the route loads. Local 2/2 each.
- **Dashboards · Table/Line chart query**: the saved dashboard panel transiently returns "No Data" under CI load (WAL lag) though the data exists (it rendered in Visualize) → `metaData` never populates → query-inspector item never mounts. Fix: refresh the panel until data loads before opening the inspector (non-masking; bounded). Local 2/2.
- **Alerts · ML-04 several recipients in a single message**: the shared Mailpit sink is counted globally; the prior serial delivery test also mails the one org recipient, and its async delivery can land after `clear()` → count reads 2. Fix: drain the sink to stable-empty before sending (only one valid org recipient exists, so the count can't be scoped by address). CI-only verifiable (local SMTP-detection gate).

Table/Line and ML-04 are CI-load / mail-infra races that don't reproduce locally; proven via the CI 3x first-try gate.
