### PR TITLE
fix(org): address org-management review nits (backport)

### DIFF
--- a/web/src/components/iam/organizations/OrgCleanupTasksDialog.vue
+++ b/web/src/components/iam/organizations/OrgCleanupTasksDialog.vue
@@ -399,7 +399,7 @@ export default defineComponent({
       loading.value = true;
       try {
         const res = await organizationsService.get_cleanup_tasks(
-          store.state.selectedOrganization.identifier,
+          store.state.zoConfig.meta_org,
           props.orgId,
         );
         tasks.value = res.data ?? [];

--- a/web/src/components/settings/OrganizationManagement.spec.ts
+++ b/web/src/components/settings/OrganizationManagement.spec.ts
@@ -1090,7 +1090,7 @@ describe("OrganizationManagement.vue", () => {
 
     it("should render the status badge for an active org", async () => {
       await mountWithRow(orgRow({ status: "active" }));
-      expect(wrapper.find('[data-test="otable-status-0"]').text()).toBe("active");
+      expect(wrapper.find('[data-test="otable-status-0"]').text()).toBe("Active");
       expect(wrapper.find('[data-test="org-management-resurrect-btn"]').exists()).toBe(false);
       expect(wrapper.find('[data-test="org-management-cleanup-tasks-btn"]').exists()).toBe(false);
     });
@@ -1124,7 +1124,7 @@ describe("OrganizationManagement.vue", () => {
       await mountWithRow(orgRow({ status: "deleting" }));
       expect(wrapper.find('[data-test="org-management-cleanup-tasks-btn"]').exists()).toBe(true);
       expect(wrapper.find('[data-test="org-management-resurrect-btn"]').exists()).toBe(false);
-      expect(wrapper.find('[data-test="otable-status-0"]').text()).toBe("deleting");
+      expect(wrapper.find('[data-test="otable-status-0"]').text()).toBe("Deleting");
     });
 
     it("should open the cleanup dialog targeting the clicked org", async () => {
@@ -1140,11 +1140,14 @@ describe("OrganizationManagement.vue", () => {
       mockResurrect.mockResolvedValue({});
       await mountWithRow(orgRow({ status: "pending_deletion" }));
       mockGetAdminOrg.mockClear();
+      // meta org is read at call time and must differ from the selected org so
+      // the assertion proves resurrect targets zoConfig.meta_org, not the selection.
+      store.state.zoConfig.meta_org = "meta-distinct";
 
       await wrapper.find('[data-test="org-management-resurrect-btn"]').trigger("click");
       await flushPromises();
 
-      expect(mockResurrect).toHaveBeenCalledWith("default", "test-org");
+      expect(mockResurrect).toHaveBeenCalledWith("meta-distinct", "test-org");
       expect(mockToastFn).toHaveBeenCalledWith(
         expect.objectContaining({ variant: "success", message: "Organization resurrected." }),
       );

--- a/web/src/components/settings/OrganizationManagement.vue
+++ b/web/src/components/settings/OrganizationManagement.vue
@@ -102,7 +102,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               "
               size="sm"
             >
-              {{ row.status === "pending_deletion" ? pendingLabel(row) : row.status }}
+              {{ statusLabel(row) }}
             </OBadge>
           </template>
           <template #cell-actions="{ row }">
@@ -803,8 +803,16 @@ export default defineComponent({
       showCleanupDialog.value = true;
     };
 
+    const statusLabel = (row: any): string => {
+      if (row.status === "pending_deletion") return pendingLabel(row);
+      if (row.status === "deleting") return t("organization.statusDeleting");
+      if (row.status === "active") return t("organization.statusActive");
+      return row.status;
+    };
+
     const pendingLabel = (row: any): string => {
       if (!row.deleted_at || !row.grace_period_days) return t("organization.pendingDeletion");
+      // deleted_at is micros → ms
       const deletedAtMs = row.deleted_at / 1000;
       const windowMs = row.grace_period_days * 86400 * 1000;
       const msLeft = deletedAtMs + windowMs - Date.now();
@@ -815,7 +823,7 @@ export default defineComponent({
     const resurrectOrganization = async (row: any) => {
       try {
         await OrganizationServices.resurrect_org(
-          store.state.selectedOrganization.identifier,
+          store.state.zoConfig.meta_org,
           row.identifier,
         );
         toast({ variant: "success", message: t("iam.listOrganizations.organizationResurrected") });
@@ -1194,6 +1202,7 @@ export default defineComponent({
       cleanupTargetOrg,
       viewCleanupTasks,
       pendingLabel,
+      statusLabel,
       resurrectOrganization,
       store,
       // Form wiring (Options-API: schemas/defaults MUST be returned so :schema

--- a/web/src/locales/languages/en-US.json
+++ b/web/src/locales/languages/en-US.json
@@ -2416,7 +2416,9 @@
     "subscription_plan": "Subscription Plan",
     "pendingDeletion": "Pending deletion",
     "daysLeft": "{n} days left",
-    "resurrect": "Resurrect organization"
+    "resurrect": "Resurrect organization",
+    "statusActive": "Active",
+    "statusDeleting": "Deleting"
   },
   "template": {
     "search": "Search Template"


### PR DESCRIPTION
Backport of #14431 to `branch-v1.0.0`, addressing the code-review comments from the org-management restructure (already merged here via #14388):

- **Meta org identifier** — `resurrect_org` and `get_cleanup_tasks` now read `zoConfig.meta_org` directly instead of the selected org, so they keep working on a deployment that renamed its meta org. Test fixture updated so the two identifiers differ.
- **Status badge localization** — `active`/`deleting` were raw backend enums for non-English locales while `pending_deletion` was localized; all statuses now go through a `statusLabel()` helper with i18n keys.
- **Comment** — restored the `deleted_at` micros→ms one-liner.

Web-only. 125 tests pass, lint clean.
