### PR TITLE
perf(promql): stream the fused aggregation over the WAL rows too

### DIFF
--- a/src/promql/src/engine/call.rs
+++ b/src/promql/src/engine/call.rs
@@ -302,14 +302,7 @@ mod tests {
             _matchers: promql_parser::label::Matchers,
             _label_selector: hashbrown::HashSet<String>,
             _filters: &mut [(String, Vec<String>)],
-        ) -> Result<
-            Vec<(
-                datafusion::prelude::SessionContext,
-                Arc<datafusion::arrow::datatypes::Schema>,
-                config::meta::search::ScanStats,
-                bool,
-            )>,
-        > {
+        ) -> Result<Vec<crate::SelectorContext>> {
             self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(vec![])
         }

--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -318,14 +318,7 @@ pub(crate) mod tests {
             _machers: promql_parser::label::Matchers,
             _label_selector: HashSet<String>,
             _filters: &mut [(String, Vec<String>)],
-        ) -> datafusion::error::Result<
-            Vec<(
-                datafusion::prelude::SessionContext,
-                std::sync::Arc<datafusion::arrow::datatypes::Schema>,
-                config::meta::search::ScanStats,
-                bool,
-            )>,
-        > {
+        ) -> datafusion::error::Result<Vec<crate::SelectorContext>> {
             Ok(vec![])
         }
     }
@@ -345,14 +338,7 @@ pub(crate) mod tests {
             matchers: promql_parser::label::Matchers,
             _label_selector: HashSet<String>,
             _filters: &mut [(String, Vec<String>)],
-        ) -> datafusion::error::Result<
-            Vec<(
-                datafusion::prelude::SessionContext,
-                std::sync::Arc<datafusion::arrow::datatypes::Schema>,
-                config::meta::search::ScanStats,
-                bool,
-            )>,
-        > {
+        ) -> datafusion::error::Result<Vec<crate::SelectorContext>> {
             *self.captured.lock().unwrap() = Some(matchers);
             Ok(vec![])
         }

--- a/src/promql/src/engine/selector.rs
+++ b/src/promql/src/engine/selector.rs
@@ -16,17 +16,10 @@
 //! Vector/matrix selector evaluation and data loading. Reads `ctx`,
 //! `label_selector`, and `skip_labels`; writes `result_type`.
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
-use config::meta::{
-    promql::{NAME_LABEL, value::*},
-    search::ScanStats,
-};
-use datafusion::{
-    arrow::datatypes::Schema,
-    error::{DataFusionError, Result},
-    prelude::SessionContext,
-};
+use config::meta::promql::{NAME_LABEL, value::*};
+use datafusion::error::{DataFusionError, Result};
 use futures::future::try_join_all;
 use hashbrown::HashMap;
 use infra::errors::ErrorCodes;
