### PR TITLE
test: E2E coverage for composite alert trigger timestamps & status timeline

### DIFF
--- a/tests/ui-testing/pages/alertsPages/compositeAlertsPage.js
+++ b/tests/ui-testing/pages/alertsPages/compositeAlertsPage.js
@@ -22,11 +22,14 @@ export class CompositeAlertsPage {
       previewResult: '[data-test="alerts-composite-preview-result"]',
       previewRow: (id) => `[data-test="alerts-composite-preview-child-${id}"]`,
       save: '[data-test="add-alert-submit-btn"]',
-      listCompositeTab: '[data-test="tab-composite"]',
+      // `alert-list-tab-${tab.value}` (AlertList.vue) — was stale as `tab-composite`.
+      listCompositeTab: '[data-test="alert-list-tab-composite"]',
       listBadge: (id) => `[data-test="alert-list-composite-badge-${id}"]`,
       listChildCount: (id) => `[data-test="alert-list-child-count-${id}"]`,
       listReferenceCount: (id) => `[data-test="alert-list-reference-count-${id}"]`,
-      alertListCompositeTab: '[data-test="alert-list-tab-composite"]',
+      listNameCell: (name) => `[data-test="alert-list-${name}-name-cell"]`,
+      listLastTriggeredCell: '[data-test="o2-table-cell-last_triggered_at"]',
+      listLastSatisfiedCell: '[data-test="o2-table-cell-last_satisfied_at"]',
       cloneButton: (name) => `[data-test="alert-list-${name}-clone-alert"]`,
       cloneDialog: '[data-test="alert-list-form-dialog"]',
       cloneNameInputField: '[data-test="to-be-clone-alert-name-field"]',
@@ -40,6 +43,14 @@ export class CompositeAlertsPage {
       detailExpression: '[data-test="alerts-composite-detail-expression"]',
       detailChildren: '[data-test="alerts-composite-detail-children-table"]',
       detailChild: (id) => `[data-test="alerts-composite-detail-child-${id}"]`,
+      detailChildLink: (id) => `[data-test="alerts-composite-detail-child-link-${id}"]`,
+      detailLevelAt: (id) => `[data-test="alerts-composite-detail-level-at-${id}"]`,
+      detailEvaluationTimestamp: '[data-test="alerts-composite-detail-evaluated-at"]',
+      timeline: '[data-test="alerts-composite-timeline"]',
+      timelineWindow: (value) => `[data-test="alerts-composite-timeline-window-${value}"]`,
+      timelineLevel: (id) => `[data-test="alerts-composite-timeline-level-${id}"]`,
+      timelineEmpty: '[data-test="alerts-composite-timeline-empty"]',
+      previewError: (code) => `[data-test="alerts-composite-preview-error-${code}"]`,
       missingJob: '[data-test="alerts-composite-detail-missing-job"]',
       referenceChip: '[data-test="alerts-composite-reference-chip"]',
       referenceConflict: '[data-test="alerts-composite-reference-conflict"]',
@@ -62,6 +73,22 @@ export class CompositeAlertsPage {
 
   listReferenceCount(id) {
     return this.page.locator(this.locators.listReferenceCount(id));
+  }
+
+  listNameCell(name) {
+    return this.page.locator(this.locators.listNameCell(name));
+  }
+
+  listRow(name) {
+    return this.page.locator('tr', { has: this.page.locator(this.locators.listNameCell(name)) });
+  }
+
+  listLastTriggeredCell(name) {
+    return this.listRow(name).locator(this.locators.listLastTriggeredCell);
+  }
+
+  listLastSatisfiedCell(name) {
+    return this.listRow(name).locator(this.locators.listLastSatisfiedCell);
   }
 
   childNameCell(name) {
@@ -110,6 +137,38 @@ export class CompositeAlertsPage {
 
   detailChild(id) {
     return this.page.locator(this.locators.detailChild(id));
+  }
+
+  detailChildLink(id) {
+    return this.page.locator(this.locators.detailChildLink(id));
+  }
+
+  detailLevelAt(id) {
+    return this.page.locator(this.locators.detailLevelAt(id));
+  }
+
+  detailEvaluationTimestamp() {
+    return this.page.locator(this.locators.detailEvaluationTimestamp);
+  }
+
+  timeline() {
+    return this.page.locator(this.locators.timeline);
+  }
+
+  timelineWindow(value) {
+    return this.page.locator(this.locators.timelineWindow(value));
+  }
+
+  timelineLevel(id) {
+    return this.page.locator(this.locators.timelineLevel(id));
+  }
+
+  timelineEmpty() {
+    return this.page.locator(this.locators.timelineEmpty);
+  }
+
+  previewError(code) {
+    return this.page.locator(this.locators.previewError(code));
   }
 
   missingJob() {
@@ -191,10 +250,6 @@ export class CompositeAlertsPage {
 
   // ---- Composite clone dialog (AlertList.vue clone flow) ----
 
-  alertListCompositeTab() {
-    return this.page.locator(this.locators.alertListCompositeTab);
-  }
-
   cloneButton(name) {
     return this.page.locator(this.locators.cloneButton(name));
   }
@@ -232,7 +287,7 @@ export class CompositeAlertsPage {
   }
 
   async openCompositeTab() {
-    await this.alertListCompositeTab().click();
+    await this.listCompositeTab().click();
   }
 
   async clickCloneButton(name) {

--- a/tests/ui-testing/playwright-tests/Alerts/alerts-composite-ui.spec.js
+++ b/tests/ui-testing/playwright-tests/Alerts/alerts-composite-ui.spec.js
@@ -234,4 +234,200 @@ test.describe('Composite alerts — UI scenarios', {
     await expect(pm.compositeAlertsPage.expressionOr()).toBeFocused();
     await expect(pm.compositeAlertsPage.previewResult()).toHaveAttribute('aria-live', 'polite');
   });
+
+  test('composite list shows populated Last Triggered and Last Satisfied timestamps', { tag: ['@composite-alert-trigger-timestamps', '@alerts', '@all'] }, async ({ page }) => {
+    const first = await createChild(page, uniq('composite_ts_a'));
+    const second = await createChild(page, uniq('composite_ts_b'));
+    const composite = await createCompositeFixture(page, [first, second]);
+
+    await page.route(/\/api\/v2\/[^/]+\/alerts\?/, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      const response = await route.fetch();
+      const body = await response.json();
+      body.list = (body.list || []).map((item) => (
+        item.name === composite.name
+          ? { ...item, last_triggered_at: 1786500000000000, last_satisfied_at: 1786500015000000 }
+          : item
+      ));
+      await route.fulfill({ response, json: body });
+    });
+
+    await page.goto(`/web/alerts?org_identifier=${urls().org}&folder=default`);
+    await pm.compositeAlertsPage.listCompositeTab().click();
+    await expect(pm.compositeAlertsPage.listNameCell(composite.name)).toBeVisible();
+
+    await expect(pm.compositeAlertsPage.listLastTriggeredCell(composite.name)).not.toContainText('Never');
+    await expect(pm.compositeAlertsPage.listLastSatisfiedCell(composite.name)).not.toContainText('Never');
+  });
+
+  test('composite list shows Never when no scheduler trigger data exists', { tag: ['@composite-alert-trigger-timestamps', '@alerts', '@all'] }, async ({ page }) => {
+    const first = await createChild(page, uniq('composite_never_a'));
+    const second = await createChild(page, uniq('composite_never_b'));
+    const composite = await createCompositeFixture(page, [first, second]);
+
+    await page.goto(`/web/alerts?org_identifier=${urls().org}&folder=default`);
+    await pm.compositeAlertsPage.listCompositeTab().click();
+    await expect(pm.compositeAlertsPage.listNameCell(composite.name)).toBeVisible();
+
+    await expect(pm.compositeAlertsPage.listLastTriggeredCell(composite.name)).toContainText('Never');
+    await expect(pm.compositeAlertsPage.listLastSatisfiedCell(composite.name)).toContainText('Never');
+  });
+
+  test('composite form preview surfaces the real validation-error message', { tag: ['@composite-alert-trigger-timestamps', '@alerts', '@all'] }, async ({ page }) => {
+    const first = await createChild(page, uniq('composite_err_a'));
+    const second = await createChild(page, uniq('composite_err_b'));
+
+    await page.route('**/api/v2/*/alerts/composites/validate', async (route) => {
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'child_cycle_detected' }),
+      });
+    });
+
+    await pm.compositeAlertsPage.openCreate();
+    await pm.compositeAlertsPage.chooseCompositeType();
+    await pm.compositeAlertsPage.searchAndSelect(first.name, first.id);
+    await pm.compositeAlertsPage.searchAndSelect(second.name, second.id);
+
+    await expect(pm.compositeAlertsPage.previewError('child_cycle_detected')).toBeVisible();
+    await expect(pm.compositeAlertsPage.previewError('child_cycle_detected')).toContainText('child_cycle_detected');
+  });
+
+  test('composite detail renders each child Last computed level_at timestamp', { tag: ['@composite-alert-trigger-timestamps', '@alerts', '@all'] }, async ({ page }) => {
+    const first = await createChild(page, uniq('composite_level_a'));
+    const second = await createChild(page, uniq('composite_level_b'));
+    const composite = await createCompositeFixture(page, [first, second]);
+
+    await page.route(`**/api/v2/*/alerts/${composite.id}*`, async (route) => {
+      const response = await route.fetch();
+      const body = await response.json();
+      body.children = (body.children || []).map((child) => (
+        child.alert_id === first.id ? { ...child, level_at: 1786500000000000 } : child
+      ));
+      await route.fulfill({ response, json: body });
+    });
+
+    await pm.compositeAlertsPage.openDetail(composite.id);
+
+    await expect(pm.compositeAlertsPage.detailLevelAt(first.id)).toContainText(/\d/);
+    await expect(pm.compositeAlertsPage.detailLevelAt(second.id)).toContainText('—');
+  });
+
+  test('composite detail renders the status timeline with per-child lanes and current-level badges', { tag: ['@composite-alert-trigger-timestamps', '@alerts', '@all'] }, async ({ page }) => {
+    const first = await createChild(page, uniq('composite_tl_a'));
+    const second = await createChild(page, uniq('composite_tl_b'));
+    const composite = await createCompositeFixture(page, [first, second]);
+
+    await page.route('**/api/v2/*/alerts/*/composite-timeline*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          from: 1000000000000000,
+          to: 1000001000000000,
+          children: [
+            { alert_id: first.id, slot: 0, name: first.name, accessible: true, current_level: 'critical', level_since: 1000000500000000, transitions: [] },
+            { alert_id: second.id, slot: 1, name: second.name, accessible: true, current_level: 'warning', level_since: 1000000600000000, transitions: [] },
+          ],
+          result: { alert_id: composite.id, slot: null, name: composite.name, accessible: true, current_level: 'critical', level_since: 1000000500000000, transitions: [] },
+        }),
+      });
+    });
+
+    await pm.compositeAlertsPage.openDetail(composite.id);
+
+    await expect(pm.compositeAlertsPage.timeline()).toBeVisible();
+    await expect(pm.compositeAlertsPage.timelineLevel(first.id)).toBeVisible();
+    await expect(pm.compositeAlertsPage.timelineLevel(second.id)).toBeVisible();
+  });
+
+  test('timeline window toggle re-fetches for 1h and 1d', { tag: ['@composite-alert-trigger-timestamps', '@alerts', '@all'] }, async ({ page }) => {
+    const first = await createChild(page, uniq('composite_win_a'));
+    const second = await createChild(page, uniq('composite_win_b'));
+    const composite = await createCompositeFixture(page, [first, second]);
+
+    let timelineRequests = 0;
+    await page.route('**/api/v2/*/alerts/*/composite-timeline*', async (route) => {
+      timelineRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          from: 1000000000000000,
+          to: 1000001000000000,
+          children: [
+            { alert_id: first.id, slot: 0, name: first.name, accessible: true, current_level: 'critical', level_since: 1000000500000000, transitions: [] },
+          ],
+          result: { alert_id: composite.id, slot: null, name: composite.name, accessible: true, current_level: 'critical', level_since: 1000000500000000, transitions: [] },
+        }),
+      });
+    });
+
+    await pm.compositeAlertsPage.openDetail(composite.id);
+    await expect(pm.compositeAlertsPage.timeline()).toBeVisible();
+    await expect.poll(() => timelineRequests).toBe(1);
+
+    await pm.compositeAlertsPage.timelineWindow('1h').click();
+    await expect(pm.compositeAlertsPage.timelineWindow('1h')).toHaveAttribute('data-state', 'on');
+    await expect.poll(() => timelineRequests).toBe(2);
+
+    await pm.compositeAlertsPage.timelineWindow('1d').click();
+    await expect(pm.compositeAlertsPage.timelineWindow('1d')).toHaveAttribute('data-state', 'on');
+    await expect.poll(() => timelineRequests).toBe(3);
+  });
+
+  test('timeline shows the empty state when the fetch fails', { tag: ['@composite-alert-trigger-timestamps', '@alerts', '@all'] }, async ({ page }) => {
+    const first = await createChild(page, uniq('composite_empty_a'));
+    const second = await createChild(page, uniq('composite_empty_b'));
+    const composite = await createCompositeFixture(page, [first, second]);
+
+    await page.route('**/api/v2/*/alerts/*/composite-timeline*', async (route) => {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
+    });
+
+    await pm.compositeAlertsPage.openDetail(composite.id);
+
+    await expect(pm.compositeAlertsPage.timelineEmpty()).toBeVisible();
+  });
+
+  test('inaccessible child renders only the raw alert_id without a link or timestamp', { tag: ['@composite-alert-trigger-timestamps', '@alerts', '@all'] }, async ({ page }) => {
+    const first = await createChild(page, uniq('composite_mask_a'));
+    const second = await createChild(page, uniq('composite_mask_b'));
+    const composite = await createCompositeFixture(page, [first, second]);
+
+    await page.route(`**/api/v2/*/alerts/${composite.id}*`, async (route) => {
+      const response = await route.fetch();
+      const body = await response.json();
+      body.children = (body.children || []).map((child) => (
+        child.alert_id === first.id ? { alert_id: first.id, accessible: false, name: null } : child
+      ));
+      await route.fulfill({ response, json: body });
+    });
+
+    await pm.compositeAlertsPage.openDetail(composite.id);
+
+    await expect(pm.compositeAlertsPage.detailChild(first.id)).toContainText(first.id);
+    await expect(pm.compositeAlertsPage.detailChildLink(first.id)).toHaveCount(0);
+    await expect(pm.compositeAlertsPage.detailLevelAt(first.id)).toHaveCount(0);
+  });
+
+  test.fixme('composite evaluation timestamp evaluated_at is not rendered — not wired: CompositeAlertDetail.vue binds only evaluation.result/evaluation.level', { tag: ['@composite-alert-trigger-timestamps', '@alerts', '@all'] }, async ({ page }) => {
+    const first = await createChild(page, uniq('composite_eval_a'));
+    const second = await createChild(page, uniq('composite_eval_b'));
+    const composite = await createCompositeFixture(page, [first, second]);
+
+    await page.route(`**/api/v2/*/alerts/${composite.id}*`, async (route) => {
+      const response = await route.fetch();
+      const body = await response.json();
+      body.evaluation = { result: true, level: 'critical', evaluated_at: 1786500015000000 };
+      await route.fulfill({ response, json: body });
+    });
+
+    await pm.compositeAlertsPage.openDetail(composite.id);
+    await expect(pm.compositeAlertsPage.detailEvaluationTimestamp()).toContainText(/\d/);
+  });
 });


