### PR TITLE
fix: sanitize v-html output in anomaly summary and rich text reference preview

### DIFF
--- a/web/src/components/RichTextInput.vue
+++ b/web/src/components/RichTextInput.vue
@@ -119,6 +119,17 @@ export default defineComponent({
     const detailCardContent = ref("");
     const cardPosition = ref({ top: 0, left: 0, below: false });
 
+    // Escape before embedding in HTML — mirrors anomalySummaryGenerator.ts's esc().
+    // JSON.stringify doesn't escape </>/&, so an unescaped token (e.g. a string value
+    // containing "<b>") would be parsed as markup by DOMPurify instead of shown as text.
+    const esc = (s: string) =>
+      String(s)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+
     // Helper to format JSON with syntax highlighting
     const formatContent = (content: string): string => {
       try {
@@ -140,11 +151,10 @@ export default defineComponent({
             } else if (/null/.test(match)) {
               cls = "json-null";
             }
-            return `<span class="${cls}">${match}</span>`;
+            return `<span class="${cls}">${esc(match)}</span>`;
           },
         );
-        // matched tokens are substrings of the referenced content (log/dashboard data), so
-        // sanitize before v-html renders it
+        // matched tokens are already escaped above; DOMPurify stays as defense-in-depth
         return DOMPurify.sanitize(highlighted, {
           ALLOWED_TAGS: ["span"],
           ALLOWED_ATTR: ["class"],

--- a/web/src/components/RichTextInput.vue
+++ b/web/src/components/RichTextInput.vue
@@ -50,6 +50,7 @@
 </template>
 
 <script lang="ts">
+import DOMPurify from "dompurify";
 import { useI18nTyped, type I18nText } from "@/types/i18n";
 import {
   computed,
@@ -124,7 +125,7 @@ export default defineComponent({
         const parsed = JSON.parse(content);
         const formatted = JSON.stringify(parsed, null, 2);
         // Apply syntax highlighting
-        return formatted.replace(
+        const highlighted = formatted.replace(
           /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
           (match) => {
             let cls = "json-number";
@@ -142,6 +143,12 @@ export default defineComponent({
             return `<span class="${cls}">${match}</span>`;
           },
         );
+        // matched tokens are substrings of the referenced content (log/dashboard data), so
+        // sanitize before v-html renders it
+        return DOMPurify.sanitize(highlighted, {
+          ALLOWED_TAGS: ["span"],
+          ALLOWED_ATTR: ["class"],
+        });
       } catch {
         // Not JSON, return plain text with line breaks preserved
         return content.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\n/g, "<br>");

--- a/web/src/components/anomaly_detection/AnomalySummary.vue
+++ b/web/src/components/anomaly_detection/AnomalySummary.vue
@@ -48,6 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <script setup lang="ts">
 import { computed, ref, nextTick, watch, onMounted } from "vue";
+import DOMPurify from "dompurify";
 import { generateAnomalySummary } from "@/utils/alerts/anomalySummaryGenerator";
 import OButton from "@/lib/core/Button/OButton.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
@@ -65,8 +66,12 @@ const props = defineProps<{
 const summaryContainer = ref<HTMLElement | null>(null);
 const showScrollToBottom = ref(false);
 
+// generator interpolates user-controlled config/destination values unescaped, so sanitize before v-html
 const summaryText = computed(() =>
-  generateAnomalySummary(props.config, props.destinations, t, props.wizardStep),
+  DOMPurify.sanitize(
+    generateAnomalySummary(props.config, props.destinations, t, props.wizardStep),
+    { ALLOWED_TAGS: ["div", "span", "strong"], ALLOWED_ATTR: ["class"] },
+  ),
 );
 
 const checkScrollState = () => {

--- a/web/src/utils/alerts/anomalySummaryGenerator.ts
+++ b/web/src/utils/alerts/anomalySummaryGenerator.ts
@@ -6,6 +6,17 @@
 
 import { raw, type TranslateFn } from "@/types/i18n";
 
+// Escape user-controlled strings before embedding in HTML (XSS prevention) —
+// mirrors alertSummaryGenerator.ts's esc(), so both generators emit HTML that
+// is already safe rather than leaving escaping to whoever calls v-html.
+const esc = (s: string) =>
+  String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
 export function generateAnomalySummary(
   config: any,
   destinations: any[],
@@ -18,7 +29,8 @@ export function generateAnomalySummary(
 
   // The markup stays here rather than in en-US.json: translators get whole
   // sentences with {placeholders} and never have to preserve a tag.
-  const chip = (value: string | number) => `<span class="summary-clickable">${value}</span>`;
+  const chip = (value: string | number) =>
+    `<span class="summary-clickable">${esc(String(value))}</span>`;
 
   // Step 1+: Stream & query info
   if (wizardStep >= 1) {
@@ -130,14 +142,14 @@ export function generateAnomalySummary(
 function generatePlainEnglish(config: any, wizardStep: number, t: TranslateFn): string {
   if (!config.stream_name) return "";
 
-  const stream = config.stream_name;
-  const fn = config.detection_function || "count";
-  const schedule = `${config.schedule_interval_value}${config.schedule_interval_unit}`;
+  const stream = esc(config.stream_name);
+  const fn = esc(config.detection_function || "count");
+  const schedule = esc(`${config.schedule_interval_value}${config.schedule_interval_unit}`);
   const trainingDays = config.training_window_days || 14;
 
   if (wizardStep < 2) {
     return t("alerts.anomaly.summaryConfiguring", {
-      streamType: config.stream_type || "logs",
+      streamType: esc(config.stream_type || "logs"),
       stream,
     });
   }


### PR DESCRIPTION
generateAnomalySummary() and RichTextInput's JSON reference preview both interpolate user-controlled values (stream names, detection functions, destination labels, referenced log/dashboard content) into HTML strings without escaping before rendering via v-html, allowing stored XSS.

