### PR TITLE
test: search backend API regression coverage (PromQL + histogram)

### DIFF
--- a/tests/api-testing/tests/regression/test_histogram_bucket_count_matches_total.py
+++ b/tests/api-testing/tests/regression/test_histogram_bucket_count_matches_total.py
@@ -1,0 +1,107 @@
+"""
+Histogram Bucket Count Regression (openobserve#13946)
+
+The sum of histogram bucket counts exceeded count(*) over the same time
+range (e.g. 2744 vs 2704). #12313 snapped the follower scan start_time DOWN
+to the histogram bucket boundary to keep the first chart bucket fully
+populated -- but that widened the actual scan window, so records in
+[bucket_start, requested_start) (data the user explicitly excluded) got
+counted into the first bucket, while a separate count(*) query (no
+histogram_interval) scanned the exact requested range.
+
+Fixed by #13969: the scan window sent to followers now equals the requested
+range exactly, so buckets only count in-range records and
+sum(buckets) == count(*) always holds (first bucket may be partial, which
+is correct -- Elasticsearch/Kibana date_histogram semantics).
+
+This test picks a start_time that deliberately does NOT align to the
+histogram bucket boundary, which is what exposed the bug: an aligned start
+never widened the window in the first place.
+"""
+
+import time
+from datetime import datetime, timezone
+
+STREAM = "regression_13946_stream"
+INTERVAL_SECONDS = 10
+
+
+def test_histogram_bucket_sum_matches_count_star(create_session, base_url):
+    session = create_session
+    org_id = "default"
+
+    # One record per second for 100s, so a 10s-aligned start would land
+    # exactly on a bucket edge; offsetting the query start by 3s does not.
+    now = datetime.now(timezone.utc)
+    base_ts_us = int(now.timestamp() * 1_000_000) - 100_000_000
+
+    records = []
+    for i in range(100):
+        records.append(
+            {
+                "_timestamp": base_ts_us + i * 1_000_000,
+                "level": "info",
+                "message": f"regression-13946-{i}",
+                "source": STREAM,
+            }
+        )
+    ingest_resp = session.post(f"{base_url}api/{org_id}/{STREAM}/_json", json=records)
+    assert ingest_resp.status_code == 200, (
+        f"ingest failed: {ingest_resp.status_code} {ingest_resp.text}"
+    )
+
+    time.sleep(3)  # let the write path become searchable
+
+    # Deliberately mid-bucket: 3s past the 10s boundary that base_ts_us
+    # itself starts on, and ending 4s before the natural end -- so both
+    # the first AND last bucket are partial, exactly the case #12313's
+    # snap mishandled.
+    start_time = base_ts_us + 3_000_000
+    end_time = base_ts_us + 96_000_000
+
+    count_payload = {
+        "query": {
+            "sql": f'select count(*) as total from "{STREAM}" WHERE source=\'{STREAM}\'',
+            "start_time": start_time,
+            "end_time": end_time,
+            "from": 0,
+            "size": 0,
+            "quick_mode": False,
+            "track_total_hits": False,
+        }
+    }
+    count_resp = session.post(f"{base_url}api/{org_id}/_search?type=logs", json=count_payload)
+    assert count_resp.status_code == 200, (
+        f"count(*) query failed: {count_resp.status_code} {count_resp.text}"
+    )
+    count_hits = count_resp.json().get("hits", [])
+    total_count = count_hits[0]["total"] if count_hits else 0
+
+    histogram_payload = {
+        "query": {
+            "sql": (
+                f"select histogram(_timestamp, '{INTERVAL_SECONDS} second') AS zo_sql_key, "
+                f"count(*) AS zo_sql_num from \"{STREAM}\" WHERE source='{STREAM}' "
+                "GROUP BY zo_sql_key ORDER BY zo_sql_key"
+            ),
+            "start_time": start_time,
+            "end_time": end_time,
+            "from": 0,
+            "size": 0,
+            "quick_mode": False,
+            "track_total_hits": False,
+        }
+    }
+    histogram_resp = session.post(
+        f"{base_url}api/{org_id}/_search?type=logs", json=histogram_payload
+    )
+    assert histogram_resp.status_code == 200, (
+        f"histogram query failed: {histogram_resp.status_code} {histogram_resp.text}"
+    )
+    bucket_sum = sum(row["zo_sql_num"] for row in histogram_resp.json().get("hits", []))
+
+    assert bucket_sum == total_count, (
+        f"sum(histogram buckets)={bucket_sum} != count(*)={total_count} over the same "
+        f"[{start_time}, {end_time}] range -- reproduces #13946's over-count from "
+        f"scanning past the requested start to fill the first bucket"
+    )

