### PR TITLE
test: E2E coverage for composite alert clone

### DIFF
--- a/tests/ui-testing/pages/alertsPages/compositeAlertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/compositeAlertsPage.js
@@ -26,6 +26,16 @@ export class CompositeAlertsPage {
       listBadge: (id) => `[data-test="alert-list-composite-badge-${id}"]`,
       listChildCount: (id) => `[data-test="alert-list-child-count-${id}"]`,
       listReferenceCount: (id) => `[data-test="alert-list-reference-count-${id}"]`,
+      alertListCompositeTab: '[data-test="alert-list-tab-composite"]',
+      cloneButton: (name) => `[data-test="alert-list-${name}-clone-alert"]`,
+      cloneDialog: '[data-test="alert-list-form-dialog"]',
+      cloneNameInputField: '[data-test="to-be-clone-alert-name-field"]',
+      cloneStreamType: '[data-test="to-be-clone-stream-type"]',
+      cloneStreamName: '[data-test="to-be-clone-stream-name"]',
+      cloneSubmitButton: '[data-test="alert-list-form-dialog"] [data-test="o-dialog-primary-btn"]',
+      cloneCancelButton: '[data-test="alert-list-form-dialog"] [data-test="o-dialog-secondary-btn"]',
+      cloneFolderPicker: '[data-test="alert-list-form-dialog"] [data-test="alerts-index-dropdown-stream_type"]',
+      toastMessage: '[data-test="o-toast-message"]',
       detailResult: '[data-test="alerts-composite-detail-result"]',
       detailExpression: '[data-test="alerts-composite-detail-expression"]',
       detailChildren: '[data-test="alerts-composite-detail-children-table"]',
@@ -177,5 +187,97 @@ export class CompositeAlertsPage {
 
   async expectPreviewChild(id, pattern) {
     await expect(this.page.locator(this.locators.previewRow(id))).toContainText(pattern);
+  }
+
+  // ---- Composite clone dialog (AlertList.vue clone flow) ----
+
+  alertListCompositeTab() {
+    return this.page.locator(this.locators.alertListCompositeTab);
+  }
+
+  cloneButton(name) {
+    return this.page.locator(this.locators.cloneButton(name));
+  }
+
+  cloneDialog() {
+    return this.page.locator(this.locators.cloneDialog);
+  }
+
+  cloneNameInputField() {
+    return this.page.locator(this.locators.cloneNameInputField);
+  }
+
+  cloneStreamTypeSelect() {
+    return this.page.locator(this.locators.cloneStreamType);
+  }
+
+  cloneStreamNameSelect() {
+    return this.page.locator(this.locators.cloneStreamName);
+  }
+
+  cloneSubmitButton() {
+    return this.page.locator(this.locators.cloneSubmitButton);
+  }
+
+  cloneCancelButton() {
+    return this.page.locator(this.locators.cloneCancelButton);
+  }
+
+  cloneFolderPicker() {
+    return this.page.locator(this.locators.cloneFolderPicker);
+  }
+
+  successToast(message) {
+    return this.page.locator(this.locators.toastMessage).filter({ hasText: message }).first();
+  }
+
+  async openCompositeTab() {
+    await this.alertListCompositeTab().click();
+  }
+
+  async clickCloneButton(name) {
+    await this.cloneButton(name).click();
+  }
+
+  async fillCloneName(name) {
+    await this.cloneNameInputField().fill(name);
+  }
+
+  async submitClone() {
+    await this.cloneSubmitButton().click();
+  }
+
+  async cancelClone() {
+    await this.cloneCancelButton().click();
+  }
+
+  async selectCloneFolder(folderId) {
+    await this.cloneFolderPicker().locator('[data-test$="-trigger"]').first().click();
+    const option = this.page
+      .locator(`[data-test="alerts-index-dropdown-stream_type-option"][data-test-value="${folderId}"]`)
+      .first();
+    await expect(option).toBeVisible({ timeout: 10000 });
+    await option.click();
+  }
+
+  async expectCloneDialogVisible() {
+    await expect(this.cloneDialog()).toBeVisible({ timeout: 10000 });
+  }
+
+  async expectCloneDialogHidden() {
+    await expect(this.cloneDialog()).toBeHidden({ timeout: 10000 });
+  }
+
+  async expectCloneNamePrefilled(name) {
+    await expect(this.cloneNameInputField()).toHaveValue(name);
+  }
+
+  async expectStreamSelectsHidden() {
+    await expect(this.cloneStreamTypeSelect()).toHaveCount(0);
+    await expect(this.cloneStreamNameSelect()).toHaveCount(0);
+  }
+
+  async expectCloneSuccessToast() {
+    await expect(this.successToast('Alert Cloned Successfully')).toBeVisible({ timeout: 30000 });
   }
 }

--- a/tests/ui-testing/playwright-tests/Alerts/alerts-composite-clone.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alerts-composite-clone.spec.js
@@ -1,0 +1,205 @@
+// Copyright 2026 OpenObserve Inc.
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const logData = require('../../fixtures/log.json');
+const PageManager = require('../../pages/page-manager.js');
+const testLogger = require('../utils/test-logger.js');
+const { getOrgIdentifier } = require('../utils/cloud-auth.js');
+const {
+  uniq, simpleAlert, compositeAlert,
+  createAlert, findAlertId, findAlertIdInFolder, getAlert,
+  deleteAlertInFolder, deleteAlertFolder, seedAlertFixtures, createAlertFolder,
+} = require('../utils/alerts-api-helpers.js');
+
+test.describe('Clone Composite Alerts testcases', {
+  tag: ['@alerts', '@alerts-composite'],
+}, () => {
+  test.describe.configure({ mode: 'parallel' });
+
+  let pm;
+  // Track alerts as { id, folderId } so cleanup deletes the composite before
+  // its child regardless of which folder a cross-folder clone landed in.
+  let created = [];
+  let createdFolders = [];
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    pm = new PageManager(page);
+    created = [];
+    createdFolders = [];
+    await seedAlertFixtures(page);
+    await navigateToBase(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    for (const { id, folderId } of [...created].reverse()) {
+      await deleteAlertInFolder(page, id, folderId);
+    }
+    for (const folderId of [...createdFolders].reverse()) {
+      await deleteAlertFolder(page, folderId);
+    }
+  });
+
+  async function createChild(page, name) {
+    const response = await createAlert(page, simpleAlert(name));
+    expect(response.status(), await response.text()).toBe(200);
+    const id = await findAlertId(page, name);
+    expect(id).toBeTruthy();
+    created.push({ id, folderId: 'default' });
+    return { id, name };
+  }
+
+  async function createCompositeFixture(page, children) {
+    const name = uniq('composite_clone');
+    const response = await createAlert(
+      page,
+      compositeAlert(name, children.map((child) => child.id)),
+    );
+    expect(response.status(), await response.text()).toBe(200);
+    const id = await findAlertId(page, name);
+    expect(id).toBeTruthy();
+    created.push({ id, folderId: 'default' });
+    return { id, name };
+  }
+
+  async function openCompositeList(page) {
+    await page.goto(`${logData.alertUrl}?org_identifier=${getOrgIdentifier()}&folder=default`);
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await pm.compositeAlertsPage.openCompositeTab();
+  }
+
+  test('should hide stream selects and clone a composite alert into the same folder', {
+    tag: ['@composite-alert-clone', '@all', '@alerts', '@alerts-composite', '@P0'],
+  }, async ({ page }) => {
+    const child = await createChild(page, uniq('composite_clone_child'));
+    const source = await createCompositeFixture(page, [child]);
+
+    await openCompositeList(page);
+    await expect(pm.compositeAlertsPage.listBadge(source.id)).toBeVisible();
+    await expect(pm.compositeAlertsPage.listChildCount(source.id)).toContainText('1');
+
+    await pm.compositeAlertsPage.clickCloneButton(source.name);
+    await pm.compositeAlertsPage.expectCloneDialogVisible();
+    await pm.compositeAlertsPage.expectCloneNamePrefilled(source.name);
+    await pm.compositeAlertsPage.expectStreamSelectsHidden();
+
+    const newName = `${source.name} - Copy`;
+    await pm.compositeAlertsPage.fillCloneName(newName);
+    await pm.compositeAlertsPage.submitClone();
+    await pm.compositeAlertsPage.expectCloneSuccessToast();
+
+    const newId = await findAlertId(page, newName);
+    expect(newId, 'cloned composite must exist in the same folder').toBeTruthy();
+    created.push({ id: newId, folderId: 'default' });
+    await expect(pm.compositeAlertsPage.listBadge(newId)).toBeVisible();
+    await expect(pm.compositeAlertsPage.listChildCount(newId)).toContainText('1');
+    testLogger.info('Composite cloned into the same folder with a preserved child count');
+  });
+
+  test('should preserve composite identity when cloned (not flattened to simple)', {
+    tag: ['@composite-alert-clone', '@all', '@alerts', '@alerts-composite', '@P1'],
+  }, async ({ page }) => {
+    const child = await createChild(page, uniq('composite_clone_child'));
+    const source = await createCompositeFixture(page, [child]);
+    const sourceAlert = await getAlert(page, source.id);
+    expect(sourceAlert, 'GET must return the source composite').toBeTruthy();
+    expect(sourceAlert.alert_type).toBe('composite');
+    expect(sourceAlert.composite_condition, 'source composite must store its condition').toBeTruthy();
+
+    await openCompositeList(page);
+    await pm.compositeAlertsPage.clickCloneButton(source.name);
+    await pm.compositeAlertsPage.expectCloneDialogVisible();
+    await pm.compositeAlertsPage.expectStreamSelectsHidden();
+
+    const newName = `${source.name} - Copy`;
+    await pm.compositeAlertsPage.fillCloneName(newName);
+    await pm.compositeAlertsPage.submitClone();
+    await pm.compositeAlertsPage.expectCloneSuccessToast();
+
+    const newId = await findAlertId(page, newName);
+    expect(newId, 'cloned composite must be findable by name').toBeTruthy();
+    created.push({ id: newId, folderId: 'default' });
+
+    const clone = await getAlert(page, newId);
+    expect(clone, 'GET must return the cloned composite').toBeTruthy();
+    expect(clone.alert_type).toBe('composite');
+    expect(clone.composite_condition, 'clone must keep its composite_condition').toBeTruthy();
+    expect(clone.composite_condition.expression).toBe(sourceAlert.composite_condition.expression);
+    expect(clone.composite_condition.expression).toContain(`{${child.id}}`);
+    await expect(pm.compositeAlertsPage.listBadge(newId)).toBeVisible();
+    testLogger.info('Cloned composite preserved its type and child-referencing expression');
+  });
+
+  test('should route a composite clone into a different folder', {
+    tag: ['@composite-alert-clone', '@all', '@alerts', '@alerts-composite', '@P1'],
+  }, async ({ page }) => {
+    const targetFolderId = await createAlertFolder(page, uniq('clone_target'));
+    createdFolders.push(targetFolderId);
+    const child = await createChild(page, uniq('composite_clone_child'));
+    const source = await createCompositeFixture(page, [child]);
+
+    await openCompositeList(page);
+    await pm.compositeAlertsPage.clickCloneButton(source.name);
+    await pm.compositeAlertsPage.expectCloneDialogVisible();
+    await pm.compositeAlertsPage.expectStreamSelectsHidden();
+    await pm.compositeAlertsPage.selectCloneFolder(targetFolderId);
+
+    const newName = `${source.name} - Copy`;
+    await pm.compositeAlertsPage.fillCloneName(newName);
+    await pm.compositeAlertsPage.submitClone();
+    await pm.compositeAlertsPage.expectCloneSuccessToast();
+
+    const newId = await findAlertIdInFolder(page, newName, targetFolderId);
+    expect(newId, 'cloned composite must land in the chosen target folder').toBeTruthy();
+    created.push({ id: newId, folderId: targetFolderId });
+    expect(await findAlertId(page, newName), 'clone must NOT remain in the default folder').toBeUndefined();
+    testLogger.info('Composite clone routed to the target folder, not default');
+  });
+
+  test('should cancel the clone dialog without creating an alert', {
+    tag: ['@composite-alert-clone', '@all', '@alerts', '@alerts-composite', '@P1'],
+  }, async ({ page }) => {
+    const child = await createChild(page, uniq('composite_clone_child'));
+    const source = await createCompositeFixture(page, [child]);
+
+    await openCompositeList(page);
+    await pm.compositeAlertsPage.clickCloneButton(source.name);
+    await pm.compositeAlertsPage.expectCloneDialogVisible();
+    await pm.compositeAlertsPage.expectStreamSelectsHidden();
+
+    await pm.compositeAlertsPage.cancelClone();
+    await pm.compositeAlertsPage.expectCloneDialogHidden();
+
+    expect(await findAlertId(page, `${source.name} - Copy`), 'cancel must not create a clone').toBeUndefined();
+    testLogger.info('Cancel dismissed the dialog and created no clone');
+  });
+
+  test('should clone a composite whose child alert was deleted', {
+    tag: ['@composite-alert-clone', '@all', '@alerts', '@alerts-composite', '@P2'],
+  }, async ({ page }) => {
+    const child = await createChild(page, uniq('composite_clone_child'));
+    const source = await createCompositeFixture(page, [child]);
+
+    // Clone is id-based and copies the stored expression; a deleted child must
+    // not block it. Remove the child from the tracked cleanup set first.
+    await deleteAlertInFolder(page, child.id, 'default');
+    created = created.filter((entry) => entry.id !== child.id);
+
+    await openCompositeList(page);
+    await pm.compositeAlertsPage.clickCloneButton(source.name);
+    await pm.compositeAlertsPage.expectCloneDialogVisible();
+    await pm.compositeAlertsPage.expectStreamSelectsHidden();
+
+    const newName = `${source.name} - Copy`;
+    await pm.compositeAlertsPage.fillCloneName(newName);
+    await pm.compositeAlertsPage.submitClone();
+    await pm.compositeAlertsPage.expectCloneSuccessToast();
+
+    const newId = await findAlertId(page, newName);
+    expect(newId, 'clone with a stale child reference must still be created').toBeTruthy();
+    created.push({ id: newId, folderId: 'default' });
+    await expect(pm.compositeAlertsPage.listBadge(newId)).toBeVisible();
+    await expect(pm.compositeAlertsPage.listChildCount(newId)).toBeVisible();
+    testLogger.info('Composite cloned despite its child having been deleted');
+  });
+});

