### PR TITLE
test: LLM provider type & API key handling regression (o2-enterprise#2598)

### DIFF
--- a/tests/ui-testing/pages/onlineEvalsPages/llmProvidersPage.js
+++ b/tests/ui-testing/pages/onlineEvalsPages/llmProvidersPage.js
@@ -1,0 +1,213 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// Page Object Model for the Settings > LLM Providers surface (online evals).
+// Covers the ProviderFormPage (create/edit) and the LlmProvidersSettings list.
+//
+// Enterprise/cloud-only: the `llm_providers` route is only pushed when the build
+// is enterprise or cloud (useManagementRoutes.ts), and the settings tab is gated
+// by `(isEnt || isCloud) && online_evals_enabled`. navigateToLlmProviders() probes
+// positively for the page mount and returns a boolean so callers can gate to a
+// clean SKIP on the OSS binary (mirrors navigateToModelPricing).
+
+export class LlmProvidersPage {
+    /**
+     * @param {import('@playwright/test').Page} page
+     */
+    constructor(page) {
+        this.page = page;
+
+        // ── List / shell ─────────────────────────────────────────────────────
+        this.settingsRoot = '[data-test="llm-providers-settings"]';
+        this.addProviderBtn = '[data-test="llm-providers-add-btn"]';
+        this.providersTable = '[data-test="llm-providers-table"]';
+        this.emptyState = '[data-test="llm-providers-empty-state"]';
+
+        // ── Provider form (create/edit) ──────────────────────────────────────
+        // OFormInput forwards data-test to the wrapper; the real <input> carries
+        // the `-field` suffix (OInput). OFormSelect forwards to the wrapper, with
+        // `-trigger`, `-option` (per option, plus data-test-value) suffixes.
+        this.formTitle = '[data-test="provider-form-title"]';
+        this.nameField = '[data-test="provider-form-name-input-field"]';
+        this.typeSelectTrigger = '[data-test="provider-form-type-select-trigger"]';
+        this.typeSelectOptionBase = '[data-test="provider-form-type-select-option"]';
+        this.endpointField = '[data-test="provider-form-endpoint-input-field"]';
+        this.defaultModelField = '[data-test="provider-form-default-model-input-field"]';
+        this.apiKeyField = '[data-test="provider-form-api-key-input-field"]';
+        this.saveBtn = '[data-test="provider-form-save-btn"]';
+        this.cancelBtn = '[data-test="provider-form-cancel-btn"]';
+        this.backBtn = '[data-test="provider-form-back-btn"]';
+
+        // The API-key "required" `*` marker is a conditional span with no data-test.
+        // It renders only in create mode for openai/deepseek/anthropic. It lives in
+        // the API Key label row (div.text-text-heading containing the "API Key" text),
+        // so scope the `*` span to that row. (Recommended upstream fix: give it
+        // data-test="provider-form-api-key-required"; fallback selector used here.)
+        this.apiKeyRequiredMarker =
+            'div.text-text-heading:has-text("API Key") span.text-status-error-text';
+
+        // ── Toast notifications (same audit pattern as the settings POM) ─────
+        this.toastSuccess = '[data-test-variant="success"]';
+        this.toastError = '[data-test-variant="error"]';
+
+        // ── Confirm dialog (provider delete) ─────────────────────────────────
+        this.confirmDialog = '[data-test="confirm-dialog"]';
+        this.confirmDialogOkBtn = '[data-test="o-dialog-primary-btn"]';
+    }
+
+    // ── Navigation ────────────────────────────────────────────────────────────
+
+    /**
+     * Navigate directly to Settings > LLM Providers and wait for the page mount.
+     * Enterprise/cloud-only: on the OSS binary the route does not exist, so the
+     * mount signal never appears and this returns false for a clean SKIP.
+     * @returns {Promise<boolean>}
+     */
+    async navigateToLlmProviders() {
+        const base = process.env.ZO_BASE_URL || 'http://localhost:5080';
+        const org = process.env.ORGNAME || 'default';
+        try {
+            await this.page.goto(`${base}/web/settings/llm_providers?org_identifier=${org}`, {
+                timeout: 60000,
+            });
+            await this.page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+            await this.page
+                .locator(this.settingsRoot)
+                .waitFor({ state: 'visible', timeout: 15000 });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    // ── List / form chrome ────────────────────────────────────────────────────
+
+    async clickAddProvider() {
+        const addBtn = this.page.locator(this.addProviderBtn);
+        await addBtn.waitFor({ state: 'visible', timeout: 10000 });
+        await addBtn.click();
+        await this.page.locator(this.formTitle).waitFor({ state: 'visible', timeout: 10000 });
+    }
+
+    async clickCancel() {
+        const cancelBtn = this.page.locator(this.cancelBtn);
+        await cancelBtn.waitFor({ state: 'visible', timeout: 10000 });
+        await cancelBtn.click();
+        await this.page.locator(this.formTitle).waitFor({ state: 'hidden', timeout: 10000 });
+    }
+
+    getAddProviderBtnLocator() {
+        return this.page.locator(this.addProviderBtn);
+    }
+
+    getFormTitleLocator() {
+        return this.page.locator(this.formTitle);
+    }
+
+    // ── Provider type select ──────────────────────────────────────────────────
+
+    async openProviderTypeSelect() {
+        await this.page.locator(this.typeSelectTrigger).click();
+        await this.page
+            .locator(this.typeSelectOptionBase)
+            .first()
+            .waitFor({ state: 'visible', timeout: 10000 });
+    }
+
+    async selectProviderType(value) {
+        await this.page.locator(this.typeSelectTrigger).click();
+        const option = this.page.locator(
+            `${this.typeSelectOptionBase}[data-test-value="${value}"]`,
+        );
+        await option.waitFor({ state: 'visible', timeout: 10000 });
+        await option.click();
+    }
+
+    getProviderTypeTriggerLocator() {
+        return this.page.locator(this.typeSelectTrigger);
+    }
+
+    getProviderTypeOptionLocator(value) {
+        return this.page.locator(`${this.typeSelectOptionBase}[data-test-value="${value}"]`);
+    }
+
+    // ── Form fields ───────────────────────────────────────────────────────────
+
+    async fillName(value) {
+        const input = this.page.locator(this.nameField);
+        await input.waitFor({ state: 'visible', timeout: 10000 });
+        await input.fill(value);
+    }
+
+    async fillEndpoint(value) {
+        const input = this.page.locator(this.endpointField);
+        await input.waitFor({ state: 'visible', timeout: 10000 });
+        await input.fill(value);
+    }
+
+    async fillDefaultModel(value) {
+        const input = this.page.locator(this.defaultModelField);
+        await input.waitFor({ state: 'visible', timeout: 10000 });
+        await input.fill(value);
+    }
+
+    async fillApiKey(value) {
+        const input = this.page.locator(this.apiKeyField);
+        await input.waitFor({ state: 'visible', timeout: 10000 });
+        await input.fill(value);
+    }
+
+    getApiKeyFieldLocator() {
+        return this.page.locator(this.apiKeyField);
+    }
+
+    async clickSave() {
+        await this.page.locator(this.saveBtn).click();
+    }
+
+    // ── API-key required marker ───────────────────────────────────────────────
+
+    getApiKeyRequiredMarkerLocator() {
+        return this.page.locator(this.apiKeyRequiredMarker);
+    }
+
+    // ── List rows ─────────────────────────────────────────────────────────────
+
+    getProviderRowNameLocator(name) {
+        return this.page.locator(this.providersTable).getByText(name, { exact: true });
+    }
+
+    async clickEditProvider(name) {
+        const editBtn = this.page.locator(`[data-test="llm-providers-${name}-edit-btn"]`);
+        await editBtn.waitFor({ state: 'visible', timeout: 10000 });
+        await editBtn.click();
+        await this.page.locator(this.formTitle).waitFor({ state: 'visible', timeout: 10000 });
+    }
+
+    /**
+     * Delete a provider via the list row's delete action + confirm dialog.
+     * Best-effort cleanup helper — callers wrap it in try/catch.
+     */
+    async deleteProvider(name) {
+        await this.navigateToLlmProviders();
+        const deleteBtn = this.page.locator(`[data-test="llm-providers-${name}-delete-btn"]`);
+        await deleteBtn.waitFor({ state: 'visible', timeout: 10000 });
+        await deleteBtn.click();
+        const okBtn = this.page.locator(`${this.confirmDialog} ${this.confirmDialogOkBtn}`);
+        await okBtn.waitFor({ state: 'visible', timeout: 5000 });
+        await okBtn.click();
+        await this.page
+            .locator(`[data-test="llm-providers-${name}-delete-btn"]`)
+            .waitFor({ state: 'hidden', timeout: 10000 })
+            .catch(() => {});
+    }
+
+    // ── Toast locators ────────────────────────────────────────────────────────
+
+    getToastSuccessLocator() {
+        return this.page.locator(this.toastSuccess);
+    }
+
+    getToastErrorLocator() {
+        return this.page.locator(this.toastError);
+    }
+}

--- a/tests/ui-testing/pages/page-manager.js
+++ b/tests/ui-testing/pages/page-manager.js
@@ -122,6 +122,9 @@ const FunctionsFormValidationPage = require("./functionsPages/functionsFormValid
 // ===== ANOMALY DETECTION PAGE OBJECTS =====
 const { AnomalyDetectionPage } = require("./anomalyPages/anomalyDetectionPage.js");
 
+// ===== ONLINE EVALS PAGE OBJECTS =====
+import { LlmProvidersPage } from "./onlineEvalsPages/llmProvidersPage.js";
+
 class PageManager {
   /**
    * @param {import('@playwright/test').Page} page - Playwright page instance
@@ -255,6 +258,9 @@ class PageManager {
     // ===== ANOMALY DETECTION PAGE OBJECTS =====
     this.anomalyDetectionPage = new AnomalyDetectionPage(page, this.commonActions);
     this.aiToolsetsFormValidation = new AiToolsetsFormValidationPage(page);
+
+    // ===== ONLINE EVALS PAGE OBJECTS =====
+    this.llmProvidersPage = new LlmProvidersPage(page);
 
     // ===== RUM PAGE OBJECTS =====
     this.rumFormValidation = new RumFormValidationPage(page);

--- a/tests/ui-testing/playwright-tests/OnlineEvals/llmProviderTypes.spec.js
+++ b/tests/ui-testing/playwright-tests/OnlineEvals/llmProviderTypes.spec.js
@@ -1,0 +1,243 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// Online Evals — LLM Provider Types & API Key Handling (enterprise/cloud-only)
+// Covers:
+//   - New provider types (vLLM, OpenAI-compatible) selectable in the create form
+//   - API-key "required" marker toggles with the provider type (create mode only)
+//   - Create a keyless vLLM provider (default endpoint, no API key)
+//   - Create an OpenAI-compatible provider with a custom endpoint + key
+//   - OpenAI-compatible without an endpoint → "endpoint is required" error
+//   - Editing a provider with a blank key preserves the stored key
+//   - No API-key "required" marker in edit mode
+//   - Cancel returns to the provider list without persisting
+//
+// Enterprise gating: the `llm_providers` route only exists on enterprise/cloud
+// builds (useManagementRoutes.ts pushes it when isEnterprise || isCloud). Each test
+// probes navigateToLlmProviders() and skips cleanly on the OSS binary.
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+// Per-test unique provider names (tests run --workers in parallel; a fixed name
+// would collide across runs). Timestamp + short random suffix is collision-safe.
+function uniqueName(prefix) {
+    return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+test.describe("Online Evals LLM Provider Types & API Key Handling", () => {
+    test.describe.configure({ mode: 'parallel' });
+    let pm;
+
+    test.beforeEach(async ({ page }, testInfo) => {
+        testLogger.testStart(testInfo.title, testInfo.file);
+        await navigateToBase(page);
+        pm = new PageManager(page);
+        pm.createdProviderNames = [];
+        // Enterprise/cloud-only surface — probe positively and skip on OSS.
+        const available = await pm.llmProvidersPage.navigateToLlmProviders();
+        if (!available) {
+            test.skip(true, 'LLM Providers is an enterprise/cloud-only feature — absent in the OSS build');
+            return;
+        }
+        testLogger.info('Navigated to Settings > LLM Providers');
+    });
+
+    test.afterEach(async () => {
+        // Best-effort cleanup of providers created by this test. Not an assertion —
+        // a failed delete is logged, never thrown.
+        if (!pm || !pm.createdProviderNames || pm.createdProviderNames.length === 0) return;
+        for (const name of pm.createdProviderNames) {
+            try {
+                await pm.llmProvidersPage.deleteProvider(name);
+            } catch (e) {
+                testLogger.warn(`Cleanup failed for provider ${name}: ${e.message}`);
+            }
+        }
+    });
+
+    test("should expose vLLM and OpenAI-compatible in the provider type dropdown", {
+        tag: ['@llm-provider-types', '@all', '@P0']
+    }, async () => {
+        testLogger.info('Verifying the new provider types are present in the type dropdown');
+
+        await pm.llmProvidersPage.clickAddProvider();
+        await pm.llmProvidersPage.openProviderTypeSelect();
+
+        await expect(pm.llmProvidersPage.getProviderTypeOptionLocator('vllm')).toBeVisible();
+        await expect(pm.llmProvidersPage.getProviderTypeOptionLocator('openai_compatible')).toBeVisible();
+
+        testLogger.info('vLLM and OpenAI-compatible options are present');
+    });
+
+    test("should toggle the API key required marker with the provider type", {
+        tag: ['@llm-provider-types', '@all', '@P0']
+    }, async () => {
+        testLogger.info('Verifying the API-key required marker tracks the provider type');
+
+        await pm.llmProvidersPage.clickAddProvider();
+
+        // Default type is openai → the "*" marker is visible.
+        await expect(pm.llmProvidersPage.getApiKeyRequiredMarkerLocator()).toBeVisible();
+
+        // Self-hosted / keyless types hide the marker.
+        await pm.llmProvidersPage.selectProviderType('vllm');
+        await expect(pm.llmProvidersPage.getProviderTypeTriggerLocator())
+            .toHaveAttribute('data-test-selected-value', 'vllm');
+        await expect(pm.llmProvidersPage.getApiKeyRequiredMarkerLocator()).not.toBeVisible();
+
+        await pm.llmProvidersPage.selectProviderType('openai_compatible');
+        await expect(pm.llmProvidersPage.getProviderTypeTriggerLocator())
+            .toHaveAttribute('data-test-selected-value', 'openai_compatible');
+        await expect(pm.llmProvidersPage.getApiKeyRequiredMarkerLocator()).not.toBeVisible();
+
+        // A cloud provider that requires a key shows the marker again.
+        await pm.llmProvidersPage.selectProviderType('deepseek');
+        await expect(pm.llmProvidersPage.getProviderTypeTriggerLocator())
+            .toHaveAttribute('data-test-selected-value', 'deepseek');
+        await expect(pm.llmProvidersPage.getApiKeyRequiredMarkerLocator()).toBeVisible();
+
+        testLogger.info('API-key required marker toggles correctly per provider type');
+    });
+
+    test("should create a keyless vLLM provider", {
+        tag: ['@llm-provider-types', '@all', '@P0']
+    }, async () => {
+        testLogger.info('Creating a vLLM provider with no API key');
+        const name = uniqueName('e2e-vllm');
+        pm.createdProviderNames.push(name);
+
+        await pm.llmProvidersPage.clickAddProvider();
+        await pm.llmProvidersPage.fillName(name);
+        await pm.llmProvidersPage.selectProviderType('vllm');
+        await expect(pm.llmProvidersPage.getProviderTypeTriggerLocator())
+            .toHaveAttribute('data-test-selected-value', 'vllm');
+        await pm.llmProvidersPage.fillDefaultModel('llama3.2');
+        // Endpoint and API key intentionally left blank (vLLM supplies the default
+        // endpoint and runs keyless).
+        await pm.llmProvidersPage.clickSave();
+
+        await expect(pm.llmProvidersPage.getToastSuccessLocator().first()).toBeVisible({ timeout: 10000 });
+        await expect(pm.llmProvidersPage.getToastErrorLocator()).toHaveCount(0);
+        await expect(pm.llmProvidersPage.getProviderRowNameLocator(name)).toBeVisible();
+
+        testLogger.info('Keyless vLLM provider created successfully');
+    });
+
+    test("should create an OpenAI-compatible provider with a custom endpoint and API key", {
+        tag: ['@llm-provider-types', '@all', '@P1']
+    }, async () => {
+        testLogger.info('Creating an OpenAI-compatible provider with endpoint and key');
+        const name = uniqueName('e2e-oai');
+        pm.createdProviderNames.push(name);
+
+        await pm.llmProvidersPage.clickAddProvider();
+        await pm.llmProvidersPage.fillName(name);
+        await pm.llmProvidersPage.selectProviderType('openai_compatible');
+        await expect(pm.llmProvidersPage.getProviderTypeTriggerLocator())
+            .toHaveAttribute('data-test-selected-value', 'openai_compatible');
+        await pm.llmProvidersPage.fillEndpoint('https://api.minimax.io/v1/chat/completions');
+        await pm.llmProvidersPage.fillDefaultModel('MiniMax-M3');
+        await pm.llmProvidersPage.fillApiKey('sk-test');
+        await pm.llmProvidersPage.clickSave();
+
+        await expect(pm.llmProvidersPage.getToastSuccessLocator().first()).toBeVisible({ timeout: 10000 });
+        await expect(pm.llmProvidersPage.getToastErrorLocator()).toHaveCount(0);
+        await expect(pm.llmProvidersPage.getProviderRowNameLocator(name)).toBeVisible();
+
+        testLogger.info('OpenAI-compatible provider created successfully');
+    });
+
+    test("should show an endpoint required error for OpenAI-compatible without an endpoint", {
+        tag: ['@llm-provider-types', '@all', '@P1']
+    }, async () => {
+        testLogger.info('Verifying endpoint-required error for openai_compatible');
+        const name = uniqueName('e2e-oai-noep');
+        // No provider is created (save fails) — no cleanup name to track.
+
+        await pm.llmProvidersPage.clickAddProvider();
+        await pm.llmProvidersPage.fillName(name);
+        await pm.llmProvidersPage.selectProviderType('openai_compatible');
+        await expect(pm.llmProvidersPage.getProviderTypeTriggerLocator())
+            .toHaveAttribute('data-test-selected-value', 'openai_compatible');
+        await pm.llmProvidersPage.fillDefaultModel('MiniMax-M3');
+        await pm.llmProvidersPage.fillApiKey('sk-test');
+        // Endpoint intentionally left blank — openai_compatible has no default endpoint.
+        await pm.llmProvidersPage.clickSave();
+
+        await expect(pm.llmProvidersPage.getToastErrorLocator().first())
+            .toContainText(/endpoint is required/i, { timeout: 10000 });
+        await expect(pm.llmProvidersPage.getToastSuccessLocator()).toHaveCount(0);
+        // The form stays open on validation failure.
+        await expect(pm.llmProvidersPage.getFormTitleLocator()).toBeVisible();
+
+        testLogger.info('Endpoint-required error shown correctly');
+    });
+
+    test("should preserve the stored API key when editing with a blank key", {
+        tag: ['@llm-provider-types', '@all', '@P1']
+    }, async () => {
+        testLogger.info('Verifying blank-key edit preserves the stored key');
+        const name = uniqueName('e2e-openai');
+        pm.createdProviderNames.push(name);
+
+        // Create an OpenAI provider (openai requires an API key).
+        await pm.llmProvidersPage.clickAddProvider();
+        await pm.llmProvidersPage.fillName(name);
+        await pm.llmProvidersPage.fillDefaultModel('gpt-4o');
+        await pm.llmProvidersPage.fillApiKey('sk-test');
+        await pm.llmProvidersPage.clickSave();
+        await expect(pm.llmProvidersPage.getToastSuccessLocator().first()).toBeVisible({ timeout: 10000 });
+
+        // Edit it: the write-only key seeds blank; leave it blank and change the model.
+        await pm.llmProvidersPage.clickEditProvider(name);
+        await expect(pm.llmProvidersPage.getApiKeyFieldLocator()).toHaveValue('');
+        await pm.llmProvidersPage.fillDefaultModel('gpt-4o-mini');
+        await pm.llmProvidersPage.clickSave();
+
+        // Observable proxy: save succeeds with no "No API key" / "Failed to save" error.
+        await expect(pm.llmProvidersPage.getToastSuccessLocator().first()).toBeVisible({ timeout: 10000 });
+        await expect(pm.llmProvidersPage.getToastErrorLocator()).toHaveCount(0);
+
+        testLogger.info('Blank-key edit preserved the stored API key');
+    });
+
+    test("should not show the API key required marker in edit mode", {
+        tag: ['@llm-provider-types', '@all', '@P2']
+    }, async () => {
+        testLogger.info('Verifying the required marker is hidden in edit mode');
+        const name = uniqueName('e2e-openai-edit');
+        pm.createdProviderNames.push(name);
+
+        await pm.llmProvidersPage.clickAddProvider();
+        await pm.llmProvidersPage.fillName(name);
+        await pm.llmProvidersPage.fillDefaultModel('gpt-4o');
+        await pm.llmProvidersPage.fillApiKey('sk-test');
+        await pm.llmProvidersPage.clickSave();
+        await expect(pm.llmProvidersPage.getToastSuccessLocator().first()).toBeVisible({ timeout: 10000 });
+
+        await pm.llmProvidersPage.clickEditProvider(name);
+        // In edit mode the marker is hidden even for openai (the authEditNote callout
+        // explains leave-blank-to-keep instead).
+        await expect(pm.llmProvidersPage.getApiKeyRequiredMarkerLocator()).not.toBeVisible();
+
+        testLogger.info('API-key required marker correctly hidden in edit mode');
+    });
+
+    test("should close the form without persisting when cancel is clicked", {
+        tag: ['@llm-provider-types', '@all', '@P2']
+    }, async () => {
+        testLogger.info('Verifying cancel returns to the provider list');
+
+        await pm.llmProvidersPage.clickAddProvider();
+        await expect(pm.llmProvidersPage.getFormTitleLocator()).toBeVisible();
+
+        await pm.llmProvidersPage.clickCancel();
+
+        await expect(pm.llmProvidersPage.getFormTitleLocator()).not.toBeVisible();
+        await expect(pm.llmProvidersPage.getAddProviderBtnLocator()).toBeVisible();
+        await expect(pm.llmProvidersPage.getToastErrorLocator()).toHaveCount(0);
+
+        testLogger.info('Cancel returned to the provider list without persisting');
+    });
+});


### PR DESCRIPTION
## Summary
Regression coverage for **openobserve#13754** ("Can't edit Provider"), tracked in [o2-enterprise#2598](https://github.com/openobserve/o2-enterprise/issues/2598).

Fixed by #13739: editing an Online Evals LLM provider without re-entering its API key used to clear the stored key; now it's preserved.

Test originally generated by the AutoE2E bot on `autoe2e/pr-13739`, never merged (branch had drifted well behind `main`). Rebuilt cleanly here: pulled the three relevant files at their final ("healed") state, hand-merged the `page-manager.js` registration (the branch's whole-file version would have reverted many unrelated registrations added since main moved on).

**This is the first Playwright spec for the OnlineEvals area** — no existing CI shard (OSS or enterprise) runs anything under `playwright-tests/OnlineEvals/` yet. AI Observability/Online Evals is enterprise/cloud-gated (`isEnterpriseOrCloud` in `AIObservability/Index.vue`).

**Paired PR:** [openobserve/o2-enterprise#2610](https://github.com/openobserve/o2-enterprise/pull/2610) (same branch name) adds a new `OnlineEvals` shard to `ci_matrix.ent.json` so this actually runs in CI.

## Test plan
- [x] `npx playwright test playwright-tests/OnlineEvals/ --list` — 8 tests discover cleanly
- [x] Selectors cross-checked against `ProviderFormPage.vue` and `LlmProvidersSettings.vue` on current `main`
- [ ] CI Playwright run (enterprise matrix, via the paired PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)