### PR TITLE
fix(iam): keep _meta org list out of the header switcher dropdown

### DIFF
--- a/web/src/components/iam/organizations/ListOrganizations.spec.js
+++ b/web/src/components/iam/organizations/ListOrganizations.spec.js
@@ -11,10 +11,9 @@ import OTable from "@/lib/core/Table/OTable.vue";
 vi.mock("@/services/organizations", () => ({
   default: {
     list: vi.fn(),
-    // getOrganizations() sources the list from the _meta admin endpoint (so it can
-    // surface status / deleted_at); resurrect_org + delete_org are used by row actions.
+    // get_admin_org is mocked purely so a regression that reintroduces the
+    // all-orgs endpoint here fails loudly instead of hitting the network.
     get_admin_org: vi.fn(),
-    resurrect_org: vi.fn(),
     delete_org: vi.fn(),
   },
 }));
@@ -68,9 +67,6 @@ describe("ListOrganizations", () => {
         selectedOrganization: {
           identifier: "test-org",
         },
-        // useIsMetaOrg compares selectedOrganization.identifier to zoConfig.meta_org.
-        // "test-org" !== "_meta" → isMetaOrg is false → getOrganizations() uses the
-        // regular list() endpoint (the non-admin path these tests exercise).
         zoConfig: {
           meta_org: "_meta",
         },
@@ -104,13 +100,6 @@ describe("ListOrganizations", () => {
 
     // Mock the organizations service list method
     organizationsService.list.mockResolvedValue(mockOrganizations);
-    // getOrganizations() now reads from the _meta admin endpoint. Delegate it to
-    // whatever `list` is currently mocked to return (incl. per-test mockResolvedValueOnce),
-    // so existing test data setups keep driving the component unchanged.
-    organizationsService.get_admin_org.mockImplementation((...args) =>
-      organizationsService.list(...args),
-    );
-    organizationsService.resurrect_org.mockResolvedValue({});
     organizationsService.delete_org.mockResolvedValue({});
 
     wrapper = mount(ListOrganizations, {
@@ -178,8 +167,8 @@ describe("ListOrganizations", () => {
       const columns = wrapper.vm.columns;
       // The row index is rendered by OTable's `show-index` prop, so there is no
       // "#" column in the definition. Non-cloud columns are:
-      // name, identifier, type, status, actions = 5
-      expect(columns.map((c) => c.id)).toEqual(["name", "identifier", "type", "status", "actions"]);
+      // name, identifier, type, actions = 4
+      expect(columns.map((c) => c.id)).toEqual(["name", "identifier", "type", "actions"]);
       expect(columns.map((c) => c.id)).not.toContain("plan");
       expect(columns[columns.length - 1].isAction).toBe(true);
     });
@@ -209,12 +198,11 @@ describe("ListOrganizations", () => {
 
       await flushPromises();
       // When isCloud is true a "plan" column is inserted before "actions":
-      // name, identifier, type, status, plan, actions = 6
+      // name, identifier, type, plan, actions = 5
       expect(wrapperWithCloud.vm.columns.map((c) => c.id)).toEqual([
         "name",
         "identifier",
         "type",
-        "status",
         "plan",
         "actions",
       ]);
@@ -225,21 +213,22 @@ describe("ListOrganizations", () => {
   });
 
   describe("Data Loading", () => {
-    it("should load organizations on mount via the regular list endpoint (non-_meta context)", async () => {
+    it("should load organizations on mount via the user-scoped list endpoint", async () => {
       await flushPromises();
-      // selectedOrganization is "test-org" (not _meta) → isMetaOrg is false →
-      // getOrganizations() uses the regular list() endpoint, not the admin one.
-      expect(organizationsService.list).toHaveBeenCalled();
+      expect(organizationsService.list).toHaveBeenCalledWith(0, 1000000, "name", false, "");
       expect(organizationsService.get_admin_org).not.toHaveBeenCalled();
       // The user-scoped list feeds the header switcher.
       expect(mockStore.dispatch).toHaveBeenCalledWith("setOrganizations", expect.anything());
     });
 
-    it("should use the _meta admin endpoint when the selected org is _meta on cloud", async () => {
-      config.isCloud = "true";
+    it.each([
+      ["cloud", "true"],
+      ["off-cloud", "false"],
+    ])("should stay user-scoped in the _meta context on %s", async (_label, isCloud) => {
+      config.isCloud = isCloud;
       organizationsService.list.mockClear();
       organizationsService.get_admin_org.mockClear();
-      organizationsService.get_admin_org.mockResolvedValue(mockOrganizations);
+      organizationsService.list.mockResolvedValue(mockOrganizations);
       mockStore.dispatch.mockClear();
       const metaWrapper = mount(ListOrganizations, {
         global: {
@@ -249,7 +238,6 @@ describe("ListOrganizations", () => {
               ...mockStore,
               state: {
                 ...mockStore.state,
-                // Selecting the _meta org flips isMetaOrg true → admin endpoint on cloud.
                 selectedOrganization: { identifier: "_meta" },
               },
             },
@@ -258,38 +246,14 @@ describe("ListOrganizations", () => {
         },
       });
       await flushPromises();
-      expect(organizationsService.get_admin_org).toHaveBeenCalledWith("_meta");
-      expect(organizationsService.list).not.toHaveBeenCalled();
-      // The all-orgs admin view must NOT leak into the header switcher.
-      expect(mockStore.dispatch).not.toHaveBeenCalledWith("setOrganizations", expect.anything());
-      metaWrapper.unmount();
-      config.isCloud = "false";
-    });
-
-    it("should fall back to the regular list for _meta off-cloud", async () => {
-      config.isCloud = "false";
-      organizationsService.list.mockClear();
-      organizationsService.get_admin_org.mockClear();
-      organizationsService.list.mockResolvedValue(mockOrganizations);
-      const metaWrapper = mount(ListOrganizations, {
-        global: {
-          plugins: [i18n, router],
-          provide: {
-            store: {
-              ...mockStore,
-              state: {
-                ...mockStore.state,
-                selectedOrganization: { identifier: "_meta" },
-              },
-            },
-          },
-          stubs: { OTable: true },
-        },
-      });
-      await flushPromises();
-      expect(organizationsService.list).toHaveBeenCalled();
+      // IAM lists only the user's own orgs: the all-orgs admin endpoint belongs
+      // to Settings → Organization Management, never here.
+      expect(organizationsService.list).toHaveBeenCalledWith(0, 1000000, "name", false, "");
       expect(organizationsService.get_admin_org).not.toHaveBeenCalled();
+      // Always the user-scoped list, so it always feeds the header switcher.
+      expect(mockStore.dispatch).toHaveBeenCalledWith("setOrganizations", expect.anything());
       metaWrapper.unmount();
+      config.isCloud = "false";
     });
 
     it("should transform organization data correctly", async () => {
@@ -300,9 +264,6 @@ describe("ListOrganizations", () => {
 
     it("should load organizations into the local list", async () => {
       await flushPromises();
-      // getOrganizations() populates the component's own list and deliberately does
-      // NOT dispatch setOrganizations (the navbar switcher keeps its own filtered
-      // list of non-deleting orgs).
       expect(wrapper.vm.organizations).toHaveLength(mockOrganizations.data.data.length);
       expect(wrapper.vm.organizations[0].identifier).toBe(
         mockOrganizations.data.data[0].identifier,

--- a/web/src/components/iam/organizations/ListOrganizations.spec.js
+++ b/web/src/components/iam/organizations/ListOrganizations.spec.js
@@ -231,6 +231,8 @@ describe("ListOrganizations", () => {
       // getOrganizations() uses the regular list() endpoint, not the admin one.
       expect(organizationsService.list).toHaveBeenCalled();
       expect(organizationsService.get_admin_org).not.toHaveBeenCalled();
+      // The user-scoped list feeds the header switcher.
+      expect(mockStore.dispatch).toHaveBeenCalledWith("setOrganizations", expect.anything());
     });
 
     it("should use the _meta admin endpoint when the selected org is _meta on cloud", async () => {
@@ -238,6 +240,7 @@ describe("ListOrganizations", () => {
       organizationsService.list.mockClear();
       organizationsService.get_admin_org.mockClear();
       organizationsService.get_admin_org.mockResolvedValue(mockOrganizations);
+      mockStore.dispatch.mockClear();
       const metaWrapper = mount(ListOrganizations, {
         global: {
           plugins: [i18n, router],
@@ -257,6 +260,8 @@ describe("ListOrganizations", () => {
       await flushPromises();
       expect(organizationsService.get_admin_org).toHaveBeenCalledWith("_meta");
       expect(organizationsService.list).not.toHaveBeenCalled();
+      // The all-orgs admin view must NOT leak into the header switcher.
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith("setOrganizations", expect.anything());
       metaWrapper.unmount();
       config.isCloud = "false";
     });

--- a/web/src/components/iam/organizations/ListOrganizations.vue
+++ b/web/src/components/iam/organizations/ListOrganizations.vue
@@ -103,37 +103,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <span v-else class="text-text-body">—</span>
           </template>
 
-          <template #cell-status="{ row }">
-            <OBadge
-              :variant="
-                row.status === 'pending_deletion'
-                  ? 'warning'
-                  : row.status === 'deleting'
-                    ? 'warning'
-                    : 'success-soft'
-              "
-              size="sm"
-            >
-              {{ row.status === "pending_deletion" ? pendingLabel(row) : row.status }}
-            </OBadge>
-          </template>
-
           <template #cell-actions="{ row }">
             <!-- Edit is pinned first so it stays column-aligned across every row,
-                 regardless of which trailing actions a row shows. It is disabled
-                 while the org is being deleted (editing a deleting org is a no-op). -->
+                 regardless of which trailing actions a row shows. -->
             <div class="flex items-center justify-start gap-1">
               <OButton
                 data-test="organization-name-edit"
                 variant="ghost"
                 size="icon-sm"
-                :disabled="row.status !== 'active'"
-                :title="
-                  row.status === 'deleting'
-                    ? t('iam.listOrganizations.cannotEditWhileDeleting')
-                    : t('iam.listOrganizations.edit')
-                "
-                @click="row.status === 'active' && renameOrganization(row)"
+                :title="t('iam.listOrganizations.edit')"
+                @click="renameOrganization(row)"
               >
                 <OIcon name="edit" size="sm" />
               </OButton>
@@ -147,26 +126,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               >
                 <OIcon name="delete" size="sm" />
               </OButton>
-              <OButton
-                v-if="row.status === 'deleting'"
-                data-test="organization-cleanup-tasks"
-                variant="ghost"
-                size="icon-sm"
-                :title="t('iam.listOrganizations.viewDeletionProgress')"
-                @click="viewCleanupTasks(row)"
-              >
-                <OIcon name="history" size="sm" />
-              </OButton>
-              <OButton
-                v-if="row.status === 'pending_deletion'"
-                data-test="organization-resurrect"
-                variant="ghost"
-                size="icon-sm"
-                :title="t('organization.resurrect')"
-                @click="resurrectOrganization(row)"
-              >
-                <OIcon name="undo" size="sm" />
-              </OButton>
             </div>
           </template>
         </OTable>
@@ -177,12 +136,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       @update:open="onDrawerOpenChange"
       @updated="updateOrganizationList"
       :model-value="toBeUpdatedOrganization"
-    />
-    <OrgCleanupTasksDialog
-      :open="showCleanupDialog"
-      :org-id="cleanupTargetOrg.id"
-      :org-name="cleanupTargetOrg.name"
-      @update:open="showCleanupDialog = $event"
     />
   </OPageLayout>
 </template>
@@ -197,15 +150,12 @@ import { useI18nTyped } from "@/types/i18n";
 
 import organizationsService from "@/services/organizations";
 import { useConfirmDialog } from "@/composables/useConfirmDialog";
-import useIsMetaOrg from "@/composables/useIsMetaOrg";
 import AddUpdateOrganization from "@/components/iam/organizations/AddUpdateOrganization.vue";
-import OrgCleanupTasksDialog from "@/components/iam/organizations/OrgCleanupTasksDialog.vue";
 import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
 import OButton from "@/lib/core/Button/OButton.vue";
 import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
 import OTag from "@/lib/core/Badge/OTag.vue";
 import OCodeCell from "@/lib/core/Table/cells/OCodeCell.vue";
-import OBadge from "@/lib/core/Badge/OBadge.vue";
 import OPageLayout from "@/lib/core/PageLayout/OPageLayout.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OSearchInput from "@/lib/forms/SearchInput/OSearchInput.vue";
@@ -224,12 +174,10 @@ export default defineComponent({
   components: {
     OCodeCell,
     AddUpdateOrganization,
-    OrgCleanupTasksDialog,
     OEmptyState,
     OButton,
     OTooltip,
     OTag,
-    OBadge,
     OPageLayout,
     OIcon,
     OTable,
@@ -237,7 +185,6 @@ export default defineComponent({
   },
   setup() {
     const store = useStore();
-    const { isMetaOrg } = useIsMetaOrg();
     const router = useRouter();
     const { t } = useI18nTyped();
     const organizations = ref([]);
@@ -246,8 +193,6 @@ export default defineComponent({
     const showJoinOrganizationDialog = ref(false);
     const showOrgAPIKeyDialog = ref(false);
     const organizationAPIKey = ref("");
-    const showCleanupDialog = ref(false);
-    const cleanupTargetOrg = ref({ id: "", name: "" });
     const filterQuery = ref("");
     const toBeUpdatedOrganization = ref({
       id: "",
@@ -283,16 +228,6 @@ export default defineComponent({
         resizable: true,
         hideable: true,
         size: 150,
-        meta: { align: "left" },
-      },
-      {
-        id: "status",
-        header: t("iam.listOrganizations.status"),
-        accessorKey: "status",
-        sortable: true,
-        resizable: true,
-        hideable: true,
-        size: 120,
         meta: { align: "left" },
       },
     ];
@@ -361,20 +296,10 @@ export default defineComponent({
         timeout: 0,
       });
       loading.value = true;
-      // In the _meta admin context on cloud, use the admin endpoint so admins can
-      // track org deletion status; otherwise use the regular list. Access is always
-      // enforced server-side.
-      const useAdminEndpoint = isMetaOrg.value && config.isCloud === "true";
-      const request = useAdminEndpoint
-        ? organizationsService.get_admin_org("_meta")
-        : organizationsService.list(0, 1000000, "name", false, "");
-      request
+      organizationsService
+        .list(0, 1000000, "name", false, "")
         .then((res) => {
-          // Only the user-scoped list feeds the header switcher; the _meta admin
-          // view lists all orgs and must not leak them into the org dropdown.
-          if (!useAdminEndpoint) {
-            store.dispatch("setOrganizations", res.data.data);
-          }
+          store.dispatch("setOrganizations", res.data.data);
 
           const billingPlans = {
             "0": "Free",
@@ -389,9 +314,6 @@ export default defineComponent({
               identifier: data.identifier,
               type: convertToTitleCase(data.type),
               plan: billingPlans[data.plan] || "-",
-              status: data.status ?? "active",
-              deleted_at: data.deleted_at ?? null,
-              grace_period_days: data.grace_period_days ?? null,
               _userRole: data.role ?? data.user_role ?? "",
             };
 
@@ -512,7 +434,6 @@ export default defineComponent({
     // Only shown on cloud builds; user must be root or an admin of that org.
     const canDeleteOrg = (row: any): boolean => {
       if (config.isCloud !== "true") return false;
-      if (row.status === "deleting") return false;
       const role = row._userRole?.toLowerCase();
       return role === "root" || role === "admin";
     };
@@ -539,36 +460,7 @@ export default defineComponent({
       }
     };
 
-    const viewCleanupTasks = (row: any) => {
-      cleanupTargetOrg.value = { id: row.identifier, name: row.name };
-      showCleanupDialog.value = true;
-    };
-
-    const pendingLabel = (row: any): string => {
-      if (!row.deleted_at || !row.grace_period_days) return t("organization.pendingDeletion");
-      const deletedAtMs = row.deleted_at / 1000; // micros → ms
-      const windowMs = row.grace_period_days * 86400 * 1000;
-      const msLeft = deletedAtMs + windowMs - Date.now();
-      const daysLeft = Math.max(0, Math.ceil(msLeft / 86400000));
-      return `${t("organization.pendingDeletion")} — ${t("organization.daysLeft", { n: daysLeft })}`;
-    };
-
-    const resurrectOrganization = async (row: any) => {
-      try {
-        await organizationsService.resurrect_org("_meta", row.identifier);
-        toast({ variant: "success", message: t("iam.listOrganizations.organizationResurrected") });
-        getOrganizations();
-      } catch (e: any) {
-        toast({
-          variant: "error",
-          message: e?.response?.data?.message || t("iam.listOrganizations.failedToResurrect"),
-        });
-      }
-    };
-
     const renameOrganization = (row: any) => {
-      // Guard: an org being deleted cannot be edited (the UI button is also disabled).
-      if (row.status === "deleting") return;
       toBeUpdatedOrganization.value = {
         id: row.identifier,
         name: row.name,
@@ -607,8 +499,6 @@ export default defineComponent({
       showJoinOrganizationDialog,
       showOrgAPIKeyDialog,
       organizationAPIKey,
-      showCleanupDialog,
-      cleanupTargetOrg,
       addOrganization,
       getOrganizations,
       inviteTeam,
@@ -616,12 +506,9 @@ export default defineComponent({
       hideAddOrgDialog,
       onDrawerOpenChange,
       renameOrganization,
-      viewCleanupTasks,
       canDeleteOrg,
       deleteOrganization,
       toBeUpdatedOrganization,
-      pendingLabel,
-      resurrectOrganization,
     };
   },
   methods: {

--- a/web/src/components/iam/organizations/ListOrganizations.vue
+++ b/web/src/components/iam/organizations/ListOrganizations.vue
@@ -370,8 +370,11 @@ export default defineComponent({
         : organizationsService.list(0, 1000000, "name", false, "");
       request
         .then((res) => {
-          // Sync Vuex so the header org selector updates without a page reload.
-          store.dispatch("setOrganizations", res.data.data);
+          // Only the user-scoped list feeds the header switcher; the _meta admin
+          // view lists all orgs and must not leak them into the org dropdown.
+          if (!useAdminEndpoint) {
+            store.dispatch("setOrganizations", res.data.data);
+          }
 
           const billingPlans = {
             "0": "Free",

--- a/web/src/components/iam/organizations/OrgCleanupTasksDialog.vue
+++ b/web/src/components/iam/organizations/OrgCleanupTasksDialog.vue
@@ -243,6 +243,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <script lang="ts">
 import { defineComponent, ref, computed, watch, onUnmounted } from "vue";
+import { useStore } from "vuex";
 import { useI18nTyped } from "@/types/i18n";
 import ODialog from "@/lib/overlay/Dialog/ODialog.vue";
 import OButton from "@/lib/core/Button/OButton.vue";
@@ -276,6 +277,7 @@ export default defineComponent({
   emits: ["update:open"],
   setup(props) {
     const { t } = useI18nTyped();
+    const store = useStore();
     const tasks = ref<CleanupTask[]>([]);
     const loading = ref(false);
     let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -396,7 +398,10 @@ export default defineComponent({
       if (!props.orgId) return;
       loading.value = true;
       try {
-        const res = await organizationsService.get_cleanup_tasks(props.orgId);
+        const res = await organizationsService.get_cleanup_tasks(
+          store.state.selectedOrganization.identifier,
+          props.orgId,
+        );
         tasks.value = res.data ?? [];
       } catch (e) {
         // silently fail — next poll will retry

--- a/web/src/components/settings/OrganizationManagement.spec.ts
+++ b/web/src/components/settings/OrganizationManagement.spec.ts
@@ -65,6 +65,7 @@ vi.mock("@/services/organizations", () => ({
     extend_external_contract: vi.fn(),
     revoke_external_contract: vi.fn(),
     set_quota_usage_limit: vi.fn(),
+    resurrect_org: vi.fn(),
   },
 }));
 
@@ -166,8 +167,8 @@ const ODialogStub = {
   `,
 };
 
-// Stub OTable so tests are fast. The stub renders the #cell-actions slot
-// for every row in `data` so action-button tests can find rendered buttons.
+// Stub OTable so tests are fast. The stub renders the #cell-actions and
+// #cell-status slots for every row in `data` so cell tests find real output.
 const OTableStub = {
   name: "OTable",
   inheritAttrs: false,
@@ -176,6 +177,7 @@ const OTableStub = {
     <div data-test="org-management-list-table">
       <slot name="toolbar" />
       <div v-for="(row, idx) in (data || [])" :key="idx" :data-test="'otable-row-' + idx">
+        <span :data-test="'otable-status-' + idx"><slot name="cell-status" :row="row" /></span>
         <slot name="cell-actions" :row="row" />
       </div>
       <slot name="empty" v-if="!data || data.length === 0" />
@@ -301,21 +303,22 @@ describe("OrganizationManagement.vue", () => {
     it("should have correct column configuration", () => {
       wrapper = createWrapper();
       const columns = wrapper.vm.columns;
-      expect(columns).toHaveLength(14);
+      expect(columns).toHaveLength(15);
       expect(columns[0].id).toBe("name");
       expect(columns[1].id).toBe("identifier");
       expect(columns[2].id).toBe("subscription_status");
-      expect(columns[3].id).toBe("billing_provider");
-      expect(columns[4].id).toBe("ai_credits_used");
-      expect(columns[5].id).toBe("ai_credits_total");
-      expect(columns[6].id).toBe("browser_steps_used");
-      expect(columns[7].id).toBe("browser_steps_total");
-      expect(columns[8].id).toBe("protocol_steps_used");
-      expect(columns[9].id).toBe("protocol_steps_total");
-      expect(columns[10].id).toBe("created_on");
-      expect(columns[11].id).toBe("trial_expiry");
-      expect(columns[12].id).toBe("contract_end_date");
-      expect(columns[13].id).toBe("actions");
+      expect(columns[3].id).toBe("status");
+      expect(columns[4].id).toBe("billing_provider");
+      expect(columns[5].id).toBe("ai_credits_used");
+      expect(columns[6].id).toBe("ai_credits_total");
+      expect(columns[7].id).toBe("browser_steps_used");
+      expect(columns[8].id).toBe("browser_steps_total");
+      expect(columns[9].id).toBe("protocol_steps_used");
+      expect(columns[10].id).toBe("protocol_steps_total");
+      expect(columns[11].id).toBe("created_on");
+      expect(columns[12].id).toBe("trial_expiry");
+      expect(columns[13].id).toBe("contract_end_date");
+      expect(columns[14].id).toBe("actions");
     });
 
     it("should have subscription plans mapping", () => {
@@ -470,6 +473,9 @@ describe("OrganizationManagement.vue", () => {
         contract_end_date: 0,
         contract_end_date_display: "-",
         org_storage_enabled: false,
+        status: "active",
+        deleted_at: null,
+        grace_period_days: null,
       });
     });
 
@@ -1051,6 +1057,112 @@ describe("OrganizationManagement.vue", () => {
       // Storage enable button should NOT show
       const storageEnableBtn = wrapper.find('[data-test="org-management-storage-enable-btn"]');
       expect(storageEnableBtn.exists()).toBe(false);
+    });
+  });
+
+  describe("Organization Deletion Status", () => {
+    const orgRow = (overrides: Record<string, any> = {}) => ({
+      id: 1,
+      name: "Test Org",
+      identifier: "test-org",
+      plan: "0",
+      created_at: 123456789,
+      trial_expires_at: 987654321,
+      billing_provider: "-",
+      org_storage_enabled: true,
+      ...overrides,
+    });
+
+    const mountWithRow = async (row: Record<string, any>) => {
+      store.state.zoConfig.meta_org = "default";
+      mockGetAdminOrg.mockResolvedValue({ data: { data: [row] } });
+      wrapper = createWrapper();
+      await flushPromises();
+      await nextTick();
+    };
+
+    it("should default a row with no status field to active", async () => {
+      await mountWithRow(orgRow());
+      expect(wrapper.vm.tabledata[0].status).toBe("active");
+      expect(wrapper.vm.tabledata[0].deleted_at).toBeNull();
+      expect(wrapper.vm.tabledata[0].grace_period_days).toBeNull();
+    });
+
+    it("should render the status badge for an active org", async () => {
+      await mountWithRow(orgRow({ status: "active" }));
+      expect(wrapper.find('[data-test="otable-status-0"]').text()).toBe("active");
+      expect(wrapper.find('[data-test="org-management-resurrect-btn"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="org-management-cleanup-tasks-btn"]').exists()).toBe(false);
+    });
+
+    it("should render the pending-deletion badge with the days remaining", async () => {
+      const threeDaysAgoMicros = (Date.now() - 3 * 86400000) * 1000;
+      await mountWithRow(
+        orgRow({
+          status: "pending_deletion",
+          deleted_at: threeDaysAgoMicros,
+          grace_period_days: 10,
+        }),
+      );
+      expect(wrapper.find('[data-test="otable-status-0"]').text()).toBe(
+        "Pending deletion — 7 days left",
+      );
+    });
+
+    it("should fall back to the bare pending label without a grace period", async () => {
+      await mountWithRow(orgRow({ status: "pending_deletion" }));
+      expect(wrapper.find('[data-test="otable-status-0"]').text()).toBe("Pending deletion");
+    });
+
+    it("should show only the resurrect button for a pending_deletion org", async () => {
+      await mountWithRow(orgRow({ status: "pending_deletion" }));
+      expect(wrapper.find('[data-test="org-management-resurrect-btn"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="org-management-cleanup-tasks-btn"]').exists()).toBe(false);
+    });
+
+    it("should show only the cleanup-tasks button for a deleting org", async () => {
+      await mountWithRow(orgRow({ status: "deleting" }));
+      expect(wrapper.find('[data-test="org-management-cleanup-tasks-btn"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="org-management-resurrect-btn"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="otable-status-0"]').text()).toBe("deleting");
+    });
+
+    it("should open the cleanup dialog targeting the clicked org", async () => {
+      await mountWithRow(orgRow({ status: "deleting" }));
+      await wrapper.find('[data-test="org-management-cleanup-tasks-btn"]').trigger("click");
+      expect(wrapper.vm.showCleanupDialog).toBe(true);
+      expect(wrapper.vm.cleanupTargetOrg).toEqual({ id: "test-org", name: "Test Org" });
+    });
+
+    it("should resurrect against the configured meta org and refresh the list", async () => {
+      const { default: mockedOrgService } = await import("@/services/organizations");
+      const mockResurrect = (mockedOrgService as any).resurrect_org;
+      mockResurrect.mockResolvedValue({});
+      await mountWithRow(orgRow({ status: "pending_deletion" }));
+      mockGetAdminOrg.mockClear();
+
+      await wrapper.find('[data-test="org-management-resurrect-btn"]').trigger("click");
+      await flushPromises();
+
+      expect(mockResurrect).toHaveBeenCalledWith("default", "test-org");
+      expect(mockToastFn).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "success", message: "Organization resurrected." }),
+      );
+      expect(mockGetAdminOrg).toHaveBeenCalled();
+    });
+
+    it("should surface the server message when resurrect fails", async () => {
+      const { default: mockedOrgService } = await import("@/services/organizations");
+      const mockResurrect = (mockedOrgService as any).resurrect_org;
+      mockResurrect.mockRejectedValue({ response: { data: { message: "Grace period expired" } } });
+      await mountWithRow(orgRow({ status: "pending_deletion" }));
+
+      await wrapper.find('[data-test="org-management-resurrect-btn"]').trigger("click");
+      await flushPromises();
+
+      expect(mockToastFn).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "error", message: "Grace period expired" }),
+      );
     });
   });
 

--- a/web/src/components/settings/OrganizationManagement.vue
+++ b/web/src/components/settings/OrganizationManagement.vue
@@ -93,6 +93,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <template #cell-protocol_steps_total="{ row }">
             {{ formatCredits(row.protocol_steps_limit) }}
           </template>
+          <template #cell-status="{ row }">
+            <OBadge
+              :variant="
+                row.status === 'pending_deletion' || row.status === 'deleting'
+                  ? 'warning'
+                  : 'success-soft'
+              "
+              size="sm"
+            >
+              {{ row.status === "pending_deletion" ? pendingLabel(row) : row.status }}
+            </OBadge>
+          </template>
           <template #cell-actions="{ row }">
             <div class="flex items-center justify-center gap-1">
               <OButton
@@ -164,6 +176,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 data-test="org-management-storage-enabled-btn"
               >
                 <OTooltip :content="t('settings.organizationManagementPage.storageEnabled')" />
+              </OButton>
+              <OButton
+                v-if="row.status === 'deleting'"
+                variant="ghost"
+                size="icon-xs-circle"
+                icon-left="history"
+                data-test="org-management-cleanup-tasks-btn"
+                @click.stop="viewCleanupTasks(row)"
+              >
+                <OTooltip :content="t('iam.listOrganizations.viewDeletionProgress')" />
+              </OButton>
+              <OButton
+                v-if="row.status === 'pending_deletion'"
+                variant="ghost"
+                size="icon-xs-circle"
+                icon-left="undo"
+                data-test="org-management-resurrect-btn"
+                @click.stop="resurrectOrganization(row)"
+              >
+                <OTooltip :content="t('organization.resurrect')" />
               </OButton>
             </div>
           </template>
@@ -357,12 +389,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </OForm>
     </ODialog>
+
+    <OrgCleanupTasksDialog
+      :open="showCleanupDialog"
+      :org-id="cleanupTargetOrg.id"
+      :org-name="cleanupTargetOrg.name"
+      @update:open="showCleanupDialog = $event"
+    />
   </div>
 </template>
 <script lang="ts">
 import { ref, onMounted, watch, defineComponent, computed } from "vue";
 import { useI18nTyped, type I18nText } from "@/types/i18n";
 import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
+import OBadge from "@/lib/core/Badge/OBadge.vue";
+import OrgCleanupTasksDialog from "@/components/iam/organizations/OrgCleanupTasksDialog.vue";
 import { timestampToTimezoneDate, getImageURL } from "@/utils/zincutils";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
@@ -406,6 +447,8 @@ export default defineComponent({
   components: {
     OPageLayout,
     OEmptyState,
+    OBadge,
+    OrgCleanupTasksDialog,
     OButton,
     ODialog,
     OTooltip,
@@ -429,6 +472,8 @@ export default defineComponent({
     const tabledata = ref<any>([]);
     const resultTotal = ref(0);
     const filterQuery = ref("");
+    const showCleanupDialog = ref(false);
+    const cleanupTargetOrg = ref({ id: "", name: "" });
 
     // Usage allowance state — one dialog for every quota pool, the active tab
     // naming the pool. Tab names are the backend TrialQuotaPool keys.
@@ -552,6 +597,16 @@ export default defineComponent({
         meta: { align: "left" },
       },
       {
+        id: "status",
+        header: t("iam.listOrganizations.status"),
+        accessorKey: "status",
+        sortable: true,
+        resizable: true,
+        hideable: true,
+        size: COL.status,
+        meta: { align: "left" },
+      },
+      {
         id: "billing_provider",
         header: t("settings.organizationManagementPage.provider"),
         accessorKey: "billing_provider",
@@ -656,8 +711,8 @@ export default defineComponent({
         header: t("settings.actions"),
         isAction: true,
         pinned: "right",
-        size: 240,
-        meta: { align: "center", actionCount: 4 },
+        size: 300,
+        meta: { align: "center", actionCount: 5 },
       },
     ];
 
@@ -717,6 +772,9 @@ export default defineComponent({
               contract_end_date: responseData[i].contract_end_date || 0,
               contract_end_date_display: formatMicrosToDate(responseData[i].contract_end_date),
               org_storage_enabled: responseData[i].org_storage_enabled || false,
+              status: responseData[i].status ?? "active",
+              deleted_at: responseData[i].deleted_at ?? null,
+              grace_period_days: responseData[i].grace_period_days ?? null,
             });
           }
 
@@ -738,6 +796,36 @@ export default defineComponent({
             });
           }
         });
+    };
+
+    const viewCleanupTasks = (row: any) => {
+      cleanupTargetOrg.value = { id: row.identifier, name: row.name };
+      showCleanupDialog.value = true;
+    };
+
+    const pendingLabel = (row: any): string => {
+      if (!row.deleted_at || !row.grace_period_days) return t("organization.pendingDeletion");
+      const deletedAtMs = row.deleted_at / 1000;
+      const windowMs = row.grace_period_days * 86400 * 1000;
+      const msLeft = deletedAtMs + windowMs - Date.now();
+      const daysLeft = Math.max(0, Math.ceil(msLeft / 86400000));
+      return `${t("organization.pendingDeletion")} — ${t("organization.daysLeft", { n: daysLeft })}`;
+    };
+
+    const resurrectOrganization = async (row: any) => {
+      try {
+        await OrganizationServices.resurrect_org(
+          store.state.selectedOrganization.identifier,
+          row.identifier,
+        );
+        toast({ variant: "success", message: t("iam.listOrganizations.organizationResurrected") });
+        getData();
+      } catch (e: any) {
+        toast({
+          variant: "error",
+          message: e?.response?.data?.message || t("iam.listOrganizations.failedToResurrect"),
+        });
+      }
     };
 
     const toggleExtendTrialDialog = (row: any) => {
@@ -1102,6 +1190,11 @@ export default defineComponent({
       filterQuery,
       filterData,
       visibleRows,
+      showCleanupDialog,
+      cleanupTargetOrg,
+      viewCleanupTasks,
+      pendingLabel,
+      resurrectOrganization,
       store,
       // Form wiring (Options-API: schemas/defaults MUST be returned so :schema
       // resolves and validation runs).

--- a/web/src/services/organizations.ts
+++ b/web/src/services/organizations.ts
@@ -103,8 +103,8 @@ const organizations = {
     return http().delete(`/api/${orgIdentifier}/external_contract/${targetOrgId}`);
   },
 
-  get_cleanup_tasks: (targetOrgId: string) => {
-    return http().get(`/api/_meta/org_cleanup_tasks/${targetOrgId}`);
+  get_cleanup_tasks: (metaOrg: string, targetOrgId: string) => {
+    return http().get(`/api/${metaOrg}/org_cleanup_tasks/${targetOrgId}`);
   },
   delete_org: (orgIdentifier: string) => {
     return http().delete(`/api/${orgIdentifier}/organizations`);


### PR DESCRIPTION
### What the bug was
On cloud, after switching to the `_meta` org and opening **IAM → Organizations**, the header org-switcher dropdown started listing **all organizations** instead of only the user's own. The IAM page is meant to show all orgs (admins track org deletion there) — the problem was that it also pushed that all-orgs list into the top dropdown.

### Why it happened
After loading its list, the IAM page calls `setOrganizations`, which is the data source for the header dropdown. On the `_meta` admin path that list is *all* orgs, so the dropdown filled up with them. #13092 deliberately did not feed the dropdown from the admin view; #13369 ("…org dropdown update when new org added") re-added that dispatch unconditionally, bringing the leak back.

### What we fixed
Only feed the dropdown from the user-scoped list — dispatch `setOrganizations` on the regular `list()` path only, and skip it on the `_meta` admin (all-orgs) path. IAM → Organizations still shows all orgs for admins; the dropdown now only ever shows the user's own orgs.

Web-only, one component. Unit tests assert the admin view does not update the dropdown, while the user-scoped path still does.
