### PR TITLE
fix(logs): reset field-list pagination when stream changes via SQL mode

### DIFF
--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -717,6 +717,17 @@ export default defineComponent({
       },
     );
 
+    // Reset to page 1 whenever the selected stream(s) change. Covers the SQL
+    // Mode path too: useSearchBar's onStreamChange swaps selectedStreamFields
+    // directly and has no reference to this component's local pagination state.
+    watch(
+      () => searchObj.data.stream.selectedStream,
+      () => {
+        resetPagination();
+      },
+      { deep: true },
+    );
+
     // Close the stream-select dropdown whenever the Source Details drawer opens
     // so the open popover does not obscure the drawer in both single and multi-select mode.
     watch(


### PR DESCRIPTION
Switching streams through the SQL query editor updates selectedStreamFields directly in useSearchBar's onStreamChange, which has no way to reset IndexList's local pagination state. If the user was on a later page, the new stream's shorter field list rendered "No field found in selected stream" even though fields loaded fine.