### PR TITLE
test: Workflows canvas branch connectors & control polish regression (o2-enterprise#2598)

### DIFF
--- a/tests/ui-testing/pages/workflowsPages/workflowsPage.js
+++ b/tests/ui-testing/pages/workflowsPages/workflowsPage.js
@@ -66,6 +66,8 @@ class WorkflowsPage {
     this.paletteCondition = '[data-test="workflow-palette-condition-default-btn"]';
     this.paletteFunction = '[data-test="workflow-palette-function-default-btn"]';
     this.paletteDestination = '[data-test="workflow-palette-destination-output-btn"]';
+    // Branch is ioType "default" (a logic node), so its palette card keys as branch-default.
+    this.paletteBranch = '[data-test="workflow-palette-branch-default-btn"]';
     // Trigger node (delete only visible on node hover). The hover-`+` add-out
     // button no longer exists — clicking the node's SOURCE HANDLE opens the step
     // picker instead.
@@ -124,6 +126,13 @@ class WorkflowsPage {
     this.nodeTestPassedFor = (t) =>
       `[data-test="workflow-node-${t}-test-ok"], [data-test="workflow-node-${t}-test-rehearsal"]`;
     this.nodeTestErrorFor = (t) => `[data-test="workflow-node-${t}-test-error"]`;
+    // Branch-arm append connectors (WorkflowCanvas appendPointsFor) — the hover-revealed
+    // `+` points, each carrying an SVG path whose `d` starts at the arm's own source handle.
+    this.appendAdd = '[data-test="workflow-flow-append-add"]';
+    this.appendAddPath = '[data-test="workflow-flow-append-add"] svg path';
+    // Node hover actions (WorkflowNode): the disable/enable toggle and the Disabled badge.
+    this.nodeDisableToggle = '[data-test="workflows-node-disable-toggle"]';
+    this.nodeDisabledBadgeFor = (t) => `[data-test="workflow-node-${t}-disabled-badge"]`;
     this.listRowPrefixFor = (n) => `[data-test^="workflow-list-${n}-"]`;
     this.listRowActionFor = (n, a) => `[data-test="workflow-list-${n}-${a}"]`;
     // NDV output pane — on a successful destination send this holds the sink's
@@ -345,10 +354,15 @@ class WorkflowsPage {
     await rail.waitFor({ state: 'visible' });
   }
 
-  async addNodeFromPalette(type /* 'condition' | 'function' | 'destination' */) {
+  async addNodeFromPalette(type /* 'condition' | 'function' | 'destination' | 'branch' */) {
     await this.closeOpenDrawer();
     await this.ensureNodePaletteOpen();
-    const paletteSel = { condition: this.paletteCondition, function: this.paletteFunction, destination: this.paletteDestination }[type];
+    const paletteSel = {
+      condition: this.paletteCondition,
+      function: this.paletteFunction,
+      destination: this.paletteDestination,
+      branch: this.paletteBranch,
+    }[type];
     await this.page.locator(paletteSel).click({ timeout: DRAWER_TIMEOUT_MS });
     // "Insert-immediately" — the palette adds the node in Set-up-later mode and
     // does NOT auto-open the config panel. Click the freshly-added node to open
@@ -800,6 +814,74 @@ class WorkflowsPage {
   // ---------- enable / disable ----------
   async toggleEnable(name) {
     await this.page.locator(this.listRowActionFor(name, 'pause-start-action')).first().click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  // ---------- list pause/resume control variant ----------
+  // The pause/resume row action is a single OButton whose `:variant` flips between
+  // ghost-destructive (enabled -> pause) and ghost-success (paused -> resume). Both the
+  // `data-row-action` state and the variant class land on the same <button> root.
+  async listActionRowState(name) {
+    const btn = this.page.locator(this.listRowActionFor(name, 'pause-start-action')).first();
+    await btn.waitFor({ state: 'visible', timeout: LIST_TIMEOUT_MS });
+    return (await btn.getAttribute('data-row-action')) || '';
+  }
+
+  async listActionClasses(name) {
+    const btn = this.page.locator(this.listRowActionFor(name, 'pause-start-action')).first();
+    await btn.waitFor({ state: 'visible', timeout: LIST_TIMEOUT_MS });
+    return ((await btn.getAttribute('class')) || '').split(/\s+/);
+  }
+
+  // ---------- branch-arm connector geometry ----------
+  /**
+   * Hover the Branch node to reveal its per-arm append `+` connectors, then read each
+   * connector's SVG path start-x. Each path's `d` is `M <cx> 0 ...`; the fix under test puts
+   * `cx` at the arm's OWN handle offset (small, per-arm), not the old shared convergence
+   * point (|cx| == ARM_GAP/2 == 44). Returns the parsed start-x values in DOM order.
+   */
+  async branchAppendConnectorPaths() {
+    await this.page.locator(this.nodeFor('branch')).hover({ timeout: DRAWER_TIMEOUT_MS });
+    const paths = this.page.locator(this.appendAddPath);
+    await paths.first().waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    return paths.evaluateAll((els) =>
+      els.map((el) => {
+        const d = el.getAttribute('d') || '';
+        const m = /^M\s*(-?[\d.]+)\s+0\b/.exec(d);
+        return m ? parseFloat(m[1]) : null;
+      })
+    );
+  }
+
+  // ---------- node status badges ----------
+  /**
+   * Hover the node (revealing its hover actions) and click the disable/enable toggle, which
+   * flips the step's muted state. Scoped to the node so multiple nodes can't collide.
+   */
+  async disableNode(nodeType) {
+    const node = this.page.locator(this.nodeFor(nodeType));
+    await node.hover({ timeout: DRAWER_TIMEOUT_MS });
+    const toggle = node.locator(this.nodeDisableToggle);
+    await toggle.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await toggle.click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async expectNodeDisabledBadge(nodeType) {
+    await expect(this.page.locator(this.nodeDisabledBadgeFor(nodeType))).toBeVisible({
+      timeout: DRAWER_TIMEOUT_MS,
+    });
+  }
+
+  /**
+   * The Disabled badge lives inside the status-glyph strip that must now wrap (flex-wrap) and
+   * cap its width (max-w-*) so several badges stay inside the card. Read the badge's direct
+   * parent (that strip) and assert the two structural classes are present.
+   */
+  async expectStatusStripWraps(nodeType) {
+    const badge = this.page.locator(this.nodeDisabledBadgeFor(nodeType));
+    await badge.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    const classes = await badge.evaluate((el) => (el.parentElement ? el.parentElement.className : ''));
+    expect(classes).toContain('flex-wrap');
+    expect(classes).toContain('max-w-');
   }
 }
 

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-canvas-branch-connectors.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-canvas-branch-connectors.spec.js
@@ -1,0 +1,129 @@
+/**
+ * Workflows v1 — canvas Branch-arm connector geometry & control-polish.
+ *
+ * Covers three committed, WIRED visual/control changes:
+ *  1. Branch-arm append connectors originate from each arm's OWN source handle (WorkflowCanvas.vue
+ *     appendPointsFor — `handleDx` mirrors FlowNodeCard's handleOffset), not a shared centre point.
+ *  2. Node status-badge strip wraps (flex-wrap) and caps its width (max-w-[calc(100%-2.25rem)]) so
+ *     multiple glyphs stay inside the card (WorkflowNode.vue).
+ *  3. Resume control on a paused workflow is ghost-success (green/positive); pause stays
+ *     ghost-destructive (WorkflowsList.vue `:variant`).
+ *
+ * Enterprise-only feature: these specs run ONLY in the ENT playwright matrix (never wired into OSS),
+ * where Workflows is enabled by default (O2_WORKFLOWS_ENABLED=true). No runtime availability skip —
+ * assertEnabled() fails loudly if the feature is missing.
+ *
+ * Self-cleaning: every artifact is namespaced `wf_auto_*`; cleanup.spec.js sweeps these by prefix.
+ * No data ingestion — these are pure UI canvas + list rendering assertions.
+ *
+ * Known quirks handled by the page object: K9 (Save tooltip intercept -> JS click), K10 (~18s list load).
+ */
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+const uniq = () => `${Date.now().toString(36).slice(-5)}${Math.random().toString(36).slice(2, 5)}`;
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe(
+  'Workflows canvas branch connectors & control polish',
+  { tag: ['@workflow-canvas-branch-connectors', '@workflows', '@enterprise', '@all'] },
+  () => {
+    let pm;
+
+    test.beforeEach(async ({ page }, testInfo) => {
+      testLogger.testStart(testInfo.title, testInfo.file);
+      await navigateToBase(page);
+      pm = new PageManager(page);
+      // Enterprise-only feature: fail loudly if the build under test lacks Workflows — never skip.
+      await pm.workflowsPage.assertEnabled();
+    });
+
+    // P0 + P2 — the pause/resume control carries the right variant in BOTH states: an enabled
+    // workflow shows a destructive pause action, and once paused the same control becomes the
+    // positive green resume action (the headline control-polish change, WorkflowsList.vue:153).
+    test(
+      'should style the pause/resume control with the correct variant in both states',
+      { tag: ['@workflowCanvasBranchConnectors'] },
+      async () => {
+        const id = uniq();
+        const name = `wf_auto_${id}`;
+        await pm.workflowsPage.buildTriggerToDestinationAndSave({
+          name,
+          destName: `wf_auto_dest_${id}`,
+          url: `http://localhost:5080/api/${process.env.ORGNAME || 'default'}/wf_auto_sink/_json`,
+        });
+        await pm.workflowsPage.goToList();
+        await pm.workflowsPage.search(name);
+
+        // Enabled -> the control is a destructive pause action (P2, symmetric guard).
+        expect(await pm.workflowsPage.listActionRowState(name)).toBe('pause');
+        expect(await pm.workflowsPage.listActionClasses(name)).toContain(
+          'text-button-ghost-destructive-text'
+        );
+
+        // Pause the workflow, then assert the state flip actually landed before checking the variant.
+        await pm.workflowsPage.toggleEnable(name);
+        await expect
+          .poll(() => pm.workflowsPage.listActionRowState(name), { timeout: 30000 })
+          .toBe('resume');
+
+        // Paused -> the control is the positive green resume action (P0, the headline change).
+        expect(await pm.workflowsPage.listActionClasses(name)).toContain(
+          'text-button-ghost-success-text'
+        );
+        testLogger.info('pause/resume variant verified in both states');
+      }
+    );
+
+    // P1 — a multi-arm Branch's append connectors no longer converge on one point: each arm's `+`
+    // starts at that arm's own handle offset, so the two connector start-x values are distinct and
+    // sit close to their handles (|x| < ARM_GAP/2 == 44) instead of the old shared |x| == 44.
+    test(
+      'should place each branch arm connector at its own source handle',
+      { tag: ['@workflowCanvasBranchConnectors'] },
+      async () => {
+        await pm.workflowsPage.goToAdd();
+        await pm.workflowsPage.addNodeFromPalette('branch');
+        // addNodeFromPalette opens the branch config drawer; close it so the canvas is hoverable.
+        await pm.workflowsPage.bindNodeDrawerIfOpen();
+
+        const xs = await pm.workflowsPage.branchAppendConnectorPaths();
+        testLogger.info('branch arm connector start-x values', { xs });
+
+        // A fresh Branch is born with two arms (case-0 + else) -> two append points.
+        expect(xs).toHaveLength(2);
+        // Every connector parsed a real `M <x> 0` start coordinate.
+        expect(xs.every((x) => Number.isFinite(x))).toBe(true);
+        // Each arm's connector originates at its OWN handle, so the two start-x values differ.
+        expect(new Set(xs).size).toBe(2);
+        // And each sits close to its own handle, well inside the inter-arm gap (ARM_GAP = 88).
+        for (const x of xs) {
+          expect(Math.abs(x)).toBeLessThan(44);
+        }
+        testLogger.info('Test completed');
+      }
+    );
+
+    // P1 — the status-badge strip wraps and caps its width so a Disabled badge stays inside the
+    // card; the badge appears when a non-trigger node is disabled via its hover toggle.
+    test(
+      'should render the disabled badge inside a wrapping status strip',
+      { tag: ['@workflowCanvasBranchConnectors'] },
+      async () => {
+        await pm.workflowsPage.goToAdd();
+        await pm.workflowsPage.addNodeFromPalette('destination');
+        await pm.workflowsPage.bindNodeDrawerIfOpen();
+
+        // Hover the node and click its disable toggle (the badge appearing is the effect guard).
+        await pm.workflowsPage.disableNode('destination');
+        await pm.workflowsPage.expectNodeDisabledBadge('destination');
+        // The badge's containing strip must carry flex-wrap + a max-w cap (the structural change).
+        await pm.workflowsPage.expectStatusStripWraps('destination');
+        testLogger.info('Test completed');
+      }
+    );
+  }
+);


### PR DESCRIPTION
## Summary
Regression coverage for **o2-enterprise#2581** ("Workflow Issues"), tracked in [o2-enterprise#2598](https://github.com/openobserve/o2-enterprise/issues/2598) (test-coverage backlog for P0/P1 bugs).

Fixed by #14356 (`fix: workflows issues UI / UX`):
1. Branch-node arm connectors converging on one point instead of each arm's own handle (the reported "overlap" bug)
2. Node status-badge strip not wrapping, causing badge overlap
3. Pause/resume list action using the wrong (non-green) variant when resuming a paused workflow

Test originally generated by the AutoE2E bot on `autoe2e/pr-14356`, never merged (branch had drifted behind `main`). Rebuilt cleanly here: selectors re-verified against current `main`, including confirming the `branch`/`default` palette selector via `useWorkflowCanvas.ts`'s `nodeMeta` table.

**Placement:** `Workflows/`, not `RegressionSet/` — this area's existing enterprise CI wiring (`ci_matrix.ent.json` in the private o2-enterprise repo) already points at `actual_folder: "Workflows"`, so this matches the AutoE2E bot's original (correct) placement rather than creating an orphaned, unwired folder.

**Paired PR:** [openobserve/o2-enterprise#2609](https://github.com/openobserve/o2-enterprise/pull/2609) (same branch name `regression/workflows-p0-2598`) registers this new spec filename in the enterprise `Workflows` shard's `run_files` — Workflows is enterprise/cloud-gated, and its E2E CI matrix lives in that private repo.

## Test plan
- [x] `npx playwright test playwright-tests/Workflows/ --list` — 35 tests across 6 files discover cleanly (3 new + 32 pre-existing)
- [x] Selectors cross-checked against `WorkflowCanvas.vue`, `WorkflowNode.vue`, `WorkflowsList.vue`, `NodePalette.vue`, `useWorkflowCanvas.ts` on current `main`
- [ ] CI Playwright run (enterprise matrix, via the paired PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)