### PR TITLE
fix(nav): close an open dropdown before the rail flyout opens

### DIFF
--- a/web/src/lib/core/Navbar/ONavGroup.spec.ts
+++ b/web/src/lib/core/Navbar/ONavGroup.spec.ts
@@ -114,6 +114,63 @@ describe("ONavGroup", () => {
     expect(flyout().exists()).toBe(true);
   });
 
+  /**
+   * A dropdown is portaled after this flyout and sits on a higher layer, so it
+   * paints over the menu the pointer is on. Escape is what reka's dismissable
+   * layers listen for; the flyout sends it before showing itself.
+   */
+  it("closes an open dropdown before showing the flyout", async () => {
+    const popper = document.createElement("div");
+    popper.setAttribute("data-reka-popper-content-wrapper", "");
+    document.body.appendChild(popper);
+    const keys: string[] = [];
+    const listener = (e: Event) => keys.push((e as KeyboardEvent).key);
+    document.addEventListener("keydown", listener);
+
+    wrapper = mountGroup();
+    await hoverOpen();
+
+    document.removeEventListener("keydown", listener);
+    popper.remove();
+    expect(keys).toContain("Escape");
+    expect(flyout().exists()).toBe(true);
+  });
+
+  // Nothing to dismiss must stay silent: a stray Escape would close whatever
+  // else is listening, and hovering the rail is not a dismissal gesture.
+  it("sends no Escape when no dropdown is open", async () => {
+    const keys: string[] = [];
+    const listener = (e: Event) => keys.push((e as KeyboardEvent).key);
+    document.addEventListener("keydown", listener);
+
+    wrapper = mountGroup();
+    await hoverOpen();
+
+    document.removeEventListener("keydown", listener);
+    expect(keys).not.toContain("Escape");
+  });
+
+  // A dialog or drawer owns Escape while it is open, and the rail stays
+  // reachable beside a drawer — so the flyout must not fire the key there.
+  it("leaves an open dialog alone", async () => {
+    const popper = document.createElement("div");
+    popper.setAttribute("data-reka-popper-content-wrapper", "");
+    const overlay = document.createElement("div");
+    overlay.setAttribute("data-test", "o-dialog-overlay");
+    document.body.append(popper, overlay);
+    const keys: string[] = [];
+    const listener = (e: Event) => keys.push((e as KeyboardEvent).key);
+    document.addEventListener("keydown", listener);
+
+    wrapper = mountGroup();
+    await hoverOpen();
+
+    document.removeEventListener("keydown", listener);
+    popper.remove();
+    overlay.remove();
+    expect(keys).not.toContain("Escape");
+  });
+
   it("positions the flyout after the rail in LTR", async () => {
     document.documentElement.dir = "ltr";
     wrapper = mountGroup();

--- a/web/src/lib/core/Navbar/ONavGroup.vue
+++ b/web/src/lib/core/Navbar/ONavGroup.vue
@@ -312,8 +312,30 @@ async function positionFlyout() {
   };
 }
 
+/**
+ * Send any open dropdown away before the flyout appears.
+ *
+ * Both are page menus, but a dropdown is portaled after this flyout AND sits on
+ * a higher layer, so it paints over the menu the pointer is actually on.
+ * Raising the flyout is the wrong lever: it would have to clear 10001, which is
+ * above the modal layer, and a nav menu floating over a dialog is worse than
+ * the overlap it would fix. One menu at a time is the behaviour anyway.
+ *
+ * Escape is what reka's dismissable layers listen for. It is scoped to the case
+ * where a popper is the topmost layer — with a dialog or drawer open the same
+ * key would close that instead, and the rail is reachable beside a drawer.
+ */
+function dismissOpenDropdowns() {
+  if (!document.querySelector("[data-reka-popper-content-wrapper]")) return;
+  if (document.querySelector('[data-test="o-dialog-overlay"], [data-test="o-drawer-overlay"]')) {
+    return;
+  }
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+}
+
 async function open() {
   if (visibleChildren.value.length === 0) return;
+  dismissOpenDropdowns();
   clearTimers();
   isOpen.value = true;
   openGroupKey.value = props.groupKey;


### PR DESCRIPTION
## The bug

Hovering the nav rail while a dropdown is open leaves **both menus on screen**, and the dropdown covers the flyout the pointer is actually on.

Reported against the SLO source-alert picker, but nothing about it is SLO-specific — it reproduces with any dropdown on any page.

Measured before the fix, with the SLO alert-source list open and `Reliability` hovered:

| | z-index | box |
|---|---|---|
| `.nav-group-flyout` | 6000 | x 92–309, y 370–590 |
| dropdown popover | 10001 | x 114–922, y 549–809 |

Overlapping region: x 114–309, y 549–590.

## Why not just raise the flyout

Two reasons, and the second is the decisive one:

1. The flyout is `Teleport`ed to body when the group mounts, so it sits **earlier in the DOM** than any dropdown (measured: index 338 vs 373). At equal z-index the dropdown still wins — a z change alone fixes nothing.
2. Dropdowns render at `z-10001`, which `lib/styles/tokens/base.css` reserves for *"Tooltips / toasts above modals"* — above the 9998/9999 modal layer. For the flyout to outrank a dropdown it would have to outrank **dialogs** too, and a nav menu floating over a dialog is a worse bug than the overlap.

The real defect is two page menus open at once. So the flyout dismisses the dropdown on its way up.

## How

`Escape` is what reka's dismissable layers listen for. It is scoped to the case where a popper is the topmost layer:

- no `[data-reka-popper-content-wrapper]` open → nothing dispatched (hovering the rail is not a dismissal gesture)
- a dialog or drawer overlay present → nothing dispatched, because that layer owns Escape and the rail stays reachable beside a drawer

## Verification

Browser-measured on a local build — dropdown open before the hover, flyout open after, and the overlap is gone:

```
dropdownOpenBefore : true
flyoutOpen         : true
dropdownOpen       : false
overlapPx          : 0
```

| | |
|---|---|
| `ONavGroup` unit tests | **101 passed** (3 new, one per path above) |
| Full web unit suite | **47,395 passed** / 1,578 files |
| SLO e2e (heavy `OSelect` user) | **54 passed** |

The one failure in the full suite is `ConfigPanel.spec.ts > legend height`, which passes in isolation both with and without this change and imports nothing from `Navbar` — a pre-existing ordering flake.