### PR TITLE
test: run the Search History regression from the ENT matrix only

### DIFF
--- a/tests/ui-testing/ci-matrix/ci_matrix_regression.json
+++ b/tests/ui-testing/ci-matrix/ci_matrix_regression.json
@@ -9,7 +9,6 @@
       "logs-9754.spec.js",
       "logs-9044-7354.spec.js",
       "logs-multistream-matchall-pagination.spec.js",
-      "logs-14283.spec.js",
       "logs-14303-streaming-render.spec.js"
     ],
     "disabled": []

--- a/tests/ui-testing/pages/logsPages/searchHistoryPage.js
+++ b/tests/ui-testing/pages/logsPages/searchHistoryPage.js
@@ -7,6 +7,10 @@ const testLogger = require('../../playwright-tests/utils/test-logger.js');
  * Search History is backed by usage reporting, so rows only appear once the usage
  * batch has been published — every read here polls the refresh button rather than
  * assuming the row is present on first paint.
+ *
+ * ENTERPRISE ONLY since #14316: SearchHistory.vue is gated on `zoConfig.usage_enabled`,
+ * which an OSS build hardcodes false, so on OSS the page renders only its "enable usage
+ * reporting" placeholder and none of these selectors exist.
  */
 export class SearchHistoryPage {
   constructor(page) {

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-14283.spec.js
@@ -10,6 +10,12 @@ const logData = require('../../../fixtures/log.json');
 // on top of the query carried in the URL, and the re-applied query was silently dropped.
 // The regression only shows up when the logs page has already been used in the session —
 // that is what puts the stale query in the cache — hence the two searches in beforeEach.
+//
+// ENTERPRISE ONLY. #14316 made the usage stream enterprise-only, and SearchHistory.vue is
+// gated on `zoConfig.usage_enabled`, which an OSS build now hardcodes false — the page
+// renders its "enable usage reporting" placeholder and no query can ever be re-applied.
+// This spec therefore runs from the ENT overlay (ci_matrix_regression.ent.json), not from
+// the OSS base matrix.
 test.describe('Regression: Search History re-apply retains the query (#14283)', () => {
   test.describe.configure({ mode: 'serial' });
 


### PR DESCRIPTION
The `Logs-Regression` shard has failed on every run since #14316 ("feat(usage): make the usage stream enterprise only") merged on 2026-09-10, with `logs-14283.spec.js` timing out on `[data-test="search-history-get-history-btn"]`.

## Why it cannot pass on OSS

`usage_enabled` is `enterprise_value!(false, true)` in `src/api/management/src/request/status/mod.rs` — hardcoded `false` on an OSS build, and no env var can turn it back on. `SearchHistory.vue` gates its entire page on `store.state.zoConfig.usage_enabled`; the `v-else` renders only the "enable usage reporting" placeholder, so the refresh button the page object waits for never mounts.

The regression workflow builds with plain `cargo build --profile release-ci` (no `--features enterprise`), so this is permanent, not flake. #14316 also dropped `ZO_USAGE_REPORTING_ENABLED: true` from the workflow env, which matches the timing: the last green run (09-09 17:34) still had it.

## Change

- Drop `logs-14283.spec.js` from the OSS base regression matrix.
- Header notes on the spec and on `searchHistoryPage.js` recording the gate, so it is not re-added to the OSS matrix later.

The spec file stays here — every spec lives in this repo, including the ENT-only ones such as `logs-ent.spec.js`; only the matrix decides who runs it. The paired o2-enterprise PR appends it to the overlay, where the binary is enterprise and `ZO_USAGE_REPORTING_ENABLED` is still set, so the coverage is kept rather than deleted.

## Paired PR

openobserve/o2-enterprise, same branch name `fix/search-history-enterprise-only`.

## Verification

Ran `.github/scripts/build-ci-matrix.js` against both manifests: `Logs-Regression` no longer lists the spec for OSS, and base+overlay does list it for ENT. That also exercises the script guard that an overlay must never re-list a base spec.