### PR TITLE
fix(alerts): guard Import Semantic Groups route on OSS builds (v1.0.0)

### DIFF
--- a/web/src/composables/shared/router.ts
+++ b/web/src/composables/shared/router.ts
@@ -915,6 +915,7 @@ const useRoutes = () => {
       },
     },
     {
+      // Correlation engine is enterprise/cloud-only: bounce to Alerts on OSS — mirrors anomaly/alert-sources guards.
       path: "alerts/import-semantic-groups",
       name: "importSemanticGroups",
       component: () => import("@/components/alerts/ImportSemanticGroups.vue"),
@@ -922,6 +923,12 @@ const useRoutes = () => {
         titleKey: "correlation.importSemanticGroups.title",
       },
       beforeEnter(to: any, from: any, next: any) {
+        const store = (window as any).store;
+        const isOss = store?.state?.zoConfig?.build_type === "opensource";
+        if (isOss || (config.isEnterprise !== "true" && config.isCloud !== "true")) {
+          next({ name: "alertList", query: { org_identifier: to.query.org_identifier } });
+          return;
+        }
         routeGuard(to, from, next);
       },
     },


### PR DESCRIPTION
Backport of #14364 to `branch-v1.0.0` · Ref #14363

### What
Add an OSS/non-enterprise/non-cloud route guard to the `importSemanticGroups` route (`/alerts/import-semantic-groups`) so it redirects to the alerts list instead of rendering the enterprise correlation Import UI.

### Why
Semantic groups are part of the enterprise alert-correlation engine. On an OSS build (`build_type: opensource`) the page was reachable by direct URL and rendered a working-looking JSON upload + Import UI, but the backing APIs (`/semantic_groups`, `/_correlate`) return 404 there, so any import fails — dead UI. The route only used the generic auth `routeGuard`, unlike the neighboring `alerts/anomaly/add` and `alert-sources` routes.

### Change
Mirror the existing anomaly/alert-sources guard: `isOss || (isEnterprise !== "true" && isCloud !== "true")` → redirect to `alertList`. Web-only, OSS-scoped; enterprise/cloud builds are unaffected (`isEnterprise === "true"`).

Identical diff to #14364 (targets `main`).
