### PR TITLE
refactor(promql): remove redundant aggregation wrappers

### DIFF
--- a/src/promql/src/aggregations/avg.rs
+++ b/src/promql/src/aggregations/avg.rs
@@ -13,31 +13,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::promql::value::{EvalContext, Sample, Value};
-use datafusion::error::Result;
+use config::meta::promql::value::Sample;
 use hashbrown::HashMap;
-use promql_parser::parser::LabelModifier;
 
 use crate::{
     aggregations::{Accumulate, AggFunc},
     common::kahan_sum_increment,
 };
-
-pub fn avg(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    let start = std::time::Instant::now();
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] avg() started",
-        eval_ctx.trace_id,
-    );
-
-    let result = super::eval_aggregate(param, data, Avg, eval_ctx);
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] avg() execution took: {:?}",
-        eval_ctx.trace_id,
-        start.elapsed()
-    );
-    result
-}
 
 pub struct Avg;
 
@@ -108,15 +90,16 @@ impl Accumulate for AvgAccumulate {
 mod tests {
     use std::sync::Arc;
 
-    use config::meta::promql::value::{Label, RangeValue, Sample, Value};
+    use config::meta::promql::value::{EvalContext, Label, RangeValue, Sample, Value};
 
     use super::*;
+    use crate::aggregations::eval_aggregate;
 
     #[test]
     fn test_avg_value_none_input() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = avg(&None, Value::None, &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::None, Avg, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -124,7 +107,7 @@ mod tests {
     fn test_avg_invalid_input_returns_err() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = avg(&None, Value::Float(1.0), &eval_ctx);
+        let result = eval_aggregate(&None, Value::Float(1.0), Avg, &eval_ctx);
         assert!(result.is_err());
     }
 
@@ -132,7 +115,7 @@ mod tests {
     fn test_avg_empty_matrix_returns_none() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = avg(&None, Value::Matrix(vec![]), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::Matrix(vec![]), Avg, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -175,7 +158,7 @@ mod tests {
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
 
         // Test avg without label grouping - all samples should be averaged together
-        let result = avg(&None, data.clone(), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, data.clone(), Avg, &eval_ctx).unwrap();
 
         match result {
             Value::Matrix(matrix) => {

--- a/src/promql/src/aggregations/count.rs
+++ b/src/promql/src/aggregations/count.rs
@@ -13,28 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::promql::value::{EvalContext, Sample, Value};
-use datafusion::error::Result;
+use config::meta::promql::value::Sample;
 use hashbrown::HashMap;
-use promql_parser::parser::LabelModifier;
 
 use crate::aggregations::{Accumulate, AggFunc};
-
-pub fn count(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    let start = std::time::Instant::now();
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] count() started",
-        eval_ctx.trace_id,
-    );
-
-    let result = super::eval_aggregate(param, data, Count, eval_ctx);
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] count() execution took: {:?}",
-        eval_ctx.trace_id,
-        start.elapsed()
-    );
-    result
-}
 
 pub struct Count;
 
@@ -89,15 +71,16 @@ impl Accumulate for CountAccumulate {
 mod tests {
     use std::sync::Arc;
 
-    use config::meta::promql::value::{Label, RangeValue, Sample, Value};
+    use config::meta::promql::value::{EvalContext, Label, RangeValue, Sample, Value};
 
     use super::*;
+    use crate::aggregations::eval_aggregate;
 
     #[test]
     fn test_count_value_none_input() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = count(&None, Value::None, &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::None, Count, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -105,7 +88,7 @@ mod tests {
     fn test_count_invalid_input_returns_err() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = count(&None, Value::Float(1.0), &eval_ctx);
+        let result = eval_aggregate(&None, Value::Float(1.0), Count, &eval_ctx);
         assert!(result.is_err());
     }
 
@@ -113,7 +96,7 @@ mod tests {
     fn test_count_empty_matrix_returns_none() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = count(&None, Value::Matrix(vec![]), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::Matrix(vec![]), Count, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -156,7 +139,7 @@ mod tests {
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
 
         // Test count without label grouping - all samples should be counted together
-        let result = count(&None, data.clone(), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, data.clone(), Count, &eval_ctx).unwrap();
 
         match result {
             Value::Matrix(matrix) => {

--- a/src/promql/src/aggregations/group.rs
+++ b/src/promql/src/aggregations/group.rs
@@ -13,30 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::promql::value::{EvalContext, Sample, Value};
-use datafusion::error::Result;
+use config::meta::promql::value::Sample;
 use hashbrown::HashSet;
-use promql_parser::parser::LabelModifier;
 
 use crate::aggregations::{Accumulate, AggFunc};
 
 /// https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
-pub fn group(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    let start = std::time::Instant::now();
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] group() started",
-        eval_ctx.trace_id,
-    );
-
-    let result = super::eval_aggregate(param, data, Group, eval_ctx);
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] group() execution took: {:?}",
-        eval_ctx.trace_id,
-        start.elapsed()
-    );
-    result
-}
-
 pub struct Group;
 
 impl AggFunc for Group {
@@ -88,15 +70,16 @@ impl Accumulate for GroupAccumulate {
 mod tests {
     use std::sync::Arc;
 
-    use config::meta::promql::value::{Label, RangeValue, Sample, Value};
+    use config::meta::promql::value::{EvalContext, Label, RangeValue, Sample, Value};
 
     use super::*;
+    use crate::aggregations::eval_aggregate;
 
     #[test]
     fn test_group_value_none_input() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = group(&None, Value::None, &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::None, Group, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -104,7 +87,7 @@ mod tests {
     fn test_group_invalid_input_returns_err() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = group(&None, Value::Float(1.0), &eval_ctx);
+        let result = eval_aggregate(&None, Value::Float(1.0), Group, &eval_ctx);
         assert!(result.is_err());
     }
 
@@ -112,7 +95,7 @@ mod tests {
     fn test_group_empty_matrix_returns_none() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = group(&None, Value::Matrix(vec![]), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::Matrix(vec![]), Group, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -155,7 +138,7 @@ mod tests {
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
 
         // Test group without label grouping - should return 1.0 for each group
-        let result = group(&None, data.clone(), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, data.clone(), Group, &eval_ctx).unwrap();
 
         match result {
             Value::Matrix(matrix) => {

--- a/src/promql/src/aggregations/max.rs
+++ b/src/promql/src/aggregations/max.rs
@@ -13,28 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::promql::value::{EvalContext, Sample, Value};
-use datafusion::error::Result;
+use config::meta::promql::value::Sample;
 use hashbrown::HashMap;
-use promql_parser::parser::LabelModifier;
 
 use crate::aggregations::{Accumulate, AggFunc};
-
-pub fn max(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    let start = std::time::Instant::now();
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] max() started",
-        eval_ctx.trace_id,
-    );
-
-    let result = super::eval_aggregate(param, data, Max, eval_ctx);
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] max() execution took: {:?}",
-        eval_ctx.trace_id,
-        start.elapsed()
-    );
-    result
-}
 
 pub struct Max;
 
@@ -97,15 +79,16 @@ impl Accumulate for MaxAccumulate {
 mod tests {
     use std::sync::Arc;
 
-    use config::meta::promql::value::{Label, RangeValue, Sample, Value};
+    use config::meta::promql::value::{EvalContext, Label, RangeValue, Sample, Value};
 
     use super::*;
+    use crate::aggregations::eval_aggregate;
 
     #[test]
     fn test_max_value_none_input() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = max(&None, Value::None, &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::None, Max, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -113,7 +96,7 @@ mod tests {
     fn test_max_invalid_input_returns_err() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = max(&None, Value::Float(1.0), &eval_ctx);
+        let result = eval_aggregate(&None, Value::Float(1.0), Max, &eval_ctx);
         assert!(result.is_err());
     }
 
@@ -121,7 +104,7 @@ mod tests {
     fn test_max_empty_matrix_returns_none() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = max(&None, Value::Matrix(vec![]), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::Matrix(vec![]), Max, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -164,7 +147,7 @@ mod tests {
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
 
         // Test max without label grouping - should return the maximum value
-        let result = max(&None, data.clone(), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, data.clone(), Max, &eval_ctx).unwrap();
 
         match result {
             Value::Matrix(matrix) => {

--- a/src/promql/src/aggregations/min.rs
+++ b/src/promql/src/aggregations/min.rs
@@ -13,29 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::promql::value::{EvalContext, Sample, Value};
-use datafusion::error::Result;
+use config::meta::promql::value::Sample;
 use hashbrown::HashMap;
-use promql_parser::parser::LabelModifier;
 
 use crate::aggregations::{Accumulate, AggFunc};
-
-/// Aggregates Matrix input for range queries
-pub fn min(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    let start = std::time::Instant::now();
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] min() started",
-        eval_ctx.trace_id
-    );
-
-    let result = super::eval_aggregate(param, data, Min, eval_ctx);
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] min() execution took: {:?}",
-        eval_ctx.trace_id,
-        start.elapsed()
-    );
-    result
-}
 
 pub struct Min;
 
@@ -95,15 +76,16 @@ impl Accumulate for MinAccumulate {
 mod tests {
     use std::sync::Arc;
 
-    use config::meta::promql::value::{Label, RangeValue, Sample, Value};
+    use config::meta::promql::value::{EvalContext, Label, RangeValue, Sample, Value};
 
     use super::*;
+    use crate::aggregations::eval_aggregate;
 
     #[test]
     fn test_min_value_none_input() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = min(&None, Value::None, &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::None, Min, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -111,7 +93,7 @@ mod tests {
     fn test_min_invalid_input_returns_err() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = min(&None, Value::Float(1.0), &eval_ctx);
+        let result = eval_aggregate(&None, Value::Float(1.0), Min, &eval_ctx);
         assert!(result.is_err());
     }
 
@@ -119,7 +101,7 @@ mod tests {
     fn test_min_empty_matrix_returns_none() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = min(&None, Value::Matrix(vec![]), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::Matrix(vec![]), Min, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -162,7 +144,7 @@ mod tests {
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
 
         // Test min without label grouping - should return the minimum value
-        let result = min(&None, data.clone(), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, data.clone(), Min, &eval_ctx).unwrap();
 
         match result {
             Value::Matrix(matrix) => {

--- a/src/promql/src/aggregations/mod.rs
+++ b/src/promql/src/aggregations/mod.rs
@@ -39,17 +39,17 @@ mod stdvar;
 mod sum;
 mod topk;
 
-pub(crate) use avg::avg;
+pub(crate) use avg::Avg;
 pub(crate) use bottomk::bottomk;
-pub(crate) use count::count;
+pub(crate) use count::Count;
 pub(crate) use count_values::count_values;
-pub(crate) use group::group;
-pub(crate) use max::max;
-pub(crate) use min::min;
+pub(crate) use group::Group;
+pub(crate) use max::Max;
+pub(crate) use min::Min;
 pub(crate) use quantile::quantile;
-pub(crate) use stddev::stddev;
-pub(crate) use stdvar::stdvar;
-pub(crate) use sum::sum;
+pub(crate) use stddev::Stddev;
+pub(crate) use stdvar::Stdvar;
+pub(crate) use sum::Sum;
 pub(crate) use topk::topk;
 
 /// Series per parallel partial-aggregation chunk when a single group is large.

--- a/src/promql/src/aggregations/stddev.rs
+++ b/src/promql/src/aggregations/stddev.rs
@@ -13,31 +13,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::promql::value::{EvalContext, Sample, Value};
-use datafusion::error::Result;
+use config::meta::promql::value::Sample;
 use hashbrown::HashMap;
-use promql_parser::parser::LabelModifier;
 
 use crate::{
     aggregations::{Accumulate, AggFunc},
     common::std_deviation2,
 };
-
-pub fn stddev(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    let start = std::time::Instant::now();
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] stddev() started",
-        eval_ctx.trace_id,
-    );
-
-    let result = super::eval_aggregate(param, data, Stddev, eval_ctx);
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] stddev() execution took: {:?}",
-        eval_ctx.trace_id,
-        start.elapsed()
-    );
-    result
-}
 
 pub struct Stddev;
 
@@ -110,15 +92,16 @@ impl Accumulate for StddevAccumulate {
 mod tests {
     use std::sync::Arc;
 
-    use config::meta::promql::value::{Label, RangeValue, Sample, Value};
+    use config::meta::promql::value::{EvalContext, Label, RangeValue, Sample, Value};
 
     use super::*;
+    use crate::aggregations::eval_aggregate;
 
     #[test]
     fn test_stddev_value_none_input() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = stddev(&None, Value::None, &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::None, Stddev, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -126,7 +109,7 @@ mod tests {
     fn test_stddev_invalid_input_returns_err() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = stddev(&None, Value::Float(1.0), &eval_ctx);
+        let result = eval_aggregate(&None, Value::Float(1.0), Stddev, &eval_ctx);
         assert!(result.is_err());
     }
 
@@ -134,7 +117,7 @@ mod tests {
     fn test_stddev_empty_matrix_returns_none() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = stddev(&None, Value::Matrix(vec![]), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::Matrix(vec![]), Stddev, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -177,7 +160,7 @@ mod tests {
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
 
         // Test stddev without label grouping - should return standard deviation
-        let result = stddev(&None, data.clone(), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, data.clone(), Stddev, &eval_ctx).unwrap();
 
         match result {
             Value::Matrix(matrix) => {

--- a/src/promql/src/aggregations/stdvar.rs
+++ b/src/promql/src/aggregations/stdvar.rs
@@ -13,31 +13,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::promql::value::{EvalContext, Sample, Value};
-use datafusion::error::Result;
+use config::meta::promql::value::Sample;
 use hashbrown::HashMap;
-use promql_parser::parser::LabelModifier;
 
 use crate::{
     aggregations::{Accumulate, AggFunc},
     common::std_variance2,
 };
-
-pub fn stdvar(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    let start = std::time::Instant::now();
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] stdvar() started",
-        eval_ctx.trace_id,
-    );
-
-    let result = super::eval_aggregate(param, data, Stdvar, eval_ctx);
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] stdvar() execution took: {:?}",
-        eval_ctx.trace_id,
-        start.elapsed()
-    );
-    result
-}
 
 pub struct Stdvar;
 
@@ -110,15 +92,16 @@ impl Accumulate for StdvarAccumulate {
 mod tests {
     use std::sync::Arc;
 
-    use config::meta::promql::value::{Label, RangeValue, Sample, Value};
+    use config::meta::promql::value::{EvalContext, Label, RangeValue, Sample, Value};
 
     use super::*;
+    use crate::aggregations::eval_aggregate;
 
     #[test]
     fn test_stdvar_value_none_input() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = stdvar(&None, Value::None, &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::None, Stdvar, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -126,7 +109,7 @@ mod tests {
     fn test_stdvar_invalid_input_returns_err() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = stdvar(&None, Value::Float(1.0), &eval_ctx);
+        let result = eval_aggregate(&None, Value::Float(1.0), Stdvar, &eval_ctx);
         assert!(result.is_err());
     }
 
@@ -134,7 +117,7 @@ mod tests {
     fn test_stdvar_empty_matrix_returns_none() {
         let timestamp = 1640995200;
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
-        let result = stdvar(&None, Value::Matrix(vec![]), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::Matrix(vec![]), Stdvar, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -177,7 +160,7 @@ mod tests {
         let eval_ctx = EvalContext::new(timestamp, timestamp + 1, 1, "test".to_string());
 
         // Test stdvar without label grouping - should return variance
-        let result = stdvar(&None, data.clone(), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, data.clone(), Stdvar, &eval_ctx).unwrap();
 
         match result {
             Value::Matrix(matrix) => {

--- a/src/promql/src/aggregations/sum.rs
+++ b/src/promql/src/aggregations/sum.rs
@@ -13,32 +13,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::promql::value::{EvalContext, Sample, Value};
-use datafusion::error::Result;
+use config::meta::promql::value::Sample;
 use hashbrown::HashMap;
-use promql_parser::parser::LabelModifier;
 
 use crate::{
     aggregations::{Accumulate, AggFunc},
     common::kahan_sum_increment,
 };
-
-/// Aggregates Matrix input for range queries
-pub fn sum(param: &Option<LabelModifier>, data: Value, eval_ctx: &EvalContext) -> Result<Value> {
-    let start = std::time::Instant::now();
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] sum() started",
-        eval_ctx.trace_id
-    );
-
-    let result = super::eval_aggregate(param, data, Sum, eval_ctx);
-    log::info!(
-        "[trace_id: {}] [PromQL Timing] sum() execution took: {:?}",
-        eval_ctx.trace_id,
-        start.elapsed()
-    );
-    result
-}
 
 pub struct Sum;
 
@@ -98,16 +79,17 @@ impl Accumulate for SumAccumulate {
 mod tests {
     use std::sync::Arc;
 
-    use config::meta::promql::value::{Label, RangeValue, Sample, Value};
+    use config::meta::promql::value::{EvalContext, Label, RangeValue, Sample, Value};
     use promql_parser::parser::LabelModifier;
 
     use super::*;
+    use crate::aggregations::eval_aggregate;
 
     #[test]
     fn test_sum_value_none_input() {
         let ts = 1640995200;
         let eval_ctx = EvalContext::new(ts, ts + 1, 1, "test".to_string());
-        let result = sum(&None, Value::None, &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::None, Sum, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -115,7 +97,7 @@ mod tests {
     fn test_sum_invalid_input_returns_err() {
         let ts = 1640995200;
         let eval_ctx = EvalContext::new(ts, ts + 1, 1, "test".to_string());
-        let result = sum(&None, Value::Float(1.0), &eval_ctx);
+        let result = eval_aggregate(&None, Value::Float(1.0), Sum, &eval_ctx);
         assert!(result.is_err());
     }
 
@@ -123,7 +105,7 @@ mod tests {
     fn test_sum_empty_matrix_returns_none() {
         let ts = 1640995200;
         let eval_ctx = EvalContext::new(ts, ts + 1, 1, "test".to_string());
-        let result = sum(&None, Value::Matrix(vec![]), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::Matrix(vec![]), Sum, &eval_ctx).unwrap();
         assert!(matches!(result, Value::None));
     }
 
@@ -188,7 +170,7 @@ mod tests {
         let eval_ctx = EvalContext::new(ts1, ts3 + 1, 1000, "test".to_string());
 
         // Test 1: sum without label grouping (all series summed together)
-        let result = sum(&None, Value::Matrix(matrix.clone()), &eval_ctx).unwrap();
+        let result = eval_aggregate(&None, Value::Matrix(matrix.clone()), Sum, &eval_ctx).unwrap();
 
         match result {
             Value::Matrix(result_matrix) => {
@@ -210,7 +192,7 @@ mod tests {
         let param = Some(LabelModifier::Include(promql_parser::label::Labels {
             labels: vec!["job".to_string()],
         }));
-        let result = sum(&param, Value::Matrix(matrix.clone()), &eval_ctx).unwrap();
+        let result = eval_aggregate(&param, Value::Matrix(matrix.clone()), Sum, &eval_ctx).unwrap();
 
         match result {
             Value::Matrix(result_matrix) => {

--- a/src/promql/src/engine/aggregate.rs
+++ b/src/promql/src/engine/aggregate.rs
@@ -78,14 +78,30 @@ impl Engine {
         let eval_ctx = self.eval_ctx.clone();
 
         Ok(match op.id() {
-            token::T_SUM => aggregations::sum(modifier, input, &eval_ctx)?,
-            token::T_AVG => aggregations::avg(modifier, input, &eval_ctx)?,
-            token::T_COUNT => aggregations::count(modifier, input, &eval_ctx)?,
-            token::T_MIN => aggregations::min(modifier, input, &eval_ctx)?,
-            token::T_MAX => aggregations::max(modifier, input, &eval_ctx)?,
-            token::T_GROUP => aggregations::group(modifier, input, &eval_ctx)?,
-            token::T_STDDEV => aggregations::stddev(modifier, input, &eval_ctx)?,
-            token::T_STDVAR => aggregations::stdvar(modifier, input, &eval_ctx)?,
+            token::T_SUM => {
+                aggregations::eval_aggregate(modifier, input, aggregations::Sum, &eval_ctx)?
+            }
+            token::T_AVG => {
+                aggregations::eval_aggregate(modifier, input, aggregations::Avg, &eval_ctx)?
+            }
+            token::T_COUNT => {
+                aggregations::eval_aggregate(modifier, input, aggregations::Count, &eval_ctx)?
+            }
+            token::T_MIN => {
+                aggregations::eval_aggregate(modifier, input, aggregations::Min, &eval_ctx)?
+            }
+            token::T_MAX => {
+                aggregations::eval_aggregate(modifier, input, aggregations::Max, &eval_ctx)?
+            }
+            token::T_GROUP => {
+                aggregations::eval_aggregate(modifier, input, aggregations::Group, &eval_ctx)?
+            }
+            token::T_STDDEV => {
+                aggregations::eval_aggregate(modifier, input, aggregations::Stddev, &eval_ctx)?
+            }
+            token::T_STDVAR => {
+                aggregations::eval_aggregate(modifier, input, aggregations::Stdvar, &eval_ctx)?
+            }
             token::T_TOPK => {
                 let param_expr = param.clone().unwrap();
                 let k_value = self.exec_expr(&param_expr).await?;

--- a/src/promql/src/engine/aggregate.rs
+++ b/src/promql/src/engine/aggregate.rs
@@ -25,7 +25,10 @@ use promql_parser::parser::{
 };
 
 use super::Engine;
-use crate::{aggregations, functions, fused};
+use crate::{
+    aggregations::{self, Avg, Count, Group, Max, Min, Stddev, Stdvar, Sum, eval_aggregate},
+    functions, fused,
+};
 
 /// A recognized fused shape: `agg(range_func(...))`, or `agg(instant_selector)` read as
 /// `last_over_time` over the lookback window.
@@ -77,34 +80,18 @@ impl Engine {
 
         let eval_ctx = self.eval_ctx.clone();
 
-        Ok(match op.id() {
-            token::T_SUM => {
-                aggregations::eval_aggregate(modifier, input, aggregations::Sum, &eval_ctx)?
-            }
-            token::T_AVG => {
-                aggregations::eval_aggregate(modifier, input, aggregations::Avg, &eval_ctx)?
-            }
-            token::T_COUNT => {
-                aggregations::eval_aggregate(modifier, input, aggregations::Count, &eval_ctx)?
-            }
-            token::T_MIN => {
-                aggregations::eval_aggregate(modifier, input, aggregations::Min, &eval_ctx)?
-            }
-            token::T_MAX => {
-                aggregations::eval_aggregate(modifier, input, aggregations::Max, &eval_ctx)?
-            }
-            token::T_GROUP => {
-                aggregations::eval_aggregate(modifier, input, aggregations::Group, &eval_ctx)?
-            }
-            token::T_STDDEV => {
-                aggregations::eval_aggregate(modifier, input, aggregations::Stddev, &eval_ctx)?
-            }
-            token::T_STDVAR => {
-                aggregations::eval_aggregate(modifier, input, aggregations::Stdvar, &eval_ctx)?
-            }
+        match op.id() {
+            token::T_SUM => eval_aggregate(modifier, input, Sum, &eval_ctx),
+            token::T_AVG => eval_aggregate(modifier, input, Avg, &eval_ctx),
+            token::T_COUNT => eval_aggregate(modifier, input, Count, &eval_ctx),
+            token::T_MIN => eval_aggregate(modifier, input, Min, &eval_ctx),
+            token::T_MAX => eval_aggregate(modifier, input, Max, &eval_ctx),
+            token::T_GROUP => eval_aggregate(modifier, input, Group, &eval_ctx),
+            token::T_STDDEV => eval_aggregate(modifier, input, Stddev, &eval_ctx),
+            token::T_STDVAR => eval_aggregate(modifier, input, Stdvar, &eval_ctx),
             token::T_TOPK => {
-                let param_expr = param.clone().unwrap();
-                let k_value = self.exec_expr(&param_expr).await?;
+                let param_expr = param.as_ref().unwrap();
+                let k_value = self.exec_expr(param_expr).await?;
                 let k = match k_value {
                     Value::Float(f) => f as usize,
                     _ => {
@@ -113,11 +100,11 @@ impl Engine {
                         ));
                     }
                 };
-                aggregations::topk(k, modifier, input, &eval_ctx)?
+                aggregations::topk(k, modifier, input, &eval_ctx)
             }
             token::T_BOTTOMK => {
-                let param_expr = param.clone().unwrap();
-                let k_value = self.exec_expr(&param_expr).await?;
+                let param_expr = param.as_ref().unwrap();
+                let k_value = self.exec_expr(param_expr).await?;
                 let k = match k_value {
                     Value::Float(f) => f as usize,
                     _ => {
@@ -126,11 +113,11 @@ impl Engine {
                         ));
                     }
                 };
-                aggregations::bottomk(k, modifier, input, &eval_ctx)?
+                aggregations::bottomk(k, modifier, input, &eval_ctx)
             }
             token::T_COUNT_VALUES => {
-                let param_expr = param.clone().unwrap();
-                let label_name = self.exec_expr(&param_expr).await?;
+                let param_expr = param.as_ref().unwrap();
+                let label_name = self.exec_expr(param_expr).await?;
                 let label_name_str = match label_name {
                     Value::String(s) => s,
                     _ => {
@@ -139,11 +126,11 @@ impl Engine {
                         ));
                     }
                 };
-                aggregations::count_values(&label_name_str, modifier, input, &eval_ctx)?
+                aggregations::count_values(&label_name_str, modifier, input, &eval_ctx)
             }
             token::T_QUANTILE => {
-                let param_expr = param.clone().unwrap();
-                let qtile_value = self.exec_expr(&param_expr).await?;
+                let param_expr = param.as_ref().unwrap();
+                let qtile_value = self.exec_expr(param_expr).await?;
                 let qtile = match qtile_value {
                     Value::Float(f) => f,
                     _ => {
@@ -152,14 +139,12 @@ impl Engine {
                         ));
                     }
                 };
-                aggregations::quantile(qtile, input, &eval_ctx)?
+                aggregations::quantile(qtile, input, &eval_ctx)
             }
-            _ => {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Unsupported Aggregate: {op:?}"
-                )));
-            }
-        })
+            _ => Err(DataFusionError::NotImplemented(format!(
+                "Unsupported Aggregate: {op:?}"
+            ))),
+        }
     }
 
     /// The fused fold over an already-materialized matrix, bounded by the query timeout.

--- a/src/promql/src/engine/streaming.rs
+++ b/src/promql/src/engine/streaming.rs
@@ -607,17 +607,45 @@ mod tests {
     async fn test_instant_agg_matches_generic_streaming_and_materialized() {
         type Agg = fn(&Option<LabelModifier>, Value, &EvalContext) -> Result<Value>;
         let cases: [(&str, &str, Agg); 4] = [
-            ("sum(m)", "m", crate::aggregations::sum),
-            ("count(m)", "m", crate::aggregations::count),
+            ("sum(m)", "m", |modifier, input, eval_ctx| {
+                crate::aggregations::eval_aggregate(
+                    modifier,
+                    input,
+                    crate::aggregations::Sum,
+                    eval_ctx,
+                )
+            }),
+            ("count(m)", "m", |modifier, input, eval_ctx| {
+                crate::aggregations::eval_aggregate(
+                    modifier,
+                    input,
+                    crate::aggregations::Count,
+                    eval_ctx,
+                )
+            }),
             (
                 "avg(m offset 30s)",
                 "m offset 30s",
-                crate::aggregations::avg,
+                |modifier, input, eval_ctx| {
+                    crate::aggregations::eval_aggregate(
+                        modifier,
+                        input,
+                        crate::aggregations::Avg,
+                        eval_ctx,
+                    )
+                },
             ),
             (
                 "max(m offset 30s)",
                 "m offset 30s",
-                crate::aggregations::max,
+                |modifier, input, eval_ctx| {
+                    crate::aggregations::eval_aggregate(
+                        modifier,
+                        input,
+                        crate::aggregations::Max,
+                        eval_ctx,
+                    )
+                },
             ),
         ];
         for (query, selector, agg) in cases {

--- a/src/promql/src/fused/materialized.rs
+++ b/src/promql/src/fused/materialized.rs
@@ -155,14 +155,30 @@ mod tests {
     #[tokio::test]
     async fn test_fused_range_agg_matches_generic_for_all_pairs() {
         let agg_cases: [(FusedAggOp, GenericAgg); 8] = [
-            (FusedAggOp::Avg, aggregations::avg),
-            (FusedAggOp::Count, aggregations::count),
-            (FusedAggOp::Group, aggregations::group),
-            (FusedAggOp::Max, aggregations::max),
-            (FusedAggOp::Min, aggregations::min),
-            (FusedAggOp::Stddev, aggregations::stddev),
-            (FusedAggOp::Stdvar, aggregations::stdvar),
-            (FusedAggOp::Sum, aggregations::sum),
+            (FusedAggOp::Avg, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Avg, eval_ctx)
+            }),
+            (FusedAggOp::Count, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Count, eval_ctx)
+            }),
+            (FusedAggOp::Group, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Group, eval_ctx)
+            }),
+            (FusedAggOp::Max, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Max, eval_ctx)
+            }),
+            (FusedAggOp::Min, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Min, eval_ctx)
+            }),
+            (FusedAggOp::Stddev, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Stddev, eval_ctx)
+            }),
+            (FusedAggOp::Stdvar, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Stdvar, eval_ctx)
+            }),
+            (FusedAggOp::Sum, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Sum, eval_ctx)
+            }),
         ];
         let range_cases = [
             "avg_over_time",
@@ -238,14 +254,30 @@ mod tests {
             .collect::<Vec<_>>();
 
         let agg_cases: [(FusedAggOp, GenericAgg); 8] = [
-            (FusedAggOp::Avg, aggregations::avg),
-            (FusedAggOp::Count, aggregations::count),
-            (FusedAggOp::Group, aggregations::group),
-            (FusedAggOp::Max, aggregations::max),
-            (FusedAggOp::Min, aggregations::min),
-            (FusedAggOp::Stddev, aggregations::stddev),
-            (FusedAggOp::Stdvar, aggregations::stdvar),
-            (FusedAggOp::Sum, aggregations::sum),
+            (FusedAggOp::Avg, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Avg, eval_ctx)
+            }),
+            (FusedAggOp::Count, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Count, eval_ctx)
+            }),
+            (FusedAggOp::Group, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Group, eval_ctx)
+            }),
+            (FusedAggOp::Max, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Max, eval_ctx)
+            }),
+            (FusedAggOp::Min, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Min, eval_ctx)
+            }),
+            (FusedAggOp::Stddev, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Stddev, eval_ctx)
+            }),
+            (FusedAggOp::Stdvar, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Stdvar, eval_ctx)
+            }),
+            (FusedAggOp::Sum, |modifier, input, eval_ctx| {
+                aggregations::eval_aggregate(modifier, input, aggregations::Sum, eval_ctx)
+            }),
         ];
         for (op, generic_agg) in agg_cases {
             for modifier in [None, by(&["path"])] {
@@ -302,8 +334,18 @@ mod tests {
             .collect::<Vec<_>>();
 
         for (op, generic_agg) in [
-            (FusedAggOp::Sum, aggregations::sum as GenericAgg),
-            (FusedAggOp::Avg, aggregations::avg as GenericAgg),
+            (
+                FusedAggOp::Sum,
+                (|modifier, input, eval_ctx| {
+                    aggregations::eval_aggregate(modifier, input, aggregations::Sum, eval_ctx)
+                }) as GenericAgg,
+            ),
+            (
+                FusedAggOp::Avg,
+                (|modifier, input, eval_ctx| {
+                    aggregations::eval_aggregate(modifier, input, aggregations::Avg, eval_ctx)
+                }) as GenericAgg,
+            ),
         ] {
             let generic_input =
                 range_eval("rate", Value::Matrix(matrix.clone()), &eval_ctx).unwrap();


### PR DESCRIPTION
The sum, avg, count, min, max, group, stddev, and stdvar entry points only forwarded to `eval_aggregate` and emitted redundant timing logs. Remove these wrappers and pass the aggregation types directly to the shared evaluator from engine dispatch. Keep the shared evaluator’s existing timing logs and aggregation behavior, and update unit and fused/streaming comparison tests to use it directly.

Validation:
- `cargo test -p promql --lib`: 429 passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
