### PR TITLE
fix: builder tab saved views apply issue (#14231)

### DIFF
--- a/web/src/plugins/logs/BuildQueryPage.vue
+++ b/web/src/plugins/logs/BuildQueryPage.vue
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, defineAsyncComponent, provide } from "vue";
+import { ref, onMounted, watch, defineAsyncComponent, provide } from "vue";
 import { useRouter } from "vue-router";
 import { useI18nTyped } from "@/types/i18n";
 import useDashboardPanelData from "@/composables/dashboard/useDashboardPanel";
@@ -478,6 +478,19 @@ const addPanelToDashboard = () => {
 // ============================================================================
 // Watchers
 // ============================================================================
+
+// Applying a saved view while already on the build tab does not remount this
+// component, so onMounted never re-reads savedBuildConfig. Re-initialize here so
+// the applied view is reflected. initializeFromQuery consumes and nulls it, so a
+// fresh non-null value always signals a newly applied saved view.
+watch(
+  () => searchObj.meta.savedBuildConfig,
+  (config) => {
+    if (config) {
+      initializeFromQuery();
+    }
+  },
+);
 
 // NOTE: URL sync for build mode fields is handled by explicit actions (runQuery, apply)
 // rather than a deep watcher. A deep watcher here would call router.push on every


### PR DESCRIPTION
Backport of #14231 to branch-v1.0.0.

## Why

alpha1's enterprise build deploys from `branch-v1.0.0`, not `main`. #14231 (merged to `main` on 2026-09-07) was never backported here, so alpha1's RegressionSet shard kept failing on bug #14228's regression test (added by #14245, also main-only): the test suite is checked out from `main`, but the app it exercises still has the bug on this branch. Confirmed via `git merge-base --is-ancestor` that the fix commit was not an ancestor of `branch-v1.0.0` (or of the commit currently deployed on alpha1).

## The bug (#14228)

Applying a Builder saved view while already on the Build tab didn't apply — the builder kept showing its previous state. `BuildQueryPage` only mounts when toggling *into* the Builder tab (`v-if="logsVisualizeToggle == 'build'"`), and the saved-view config (`searchObj.meta.savedBuildConfig`) was consumed exactly once, in `onMounted`. Applying from another tab flips the toggle and remounts the component; applying while already on Builder doesn't, so the config was set but never read.

## The fix

Added a watcher on `searchObj.meta.savedBuildConfig` in `BuildQueryPage.vue` that re-runs `initializeFromQuery()` whenever a fresh (non-null) config appears, regardless of mount state.

Cherry-picked cleanly, no conflicts.