### PR TITLE
fix(alerts): run workflows for incident alerts

### DIFF
--- a/src/core/src/alerts/alert.rs
+++ b/src/core/src/alerts/alert.rs
@@ -2570,7 +2570,7 @@ impl AlertExt for Alert {
             Err(AlertError::SendNotificationError {
                 error_message: outcome.error_message,
             })
-        } else if self.destinations.is_empty() && workflow_error == self.workflows.len() {
+        } else if all_workflows_failed(attempted, self.workflows.len(), workflow_error) {
             Err(AlertError::SendNotificationError {
                 error_message: workflow_err_msg,
             })
@@ -2578,6 +2578,14 @@ impl AlertExt for Alert {
             Ok(outcome)
         }
     }
+}
+
+fn all_workflows_failed(
+    attempted_destinations: usize,
+    workflow_count: usize,
+    workflow_errors: usize,
+) -> bool {
+    attempted_destinations == 0 && workflow_count > 0 && workflow_errors == workflow_count
 }
 
 /// Build the notification context for a send, resolving the row template
@@ -4176,7 +4184,14 @@ mod send_path_tests {
 
     #[cfg(feature = "enterprise")]
     use super::incident_path_notified;
-    use super::{NotificationOutcome, choose_template};
+    use super::{NotificationOutcome, all_workflows_failed, choose_template};
+
+    #[test]
+    fn skipped_incident_destinations_do_not_hide_total_workflow_failure() {
+        assert!(all_workflows_failed(0, 1, 1));
+        assert!(!all_workflows_failed(0, 1, 0));
+        assert!(!all_workflows_failed(1, 1, 1));
+    }
 
     fn tpl(name: &str) -> Template {
         Template {

--- a/src/core/src/alerts/scheduler/handlers.rs
+++ b/src/core/src/alerts/scheduler/handlers.rs
@@ -951,9 +951,17 @@ async fn handle_composite_alert_trigger(
             #[cfg(not(feature = "enterprise"))]
             let incident_handled = false;
 
-            let delivery_result = if incident_handled {
+            let delivery_result = if !should_dispatch_after_incident(
+                incident_handled,
+                !notification_alert.workflows.is_empty(),
+            ) {
                 Ok(crate::alerts::alert::NotificationOutcome::default())
             } else {
+                let skip_destinations = if incident_handled {
+                    &notification_alert.destinations
+                } else {
+                    &scheduled_data.notified_destinations
+                };
                 notification_alert
                     .send_notification(
                         trace_id,
@@ -964,7 +972,7 @@ async fn handle_composite_alert_trigger(
                         Some(evaluated.level),
                         Some(i32::from(evaluated.result) as f64),
                         None,
-                        &scheduled_data.notified_destinations,
+                        skip_destinations,
                     )
                     .await
             };
@@ -1090,6 +1098,13 @@ async fn handle_composite_alert_trigger(
     trigger.data = config::utils::json::to_string(&scheduled_data)?;
     let _ = infra::scheduler::complete_claim(trigger).await?;
     Ok(())
+}
+
+fn should_dispatch_after_incident(
+    incident_destinations_handled: bool,
+    has_workflows: bool,
+) -> bool {
+    !incident_destinations_handled || has_workflows
 }
 
 fn composite_notification_alert(
@@ -2523,9 +2538,8 @@ async fn handle_alert_triggers(
         //     );
         // }
 
-        // True when incident correlation ran and handled the notification internally
-        // (either sent it for a new incident/alert type, or suppressed it for a repeat).
-        // When false, the direct send_notification() call below fires instead.
+        // True when incident correlation handled destination delivery internally.
+        // Alert-attached workflows are still dispatched through send_notification below.
         #[cfg(feature = "enterprise")]
         let incident_handled_notification = if alert.creates_incident
             && o2_enterprise::enterprise::common::config::get_config()
@@ -2603,7 +2617,10 @@ async fn handle_alert_triggers(
             trigger_data_stream.dedup_suppressed = Some(false);
         }
 
-        if incident_handled_notification {
+        if !should_dispatch_after_incident(
+            incident_handled_notification,
+            !alert.workflows.is_empty(),
+        ) {
             // Notification was handled (sent or suppressed) inside correlate_alert_to_incident.
             // Still advance the trigger state so the scheduler moves forward normally.
             record_delivery(&mut trigger_data);
@@ -2614,17 +2631,18 @@ async fn handle_alert_triggers(
             };
             new_trigger.data = json::to_string(&trigger_data).unwrap();
             db::scheduler::update_trigger(new_trigger, true, &query_trace_id).await?;
-        } else if let Some(dispatch) = dispatch_per_group(
-            &alert,
-            &scheduler_trace_id,
-            trigger_results.group_classification.as_ref(),
-            &data,
-            trigger_results.end_time,
-            eval_level,
-            Some(start_time),
-            triggered_at,
-        )
-        .await
+        } else if !incident_handled_notification
+            && let Some(dispatch) = dispatch_per_group(
+                &alert,
+                &scheduler_trace_id,
+                trigger_results.group_classification.as_ref(),
+                &data,
+                trigger_results.end_time,
+                eval_level,
+                Some(start_time),
+                triggered_at,
+            )
+            .await
         {
             // Per-group dispatch REPLACES the alert-level send (§5.5 MN-1):
             // sending both would page the worst group twice per incident.
@@ -2721,7 +2739,14 @@ async fn handle_alert_triggers(
             new_trigger.data = json::to_string(&trigger_data).unwrap();
             db::scheduler::update_trigger(new_trigger, true, &query_trace_id).await?;
         } else {
-            // Direct notification — creates_incident=false, or incident correlation errored.
+            // Incident correlation owns destination delivery, but workflows are
+            // dispatched only here. Skip destinations already handled by the
+            // incident path so the same firing cannot page them twice.
+            let skip_destinations: &[String] = if incident_handled_notification {
+                &alert.destinations
+            } else {
+                &trigger_data.notified_destinations
+            };
             match alert
                 .send_notification(
                     &scheduler_trace_id,
@@ -2732,11 +2757,7 @@ async fn handle_alert_triggers(
                     eval_level,
                     trigger_results.actual_value,
                     None,
-                    // Retry ledger (§6.1): destinations that already landed on
-                    // a prior attempt of THIS notification cycle are skipped,
-                    // so a retry driven by one flaky destination cannot
-                    // double-page the ones that succeeded.
-                    &trigger_data.notified_destinations,
+                    skip_destinations,
                 )
                 .await
             {
@@ -5617,6 +5638,13 @@ mod tests {
     use config::meta::stream::StreamType;
 
     use super::*;
+
+    #[test]
+    fn incident_destination_delivery_does_not_suppress_attached_workflows() {
+        assert!(should_dispatch_after_incident(true, true));
+        assert!(!should_dispatch_after_incident(true, false));
+        assert!(should_dispatch_after_incident(false, false));
+    }
 
     // ── Task 11: per-destination retry ledger (§6.1) ────────────────────────
 


### PR DESCRIPTION
## Problem

Scheduled alerts with creates_incident = true stopped after incident correlation. Incident destinations were notified, but attached workflows never ran because they are dispatched only through send_notification. Workflow-only composites could then enter their silence window without delivering anything.

  ## Approach

Continue through send_notification when workflows are attached, while skipping destinations already handled by incident correlation. Complete workflow failures now follow the existing retry path instead of being recorded as successful delivery.

  Fixes #14406.