### PR TITLE
fix(dashboards): drop stream events from a superseded PromQL panel run (v1.0.0)

### DIFF
--- a/web/src/composables/dashboard/usePanelPromQLExecutor.spec.ts
+++ b/web/src/composables/dashboard/usePanelPromQLExecutor.spec.ts
@@ -489,3 +489,85 @@ describe("streaming PromQL errors reach the user as sentences", () => {
     expect(detail.code).toBe(404);
   });
 });
+
+describe("a superseded run cannot write over the newer one (#14350)", () => {
+  // A superseded run's stream is never cancelled, so its handlers must go quiet once its controller is aborted.
+  const supersededRun = async () => {
+    const { ctx, state, fetchQueryDataWithHttpStream, removeTraceId } = makeCtx();
+    const abortController = new AbortController();
+    let handlers: any;
+    (fetchQueryDataWithHttpStream as any).mockImplementation((_payload: any, h: any) => {
+      handlers = h;
+    });
+
+    const { executePromQL } = usePanelPromQLExecutor(ctx as any);
+    await executePromQL(0, 300_000_000, abortController);
+
+    // The newer run has rendered by now; this one is history.
+    state.data = [{ result: [{ metric: { environment: "development" }, values: [[1, "1"]] }] }];
+    state.loading = false;
+    abortController.abort();
+
+    return { state, handlers, removeTraceId };
+  };
+
+  it("drops a late promql_response instead of overwriting the rendered results", async () => {
+    const { state, handlers } = await supersededRun();
+    const rendered = state.data;
+
+    handlers.data({}, { type: "promql_response", content: { results: { result: [] } } });
+
+    expect(state.data).toBe(rendered);
+  });
+
+  it("drops a late progress frame instead of re-flagging partial data", async () => {
+    const { state, handlers } = await supersededRun();
+
+    handlers.data({}, { type: "event_progress", content: { percent: 40 } });
+
+    expect(state.loadingProgressPercentage).toBe(0);
+    expect(state.isPartialData).toBe(false);
+  });
+
+  it("drops a late completion but still releases the trace id", async () => {
+    const { state, handlers, removeTraceId } = await supersededRun();
+    const rendered = state.data;
+
+    handlers.complete({}, {});
+
+    expect(state.data).toBe(rendered);
+    expect(removeTraceId).toHaveBeenCalledWith("mock-trace-id");
+  });
+
+  it("drops a late error instead of showing it over the newer results", async () => {
+    const { state, handlers, removeTraceId } = await supersededRun();
+
+    handlers.error({}, { content: { message: "query failed", code: 400 } });
+
+    expect(state.errorDetail.message).toBe("");
+    expect(removeTraceId).toHaveBeenCalledWith("mock-trace-id");
+  });
+
+  it("still lets the run that owns the controller write its results", async () => {
+    const { ctx, state, fetchQueryDataWithHttpStream } = makeCtx();
+    const abortController = new AbortController();
+    let handlers: any;
+    (fetchQueryDataWithHttpStream as any).mockImplementation((_payload: any, h: any) => {
+      handlers = h;
+    });
+
+    const { executePromQL } = usePanelPromQLExecutor(ctx as any);
+    await executePromQL(0, 300_000_000, abortController);
+
+    handlers.data({}, { type: "event_progress", content: { percent: 40 } });
+    handlers.data(
+      {},
+      { type: "promql_response", content: { results: { result: [{ metric: {}, values: [] }] } } },
+    );
+    handlers.complete({}, {});
+
+    expect(state.loadingProgressPercentage).toBe(40);
+    expect(state.data[0].result).toHaveLength(1);
+    expect(state.loading).toBe(false);
+  });
+});

--- a/web/src/composables/dashboard/usePanelPromQLExecutor.ts
+++ b/web/src/composables/dashboard/usePanelPromQLExecutor.ts
@@ -214,7 +214,11 @@ export const usePanelPromQLExecutor = (ctx: {
               enableLogging: false,
             });
 
+            // loadData() aborts the old run's controller but never cancels its stream, so a superseded run keeps delivering frames that would overwrite the newer run's results — an empty first partition then strands the panel on "No Data".
+            const isSuperseded = () => !!abortControllerRef?.signal?.aborted;
+
             const handlePromQLResponse = (data: any, res: any) => {
+              if (isSuperseded()) return;
               if (res.type === "event_progress") {
                 state.loadingProgressPercentage = res?.content?.percent ?? 0;
                 state.isPartialData = true;
@@ -253,6 +257,10 @@ export const usePanelPromQLExecutor = (ctx: {
             };
 
             const handlePromQLError = (data: any, err: any) => {
+              if (isSuperseded()) {
+                removeTraceId(traceId);
+                return;
+              }
               // Mark this query as completed (even with error)
               completedQueries.add(queryIndex);
 
@@ -277,6 +285,10 @@ export const usePanelPromQLExecutor = (ctx: {
             };
 
             const handlePromQLComplete = () => {
+              if (isSuperseded()) {
+                removeTraceId(traceId);
+                return;
+              }
               // Mark this query as completed
               completedQueries.add(queryIndex);
 


### PR DESCRIPTION
Backport of #14369 to `branch-v1.0.0`. Fixes #14350.

Clean cherry-pick (`-x`) of the same commit — `usePanelPromQLExecutor.ts`, its spec, and `usePanelDataLoader.ts` are byte-identical between `main` and `branch-v1.0.0`, so there is no adaptation.

## Root cause

`usePanelDataLoader.loadData()` aborts the previous run's `AbortController` and creates a new one, but **nothing cancels the PromQL stream that run already started** — `cancelStreamQueryBasedOnRequestId` is only reached from the Cancel button and on unmount. `usePanelPromQLExecutor` checked `signal.aborted` only once, *before* firing, so a superseded run's `promql_response` / `progress` / `complete` / `error` handlers kept writing `state.data` and `state.loading` after a newer run had already rendered.

The backend partitions `query_range` by time with a routinely empty first partition, so a superseded run writes `[{result: []}]` last and wins: the panel is stuck at "No Data" / "0 of 0" while the legend selector still shows the series. Under load two runs overlap; on a quiet server they don't — hence the CI-only flake.

## Change

An `isSuperseded()` guard on all four handlers in `usePanelPromQLExecutor.ts`; late `complete`/`error` still release their trace id. Covers every PromQL panel type on dashboards and Metrics → Visualize.

`TableRenderer` is not at fault (verified in a real browser that it renders streamed frames correctly), so the streaming-awareness change the issue suggested is not included.

## Verification on this branch

Run against `branch-v1.0.0` with its own dependencies installed:

- 1128 tests green across `composables/dashboard` plus the `PanelSchemaRenderer` / `PromQLTableChart` / `TableRenderer` specs, including the 5 new regression tests
- eslint clean, prettier clean, `vue-tsc --noEmit` exit 0

The before/after browser reproduction is in #14369.
