### PR TITLE
fix: resolve the trace details window when from/to are absent from the URL

### DIFF
--- a/src/api/search/src/traces/time_index/mod.rs
+++ b/src/api/search/src/traces/time_index/mod.rs
@@ -1727,6 +1727,15 @@ mod tests {
         assert_eq!(union_ranges(None, None), None);
     }
 
+    #[test]
+    fn union_takes_the_index_range_when_the_caller_sends_none() {
+        let index = TraceTimeRange {
+            start_time: 10,
+            end_time: 20,
+        };
+        assert_eq!(union_ranges(None, Some(index)), Some(index));
+    }
+
     fn outcome(stream_index: usize) -> LookupOutcome {
         LookupOutcome {
             key_index: 0,

--- a/web/src/plugins/traces/TraceDetails.spec.ts
+++ b/web/src/plugins/traces/TraceDetails.spec.ts
@@ -2478,6 +2478,152 @@ describe("TraceDetails", () => {
     });
   });
 
+  // Regression: a bare Number() on absent query params produced NaN, which
+  // passes the `!= null` guard in search.ts and reaches the API as "NaN".
+  describe("Bug fix: missing from/to in URL query params", () => {
+    // Records the details URL the component actually requested, so we can
+    // assert on what reached the wire rather than only on internal state.
+    let requestedUrl: string;
+
+    // Helper that builds a full mount with a custom route query so we can
+    // control which time-window params (if any) arrive via the URL.
+    function mountWithTimeQuery(range: { from?: string; to?: string }) {
+      vi.spyOn(router, "currentRoute", "get").mockReturnValue({
+        value: {
+          query: {
+            trace_id: "test-trace-id",
+            stream: "test-stream",
+            org_identifier: "default",
+            ...(range.from !== undefined ? { from: range.from } : {}),
+            ...(range.to !== undefined ? { to: range.to } : {}),
+          },
+          name: "traceDetails",
+        },
+      } as any);
+
+      return mount(TraceDetails, {
+        attachTo: "#app",
+        props: { traceId: "test-trace-id" },
+        global: {
+          plugins: [i18n, router],
+          provide: { store },
+          stubs: {
+            ODrawer: ODrawerStub,
+            CodeQueryEditor: {
+              name: "CodeQueryEditor",
+              props: ["query", "language"],
+              emits: ["update:query"],
+              template: '<div data-test="trace-details-filters-code-editor" />',
+            },
+            "chart-renderer": {
+              template: '<div data-test="chart-renderer">Chart</div>',
+              props: ["data", "id"],
+              emits: ["updated:chart"],
+            },
+            "trace-tree": {
+              template: '<div data-test="trace-tree">Trace Tree</div>',
+              props: [
+                "collapseMapping",
+                "spans",
+                "baseTracePosition",
+                "spanDimensions",
+                "spanMap",
+                "leftWidth",
+                "searchQuery",
+                "spanList",
+              ],
+              emits: ["toggle-collapse", "select-span", "update-current-index", "search-result"],
+            },
+            "trace-header": {
+              template: '<div data-test="trace-header">Trace Header</div>',
+              props: ["baseTracePosition", "splitterWidth"],
+              emits: ["resize-start"],
+            },
+            "trace-details-sidebar": {
+              template: '<div data-test="trace-details-sidebar">Sidebar</div>',
+              props: [
+                "span",
+                "baseTracePosition",
+                "searchQuery",
+                "streamName",
+                "serviceStreamsEnabled",
+                "parentMode",
+                "activeTab",
+                "selectedLogStreams",
+                "showLogStreamSelector",
+              ],
+              emits: [
+                "view-logs",
+                "close",
+                "open-trace",
+                "add-filter",
+                "apply-filter-immediately",
+                "update:activeTab",
+              ],
+            },
+          },
+        },
+      });
+    }
+
+    beforeEach(() => {
+      requestedUrl = "";
+      globalThis.server.use(
+        http.get(
+          `${store.state.API_ENDPOINT}/api/${store.state.selectedOrganization.identifier}/:stream/traces/:traceId/details`,
+          ({ request }) => {
+            requestedUrl = request.url;
+            return HttpResponse.json(tracesMockData.tracesDetails.traceSpans);
+          },
+        ),
+      );
+    });
+
+    it("resolves a finite window when from/to are absent", async () => {
+      const localWrapper = mountWithTimeQuery({});
+      await flushPromises();
+
+      expect(localWrapper.vm.effectiveTimeRange).toEqual({ from: 0, to: 0 });
+      localWrapper.unmount();
+    });
+
+    // The API rejects the literal string "NaN", so this is the assertion that
+    // actually fails before the fix.
+    it("never sends NaN bounds to the details API", async () => {
+      const localWrapper = mountWithTimeQuery({});
+      await flushPromises();
+
+      expect(requestedUrl).not.toContain("NaN");
+      expect(requestedUrl).toContain("start_time=0");
+      expect(requestedUrl).toContain("end_time=0");
+      localWrapper.unmount();
+    });
+
+    // Half a window is its own API error, so one usable bound must not survive
+    // on its own.
+    it("collapses both bounds when only one is present", async () => {
+      const localWrapper = mountWithTimeQuery({ from: "1752490492843" });
+      await flushPromises();
+
+      expect(localWrapper.vm.effectiveTimeRange).toEqual({ from: 0, to: 0 });
+      localWrapper.unmount();
+    });
+
+    it("still honours the URL window when from/to are present", async () => {
+      const localWrapper = mountWithTimeQuery({
+        from: "1752490492843",
+        to: "1752490493164",
+      });
+      await flushPromises();
+
+      expect(localWrapper.vm.effectiveTimeRange).toEqual({
+        from: 1752490492843,
+        to: 1752490493164,
+      });
+      localWrapper.unmount();
+    });
+  });
+
   describe("Priority 3: Search Navigation", () => {
     let mockTraceTreeRef: any;
 

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -923,7 +923,7 @@ import TraceTimelineIcon from "@/components/icons/TraceTimelineIcon.vue";
 import ServiceMapIcon from "@/components/icons/ServiceMapIcon.vue";
 import { convertTimelineData, convertTraceServiceMapData } from "@/utils/traces/convertTraceData";
 import { getAllSpanColors } from "@/utils/traces/traceColors";
-import { resolveSessionId } from "./traceDetails.utils";
+import { resolveSessionId, resolveUrlTimeRange } from "./traceDetails.utils";
 import { buildFilterTerm, applyFilterTerm } from "@/utils/traces/filterUtils";
 import { buildPatternConsolidatedTree } from "@/utils/traces/patternDetection";
 import { useTracePatternTree } from "@/composables/useTracePatternTree";
@@ -1491,10 +1491,10 @@ export default defineComponent({
         };
       }
       // Standalone mode - get from URL
-      return {
-        from: Number(router.currentRoute.value.query.from),
-        to: Number(router.currentRoute.value.query.to),
-      };
+      return resolveUrlTimeRange(
+        router.currentRoute.value.query.from,
+        router.currentRoute.value.query.to,
+      );
     });
 
     const effectiveOrgIdentifier = computed(() => {

--- a/web/src/plugins/traces/traceDetails.utils.spec.ts
+++ b/web/src/plugins/traces/traceDetails.utils.spec.ts
@@ -4,7 +4,7 @@
 // session ID to display in the trace-details header.
 
 import { describe, it, expect } from "vitest";
-import { resolveSessionId } from "./traceDetails.utils";
+import { resolveSessionId, resolveUrlTimeRange } from "./traceDetails.utils";
 
 describe("resolveSessionId", () => {
   // Empty / null / undefined inputs → "" so the header template hides
@@ -79,5 +79,43 @@ describe("resolveSessionId", () => {
   it("treats empty-string IDs as missing", () => {
     const spans = [{ session_id: "" }, { session_id: "real" }];
     expect(resolveSessionId(spans)).toBe("real");
+  });
+});
+
+describe("resolveUrlTimeRange", () => {
+  // 0/0 is the endpoint's "no caller range", so an absent window lets the
+  // trace time index derive it from the trace itself.
+  it.each([
+    [undefined, undefined],
+    ["", ""],
+    ["abc", "def"],
+  ])("collapses unusable bounds %j / %j to 0/0", (from, to) => {
+    expect(resolveUrlTimeRange(from, to)).toEqual({ from: 0, to: 0 });
+  });
+
+  // Half a window is its own 400 ("must be provided together" / "must both be
+  // zero or non-zero"), so one good bound must never survive on its own.
+  it.each([
+    ["1752490492843", undefined],
+    [undefined, "1752490493164"],
+    ["1752490492843", "0"],
+    ["0", "1752490493164"],
+  ])("collapses both bounds when only one is usable: %j / %j", (from, to) => {
+    expect(resolveUrlTimeRange(from, to)).toEqual({ from: 0, to: 0 });
+  });
+
+  // Inverted and non-positive pairs are 400s too.
+  it.each([
+    ["1752490493164", "1752490492843"],
+    ["-2", "-1"],
+  ])("collapses inverted or non-positive bounds %j / %j", (from, to) => {
+    expect(resolveUrlTimeRange(from, to)).toEqual({ from: 0, to: 0 });
+  });
+
+  it("passes a sane window through unchanged", () => {
+    expect(resolveUrlTimeRange("1752490492843", "1752490493164")).toEqual({
+      from: 1752490492843,
+      to: 1752490493164,
+    });
   });
 });

--- a/web/src/plugins/traces/traceDetails.utils.ts
+++ b/web/src/plugins/traces/traceDetails.utils.ts
@@ -49,3 +49,16 @@ export function resolveSessionId(spans: any[] | null | undefined): string {
   const s: any = spans.find((sp: any) => sp?.gen_ai_conversation_id || sp?.session_id);
   return s ? String(s.gen_ai_conversation_id || s.session_id || "") : "";
 }
+
+/**
+ * Resolve the trace-details window from the route query. Unusable bounds
+ * collapse to `0/0` — the API's "no caller range" — and always together,
+ * because a half-valid pair is itself rejected.
+ */
+export function resolveUrlTimeRange(from: unknown, to: unknown): { from: number; to: number } {
+  const start = Number(from);
+  const end = Number(to);
+  const usable =
+    Number.isFinite(start) && Number.isFinite(end) && start > 0 && end > 0 && start <= end;
+  return usable ? { from: start, to: end } : { from: 0, to: 0 };
+}


### PR DESCRIPTION
Fixes #14243

## What was happening

Opening trace details from a link that carries no `from`/`to` reported the trace as missing, then redirected to the traces list — which promptly listed that same trace's spans. The trace was always there; only the time window was broken.

```mermaid
flowchart LR
  A["trace-details link<br/>no from / to"] --> B["Number(undefined)<br/><b>NaN</b>"]
  B --> C["start_time=NaN<br/>end_time=NaN<br/>hint_ts=NaN"]
  C --> D["400<br/>Invalid start_time parameter"]
  D --> E["'Trace not found'<br/>+ redirect to list"]
```

## Root cause

`effectiveTimeRange` read the window straight from the route with a bare `Number()`:

```js
from: Number(router.currentRoute.value.query.from),
to: Number(router.currentRoute.value.query.to),
```

With the params absent that yields `NaN`, which also propagates into `hint_ts`, derived as the midpoint of the two bounds. `search.ts` guards each param with `!= null` before adding it to the query string — and `NaN != null` is `true`, so all three survive the guard and go out as the literal string `"NaN"`. `parse_optional_time_range` then fails to parse them and returns `400`, the `catch` in `getTraceDetails` calls `showTraceDetailsError()`, and the page redirects away.

## The fix

The endpoint accepts a sane non-zero pair, or `start_time=0&end_time=0` meaning "no caller range" — in which case the trace time index derives the window from the trace itself. Every other shape is a `400`, including a half window (`must be provided together`), a mixed-zero pair (`must both be zero or non-zero`) and an inverted pair (`must not be greater than end_time`).

So the window is now resolved through a guard that keeps a usable pair and otherwise collapses **both** bounds to `0` — never one real bound and one placeholder, which is itself rejected.

```mermaid
flowchart LR
  A["trace-details link<br/>no from / to"] --> B["resolveUrlTimeRange<br/><b>0 , 0</b>"]
  B --> C["start_time=0<br/>end_time=0<br/>hint_ts=0"]
  C --> D["no caller range<br/>→ trace time index"]
  D --> E["200 + spans<br/>URL rewritten with<br/>the resolved window"]
```

New pure helper in the existing `traceDetails.utils.ts`:

```ts
export function resolveUrlTimeRange(from: unknown, to: unknown): { from: number; to: number } {
  const start = Number(from);
  const end = Number(to);
  const usable =
    Number.isFinite(start) && Number.isFinite(end) && start > 0 && end > 0 && start <= end;
  return usable ? { from: start, to: end } : { from: 0, to: 0 };
}
```

and one call site in `TraceDetails.vue`. `hint_ts` needs no separate guard: the bounds are always finite now, so the midpoint is `0`, which the API reads as "no hint".

Returning `0` rather than leaving the bounds undefined keeps `effectiveTimeRange` typed `{ from: number; to: number }`, so its other consumers — the evaluation and dataset targets, `handleExpandToFullView`, the DAG props — are untouched.

## Behaviour matrix

What the page sends to `/details` in each case, and what the user ends up with. Verified against a local node before and after the change.

| # | link | before — params sent | | before | after — params sent | | after |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | no `from`/`to` | `start_time=NaN&end_time=NaN&hint_ts=NaN` | `400` | trace not found | `start_time=0&end_time=0&hint_ts=0` | `200` | **renders** |
| 2 | valid `from`/`to` | `start_time=<us>&end_time=<us>&hint_ts=<us>` | `200` | renders | *unchanged* | `200` | renders |
| 3 | `from` only | `start_time=<us>&end_time=NaN&hint_ts=NaN` | `400` | trace not found | `start_time=0&end_time=0&hint_ts=0` | `200` | **renders** |
| 4 | `from=abc&to=def` | `start_time=NaN&end_time=NaN&hint_ts=NaN` | `400` | trace not found | `start_time=0&end_time=0&hint_ts=0` | `200` | **renders** |
| 5 | `from` > `to` | passed through inverted | `400` | trace not found | `start_time=0&end_time=0&hint_ts=0` | `200` | **renders** |
| 6 | trace genuinely missing | `start_time=NaN&end_time=NaN&hint_ts=NaN` | `400` | trace not found | `start_time=0&end_time=0&hint_ts=0` | `400` | trace not found |

Rows 1 and 3-5 are the fix. Row 2 is the ordinary in-app path — a link that already carries a valid window passes through untouched, not overridden.

Row 6 is unchanged on purpose: a trace that really isn't there still reports not found. The status differs (the index has nothing to resolve, so the request is rejected rather than returning zero hits) but both paths converge on the same `showTraceDetailsError()` branch, so the user sees exactly what they see today.

One further visible effect on rows 1 and 3-5: once the trace loads, `updateUrlQueryParams` rewrites the address bar with the window the backend resolved, so a link that arrived without one becomes a complete, precise link after it opens.

## Tests

- `traceDetails.utils.spec.ts` — table-driven coverage of the helper: absent, empty, non-numeric, half-valid, mixed-zero, inverted and non-positive bounds all collapse to `0/0`; a sane window passes through untouched.
- `TraceDetails.spec.ts` — regression block for standalone mode with the params absent, including an assertion that no `NaN` reaches the details request. These fail on `main` and pass with the change.
- `time_index/mod.rs` — adds the `union_ranges(None, Some(range))` case, the arm this fix relies on, which the existing test did not cover.

