### PR TITLE
fix(metrics): restore query builder filters after leaving Custom Chart

### DIFF
--- a/web/src/components/dashboards/addPanel/QueryTypeSelector.vue
+++ b/web/src/components/dashboards/addPanel/QueryTypeSelector.vue
@@ -130,6 +130,7 @@ export default defineComponent({
       if (dashboardPanelData.data.type == "custom_chart") {
         // For custom_chart, check the actual query type and customQuery flag
         selectedButtonType.value = "custom";
+        await nextTick();
         ignoreSelectedButtonTypeUpdate.value = false;
         return;
       }


### PR DESCRIPTION
Fixes a bug where switching the Metrics Visualize chart type to "Custom Chart" and then back to any other chart type (line, bar, etc.) permanently hides the PromQL query builder UI (Label Filters, Operations, Options: Legend) — even after a full page refresh.

### Root cause: 
QueryTypeSelector.vue's initializeSelectedButtonType() cleared its re-entrancy guard (ignoreSelectedButtonTypeUpdate) synchronously in the custom_chart branch, instead of awaiting nextTick() first like every other branch. Because the watch(selectedButtonType, ...) handler runs on the next tick, the guard was already false by the time it fired, so it incorrectly flipped customQuery to true on mount — even though the user never touched the builder/custom toggle.
Nothing ever resets customQuery back to false when leaving Custom Chart, so promqlBuilderMode (queryType === "promql" && !customQuery) stayed false forever, hiding the builder UI. Because this flag is serialized into the metrics_data URL param, the broken state survived page refreshes too.
Fix: await nextTick() before clearing the guard in the custom_chart branch, matching the existing pattern used elsewhere in the function, so the watcher stays suppressed during the guarded window and customQuery is never incorrectly mutated.

### Test plan
 npm run type-check:app (vue-tsc) passes with no errors
 eslint on the changed file passes with no errors
 Manually verify in browser: Metrics → Visualize → select a stream/query → switch to Custom Chart → switch back to Line/Bar → confirm Label Filters/Operations/Legend reappear, including after a page refresh