### PR TITLE
ci: add ready-for-ci label when "Merge when ready" is clicked

### DIFF
--- a/.github/workflows/auto-merge-ready-for-ci.yml
+++ b/.github/workflows/auto-merge-ready-for-ci.yml
@@ -1,0 +1,29 @@
+name: Auto Merge Ready For CI
+
+# "Merge when ready" cannot queue a PR while ci-gate is pending, so label it the way the author would have.
+on:
+  # pull_request_target so a fork PR is labelled too; no checkout, so nothing untrusted runs.
+  pull_request_target:
+    types: [auto_merge_enabled]
+
+permissions: {}
+
+jobs:
+  label:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Add ready-for-ci label
+        env:
+          # A label added with GITHUB_TOKEN fires no `labeled` event, so the gated workflows would never start.
+          GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if gh pr edit "$NUMBER" --add-label "ready-for-ci"; then
+            echo "Labeled PR #$NUMBER with ready-for-ci"
+          else
+            echo "::error::Could not label PR #$NUMBER"
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,9 @@ reworded:
 
 - CI runs on a PR only while it carries the `ready-for-ci` label and is not a draft
   (no label or draft = nothing runs except `ci-gate`, and no red checks). Add the
-  label when you want the run, not when you open the PR. Which suites run is decided by path detection, never by
-  a label. The merge queue only compiles and unit-tests the merged code, so the
+  label when you want the run, not when you open the PR; clicking "Merge when
+  ready" adds it automatically if it is missing. Which suites run is decided by
+  path detection, never by a label. The merge queue only compiles and unit-tests the merged code, so the
   labelled PR run is the one that has to be green.
 - PR titles starting with `feat:` require `Design at: #xxx` as the FIRST line
   of the description (enforced by `.github/workflows/feat-design-checker.yml`);


### PR DESCRIPTION
## What

New workflow `auto-merge-ready-for-ci.yml`: on `pull_request_target` / `auto_merge_enabled`, if the PR does not carry `ready-for-ci`, add it with `ORG_ADMIN_TOKEN`. Skipped entirely when the label is already present. CLAUDE.md's PR conventions line notes the new behaviour.

## Why

Clicking "Merge when ready" on an unlabelled PR currently goes nowhere: `ci-gate` stays pending, so the PR never enters the merge queue, and the workflows that already listen to `auto_merge_enabled` (`playwright`, `dispatch-event-enterprise`, `ent-e2e-gate`) skip because the label is missing. The click expresses the same intent as adding the label by hand, so do it automatically.

## Reviewer notes

- The PAT is required, not a convenience: a label added with `GITHUB_TOKEN` fires no `labeled` event, so none of the gated suites would start. Same mechanism as the dependabot step in `auto-assign-metadata.yml`.
- `pull_request_target` with no checkout, the same model as `ci-gate`, so fork PRs get labelled too. Only users with write access can enable auto-merge, so this is equivalent to a maintainer adding the label.
- The `labeled` event produced by this workflow carries a non-null `auto_merge`, so `playwright` runs its full matrix and the enterprise dispatch fires as before.
- `auto_merge_disabled` is deliberately not handled: removing the label would reset CI.
- Verified with actionlint only. The real event flow needs one PR after merge: click "Merge when ready" without the label and confirm it gets added and `ci-gate` turns green.