### PR TITLE
fix(web): truncate long span and service names in trace detail

### DIFF
--- a/web/src/plugins/traces/TraceDetails.spec.ts
+++ b/web/src/plugins/traces/TraceDetails.spec.ts
@@ -16,6 +16,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import TraceDetails from "@/plugins/traces/TraceDetails.vue";
+import OPageHeader from "@/lib/core/PageHeader/OPageHeader.vue";
 import i18n from "@/locales";
 import store from "@/test/unit/helpers/store";
 import router from "@/test/unit/helpers/router";
@@ -332,6 +333,17 @@ describe("TraceDetails", () => {
       expect(operationName.text()).toContain(
         tracesMockData.tracesDetails.traceSpans.hits[0].operation_name,
       );
+    });
+
+    it("should constrain the operation name so a long one ellipsises", () => {
+      const operationName = wrapper.find('[data-test="trace-details-operation-name"]');
+
+      expect(operationName.classes()).toContain("truncate");
+      expect(operationName.attributes("title")).toBe(
+        tracesMockData.tracesDetails.traceSpans.hits[0].operation_name,
+      );
+      // The ellipsis only fires if the header also lets the title block shrink.
+      expect(wrapper.findComponent(OPageHeader).props("titleOverflow")).toBe("visible");
     });
 
     it("should display trace ID in toolbar", () => {

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -35,8 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <!-- Standalone (routed) header: shared OPageHeader -->
         <OPageHeader
           v-if="mode === 'standalone'"
-          :title="traceTree[0]?.operationName || t('traces.loadingTrace')"
-          title-data-test="trace-details-operation-name"
+          title-overflow="visible"
           :back="
             showBackButton
               ? {
@@ -47,6 +46,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           "
           class=""
         >
+          <!-- Operation names run long (SQL, URLs); the default header title never shrinks, so it never ellipsises. -->
+          <template #title>
+            <span
+              data-test="trace-details-operation-name"
+              class="block truncate"
+              :title="traceTree[0]?.operationName"
+            >
+              {{ traceTree[0]?.operationName || t("traces.loadingTrace") }}
+            </span>
+          </template>
+
           <template #subtitle>
             <div class="text-2xs text-text-secondary flex items-center space-x-2 whitespace-nowrap">
               <span>{{ formatTimestamp(traceStartTime, store.state.timezone) }}</span>

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -108,7 +108,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <div class="bg-text-label h-4 w-px py-0" />
               <!-- Span Count Badge -->
               <span class="inline-flex">
-                <OTag type="logsResultChip" value="neutral" data-test="trace-details-spans-count">
+                <!-- sm + py-1! keeps both count chips at 1.1875rem: anything over the header's fixed 1.25rem subtitle band grows into the title's descenders. -->
+                <OTag
+                  type="logsResultChip"
+                  value="neutral"
+                  size="sm"
+                  data-test="trace-details-spans-count"
+                  class="py-1!"
+                >
                   <span data-test="span-count-text">
                     {{ formatLargeNumber(effectiveSpanList.length) }}
                     {{ t("traces.spansLabel") }}
@@ -124,7 +131,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <OTag
                   type="logsResultChip"
                   value="error"
+                  size="sm"
                   data-test="trace-details-error-spans-count"
+                  class="py-1!"
                 >
                   <span
                     >{{ formatLargeNumber(errorSpansCount) }} {{ t("traces.errorsLabel") }}</span

--- a/web/src/plugins/traces/TraceTree.spec.ts
+++ b/web/src/plugins/traces/TraceTree.spec.ts
@@ -312,6 +312,22 @@ describe("TraceTree", () => {
     expect(serviceNameElements[1].text()).toBe(mockSpans[1].serviceName);
   });
 
+  it("should constrain span names so long ones ellipsise", () => {
+    for (const span of mockSpans) {
+      const operationName = wrapper.find(
+        `[data-test="trace-tree-span-operation-name-${span.spanId}"]`,
+      );
+      // min-w-0: without it the flex item keeps its full text width and the row's ellipsis never fires.
+      expect(operationName.classes()).toEqual(expect.arrayContaining(["truncate", "min-w-0"]));
+
+      const serviceName = wrapper.find(`[data-test="trace-tree-span-service-name-${span.spanId}"]`);
+      // shrink-0 + a cap: flex shrinks in proportion to width, so a long operation name would otherwise eat the service name first.
+      expect(serviceName.classes()).toEqual(
+        expect.arrayContaining(["truncate", "shrink-0", "max-w-[40%]"]),
+      );
+    }
+  });
+
   it("should render error icon for error spans", () => {
     const errorIcon = wrapper.find('[data-test="trace-tree-span-error-icon-6702b0494b2b6e57"]');
     expect(errorIcon.exists()).toBe(true);

--- a/web/src/plugins/traces/TraceTree.spec.ts
+++ b/web/src/plugins/traces/TraceTree.spec.ts
@@ -323,9 +323,16 @@ describe("TraceTree", () => {
       const serviceName = wrapper.find(`[data-test="trace-tree-span-service-name-${span.spanId}"]`);
       // shrink-0 + a cap: flex shrinks in proportion to width, so a long operation name would otherwise eat the service name first.
       expect(serviceName.classes()).toEqual(
-        expect.arrayContaining(["truncate", "shrink-0", "max-w-[40%]"]),
+        expect.arrayContaining(["truncate", "shrink-0", "max-w-[50%]"]),
       );
     }
+  });
+
+  it("should size the name row from the column, not from its own text", () => {
+    // Without w-full the row is content-sized and the service name's cap would
+    // bound it against its own text, truncating names that had room to spare.
+    const nameRow = wrapper.find(".span-name-section-content");
+    expect(nameRow.classes()).toEqual(expect.arrayContaining(["w-full", "min-w-0"]));
   });
 
   it("should render error icon for error spans", () => {

--- a/web/src/plugins/traces/TraceTree.spec.ts
+++ b/web/src/plugins/traces/TraceTree.spec.ts
@@ -1435,6 +1435,24 @@ describe("TraceTree", () => {
     });
   });
 
+  describe("span name tooltips", () => {
+    // Both names sit in one row; a title on their shared ancestor made the
+    // service name report the operation name on hover.
+    it("titles the service name with the service name", () => {
+      const serviceName = wrapper.find(
+        '[data-test="trace-tree-span-service-name-d9603ec7f76eb499"]',
+      );
+      expect(serviceName.attributes("title")).toBe("scheduler");
+    });
+
+    it("titles the operation name with the operation name", () => {
+      const operationName = wrapper.find(
+        '[data-test="trace-tree-span-operation-name-d9603ec7f76eb499"]',
+      );
+      expect(operationName.attributes("title")).toBe("service:alerts:evaluate_scheduled");
+    });
+  });
+
   describe("viewSpanLogs", () => {
     // A formatted tree node — what the `spans` prop holds: camelCase keys and
     // microsecond timestamps. This is NOT the shape buildQueryDetails accepts.

--- a/web/src/plugins/traces/TraceTree.vue
+++ b/web/src/plugins/traces/TraceTree.vue
@@ -166,8 +166,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         :title="t('traces.traceTree.errorSpan')"
                         :data-test="`trace-tree-span-error-icon-${(spans as any[])[virtualRow.index].spanId}`"
                       />
+                      <!-- shrink-0 + a cap, not plain shrink: flex shrinks items in proportion to their width, so a long operation name would eat the service name first. -->
                       <span
-                        class="me-2 text-sm font-bold font-medium"
+                        class="me-2 max-w-[40%] shrink-0 truncate text-sm font-bold font-medium"
                         :class="{
                           'bg-table-highlight-bg text-table-highlight-text font-bold':
                             isHighlighted((spans as any[])[virtualRow.index].spanId),
@@ -193,8 +194,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         alt=""
                         :data-test="`trace-tree-span-tech-icon-${(spans as any[])[virtualRow.index].spanId}`"
                       />
+                      <!-- min-w-0: a flex item defaults to min-width:auto and would refuse to shrink, so the row's ellipsis never fires. -->
                       <span
-                        class="text-text-secondary text-sm"
+                        class="text-text-secondary min-w-0 truncate text-sm"
                         :data-test="`trace-tree-span-operation-name-${(spans as any[])[virtualRow.index].spanId}`"
                         >{{ (spans as any[])[virtualRow.index].operationName }}</span
                       >

--- a/web/src/plugins/traces/TraceTree.vue
+++ b/web/src/plugins/traces/TraceTree.vue
@@ -157,7 +157,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     "
                     :data-test="`trace-tree-span-select-btn-${(spans as any[])[virtualRow.index].spanId}`"
                   >
-                    <div class="span-name-section-content flex items-center truncate">
+                    <!-- w-full: content-sized, this box shrinks with its own text, so the service name's cap would resolve against the text it is meant to bound. -->
+                    <div
+                      class="span-name-section-content flex w-full min-w-0 items-center truncate"
+                    >
                       <OIcon
                         v-if="(spans as any[])[virtualRow.index].spanStatus === 'ERROR'"
                         name="error"
@@ -166,9 +169,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         :title="t('traces.traceTree.errorSpan')"
                         :data-test="`trace-tree-span-error-icon-${(spans as any[])[virtualRow.index].spanId}`"
                       />
-                      <!-- shrink-0 + a cap, not plain shrink: flex shrinks items in proportion to their width, so a long operation name would eat the service name first. -->
+                      <!-- shrink-0 + a cap, not plain shrink: flex shrinks in proportion to width, so a long operation name would eat a short service name first. -->
                       <span
-                        class="me-2 max-w-[40%] shrink-0 truncate text-sm font-bold font-medium"
+                        class="me-2 max-w-[50%] shrink-0 truncate text-sm font-bold font-medium"
                         :class="{
                           'bg-table-highlight-bg text-table-highlight-text font-bold':
                             isHighlighted((spans as any[])[virtualRow.index].spanId),

--- a/web/src/plugins/traces/TraceTree.vue
+++ b/web/src/plugins/traces/TraceTree.vue
@@ -102,7 +102,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 }`,
               }"
               class="flex flex-col items-start justify-start truncate"
-              :title="(spans as any[])[virtualRow.index].operationName"
             >
               <div
                 class="relative-position operation-name-container bg-surface-base flex h-7.5 w-full cursor-pointer flex-nowrap items-center overflow-visible"
@@ -179,6 +178,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             currentSelectedValue === (spans as any[])[virtualRow.index].spanId,
                         }"
                         :data-test="`trace-tree-span-service-name-${(spans as any[])[virtualRow.index].spanId}`"
+                        :title="(spans as any[])[virtualRow.index].resolvedIdentity"
                       >
                         {{ (spans as any[])[virtualRow.index].resolvedIdentity }}
                       </span>
@@ -201,6 +201,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       <span
                         class="text-text-secondary min-w-0 truncate text-sm"
                         :data-test="`trace-tree-span-operation-name-${(spans as any[])[virtualRow.index].spanId}`"
+                        :title="(spans as any[])[virtualRow.index].operationName"
                         >{{ (spans as any[])[virtualRow.index].operationName }}</span
                       >
                     </div>


### PR DESCRIPTION
Fixes item 2 of #14337. Item 1 (the span duration underflow) is not touched here — it is a backend change and belongs in its own PR.

## The problem

A span name that is too long to fit is supposed to shorten with a "…" (`POST /very/long/pa…`). Instead the name laid itself out at its full natural width and was hard-clipped at the right edge of the screen, with no "…" and no horizontal scrollbar — so there was no sign the name had been cut, and no way to see the end of it. Real span names are often long (full SQL statements, long URLs, GraphQL queries), so this is reachable in normal use.

The ellipsis rules were already in the CSS. Nothing constrained the boxes they were on, and CSS only draws an ellipsis when text is confined to a box narrower than itself.

## What was wrong, and what changed

**Trace-detail header (standalone / routed).** `TraceDetails.vue` passed the title to `OPageHeader`, whose default mode puts `truncate` on the `<h1>` but `shrink-0` on the block wrapping it — so the `<h1>` was never narrower than its text and `truncate` had nothing to do. Switched to the pattern the prop already documents for this case: `title-overflow="visible"` plus a `#title` slot whose content owns its own overflow. This is the same shape `ErrorHeader.vue` uses for its long dynamic title.

**Waterfall row (`TraceTree.vue`).** Two things were wrong here.

The service and operation names are flex items, and a flex item defaults to `min-width: auto` — it refuses to shrink below its content, so the row's ellipsis applied to a box the text had already overflowed. The operation name now takes `min-w-0 truncate` and absorbs the overflow.

The service name needs different treatment: flex distributes shrinkage in proportion to each item's width, so a 1452px operation name beside a 65px service name shrinks the *service* name to ~22px ("s…"). It therefore gets `shrink-0` and a `max-w-[50%]` cap instead, so it keeps its natural width but still ellipsises when it is genuinely too long.

That cap only works if it has a stable base. `.span-name-section-content` was content-sized — 310px on a short row, 534px on a long one, inside the same fixed 538px column — so a percentage resolved against the very text it was meant to bound and truncated names that had room to spare. It now takes `w-full`, so both the cap and flex shrinking resolve against the column.

The embedded (drawer) header already truncated correctly and is unchanged.

## Verification

Measured in Chromium at 1440px against the real components with the app's compiled CSS: a 200-character operation name, a 61-character service name, and a 600px name column.

Header:

| | before | after |
|---|---|---|
| title width | 1659px (= full text; right edge 1722px, off-screen) | 1365px, ellipsis inside the viewport |
| page horizontal overflow | none | none (unchanged) |

Waterfall, four row shapes:

| row | service | operation |
|---|---|---|
| both fit | 232/232px, untouched | 47/47px, untouched |
| short service + long operation | 65/65px, untouched | ellipsised |
| long service + medium operation | 267/431px, ellipsised | 236/289px, ellipsised |
| both long | 267/431px, ellipsised | 236/1452px, ellipsised |

Before the fix these were 232px, 431px and 1452px wide — full natural width, hard-clipped, no ellipsis anywhere. At a narrow 300px column every name still ellipsises and stays visible; neither name collapses to zero width.

Unit tests added to `TraceDetails.spec.ts` and `TraceTree.spec.ts` pin the constraints (jsdom does not lay out, so these assert the constraints rather than the rendered ellipsis). Full traces suite: 352 passed, 14 skipped. `prettier --check`, `eslint`, `lint:tokens`, `lint:design` and `vue-tsc` are clean.

## Notes

- No new component API, no CSS block, no inline styles, no hardcoded `px`.
- `OPageHeader`'s default `shrink-0` means no page with a long dynamic title can ellipsise. Fixing that in the library would touch every page that uses the header, and the `shrink-0` is deliberate (it stops a short static title being squeezed by the inline tabs strip), so it is left alone here and is worth a separate issue.
