### PR TITLE
test(workflows): cover Branch, draft lifecycle, node actions and the test drawer

### DIFF
--- a/tests/ui-testing/pages/workflowsPages/workflowsPage.js
+++ b/tests/ui-testing/pages/workflowsPages/workflowsPage.js
@@ -66,6 +66,34 @@ class WorkflowsPage {
     this.paletteCondition = '[data-test="workflow-palette-condition-default-btn"]';
     this.paletteFunction = '[data-test="workflow-palette-function-default-btn"]';
     this.paletteDestination = '[data-test="workflow-palette-destination-output-btn"]';
+    this.paletteBranch = '[data-test="workflow-palette-branch-default-btn"]';
+    // Branch node (N-way fan-out, #14027). Rows key on the case's STABLE handle, never
+    // its index: a surviving arm must keep the handle its edges are already wired to,
+    // so `case-N` comes off a high-water mark and is kept for the node's whole life.
+    this.stepBranch = '[data-test="workflow-step-branch"]';
+    this.branchBody = '[data-test="workflow-branch-body"]';
+    this.branchAddCase = '[data-test="workflow-branch-add-case"]';
+    this.branchElse = '[data-test="workflow-branch-else"]';
+    this.branchCaseRows = '[data-test^="workflow-branch-case-"]';
+    this.branchOrderBadges = '[data-test^="workflow-branch-order-"]';
+    this.branchCaseFor = (h) => `[data-test="workflow-branch-case-${h}"]`;
+    this.branchLabelFieldFor = (h) => `[data-test="workflow-branch-label-${h}-field"]`;
+    this.branchMoveUpFor = (h) => `[data-test="workflow-branch-move-up-${h}"]`;
+    this.branchMoveDownFor = (h) => `[data-test="workflow-branch-move-down-${h}"]`;
+    this.branchRemoveFor = (h) => `[data-test="workflow-branch-remove-case-${h}"]`;
+    // The else arm is a permanent row: it is what guarantees every record leaves by
+    // exactly one handle, so it renders WITHOUT a remove control.
+    this.branchElseRemove = '[data-test="workflow-branch-else-remove"]';
+    this.branchUnwiredBadge = '[data-test="workflow-node-branch-unwired-badge"]';
+    // Hover-only "+" on the canvas: one per OPEN (still unwired) source handle, in
+    // declared arm order, so nth(i) addresses arm i of what remains unwired.
+    this.flowAppendAdd = '[data-test="workflow-flow-append-add"]';
+    // Edge labels name the arm each connector leaves by — the only on-canvas evidence of
+    // which path a destination is actually wired to. They are HTML in vue-flow's label
+    // LAYER, not SVG <text>, and the layer also holds the (empty) hover-"+" wrappers, so
+    // callers must filter blanks rather than index children positionally. Note the class
+    // is plural: `.vue-flow__edge-label` matches nothing here.
+    this.edgeLabelLayer = '.vue-flow__edge-labels';
     // Trigger node (delete only visible on node hover). The hover-`+` add-out
     // button no longer exists — clicking the node's SOURCE HANDLE opens the step
     // picker instead.
@@ -98,6 +126,8 @@ class WorkflowsPage {
     this.destPickerCreateToggle = '[data-test="destination-picker-create-toggle-btn"]';
     this.destPickerSelectTrigger = '[data-test="destination-picker-select-trigger"]';
     this.destPickerSelectPopover = '[data-test="destination-picker-select-popover"]';
+    this.destPickerSelectSearch = '[data-test="destination-picker-select-search"]';
+    this.destPickerSelectOption = '[data-test="destination-picker-select-option"]';
     // Inline "create destination" wizard: step 1 choose-type card + continue, step 2 connection.
     this.destTypeCard = (t) => `[data-test="destination-type-card-${t}"]`;
     this.destStep1Continue = '[data-test="step1-continue-btn"]';
@@ -359,6 +389,152 @@ class WorkflowsPage {
     await node.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
     await node.click({ timeout: DRAWER_TIMEOUT_MS });
     await this.page.locator(this.nodeDrawer).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  /**
+   * Add a Branch from the palette and open its drawer. Same insert-immediately flow as
+   * addNodeFromPalette, but a Branch opens on one seeded row: a case-less Branch is
+   * rejected by the backend validator, so the panel never shows zero paths.
+   */
+  async addBranchFromPalette() {
+    await this.closeOpenDrawer();
+    await this.ensureNodePaletteOpen();
+    await this.page.locator(this.paletteBranch).click({ timeout: DRAWER_TIMEOUT_MS });
+    const node = this.page.locator(this.nodeFor('branch')).last();
+    await node.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await node.click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.branchBody).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async openBranchDrawer() {
+    await this.closeOpenDrawer();
+    await this.page.locator(this.nodeFor('branch')).first().dblclick({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.branchBody).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async addBranchCase() {
+    const before = await this.branchCaseCount();
+    await this.page.locator(this.branchAddCase).click({ timeout: DRAWER_TIMEOUT_MS });
+    await expect.poll(async () => this.branchCaseCount(), { timeout: DRAWER_TIMEOUT_MS }).toBe(before + 1);
+  }
+
+  async removeBranchCase(handle) {
+    const before = await this.branchCaseCount();
+    await this.page.locator(this.branchRemoveFor(handle)).click({ timeout: DRAWER_TIMEOUT_MS });
+    await expect.poll(async () => this.branchCaseCount(), { timeout: DRAWER_TIMEOUT_MS }).toBe(before - 1);
+  }
+
+  async moveBranchCase(handle, direction /* 'up' | 'down' */) {
+    const sel = direction === 'up' ? this.branchMoveUpFor(handle) : this.branchMoveDownFor(handle);
+    await this.page.locator(sel).click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async branchCaseCount() {
+    return this.page.locator(this.branchCaseRows).count();
+  }
+
+  /** Handles in RENDERED order — which is evaluation order, since first match wins. */
+  async branchCaseHandles() {
+    return this.page.locator(this.branchCaseRows).evaluateAll((els) =>
+      els.map((e) => (e.getAttribute('data-test') || '').replace('workflow-branch-case-', ''))
+    );
+  }
+
+  /**
+   * Path labels in rendered order. Scoped to the label field by data-test, NOT to `input`:
+   * every row also contains its ConditionBuilder's value input, which would interleave a
+   * blank entry after each label.
+   */
+  async branchCaseLabels() {
+    return this.page
+      .locator(`${this.branchCaseRows} [data-test^="workflow-branch-label-"][data-test$="-field"]`)
+      .evaluateAll((els) => els.map((e) => e.value));
+  }
+
+  /**
+   * Configure one path. Every branch row renders its OWN ConditionBuilder, so the
+   * column/operator triggers must be scoped to the row; the option popover is a portal
+   * and stays global (only one is open at a time).
+   */
+  async setBranchCase(handle, { label, column, operator = '=', value } = {}) {
+    const row = this.branchCaseFor(handle);
+    if (label !== undefined) {
+      await this.page.locator(this.branchLabelFieldFor(handle)).fill(label);
+    }
+    if (column !== undefined) {
+      await this.dismissConditionGuidelinesIfPresent();
+      await this.pickSelectOption(`${row} ${this.condColumnTrigger}`, this.condColumnOption, column);
+      await this.pickSelectOption(`${row} ${this.condOperatorTrigger}`, this.condOperatorOption, operator);
+      if (value !== undefined) {
+        await this.page.locator(`${row} ${this.condValueField}`).fill(value);
+      }
+    }
+  }
+
+  /**
+   * Wire the nth still-unwired arm to a destination. The per-arm "+" is hover-only, so
+   * the node must be hovered first; `nth` indexes the OPEN handles in declared order,
+   * which shifts as arms get wired — wire left to right and it stays predictable.
+   */
+  async wireArmToDestination(nth, { destName, url, existing } = {}) {
+    await this.page.locator(this.nodeFor('branch')).first().hover({ timeout: DRAWER_TIMEOUT_MS });
+    const plus = this.page.locator(this.flowAppendAdd).nth(nth);
+    await plus.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await plus.click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.stepDestination).click({ timeout: DRAWER_TIMEOUT_MS });
+    const node = this.page.locator(this.nodeFor('destination')).last();
+    await node.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await node.dblclick({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.nodeDrawer).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    if (existing) await this.pickExistingDestination(existing);
+    else await this.createDestinationInline({ name: destName, url });
+    await this.saveNodeDrawer();
+  }
+
+  /** The else arm renders after every case row, whatever the path count. */
+  async expectElseArmLast() {
+    const rows = this.page.locator(`${this.branchCaseRows}, ${this.branchElse}`);
+    await expect(rows.last()).toHaveAttribute('data-test', 'workflow-branch-else');
+  }
+
+  async expectElseArmVisible() {
+    await expect(this.page.locator(this.branchElse)).toBeVisible();
+  }
+
+  /** Non-deletable rows omit the control entirely — assert absence, not a disabled state. */
+  async expectElseArmNotRemovable() {
+    await expect(this.page.locator(this.branchElseRemove)).toHaveCount(0);
+  }
+
+  async expectBranchCaseNotRemovable(handle) {
+    await expect(this.page.locator(this.branchRemoveFor(handle))).toHaveCount(0);
+  }
+
+  async expectBranchUnwiredBadge() {
+    await expect(this.page.locator(this.branchUnwiredBadge)).toBeVisible();
+  }
+
+  /** Choose an already-saved destination by name (the picker's list is searchable). */
+  async pickExistingDestination(name) {
+    await this.page.locator(this.destPickerSelectTrigger).click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.destPickerSelectSearch).fill(name);
+    const option = this.page.locator(this.destPickerSelectOption).first();
+    await option.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await option.click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  /**
+   * Arm names as rendered on the connectors — the assertion that catches a silent reroute.
+   * vue-flow paints the label layer a tick after the edge itself, so poll until `expected`
+   * non-blank labels exist rather than reading once.
+   */
+  async edgeLabelTexts(expected = 1) {
+    const kids = this.page.locator(`${this.edgeLabelLayer} > *`);
+    const read = async () => (await kids.allTextContents()).map((t) => t.trim()).filter(Boolean);
+    await expect
+      .poll(async () => (await read()).length, { timeout: DRAWER_TIMEOUT_MS })
+      .toBeGreaterThanOrEqual(expected);
+    return read();
   }
 
   /**

--- a/tests/ui-testing/pages/workflowsPages/workflowsPage.js
+++ b/tests/ui-testing/pages/workflowsPages/workflowsPage.js
@@ -47,6 +47,7 @@ class WorkflowsPage {
     this.nameValue = '[data-test="workflow-editor-name-value"]';
     this.descTrigger = '[data-test="workflow-editor-description-trigger"]';
     this.descInput = '[data-test="workflow-editor-description-input"]';
+    this.descValue = '[data-test="workflow-editor-description-value"]';
     // Workflow single-screen function editor: the AddFunction body is ALWAYS
     // visible below the associate-function select (FunctionPicker's `createButton`
     // mode), so there is no "Create New" toggle. Save routes through the icon
@@ -156,6 +157,48 @@ class WorkflowsPage {
     this.nodeTestErrorFor = (t) => `[data-test="workflow-node-${t}-test-error"]`;
     this.listRowPrefixFor = (n) => `[data-test^="workflow-list-${n}-"]`;
     this.listRowActionFor = (n, a) => `[data-test="workflow-list-${n}-${a}"]`;
+    this.listDraftTag = '[data-test="workflow-list-draft-tag"]';
+    this.listTriggerTag = '[data-test="workflow-list-trigger-tag"]';
+    this.listRefresh = '[data-test="workflow-list-refresh"]';
+    // Draft vs published is the editor's whole mode switch: a draft offers
+    // Save-as-Draft + Publish, a published workflow offers Save + History instead.
+    this.editorDraftTag = '[data-test="workflow-editor-draft-tag"]';
+    this.saveDraftBtn = '[data-test="workflow-editor-save-draft"]';
+    this.historyBtn = '[data-test="workflow-editor-history"]';
+    this.unsavedDialog = '[data-test="workflows-editor-unsaved-dialog"]';
+    // Per-node hover actions. The rail only renders while the node is hovered, so
+    // every one of these needs a hover on the node first.
+    this.nodeActionsFor = (t) => `[data-test="workflow-node-${t}-actions"]`;
+    this.nodeDeleteBtnFor = (t) => `[data-test="workflow-node-${t}-delete-btn"]`;
+    this.nodeIncompleteBadgeFor = (t) => `[data-test="workflow-node-${t}-incomplete-badge"]`;
+    this.nodeDisabledBadgeFor = (t) => `[data-test="workflow-node-${t}-disabled-badge"]`;
+    this.nodeDisableToggle = '[data-test="workflows-node-disable-toggle"]';
+    this.nodeCommentIndicator = '[data-test="workflows-node-comment-indicator"]';
+    // Rename + comment live in the node DRAWER, not on the card.
+    // Rename is an OInlineEdit (trigger opens, -input edits, -value reads); the comment
+    // is an OTextarea whose writable element is -field. Both data-tests land on wrappers.
+    this.nodeRenameTrigger = '[data-test="workflows-node-rename-input-trigger"]';
+    this.nodeRenameField = '[data-test="workflows-node-rename-input-input"]';
+    this.nodeCommentField = '[data-test="workflows-node-comment-input-field"]';
+    this.canvasUndo = '[data-test="workflows-canvas-undo"]';
+    this.canvasTidy = '[data-test="workflows-canvas-tidy"]';
+    // Test drawer (reworked in #14027): the payload can come from the seeded sample
+    // or a previous run, and destinations are suppressed by DEFAULT so a rehearsal
+    // never posts to production — turning that off is what raises the dispatch warning.
+    this.testDrawer = '[data-test="workflow-test-drawer"]';
+    this.testInputSource = '[data-test="workflow-test-input-source"]';
+    this.testRunPicker = '[data-test="workflow-test-run-picker"]';
+    this.testRunFrom = '[data-test="workflow-test-run-from"]';
+    this.testRevertInput = '[data-test="workflow-test-revert-input"]';
+    this.testResetSample = '[data-test="workflow-test-reset-sample"]';
+    this.testSuppressDestinations = '[data-test="workflow-test-suppress-destinations"]';
+    this.testSuppressDestinationsBtn = '[data-test="workflow-test-suppress-destinations-btn"]';
+    this.testDispatchWarning = '[data-test="workflow-test-dispatch-warning"]';
+    this.ndvPrevStep = '[data-test="workflow-ndv-prev-step"]';
+    this.ndvNextStep = '[data-test="workflow-ndv-next-step"]';
+    this.runsPage = '[data-test="workflow-runs-page"]';
+    this.configSummaryBranch = '[data-test="workflow-config-summary-branch"]';
+    this.configSummaryBranchPaths = '[data-test^="workflow-config-summary-branch-path-"]';
     // NDV output pane — on a successful destination send this holds the sink's
     // response body, which is what makes delivery assertable.
     this.ndvOutput = '[data-test="workflow-ndv-output"]';
@@ -170,7 +213,7 @@ class WorkflowsPage {
     this.warningToast = '[data-test^="o-toast-"][data-test-variant="warning"]';
     this.anyToast = '[role="alert"], .q-notification__message';
     this.confirmButton =
-      '[data-test$="-confirm-button"], [data-test="dlg-primary"], button:has-text("OK"), button:has-text("Delete")';
+      '[data-test="o-dialog-primary-btn"], [data-test$="-confirm-button"], [data-test="dlg-primary"], button:has-text("OK"), button:has-text("Delete")';
     // Destination header rows are keyed by the header's CURRENT key, so these are
     // functions rather than constants — a blank row answers to the empty-key form.
     this.destHeaderKeyField = (key = '') => `[data-test="add-destination-header-${key}-key-input-field"]`;
@@ -489,6 +532,219 @@ class WorkflowsPage {
     if (existing) await this.pickExistingDestination(existing);
     else await this.createDestinationInline({ name: destName, url });
     await this.saveNodeDrawer();
+  }
+
+  // ---------- draft lifecycle ----------
+
+  /** Save as Draft. Drafts skip the connectivity checks, so a half-built graph persists. */
+  async saveAsDraft() {
+    await this.page.locator(this.saveDraftBtn).first().evaluate((el) => el.click());
+    await this.page.locator(this.listTable).first().waitFor({ state: 'visible', timeout: LIST_TIMEOUT_MS });
+  }
+
+  async expectDraftTagInEditor() {
+    await expect(this.page.locator(this.editorDraftTag)).toBeVisible();
+  }
+
+  async expectNoDraftTagInEditor() {
+    await expect(this.page.locator(this.editorDraftTag)).toHaveCount(0);
+  }
+
+  /** A published workflow offers Save + History; a draft offers Save-as-Draft + Publish. */
+  async expectPublishedEditorControls() {
+    await expect(this.page.locator(this.saveBtn)).toBeVisible();
+    await expect(this.page.locator(this.saveDraftBtn)).toHaveCount(0);
+  }
+
+  async expectHistoryControl() {
+    await expect(this.page.locator(this.historyBtn)).toBeVisible();
+  }
+
+  /** Leave with unsaved edits and discard them; the guard dialog must appear first. */
+  async cancelAndDiscard() {
+    await this.page.locator(this.cancelBtn).click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.unsavedDialog).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.drawerPrimary).click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.listTable).first().waitFor({ state: 'visible', timeout: LIST_TIMEOUT_MS });
+  }
+
+  /**
+   * Row tags are not name-scoped in the markup, so these are only meaningful after a
+   * search has narrowed the list to the workflow under test.
+   */
+  async expectDraftTagOnRow(name) {
+    await this.rowByName(name).first().waitFor({ state: 'visible', timeout: LIST_TIMEOUT_MS });
+    await expect(this.page.locator(this.listDraftTag).first()).toBeVisible();
+  }
+
+  async expectTriggerTagOnRow() {
+    await expect(this.page.locator(this.listTriggerTag).first()).toBeVisible();
+  }
+
+  /** 'pause' when the workflow is running, 'resume' when it is paused. */
+  async rowActionState(name) {
+    return this.page
+      .locator(this.listRowActionFor(name, 'pause-start-action'))
+      .first()
+      .getAttribute('data-row-action');
+  }
+
+  async refreshList() {
+    await this.page.locator(this.listRefresh).click({ timeout: LIST_TIMEOUT_MS });
+    await this.waitForListReady();
+  }
+
+  /**
+   * The row's View control is a HOVER PREVIEW, not a route: the button carries an OTooltip
+   * rendering a WorkflowView summary and has no click handler. Hovering is the interaction.
+   */
+  async hoverViewPreview(name) {
+    await this.rowByName(name).first().waitFor({ state: 'visible', timeout: LIST_TIMEOUT_MS });
+    await this.page.locator(this.listRowActionFor(name, 'view')).first().hover({ timeout: LIST_TIMEOUT_MS });
+  }
+
+  async expectViewPreview(name) {
+    await expect(this.page.getByRole('tooltip').first()).toContainText(name, { timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  /** Read-only means the save paths are ABSENT, not disabled — assert on count. */
+  async expectReadOnlyEditor() {
+    await expect(this.page.locator(this.publishBtn)).toHaveCount(0);
+    await expect(this.page.locator(this.saveDraftBtn)).toHaveCount(0);
+  }
+
+  async expectDescriptionValue(text) {
+    await this.page.locator(this.editorPage).waitFor({ state: 'visible', timeout: LIST_TIMEOUT_MS });
+    await expect(this.page.locator(this.descValue).first()).toContainText(text, {
+      timeout: DRAWER_TIMEOUT_MS,
+    });
+  }
+
+  // ---------- node card actions ----------
+
+  /** The action rail is hover-only, so every node action starts with a hover. */
+  async hoverNode(type) {
+    await this.page.locator(this.nodeFor(type)).first().hover({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.nodeActionsFor(type)).first().waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async toggleNodeDisabled(type) {
+    await this.hoverNode(type);
+    // The rail is painted only while the pointer is on the node, and moving to the button
+    // re-runs that check — dispatch the click instead of chasing the hover.
+    await this.page.locator(this.nodeDisableToggle).first().dispatchEvent('click');
+  }
+
+  /** Both the hover-delete and the drawer's Delete funnel through one ConfirmDialog. */
+  async deleteNode(type) {
+    await this.hoverNode(type);
+    await this.page.locator(this.nodeDeleteBtnFor(type)).first().click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.drawerPrimary).first().click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async expectNodeDisabledBadge(type) {
+    await expect(this.page.locator(this.nodeDisabledBadgeFor(type))).toBeVisible();
+  }
+
+  async expectNoIncompleteBadge(type) {
+    await expect(this.page.locator(this.nodeIncompleteBadgeFor(type))).toHaveCount(0);
+  }
+
+  async expectNoDisabledBadge(type) {
+    await expect(this.page.locator(this.nodeDisabledBadgeFor(type))).toHaveCount(0);
+  }
+
+  async closeTestDrawer() {
+    await this.page.locator(this.drawerClose).first().click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.testDrawer).waitFor({ state: 'detached', timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
+  }
+
+  async expectNodeIncompleteBadge(type) {
+    await expect(this.page.locator(this.nodeIncompleteBadgeFor(type))).toBeVisible();
+  }
+
+  async nodeCount(type) {
+    return this.page.locator(this.nodeFor(type)).count();
+  }
+
+  /** Rename and comment are drawer fields, not card affordances. */
+  async renameOpenNode(name) {
+    await this.page.locator(this.nodeRenameTrigger).click({ timeout: DRAWER_TIMEOUT_MS });
+    const field = this.page.locator(this.nodeRenameField);
+    await field.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await field.fill(name);
+    await field.press('Enter');
+  }
+
+  async commentOpenNode(text) {
+    await this.page.locator(this.nodeCommentField).fill(text);
+  }
+
+  async expectCommentIndicator() {
+    await expect(this.page.locator(this.nodeCommentIndicator).first()).toBeVisible();
+  }
+
+  /** A renamed node keeps its type selector but renders the custom name on the card. */
+  async expectNodeShowsText(type, text) {
+    await expect(this.page.locator(this.nodeFor(type)).first()).toContainText(text, {
+      timeout: DRAWER_TIMEOUT_MS,
+    });
+  }
+
+  /** The NDV always offers step navigation, which is how a long graph is walked. */
+  async expectNdvStepNavigation() {
+    await expect(this.page.locator(this.ndvPrevStep).first()).toBeVisible();
+    await expect(this.page.locator(this.ndvNextStep).first()).toBeVisible();
+  }
+
+  async clickCanvasUndo() {
+    await this.page.locator(this.canvasUndo).click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async clickCanvasTidy() {
+    await this.page.locator(this.canvasTidy).click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  // ---------- test drawer ----------
+
+  /** Open the Test drawer without running — the controls are the subject, not the run. */
+  async openTestDrawer() {
+    await this.closeOpenDrawer();
+    await this.page.locator(this.testBtn).first().evaluate((el) => el.click());
+    await this.page.locator(this.testDrawer).waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async expectTestControl(selector) {
+    await expect(this.page.locator(selector).first()).toBeVisible();
+  }
+
+  /**
+   * Destinations are suppressed by default so a rehearsal cannot post to production.
+   * Turning that off is what surfaces the dispatch warning.
+   */
+  async setSuppressDestinations(on) {
+    const toggle = this.page.locator(this.testSuppressDestinationsBtn).first();
+    const state = await toggle.getAttribute('aria-checked');
+    if (String(on) !== state) await toggle.click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async expectSuppressDestinations(on) {
+    const toggle = this.page.locator(this.testSuppressDestinationsBtn).first();
+    await expect(toggle).toHaveAttribute('aria-checked', String(on), { timeout: DRAWER_TIMEOUT_MS });
+  }
+
+  async expectDispatchWarning() {
+    await expect(this.page.locator(this.testDispatchWarning)).toBeVisible();
+  }
+
+  async expectNoDispatchWarning() {
+    await expect(this.page.locator(this.testDispatchWarning)).toHaveCount(0);
+  }
+
+  // ---------- branch summary ----------
+
+  async branchSummaryPathCount() {
+    return this.page.locator(this.configSummaryBranchPaths).count();
   }
 
   /** The else arm renders after every case row, whatever the path count. */
@@ -954,6 +1210,15 @@ class WorkflowsPage {
 
   /** Delete via row action (in the more-options menu). Returns any error toast (delete-protected
    *  when linked to an alert). */
+  /** Like deleteByName but surfaces a miss instead of swallowing it — for assertions. */
+  async deleteByNameStrict(name) {
+    await this.page.locator(this.listRowActionFor(name, 'more-options')).first().click({ timeout: LIST_TIMEOUT_MS });
+    const item = this.page.locator(this.listRowActionFor(name, 'delete')).first();
+    await item.waitFor({ state: 'visible', timeout: DRAWER_TIMEOUT_MS });
+    await item.click({ timeout: DRAWER_TIMEOUT_MS });
+    await this.page.locator(this.drawerPrimary).first().click({ timeout: DRAWER_TIMEOUT_MS });
+  }
+
   async deleteByName(name) {
     await this.page.locator(this.listRowActionFor(name, 'more-options')).first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});
     await this.page.locator(this.listRowActionFor(name, 'delete')).first().click({ timeout: DRAWER_TIMEOUT_MS }).catch(() => {});

--- a/tests/ui-testing/pages/workflowsPages/workflowsPage.js
+++ b/tests/ui-testing/pages/workflowsPages/workflowsPage.js
@@ -476,6 +476,16 @@ class WorkflowsPage {
     return this.page.locator(this.branchCaseRows).count();
   }
 
+  /**
+   * The ordinal badge on each case row, in rendered order. These are the user-visible
+   * statement of evaluation order, so they must renumber when rows move or are removed.
+   */
+  async branchOrderValues() {
+    return this.page
+      .locator(this.branchOrderBadges)
+      .evaluateAll((els) => els.map((e) => (e.textContent || '').trim()));
+  }
+
   /** Handles in RENDERED order — which is evaluation order, since first match wins. */
   async branchCaseHandles() {
     return this.page.locator(this.branchCaseRows).evaluateAll((els) =>

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-branch.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-branch.spec.js
@@ -1,0 +1,189 @@
+/**
+ * Workflows v1 — Branch node (BR-01..BR-08)
+ *
+ * Enterprise-only. The Branch is the N-way generalisation of Condition: each path is an
+ * optional label plus a ConditionBuilder, evaluated TOP-DOWN with FIRST MATCH WINS, and a
+ * permanent trailing "Everything Else" arm so every record leaves by exactly one handle.
+ * Row order is therefore routing, not decoration.
+ *
+ * The node shipped in #14027 (2026-09-03), two days AFTER the Workflows E2E suite merged in
+ * #14065 — so until this file it had no end-to-end coverage at all. A silent-reroute defect
+ * (deleting a wired path re-points its destination at "Everything Else" on reload) was found
+ * by hand in that gap; BR-04 pins the half of the guard that already works. The regression
+ * for the defect itself is deliberately NOT here — it fails until the fix lands.
+ *
+ * Self-cleaning: every artifact is namespaced `wf_auto_*`; cleanup.spec.js sweeps by prefix.
+ */
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+const uniq = () => `${Date.now().toString(36).slice(-5)}${Math.random().toString(36).slice(2, 5)}`;
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@all'] }, () => {
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await pm.workflowsPage.assertEnabled();
+  });
+
+  // BR-06 — Add Path mints a new arm, and the else row stays pinned last however many
+  // paths exist. The order badges are 1..N for the cases and N+1 for else.
+  test('BR-06: Add Path appends an arm and Everything Else stays last', { tag: ['@workflowsBranch'] }, async () => {
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
+    await pm.workflowsPage.addBranchFromPalette();
+
+    expect(await pm.workflowsPage.branchCaseCount()).toBe(1);
+    await pm.workflowsPage.addBranchCase();
+    await pm.workflowsPage.addBranchCase();
+    expect(await pm.workflowsPage.branchCaseCount()).toBe(3);
+
+    await pm.workflowsPage.expectElseArmLast();
+  });
+
+  // BR-07 — the else arm is what guarantees every record leaves by exactly one handle, so
+  // it is deliberately not deletable. Assert ABSENCE of a remove control, not a disabled one.
+  test('BR-07: the Everything Else arm cannot be removed', { tag: ['@workflowsBranch'] }, async () => {
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
+    await pm.workflowsPage.addBranchFromPalette();
+
+    await pm.workflowsPage.expectElseArmVisible();
+    await pm.workflowsPage.expectElseArmNotRemovable();
+
+    // A lone case also hides its own remove control — a Branch always keeps >=1 path.
+    const [only] = await pm.workflowsPage.branchCaseHandles();
+    await pm.workflowsPage.expectBranchCaseNotRemovable(only);
+  });
+
+  // BR-05 — move up/down reorders evaluation. Because first match wins, the rendered order
+  // IS the routing, so the labels must follow the move rather than the handles being renamed.
+  test('BR-05: move up/down reorders the paths without renaming handles', { tag: ['@workflowsBranch'] }, async () => {
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
+    await pm.workflowsPage.addBranchFromPalette();
+
+    const [first] = await pm.workflowsPage.branchCaseHandles();
+    await pm.workflowsPage.setBranchCase(first, { label: 'FIRST' });
+    await pm.workflowsPage.addBranchCase();
+    const handles = await pm.workflowsPage.branchCaseHandles();
+    const second = handles[1];
+    await pm.workflowsPage.setBranchCase(second, { label: 'SECOND' });
+
+    expect(await pm.workflowsPage.branchCaseLabels()).toEqual(['FIRST', 'SECOND']);
+
+    await pm.workflowsPage.moveBranchCase(second, 'up');
+    expect(await pm.workflowsPage.branchCaseLabels()).toEqual(['SECOND', 'FIRST']);
+    // Handles travel WITH their row — reordering must never re-point an existing edge.
+    expect(await pm.workflowsPage.branchCaseHandles()).toEqual([second, first]);
+  });
+
+  // BR-09 — handles are minted off a high-water mark and kept for the node's life. Deleting
+  // a path must not re-index the survivors, or every edge wired to them would silently move.
+  test('BR-09: deleting a path leaves surviving handles untouched', { tag: ['@workflowsBranch'] }, async () => {
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
+    await pm.workflowsPage.addBranchFromPalette();
+    await pm.workflowsPage.addBranchCase();
+    await pm.workflowsPage.addBranchCase();
+
+    const before = await pm.workflowsPage.branchCaseHandles();
+    expect(before).toHaveLength(3);
+
+    await pm.workflowsPage.removeBranchCase(before[0]);
+
+    const after = await pm.workflowsPage.branchCaseHandles();
+    expect(after).toEqual([before[1], before[2]]);
+    // A new path after a delete takes the NEXT free handle, never a recycled one.
+    await pm.workflowsPage.addBranchCase();
+    const grown = await pm.workflowsPage.branchCaseHandles();
+    expect(grown.slice(0, 2)).toEqual([before[1], before[2]]);
+    expect(before).not.toContain(grown[2]);
+  });
+
+  // BR-08 — an arm with no outgoing edge is flagged on the canvas. A fresh Branch has every
+  // arm open, so the badge must be present before anything is wired.
+  test('BR-08: an unwired arm is flagged on the node', { tag: ['@workflowsBranch'] }, async () => {
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
+    await pm.workflowsPage.addBranchFromPalette();
+    await pm.workflowsPage.saveNodeDrawer();
+
+    await pm.workflowsPage.expectBranchUnwiredBadge();
+  });
+
+  // BR-02 — the whole point of the node: two configured paths, each wired to its own sink,
+  // published. The edge labels are the only on-canvas evidence of which arm feeds which
+  // destination, so they are what we assert.
+  test('BR-02: builds and publishes a two-path branch with labelled arms', { tag: ['@workflowsBranch'] }, async () => {
+    const name = `wf_auto_br_${uniq()}`;
+    const dest = `wf_auto_dest_${uniq()}`;
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(name);
+    await pm.workflowsPage.addBranchFromPalette();
+
+    const [h0] = await pm.workflowsPage.branchCaseHandles();
+    await pm.workflowsPage.setBranchCase(h0, {
+      label: 'CRITICAL', column: 'meta_alert_name', operator: '=', value: 'crit_marker',
+    });
+    await pm.workflowsPage.addBranchCase();
+    const [, h1] = await pm.workflowsPage.branchCaseHandles();
+    await pm.workflowsPage.setBranchCase(h1, {
+      label: 'WARNING', column: 'meta_alert_name', operator: '=', value: 'warn_marker',
+    });
+    await pm.workflowsPage.saveNodeDrawer();
+
+    await pm.workflowsPage.wireArmToDestination(0, { destName: dest, url: 'https://example.com/wf' });
+    await pm.workflowsPage.wireArmToDestination(0, { existing: dest });
+
+    const labels = (await pm.workflowsPage.edgeLabelTexts(2)).join(" ");
+    testLogger.info('branch edge labels', { labels });
+    expect(labels).toContain('CRITICAL');
+    expect(labels).toContain('WARNING');
+
+    await pm.workflowsPage.publishAndExpectAccepted();
+    await pm.workflowsPage.skipLinkAlerts();
+  });
+
+  // BR-04 — deleting a path whose arm still carries an edge leaves the graph routing through
+  // a handle the node no longer declares. The backend would reject that mid-run with a raw
+  // uuid, so the editor refuses first. This is the guard that works today; the draft path
+  // around it is the open defect.
+  test('BR-04: deleting a wired path blocks publish', { tag: ['@workflowsBranch'] }, async () => {
+    const name = `wf_auto_br_${uniq()}`;
+    const dest = `wf_auto_dest_${uniq()}`;
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(name);
+    await pm.workflowsPage.addBranchFromPalette();
+
+    const [h0] = await pm.workflowsPage.branchCaseHandles();
+    await pm.workflowsPage.setBranchCase(h0, {
+      label: 'CRITICAL', column: 'meta_alert_name', operator: '=', value: 'crit_marker',
+    });
+    await pm.workflowsPage.addBranchCase();
+    const [, h1] = await pm.workflowsPage.branchCaseHandles();
+    await pm.workflowsPage.setBranchCase(h1, {
+      label: 'WARNING', column: 'meta_alert_name', operator: '=', value: 'warn_marker',
+    });
+    await pm.workflowsPage.saveNodeDrawer();
+
+    await pm.workflowsPage.wireArmToDestination(0, { destName: dest, url: 'https://example.com/wf' });
+    await pm.workflowsPage.wireArmToDestination(0, { existing: dest });
+
+    // Drop the arm that is already feeding a destination.
+    await pm.workflowsPage.openBranchDrawer();
+    await pm.workflowsPage.removeBranchCase(h0);
+    await pm.workflowsPage.saveNodeDrawer();
+
+    const msg = await pm.workflowsPage.publishAndCaptureRejection();
+    testLogger.info('publish rejection after deleting a wired path', { msg });
+    expect(msg.toLowerCase()).toContain('branch');
+  });
+});

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-branch.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-branch.spec.js
@@ -1,5 +1,5 @@
 /**
- * Workflows v1 — Branch node (BR-01..BR-08)
+ * Workflows v1 — Branch node (BR-02, BR-04..BR-09, BR-11)
  *
  * Enterprise-only. The Branch is the N-way generalisation of Condition: each path is an
  * optional label plus a ConditionBuilder, evaluated TOP-DOWN with FIRST MATCH WINS, and a
@@ -34,7 +34,8 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
   });
 
   // BR-06 — Add Path mints a new arm, and the else row stays pinned last however many
-  // paths exist. The order badges are 1..N for the cases and N+1 for else.
+  // paths exist. The ordinal badges are the user-visible statement of evaluation order,
+  // so they must read 1..N over the case rows.
   test('BR-06: Add Path appends an arm and Everything Else stays last', { tag: ['@workflowsBranch'] }, async () => {
     await pm.workflowsPage.goToAdd();
     await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
@@ -44,6 +45,7 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
     await pm.workflowsPage.addBranchCase();
     await pm.workflowsPage.addBranchCase();
     expect(await pm.workflowsPage.branchCaseCount()).toBe(3);
+    expect(await pm.workflowsPage.branchOrderValues()).toEqual(['1', '2', '3']);
 
     await pm.workflowsPage.expectElseArmLast();
   });
@@ -83,6 +85,8 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
     expect(await pm.workflowsPage.branchCaseLabels()).toEqual(['SECOND', 'FIRST']);
     // Handles travel WITH their row — reordering must never re-point an existing edge.
     expect(await pm.workflowsPage.branchCaseHandles()).toEqual([second, first]);
+    // The ordinals renumber to match the new evaluation order.
+    expect(await pm.workflowsPage.branchOrderValues()).toEqual(['1', '2']);
   });
 
   // BR-09 — handles are minted off a high-water mark and kept for the node's life. Deleting

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-branch.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-branch.spec.js
@@ -186,4 +186,24 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
     testLogger.info('publish rejection after deleting a wired path', { msg });
     expect(msg.toLowerCase()).toContain('branch');
   });
+  // BR-11 — path labels are persisted config, not view state: they must survive a draft
+  // checkpoint and come back in the same order, since order is evaluation order.
+  test('BR-11: path labels survive a draft save and reopen', { tag: ['@workflowsBranch'] }, async () => {
+    const name = `wf_auto_br_${uniq()}`;
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(name);
+    await pm.workflowsPage.addBranchFromPalette();
+
+    const [h0] = await pm.workflowsPage.branchCaseHandles();
+    await pm.workflowsPage.setBranchCase(h0, { label: 'ALPHA' });
+    await pm.workflowsPage.addBranchCase();
+    const [, h1] = await pm.workflowsPage.branchCaseHandles();
+    await pm.workflowsPage.setBranchCase(h1, { label: 'BETA' });
+    await pm.workflowsPage.saveNodeDrawer();
+    await pm.workflowsPage.saveAsDraft();
+
+    await pm.workflowsPage.openEdit(name);
+    await pm.workflowsPage.openBranchDrawer();
+    expect(await pm.workflowsPage.branchCaseLabels()).toEqual(['ALPHA', 'BETA']);
+  });
 });

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-branch.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-branch.spec.js
@@ -33,13 +33,19 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
     await pm.workflowsPage.assertEnabled();
   });
 
+  /** A named workflow on the editor with one Branch placed and its drawer open. */
+  const withBranch = async (name = `wf_auto_br_${uniq()}`) => {
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(name);
+    await pm.workflowsPage.addBranchFromPalette();
+    return name;
+  };
+
   // BR-06 — Add Path mints a new arm, and the else row stays pinned last however many
   // paths exist. The ordinal badges are the user-visible statement of evaluation order,
   // so they must read 1..N over the case rows.
   test('BR-06: Add Path appends an arm and Everything Else stays last', { tag: ['@workflowsBranch'] }, async () => {
-    await pm.workflowsPage.goToAdd();
-    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
-    await pm.workflowsPage.addBranchFromPalette();
+    await withBranch();
 
     expect(await pm.workflowsPage.branchCaseCount()).toBe(1);
     await pm.workflowsPage.addBranchCase();
@@ -53,9 +59,7 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
   // BR-07 — the else arm is what guarantees every record leaves by exactly one handle, so
   // it is deliberately not deletable. Assert ABSENCE of a remove control, not a disabled one.
   test('BR-07: the Everything Else arm cannot be removed', { tag: ['@workflowsBranch'] }, async () => {
-    await pm.workflowsPage.goToAdd();
-    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
-    await pm.workflowsPage.addBranchFromPalette();
+    await withBranch();
 
     await pm.workflowsPage.expectElseArmVisible();
     await pm.workflowsPage.expectElseArmNotRemovable();
@@ -68,9 +72,7 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
   // BR-05 — move up/down reorders evaluation. Because first match wins, the rendered order
   // IS the routing, so the labels must follow the move rather than the handles being renamed.
   test('BR-05: move up/down reorders the paths without renaming handles', { tag: ['@workflowsBranch'] }, async () => {
-    await pm.workflowsPage.goToAdd();
-    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
-    await pm.workflowsPage.addBranchFromPalette();
+    await withBranch();
 
     const [first] = await pm.workflowsPage.branchCaseHandles();
     await pm.workflowsPage.setBranchCase(first, { label: 'FIRST' });
@@ -92,9 +94,7 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
   // BR-09 — handles are minted off a high-water mark and kept for the node's life. Deleting
   // a path must not re-index the survivors, or every edge wired to them would silently move.
   test('BR-09: deleting a path leaves surviving handles untouched', { tag: ['@workflowsBranch'] }, async () => {
-    await pm.workflowsPage.goToAdd();
-    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
-    await pm.workflowsPage.addBranchFromPalette();
+    await withBranch();
     await pm.workflowsPage.addBranchCase();
     await pm.workflowsPage.addBranchCase();
 
@@ -115,9 +115,7 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
   // BR-08 — an arm with no outgoing edge is flagged on the canvas. A fresh Branch has every
   // arm open, so the badge must be present before anything is wired.
   test('BR-08: an unwired arm is flagged on the node', { tag: ['@workflowsBranch'] }, async () => {
-    await pm.workflowsPage.goToAdd();
-    await pm.workflowsPage.setName(`wf_auto_br_${uniq()}`);
-    await pm.workflowsPage.addBranchFromPalette();
+    await withBranch();
     await pm.workflowsPage.saveNodeDrawer();
 
     await pm.workflowsPage.expectBranchUnwiredBadge();
@@ -129,9 +127,7 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
   test('BR-02: builds and publishes a two-path branch with labelled arms', { tag: ['@workflowsBranch'] }, async () => {
     const name = `wf_auto_br_${uniq()}`;
     const dest = `wf_auto_dest_${uniq()}`;
-    await pm.workflowsPage.goToAdd();
-    await pm.workflowsPage.setName(name);
-    await pm.workflowsPage.addBranchFromPalette();
+    await withBranch(name);
 
     const [h0] = await pm.workflowsPage.branchCaseHandles();
     await pm.workflowsPage.setBranchCase(h0, {
@@ -163,9 +159,7 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
   test('BR-04: deleting a wired path blocks publish', { tag: ['@workflowsBranch'] }, async () => {
     const name = `wf_auto_br_${uniq()}`;
     const dest = `wf_auto_dest_${uniq()}`;
-    await pm.workflowsPage.goToAdd();
-    await pm.workflowsPage.setName(name);
-    await pm.workflowsPage.addBranchFromPalette();
+    await withBranch(name);
 
     const [h0] = await pm.workflowsPage.branchCaseHandles();
     await pm.workflowsPage.setBranchCase(h0, {
@@ -194,9 +188,7 @@ test.describe('Workflows branch node', { tag: ['@workflows', '@enterprise', '@al
   // checkpoint and come back in the same order, since order is evaluation order.
   test('BR-11: path labels survive a draft save and reopen', { tag: ['@workflowsBranch'] }, async () => {
     const name = `wf_auto_br_${uniq()}`;
-    await pm.workflowsPage.goToAdd();
-    await pm.workflowsPage.setName(name);
-    await pm.workflowsPage.addBranchFromPalette();
+    await withBranch(name);
 
     const [h0] = await pm.workflowsPage.branchCaseHandles();
     await pm.workflowsPage.setBranchCase(h0, { label: 'ALPHA' });

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-canvas.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-canvas.spec.js
@@ -1,0 +1,117 @@
+/**
+ * Workflows v1 — node card actions and canvas controls (NOD-*, NDV-*)
+ *
+ * Enterprise-only. The node card carries a hover-only action rail (disable, delete) plus
+ * two status badges, and the drawer owns rename and comment. None of it had coverage.
+ *
+ * Two behaviours here are load-bearing rather than cosmetic:
+ *  - `incomplete` means "not finished yet" and is what blocks Publish, so the badge is the
+ *    user's only pointer to which step is holding a publish back.
+ *  - `disabled` keeps a node on the canvas but out of the run set, so the badge is the
+ *    difference between a step that will fire and one that will not.
+ *
+ * Self-cleaning: every artifact is namespaced `wf_auto_*`; cleanup.spec.js sweeps by prefix.
+ */
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+const uniq = () => `${Date.now().toString(36).slice(-5)}${Math.random().toString(36).slice(2, 5)}`;
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Workflows canvas & node actions', { tag: ['@workflows', '@enterprise', '@all'] }, () => {
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await pm.workflowsPage.assertEnabled();
+  });
+
+  /** Trigger + one unconfigured Condition, drawer left open. */
+  const withCondition = async () => {
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(`wf_auto_nod_${uniq()}`);
+    await pm.workflowsPage.addNodeFromPalette('condition');
+  };
+
+  // NOD-05 — a node added from the palette arrives in "set up later" mode. The badge is
+  // what tells the author which step is not finished, so it must be there before config.
+  test('NOD-05: an unconfigured node is badged incomplete', { tag: ['@workflowsCanvas'] }, async () => {
+    await withCondition();
+    await pm.workflowsPage.saveNodeDrawer();
+    await pm.workflowsPage.expectNodeIncompleteBadge('condition');
+  });
+
+  // NOD-01 — a renamed node keeps its type but shows the custom name, which is how a
+  // graph with three Conditions stays readable.
+  test('NOD-01: a node can be renamed from its drawer', { tag: ['@workflowsCanvas'] }, async () => {
+    const label = `renamed_${uniq()}`;
+    await withCondition();
+    await pm.workflowsPage.renameOpenNode(label);
+    await pm.workflowsPage.saveNodeDrawer();
+    await pm.workflowsPage.expectNodeShowsText('condition', label);
+  });
+
+  // NOD-02 — a comment is authoring metadata; the card advertises it with a glyph so the
+  // note is discoverable without opening every node.
+  test('NOD-02: commenting a node surfaces the indicator glyph', { tag: ['@workflowsCanvas'] }, async () => {
+    await withCondition();
+    await pm.workflowsPage.commentOpenNode(`note ${uniq()}`);
+    await pm.workflowsPage.saveNodeDrawer();
+    await pm.workflowsPage.expectCommentIndicator();
+  });
+
+
+  // NOD-04 — delete removes the node from the graph.
+  test('NOD-04: a node can be deleted from its hover actions', { tag: ['@workflowsCanvas'] }, async () => {
+    await withCondition();
+    await pm.workflowsPage.saveNodeDrawer();
+    expect(await pm.workflowsPage.nodeCount('condition')).toBe(1);
+
+    await pm.workflowsPage.deleteNode('condition');
+    await expect.poll(async () => pm.workflowsPage.nodeCount('condition'), { timeout: 15000 }).toBe(0);
+  });
+
+  // NOD-06 — undo is the safety net for the delete above; a mis-click must be recoverable
+  // without rebuilding the subtree.
+  test('NOD-06: canvas undo restores a deleted node', { tag: ['@workflowsCanvas'] }, async () => {
+    await withCondition();
+    await pm.workflowsPage.saveNodeDrawer();
+    await pm.workflowsPage.deleteNode('condition');
+    await expect.poll(async () => pm.workflowsPage.nodeCount('condition'), { timeout: 15000 }).toBe(0);
+
+    await pm.workflowsPage.clickCanvasUndo();
+    await expect.poll(async () => pm.workflowsPage.nodeCount('condition'), { timeout: 15000 }).toBe(1);
+  });
+
+  // NOD-07 — tidy re-lays the graph. It must not disturb the graph itself, so the node
+  // count is the invariant worth pinning.
+  test('NOD-07: canvas tidy preserves the graph', { tag: ['@workflowsCanvas'] }, async () => {
+    await withCondition();
+    await pm.workflowsPage.saveNodeDrawer();
+    const before = await pm.workflowsPage.nodeCount('condition');
+
+    await pm.workflowsPage.clickCanvasTidy();
+    await expect.poll(async () => pm.workflowsPage.nodeCount('condition'), { timeout: 15000 }).toBe(before);
+  });
+
+  // NDV-08 — the detail view is also how a long graph is walked: every open node offers
+  // prev/next step navigation, so the author never has to close and re-open to move on.
+  test('NDV-08: the node detail view offers step navigation', { tag: ['@workflowsCanvas'] }, async () => {
+    await withCondition();
+    await pm.workflowsPage.expectNdvStepNavigation();
+  });
+  // NOD-08 — the incomplete badge is a live signal, not a one-off: configuring the node
+  // must clear it, or the author can never tell what is still blocking a publish.
+  test('NOD-08: configuring a node clears its incomplete badge', { tag: ['@workflowsCanvas'] }, async () => {
+    await withCondition();
+    await pm.workflowsPage.setCondition({ column: 'meta_alert_name', operator: '=', value: 'x' });
+    await pm.workflowsPage.saveNodeDrawer();
+    await pm.workflowsPage.expectNoIncompleteBadge('condition');
+  });
+
+});

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-lifecycle.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-lifecycle.spec.js
@@ -1,0 +1,160 @@
+/**
+ * Workflows v1 — draft lifecycle and list operations (DRF-*, EDT-*, LST-*)
+ *
+ * Enterprise-only. Two surfaces that shipped without coverage:
+ *
+ *  - The DRAFT mode switch. A draft offers Save-as-Draft + Publish and skips the
+ *    connectivity checks so a half-built graph can be parked; a published workflow offers
+ *    Save + History instead and is validated on every save. Which controls exist IS the
+ *    mode, so the tests assert on the controls rather than on a flag.
+ *  - The list row: pause/resume, delete, read-only view, and the draft/trigger tags
+ *    (#14260, #14315 and #14356 all landed here with no test).
+ *
+ * Self-cleaning: every artifact is namespaced `wf_auto_*`; cleanup.spec.js sweeps by prefix.
+ */
+
+const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+const uniq = () => `${Date.now().toString(36).slice(-5)}${Math.random().toString(36).slice(2, 5)}`;
+const URL_STUB = 'https://example.com/wf-lifecycle';
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Workflows lifecycle & list', { tag: ['@workflows', '@enterprise', '@all'] }, () => {
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await pm.workflowsPage.assertEnabled();
+  });
+
+  /** A complete, publishable graph: trigger -> configured destination. */
+  const buildGraph = async (name) => {
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(name);
+    await pm.workflowsPage.addNodeFromPalette('destination');
+    await pm.workflowsPage.createDestinationInline({ name: `wf_auto_dest_${uniq()}`, url: URL_STUB });
+    await pm.workflowsPage.saveNodeDrawer();
+  };
+
+  // DRF-01 — Save as Draft parks the graph and marks it a draft in both places the user
+  // looks: the row in the list, and the editor header when it is reopened.
+  test('DRF-01: Save as Draft tags the workflow in the list and the editor', { tag: ['@workflowsLifecycle'] }, async () => {
+    const name = `wf_auto_drf_${uniq()}`;
+    await buildGraph(name);
+    await pm.workflowsPage.saveAsDraft();
+
+    await pm.workflowsPage.search(name);
+    await pm.workflowsPage.expectDraftTagOnRow(name);
+
+    await pm.workflowsPage.openEdit(name);
+    await pm.workflowsPage.expectDraftTagInEditor();
+  });
+
+  // DRF-02 — promoting a draft flips the editor's whole mode: the draft tag goes, and the
+  // Save-as-Draft control is replaced by Save.
+  test('DRF-02: publishing a draft clears draft mode', { tag: ['@workflowsLifecycle'] }, async () => {
+    const name = `wf_auto_drf_${uniq()}`;
+    await buildGraph(name);
+    await pm.workflowsPage.saveAsDraft();
+
+    await pm.workflowsPage.search(name);
+    await pm.workflowsPage.openEdit(name);
+    await pm.workflowsPage.publishAndExpectAccepted();
+    await pm.workflowsPage.skipLinkAlerts();
+
+    await pm.workflowsPage.search(name);
+    await pm.workflowsPage.openEdit(name);
+    await pm.workflowsPage.expectNoDraftTagInEditor();
+    await pm.workflowsPage.expectPublishedEditorControls();
+  });
+
+
+
+  // EDT-02 — run history is only meaningful for something that can actually run, so the
+  // History control belongs to published workflows and must be reachable there.
+  test('EDT-02: a published workflow exposes run history', { tag: ['@workflowsLifecycle'] }, async () => {
+    const name = `wf_auto_edt_${uniq()}`;
+    await buildGraph(name);
+    await pm.workflowsPage.publishAndExpectAccepted();
+    await pm.workflowsPage.skipLinkAlerts();
+
+    await pm.workflowsPage.search(name);
+    await pm.workflowsPage.openEdit(name);
+    await pm.workflowsPage.expectHistoryControl();
+  });
+
+  // LST-03 — pause/resume is the enable flag. The row action reports which way it will go
+  // via data-row-action, so a toggle must flip that value.
+  test('LST-03: pause and resume flip the row action', { tag: ['@workflowsLifecycle'] }, async () => {
+    const name = `wf_auto_lst_${uniq()}`;
+    await buildGraph(name);
+    await pm.workflowsPage.publishAndExpectAccepted();
+    await pm.workflowsPage.skipLinkAlerts();
+
+    await pm.workflowsPage.search(name);
+    const before = await pm.workflowsPage.rowActionState(name);
+    expect(before).toBe('pause');
+
+    await pm.workflowsPage.toggleEnable(name);
+    await expect.poll(async () => pm.workflowsPage.rowActionState(name), { timeout: 20000 }).toBe('resume');
+  });
+
+
+
+  // LST-06 — every row advertises its trigger kind; a draft row additionally carries the
+  // draft tag. Both are how the list is scanned.
+  test('LST-06: rows carry a trigger tag', { tag: ['@workflowsLifecycle'] }, async () => {
+    const name = `wf_auto_lst_${uniq()}`;
+    await buildGraph(name);
+    await pm.workflowsPage.publishAndExpectAccepted();
+    await pm.workflowsPage.skipLinkAlerts();
+
+    await pm.workflowsPage.search(name);
+    await pm.workflowsPage.expectTriggerTagOnRow();
+  });
+
+  // LST-07 — refresh re-fetches rather than repainting cached rows. Hit by hand during the
+  // branch work: a workflow created out-of-band is invisible until this is pressed.
+  test('LST-07: refresh re-fetches the list', { tag: ['@workflowsLifecycle'] }, async () => {
+    const name = `wf_auto_lst_${uniq()}`;
+    await buildGraph(name);
+    await pm.workflowsPage.saveAsDraft();
+
+    await pm.workflowsPage.refreshList();
+    await pm.workflowsPage.search(name);
+    expect(await pm.workflowsPage.isPresent(name)).toBe(true);
+  });
+  // DRF-05 — a draft is a CHECKPOINT the author may take repeatedly, so saving twice must
+  // succeed rather than tripping the "no changes" guard that Publish uses.
+  test('DRF-05: Save as Draft can be repeated', { tag: ['@workflowsLifecycle'] }, async () => {
+    const name = `wf_auto_drf_${uniq()}`;
+    await buildGraph(name);
+    await pm.workflowsPage.saveAsDraft();
+
+    await pm.workflowsPage.search(name);
+    await pm.workflowsPage.openEdit(name);
+    await pm.workflowsPage.saveAsDraft();
+    await pm.workflowsPage.search(name);
+    expect(await pm.workflowsPage.isPresent(name)).toBe(true);
+  });
+  // LST-08 — pause and resume must round-trip: a paused workflow that is resumed is back
+  // in exactly the state it started in, which is what makes the control safe to use.
+  test('LST-08: pause then resume returns the row to running', { tag: ['@workflowsLifecycle'] }, async () => {
+    const name = `wf_auto_lst_${uniq()}`;
+    await buildGraph(name);
+    await pm.workflowsPage.publishAndExpectAccepted();
+    await pm.workflowsPage.skipLinkAlerts();
+
+    await pm.workflowsPage.search(name);
+    await pm.workflowsPage.toggleEnable(name);
+    await expect.poll(async () => pm.workflowsPage.rowActionState(name), { timeout: 20000 }).toBe('resume');
+
+    await pm.workflowsPage.toggleEnable(name);
+    await expect.poll(async () => pm.workflowsPage.rowActionState(name), { timeout: 20000 }).toBe('pause');
+  });
+});

--- a/tests/ui-testing/playwright-tests/Workflows/workflows-test-dialog.spec.js
+++ b/tests/ui-testing/playwright-tests/Workflows/workflows-test-dialog.spec.js
@@ -1,0 +1,74 @@
+/**
+ * Workflows v1 — the Test drawer (TST-*)
+ *
+ * Enterprise-only. Reworked in #14027: a rehearsal can now take its payload from the
+ * seeded sample OR from a previous run, start from a chosen step, and — critically —
+ * suppresses destinations BY DEFAULT so testing a workflow cannot post to production.
+ *
+ * That default is the safety property worth pinning: only the suppressed state is safe,
+ * and turning it off must warn before anything is dispatched. These tests exercise the
+ * controls WITHOUT running, so they stay fast and never send.
+ *
+ * Self-cleaning: every artifact is namespaced `wf_auto_*`; cleanup.spec.js sweeps by prefix.
+ */
+
+const { test, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
+const testLogger = require('../utils/test-logger.js');
+const PageManager = require('../../pages/page-manager.js');
+
+const uniq = () => `${Date.now().toString(36).slice(-5)}${Math.random().toString(36).slice(2, 5)}`;
+const URL_STUB = 'https://example.com/wf-test-drawer';
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Workflows test drawer', { tag: ['@workflows', '@enterprise', '@all'] }, () => {
+  let pm;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+    await navigateToBase(page);
+    pm = new PageManager(page);
+    await pm.workflowsPage.assertEnabled();
+    await pm.workflowsPage.goToAdd();
+    await pm.workflowsPage.setName(`wf_auto_tst_${uniq()}`);
+    await pm.workflowsPage.addNodeFromPalette('destination');
+    await pm.workflowsPage.createDestinationInline({ name: `wf_auto_dest_${uniq()}`, url: URL_STUB });
+    await pm.workflowsPage.saveNodeDrawer();
+  });
+
+  // TST-01 — the drawer opens and offers a payload source. Without this control a
+  // rehearsal can only ever use the seeded sample.
+  test('TST-01: the test drawer offers an input source', { tag: ['@workflowsTestDrawer'] }, async () => {
+    await pm.workflowsPage.openTestDrawer();
+    await pm.workflowsPage.expectTestControl(pm.workflowsPage.testInputSource);
+  });
+
+  // TST-06 — a rehearsal can start partway down the graph, which is what makes debugging
+  // a long workflow cheap.
+  test('TST-06: the test drawer offers a run-from step', { tag: ['@workflowsTestDrawer'] }, async () => {
+    await pm.workflowsPage.openTestDrawer();
+    await pm.workflowsPage.expectTestControl(pm.workflowsPage.testRunFrom);
+  });
+
+  // TST-04 — reset-to-sample is the escape hatch after editing the payload by hand.
+  test('TST-04: reset to sample is offered', { tag: ['@workflowsTestDrawer'] }, async () => {
+    await pm.workflowsPage.openTestDrawer();
+    await pm.workflowsPage.expectTestControl(pm.workflowsPage.testResetSample);
+  });
+
+  // TST-05a — destinations are suppressed by DEFAULT. This is the safety property: opening
+  // the drawer and pressing Run must not be able to post to a live endpoint.
+  test('TST-05a: destinations are suppressed by default', { tag: ['@workflowsTestDrawer'] }, async () => {
+    await pm.workflowsPage.openTestDrawer();
+    await pm.workflowsPage.expectSuppressDestinations(true);
+    await pm.workflowsPage.expectNoDispatchWarning();
+  });
+
+  // TST-05b — turning suppression off means a rehearsal WILL send for real, so the drawer
+  // has to say so before the author presses Run.
+  test('TST-05b: un-suppressing destinations warns that the run will dispatch', { tag: ['@workflowsTestDrawer'] }, async () => {
+    await pm.workflowsPage.openTestDrawer();
+    await pm.workflowsPage.setSuppressDestinations(false);
+    await pm.workflowsPage.expectDispatchWarning();
+  });
+});


### PR DESCRIPTION
29 E2E tests across four specs for Workflows surfaces that had **no coverage at all**, taking the suite from 32 to 61.

Pairs with **o2-enterprise#2615** on the same branch name, which registers all four specs in the enterprise matrix. Both must land together or the matrix names files that don't exist.

### Why now

The Branch node shipped in #14027 on 2026-09-03 — two days *after* the Workflows E2E suite merged in #14065 — so nothing ever exercised it. A silent-routing defect was found by hand in exactly that gap (o2-enterprise#2581). The draft lifecycle, node actions and the reworked test drawer landed in the same PR and were equally untested.

### What's covered

**`workflows-branch.spec.js` — 8**

| | |
|---|---|
| BR-02 | builds and publishes a two-path branch; asserts the arm labels on the connectors |
| BR-04 | deleting a path that still feeds a destination blocks publish |
| BR-05 | move up/down reorders paths without renaming handles; ordinals renumber |
| BR-06 | Add Path appends an arm; ordinals read 1..N; Everything Else stays last |
| BR-07 | the Everything Else arm has no remove control |
| BR-08 | an unwired arm is flagged on the node |
| BR-09 | deleting a path leaves surviving handles untouched |
| BR-11 | path labels survive a draft save and reopen |

Order and handles get their own tests because they are **routing**, not presentation: paths evaluate top-down with first-match-wins, and a handle is what an edge is wired to — re-indexing on delete would silently re-point live edges.

**`workflows-lifecycle.spec.js` — 8** · draft tags in row and editor (DRF-01), publishing clears draft mode (DRF-02), drafts are repeatable checkpoints (DRF-05), published workflows expose run history (EDT-02), pause/resume flips the row action (LST-03), the full pause→resume round trip (LST-08), rows carry a trigger tag (LST-06), refresh re-fetches (LST-07).

**`workflows-canvas.spec.js` — 8** · incomplete badge appears and clears, rename, comment indicator, delete via hover actions (with confirm), undo restores a deleted node, tidy preserves the graph, NDV step navigation.

**`workflows-test-dialog.spec.js` — 5** · input source, run-from, reset-to-sample, and the safety property that matters: destinations are **suppressed by default** so a rehearsal cannot post to production, and un-suppressing raises a dispatch warning.

### Things the source did not predict

Each cost a live run to find and is now encoded in the page object so the next author doesn't rediscover it:

- **Edge labels are HTML in vue-flow's `.vue-flow__edge-labels` layer, not SVG `<text>`.** The singular `.vue-flow__edge-label` matches nothing. That layer also holds the empty hover-`+` wrappers, so labels must be filtered for blanks rather than indexed positionally.
- **The row's View control is a hover preview, not a route** — it carries an `OTooltip` rendering a `WorkflowView` summary and has no click handler at all.
- Node delete funnels through a shared `ConfirmDialog`, so deleting is two steps.
- Rename is an `OInlineEdit` (`-trigger` opens, `-input` edits, `-value` reads); the comment is an `OTextarea` whose writable element is `-field`.
- Every branch row owns its own `ConditionBuilder`, so reading labels via `input` interleaves each row's condition value field.

### Deliberately not included

- **BR-01 / DRF-03** — the regression for the silent-reroute defect. It **fails until the fix lands**, so it ships with the fix rather than turning the suite red for a known reason. BR-04 covers the half of the guard that works today.
- **Node disable toggle** — does not fire through automation (dispatched clicks don't trigger it).
- **Test drawer close control** — not identifiable from markup.
- **List pagination / unauthorised empty state** — no selectors, and the latter needs a second RBAC user.
- **Workflow delete from the list row** — the row's delete path did not complete reliably through automation; worth its own look rather than a silently-catching helper.
- **Unsaved-changes guard, and description persistence** — the guard dialog and the inline-edit `-value` readback both proved unreliable to drive; the description is an `OInlineEdit`, not a plain field.

Cut rather than shipped flaky; each is worth its own investigation. Nothing here is a known product defect except BR-01/DRF-03.

### Verification

**ENT CI (authoritative): 61 passed, 0 failed** in 1.8m at 5 workers — [o2-enterprise run 34609247995](https://github.com/openobserve/o2-enterprise/actions/runs/34609247995), all nine Workflows specs executed. The two incident cases that flake locally (INC-05, INC-06) both passed there.

Locally against `main.common-dev` @ `fc7f51ad41` at `--workers=2`: **29/29** for the new specs, 59/61 for the whole suite (the two are those same pre-existing incident flakes, untouched by this PR).

Artifacts are named `wf_auto_*`, which `cleanup.spec.js` already sweeps.

> Note: the shard-triage bot reports these paths match no OSS shard globs, so **OSS CI never executes these specs** — green checks here say nothing about them. Workflows is enterprise-only; the real signal is the ENT run linked above.

