### PR TITLE
fix(dashboards): drop stream events from a superseded PromQL panel run

### DIFF
--- a/web/src/composables/dashboard/usePanelPromQLExecutor.spec.ts
+++ b/web/src/composables/dashboard/usePanelPromQLExecutor.spec.ts
@@ -489,3 +489,85 @@ describe("streaming PromQL errors reach the user as sentences", () => {
     expect(detail.code).toBe(404);
   });
 });
+
+describe("a superseded run cannot write over the newer one (#14350)", () => {
+  // A superseded run's stream is never cancelled, so its handlers must go quiet once its controller is aborted.
+  const supersededRun = async () => {
+    const { ctx, state, fetchQueryDataWithHttpStream, removeTraceId } = makeCtx();
+    const abortController = new AbortController();
+    let handlers: any;
+    (fetchQueryDataWithHttpStream as any).mockImplementation((_payload: any, h: any) => {
+      handlers = h;
+    });
+
+    const { executePromQL } = usePanelPromQLExecutor(ctx as any);
+    await executePromQL(0, 300_000_000, abortController);
+
+    // The newer run has rendered by now; this one is history.
+    state.data = [{ result: [{ metric: { environment: "development" }, values: [[1, "1"]] }] }];
+    state.loading = false;
+    abortController.abort();
+
+    return { state, handlers, removeTraceId };
+  };
+
+  it("drops a late promql_response instead of overwriting the rendered results", async () => {
+    const { state, handlers } = await supersededRun();
+    const rendered = state.data;
+
+    handlers.data({}, { type: "promql_response", content: { results: { result: [] } } });
+
+    expect(state.data).toBe(rendered);
+  });
+
+  it("drops a late progress frame instead of re-flagging partial data", async () => {
+    const { state, handlers } = await supersededRun();
+
+    handlers.data({}, { type: "event_progress", content: { percent: 40 } });
+
+    expect(state.loadingProgressPercentage).toBe(0);
+    expect(state.isPartialData).toBe(false);
+  });
+
+  it("drops a late completion but still releases the trace id", async () => {
+    const { state, handlers, removeTraceId } = await supersededRun();
+    const rendered = state.data;
+
+    handlers.complete({}, {});
+
+    expect(state.data).toBe(rendered);
+    expect(removeTraceId).toHaveBeenCalledWith("mock-trace-id");
+  });
+
+  it("drops a late error instead of showing it over the newer results", async () => {
+    const { state, handlers, removeTraceId } = await supersededRun();
+
+    handlers.error({}, { content: { message: "query failed", code: 400 } });
+
+    expect(state.errorDetail.message).toBe("");
+    expect(removeTraceId).toHaveBeenCalledWith("mock-trace-id");
+  });
+
+  it("still lets the run that owns the controller write its results", async () => {
+    const { ctx, state, fetchQueryDataWithHttpStream } = makeCtx();
+    const abortController = new AbortController();
+    let handlers: any;
+    (fetchQueryDataWithHttpStream as any).mockImplementation((_payload: any, h: any) => {
+      handlers = h;
+    });
+
+    const { executePromQL } = usePanelPromQLExecutor(ctx as any);
+    await executePromQL(0, 300_000_000, abortController);
+
+    handlers.data({}, { type: "event_progress", content: { percent: 40 } });
+    handlers.data(
+      {},
+      { type: "promql_response", content: { results: { result: [{ metric: {}, values: [] }] } } },
+    );
+    handlers.complete({}, {});
+
+    expect(state.loadingProgressPercentage).toBe(40);
+    expect(state.data[0].result).toHaveLength(1);
+    expect(state.loading).toBe(false);
+  });
+});

--- a/web/src/composables/dashboard/usePanelPromQLExecutor.ts
+++ b/web/src/composables/dashboard/usePanelPromQLExecutor.ts
@@ -214,7 +214,11 @@ export const usePanelPromQLExecutor = (ctx: {
               enableLogging: false,
             });
 