--- a/tests/api-testing/tests/regression/test_promql_mixed_case_metric_name.py
+++ b/tests/api-testing/tests/regression/test_promql_mixed_case_metric_name.py
@@ -1,0 +1,120 @@
+"""
+PromQL Mixed-Case Metric Name Regression (openobserve#13926)
+
+With ZO_FORMAT_STREAM_NAME_TO_LOWERCASE=false, ingestion preserves a metric
+name's original case, but the PromQL WAL distributed plan sent it to
+DataFusion as an unquoted SQL table name -- which DataFusion lowercases in
+the Flight receiver before schema lookup. An exact mixed-case query then
+returned no data even though the metric had just been ingested.
+
+Fixed by #13937: the metric is represented as a case-preserving
+TableReference::bare and its quoted form is serialized into the placeholder
+physical plan.
+
+ZO_FORMAT_STREAM_NAME_TO_LOWERCASE defaults to true, so this bug only
+reproduces with it explicitly set to false -- the server must be restarted
+with that env var for the case-preservation assertion below to be
+meaningful. The label-values lookup makes the test self-adapting either
+way: it queries whatever name the server actually stored, so it still
+passes (less meaningfully) under the default lowercase-everything config.
+"""
+
+import time
+import pytest
+
+
+MIXED_CASE_METRIC = "MyMixedCaseMetric_13926"
+
+
+def test_promql_query_returns_data_for_ingested_metric_name(create_session, base_url):
+    """Ingest a mixed-case metric, then query the PromQL API using the exact
+    name the server reports for it via label values. Must not come back
+    empty -- that emptiness, on an unquoted exact-case query, was the bug.
+    """
+    session = create_session
+    org_id = "default"
+    now_us = int(time.time() * 1_000_000)
+
+    payload = [
+        {
+            "__name__": MIXED_CASE_METRIC,
+            "__type__": "gauge",
+            "namespace": "regression_13926",
+            "_timestamp": now_us,
+            "value": 42.0,
+        }
+    ]
+    resp = session.post(f"{base_url}api/{org_id}/ingest/metrics/_json", json=payload)
+    assert resp.status_code == 200, f"metric ingest failed: {resp.status_code} {resp.text}"
+
+    # Give the write path a moment to become searchable.
+    time.sleep(2)
+
+    # Discover the name as the server actually stored it, so this test is
+    # meaningful whether ZO_FORMAT_STREAM_NAME_TO_LOWERCASE is true or false.
+    labels_resp = session.get(
+        f"{base_url}api/{org_id}/prometheus/api/v1/label/__name__/values"
+    )
+    assert labels_resp.status_code == 200, (
+        f"label values query failed: {labels_resp.status_code} {labels_resp.text}"
+    )
+    stored_names = labels_resp.json().get("data", [])
+    matches = [n for n in stored_names if n.lower() == MIXED_CASE_METRIC.lower()]
+    assert matches, (
+        f"ingested metric {MIXED_CASE_METRIC!r} not found in label values at all: {stored_names}"
+    )
+    stored_name = matches[0]
+
+    query_resp = session.get(
+        f"{base_url}api/{org_id}/prometheus/api/v1/query",
+        params={"query": stored_name},
+    )
+    assert query_resp.status_code == 200, (
+        f"query for stored name {stored_name!r} failed: "
+        f"{query_resp.status_code} {query_resp.text}"
+    )
+    result = query_resp.json().get("data", {}).get("result", [])
+    assert result, (
+        f"query for {stored_name!r} (as reported by label values) returned no "
+        f"data -- this is exactly the #13926 symptom: an exact-case query "
+        f"against a mixed-case metric name returning empty"
+    )
+
+
+@pytest.mark.skip(
+    reason=(
+        "Requires the server restarted with ZO_FORMAT_STREAM_NAME_TO_LOWERCASE=false "
+        "to actually exercise case preservation; the assertion above is the "
+        "env-agnostic version of this same check. Kept here, skipped, as "
+        "documentation of the exact reported repro for whoever runs that config."
+    )
+)
+def test_promql_query_preserves_exact_mixed_case_name(create_session, base_url):
+    session = create_session
+    org_id = "default"
+    now_us = int(time.time() * 1_000_000)
+
+    payload = [
+        {
+            "__name__": MIXED_CASE_METRIC,
+            "__type__": "gauge",
+            "namespace": "regression_13926",
+            "_timestamp": now_us,
+            "value": 42.0,
+        }
+    ]
+    resp = session.post(f"{base_url}api/{org_id}/ingest/metrics/_json", json=payload)
+    assert resp.status_code == 200
+
+    time.sleep(2)
+
+    query_resp = session.get(
+        f"{base_url}api/{org_id}/prometheus/api/v1/query",
+        params={"query": MIXED_CASE_METRIC},
+    )
+    assert query_resp.status_code == 200
+    result = query_resp.json().get("data", {}).get("result", [])
+    assert result, (
+        f"exact mixed-case query for {MIXED_CASE_METRIC!r} returned no data -- "
+        f"reproduces #13926 under ZO_FORMAT_STREAM_NAME_TO_LOWERCASE=false"
+    )