--- a/tests/ui-testing/playwright-tests/utils/alerts-api-helpers.js
+++ b/tests/ui-testing/playwright-tests/utils/alerts-api-helpers.js
@@ -137,6 +137,29 @@ async function findAlertId(page, name) {
   return (await listAlerts(page)).find((a) => a.name === name)?.alert_id;
 }
 
+/** Folder-aware list of alerts (the default listAlerts hardcodes folder=default). */
+async function listAlertsInFolder(page, folderId) {
+  const folder = folderId || 'default';
+  return (await (await api(page, 'get', `${urls().v2}/alerts?folder=${folder}&page_size=100`)).json()).list || [];
+}
+
+/** Find an alert by name within a specific folder (cross-folder clone lookup). */
+async function findAlertIdInFolder(page, name, folderId) {
+  return (await listAlertsInFolder(page, folderId)).find((a) => a.name === name)?.alert_id;
+}
+
+/** Best-effort delete of one alert in an arbitrary folder (default when omitted). */
+async function deleteAlertInFolder(page, id, folderId) {
+  if (!id) return;
+  await api(page, 'delete', `${urls().v2}/alerts/${id}?folder=${folderId || 'default'}`).catch(() => {});
+}
+
+/** Best-effort delete of an alerts folder (must already be empty). */
+async function deleteAlertFolder(page, folderId) {
+  if (!folderId) return;
+  await api(page, 'delete', `${urls().v2}/folders/alerts/${folderId}`).catch(() => {});
+}
+
 /** Best-effort delete of the given alert_ids (used in afterEach). */
 async function deleteAlerts(page, ids) {
   const { v2 } = urls();
@@ -249,6 +272,7 @@ module.exports = {
   simpleAlert, multiAlert, groupedSimpleAlert, realtimeAlert, cronAlert,
   compositeAlert, validateComposite, getCompositeReferences,
   createAlert, listAlerts, findAlertId, getAlert, deleteAlerts, seedAlertFixtures,
+  listAlertsInFolder, findAlertIdInFolder, deleteAlertInFolder, deleteAlertFolder,
   createAlertFolder, ingest, getAlertGroups, getAlertTransitions,
   waitForAlertOutcome, waitForAlertLevel, isFiringOutcome,
 };


### PR DESCRIPTION
## Summary
- Regression coverage for [openobserve#14306](https://github.com/openobserve/openobserve/issues/14306) ("Composite alert clone does not work"), tracked in [o2-enterprise#2598](https://github.com/openobserve/o2-enterprise/issues/2598).
- Fixed by #14351 (route composite alert clone through the dedicated `/clone` endpoint instead of flattening it into a simple alert).
- Test originally generated by the AutoE2E bot on `autoe2e/pr-14351`, never merged. Rebuilt onto current `main`: the page-object/helper additions are purely additive against main's current files (verified with `git diff HEAD --stat`, 0 deletions in both), so this is effectively the bot's own output, just current and with its `docs/test_generator/ci/*` hand-off bookkeeping stripped.
- Note: this PR corrects `compositeAlertsPage.js`'s `listCompositeTab`... actually adds a **new**, non-conflicting key (`alertListCompositeTab`) pointing at the current `alert-list-tab-composite` selector, alongside the pre-existing (stale) `listCompositeTab` key. #14308's test (opened separately, stacked on this branch) fixes that stale key directly — see that PR for detail.

## Test plan
- [x] `npx playwright test --list` — 5 tests discover cleanly
- [x] Clone dialog selectors (`alert-list-${name}-clone-alert`, `alert-list-form-dialog`, `to-be-clone-alert-name`) cross-checked against `web/src/components/alerts/AlertList.vue` on current `main`
- [ ] CI Playwright run

🤖 Generated with [Claude Code](https://claude.com/claude-code)