### PR TITLE
fix(nav): close an open dropdown before the rail flyout opens

### DIFF
--- a/web/src/lib/core/Navbar/ONavGroup.spec.ts
+++ b/web/src/lib/core/Navbar/ONavGroup.spec.ts
@@ -114,6 +114,63 @@ describe("ONavGroup", () => {
     expect(flyout().exists()).toBe(true);
   });
 
+  /**
+   * A dropdown is portaled after this flyout and sits on a higher layer, so it
+   * paints over the menu the pointer is on. Escape is what reka's dismissable
+   * layers listen for; the flyout sends it before showing itself.
+   */
+  it("closes an open dropdown before showing the flyout", async () => {
+    const popper = document.createElement("div");
+    popper.setAttribute("data-reka-popper-content-wrapper", "");
+    document.body.appendChild(popper);
+    const keys: string[] = [];
+    const listener = (e: Event) => keys.push((e as KeyboardEvent).key);
+    document.addEventListener("keydown", listener);
+
+    wrapper = mountGroup();
+    await hoverOpen();
+
+    document.removeEventListener("keydown", listener);
+    popper.remove();
+    expect(keys).toContain("Escape");
+    expect(flyout().exists()).toBe(true);
+  });
+
+  // Nothing to dismiss must stay silent: a stray Escape would close whatever
+  // else is listening, and hovering the rail is not a dismissal gesture.
+  it("sends no Escape when no dropdown is open", async () => {
+    const keys: string[] = [];
+    const listener = (e: Event) => keys.push((e as KeyboardEvent).key);
+    document.addEventListener("keydown", listener);
+
+    wrapper = mountGroup();
+    await hoverOpen();
+
+    document.removeEventListener("keydown", listener);
+    expect(keys).not.toContain("Escape");
+  });
+
+  // A dialog or drawer owns Escape while it is open, and the rail stays
+  // reachable beside a drawer — so the flyout must not fire the key there.
+  it("leaves an open dialog alone", async () => {
+    const popper = document.createElement("div");
+    popper.setAttribute("data-reka-popper-content-wrapper", "");
+    const overlay = document.createElement("div");
+    overlay.setAttribute("data-test", "o-dialog-overlay");
+    document.body.append(popper, overlay);
+    const keys: string[] = [];
+    const listener = (e: Event) => keys.push((e as KeyboardEvent).key);
+    document.addEventListener("keydown", listener);
+
+    wrapper = mountGroup();
+    await hoverOpen();
+
+    document.removeEventListener("keydown", listener);
+    popper.remove();
+    overlay.remove();
+    expect(keys).not.toContain("Escape");
+  });
+
   // The Infra tile holds ONE child (Database Monitoring) behind the
   // `databaseMonitoring` runtime gate. Rendering the tile regardless of its
   // children would leave a dead "Infra" entry on every build with the feature

--- a/web/src/lib/core/Navbar/ONavGroup.vue
+++ b/web/src/lib/core/Navbar/ONavGroup.vue
@@ -309,8 +309,30 @@ async function positionFlyout() {
   };
 }
 
+/**
+ * Send any open dropdown away before the flyout appears.
+ *
+ * Both are page menus, but a dropdown is portaled after this flyout AND sits on
+ * a higher layer, so it paints over the menu the pointer is actually on.
+ * Raising the flyout is the wrong lever: it would have to clear 10001, which is
+ * above the modal layer, and a nav menu floating over a dialog is worse than
+ * the overlap it would fix. One menu at a time is the behaviour anyway.
+ *
+ * Escape is what reka's dismissable layers listen for. It is scoped to the case
+ * where a popper is the topmost layer — with a dialog or drawer open the same
+ * key would close that instead, and the rail is reachable beside a drawer.
+ */
+function dismissOpenDropdowns() {
+  if (!document.querySelector("[data-reka-popper-content-wrapper]")) return;
+  if (document.querySelector('[data-test="o-dialog-overlay"], [data-test="o-drawer-overlay"]')) {
+    return;
+  }
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+}
+
 async function open() {
   if (visibleChildren.value.length === 0) return;
+  dismissOpenDropdowns();
   clearTimers();
   isOpen.value = true;
   openGroupKey.value = props.groupKey;


### PR DESCRIPTION
Backport of #14360 to `branch-v1.0.0`.

## The bug

Hovering the nav rail while a dropdown is open leaves **both menus on screen**, and the dropdown covers the flyout the pointer is actually on.

Reported against the SLO source-alert picker, but nothing about it is SLO-specific — it reproduces with any dropdown on any page.

Measured before the fix, alert list open and `Reliability` hovered:

| | z-index | box |
|---|---|---|
| `.nav-group-flyout` | 6000 | x 92–309, y 370–590 |
| dropdown popover | 10001 | x 114–922, y 549–809 |

## Why not just raise the flyout

1. The flyout is `Teleport`ed to body when the group mounts, so it sits **earlier in the DOM** than any dropdown (measured: index 338 vs 373). At equal z-index the dropdown still wins — a z change alone fixes nothing.
2. Dropdowns render at `z-10001`, which `lib/styles/tokens/base.css` reserves for *"Tooltips / toasts above modals"* — above the 9998/9999 modal layer. For the flyout to outrank a dropdown it would have to outrank **dialogs** too, and a nav menu floating over a dialog is a worse bug than the overlap.

Two page menus open at once is the actual defect, so the flyout dismisses the dropdown on its way up.

## How

`Escape` is what reka's dismissable layers listen for, scoped to the case where a popper is the topmost layer:

- no `[data-reka-popper-content-wrapper]` open → nothing dispatched (hovering the rail is not a dismissal gesture)
- a dialog or drawer overlay present → nothing dispatched, because that layer owns Escape and the rail stays reachable beside a drawer

## Differences from the main PR

Only the test file. `branch-v1.0.0` does not carry main's LTR/RTL flyout-positioning tests, so those hunks were dropped and only the three tests this fix adds were kept. The component change is identical.

## Verification on this branch

Built and browser-measured against a fresh data store:

```
dropdownOpenBefore : true
flyoutOpen         : true
dropdownOpen       : false
overlapPx          : 0
```

`ONavGroup` unit tests: **99 passed** (3 new). Prettier clean.