@@ -38,6 +31,7 @@ use rayon::iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIter
 
 use super::Engine;
 use crate::{
+    SelectorContext,
     ast::rewrite::remove_filter_all,
     micros,
     series_loader::{LoadedMetrics, PartitionedMetrics, selector_load_data_from_datafusion},
@@ -45,7 +39,7 @@ use crate::{
 };
 
 /// One context per selected schema with its scan stats and whether the matchers still apply.
-pub(super) type SelectorContexts = Vec<(SessionContext, Arc<Schema>, ScanStats, bool)>;
+pub(super) type SelectorContexts = Vec<SelectorContext>;
 
 impl Engine {
     pub(super) fn selector_time_range(
@@ -338,7 +332,14 @@ impl Engine {
         let skip_labels = self.skip_labels;
         let mut tasks = Vec::with_capacity(ctxs.len());
         let mut abort_handles = Vec::with_capacity(ctxs.len());
-        for (ctx, schema, scan_stats, keep_filters) in ctxs {
+        for context in ctxs {
+            let SelectorContext {
+                ctx,
+                schema,
+                scan_stats,
+                keep_filters,
+                ..
+            } = context;
             let query_ctx = self.ctx.query_ctx.clone();
             let mut selector = selector.clone();
             if !keep_filters {

--- a/src/promql/src/engine/streaming.rs
+++ b/src/promql/src/engine/streaming.rs
@@ -15,8 +15,8 @@
 
 use std::{sync::Arc, time::Duration};
 
-use config::meta::promql::value::*;
-use datafusion::{arrow::datatypes::Schema, error::Result, prelude::SessionContext};
+use config::meta::{promql::value::*, search::ScanStats};
+use datafusion::error::Result;
 use futures::future::pending;
 use infra::errors::ErrorCodes;
 use promql_parser::{
@@ -29,9 +29,10 @@ use super::{
     selector::{SelectorContexts, named_selector, plain_selector},
 };
 use crate::{
-    functions, micros,
+    SelectorContext, functions, micros,
     series_stream::plan::{
-        StreamingSelector, execute_partitioned, group_label_columns, series_label_columns,
+        StreamingInputs, StreamingSelector, execute_partitioned, group_label_columns,
+        series_label_columns,
     },
     streaming_eval,
 };
@@ -152,13 +153,15 @@ impl Engine {
         op: streaming_eval::FusedAggOp,
         range: Duration,
     ) -> Result<Option<Value>> {
-        self.stream_scan_guarded(scan, |ctx, schema| async move {
-            let Some(label_cols) = group_label_columns(modifier, schema, func.name()) else {
-                return Ok(None);
-            };
+        let Some(inputs) = scan.streaming_inputs() else {
+            return Ok(None);
+        };
+        let Some(label_cols) = group_label_columns(modifier, inputs.schema, func.name()) else {
+            return Ok(None);
+        };
+        let run = async {
             let Some(sources) = execute_partitioned(
-                ctx,
-                schema,
+                &inputs,
                 &scan.streaming_selector(),
                 label_cols,
                 micros(range),
@@ -172,8 +175,8 @@ impl Engine {
             streaming_eval::aggregate(sources, op, eval)
                 .await
                 .map(|(value, _)| Some(value))
-        })
-        .await
+        };
+        self.stream_scan_guarded(scan, run).await
     }
 
     async fn stream_range_func(
@@ -182,16 +185,18 @@ impl Engine {
         func: Arc<dyn functions::RangeFunc>,
         range: Duration,
     ) -> Result<Option<(Vec<RangeValue>, usize)>> {
-        self.stream_scan_guarded(scan, |ctx, schema| async move {
-            let label_cols = if self.skip_labels {
-                vec![]
-            } else {
-                series_label_columns(schema, &scan.label_selector, func.name())
-            };
-            let eval = Arc::new(streaming_eval::RangeExpr::new(func, range, &self.eval_ctx));
+        let Some(inputs) = scan.streaming_inputs() else {
+            return Ok(None);
+        };
+        let label_cols = if self.skip_labels {
+            vec![]
+        } else {
+            series_label_columns(inputs.schema, &scan.label_selector, func.name())
+        };
+        let eval = Arc::new(streaming_eval::RangeExpr::new(func, range, &self.eval_ctx));
+        let run = async {
             match execute_partitioned(
-                ctx,
-                schema,
+                &inputs,
                 &scan.streaming_selector(),
                 label_cols,
                 micros(range),
@@ -202,30 +207,22 @@ impl Engine {
                 None => Ok(None),
                 Some(sources) => streaming_eval::eval_range(sources, eval).await.map(Some),
             }
-        })
-        .await
+        };
+        self.stream_scan_guarded(scan, run).await
     }
 
-    /// Runs `run` on the scan's single context under timeout and cancel, then accounts its stats.
-    async fn stream_scan_guarded<'s, T, Fut>(
-        &'s self,
-        scan: &'s SelectorScan,
-        run: impl FnOnce(&'s SessionContext, &'s Schema) -> Fut,
-    ) -> Result<Option<T>>
-    where
-        Fut: Future<Output = Result<Option<T>>>,
-    {
-        // a second context would split series and evaluate windows on partial data
-        let [(ctx, schema, scan_stats, _)] = scan.ctxs.as_slice() else {
-            return Ok(None);
-        };
+    /// Runs `run` under timeout and cancel, then accounts the scan's stats.
+    async fn stream_scan_guarded<T>(
+        &self,
+        scan: &SelectorScan,
+        run: impl Future<Output = Result<Option<T>>>,
+    ) -> Result<Option<T>> {
         let trace_id = &self.ctx.query_ctx.trace_id;
         let mut abort_receiver = self
             .ctx
             .table_provider
             .register_cancellation(trace_id)
             .await?;
-        let run = run(ctx, schema);
         tokio::pin!(run);
         // a cancel or an expired budget wins over a fold that happens to be ready and aborts it
         let result = tokio::select! {
@@ -256,7 +253,7 @@ impl Engine {
         let Some(result) = result? else {
             return Ok(None);
         };
-        self.ctx.scan_stats.write().await.add(scan_stats);
+        self.ctx.scan_stats.write().await.add(&scan.scan_stats());
         Ok(Some(result))
     }
 
@@ -269,14 +266,12 @@ impl Engine {
         kind: &str,
     ) -> Result<Option<SelectorScan>> {
         let query_ctx = &self.ctx.query_ctx;
-        // need_wal bails early: WAL would split series across contexts
         if !config::get_config()
             .search
             .feature_metrics_streaming_agg_enabled
             || query_ctx.query_exemplars
             || query_ctx.query_data
             || query_ctx.is_super_cluster
-            || query_ctx.need_wal
         {
             return Ok(None);
         }
@@ -286,9 +281,11 @@ impl Engine {
         let ctxs = self
             .create_selector_contexts(&selector, (start, end), &label_selector)
             .await?;
-        let scan_matchers = match ctxs.as_slice() {
-            [(_, _, _, false)] => Matchers::empty(),
-            _ => selector.matchers.clone(),
+        // only the storage context can be exact; the WAL rows were filtered when fetched
+        let scan_matchers = if ctxs.iter().any(|context| !context.keep_filters) {
+            Matchers::empty()
+        } else {
+            selector.matchers.clone()
         };
         Ok(Some(SelectorScan {
             selector,
@@ -307,6 +304,40 @@ impl SelectorScan {
             matchers: &self.scan_matchers,
             offset: self.offset,
         }
+    }
+
+    /// The contexts as one ordered input set: at most one session plus the sorted WAL rows;
+    /// `None` when no context holds rows.
+    fn streaming_inputs(&self) -> Option<StreamingInputs<'_>> {
+        let mut storage: Option<&SelectorContext> = None;
+        let mut wal = None;
+        // a context without a schema holds no rows (an empty WAL window)
+        for context in &self.ctxs {
+            if context.schema.fields().is_empty() {
+                continue;
+            }
+            if context.sorted_wal.is_some() {
+                wal = Some(context);
+            } else if storage.replace(context).is_some() {
+                // a second session would split series across contexts
+                return None;
+            }
+        }
+        let lead = storage.or(wal)?;
+        Some(StreamingInputs {
+            storage: storage.map(|context| &context.ctx),
+            wal: wal.and_then(|context| context.sorted_wal.as_deref()),
+            schema: &lead.schema,
+            partitions: lead.ctx.state().config().target_partitions(),
+        })
+    }
+
+    fn scan_stats(&self) -> ScanStats {
+        let mut stats = ScanStats::default();
+        for context in &self.ctxs {
+            stats.add(&context.scan_stats);
+        }
+        stats
     }
 }
 
@@ -333,14 +364,22 @@ mod tests {
     use tokio::sync::oneshot;
 
     use super::*;
-    use crate::{engine::tests::*, exec::PromqlContext};
+    use crate::{SortedWalRows, engine::tests::*, exec::PromqlContext};
 
     const SECOND: i64 = 1_000_000;
     const BASE: i64 = 1_000 * SECOND;
 
-    /// Serves one hash-sorted context and can hand out an already-fired cancel signal.
-    struct StreamingProvider {
+    /// A WAL context: bare when its rows are sorted, a `m` table for the loader otherwise.
+    struct WalContext {
         ctx: SessionContext,
+        sorted: Option<Arc<SortedWalRows>>,
+    }
+
+    /// Serves a hash-sorted storage context, optionally a WAL one, and can hand out an
+    /// already-fired cancel signal.
+    struct StreamingProvider {
+        storage: Option<SessionContext>,
+        wal: Option<WalContext>,
         calls: Arc<AtomicUsize>,
         canceled: bool,
         // a dropped sender reads as a cancel, so a live registration keeps it
@@ -357,14 +396,23 @@ mod tests {
             _matchers: Matchers,
             _label_selector: HashSet<String>,
             _filters: &mut [(String, Vec<String>)],
-        ) -> Result<Vec<(SessionContext, Arc<Schema>, ScanStats, bool)>> {
+        ) -> Result<Vec<SelectorContext>> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            Ok(vec![(
-                self.ctx.clone(),
-                metrics_schema(),
-                ScanStats::default(),
-                true,
-            )])
+            let context = |ctx: &SessionContext, sorted_wal| SelectorContext {
+                ctx: ctx.clone(),
+                schema: metrics_schema(),
+                scan_stats: ScanStats::default(),
+                keep_filters: true,
+                sorted_wal,
+            };
+            let mut contexts = Vec::new();
+            if let Some(storage) = &self.storage {
+                contexts.push(context(storage, None));
+            }
+            if let Some(wal) = &self.wal {
+                contexts.push(context(&wal.ctx, wal.sorted.clone()));
+            }
+            Ok(contexts)
         }
 
         async fn register_cancellation(
@@ -391,15 +439,17 @@ mod tests {
         ]))
     }
 
-    /// Two counters sampled every 20 s; the hash-sorted table exists only when `streams`.
-    fn provider(streams: bool, canceled: bool) -> StreamingProvider {
+    /// Two counters sampled every 20 s over `steps`, in `(hash, timestamp)` order.
+    fn counter_rows(steps: std::ops::Range<i64>) -> RecordBatch {
         let rows: Vec<(i64, u64, f64)> = [7u64, u64::MAX / 2]
             .into_iter()
             .flat_map(|hash| {
-                (0..10).map(move |step| (BASE + step * 20 * SECOND, hash, (step * 3) as f64))
+                steps
+                    .clone()
+                    .map(move |step| (BASE + step * 20 * SECOND, hash, (step * 3) as f64))
             })
             .collect();
-        let batch = RecordBatch::try_new(
+        RecordBatch::try_new(
             metrics_schema(),
             vec![
                 Arc::new(Int64Array::from_iter_values(rows.iter().map(|row| row.0))),
@@ -411,24 +461,85 @@ mod tests {
                 Arc::new(StringArray::from_iter_values(rows.iter().map(|_| "m"))),
             ],
         )
-        .unwrap();
-        let table = || MemTable::try_new(metrics_schema(), vec![vec![batch.clone()]]).unwrap();
+        .unwrap()
+    }
+
+    fn session() -> SessionContext {
         let mut config = SessionConfig::new().with_target_partitions(3);
         config.options_mut().optimizer.prefer_existing_sort = true;
-        let ctx = SessionContext::new_with_config(config);
-        ctx.register_table("m", Arc::new(table())).unwrap();
+        SessionContext::new_with_config(config)
+    }
+
+    fn mem_table(batch: &RecordBatch) -> MemTable {
+        MemTable::try_new(metrics_schema(), vec![vec![batch.clone()]]).unwrap()
+    }
+
+    /// The `m` table the loader reads.
+    fn register_loader_table(ctx: &SessionContext, batch: &RecordBatch) {
+        ctx.register_table("m", Arc::new(mem_table(batch))).unwrap();
+    }
+
+    /// The hash-sorted table the merge reads.
+    fn register_sorted_table(ctx: &SessionContext, batch: &RecordBatch) {
+        let sorted = mem_table(batch).with_sort_order(vec![vec![
+            col(HASH_LABEL).sort(true, false),
+            col(TIMESTAMP_COL_NAME).sort(true, false),
+        ]]);
+        ctx.register_table(format!("m{HASH_SORTED_TABLE_SUFFIX}"), Arc::new(sorted))
+            .unwrap();
+    }
+
+    /// Ten steps in storage; the hash-sorted table exists only when `streams`.
+    fn provider(streams: bool, canceled: bool) -> StreamingProvider {
+        let ctx = session();
+        let rows = counter_rows(0..10);
+        register_loader_table(&ctx, &rows);
         if streams {
-            let sorted = table().with_sort_order(vec![vec![
-                col(HASH_LABEL).sort(true, false),
-                col(TIMESTAMP_COL_NAME).sort(true, false),
-            ]]);
-            ctx.register_table(format!("m{HASH_SORTED_TABLE_SUFFIX}"), Arc::new(sorted))
-                .unwrap();
+            register_sorted_table(&ctx, &rows);
         }
         StreamingProvider {
-            ctx,
+            storage: Some(ctx),
+            wal: None,
             calls: Default::default(),
             canceled,
+            cancel: Default::default(),
+        }
+    }
+
+    /// The first five steps in storage, the last five in the WAL; a sorted WAL leaves storage
+    /// without a `m` table, so only the merge can evaluate it.
+    fn split_provider(sorted: bool, canceled: bool) -> StreamingProvider {
+        let storage = session();
+        let head = counter_rows(0..5);
+        register_sorted_table(&storage, &head);
+        let wal = session();
+        let tail = counter_rows(5..10);
+        let sorted = if sorted {
+            Some(Arc::new(SortedWalRows::new(vec![tail])))
+        } else {
+            register_loader_table(&storage, &head);
+            register_loader_table(&wal, &tail);
+            None
+        };
+        StreamingProvider {
+            storage: Some(storage),
+            wal: Some(WalContext { ctx: wal, sorted }),
+            calls: Default::default(),
+            canceled,
+            cancel: Default::default(),
+        }
+    }
+
+    /// Every row in the WAL, sorted.
+    fn wal_only_provider() -> StreamingProvider {
+        StreamingProvider {
+            storage: None,
+            wal: Some(WalContext {
+                ctx: session(),
+                sorted: Some(Arc::new(SortedWalRows::new(vec![counter_rows(0..10)]))),
+            }),
+            calls: Default::default(),
+            canceled: false,
             cancel: Default::default(),
         }
     }
@@ -456,11 +567,10 @@ mod tests {
     ) -> Engine {
         enable_streaming();
         let eval_ctx = EvalContext::new(start, BASE + 180 * SECOND, step, "test_trace".into());
-        let mut ctx = PromqlContext::new(
-            create_test_query_ctx("test_trace", "test_org", timeout),
-            provider,
-            vec![],
-        );
+        // a provider serving a WAL context is the query the search planner marks `need_wal`
+        let mut query_ctx = (*create_test_query_ctx("test_trace", "test_org", timeout)).clone();
+        query_ctx.need_wal = provider.wal.is_some();
+        let mut ctx = PromqlContext::new(Arc::new(query_ctx), provider, vec![]);
         ctx.start = eval_ctx.start;
         ctx.end = eval_ctx.end;
         if let Some(lookback) = lookback {
@@ -562,6 +672,46 @@ mod tests {
                     "{context}: {v_e} vs {v_a} at {ts_e}"
                 );
             }
+        }
+    }
+
+    /// Rows past the storage cut arrive as sorted WAL rows, which join the merge; without
+    /// storage they are the whole input.
+    #[tokio::test]
+    async fn test_sorted_wal_rows_join_the_merge() {
+        let expected = eval_sum_rate(provider(true, false), 30).await.unwrap();
+        for (name, provider) in [
+            ("storage and wal", split_provider(true, false)),
+            ("wal only", wal_only_provider()),
+        ] {
+            let actual = eval_sum_rate(provider, 30).await.unwrap();
+            assert_same_matrix(expected.clone(), actual, name);
+        }
+    }
+
+    /// Unsorted WAL rows cannot join the merge, so the query materializes on both contexts.
+    #[tokio::test]
+    async fn test_unsorted_wal_rows_materialize() {
+        let expected = eval_sum_rate(provider(true, false), 30).await.unwrap();
+        let actual = eval_sum_rate(split_provider(false, false), 30)
+            .await
+            .unwrap();
+        assert_same_matrix(expected, actual, "unsorted wal");
+    }
+
+    /// Each path reports a fired cancel in its own words: a `need_wal` query with sorted WAL
+    /// rows dies in the streaming run, one with unsorted rows in the materializing loader.
+    #[tokio::test]
+    async fn test_need_wal_streams_only_sorted_wal_rows() {
+        for (sorted, message) in [
+            (true, "streaming query canceled"),
+            (false, "grpc search canceled"),
+        ] {
+            let err = eval_sum_rate(split_provider(sorted, true), 30)
+                .await
+                .unwrap_err();
+            let text = err.to_string();
+            assert!(text.contains(message), "sorted={sorted}: {text}");
         }
     }
 

--- a/src/promql/src/lib.rs
+++ b/src/promql/src/lib.rs
@@ -43,12 +43,26 @@ mod series_stream;
 mod streaming_eval;
 pub mod utils;
 
+pub use series_stream::wal::SortedWalRows;
+
 pub const DEFAULT_LOOKBACK: Duration = Duration::from_secs(300); // 5m
 pub const MINIMAL_INTERVAL: Duration = Duration::from_secs(1); // 1s
 pub const MAX_DATA_POINTS: i64 = 256; // Width of panel: window.innerWidth / 4
 pub const DEFAULT_MAX_POINTS_PER_SERIES: usize = 30000; // Maximum number of points per series
 const DEFAULT_STEP: Duration = Duration::from_secs(15); // default step in seconds
 const MIN_TIMESERIES_POINTS_FOR_TIME_ROUNDING: i64 = 10; // Adjust this value as needed
+
+/// One context a selector scans: a session over its rows, plus those rows in hash order when
+/// they came from the WAL.
+pub struct SelectorContext {
+    pub ctx: SessionContext,
+    pub schema: Arc<Schema>,
+    pub scan_stats: ScanStats,
+    /// False once an exact index selection already applied the matchers.
+    pub keep_filters: bool,
+    /// The WAL rows in `(__hash__, _timestamp)` order, so the merge can slice them per partition.
+    pub sorted_wal: Option<Arc<SortedWalRows>>,
+}
 
 #[async_trait]
 pub trait TableProvider: Sync + Send + 'static {
@@ -60,7 +74,7 @@ pub trait TableProvider: Sync + Send + 'static {
         matchers: Matchers,
         label_selector: HashSet<String>,
         filters: &mut [(String, Vec<String>)],
-    ) -> Result<Vec<(SessionContext, Arc<Schema>, ScanStats, bool)>>;
+    ) -> Result<Vec<SelectorContext>>;
 
     /// Registers this evaluation with the host's query cancellation service.
     ///

--- a/src/promql/src/series_stream/mod.rs
+++ b/src/promql/src/series_stream/mod.rs
@@ -15,12 +15,13 @@
 
 //! Streams that deliver a query's series one at a time, so a consumer can
 //! evaluate and drop each series without materializing the full set: one over
-//! a hash-sorted scan, one over an already-materialized matrix, behind the same
-//! contract.
+//! a hash-sorted scan and sliced WAL rows, one over an already-materialized
+//! matrix, behind the same contract.
 
 pub(crate) mod hash_sorted;
 pub(crate) mod matrix;
 pub(crate) mod plan;
+pub(crate) mod wal;
 
 use config::meta::promql::value::{Labels, Sample};
 use datafusion::error::Result;
@@ -62,7 +63,7 @@ mod tests {
 
     use super::{
         hash_sorted::HashSortedSeriesStream,
-        plan::{StreamingSelector, execute_partitioned, group_label_columns},
+        plan::{StreamingInputs, StreamingSelector, execute_partitioned, group_label_columns},
     };
     use crate::{
         functions::{self, RangeFunc},
@@ -88,7 +89,7 @@ mod tests {
 
     /// The test series: counters, a counter reset, a late-only series, and a
     /// series with a null label, spread over the full hash space.
-    fn test_rows() -> Vec<Row> {
+    pub(super) fn test_rows() -> Vec<Row> {
         let dense = [10, 50, 70, 110, 130, 170];
         let series = |hash, values: [f64; 6], instance, path| {
             dense
@@ -125,7 +126,7 @@ mod tests {
         rows
     }
 
-    fn rows_to_batch(mut rows: Vec<Row>) -> RecordBatch {
+    pub(super) fn rows_to_batch(mut rows: Vec<Row>) -> RecordBatch {
         rows.sort_by_key(|row| (row.0, row.1));
         RecordBatch::try_new(
             arrow_schema(),
@@ -205,27 +206,53 @@ mod tests {
         matrix
     }
 
-    /// The sorted table's streams, projected to `label_cols`; `None` when it cannot stream.
-    pub(super) async fn sorted_table_sources(
-        ctx: &SessionContext,
+    /// The inputs' streams, projected to `label_cols`; `None` when they cannot stream.
+    pub(super) async fn input_sources(
+        inputs: &StreamingInputs<'_>,
         label_cols: Vec<String>,
         range: Duration,
-    ) -> Option<Vec<impl Future<Output = Result<HashSortedSeriesStream>> + Send + 'static>> {
+    ) -> Option<Vec<impl Future<Output = Result<HashSortedSeriesStream>> + Send + 'static + use<>>>
+    {
         let selector = StreamingSelector {
             table_name: "m",
             matchers: &Matchers::empty(),
             offset: 0,
         };
-        execute_partitioned(
-            ctx,
-            &arrow_schema(),
-            &selector,
-            label_cols,
-            micros(range),
-            &eval_ctx(),
-        )
-        .await
-        .unwrap()
+        execute_partitioned(inputs, &selector, label_cols, micros(range), &eval_ctx())
+            .await
+            .unwrap()
+    }
+
+    /// The sorted table's streams, projected to `label_cols`; `None` when it cannot stream.
+    pub(super) async fn sorted_table_sources(
+        ctx: &SessionContext,
+        label_cols: Vec<String>,
+        range: Duration,
+    ) -> Option<Vec<impl Future<Output = Result<HashSortedSeriesStream>> + Send + 'static + use<>>>
+    {
+        let schema = arrow_schema();
+        let inputs = StreamingInputs {
+            storage: Some(ctx),
+            wal: None,
+            schema: &schema,
+            partitions: 3,
+        };
+        input_sources(&inputs, label_cols, range).await
+    }
+
+    /// The aggregate over the inputs' streams; `None` when they cannot stream.
+    pub(super) async fn run_streaming_inputs(
+        inputs: &StreamingInputs<'_>,
+        modifier: &Option<LabelModifier>,
+        func_name: &str,
+        op: FusedAggOp,
+        range: Duration,
+    ) -> Option<Value> {
+        let func: Arc<dyn RangeFunc> = Arc::from(functions::fusable_range_func(func_name).unwrap());
+        let label_cols = group_label_columns(modifier, inputs.schema, func_name)?;
+        let sources = input_sources(inputs, label_cols, range).await?;
+        let eval = Arc::new(RangeExpr::new(func, range, &eval_ctx()));
+        Some(aggregate(sources, op, eval).await.unwrap().0)
     }
 
     /// The aggregate over the sorted table's streams; `None` when it cannot stream.
@@ -236,10 +263,13 @@ mod tests {
         op: FusedAggOp,
         range: Duration,
     ) -> Option<Value> {
-        let func: Arc<dyn RangeFunc> = Arc::from(functions::fusable_range_func(func_name).unwrap());
-        let label_cols = group_label_columns(modifier, &arrow_schema(), func_name)?;
-        let sources = sorted_table_sources(ctx, label_cols, range).await?;
-        let eval = Arc::new(RangeExpr::new(func, range, &eval_ctx()));
-        Some(aggregate(sources, op, eval).await.unwrap().0)
+        let schema = arrow_schema();
+        let inputs = StreamingInputs {
+            storage: Some(ctx),
+            wal: None,
+            schema: &schema,
+            partitions: 3,
+        };
+        run_streaming_inputs(&inputs, modifier, func_name, op, range).await
     }
 }

--- a/src/promql/src/series_stream/plan.rs
+++ b/src/promql/src/series_stream/plan.rs
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Planning over a selector's hash-sorted table: the label columns to project, and one set of
-//! hash-ordered input streams per partition for the hash-sorted stream to consume.
+//! Planning over a selector's hash-sorted table and WAL rows: the label columns to project, and
+//! one set of hash-ordered input streams per partition for the hash-sorted stream to consume.
 
 use std::sync::Arc;
 
@@ -42,7 +42,7 @@ use datafusion::{
 use hashbrown::HashSet;
 use promql_parser::{label::Matchers, parser::LabelModifier};
 
-use super::hash_sorted::HashSortedSeriesStream;
+use super::{hash_sorted::HashSortedSeriesStream, wal::SortedWalRows};
 use crate::{
     functions::KEEP_METRIC_NAME_FUNC,
     utils::{apply_matchers, apply_time_window},
@@ -55,11 +55,21 @@ pub(crate) struct StreamingSelector<'a> {
     pub offset: i64,
 }
 
-/// One hash-sorted stream per partition over the selector's hash-sorted table, projected to the
-/// sample columns plus `label_cols`; `None` when the layout cannot stream in order.
+/// Where a selector's ordered rows come from: the session over its files and its WAL rows.
+pub(crate) struct StreamingInputs<'a> {
+    /// The session whose hash-sorted table scans the files; `None` when every row is in the WAL.
+    pub storage: Option<&'a SessionContext>,
+    pub wal: Option<&'a SortedWalRows>,
+    pub schema: &'a Schema,
+    /// The hash partitions the merge splits into; the session's target partitions.
+    pub partitions: usize,
+}
+
+/// One hash-sorted stream per partition over the selector's hash-sorted table and WAL rows,
+/// projected to the sample columns plus `label_cols`; `None` when the layout cannot stream in
+/// order.
 pub(crate) async fn execute_partitioned(
-    ctx: &SessionContext,
-    schema: &Schema,
+    inputs: &StreamingInputs<'_>,
     selector: &StreamingSelector<'_>,
     label_cols: Vec<String>,
     lookback: i64,
@@ -67,12 +77,69 @@ pub(crate) async fn execute_partitioned(
 ) -> Result<
     Option<Vec<impl Future<Output = Result<HashSortedSeriesStream>> + Send + 'static + use<>>>,
 > {
-    if schema
+    if inputs
+        .schema
         .field_with_name(HASH_LABEL)
         .is_ok_and(|field| field.data_type() != &DataType::UInt64)
     {
         return Ok(None);
     }
+    // a label column missing from the WAL rows would abort the fold: materialize instead
+    if let Some(schema) = inputs.wal.and_then(SortedWalRows::schema)
+        && label_cols
+            .iter()
+            .any(|name| schema.field_with_name(name).is_err())
+    {
+        log::info!(
+            "[trace_id: {}] [PromQL] streaming fallback: the WAL rows lack a label column of {label_cols:?}",
+            eval_ctx.trace_id
+        );
+        return Ok(None);
+    }
+    let partitions = inputs.partitions;
+    let mut partition_inputs = match inputs.storage {
+        Some(ctx) => {
+            let Some(partition_inputs) = storage_partition_inputs(
+                ctx,
+                selector,
+                &label_cols,
+                lookback,
+                partitions,
+                eval_ctx,
+            )
+            .await?
+            else {
+                return Ok(None);
+            };
+            partition_inputs
+        }
+        None => (0..partitions).map(|_| Vec::new()).collect(),
+    };
+    if let Some(wal) = inputs.wal {
+        for (streams, (lo, hi)) in partition_inputs.iter_mut().zip(hash_partitions(partitions)) {
+            streams.extend(wal.chain(lo, hi));
+        }
+    }
+    let label_cols = Arc::new(label_cols);
+    let offset = selector.offset;
+    Ok(Some(
+        partition_inputs
+            .into_iter()
+            .map(|streams| HashSortedSeriesStream::start(streams, label_cols.clone(), offset))
+            .collect(),
+    ))
+}
+
+/// Every partition's ordered chains over the session's hash-sorted table; `None` when the table
+/// is missing or a partition's plan cannot stream in order.
+async fn storage_partition_inputs(
+    ctx: &SessionContext,
+    selector: &StreamingSelector<'_>,
+    label_cols: &[String],
+    lookback: i64,
+    partitions: usize,
+    eval_ctx: &EvalContext,
+) -> Result<Option<Vec<Vec<SendableRecordBatchStream>>>> {
     let sorted_table = format!("{}{HASH_SORTED_TABLE_SUFFIX}", selector.table_name);
     let Ok(df) = ctx.table(sorted_table.as_str()).await else {
         return Ok(None);
@@ -87,20 +154,7 @@ pub(crate) async fn execute_partitioned(
     let df = apply_matchers(df, selector.matchers)?;
     let mut columns = vec![TIMESTAMP_COL_NAME, HASH_LABEL, VALUE_LABEL];
     columns.extend(label_cols.iter().map(String::as_str));
-    let partitions = ctx.state().config().target_partitions();
-    let Some(partition_inputs) =
-        build_partition_inputs(&df, &columns, partitions, &eval_ctx.trace_id).await?
-    else {
-        return Ok(None);
-    };
-    let label_cols = Arc::new(label_cols);
-    let offset = selector.offset;
-    Ok(Some(
-        partition_inputs
-            .into_iter()
-            .map(|streams| HashSortedSeriesStream::start(streams, label_cols.clone(), offset))
-            .collect(),
-    ))
+    build_partition_inputs(&df, &columns, partitions, &eval_ctx.trace_id).await
 }
 
 /// Every partition's ordered input streams; `None` (logged) means a partition's plan cannot stream
@@ -258,12 +312,17 @@ mod tests {
     use std::time::Duration;
 
     use datafusion::{
-        arrow::datatypes::Field, datasource::MemTable, physical_plan::empty::EmptyExec,
+        arrow::{array::RecordBatch, datatypes::Field},
+        datasource::MemTable,
+        physical_plan::empty::EmptyExec,
     };
     use promql_parser::label::Labels as ModifierLabels;
 
     use super::{super::tests::*, *};
-    use crate::streaming_eval::{FusedAggOp, tests::by};
+    use crate::streaming_eval::{
+        FusedAggOp,
+        tests::{assert_matrix_close, by, canonical_matrix},
+    };
 
     #[test]
     fn test_group_label_columns_resolution() {
@@ -341,6 +400,80 @@ mod tests {
                 assert_eq!(pair[0].1.wrapping_add(1), pair[1].0);
             }
         }
+    }
+
+    /// Storage holds one "file" and the WAL the other, so only the merge across both sees every
+    /// series whole; the WAL alone must fold the same as the sorted table.
+    #[tokio::test]
+    async fn test_streaming_merges_wal_rows_into_the_partitions() {
+        let range = Duration::from_secs(60);
+        let whole = session_ctx();
+        register_sorted_table(&whole);
+        let [storage_rows, wal_rows]: [Vec<RecordBatch>; 2] =
+            sorted_partitions().try_into().unwrap();
+        let storage = session_ctx();
+        let table = MemTable::try_new(arrow_schema(), vec![storage_rows])
+            .unwrap()
+            .with_sort_order(vec![vec![
+                col(HASH_LABEL).sort(true, false),
+                col(TIMESTAMP_COL_NAME).sort(true, false),
+            ]]);
+        storage
+            .register_table(format!("m{HASH_SORTED_TABLE_SUFFIX}"), Arc::new(table))
+            .unwrap();
+        let wal = SortedWalRows::new(wal_rows);
+        let all_in_wal = SortedWalRows::new(vec![rows_to_batch(test_rows())]);
+        let schema = arrow_schema();
+
+        for modifier in [None, by(&["path"]), by(&["instance", "path"])] {
+            let expected = run_streaming(&whole, &modifier, "rate", FusedAggOp::Sum, range)
+                .await
+                .unwrap();
+            let cases = [
+                ("storage and wal", Some(&storage), &wal),
+                ("wal only", None, &all_in_wal),
+            ];
+            for (name, storage, wal) in cases {
+                let inputs = StreamingInputs {
+                    storage,
+                    wal: Some(wal),
+                    schema: &schema,
+                    partitions: 3,
+                };
+                let actual =
+                    run_streaming_inputs(&inputs, &modifier, "rate", FusedAggOp::Sum, range)
+                        .await
+                        .expect("sorted WAL rows stream");
+                assert_matrix_close(
+                    canonical_matrix(expected.clone()),
+                    canonical_matrix(actual),
+                    &format!("{name} (modifier: {modifier:?})"),
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_streaming_falls_back_when_wal_rows_lack_a_group_column() {
+        let ctx = session_ctx();
+        register_sorted_table(&ctx);
+        let schema = arrow_schema();
+        let batch = rows_to_batch(test_rows());
+        let without_path = batch.project(&[0, 1, 2, 3]).unwrap();
+        let wal = SortedWalRows::new(vec![without_path]);
+        let inputs = StreamingInputs {
+            storage: Some(&ctx),
+            wal: Some(&wal),
+            schema: &schema,
+            partitions: 3,
+        };
+        let range = Duration::from_secs(60);
+        let folded =
+            run_streaming_inputs(&inputs, &by(&["path"]), "rate", FusedAggOp::Sum, range).await;
+        assert!(folded.is_none());
+        // without the missing column the same rows merge
+        let folded = run_streaming_inputs(&inputs, &None, "rate", FusedAggOp::Sum, range).await;
+        assert!(folded.is_some());
     }
 
     #[tokio::test]

--- a/src/promql/src/series_stream/wal.rs
+++ b/src/promql/src/series_stream/wal.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The WAL rows of a selector, held in hash order so every partition's merge takes its own
+//! slice without a scan.
+
+use config::meta::promql::HASH_LABEL;
+use datafusion::{
+    arrow::{
+        array::{AsArray, RecordBatch},
+        datatypes::{SchemaRef, UInt64Type},
+    },
+    execution::SendableRecordBatchStream,
+    physical_plan::stream::RecordBatchStreamAdapter,
+};
+use futures::stream;
+
+/// Batches in `(__hash__, _timestamp)` order across their whole sequence, as one node's sorted
+/// scan or a sort-preserving merge over several delivers them.
+pub struct SortedWalRows {
+    batches: Vec<RecordBatch>,
+}
+
+impl SortedWalRows {
+    pub fn new(batches: Vec<RecordBatch>) -> Self {
+        Self { batches }
+    }
+
+    /// The schema of the rows; `None` when there are no batches.
+    pub(crate) fn schema(&self) -> Option<SchemaRef> {
+        self.batches.first().map(RecordBatch::schema)
+    }
+
+    /// The rows whose hash lies in `lo..=hi`, as one ordered chain of zero-copy slices; `None`
+    /// when there are none.
+    pub(crate) fn chain(&self, lo: u64, hi: u64) -> Option<SendableRecordBatchStream> {
+        let mut slices = Vec::new();
+        for batch in &self.batches {
+            let hashes = batch[HASH_LABEL].as_primitive::<UInt64Type>().values();
+            let (Some(first), Some(last)) = (hashes.first(), hashes.last()) else {
+                continue;
+            };
+            if *first > hi {
+                break;
+            }
+            if *last < lo {
+                continue;
+            }
+            let start = hashes.partition_point(|&hash| hash < lo);
+            let end = hashes.partition_point(|&hash| hash <= hi);
+            if end > start {
+                slices.push(batch.slice(start, end - start));
+            }
+        }
+        let schema = slices.first()?.schema();
+        Some(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::iter(slices.into_iter().map(Ok)),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::{
+        array::UInt64Array,
+        datatypes::{DataType, Field, Schema},
+    };
+    use futures::TryStreamExt;
+
+    use super::*;
+
+    fn batch(hashes: &[u64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            HASH_LABEL,
+            DataType::UInt64,
+            false,
+        )]));
+        RecordBatch::try_new(schema, vec![Arc::new(UInt64Array::from(hashes.to_vec()))]).unwrap()
+    }
+
+    /// The hashes of each batch the chain yields; `None` when there is no chain.
+    async fn chain_hashes(rows: &SortedWalRows, lo: u64, hi: u64) -> Option<Vec<Vec<u64>>> {
+        let batches: Vec<RecordBatch> = rows.chain(lo, hi)?.try_collect().await.unwrap();
+        Some(
+            batches
+                .iter()
+                .map(|batch| {
+                    batch[HASH_LABEL]
+                        .as_primitive::<UInt64Type>()
+                        .values()
+                        .to_vec()
+                })
+                .collect(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_chain_cuts_runs_at_the_partition_bounds() {
+        let rows = SortedWalRows::new(vec![
+            batch(&[1, 1, 3]),
+            batch(&[3, 5, 8]),
+            batch(&[]),
+            batch(&[8, 9, 20]),
+            batch(&[30, 31]),
+        ]);
+        // inclusive bounds, a run continuing across batches, an empty batch in between
+        assert_eq!(
+            chain_hashes(&rows, 3, 9).await,
+            Some(vec![vec![3], vec![3, 5, 8], vec![8, 9]])
+        );
+        assert_eq!(
+            chain_hashes(&rows, 0, u64::MAX)
+                .await
+                .unwrap()
+                .concat()
+                .len(),
+            11
+        );
+        assert_eq!(chain_hashes(&rows, 31, 31).await, Some(vec![vec![31]]));
+        assert_eq!(chain_hashes(&rows, 10, 19).await, None);
+        assert_eq!(chain_hashes(&rows, 32, u64::MAX).await, None);
+    }
+}

--- a/src/promql_service/src/search/grpc/mod.rs
+++ b/src/promql_service/src/search/grpc/mod.rs
@@ -27,11 +27,11 @@ use config::{
     },
     utils::time::{now_micros, second_micros},
 };
-use datafusion::{arrow::datatypes::Schema, error::DataFusionError, prelude::SessionContext};
+use datafusion::error::DataFusionError;
 use hashbrown::HashSet;
 use infra::errors::Result;
 use promql::{
-    DEFAULT_LOOKBACK, TableProvider,
+    DEFAULT_LOOKBACK, SelectorContext, TableProvider,
     ast::{
         name_visitor,
         selector_window::{SelectorWindow, selector_window},
@@ -46,8 +46,6 @@ use tokio::sync::mpsc;
 
 mod storage;
 mod wal;
-
-type Context = (SessionContext, Arc<Schema>, ScanStats, bool);
 
 /// What a range query's groups are planned from.
 struct GroupPlan {
@@ -72,7 +70,7 @@ impl TableProvider for StorageProvider {
         matchers: Matchers,
         label_selector: HashSet<String>,
         filters: &mut [(String, Vec<String>)],
-    ) -> datafusion::error::Result<Vec<Context>> {
+    ) -> datafusion::error::Result<Vec<SelectorContext>> {
         let mut ctxs = Vec::new();
         // register storage table
         let trace_id = self.trace_id.to_owned() + "-storage-" + stream_name;

--- a/src/promql_service/src/search/grpc/storage.rs
+++ b/src/promql_service/src/search/grpc/storage.rs
@@ -31,6 +31,7 @@ use infra::{
 };
 use itertools::Itertools;
 use metrics_index::MetricsFileLayout;
+use promql::SelectorContext;
 use promql_parser::label::Matchers;
 use search::{
     datafusion::{exec::register_metrics_table, sort_order::FileSortOrder},
@@ -38,8 +39,6 @@ use search::{
 };
 use search_service::match_source;
 use tracing::Instrument;
-
-use crate::search::grpc::Context;
 
 #[tracing::instrument(name = "promql:search:grpc:storage:create_context", skip(trace_id))]
 pub(crate) async fn create_context(
@@ -49,7 +48,7 @@ pub(crate) async fn create_context(
     time_range: (i64, i64),
     matchers: Matchers,
     filters: &mut [(String, Vec<String>)],
-) -> Result<Option<Context>> {
+) -> Result<Option<SelectorContext>> {
     let enter_span = tracing::span::Span::current();
 
     // check if we are allowed to search
@@ -246,7 +245,13 @@ pub(crate) async fn create_context(
         register_metrics_table(&session, schema.clone(), stream_name, files, sort_order).await?;
 
     // keep_filters=false only when the pruner proved its selections exact
-    Ok(Some((ctx, schema, scan_stats, keep_filters)))
+    Ok(Some(SelectorContext {
+        ctx,
+        schema,
+        scan_stats,
+        keep_filters,
+        sorted_wal: None,
+    }))
 }
 
 /// Prefetch the `.midx` sidecars like the Tantivy path prefetches `.ttv` files:

--- a/src/promql_service/src/search/grpc/wal.rs
+++ b/src/promql_service/src/search/grpc/wal.rs
@@ -18,19 +18,22 @@ use std::sync::Arc;
 use arrow::record_batch::RecordBatch;
 use config::{
     TIMESTAMP_COL_NAME, get_config,
-    meta::{cluster::IntoArcVec, search::ScanStats, stream::StreamType},
+    meta::{cluster::IntoArcVec, promql::HASH_LABEL, search::ScanStats, stream::StreamType},
 };
 use datafusion::{
-    arrow::datatypes::Schema,
+    arrow::datatypes::{DataType, Schema},
     common::TableReference,
     datasource::MemTable,
     error::{DataFusionError, Result},
-    physical_plan::visit_execution_plan,
+    physical_plan::{sorts::sort_preserving_merge::SortPreservingMergeExec, visit_execution_plan},
     prelude::{SessionContext, col, lit},
 };
 use hashbrown::HashSet;
 use infra::cluster::get_cached_online_ingester_nodes;
-use promql::utils::{apply_label_selector, apply_matchers};
+use promql::{
+    SelectorContext, SortedWalRows,
+    utils::{apply_label_selector, apply_matchers},
+};
 use promql_parser::label::Matchers;
 use proto::cluster_rpc::{self, IndexInfo, QueryIdentifier};
 use search::{
@@ -40,13 +43,12 @@ use search::{
             remote_scan_exec::RemoteScanExec,
         },
         exec::DataFusionContextBuilder,
+        sort_order::FileSortOrder,
         table_provider::empty_table::NewEmptyTable,
     },
     utils::ScanStatsVisitor,
 };
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-
-use crate::search::grpc::Context;
 
 #[tracing::instrument(name = "promql:search:grpc:wal:create_context", skip(trace_id))]
 pub(crate) async fn create_context(
@@ -56,7 +58,7 @@ pub(crate) async fn create_context(
     time_range: (i64, i64),
     matchers: Matchers,
     label_selector: HashSet<String>,
-) -> Result<Vec<Context>> {
+) -> Result<Vec<SelectorContext>> {
     let mut resp = vec![];
     // fetch all schema versions, get latest schema
     let schema = Arc::new(
@@ -73,6 +75,7 @@ pub(crate) async fn create_context(
     }
 
     // get wal record batches
+    let sort_order = wal_sort_order(&schema);
     let (stats, batches, schema) = get_wal_batches(
         trace_id,
         org_id,
@@ -81,17 +84,23 @@ pub(crate) async fn create_context(
         time_range,
         matchers,
         label_selector,
+        sort_order,
     )
     .await?;
 
     if batches.is_empty() {
-        return Ok(vec![(
-            SessionContext::new(),
-            Arc::new(Schema::empty()),
-            ScanStats::default(),
-            true,
-        )]);
+        return Ok(vec![SelectorContext {
+            ctx: SessionContext::new(),
+            schema: Arc::new(Schema::empty()),
+            scan_stats: ScanStats::default(),
+            keep_filters: true,
+            sorted_wal: None,
+        }]);
     }
+    // the same batches, sliced per partition by the streaming merge
+    let sorted_wal = sort_order
+        .is_sorted()
+        .then(|| Arc::new(SortedWalRows::new(batches.clone())));
 
     log::info!(
         "[trace_id {trace_id}] promql->wal->search: load wal files: batches {}, scan_size {}",
@@ -107,9 +116,28 @@ pub(crate) async fn create_context(
     let mem_table = Arc::new(MemTable::try_new(schema.clone(), vec![batches])?);
     log::info!("[trace_id {trace_id}] promql->wal->search: register mem table done");
     ctx.register_table(stream_name, mem_table)?;
-    resp.push((ctx, schema, stats, true));
+    resp.push(SelectorContext {
+        ctx,
+        schema,
+        scan_stats: stats,
+        keep_filters: true,
+        sorted_wal,
+    });
 
     Ok(resp)
+}
+
+/// The order the WAL scan asks the ingesters for: `(__hash__, _timestamp)` when the streaming
+/// merge can slice it, so the querier only merges the node streams.
+fn wal_sort_order(schema: &Schema) -> FileSortOrder {
+    let hash_is_u64 = schema
+        .field_with_name(HASH_LABEL)
+        .is_ok_and(|field| field.data_type() == &DataType::UInt64);
+    if get_config().search.feature_metrics_streaming_agg_enabled && hash_is_u64 {
+        FileSortOrder::HashTimestampAsc
+    } else {
+        FileSortOrder::None
+    }
 }
 
 /// Register a placeholder metrics table for a distributed WAL search.
@@ -144,6 +172,7 @@ async fn get_wal_batches(
     time_range: (i64, i64),
     matchers: Matchers,
     label_selector: HashSet<String>,
+    sort_order: FileSortOrder,
 ) -> Result<(ScanStats, Vec<RecordBatch>, Arc<Schema>)> {
     let cfg = get_config();
     let nodes = get_cached_online_ingester_nodes().await;
@@ -178,6 +207,10 @@ async fn get_wal_batches(
         Some(dataframe) => df = dataframe,
         None => return Ok((ScanStats::new(), vec![], Arc::new(Schema::empty()))),
     }
+    // each ingester sorts its own rows in parallel; the querier only merges
+    if sort_order.is_sorted() {
+        df = df.sort(sort_order.logical_sort_exprs())?;
+    }
 
     let plan = df.logical_plan();
     let mut physical_plan = ctx.state().create_physical_plan(plan).await?;
@@ -210,6 +243,15 @@ async fn get_wal_batches(
     };
 
     physical_plan = Arc::new(RemoteScanExec::new(physical_plan, remote_scan_node)?);
+    // the node streams are each sorted; the merge keeps the collected batches in one order
+    if sort_order.is_sorted() {
+        let ordering = sort_order
+            .physical_ordering(physical_plan.schema().as_ref())
+            .ok_or_else(|| {
+                DataFusionError::Internal("the WAL scan dropped its sort columns".to_string())
+            })?;
+        physical_plan = Arc::new(SortPreservingMergeExec::new(ordering, physical_plan));
+    }
 
     // run datafusion
     let ret = datafusion::physical_plan::collect(physical_plan.clone(), ctx.task_ctx()).await;


### PR DESCRIPTION
Any PromQL query whose window reaches into the WAL floor (`now - 3 × ZO_MAX_FILE_RETENTION_TIME`) set `need_wal`, and the streaming path bailed on that flag alone: the whole query, storage hours included, fell back to materializing the sample matrix. That is every "last N hours" dashboard panel.

This PR keeps the streaming path on when the WAL is in play:

- The WAL scan asks the ingesters for `(__hash__, _timestamp)` order and merges the node streams with a `SortPreservingMergeExec`, so the querier holds the WAL rows sorted (`SortedWalRows`). Each hash partition of the streaming merge takes a zero-copy slice of those rows as one more chain next to its storage chains, so a series that straddles storage and WAL is still folded once, in order.
- `TableProvider::create_context` returns `SelectorContext` structs (session, schema, stats, `keep_filters`, optional `sorted_wal`) instead of the 4-tuple. The `need_wal` gate is gone, replaced by "at most one session plus the sorted WAL rows"; a WAL whose rows lack a group column, or a second unsorted session, still materializes. An empty WAL window contributes no chain.
- `scan_matchers` is empty when any context is exact: only the storage context can be exact, and the WAL rows were already filtered when fetched.

Ported from the parked `feat/promql-streaming-wal` commit onto the post-#14300/#14310/#14402 layout (`fused/stream.rs` → `streaming_eval/*`, `series_stream/merge.rs` → `series_stream/plan.rs`), with `stream_scan_guarded` now taking a ready future so the inputs can borrow the scan.

### Benchmark

main `2a19a61a31` vs this branch, release + mimalloc, fresh process per (binary, query), run1 = cold wall + peak RSS, run2 = warm wall, step 60. Data: `data-faker-parquet` (hash layout, 1.17M series/h) plus a 6-minute continuation of every series (06:23:45–06:29:30, 28M samples) ingested through remote-write and pinned in the WAL (59 wal parquet files, `ZO_MAX_FILE_RETENTION_TIME=1209600`, mover size caps raised so nothing moves to storage). With that retention `need_wal` is true for every query below. All 8 responses byte-identical.

| query | main warm / peak | this PR warm / peak |
|---|---|---|
| `sum by(le,path)(rate(M[5m]))` 04:00–05:00, storage only, gate on | 1.62 s / 7.16 GiB | 0.98 s / 0.61 GiB |
| `sum by(le,path)(rate(M[5m]))` 05:30–06:30, tail in WAL | 3.46 s / 8.66 GiB | 3.78 s / 5.51 GiB |
| `sum by(le,path)(M)` 05:30–06:30 | 3.46 s / 8.41 GiB | 3.69 s / 5.52 GiB |
| `histogram_quantile(0.9, sum by(le,path)(rate(M[5m])))` 05:30–06:30 | 3.47 s / 8.48 GiB | 3.73 s / 5.49 GiB |
| `sum by(le,path)(rate(M[5m]))` 03:30–06:30 | 5.87 s / 12.56 GiB | 5.64 s / 5.63 GiB |
| `rate(M{path="/api/service-1"}[5m])` 05:30–06:30 | 1.12 s / 0.87 GiB | 1.26 s / 1.06 GiB |
| `M{path="/api/service-1"}` 05:30–06:30 | 1.24 s / 0.90 GiB | 1.41 s / 1.08 GiB |
| `sum by(le,path)(rate(M[5m]))` 06:25–06:30, WAL only | 2.45 s / 4.94 GiB | 3.53 s / 5.51 GiB |

Reading: the gate cost is gone (first row: 7.2 → 0.6 GiB when the window has no WAL rows), and the storage part of a tail query streams (3h: 12.6 → 5.6 GiB). What remains is the WAL fetch itself: 28M rows are sorted on the ingester, collected into the querier as Arrow, and held for the whole query — about 5 GiB and ~3.5 s here, ~1 s more than main's unsorted fetch (last row). That is the floor of this design, not of the fold.

### Follow-up (not in this PR)

- The wal parquet files the ingester writes under the index layout are already `(__hash__, _timestamp)`-sorted; only the memtable needs sorting. Declaring that ordering on the ingester's WAL table would turn the 28M-row sort into a merge.
- Stream the WAL rows per hash partition (a filtered fetch per partition, or a lazily merged Flight stream) instead of collecting and slicing, so the WAL slice stops being resident for the whole query.

### Tests

`cargo test -p promql -p promql-service`: 452 + 22 passed. Ported: sorted WAL rows join the merge, unsorted WAL rows materialize, WAL rows lacking a group column materialize, chain cuts at partition bounds. New: `need_wal` with sorted WAL rows takes the streaming path while unsorted rows take the loader (discriminated by which cancel message fires). `cargo fmt`, CI clippy command clean.