+            // loadData() aborts the old run's controller but never cancels its stream, so a superseded run keeps delivering frames that would overwrite the newer run's results — an empty first partition then strands the panel on "No Data".
+            const isSuperseded = () => !!abortControllerRef?.signal?.aborted;
+
             const handlePromQLResponse = (data: any, res: any) => {
+              if (isSuperseded()) return;
               if (res.type === "event_progress") {
                 state.loadingProgressPercentage = res?.content?.percent ?? 0;
                 state.isPartialData = true;
@@ -253,6 +257,10 @@ export const usePanelPromQLExecutor = (ctx: {
             };
 
             const handlePromQLError = (data: any, err: any) => {
+              if (isSuperseded()) {
+                removeTraceId(traceId);
+                return;
+              }
               // Mark this query as completed (even with error)
               completedQueries.add(queryIndex);
 
@@ -277,6 +285,10 @@ export const usePanelPromQLExecutor = (ctx: {
             };
 
             const handlePromQLComplete = () => {
+              if (isSuperseded()) {
+                removeTraceId(traceId);
+                return;
+              }
               // Mark this query as completed
               completedQueries.add(queryIndex);
 


### PR DESCRIPTION
Fixes #14350

## Root cause

`usePanelDataLoader.loadData()` aborts the previous run's `AbortController` and creates a new one, but **nothing cancels the PromQL stream that run already started** — `cancelStreamQueryBasedOnRequestId` is only reached from the Cancel button and on unmount. `usePanelPromQLExecutor` checked `signal.aborted` only once, *before* firing, so a superseded run's `promql_response` / `progress` / `complete` / `error` handlers kept writing `state.data` and `state.loading` after a newer run had already rendered.

Each run captures its own `queryResults`, and the backend partitions `query_range` by time with a routinely empty first partition (`result: []`). So a superseded run writes `[{result: []}]` **last** and wins: `noData` flips to `"No Data"`, `tableRendererData` hard-returns `{rows: [], columns: []}`, and the panel is stuck at "No Data" / "0 of 0" while the legend selector still shows the series (its reset is guarded on a non-empty option list — which is exactly the screenshot in the issue).

Under load two `loadData` runs overlap; on a quiet server the first finishes before the second starts. That is the reported "~2/15 metrics-shard runs, does not reproduce on a quiet env" profile.

## The issue's suggested fix is not the cause

The issue proposed making `TableRenderer.vue` streaming-aware, mirroring the logs fix in #14324. I verified in a real browser that the dashboard/metrics table renders streamed frames correctly — rows appear and update on every frame. `TableRenderer` is not at fault, so it is **not** touched here.

## Change

An `isSuperseded()` guard on all four handlers in `usePanelPromQLExecutor.ts`; late `complete`/`error` still release their trace id. 12 lines. It covers every PromQL panel type on both dashboards and Metrics → Visualize, not just tables.

## Reproduction

Replayed `query_range` SSE frames on real timers through the genuine `useStreamingSearch` → stream worker → executor → `PanelSchemaRenderer` → `PromQLTableChart` path in a real browser.

**Before** — run B renders, then run A's stale empty frame lands and wins permanently:

```
run B start   domRows=0  count="0 of 0"   noData=true
t=800ms       domRows=5  count="1-5 of 5" noData=false
t=1300ms      domRows=0  count="0 of 0"   noData=true   legend still shows {"__name__":"cpu_usage","environment":"development"}
... stays "0 of 0" through t=6300ms
```

**After** — 5 rows from t=800ms through t=6300ms. Also re-ran four other frame orderings (single series, all-at-once, series arriving late, slow stale run) — all correct.

## Tests

5 regression tests in `usePanelPromQLExecutor.spec.ts`. The 4 negative ones fail on unfixed code; the control one ("the run that owns the controller still writes its results") passes either way.

Gates: 1129 tests green across `composables/dashboard` plus the panel/table specs; eslint clean; prettier clean; `vue-tsc --noEmit` clean.

## Follow-ups not included here

- The superseded streams themselves are still never cancelled, so an abandoned run keeps downloading and parsing. Resource concern rather than correctness, and cancelling would touch the Cancel-button semantics.
- `usePanelSQLExecutor` aborts its own controller in a `finally`, so it cannot use the same signal as a supersede token. If the same symptom appears on SQL panels it needs a separate run token.
- PromQL series legend names are recomputed per streaming frame (`getDiscriminatingLabels` returns `[]` for a lone series, so one series is named `{"environment":"development"}` and becomes bare `development` once a second arrives). `PromQLTableChart` resets `selectedLegend` when it goes invalid, so this self-heals — a transient, not this bug.
- `PromQLTableChart`'s `#bottom` slot reads pagination props the table no longer provides (`scope.pagination` / `scope.pagesNumber` / `scope.setRowsPerPage` vs. OTable's `currentPage` / `totalPages` / `setPageSize`), so page arrows never render and rows-per-page is a dead handler on PromQL tables. Genuine but unrelated; filed separately.
