### PR TITLE
fix(orgs): create _meta at startup only in the open source build

### DIFF
--- a/src/core/src/bootstrap.rs
+++ b/src/core/src/bootstrap.rs
@@ -93,8 +93,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     cache_instance_id(&get_or_create_instance_id().await?);
 
-    // _meta used to appear only once self-reporting wrote its first stream into it,
-    // so a deployment that reports nothing never had the org its history pages read.
+    // Open source only: enterprise and cloud already create _meta when they write
+    // usage into it, and this build reports nothing, so the org never appeared.
+    #[cfg(not(feature = "enterprise"))]
     crate::organization::check_and_create_org(config::META_ORG_ID).await?;
 
     wal::init()?;


### PR DESCRIPTION
Follow-up to #14316, raised after @uddhav-o2 asked on Slack whether the `_meta` change also fires on cloud. It does, and it should not.

## Behavior changes

- `_meta` is created at startup in the open source build only. Enterprise and cloud are byte-identical to before #14316, because they already create `_meta` when they write usage into it and the schema watcher provisions the org on first write.
- Nothing else changes. The open source build keeps the fix it needs, since it no longer reports usage at all and so never gets `_meta` any other way.

## Why it matters for cloud

`check_and_create_org` does more than insert a row when the `cloud` feature is on:

- emits an `OrgCreated` cloud event
- sets a fifteen day `trial_ends_at` on the organization record
- provisions a default ingestion token and a synthetics probe token

None of that should fire for a system organization on every cloud startup. It is idempotent for an existing deployment, since the function returns early when the org exists, but a fresh cloud environment would have taken that path at boot instead of on first usage write.
