### PR TITLE
fix(orgs): create the _meta organization at startup

### DIFF
--- a/src/core/src/bootstrap.rs
+++ b/src/core/src/bootstrap.rs
@@ -93,6 +93,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     cache_instance_id(&get_or_create_instance_id().await?);
 
+    // _meta used to appear only once self-reporting wrote its first stream into it,
+    // so a deployment that reports nothing never had the org its history pages read.
+    crate::organization::check_and_create_org(config::META_ORG_ID).await?;
+
     wal::init()?;
     // because of asynchronous, we need to wait for a while
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;


### PR DESCRIPTION
Cherry-pick of the `_meta` fix from #14316 onto `branch-v1.0.0`. It missed #14348, which merged at `0aac11004d`.

## Behavior changes

- The `_meta` organization is created at startup. It used to appear only once self-reporting wrote its first stream into it, so a deployment that reports nothing never had the organization that alert history, pipeline history, workflow history and search history all read.
- Nothing else changes. `check_and_create_org` returns early when the organization already exists, so an existing deployment and every restart do nothing. No streams are created and no data is ingested.

This is the same call the schema watcher already makes at `watcher.rs:200` when a stream appears for an unknown organization, moved to startup instead of waiting for telemetry to trigger it.
