### PR TITLE
fix: write slo_status through the read-write DB client in the SLO ingest pass (#14192)

### DIFF
--- a/src/core/src/alerts/scheduler/handlers.rs
+++ b/src/core/src/alerts/scheduler/handlers.rs
@@ -140,9 +140,7 @@ async fn persist_alert_run_state(
                 .unwrap_or(false)
             });
         if transition_changed || stale_to_fresh {
-            let db = get_orm_client_rw().await;
             nudge_composite_parents(
-                db,
                 &alert.org_id,
                 alert_id,
                 infra::table::alert_composites::ChildKind::Alert,
@@ -228,9 +226,7 @@ async fn persist_alert_run_state(
             .unwrap_or(false)
         });
     if transition_changed || stale_to_fresh {
-        let db = get_orm_client_rw().await;
         nudge_composite_parents(
-            db,
             &alert.org_id,
             alert_id,
             infra::table::alert_composites::ChildKind::Alert,
@@ -619,20 +615,27 @@ fn composite_stale_k() -> i64 {
 /// same level). Idempotent and coalesced: `next_run_at` is only ever pulled
 /// earlier, never pushed out.
 async fn nudge_composite_parents(
-    db: &sea_orm::DatabaseConnection,
     org: &str,
     child_id: &str,
     child_kind: infra::table::alert_composites::ChildKind,
     now: i64,
 ) {
-    let parents =
-        match infra::table::alert_composites::list_parents(db, org, child_kind, child_id).await {
-            Ok(parents) => parents,
-            Err(error) => {
-                log::error!("[COMPOSITE_ALERT] failed to look up parents for {child_id}: {error}");
-                return;
-            }
-        };
+    let parents = match infra::table::alert_composites::list_parents(
+        get_orm_client_ro().await,
+        org,
+        child_kind,
+        child_id,
+    )
+    .await
+    {
+        Ok(parents) => parents,
+        Err(error) => {
+            log::error!("[COMPOSITE_ALERT] failed to look up parents for {child_id}: {error}");
+            return;
+        }
+    };
+    // SQLite opens the read-only pool with read_only(true), and the loop below writes.
+    let db = get_orm_client_rw().await;
     for parent in parents {
         // Order matters: generation first, then the job advance. A completion
         // that later re-reads the generation must observe the nudge.
@@ -1043,7 +1046,6 @@ async fn handle_composite_alert_trigger(
     });
     if significant {
         nudge_composite_parents(
-            db,
             &trigger.org,
             &definition.definition.id,
             infra::table::alert_composites::ChildKind::Composite,

--- a/src/core/src/slo/job.rs
+++ b/src/core/src/slo/job.rs
@@ -173,7 +173,7 @@ pub async fn run_pass(slo: &Slo, now_secs: i64) -> Result<PassOutcome, anyhow::E
 
     write_slices(&slo.org, &result.slices, now_secs).await?;
 
-    let outcome = commit_status(db, slo, &result, range.end, now_secs).await?;
+    let outcome = commit_status(slo, &result, range.end, now_secs).await?;
     if let slo_table::WriteOutcome::FencedByGeneration { expected, found } = outcome {
         return Ok(PassOutcome::Fenced { expected, found });
     }
@@ -774,12 +774,13 @@ async fn write_slices(org: &str, slices: &[SliceRow], now_secs: i64) -> Result<(
 
 /// Fold the pass's slices into the running aggregate, CAS-fenced.
 async fn commit_status(
-    db: &sea_orm::DatabaseConnection,
     slo: &Slo,
     result: &PassResult,
     watermark_end: i64,
     now_secs: i64,
 ) -> Result<slo_table::WriteOutcome, anyhow::Error> {
+    // SQLite opens the read-only pool with read_only(true), and this path always writes.
+    let db = get_orm_client_rw().await;
     let mut by_group: std::collections::BTreeMap<String, (f64, f64, i32)> = Default::default();
     for s in &result.slices {
         let e = by_group.entry(s.group_key.clone()).or_insert((0.0, 0.0, 0));


### PR DESCRIPTION
Backport of #14192 to `branch-v1.0.0`. Fixes #14189 on the 1.0.0 line.

## Why

Two scheduler paths issue a database write through the **read-only** ORM client. On SQLite — every single-node / local-mode install — that pool is opened with `.read_only(true)`, so the write is rejected outright:

```
ERROR openobserve_core::alerts::scheduler::handlers: [slo] pass failed for <id> org=default: DbError# SeaORMError# Execution Error: error returned from database: (code: 8) attempt to write a readonly database
```

Both are regressions from `ccd254ad00` ("refactor(infra): split ORM read/write clients"), which is present on `branch-v1.0.0`.

### `slo_status` never advances (#14189) — still live on 1.0.0

`run_pass` in `src/core/src/slo/job.rs` took the read-only client for its reads and handed the same handle to `commit_status`, which writes the `slo_status` row inside a transaction. `watermark_end` therefore stayed NULL after the initial backfill and every SLO-backed alert was evaluated as frozen (unobserved) forever. Plain scheduled alerts are unaffected.

### Composite parents — already mitigated on 1.0.0, now unified

Unlike `main` at the time of #14192, `branch-v1.0.0` had already been patched at both `persist_alert_run_state` call sites (`let db = get_orm_client_rw().await;` before calling `nudge_composite_parents`), so the composite-parent nudge was not broken here. This backport replaces that call-site patch with the upstream design.

## Change

Same as #14192: `commit_status` and `nudge_composite_parents` **acquire the read-write handle themselves** and no longer take a connection parameter, so no caller can supply the wrong one.

`nudge_composite_parents` keeps its `list_parents` lookup on the read-only client: when an alert has no composite parents — the common case — the function writes nothing, and that read must not queue on SQLite's single write connection.

Splitting the read and the write across two connections is safe: `apply_status_in_txn` re-reads the rollup row and re-checks `definition_generation` **inside** its own transaction (`src/infra/src/table/slo.rs`), so the early read in `run_pass` cannot commit a stale-fenced write.

## Conflict resolved during the cherry-pick

The only conflict was in `src/core/src/alerts/scheduler/handlers.rs`, at the two `persist_alert_run_state` call sites described above. Since `nudge_composite_parents` now acquires its own handles, the two `let db = get_orm_client_rw().await;` lines were removed — the parameter they fed no longer exists. Net result is byte-identical to `main` at both sites.

`src/core/src/slo/job.rs` and the third call site (`handle_composite_alert_trigger`) merged cleanly.

## Verified on this branch

- `cargo fmt --all` clean.
- `cargo clippy --workspace --all-targets -- -W clippy::too_many_lines -W clippy::cognitive_complexity -W clippy::excessive_nesting -D warnings` exits 0.
- `cargo test -p openobserve-core --lib slo::` — 206 passed, 0 failed.
- `cargo test -p openobserve-core --lib alerts::scheduler` — 64 passed, 0 failed.

## Note for the reviewer

`branch-v1.0.0` has a pre-existing `Cargo.lock` drift: any `cargo` invocation regenerates it to add an `openobserve-synthetics` and a `usage_reporting` dependency entry. That is unrelated to this port and is deliberately **not** included here — worth a separate fix on the branch.
