### PR TITLE
fix(web): gate keyboard-shortcut cheatsheet to reachable pages

### DIFF
--- a/web/src/lib/vue-shortcut-manager/ShortcutCheatsheet.vue
+++ b/web/src/lib/vue-shortcut-manager/ShortcutCheatsheet.vue
@@ -220,6 +220,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, onUnmounted } from "vue";
+import { useStore } from "vuex";
 import { raw, useI18nTyped, type I18nText } from "@/types/i18n";
 import ODialog from "@/lib/overlay/Dialog/ODialog.vue";
 import OSearchInput from "@/lib/forms/SearchInput/OSearchInput.vue";
@@ -227,7 +228,7 @@ import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OButton from "@/lib/core/Button/OButton.vue";
 import { useShortcut } from "./composables";
 import { SHORTCUT_REGISTRY, SHORTCUT_MODULES } from "./shortcutRegistry";
-import type { ShortcutEntry } from "./shortcutRegistry";
+import type { ShortcutEntry, ShortcutCapabilities } from "./shortcutRegistry";
 import { isMacOS } from "@/utils/keyboardShortcuts";
 import config from "@/aws-exports";
 
@@ -247,6 +248,15 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18nTyped();
+const store = useStore();
+
+// Edition + `/config` flags that decide which feature pages the build can reach.
+const capabilities = computed<ShortcutCapabilities>(() => ({
+  isEnterprise: config.isEnterprise === "true",
+  isCloud: config.isCloud === "true",
+  onlineEvalsEnabled: Boolean(store.state.zoConfig?.online_evals_enabled),
+  incidentsEnabled: Boolean(store.state.zoConfig?.incidents_enabled),
+}));
 
 const open = computed({
   get: () => props.open,
@@ -291,11 +301,12 @@ function entryDisplay(e: ShortcutEntry): string {
 }
 
 const allModules = computed<DisplayModule[]>(() => {
+  const caps = capabilities.value;
   return SHORTCUT_MODULES.map((m) => ({
     title: m.title ? raw(m.title) : t(m.titleKey),
     sections: m.pages.flatMap((pageKey) => {
       const group = groupByPage.get(pageKey);
-      if (!group) return [];
+      if (!group || (group.visible && !group.visible(caps))) return [];
       return [
         {
           title: t(group.pageKey, PAGE_TITLE_PARAMS[group.pageKey] ?? {}),
@@ -310,7 +321,8 @@ const allModules = computed<DisplayModule[]>(() => {
         },
       ];
     }),
-  }));
+    // A module whose every page is gated off (e.g. Settings on OSS) drops its chip entirely.
+  })).filter((m) => m.sections.length > 0);
 });
 
 const filteredModules = computed<DisplayModule[]>(() => {

--- a/web/src/lib/vue-shortcut-manager/ShortcutCheatsheet.vue
+++ b/web/src/lib/vue-shortcut-manager/ShortcutCheatsheet.vue
@@ -256,6 +256,7 @@ const capabilities = computed<ShortcutCapabilities>(() => ({
   isCloud: config.isCloud === "true",
   onlineEvalsEnabled: Boolean(store.state.zoConfig?.online_evals_enabled),
   incidentsEnabled: Boolean(store.state.zoConfig?.incidents_enabled),
+  modelPricingEnabled: Boolean(store.state.zoConfig?.model_pricing_enabled),
 }));
 
 const open = computed({

--- a/web/src/lib/vue-shortcut-manager/ShortcutCheatsheet.vue
+++ b/web/src/lib/vue-shortcut-manager/ShortcutCheatsheet.vue
@@ -254,9 +254,13 @@ const store = useStore();
 const capabilities = computed<ShortcutCapabilities>(() => ({
   isEnterprise: config.isEnterprise === "true",
   isCloud: config.isCloud === "true",
+  isMetaOrg:
+    !!store.state.zoConfig?.meta_org &&
+    store.state.selectedOrganization?.identifier === store.state.zoConfig.meta_org,
   onlineEvalsEnabled: Boolean(store.state.zoConfig?.online_evals_enabled),
   incidentsEnabled: Boolean(store.state.zoConfig?.incidents_enabled),
   modelPricingEnabled: Boolean(store.state.zoConfig?.model_pricing_enabled),
+  rbacEnabled: Boolean(store.state.zoConfig?.rbac_enabled),
 }));
 
 const open = computed({

--- a/web/src/lib/vue-shortcut-manager/__tests__/shortcutRegistry.spec.ts
+++ b/web/src/lib/vue-shortcut-manager/__tests__/shortcutRegistry.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  SHORTCUT_MODULES,
+  SHORTCUT_REGISTRY,
+  type ShortcutCapabilities,
+} from "../shortcutRegistry";
+
+const OSS: ShortcutCapabilities = {
+  isEnterprise: false,
+  isCloud: false,
+  onlineEvalsEnabled: false,
+  incidentsEnabled: false,
+};
+const ENTERPRISE: ShortcutCapabilities = {
+  isEnterprise: true,
+  isCloud: false,
+  onlineEvalsEnabled: true,
+  incidentsEnabled: true,
+};
+const CLOUD: ShortcutCapabilities = {
+  isEnterprise: false,
+  isCloud: true,
+  onlineEvalsEnabled: true,
+  incidentsEnabled: true,
+};
+
+const groupByPage = new Map(SHORTCUT_REGISTRY.map((g) => [g.pageKey, g]));
+
+/** Mirrors ShortcutCheatsheet: a page shows unless its gate rejects the caps. */
+function visiblePages(caps: ShortcutCapabilities): Set<string> {
+  const pages = new Set<string>();
+  for (const g of SHORTCUT_REGISTRY) {
+    if (!g.visible || g.visible(caps)) pages.add(g.pageKey);
+  }
+  return pages;
+}
+
+/** A module shows only while at least one of its pages is visible. */
+function visibleModuleTitles(caps: ShortcutCapabilities): string[] {
+  const pages = visiblePages(caps);
+  return SHORTCUT_MODULES.filter((m) => m.pages.some((p) => pages.has(p))).map(
+    (m) => m.title ?? m.titleKey,
+  );
+}
+
+const GATED_IN_OSS = [
+  "shortcuts.pages.searchSchedulers",
+  "shortcuts.pages.alertSources",
+  "shortcuts.pages.alertIncidents",
+  "shortcuts.pages.pipelineDestinations",
+  "shortcuts.pages.iamRoles",
+  "shortcuts.pages.iamGroups",
+  "shortcuts.pages.iamInvitations",
+  "shortcuts.pages.regexPatterns",
+  "shortcuts.pages.cipherKeys",
+  "shortcuts.pages.nodes",
+  "shortcuts.pages.modelPricing",
+  "shortcuts.pages.llmProviders",
+  "shortcuts.pages.aiToolsets",
+  "shortcuts.pages.orgManagement",
+  "shortcuts.pages.actions",
+  "shortcuts.pages.evalTemplates",
+  "shortcuts.pages.scorers",
+  "shortcuts.pages.evalJobs",
+  "shortcuts.pages.scoreConfigs",
+  "shortcuts.pages.runningQueries",
+];
+
+const OSS_PAGES = [
+  "shortcuts.pages.global",
+  "shortcuts.pages.logs",
+  "shortcuts.pages.searchHistory",
+  "shortcuts.pages.alerts",
+  "shortcuts.pages.alertDestinations",
+  "shortcuts.pages.alertTemplates",
+  "shortcuts.pages.streams",
+  "shortcuts.pages.pipelines",
+  "shortcuts.pages.functions",
+  "shortcuts.pages.reports",
+  "shortcuts.pages.iamUsers",
+  "shortcuts.pages.iamServiceAccounts",
+  "shortcuts.pages.ingestionTokens",
+  "shortcuts.pages.rumErrors",
+];
+
+describe("shortcut cheatsheet OSS gating", () => {
+  it("hides every enterprise/cloud-only page on an OSS build", () => {
+    const pages = visiblePages(OSS);
+    for (const p of GATED_IN_OSS) expect(pages.has(p), `${p} leaked into OSS`).toBe(false);
+  });
+
+  it("keeps the core OSS pages visible on an OSS build", () => {
+    const pages = visiblePages(OSS);
+    for (const p of OSS_PAGES) expect(pages.has(p), `${p} missing from OSS`).toBe(true);
+  });
+
+  it("drops the fully-gated module chips on an OSS build", () => {
+    const titles = visibleModuleTitles(OSS);
+    expect(titles).not.toContain("shortcuts.modules.settings");
+    expect(titles).not.toContain("shortcuts.modules.onlineEvals");
+    expect(titles).not.toContain("shortcuts.modules.runningQueries");
+    expect(titles).not.toContain("shortcuts.modules.actions");
+  });
+
+  it("restores every gated page on an enterprise or cloud build", () => {
+    for (const caps of [ENTERPRISE, CLOUD]) {
+      const pages = visiblePages(caps);
+      for (const p of GATED_IN_OSS) {
+        // Enterprise-only pages stay hidden on a pure cloud build.
+        const g = groupByPage.get(p)!;
+        expect(pages.has(p)).toBe(g.visible!(caps));
+      }
+    }
+  });
+
+  it("still gates online-evals and incidents behind their /config flags", () => {
+    const entNoFlags: ShortcutCapabilities = {
+      ...ENTERPRISE,
+      onlineEvalsEnabled: false,
+      incidentsEnabled: false,
+    };
+    const pages = visiblePages(entNoFlags);
+    expect(pages.has("shortcuts.pages.scorers")).toBe(false);
+    expect(pages.has("shortcuts.pages.alertIncidents")).toBe(false);
+  });
+});

--- a/web/src/lib/vue-shortcut-manager/__tests__/shortcutRegistry.spec.ts
+++ b/web/src/lib/vue-shortcut-manager/__tests__/shortcutRegistry.spec.ts
@@ -33,8 +33,6 @@ const CLOUD: ShortcutCapabilities = {
   rbacEnabled: true,
 };
 
-const groupByPage = new Map(SHORTCUT_REGISTRY.map((g) => [g.pageKey, g]));
-
 /** Mirrors ShortcutCheatsheet: a page shows unless its gate rejects the caps. */
 function visiblePages(caps: ShortcutCapabilities): Set<string> {
   const pages = new Set<string>();
@@ -111,14 +109,39 @@ describe("shortcut cheatsheet OSS gating", () => {
     expect(titles).not.toContain("shortcuts.modules.actions");
   });
 
-  it("restores every gated page on an enterprise or cloud build", () => {
-    for (const caps of [ENTERPRISE, CLOUD]) {
-      const pages = visiblePages(caps);
-      for (const p of GATED_IN_OSS) {
-        // Enterprise-only pages stay hidden on a pure cloud build.
-        const g = groupByPage.get(p)!;
-        expect(pages.has(p)).toBe(g.visible!(caps));
-      }
+  it("shows enterprise-only pages on enterprise and hides the cloud-only ones", () => {
+    const pages = visiblePages(ENTERPRISE);
+    for (const p of [
+      "shortcuts.pages.regexPatterns",
+      "shortcuts.pages.cipherKeys",
+      "shortcuts.pages.nodes",
+      "shortcuts.pages.searchSchedulers",
+      "shortcuts.pages.aiToolsets",
+      "shortcuts.pages.pipelineDestinations",
+      "shortcuts.pages.runningQueries",
+    ]) {
+      expect(pages.has(p), `${p} should show on enterprise`).toBe(true);
+    }
+    // Cloud-only pages stay hidden on a pure enterprise build.
+    expect(pages.has("shortcuts.pages.iamInvitations")).toBe(false);
+    expect(pages.has("shortcuts.pages.orgManagement")).toBe(false);
+  });
+
+  it("shows cloud-only pages on cloud and hides the enterprise-only ones", () => {
+    const pages = visiblePages(CLOUD);
+    expect(pages.has("shortcuts.pages.iamInvitations")).toBe(true);
+    expect(pages.has("shortcuts.pages.orgManagement")).toBe(true);
+    // Enterprise-only pages (incl. _meta-org cluster pages) stay hidden on cloud.
+    for (const p of [
+      "shortcuts.pages.regexPatterns",
+      "shortcuts.pages.cipherKeys",
+      "shortcuts.pages.nodes",
+      "shortcuts.pages.searchSchedulers",
+      "shortcuts.pages.aiToolsets",
+      "shortcuts.pages.pipelineDestinations",
+      "shortcuts.pages.runningQueries",
+    ]) {
+      expect(pages.has(p), `${p} should be hidden on cloud`).toBe(false);
     }
   });
 

--- a/web/src/lib/vue-shortcut-manager/__tests__/shortcutRegistry.spec.ts
+++ b/web/src/lib/vue-shortcut-manager/__tests__/shortcutRegistry.spec.ts
@@ -8,23 +8,29 @@ import {
 const OSS: ShortcutCapabilities = {
   isEnterprise: false,
   isCloud: false,
+  isMetaOrg: false,
   onlineEvalsEnabled: false,
   incidentsEnabled: false,
   modelPricingEnabled: false,
+  rbacEnabled: false,
 };
 const ENTERPRISE: ShortcutCapabilities = {
   isEnterprise: true,
   isCloud: false,
+  isMetaOrg: true,
   onlineEvalsEnabled: true,
   incidentsEnabled: true,
   modelPricingEnabled: true,
+  rbacEnabled: true,
 };
 const CLOUD: ShortcutCapabilities = {
   isEnterprise: false,
   isCloud: true,
+  isMetaOrg: true,
   onlineEvalsEnabled: true,
   incidentsEnabled: true,
   modelPricingEnabled: true,
+  rbacEnabled: true,
 };
 
 const groupByPage = new Map(SHORTCUT_REGISTRY.map((g) => [g.pageKey, g]));
@@ -126,8 +132,25 @@ describe("shortcut cheatsheet OSS gating", () => {
     const pages = visiblePages(entNoFlags);
     expect(pages.has("shortcuts.pages.scorers")).toBe(false);
     expect(pages.has("shortcuts.pages.alertIncidents")).toBe(false);
+    // Alert Sources rides the same incidents gate — the nav only reaches it via Incidents.
+    expect(pages.has("shortcuts.pages.alertSources")).toBe(false);
     // llmProviders follows online_evals_enabled; modelPricing follows model_pricing_enabled.
     expect(pages.has("shortcuts.pages.llmProviders")).toBe(false);
     expect(pages.has("shortcuts.pages.modelPricing")).toBe(false);
+  });
+
+  it("gates IAM Roles/Groups behind rbac_enabled on enterprise/cloud", () => {
+    const entNoRbac: ShortcutCapabilities = { ...ENTERPRISE, rbacEnabled: false };
+    const pages = visiblePages(entNoRbac);
+    expect(pages.has("shortcuts.pages.iamRoles")).toBe(false);
+    expect(pages.has("shortcuts.pages.iamGroups")).toBe(false);
+  });
+
+  it("gates cluster-scoped pages to the _meta org", () => {
+    const entNonMeta = visiblePages({ ...ENTERPRISE, isMetaOrg: false });
+    expect(entNonMeta.has("shortcuts.pages.nodes")).toBe(false);
+    expect(entNonMeta.has("shortcuts.pages.runningQueries")).toBe(false);
+    const cloudNonMeta = visiblePages({ ...CLOUD, isMetaOrg: false });
+    expect(cloudNonMeta.has("shortcuts.pages.orgManagement")).toBe(false);
   });
 });

--- a/web/src/lib/vue-shortcut-manager/__tests__/shortcutRegistry.spec.ts
+++ b/web/src/lib/vue-shortcut-manager/__tests__/shortcutRegistry.spec.ts
@@ -10,18 +10,21 @@ const OSS: ShortcutCapabilities = {
   isCloud: false,
   onlineEvalsEnabled: false,
   incidentsEnabled: false,
+  modelPricingEnabled: false,
 };
 const ENTERPRISE: ShortcutCapabilities = {
   isEnterprise: true,
   isCloud: false,
   onlineEvalsEnabled: true,
   incidentsEnabled: true,
+  modelPricingEnabled: true,
 };
 const CLOUD: ShortcutCapabilities = {
   isEnterprise: false,
   isCloud: true,
   onlineEvalsEnabled: true,
   incidentsEnabled: true,
+  modelPricingEnabled: true,
 };
 
 const groupByPage = new Map(SHORTCUT_REGISTRY.map((g) => [g.pageKey, g]));
@@ -113,14 +116,18 @@ describe("shortcut cheatsheet OSS gating", () => {
     }
   });
 
-  it("still gates online-evals and incidents behind their /config flags", () => {
+  it("keeps flag-gated pages hidden on enterprise/cloud when their /config flag is off", () => {
     const entNoFlags: ShortcutCapabilities = {
       ...ENTERPRISE,
       onlineEvalsEnabled: false,
       incidentsEnabled: false,
+      modelPricingEnabled: false,
     };
     const pages = visiblePages(entNoFlags);
     expect(pages.has("shortcuts.pages.scorers")).toBe(false);
     expect(pages.has("shortcuts.pages.alertIncidents")).toBe(false);
+    // llmProviders follows online_evals_enabled; modelPricing follows model_pricing_enabled.
+    expect(pages.has("shortcuts.pages.llmProviders")).toBe(false);
+    expect(pages.has("shortcuts.pages.modelPricing")).toBe(false);
   });
 });

--- a/web/src/lib/vue-shortcut-manager/shortcutRegistry.ts
+++ b/web/src/lib/vue-shortcut-manager/shortcutRegistry.ts
@@ -49,7 +49,17 @@ export interface ShortcutGroup {
   pageKey: I18nKey;
   /** Manager scope shared by this group's registerable shortcuts (omit = global). */
   scope?: string;
+  /** Hide this page in the cheatsheet unless the edition/config exposes the feature. */
+  visible?: (caps: ShortcutCapabilities) => boolean;
   shortcuts: ShortcutEntry[];
+}
+
+/** Runtime edition + `/config` flags that gate feature-specific pages. */
+export interface ShortcutCapabilities {
+  isEnterprise: boolean;
+  isCloud: boolean;
+  onlineEvalsEnabled: boolean;
+  incidentsEnabled: boolean;
 }
 
 export interface ShortcutModule {
@@ -64,6 +74,13 @@ export interface ShortcutModule {
   /** pageKeys (ShortcutGroup.pageKey) grouped under this module, in display order */
   pages: I18nKey[];
 }
+
+// Gates mirror each feature's own route guard, so the cheatsheet never lists a page OSS cannot reach.
+const enterprise = (c: ShortcutCapabilities) => c.isEnterprise;
+const cloud = (c: ShortcutCapabilities) => c.isCloud;
+const enterpriseOrCloud = (c: ShortcutCapabilities) => c.isEnterprise || c.isCloud;
+const incidents = (c: ShortcutCapabilities) => enterpriseOrCloud(c) && c.incidentsEnabled;
+const onlineEvals = (c: ShortcutCapabilities) => enterpriseOrCloud(c) && c.onlineEvalsEnabled;
 
 /**
  * Groups the flat SHORTCUT_REGISTRY into modules for the cheatsheet. Each module
@@ -455,6 +472,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.alertSources",
     scope: "alert-sources",
+    visible: enterpriseOrCloud,
     shortcuts: [
       { id: "alertSourcesAdd", key: "n", descriptionKey: "shortcuts.actions.alertSourcesAdd" },
       {
@@ -595,6 +613,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.iamRoles",
     scope: "iam-roles",
+    visible: enterpriseOrCloud,
     shortcuts: [
       { id: "iamRolesAdd", key: "n", descriptionKey: "shortcuts.actions.iamRolesAdd" },
       { id: "iamRolesRefresh", key: "r", descriptionKey: "shortcuts.actions.iamRolesRefresh" },
@@ -612,6 +631,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.iamGroups",
     scope: "iam-groups",
+    visible: enterpriseOrCloud,
     shortcuts: [
       { id: "iamGroupsAdd", key: "n", descriptionKey: "shortcuts.actions.iamGroupsAdd" },
       { id: "iamGroupsRefresh", key: "r", descriptionKey: "shortcuts.actions.iamGroupsRefresh" },
@@ -708,6 +728,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.runningQueries",
     scope: "running-queries",
+    visible: enterprise,
     shortcuts: [
       {
         id: "runningQueriesRefresh",
@@ -726,6 +747,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.alertIncidents",
     scope: "alert-incidents",
+    visible: incidents,
     shortcuts: [
       {
         id: "alertIncidentsRefresh",
@@ -739,6 +761,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.pipelineDestinations",
     scope: "pipeline-destinations",
+    visible: enterprise,
     shortcuts: [
       {
         id: "pipelineDestinationsRefresh",
@@ -765,6 +788,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.iamInvitations",
     scope: "iam-invitations",
+    visible: cloud,
     shortcuts: [
       {
         id: "iamInvitationsRefresh",
@@ -791,6 +815,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.regexPatterns",
     scope: "regex-patterns",
+    visible: enterprise,
     shortcuts: [
       {
         id: "regexPatternsRefresh",
@@ -804,6 +829,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.cipherKeys",
     scope: "cipher-keys",
+    visible: enterprise,
     shortcuts: [
       { id: "cipherKeysRefresh", key: "r", descriptionKey: "shortcuts.actions.cipherKeysRefresh" },
     ],
@@ -813,6 +839,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.nodes",
     scope: "nodes",
+    visible: enterprise,
     shortcuts: [{ id: "nodesRefresh", key: "r", descriptionKey: "shortcuts.actions.nodesRefresh" }],
   },
 
@@ -820,6 +847,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.modelPricing",
     scope: "model-pricing",
+    visible: enterpriseOrCloud,
     shortcuts: [
       {
         id: "modelPricingRefresh",
@@ -833,6 +861,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.searchSchedulers",
     scope: "search-schedulers",
+    visible: enterprise,
     shortcuts: [
       {
         id: "searchSchedulersRefresh",
@@ -868,6 +897,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.evalTemplates",
     scope: "eval-templates",
+    visible: onlineEvals,
     shortcuts: [
       {
         id: "evalTemplatesRefresh",
@@ -881,6 +911,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.scorers",
     scope: "scorers",
+    visible: onlineEvals,
     shortcuts: [
       { id: "scorersRefresh", key: "r", descriptionKey: "shortcuts.actions.scorersRefresh" },
     ],
@@ -890,6 +921,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.evalJobs",
     scope: "eval-jobs",
+    visible: onlineEvals,
     shortcuts: [
       { id: "evalJobsRefresh", key: "r", descriptionKey: "shortcuts.actions.evalJobsRefresh" },
     ],
@@ -899,6 +931,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.scoreConfigs",
     scope: "score-configs",
+    visible: onlineEvals,
     shortcuts: [
       {
         id: "scoreConfigsRefresh",
@@ -912,6 +945,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.actions",
     scope: "actions",
+    visible: enterpriseOrCloud,
     shortcuts: [
       { id: "actionsRefresh", key: "r", descriptionKey: "shortcuts.actions.actionsRefresh" },
     ],
@@ -921,6 +955,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.llmProviders",
     scope: "llm-providers",
+    visible: enterpriseOrCloud,
     shortcuts: [
       {
         id: "llmProvidersRefresh",
@@ -934,6 +969,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.aiToolsets",
     scope: "ai-toolsets",
+    visible: enterprise,
     shortcuts: [
       { id: "aiToolsetsRefresh", key: "r", descriptionKey: "shortcuts.actions.aiToolsetsRefresh" },
     ],
@@ -943,6 +979,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.orgManagement",
     scope: "organization-management",
+    visible: cloud,
     shortcuts: [
       {
         id: "orgManagementRefresh",

--- a/web/src/lib/vue-shortcut-manager/shortcutRegistry.ts
+++ b/web/src/lib/vue-shortcut-manager/shortcutRegistry.ts
@@ -54,13 +54,15 @@ export interface ShortcutGroup {
   shortcuts: ShortcutEntry[];
 }
 
-/** Runtime edition + `/config` flags that gate feature-specific pages. */
+/** Runtime edition + org scope + `/config` flags that gate feature-specific pages. */
 export interface ShortcutCapabilities {
   isEnterprise: boolean;
   isCloud: boolean;
+  isMetaOrg: boolean;
   onlineEvalsEnabled: boolean;
   incidentsEnabled: boolean;
   modelPricingEnabled: boolean;
+  rbacEnabled: boolean;
 }
 
 export interface ShortcutModule {
@@ -83,6 +85,10 @@ const enterpriseOrCloud = (c: ShortcutCapabilities) => c.isEnterprise || c.isClo
 const incidents = (c: ShortcutCapabilities) => enterpriseOrCloud(c) && c.incidentsEnabled;
 const onlineEvals = (c: ShortcutCapabilities) => enterpriseOrCloud(c) && c.onlineEvalsEnabled;
 const modelPricing = (c: ShortcutCapabilities) => enterpriseOrCloud(c) && c.modelPricingEnabled;
+const rbac = (c: ShortcutCapabilities) => enterpriseOrCloud(c) && c.rbacEnabled;
+// Cluster-scoped admin surfaces only render inside the _meta org.
+const metaAdmin = (c: ShortcutCapabilities) => c.isEnterprise && c.isMetaOrg;
+const cloudMetaAdmin = (c: ShortcutCapabilities) => c.isCloud && c.isMetaOrg;
 
 /**
  * Groups the flat SHORTCUT_REGISTRY into modules for the cheatsheet. Each module
@@ -474,7 +480,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.alertSources",
     scope: "alert-sources",
-    visible: enterpriseOrCloud,
+    visible: incidents,
     shortcuts: [
       { id: "alertSourcesAdd", key: "n", descriptionKey: "shortcuts.actions.alertSourcesAdd" },
       {
@@ -615,7 +621,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.iamRoles",
     scope: "iam-roles",
-    visible: enterpriseOrCloud,
+    visible: rbac,
     shortcuts: [
       { id: "iamRolesAdd", key: "n", descriptionKey: "shortcuts.actions.iamRolesAdd" },
       { id: "iamRolesRefresh", key: "r", descriptionKey: "shortcuts.actions.iamRolesRefresh" },
@@ -633,7 +639,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.iamGroups",
     scope: "iam-groups",
-    visible: enterpriseOrCloud,
+    visible: rbac,
     shortcuts: [
       { id: "iamGroupsAdd", key: "n", descriptionKey: "shortcuts.actions.iamGroupsAdd" },
       { id: "iamGroupsRefresh", key: "r", descriptionKey: "shortcuts.actions.iamGroupsRefresh" },
@@ -730,7 +736,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.runningQueries",
     scope: "running-queries",
-    visible: enterprise,
+    visible: metaAdmin,
     shortcuts: [
       {
         id: "runningQueriesRefresh",
@@ -841,7 +847,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.nodes",
     scope: "nodes",
-    visible: enterprise,
+    visible: metaAdmin,
     shortcuts: [{ id: "nodesRefresh", key: "r", descriptionKey: "shortcuts.actions.nodesRefresh" }],
   },
 
@@ -981,7 +987,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.orgManagement",
     scope: "organization-management",
-    visible: cloud,
+    visible: cloudMetaAdmin,
     shortcuts: [
       {
         id: "orgManagementRefresh",

--- a/web/src/lib/vue-shortcut-manager/shortcutRegistry.ts
+++ b/web/src/lib/vue-shortcut-manager/shortcutRegistry.ts
@@ -60,6 +60,7 @@ export interface ShortcutCapabilities {
   isCloud: boolean;
   onlineEvalsEnabled: boolean;
   incidentsEnabled: boolean;
+  modelPricingEnabled: boolean;
 }
 
 export interface ShortcutModule {
@@ -81,6 +82,7 @@ const cloud = (c: ShortcutCapabilities) => c.isCloud;
 const enterpriseOrCloud = (c: ShortcutCapabilities) => c.isEnterprise || c.isCloud;
 const incidents = (c: ShortcutCapabilities) => enterpriseOrCloud(c) && c.incidentsEnabled;
 const onlineEvals = (c: ShortcutCapabilities) => enterpriseOrCloud(c) && c.onlineEvalsEnabled;
+const modelPricing = (c: ShortcutCapabilities) => enterpriseOrCloud(c) && c.modelPricingEnabled;
 
 /**
  * Groups the flat SHORTCUT_REGISTRY into modules for the cheatsheet. Each module
@@ -847,7 +849,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.modelPricing",
     scope: "model-pricing",
-    visible: enterpriseOrCloud,
+    visible: modelPricing,
     shortcuts: [
       {
         id: "modelPricingRefresh",
@@ -955,7 +957,7 @@ export const SHORTCUT_REGISTRY: ShortcutGroup[] = [
   {
     pageKey: "shortcuts.pages.llmProviders",
     scope: "llm-providers",
-    visible: enterpriseOrCloud,
+    visible: onlineEvals,
     shortcuts: [
       {
         id: "llmProvidersRefresh",


### PR DESCRIPTION
Backport of openobserve/openobserve#14413 to v1.0.

The keyboard-shortcuts cheatsheet rendered its full static registry regardless of edition, org scope, or `/config` flags, so it advertised shortcuts for pages the user cannot reach — the exact class of bug it should avoid.

Each feature page now carries a visibility gate that mirrors its real route/nav guard, resolved against a small typed capability context (edition, `_meta` org, and the relevant `/config` flags). A module whose every page is gated off drops its chip entirely.

Gates applied:
- Edition: OSS hides Settings, Actions, Online Evals, Running Queries chips, plus Search Schedulers, Alert Sources/Incidents, Pipeline Destinations, IAM Roles/Groups/Invitations rows.
- Flags: LLM Providers → `online_evals_enabled`; Model Pricing → `model_pricing_enabled`; Alert Incidents & Alert Sources → `incidents_enabled`; IAM Roles/Groups → `rbac_enabled`.
- Org scope: Nodes & Running Queries → `_meta` org; Organization Management → cloud + `_meta` org.

Unit-tested in `shortcutRegistry.spec.ts`.

Fixes openobserve/o2-enterprise#2604
