### PR TITLE
fix: add search event context in promql queries

### DIFF
--- a/src/api/grpc/src/handler/grpc/mod.rs
+++ b/src/api/grpc/src/handler/grpc/mod.rs
@@ -37,6 +37,7 @@ mod tests {
             search_type: None,
             regions: vec![],
             clusters: vec![],
+            search_event_context: None,
         }
     }
 

--- a/src/api/search/src/promql/mod.rs
+++ b/src/api/search/src/promql/mod.rs
@@ -273,6 +273,7 @@ async fn query(
         search_type: None,
         regions: vec![],
         clusters: vec![],
+        search_event_context: None, // ui search queries do not have special ctx
     };
 
     search(&trace_id, org_id, req, user_email, timeout).await
@@ -613,6 +614,7 @@ async fn query_range(
         search_type: req.search_type,
         regions: req.regions,
         clusters: req.clusters,
+        search_event_context: None, // ui queries do not have special query ctx
     };
     if let Some(use_streaming) = req.use_streaming
         && use_streaming

--- a/src/config/src/meta/promql/value.rs
+++ b/src/config/src/meta/promql/value.rs
@@ -30,7 +30,10 @@ use serde::{
 
 use crate::{
     FxIndexMap,
-    meta::{promql::NAME_LABEL, search::SearchEventType},
+    meta::{
+        promql::NAME_LABEL,
+        search::{SearchEventContext, SearchEventType},
+    },
     utils::{json, sort::sort_float},
 };
 
@@ -453,6 +456,7 @@ pub struct QueryContext {
     pub use_cache: bool,
     pub timeout: u64, // seconds, query timeout
     pub search_event_type: Option<SearchEventType>,
+    pub search_event_context: Option<SearchEventContext>,
     pub regions: Vec<String>,
     pub clusters: Vec<String>,
     pub is_super_cluster: bool,

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -24,7 +24,7 @@ use utoipa::ToSchema;
 
 use crate::{
     config::get_config,
-    meta::{search, sql::OrderBy, stream::StreamType},
+    meta::{search, slo::Slo, sql::OrderBy, stream::StreamType},
     utils::{base64, json},
 };
 
@@ -1169,6 +1169,13 @@ impl SearchEventContext {
     pub fn with_report(report_key: Option<String>) -> Self {
         Self {
             report_key,
+            ..Default::default()
+        }
+    }
+
+    pub fn with_slo(slo: &Slo) -> Self {
+        Self {
+            derived_stream_key: Some(format!("slo/{}/{}/{}", slo.org, slo.name, slo.id)),
             ..Default::default()
         }
     }

--- a/src/core/src/alerts/mod.rs
+++ b/src/core/src/alerts/mod.rs
@@ -221,6 +221,7 @@ impl QueryConditionExt for QueryCondition {
                     search_type: Some(SearchEventType::Alerts),
                     regions: vec![],
                     clusters: vec![],
+                    search_event_context,
                 };
                 // check super cluster
                 #[cfg(not(feature = "enterprise"))]

--- a/src/core/src/slo/job.rs
+++ b/src/core/src/slo/job.rs
@@ -248,7 +248,7 @@ async fn fetch_rows(
             ))
         }
         SliQueryPlan::PromQl { good, total } => {
-            let ctx = SearchEventContext::with_slo(&slo);
+            let ctx = SearchEventContext::with_slo(slo);
             let good_series = prom_search(&slo.org, &good, ctx.clone()).await?;
             let total_series = prom_search(&slo.org, &total, ctx).await?;
             Ok((
@@ -262,7 +262,7 @@ async fn fetch_rows(
             ))
         }
         SliQueryPlan::PromQlValue(q) => {
-            let ctx = SearchEventContext::with_slo(&slo);
+            let ctx = SearchEventContext::with_slo(slo);
             let series = prom_search(&slo.org, &q, ctx).await?;
             Ok(promql_value_rows(
                 series,

--- a/src/core/src/slo/job.rs
+++ b/src/core/src/slo/job.rs
@@ -29,7 +29,7 @@
 use config::{
     get_config,
     meta::{
-        search::{Query, Request, RequestEncoding},
+        search::{Query, Request, RequestEncoding, SearchEventContext},
         slo::{
             CountSource, QueryLanguage, SliConfig, Slo,
             alert_uptime::{EvalInterval, UptimeGrid, uptime_slices},
@@ -248,8 +248,9 @@ async fn fetch_rows(
             ))
         }
         SliQueryPlan::PromQl { good, total } => {
-            let good_series = prom_search(&slo.org, &good).await?;
-            let total_series = prom_search(&slo.org, &total).await?;
+            let ctx = SearchEventContext::with_slo(&slo);
+            let good_series = prom_search(&slo.org, &good, ctx.clone()).await?;
+            let total_series = prom_search(&slo.org, &total, ctx).await?;
             Ok((
                 promql_rows(
                     good_series,
@@ -261,7 +262,8 @@ async fn fetch_rows(
             ))
         }
         SliQueryPlan::PromQlValue(q) => {
-            let series = prom_search(&slo.org, &q).await?;
+            let ctx = SearchEventContext::with_slo(&slo);
+            let series = prom_search(&slo.org, &q, ctx).await?;
             Ok(promql_value_rows(
                 series,
                 group_by,
@@ -526,6 +528,7 @@ pub fn promql_value_rows(
 async fn prom_search(
     org: &str,
     q: &super::query::PromQuery,
+    ctx: SearchEventContext,
 ) -> Result<Vec<PromSeries>, anyhow::Error> {
     let req = promql_service::MetricsQueryRequest {
         query: q.expr.clone(),
@@ -537,6 +540,7 @@ async fn prom_search(
         search_type: Some(config::meta::search::SearchEventType::DerivedStream),
         regions: vec![],
         clusters: vec![],
+        search_event_context: Some(ctx),
     };
     #[cfg(not(feature = "enterprise"))]
     let is_super_cluster = false;

--- a/src/db/src/folders.rs
+++ b/src/db/src/folders.rs
@@ -450,8 +450,6 @@ async fn permitted_folders(
             folder_list = Some(folder_list_with_roles);
         }
     }
-    log::info!("folder_list: {folder_list:?}");
-
     Ok(folder_list)
 }
 

--- a/src/promql/src/engine/mod.rs
+++ b/src/promql/src/engine/mod.rs
@@ -292,6 +292,7 @@ pub(crate) mod tests {
             regions: vec![],
             clusters: vec![],
             is_super_cluster: false,
+            search_event_context: None,
         })
     }
 

--- a/src/promql_service/src/search/grpc/mod.rs
+++ b/src/promql_service/src/search/grpc/mod.rs
@@ -391,6 +391,7 @@ pub async fn search_inner(
         regions: req.regions.clone(),
         clusters: req.clusters.clone(),
         is_super_cluster: req.is_super_cluster,
+        search_event_context: req.search_event_context.clone().map(Into::into),
     });
     let mut ctx = PromqlContext::new(
         query_ctx,

--- a/src/promql_service/src/search/mod.rs
+++ b/src/promql_service/src/search/mod.rs
@@ -515,6 +515,7 @@ async fn search_in_cluster(
         min_ts: Some(start),
         max_ts: Some(end),
         trace_id: Some(trace_id.to_string()),
+        search_event_context: req.search_event_context.map(Into::into),
         ..Default::default()
     };
 

--- a/src/promql_service/src/service.rs
+++ b/src/promql_service/src/service.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Request types used by the OpenObserve PromQL query service.
-use config::meta::search::SearchEventType;
+use config::meta::search::{SearchEventContext, SearchEventType};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -27,6 +27,7 @@ pub struct MetricsQueryRequest {
     pub query_exemplars: bool,
     pub use_cache: Option<bool>,
     pub search_type: Option<SearchEventType>,
+    pub search_event_context: Option<SearchEventContext>,
     pub regions: Vec<String>,
     pub clusters: Vec<String>,
 }
@@ -59,6 +60,7 @@ impl From<MetricsQueryRequest> for proto::cluster_rpc::MetricsQueryRequest {
                 .search_type
                 .map(|value| value.to_string())
                 .unwrap_or_default(),
+            search_event_context: req.search_event_context.map(Into::into),
             regions: req.regions,
             clusters: req.clusters,
             is_super_cluster: false,

--- a/src/proto/build.rs
+++ b/src/proto/build.rs
@@ -61,6 +61,7 @@ fn main() -> Result<()> {
         .type_attribute("MetricsQueryRequest", "#[derive(serde::Serialize)]")
         .type_attribute("MetricsQueryResponse", "#[derive(serde::Serialize)]")
         .type_attribute("ScanStats", "#[derive(serde::Serialize)]")
+        .type_attribute("SearchEventContext", "#[derive(serde::Serialize)]")
         .type_attribute(
             "PhysicalPlanNode.plan",
             "#[allow(clippy::large_enum_variant)]",

--- a/src/proto/proto/cluster/common.proto
+++ b/src/proto/proto/cluster/common.proto
@@ -59,3 +59,14 @@ message FileKey {
 message SimpleFileList {
     repeated string files = 1;
 }
+
+message SearchEventContext {
+    optional string alert_key = 1;
+    optional string derived_stream_key = 2;
+    optional string report_key = 3;
+    optional string dashboard_id = 4;
+    optional string dashboard_name = 5;
+    optional string dashboard_folder_id = 6;
+    optional string dashboard_folder_name = 7;
+    optional string alert_name = 8;
+}

--- a/src/proto/proto/cluster/metrics.proto
+++ b/src/proto/proto/cluster/metrics.proto
@@ -25,6 +25,7 @@ message MetricsQueryRequest {
     repeated string  regions = 11;
     repeated string clusters = 12;
     bool    is_super_cluster = 13;
+    optional SearchEventContext search_event_context = 14;
 
 }
 

--- a/src/proto/proto/cluster/search.proto
+++ b/src/proto/proto/cluster/search.proto
@@ -115,17 +115,6 @@ message SamplingConfig {
     optional int32 num_time_strata = 4;
 }
 
-message SearchEventContext {
-    optional string alert_key = 1;
-    optional string derived_stream_key = 2;
-    optional string report_key = 3;
-    optional string dashboard_id = 4;
-    optional string dashboard_name = 5;
-    optional string dashboard_folder_id = 6;
-    optional string dashboard_folder_name = 7;
-    optional string alert_name = 8;
-}
-
 message QueryStatus {
     string                trace_id = 1;
     int64               created_at = 2;

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -101,6 +101,26 @@ pub struct SimpleFileList {
     #[prost(string, repeated, tag = "1")]
     pub files: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[derive(serde::Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SearchEventContext {
+    #[prost(string, optional, tag = "1")]
+    pub alert_key: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "2")]
+    pub derived_stream_key: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "3")]
+    pub report_key: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "4")]
+    pub dashboard_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "5")]
+    pub dashboard_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "6")]
+    pub dashboard_folder_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "7")]
+    pub dashboard_folder_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "8")]
+    pub alert_name: ::core::option::Option<::prost::alloc::string::String>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileContentResponse {
     #[prost(message, repeated, tag = "1")]
@@ -506,6 +526,8 @@ pub struct MetricsQueryRequest {
     pub clusters: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(bool, tag = "13")]
     pub is_super_cluster: bool,
+    #[prost(message, optional, tag = "14")]
+    pub search_event_context: ::core::option::Option<SearchEventContext>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -1088,25 +1110,6 @@ pub struct SamplingConfig {
     /// Number of time buckets for stratified sampling (e.g., 24 for hourly over a day)
     #[prost(int32, optional, tag = "4")]
     pub num_time_strata: ::core::option::Option<i32>,
-}
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct SearchEventContext {
-    #[prost(string, optional, tag = "1")]
-    pub alert_key: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "2")]
-    pub derived_stream_key: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "3")]
-    pub report_key: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "4")]
-    pub dashboard_id: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "5")]
-    pub dashboard_name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "6")]
-    pub dashboard_folder_id: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "7")]
-    pub dashboard_folder_name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "8")]
-    pub alert_name: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct QueryStatus {


### PR DESCRIPTION
We didn't send the search event context for promql searches, so in usage stream we could not associate the search event with particular alerts or dashboards. Now we send the context so it shows up in the usaeg stream records.