### PR DESCRIPTION
## Summary
- Regression coverage for [openobserve#14308](https://github.com/openobserve/openobserve/issues/14308) ("Composite Alerts BE issues"), tracked in [o2-enterprise#2598](https://github.com/openobserve/o2-enterprise/issues/2598).
- Fixed by #14340: composite alert list now shows real Last Triggered/Last Satisfied timestamps, child detail shows each child's Last-computed `level_at`, and a status timeline was added.
- **Stacked on #14429** (this PR's base branch) — both fixes touch `compositeAlertsPage.js`, and #14429 (composite alert clone) already added a duplicate/stale-fix for the same `composite` tab locator. Please merge #14429 first; this diff is scoped to just the incremental changes on top.
- Appends new test cases into the existing `alerts-composite-ui.spec.js` describe block (matching this suite's structure) rather than creating a new file — the bot's generated branch did the same.
- While reconciling, fixed a real pre-existing bug in the page object: `listCompositeTab` pointed at a stale selector (`[data-test="tab-composite"]`) that no longer matches `AlertList.vue` (`alert-list-tab-${tab.value}` → `alert-list-tab-composite`). #14429 had worked around this by adding a second, differently-named locator for the same element; this PR fixes the original in place and removes that duplicate.
- Includes an intentional `test.fixme`: the composite evaluation timestamp (`evaluated_at`) is not actually rendered anywhere in `CompositeAlertDetail.vue` — a real, separate, undocumented gap the generated test surfaced. Left as `.fixme` rather than silently dropped or asserted against wrong behavior.

## Test plan
- [x] `npx playwright test --list` — 21 tests across both composite specs discover cleanly (13 pre-existing + 8 new)
- [x] All new selectors cross-checked against `AlertList.vue`, `CompositeAlertDetail.vue`, `CompositeStatusTimeline.vue` on current `main`
- [ ] CI Playwright run

🤖 Generated with [Claude Code](https://claude.com/claude-code)