### PR TITLE
test: retry the Logs sidebar nav until the route loads

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -4785,12 +4785,12 @@ export class LogsPage {
     }
 
     async clickMenuLinkLogsItem() {
-        await this.clickMenuLinkByType('logs');
-        // Sidebar nav is an in-SPA route change; gate on the Search toggle re-mounting before
-        // callers read persisted state. Unlike visualizeToggle, this item has no v-if guard
-        // (zoConfig.timechart_enabled, enterprise, viewport width), so it's present in every
-        // tab mode and every environment — visualizeToggle never renders when timechart_enabled
-        // is off (e.g. alpha1), which left this wait to time out every run.
+        // The sidebar item is force-clicked, so a covering overlay swallows it silently and leaves the SPA on the previous route — retry until /logs actually loads.
+        await expect(async () => {
+            await this.clickMenuLinkByType('logs');
+            await this.page.waitForURL(/\/web\/logs(\?|$)/, { timeout: 5000 });
+        }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
+        // logsToggle has no v-if guard (timechart_enabled, enterprise, viewport) so it mounts in every tab mode and environment, unlike visualizeToggle.
         await expect(this.page.locator(this.logsToggle)).toBeVisible({ timeout: 15000 });
     }
 


### PR DESCRIPTION
## Problem

`Logs/logsVisualizePersistence.spec.js` › *should persist Logs tab after switching Visualize → Logs then navigating* flakes on `clickMenuLinkLogsItem`:

```
expect(locator).toBeVisible() failed
Locator:  locator('[data-test="logs-logs-toggle"]')
Received: <element(s) not found>
Timeout:  15000ms
  at LogsPage.clickMenuLinkLogsItem (pages/logsPages/logsPage.js:4794)
```

## Root cause (from the run's blob report, not inferred)

The page snapshot captured at failure shows the app **still rendering the Dashboards page** — `heading "Dashboards"`, `"0 Dashboards"`, an Import button, and `link "Dashboards - Current page"` — while the Logs sidebar link carried only `[active]` styling.

`clickMenuLinkByType` issues `.click({ force: true })`. A forced click is dispatched into whatever covers the target and is swallowed silently, so the SPA never leaves `/dashboards` and `logs-logs-toggle` can never mount. The existing gate *detects* that state but cannot recover from it — it just waits out its 15s.

This is the same class root-caused in #14025 (forced clicks swallowed by an overlay).

## Fix

Retry the click until the route actually loads, mirroring the `gotoPipelinesPage` pattern shipped in #14113. The trailing toggle gate is unchanged.

## Verification

- `streamsExploreLogsTypePersistence.spec.js` (a caller of the changed helper): **2/2 consecutive passes**, `--retries=0`.
- `logspage.spec.js` (4 more call sites): **19 passed / 4 failed** vs **14 passed / 9 failed** on unmodified main. The 4 remaining failures are in `clickRefreshButton` (`logsPage.js:2768`), unrelated to this change and present on baseline.
- The target spec itself could **not** be run locally: the available env has `timechart_enabled=false`, so `logs-visualize-toggle` never renders and the test cannot execute there. It needs the CI gate.

Evidence run: `34391073563` (Logs-Core shard).