### PR TITLE
fix(traces): saturate span duration when end_time precedes start_time (v1.0.0)

### DIFF
--- a/src/core/src/traces/mod.rs
+++ b/src/core/src/traces/mod.rs
@@ -353,6 +353,11 @@ fn resource_attribute_key(raw_key: String) -> String {
     }
 }
 
+// Clock skew can deliver end < start; saturate instead of wrapping to ~585M years.
+fn span_duration_micros(start_time_nanos: u64, end_time_nanos: u64) -> u64 {
+    end_time_nanos.saturating_sub(start_time_nanos) / 1000
+}
+
 pub async fn otlp_proto(
     org_id: &str,
     body: Bytes,
@@ -757,7 +762,7 @@ pub async fn handle_otlp_request(
                     operation_name: span.name.clone(),
                     start_time,
                     end_time,
-                    duration: (end_time - start_time) / 1000, // microseconds
+                    duration: span_duration_micros(start_time, end_time),
                     reference: span_ref.clone(),
                     service_name: service_name.clone(),
                     attributes: span_att_map.clone(),
@@ -1723,6 +1728,7 @@ mod tests {
     use config::utils::json::json;
     use opentelemetry_proto::tonic::trace::v1::{Status, status::StatusCode};
 
+    use super::span_duration_micros;
     use crate::ingestion::grpc::get_val_for_attr;
 
     #[test]
@@ -2137,8 +2143,7 @@ mod tests {
     fn test_duration_calculation() {
         let start_time = 1_640_995_200_000_000_000u64;
         let end_time = 1_640_995_201_500_000_000u64; // 1.5 seconds later
-        let duration_micros = (end_time - start_time) / 1000;
-        assert_eq!(duration_micros, 1_500_000); // 1.5 seconds in microseconds
+        assert_eq!(span_duration_micros(start_time, end_time), 1_500_000);
     }
 
     // Test attribute key transformation for blocked fields
@@ -2780,21 +2785,17 @@ mod tests {
 
     #[test]
     fn test_span_duration_edge_cases() {
-        // Test same start and end time (zero duration)
         let start_time = 1_640_995_200_000_000_000u64;
-        let end_time = start_time;
-        let duration = (end_time - start_time) / 1000;
-        assert_eq!(duration, 0);
+        assert_eq!(span_duration_micros(start_time, start_time), 0);
+        assert_eq!(span_duration_micros(start_time, start_time + 1), 0);
+        assert_eq!(span_duration_micros(start_time, start_time + 1000), 1);
+    }
 
-        // Test very small duration (1 nanosecond)
-        let end_time_small = start_time + 1;
-        let duration_small = (end_time_small - start_time) / 1000;
-        assert_eq!(duration_small, 0); // Less than 1 microsecond rounds to 0
-
-        // Test 1 microsecond duration
-        let end_time_micro = start_time + 1000;
-        let duration_micro = (end_time_micro - start_time) / 1000;
-        assert_eq!(duration_micro, 1);
+    #[test]
+    fn test_span_duration_end_before_start_saturates_to_zero() {
+        let start_time = 1_640_995_200_000_000_000u64;
+        assert_eq!(span_duration_micros(start_time, start_time - 50_000_000), 0);
+        assert_eq!(span_duration_micros(start_time, 0), 0);
     }
 
     // Test span status extraction with attributes


### PR DESCRIPTION
Port of #14367 to `branch-v1.0.0`. Cherry-picked cleanly; the change lines are identical to the main commit.

Fixes item 1 of #14337 on the release branch. Item 2 (long-name truncation) landed on this branch in #14361.

## Problem

`handle_otlp_request` computed `duration: (end_time - start_time) / 1000` on two `u64` values with no guard. A span whose `endTimeUnixNano` is earlier than `startTimeUnixNano` (clock skew between hosts, or a misbehaving SDK) therefore:

- in release builds wrapped to ~18,446,744,073,659,551 µs (~585M years), silently dragging stream/service `avg`/`max`/`p99` latency into nonsense and drawing a garbage waterfall bar;
- in debug builds panicked with `attempt to subtract with overflow`.

All three OTLP entry points (HTTP JSON, HTTP protobuf, gRPC) funnel through this code path. The custom JSON ingest path passes `duration` through from the client and was not affected.

## Fix

Extract `span_duration_micros(start, end)` using `saturating_sub`, so `end < start` (or `end == 0`) stores a duration of `0` while keeping the span and its raw `start_time`/`end_time`. This matches the existing clamp in `time_index.rs` (`max_ts.max(min_ts)`) for the same condition.

The two existing inline-arithmetic tests now go through the helper, plus a new test for the `end < start` and `end == 0` cases.

## Notes

- Only affects newly ingested spans. Rows already stored with a wrapped duration keep skewing aggregates until they age out.
- Verified on this branch with `cargo fmt --all`, the CI clippy command, and `cargo test -p openobserve-core --lib -- traces::tests::test_span_duration traces::tests::test_duration_calculation`.