### PR TITLE
test: deflake Alerts/RUM/Logs/Metrics shard tests

### DIFF
--- a/tests/ui-testing/pages/alertsPages/alertDestinationsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertDestinationsPage.js
@@ -219,7 +219,11 @@ export class AlertDestinationsPage {
             await this.page.locator(this.customEmailsSelectTrigger).first().click();
             await popover.waitFor({ state: 'visible', timeout: 10000 });
         }
-        if (searchTerm) {
+        // The org-user list is fetched after the popover opens, so an immediate read returns [] and cannot be told apart from "no users" — gated only for the UNFILTERED read, since with a search term an empty list is the legitimate outcome under test.
+        if (!searchTerm) {
+            await this.page.locator(this.customEmailsSelectOption).first()
+                .waitFor({ state: 'attached', timeout: 15000 }).catch(() => {});
+        } else {
             const search = this.page.locator(this.customEmailsSelectSearch).first();
             if (await search.isVisible().catch(() => false)) {
                 await search.fill(searchTerm);

--- a/tests/ui-testing/pages/alertsPages/alertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/alertsPage.js
@@ -2891,7 +2891,10 @@ export class AlertsPage {
         // The folder-list refetch after navigation lags under CI load, so reload + retry once
         // (mirrors verifyAlertCreated) rather than failing on a single slow fetch.
         const firstRow = this.page.locator('[data-test^="o2-table-row-"]').first();
-        if (!(await firstRow.isVisible({ timeout: 15000 }).catch(() => false))) {
+        // waitFor, NOT isVisible({timeout}) — locator.isVisible() IGNORES its timeout and answers in ~14ms, so the wait above was really "probe once, then always reload", leaving the row one post-reload window that times out under shard contention.
+        const rowAppeared = (timeout) =>
+            firstRow.waitFor({ state: 'visible', timeout }).then(() => true).catch(() => false);
+        if (!(await rowAppeared(15000))) {
             await this.page.reload({ waitUntil: 'domcontentloaded' }).catch(() => {});
             await headerCheckbox.waitFor({ state: 'visible', timeout: 10000 });
             // The reload just put us back on the default folder. Without re-selecting, the rows
@@ -2900,7 +2903,7 @@ export class AlertsPage {
             if (this.lastNavigatedFolder && this.lastNavigatedFolder !== 'default') {
                 await this.navigateToFolder(this.lastNavigatedFolder);
             }
-            await firstRow.waitFor({ state: 'visible', timeout: 15000 });
+            await firstRow.waitFor({ state: 'visible', timeout: 30000 });
         }
         await headerCheckbox.click();
         testLogger.info('Clicked select all checkbox for export');

--- a/tests/ui-testing/pages/metricsPages/metricsExplorerPage.js
+++ b/tests/ui-testing/pages/metricsPages/metricsExplorerPage.js
@@ -237,6 +237,24 @@ export class MetricsExplorerPage {
         return this.getMetricsDataParam();
     }
 
+    /** The decoded blob once the URL stops changing, or null if none was written. NOT expect.poll: that waits for an expectation to BECOME true and cannot assert one HOLDS, so poll(hasMetricsDataParam).toBe(false) just raced the debounced write. */
+    async settleMetricsBlob(stableMs = 2000, timeout = 15000) {
+        const deadline = Date.now() + timeout;
+        let last = this.getMetricsDataParam();
+        let stableSince = Date.now();
+        while (Date.now() < deadline) {
+            await this.page.waitForTimeout(250);
+            const now = this.getMetricsDataParam();
+            if (now !== last) {
+                last = now;
+                stableSince = Date.now();
+            } else if (Date.now() - stableSince >= stableMs) {
+                break;
+            }
+        }
+        return this.decodeMetricsBlob();
+    }
+
     /** The mirror case — leaving Visualize must strip a stale blob. */
     async waitForMetricsDataCleared(timeout = 20000) {
         await expect

--- a/tests/ui-testing/pages/rumPages/rumPage.js
+++ b/tests/ui-testing/pages/rumPages/rumPage.js
@@ -264,7 +264,11 @@ export class RumPage {
     }
 
     async clickPrettyTab() {
-        await this.prettyTab.click();
+        // A click dispatched while the tab strip is still mounting is swallowed, the Pretty pane never renders, and every later Pretty assertion burns its full timeout against an unchanged Raw tab — so retry until the tab reports itself selected.
+        await expect(async () => {
+            await this.prettyTab.click({ timeout: 5000 });
+            await expect(this.prettyTab).toHaveAttribute('aria-selected', 'true', { timeout: 3000 });
+        }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
     }
 
     /** Assert the (minified) frame text — e.g. the bundle file name — is shown. */
@@ -292,11 +296,9 @@ export class RumPage {
         });
     }
 
-    /** Pretty tab's explicit "no sourcemaps" outcome (message text variants). */
+    /** Pretty tab's terminal "no sourcemaps" outcome — frames with no source_info render the unavailable panel, but NO frames fall through to the error panel (allSourceInfoNull is false when translatedStackTrace is empty), so matching only the two message strings missed the empty-frames path. */
     async expectPrettyUnavailableMessage(timeoutMs = 30000) {
-        await expect(
-            this.prettyUnavailableText.or(this.prettyTranslateFailedText).first(),
-        ).toBeVisible({ timeout: timeoutMs });
+        await this.expectPrettyUnavailableState(timeoutMs);
     }
 
     /**
@@ -317,8 +319,8 @@ export class RumPage {
     }
 
     /** The translating spinner must be gone (not hung). */
-    async expectPrettyLoadingResolved() {
-        await expect(this.prettyLoadingText).toHaveCount(0);
+    async expectPrettyLoadingResolved(timeoutMs = 30000) {
+        await expect(this.prettyLoadingText).toHaveCount(0, { timeout: timeoutMs });
     }
 
 }

--- a/tests/ui-testing/playwright-tests/Alerts/dl-email-destinations.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/dl-email-destinations.spec.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const { test, expect } = require('../utils/enhanced-baseFixtures.js');
 const PageManager = require('../../pages/page-manager.js');
 const testLogger = require('../utils/test-logger.js');
@@ -74,12 +76,41 @@ async function fillEmailForm(pm, destName, recipients) {
  * these tests were previously parked in, and a red suite would tell nobody anything.
  */
 let smtpReady = null;
-async function smtpAvailable() {
-  if (smtpReady !== null) return smtpReady;
+// The probe DELIVERS a message and only a real send proves the transport (the membership gate runs first, so a non-member recipient never observes SMTP being off, and /config exposes nothing) — so it is claimed through a file in Playwright's outputDir, wiped every run, making it one probe per RUN rather than one per worker dropping uncounted mail in the shared inbox.
+const PROBE_FILE = path.join(__dirname, '../../test-results', '.smtp-probe.json');
+async function probeSmtp() {
   const res = await api.testDestination({ type: 'email', recipients: [ORG_USER] });
   const err = ((res.body && res.body.error) || '').toLowerCase();
   // "must be part of this org" still proves SMTP is on — it failed the LATER gate.
-  smtpReady = res.status === 200 && !err.includes('smtp');
+  return res.status === 200 && !err.includes('smtp');
+}
+async function smtpAvailable() {
+  if (smtpReady !== null) return smtpReady;
+  fs.mkdirSync(path.dirname(PROBE_FILE), { recursive: true });
+  let claimed = false;
+  try {
+    // 'wx' fails if the file exists, so exactly one worker wins the claim.
+    fs.closeSync(fs.openSync(PROBE_FILE, 'wx'));
+    claimed = true;
+  } catch (_) { /* another worker is probing (or already did) */ }
+
+  if (claimed) {
+    const ready = await probeSmtp();
+    fs.writeFileSync(PROBE_FILE, JSON.stringify({ ready }));
+    smtpReady = ready;
+    return smtpReady;
+  }
+
+  const deadline = Date.now() + 60000;
+  while (Date.now() < deadline) {
+    try {
+      const raw = fs.readFileSync(PROBE_FILE, 'utf8');
+      if (raw) return (smtpReady = JSON.parse(raw).ready);
+    } catch (_) { /* winner has not written its answer yet */ }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  // The winner never answered — probe here rather than skipping the suite on a lock timeout.
+  smtpReady = await probeSmtp();
   return smtpReady;
 }
 
@@ -298,17 +329,6 @@ test.describe('Email destinations and distribution lists', () => {
     expect(await api.storedRecipients(destName), 'no partial save may survive').toBeNull();
   });
 
-  test('UI-05 · Test sends without persisting the destination', {
-    tag: ['@dlEmailDestinations', '@email', '@P1', '@all'],
-  }, async () => {
-    const destName = `auto_dest_dl_never_${RUN}`;
-    await fillEmailForm(pm, destName, ORG_USER);
-    await pm.alertDestinationsPage.clickTest();
-    await pm.alertDestinationsPage.clickCancel();
-
-    expect(await api.storedRecipients(destName), 'Test must not persist the destination').toBeNull();
-  });
-
   test('D-08 · the custom email path offers only organisation users', {
     tag: ['@dlEmailDestinations', '@email', '@P1', '@all'],
   }, async () => {
@@ -485,8 +505,20 @@ test.describe('Email destinations and distribution lists', () => {
   // These share ONE inbox, so they clear and count against common state. Nested
   // serial keeps them in a single worker and in order; the Tier A cases above
   // never touch the sink and stay parallel.
+  // Every test that SENDS mail belongs here too, even one that never reads the sink: a send from a parallel worker lands in the same inbox and is counted by whichever delivery case is mid-assertion (ML-04's "Expected: 1, Received: 2").
   test.describe('delivery', () => {
     test.describe.configure({ mode: 'serial' });
+
+  test('UI-05 · Test sends without persisting the destination', {
+    tag: ['@dlEmailDestinations', '@email', '@delivery', '@P1', '@all'],
+  }, async () => {
+    const destName = `auto_dest_dl_never_${RUN}`;
+    await fillEmailForm(pm, destName, ORG_USER);
+    await pm.alertDestinationsPage.clickTest();
+    await pm.alertDestinationsPage.clickCancel();
+
+    expect(await api.storedRecipients(destName), 'Test must not persist the destination').toBeNull();
+  });
 
   test('D-04 · envelope headers carry the configured From and only the alias in To', {
     tag: ['@dlEmailDestinations', '@email', '@delivery', '@P1', '@all'],
@@ -521,7 +553,9 @@ test.describe('Email destinations and distribution lists', () => {
     await pm.alertDestinationsPage.clickTest();
     await sink.waitForCount(1);
 
-    expect(await sink.count(), 'one message, not one per recipient').toBe(1);
+    // The regression guarded here is one message PER RECIPIENT, whose extra copy lands milliseconds later, so a count read the instant the first message arrives cannot tell it from a second still in flight — settle first.
+    const settled = await sink.countAfterSettle();
+    expect(settled, 'one message, not one per recipient').toBe(1);
   });
 
   // ══ TIER C — requires a real distribution list ═══════════════════════════

--- a/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/ftsDefaultColumn.spec.js
@@ -20,7 +20,7 @@ const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures
 const testLogger = require('../utils/test-logger.js');
 const PageManager = require('../../pages/page-manager.js');
 const logData = require("../../fixtures/log.json");
-const { ingestTestData, waitForStreamData } = require('../utils/data-ingestion.js');
+const { ingestTestData, waitForStreamData, waitForStreamListed } = require('../utils/data-ingestion.js');
 const { getOrgIdentifier } = require('../utils/cloud-auth.js');
 
 const TC008_SECOND_STREAM = 'e2e_automate_fts2_tc008';
@@ -38,6 +38,9 @@ test.describe("FTS Default Column Selection testcases", () => {
       await ingestTestData(page, TC008_SECOND_STREAM);
       expect(await waitForStreamData(page, TC008_SECOND_STREAM, 1, 30000),
         `stream ${TC008_SECOND_STREAM} never became queryable within 30s of ingestion`).toBe(true);
+      // Queryable is not the same as LISTED: the stream popover is built from /streams, which enumerates a new stream later than _search can query it.
+      expect(await waitForStreamListed(page, TC008_SECOND_STREAM, 'logs'),
+        `stream ${TC008_SECOND_STREAM} never appeared in the streams list after ingestion`).toBe(true);
     } finally {
       await context.close();
     }
@@ -58,6 +61,10 @@ test.describe("FTS Default Column Selection testcases", () => {
     // contention the UI search could fire before the just-ingested rows were queryable,
     // leaving the results table empty and timing out waitForSearchResults.
     await waitForStreamData(page, "e2e_automate", 1, 30000);
+
+    // Re-checked in THIS session rather than only the beforeAll context, because the streams list is cached per session and must be confirmed before the goto below, which is where the page caches the list the popover filters.
+    expect(await waitForStreamListed(page, TC008_SECOND_STREAM, 'logs'),
+      `stream ${TC008_SECOND_STREAM} is not listed for this session — the stream popover cannot offer it`).toBe(true);
 
     // Navigate to logs page and select stream
     await page.goto(

--- a/tests/ui-testing/playwright-tests/Metrics/metrics-explorer-share-visualize.spec.js
+++ b/tests/ui-testing/playwright-tests/Metrics/metrics-explorer-share-visualize.spec.js
@@ -152,14 +152,19 @@ test.describe("Metrics Explorer Share & Visualize Deep-Link testcases", () => {
     await pm.metricsExplorerPage.gotoExplorer({ mode: 'visualize' });
     await pm.metricsExplorerPage.waitForVisualizeReady();
 
-    // A blank Visualize carries no blob — the param only appears once there is
-    // a query to encode.
-    expect(pm.metricsExplorerPage.hasMetricsDataParam()).toBe(false);
+    // No "param is absent" assertion here: the explorer auto-picks the first metric on mount, so a pre-existing blob is a race against that — what this test owns is that the query WE type reaches the URL, hence the baseline-and-change check.
+    const before = pm.metricsExplorerPage.getMetricsDataParam();
 
     await pm.metricsExplorerPage.enterVisualizeQuery(SEEDED_METRIC);
 
     // The write-back is debounced 300ms, so poll for it.
     await pm.metricsExplorerPage.waitForMetricsDataParam();
+    await expect
+      .poll(() => pm.metricsExplorerPage.getMetricsDataParam() !== before, {
+        timeout: 20000,
+        intervals: [200, 400, 800],
+      })
+      .toBe(true);
 
     const blob = pm.metricsExplorerPage.decodeMetricsBlob();
     expect(blob).not.toBeNull();
@@ -190,30 +195,31 @@ test.describe("Metrics Explorer Share & Visualize Deep-Link testcases", () => {
     testLogger.info('Stale blob stripped on leaving Visualize');
   });
 
-  test("A blank Visualize adds no metrics_data param", {
+  test("An unbuilt Visualize never encodes an empty query into metrics_data", {
     tag: ['@metrics-explorer-share', '@P2', '@url-sync', '@edge-case', '@all']
   }, async ({ page }, testInfo) => {
     const pm = await setupTest(page, testInfo);
-    testLogger.info('Testing an unbuilt chart contributes nothing to the URL');
+    testLogger.info('Testing the encoder short-circuit on an unbuilt chart');
 
     await pm.metricsExplorerPage.gotoExplorer();
     await pm.metricsExplorerPage.expectExplorerVisible();
     await pm.metricsExplorerPage.switchToVisualize();
     await pm.metricsExplorerPage.waitForVisualizeReady();
 
-    // visualizeBlob short-circuits on an empty queries[0].query, so nothing is
-    // encoded. Assert it stays absent rather than merely reading once — the
-    // debounce means an erroneous write would land shortly after mount.
-    await expect
-      .poll(() => pm.metricsExplorerPage.hasMetricsDataParam(), {
-        timeout: 5000,
-        intervals: [500, 1000],
-        message:
-          'metrics_data appeared for a blank Visualize — base64-decode it: a real queries[0].query means the panel was seeded, an empty one means the encoder guard is too loose',
-      })
-      .toBe(false);
+    // Opening Visualize with nothing selected does not leave the panel blank — the explorer auto-picks the first metric and builds `avg(<metric>{})` within ~200ms, and a blob for that is correct — so the guard worth asserting is visualizeBlob's short-circuit: never encode an EMPTY queries[0].query.
+    const blob = await pm.metricsExplorerPage.settleMetricsBlob();
 
-    testLogger.info('Blank Visualize left the URL clean');
+    if (blob === null) {
+      testLogger.info('No metrics_data written — nothing was built, nothing encoded');
+      return;
+    }
+    expect(blob.v, 'an emitted blob must carry the current envelope version').toBe(1);
+    expect(
+      blob.data?.queries?.[0]?.query,
+      'metrics_data was written with an empty queries[0].query — the encoder short-circuit is too loose',
+    ).toBeTruthy();
+
+    testLogger.info('Auto-selected chart encoded a real query', { query: blob.data.queries[0].query });
   });
 
   test("The metrics_data blob excludes volatile keys (id, title, description)", {

--- a/tests/ui-testing/playwright-tests/utils/data-ingestion.js
+++ b/tests/ui-testing/playwright-tests/utils/data-ingestion.js
@@ -298,6 +298,41 @@ async function waitForFieldValueSearchable(page, streamName, fieldName, fieldVal
   return false;
 }
 
+/** Polls /streams until the stream is enumerated — distinct from waitForStreamData (which polls _search), because a new stream is queryable before it is listed and every stream PICKER is built from this list, not from search. */
+async function waitForStreamListed(page, streamName, streamType = 'logs', maxWaitMs = 90000, pollIntervalMs = 2000) {
+  const orgId = getOrgIdentifier();
+  const headers = getHeaders();
+  // INGESTION_URL first, then ZO_BASE_URL: on cloud the two hosts differ and only the former feeds the picker's list.
+  const rawBase = process.env.INGESTION_URL || process.env.ZO_BASE_URL || '';
+  const baseUrl = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
+
+  const startTime = Date.now();
+  while (Date.now() - startTime < maxWaitMs) {
+    try {
+      const response = await page.request.get(
+        `${baseUrl}/api/${orgId}/streams?type=${encodeURIComponent(streamType)}`,
+        { headers }
+      );
+      if (response.status() === 200) {
+        const data = await response.json().catch(() => null);
+        const list = Array.isArray(data?.list) ? data.list : [];
+        if (list.some((s) => s?.name === streamName)) {
+          testLogger.debug('Stream listed', { streamName, waitedMs: Date.now() - startTime });
+          return true;
+        }
+      } else {
+        testLogger.warn('Stream list poll got non-200', { status: response.status(), streamName });
+      }
+    } catch (e) {
+      testLogger.warn('Stream list poll error', { error: e.message, streamName });
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  testLogger.warn('Stream list poll timed out', { streamName, streamType, maxWaitMs });
+  return false;
+}
+
 module.exports = {
   ingestTestData,
   getHeaders,
@@ -306,5 +341,6 @@ module.exports = {
   ingestCustomData,
   enableLogPatternsExtraction,
   waitForStreamData,
-  waitForFieldValueSearchable
+  waitForFieldValueSearchable,
+  waitForStreamListed
 };

--- a/tests/ui-testing/playwright-tests/utils/mail-sink.js
+++ b/tests/ui-testing/playwright-tests/utils/mail-sink.js
@@ -111,6 +111,24 @@ async function waitUntilEmptyStable(stableMs = 3000, timeoutMs = 30000) {
   return false;
 }
 
+/** The message count once it has stopped changing for `stableMs` — a count read the moment the first message lands cannot tell one message apart from one still in flight, so "exactly N" callers must settle first. */
+async function countAfterSettle(stableMs = 4000, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = await count();
+  let stableSince = Date.now();
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 1000));
+    const now = await count();
+    if (now !== last) {
+      last = now;
+      stableSince = Date.now();
+    } else if (Date.now() - stableSince >= stableMs) {
+      return last;
+    }
+  }
+  return last;
+}
+
 async function waitForCount(n, timeoutMs = 120000) {
   const deadline = Date.now() + timeoutMs;
   let last = 0;
@@ -162,4 +180,4 @@ async function latest() {
   return null;
 }
 
-module.exports = { available, unavailableReason, backend, list, count, clear, waitUntilEmptyStable, waitForCount, latest };
+module.exports = { available, unavailableReason, backend, list, count, clear, waitUntilEmptyStable, countAfterSettle, waitForCount, latest };


### PR DESCRIPTION
Deflakes the five UI tests that dominated the past-12h flaky-run dashboard on the OSS Playwright shards.

| Shard | Test | Flaky runs |
| --- | --- | --- |
| Alerts | `ML-04 · several recipients travel in a single message` | 13 |
| Alerts | `Import/Export Alert Functionality` | 11 |
| RUM | `Pretty tab reports missing sourcemaps for an unmapped service` | 10 |
| Logs | `should clear FTS selection on stream change and re-resolve for new stream` | 10 |
| Metrics | `A blank Visualize adds no metrics_data param` | 9 |

## Confirmed still flaky before changing anything

CI blob reports from the last ~46 shard runs were downloaded and parsed for these five titles. All five still failed on bases dated 2026-09-10, so none had been fixed by earlier deflake work. In particular **ML-04 failed on base `3af1977ab0`, which is 12 commits AHEAD of #14346** — the previous ML-04 fix — so that fix was necessary but not sufficient.

## Root causes

**1. Alerts · ML-04** — CI: `Expected: 1 / Received: 2`. The assertion counts the WHOLE Mailpit inbox, shared by the entire Alerts shard (12 files × 5 workers), while two things mail into it concurrently: `UI-05 · Test sends without persisting the destination` sat in the outer `mode: 'parallel'` describe and calls `clickTest()`, and `smtpAvailable()` POSTed `/alerts/destinations/test` with a real recipient once per worker process. #14346's `waitUntilEmptyStable()` drains mail that arrived *before* the send; it cannot stop a concurrent message landing between `clickTest()` and `count()`.

**2. Alerts · Import/Export** — CI: `locator.waitFor: Timeout 15000ms exceeded`. `exportAlerts()` guarded its reload fallback with `firstRow.isVisible({ timeout: 15000 })`, and **`locator.isVisible()` ignores its `timeout`** — measured here at **14ms** vs `waitFor`'s correct 3314ms on the same late-appearing element. So "wait 15s, reload only if still missing" was really "probe once, then always reload", leaving the row a single post-reload window.

**3. RUM · Pretty tab** — the blob shows this PASSING on attempt 0 and failing on serial-group retries 1–3, always on the same assertion. `clickPrettyTab()` was a bare `.click()` with no confirmation the tab activated, so a click into the still-mounting tab strip is swallowed and every Pretty locator burns 30s against an unchanged Raw tab. Separately, `expectPrettyUnavailableMessage()` matched only two message *strings*, but `PrettyStackTrace.vue` has two legitimate terminal states and which renders depends on the translate response: frames with no `source_info` give `rum-pretty-stack-trace-unavailable`, while NO frames fall through to `rum-pretty-stack-trace-error` (`allSourceInfoNull` is `false` when `translatedStackTrace` is empty).

**4. Logs · FTS stream change** — CI: `selectStream: Failed to find stream ... after 5 attempts`. The gate used `waitForStreamData()`, which polls `_search`. Queryable ≠ listed: the stream popover is built from `GET /streams`, that list is cached per session, and the gate ran in a throwaway `browser.newContext()` — so the session that renders the dropdown was never confirmed to see the stream. With `skipNavigation: true` the retry loop never reloads, so all 5 attempts re-open the same stale list.

**5. Metrics · blank Visualize** — CI: `Expected: false / Received: true`. Two measured findings. A "blank" Visualize is never blank on current main: the explorer auto-picks the first metric and builds `avg(cpu_usage{})`, with `metrics_data` appearing **0–213ms** after `waitForVisualizeReady()` in 5/5 runs — and a blob for that is *correct*, the URL describes the chart on screen. The test only usually passed because `expect.poll(...).toBe(false)` waits for an expectation to BECOME true rather than asserting one HOLDS; measured, it **passed after 2ms** against a value that flipped to `true` at 800ms and stayed true. The premise was false and unfixable by synchronization, so the test is re-scoped to the guard it actually protects: `visualizeBlob` must never encode an EMPTY `queries[0].query`.

**Incidental (not on the list):** `getCustomEmailPickerOptions()` read the option list before the org-user fetch resolved, so `[]` was indistinguishable from "no users"; `D-08` began failing 2/3 once the ML-04 fix changed worker scheduling. The unfiltered read is now gated; the filtered read deliberately is not, because an empty filtered result is the behaviour under test.

## Changes

- Every mail-SENDING test moved into the serial `delivery` tier, so no send races an inbox count.
- SMTP probe claimed once per RUN via a file in Playwright's `outputDir` (verified wiped at the start of every run) instead of once per worker. Detection still uses a real send — the membership gate runs first, so a non-member recipient can never observe SMTP being off, and `/config` exposes no SMTP state.
- `sink.countAfterSettle()` settles the count before an exact-count assertion.
- `exportAlerts()` uses a real `waitFor` before falling back to a reload; post-reload wait raised to 30s.
- `clickPrettyTab()` retries until `aria-selected="true"`; the terminal-state assertion matches both states by data-test container; `expectPrettyLoadingResolved()` actually waits.
- New shared `waitForStreamListed()` gating on `GET /streams`, run in the test's OWN session before the page caches its list. (`GeneralTests/schema.spec.js` already carries a local copy of this helper for the same reason — consolidating the two is a good follow-up.)
- `settleMetricsBlob()` settles the URL before asserting, replacing the `expect.poll` misuse.

## Validation

Built from this branch's base and run locally against it: OpenObserve `8444558bdc` (debug), Mailpit v1.21.8, `ZO_SSRF_ALLOW_LOOPBACK=true`, 5 workers — matching the CI shard config.

Baseline on unmodified `main`, same machine: **ML-04 failed 3/3** (`one message, not one per recipient`).

After the fixes:

| Spec | Runs | Result |
| --- | --- | --- |
| `Alerts/dl-email-destinations.spec.js` | 4 | 26 passed / 6 skipped, 4/4 green |
| `Alerts/alerts-import.spec.js` (target test) | 3 | 3/3 green |
| `RUM/sourcemap-upload-pretty.spec.js` | 3 | 8 passed, 3/3 green |
| `Logs/ftsDefaultColumn.spec.js` | 3 | 9 passed, 3/3 green |
| `Metrics/metrics-explorer-share-visualize.spec.js` | 3 | 15 passed, 3/3 green |
| All five together | 3 | 61 passed / 6 skipped per round |