### PR DESCRIPTION
## Summary
Regression coverage for two backend/search-module items from [o2-enterprise#2598](https://github.com/openobserve/o2-enterprise/issues/2598) (test-coverage backlog). One commit per issue, both pure OSS backend fixes with no UI surface:

1. **openobserve#13926** — PromQL mixed-case metric names return empty results (fixed by #13937)
2. **openobserve#13946** — histogram bucket-count sum doesn't match count(*) (fixed by #13969)

Both were dispatched through this repo's E2E Council engine first (`.github/workflows/e2e-council-caller.yml`), which came back with useful but non-actionable results for each:
- #13937 (fix for #13926): **skipped** — the fix PR's author is not an OpenObserve org member, and the Council only processes org-authored PRs.
- #13969 (fix for #13946): correctly triaged as `Needs E2E: false` — "no user-facing UI flow to test." Right call; this is exactly why it needs an API-level pytest test instead, which the Council doesn't generate.

Both fix PRs already carry Rust unit coverage for their internal mechanism (physical-plan/codec round-trip; scan-window invariant). These pytest tests add the missing end-to-end API check the `needs: API` tag on both checklist items asks for, mirroring each PR's own manually-verified repro as an automated test.

Placed in `tests/api-testing/tests/regression/`, matching the existing per-bug pytest convention (e.g. `test_logs_to_logs_join.py`).

## Test plan
- [x] `pytest --collect-only` — both modules collect cleanly (3 tests total; one intentionally skip-marked, documented why)
- [x] Endpoint/payload shapes cross-checked against `tests/api-testing/tests/ingest/test_metrics.py` and `tests/api-testing/tests/search/test_search.py`
- [ ] Run against a live server (pytest requires `ZO_BASE_URL`/`ZO_ROOT_USER_EMAIL`/`ZO_ROOT_USER_PASSWORD`, not available in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)