### PR TITLE
fix(ui): don't mount the AI sidebar on the home page

### DIFF
--- a/web/src/layouts/MainLayout.shortcuts.spec.ts
+++ b/web/src/layouts/MainLayout.shortcuts.spec.ts
@@ -119,4 +119,33 @@ describe("MainLayout — AI chat shortcut gate", () => {
     ctrlB()!.handler();
     expect(store.state.isAiChatEnabled).toBe(true);
   });
+
+  it("should switch the home AI tab instead of opening the sidebar on home", async () => {
+    config.isEnterprise = "true";
+    store.state.zoConfig.ai_enabled = true;
+
+    wrapper = mountMainLayout();
+    await router.push({ name: "home" });
+    await flushPromises();
+
+    const dispatch = vi.spyOn(window, "dispatchEvent");
+    ctrlB()!.handler();
+
+    expect(store.state.isAiChatEnabled).toBe(false);
+    expect(
+      dispatch.mock.calls.some(([e]) => (e as CustomEvent).type === "o2:home-switch-tab"),
+    ).toBe(true);
+    dispatch.mockRestore();
+  });
+
+  it("should not mount the AI sidebar on home", async () => {
+    config.isEnterprise = "true";
+    store.state.zoConfig.ai_enabled = true;
+
+    wrapper = mountMainLayout();
+    await router.push({ name: "home" });
+    await flushPromises();
+
+    expect(wrapper.find(".o2-sidebar-right").exists()).toBe(false);
+  });
 });

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -93,7 +93,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           data-test="main-content"
           class="bg-surface-chrome-deeper flex min-h-0 flex-col pe-2 pb-2"
           :style="{
-            width: !store.state.isAiChatEnabled
+            width: !store.state.isAiChatEnabled || isHomeRoute
               ? '100%'
               : store.state.isAiChatExpanded
                 ? '50%'
@@ -120,6 +120,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <!-- Right Panel (AI Chat - unified for both general and context-specific usage) -->
         <aside
+          v-if="!isHomeRoute"
           v-show="store.state.isAiChatEnabled && isLoading"
           class="o2-sidebar o2-sidebar-right bg-surface-chrome-deeper sticky top-[var(--navbar-height,2.25rem)] shrink-0 self-start overflow-y-auto"
           :class="[
@@ -1246,6 +1247,9 @@ export default defineComponent({
       window.open(slackURL, "_blank");
     };
 
+    // Home has its own inline O2 AI tab, so the sidebar panel must not mount there too.
+    const isHomeRoute = computed(() => router.currentRoute.value.name === "home");
+
     const toggleAIChat = () => {
       // ai_enabled arrives with the async /config response, so it can't gate registration.
       if (!store.state.zoConfig.ai_enabled) return;
@@ -1396,6 +1400,7 @@ export default defineComponent({
       settings: "settings",
       closeSocket,
       splitterModel,
+      isHomeRoute,
       toggleAIChat,
       closeChat,
       getBtnLogo,


### PR DESCRIPTION
Home has its own inline O2 AI tab, so the sidebar O2AIChat was a redundant second AI instance. Gate it off the home route (and keep the home panel full-width). Adds home-route regression tests.