### PR TITLE
fix: pipeline destination Add dialog closes itself on a slow API response (#14256)

### DIFF
--- a/web/src/components/alerts/PipelinesDestinationList.spec.ts
+++ b/web/src/components/alerts/PipelinesDestinationList.spec.ts
@@ -338,7 +338,20 @@ describe("PipelinesDestinationList", () => {
   // ── editor toggle ──────────────────────────────────────────────────────────
 
   describe("editor toggle", () => {
-    it.skip("toggleDestinationEditor toggles showDestinationEditor", async () => {
+    // Registers the route (normally added by useManagementRoutes at app setup, not run in this isolated mount) so router.push updates currentRoute for real instead of throwing "No match for".
+    beforeEach(() => {
+      router.addRoute({
+        name: "pipelineDestinations",
+        path: "/test-pipeline-destinations",
+        component: { template: "<div />" },
+      });
+    });
+
+    afterEach(() => {
+      router.removeRoute("pipelineDestinations");
+    });
+
+    it("toggleDestinationEditor toggles showDestinationEditor", async () => {
       wrapper = mountComponent();
       await flushPromises();
 
@@ -349,7 +362,7 @@ describe("PipelinesDestinationList", () => {
       expect((wrapper.vm as any).showDestinationEditor).toBe(false);
     });
 
-    it.skip("editDestination(null) sets showDestinationEditor to true", async () => {
+    it("editDestination(null) sets showDestinationEditor to true", async () => {
       wrapper = mountComponent();
       await flushPromises();
       (wrapper.vm as any).editDestination(null);
@@ -357,7 +370,7 @@ describe("PipelinesDestinationList", () => {
       expect((wrapper.vm as any).showDestinationEditor).toBe(true);
     });
 
-    it.skip("editDestination with existing dest stores editingDestination", async () => {
+    it("editDestination with existing dest stores editingDestination", async () => {
       wrapper = mountComponent();
       await flushPromises();
       const dest = (wrapper.vm as any).destinations[0];
@@ -366,13 +379,34 @@ describe("PipelinesDestinationList", () => {
       expect((wrapper.vm as any).editingDestination).toEqual(dest);
     });
 
-    it.skip("clones destination so original is not mutated", async () => {
+    it("clones destination so original is not mutated", async () => {
       wrapper = mountComponent();
       await flushPromises();
       const original = { name: "orig", url: "http://x.com" };
       (wrapper.vm as any).editDestination(original);
       (wrapper.vm as any).editingDestination.name = "mutated";
       expect(original.name).toBe("orig");
+    });
+
+    it("a stale getDestinations() resolving after Add must not close the editor (regression)", async () => {
+      // Defers destinationService.list() so editDestination(null) (the Add click) can run while onBeforeMount's call is still in flight, then resolves it to reproduce the late-API-response race.
+      let resolveList!: (v: any) => void;
+      (destinationService.list as any).mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveList = resolve;
+        }),
+      );
+
+      wrapper = mountComponent();
+      (wrapper.vm as any).editDestination(null);
+      await flushPromises();
+      expect(router.currentRoute.value.query.action).toBe("add");
+      expect((wrapper.vm as any).showDestinationEditor).toBe(true);
+
+      resolveList({ data: [] });
+      await flushPromises();
+
+      expect((wrapper.vm as any).showDestinationEditor).toBe(true);
     });
 
     it("shows PipelineDestinationEditor when showDestinationEditor is true", async () => {

--- a/web/src/components/alerts/PipelinesDestinationList.vue
+++ b/web/src/components/alerts/PipelinesDestinationList.vue
@@ -377,9 +377,17 @@ export default defineComponent({
         .then((res) => (templates.value = res.data));
     };
     const updateRoute = () => {
-      if (router.currentRoute.value.query.action === "add") editDestination(null);
-      if (router.currentRoute.value.query.action === "update")
-        editDestination(getDestinationByName(router.currentRoute.value.query.name as string));
+      const action = router.currentRoute.value.query.action;
+      const name = router.currentRoute.value.query.name as string;
+      // No-op when the editor already matches the route; a stale getDestinations().then() resolution re-invokes editDestination() and flips the just-opened editor closed.
+      if (action === "add" && !showDestinationEditor.value) {
+        editDestination(null);
+      } else if (
+        action === "update" &&
+        !(showDestinationEditor.value && editingDestination.value?.name === name)
+      ) {
+        editDestination(getDestinationByName(name));
+      }
     };
     const getDestinationByName = (name: string) => {
       return destinations.value.find((destination) => destination.name === name);


### PR DESCRIPTION
Backport of #14256 to branch-v1.0.0.

## Why

alpha1's enterprise build deploys from `branch-v1.0.0`, not `main`. #14256's fix was never backported here. It hadn't been caught yet because the underlying race only fires when `getDestinations()` is still in flight when "Add" is clicked — on branch-v1.0.0 as deployed today it's flaky (can pass or fail depending on network timing) rather than a reliable failure, unlike #14418's bug which failed deterministically. Confirmed via `git merge-base --is-ancestor` that the fix commit was not an ancestor of `branch-v1.0.0`.

## The bug (originally #11483)

`updateRoute()` runs once on `PipelinesDestinationList` mount, but also runs again inside `getDestinations().then()`. If that request is still in flight when the user clicks "Add", its late resolution re-invokes `editDestination(null)`, whose `toggleDestinationEditor()` flips the just-opened editor closed again — the Add form closes itself ~500-800ms after opening. This same stale call was also firing the "Button Click" analytics `track()` twice, which was bug #11483's original "2 notifications on save" symptom.

## The fix

`updateRoute()` is now a no-op when the editor already matches the route — it only opens/switches when the route actually disagrees with current state, preserving both legitimate paths (direct navigation to `?action=add`, switching to edit a different destination) while skipping the redundant re-invocation.

## Verification on this branch

Cherry-picked cleanly, no conflicts. Ran the full `PipelinesDestinationList.spec.ts` suite on `branch-v1.0.0` post-cherry-pick:
- **Fixed**: 41/41 pass.
- **Red check** (swapped just the `.vue` fix back to pre-fix content, keeping the new test): the new regression test fails deterministically (`expected false to be true` on `showDestinationEditor`), all other 40 tests unaffected — confirms the test isn't vacuous on this branch and the fix is what's making it pass, with no collateral regressions elsewhere in the file.